### PR TITLE
Generic Vox uniform

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/xenowear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/xenowear.dm
@@ -95,4 +95,4 @@
 	slot = slot_shoes
 	sort_category = "Xenowear"
 	
-	
+*/

--- a/code/modules/client/preference_setup/loadout/lists/xenowear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/xenowear.dm
@@ -89,7 +89,7 @@
 	slot = slot_shoes
 	sort_category = "Xenowear"
 
-/datum/gear/xenowear
+/datum/gear/xenowear/toelessworkboots
 	display_name = "toeless workboots"
 	path = /obj/item/clothing/shoes/workboots/toeless
 	slot = slot_shoes

--- a/code/modules/client/preference_setup/loadout/lists/xenowear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/xenowear.dm
@@ -94,3 +94,5 @@
 	path = /obj/item/clothing/shoes/workboots/toeless
 	slot = slot_shoes
 	sort_category = "Xenowear"
+	
+	

--- a/code/modules/client/preference_setup/loadout/lists/xenowear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/xenowear.dm
@@ -70,6 +70,12 @@
 	path = /obj/item/clothing/under/permit
 	slot = slot_w_uniform
 	sort_category = "Xenowear"
+	
+/datum/gear/xenowear/voxcivassistant
+	display_name = "vox pressure suit"
+	path = /obj/item/clothing/under/vox-civ-assistant
+	slot = slot_w_uniform
+	sort_category = "Xenowear"
 
 /datum/gear/xenowear/roughspun
 	display_name = "roughspun robes"


### PR DESCRIPTION
Adds in the Vox civilian pressure suit as a xenowear option, in lieu of sprites for much of the selectable load-out.

As for why this is useful: while practically nobody plays Vox, that shouldn't mean they shouldn't have something to wear. More pressure suits can be added, after some editing to get them fitting department colors.