### PR TITLE
Sneaky PR for Sneaky Boys

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -134,7 +134,7 @@
 	perks = list(/datum/perk/suddenbrilliance)
 
 /datum/species/marqua/get_bodytype()
-	return "Mar'qua"
+	return "Mar'Qua"
 
 /datum/species/kriosan
 	name = "Kriosan"


### PR DESCRIPTION
Fixes Kazkin's typo, allowing Mar'Qua to select their dedicated hairstyles.