### PR TITLE
Hard nerf to render HP

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/big.dm
+++ b/code/modules/mob/living/simple_animal/hostile/big.dm
@@ -33,8 +33,8 @@
 	break_stuff_probability = 95
 	attacktext = "mauled"
 	faction = "deathclaw"
-	maxHealth = 900
-	health = 900
+	maxHealth = 500
+	health = 500
 	melee_damage_lower = 35
 	melee_damage_upper = 40
 	old_x = -16


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Buffing renders to ridiculous levels solely because of ONE PLAYER doing ridiculous shit after equally ridiculous levels of preparation is not good gameplay balance, as it punishes everyone for the actions of one or two autists. These things are so fast already that you will be forced into a melee encounter with them, and they hit so hard that melee is almost entirely unviable in the first place, even in groups. These things should not be taking out a party of three well-prepared people with hard-hitting guns. Vigil MacLeod is not a valid reason for over-buffing renders. It still has 500 HP with this change, which is plenty enough to make soloing them very fucking difficult if not impossible with all their other advantages. They do not need to be bullet sponges on top of everything else to make them difficult or formidable foes. This is spessman, not Warframe.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: Reduces Render HP from 900 to 500
<!--balance: Reduces Render HP from 900 to 500-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
