### PR TITLE
Adds item states to shields that have their individual sprites

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -119,6 +119,7 @@
 	name = "round handmade shield"
 	desc = "A handmade stout shield, but with a small size."
 	icon_state = "buckler"
+	item_state = "buckler"
 	flags = null
 	throw_speed = 2
 	throw_range = 6
@@ -140,6 +141,7 @@
 	name = "tray shield"
 	desc = "This one is thin, but compensate it with a good size."
 	icon_state = "tray_shield"
+	item_state = "tray_shield"
 	flags = CONDUCT
 	throw_speed = 2
 	throw_range = 4


### PR DESCRIPTION
No idea why the fuck this wasn't done before

## About The Pull Request
Does exactly what the title says, no idea why these weren't used. they're in the lefthand and righthand files too so :shrug:

## Changelog
:cl:
added item_state to buckler
added item_state to tray shield
/:cl: