### PR TITLE
Cht'mants now take toxic damage from metals and nanites

### DIFF
--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -28,6 +28,15 @@
 /datum/reagent/metal
 	reagent_type = "Metal"
 
+/datum/reagent/metal/affect_ingest(var/mob/living/carbon/M, var/alien)
+	if(M.species.reagent_tag == IS_CHTMANT)
+		M.adjustToxLoss(0.01) //Small damage to Chtmants nothing too too lethal
+
+/datum/reagent/metal/affect_blood(var/mob/living/carbon/M, var/alien)
+	if(M.species.reagent_tag == IS_CHTMANT)
+		M.adjustToxLoss(0.2)
+
+
 /datum/reagent/metal/aluminum
 	name = "Aluminum"
 	id = "aluminum"
@@ -212,6 +221,7 @@
 
 
 /datum/reagent/metal/iron/affect_ingest(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
+	..()
 	M.add_chemical_effect(CE_BLOODRESTORE, 0.8 * effect_multiplier)
 
 /datum/reagent/metal/lithium
@@ -223,6 +233,7 @@
 	color = "#808080"
 
 /datum/reagent/metal/lithium/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
+	..()
 	if(M.canmove && !M.restrained() && istype(M.loc, /turf/space))
 		step(M, pick(cardinal))
 	if(prob(5))
@@ -237,6 +248,7 @@
 	color = "#484848"
 
 /datum/reagent/metal/mercury/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
+	..()
 	if(M.canmove && !M.restrained() && istype(M.loc, /turf/space))
 		step(M, pick(cardinal))
 	if(prob(5))
@@ -262,6 +274,7 @@
 	color = "#A0A0A0"
 
 /datum/reagent/metal/potassium/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
+	..()
 	if(volume > 3)
 		M.add_chemical_effect(CE_PULSE, 1)
 	if(volume > 10)
@@ -276,6 +289,7 @@
 	color = "#C7C7C7"
 
 /datum/reagent/metal/radium/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
+	..()
 	M.apply_effect(1 * (issmall(M) ? effect_multiplier * 2 : effect_multiplier), IRRADIATE, 0) // Radium may increase your chances to cure a disease
 	if(M.virus2.len)
 		for(var/ID in M.virus2)

--- a/code/modules/reagents/reagents/nanites.dm
+++ b/code/modules/reagents/reagents/nanites.dm
@@ -1,5 +1,7 @@
 // Nanobots blood drain per unit
 #define NANOBOTS_BLOOD_DRAIN 0.003
+#define NANOBOTS_HEAVY_BLOOD_DRAIN 0.01 //.007 more then normal
+//Chtmans lose more
 
 /datum/reagent/nanites
 	name = ""
@@ -17,8 +19,11 @@
 /datum/reagent/nanites/proc/eat_blood(var/mob/living/carbon/M) // Yam !
 	var/datum/reagent/organic/blood/B = M.get_blood()
 	// blood regeneratin 0.1 u every tick so with NANOBOTS_BLOOD_DRAIN = 0.003 human can sustain 30u nanobots without losing blood
-	if(B && B.volume)
+	if(B && B.volume && !M.species.reagent_tag == IS_CHTMANT)
 		B.remove_self(volume * NANOBOTS_BLOOD_DRAIN)
+	else
+		B.remove_self(volume * NANOBOTS_HEAVY_BLOOD_DRAIN) //If we are a Chtmant we lose more
+		M.adjustToxLoss(0.1) //We also take toxin damage
 
 /datum/reagent/nanites/proc/will_occur(var/mob/living/carbon/M, var/alien, var/location)
 	if(location == CHEM_BLOOD)
@@ -70,6 +75,8 @@
 /datum/reagent/nanites/dead/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(..())
 		M.adjustToxLoss(0.2 * effect_multiplier)
+	if(M.species.reagent_tag == IS_CHTMANT) //If we are a Chtmant we take double the affect
+		M.adjustToxLoss(0.2 * effect_multiplier) //All and all this is 0.4 x effect mult + 0.1! REALLY lethal to Chtmants
 
 /datum/reagent/nanites/uncapped
 	name = "Raw Uncapped Nanobots"
@@ -91,12 +98,12 @@
 /datum/reagent/nanites/arad/will_occur(var/mob/living/carbon/M, var/alien, var/location)
 	if(..() && M.radiation)
 		return TRUE
-		
+
 
 /datum/reagent/nanites/arad/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(..())
 		M.radiation = max(M.radiation - (5 + M.radiation * 0.10) * effect_multiplier, 0)
-		
+
 
 /datum/reagent/nanites/implant_medics
 	name = "Implantoids"
@@ -119,7 +126,7 @@
 						metabolism = 1
 						constant_metabolism = TRUE
 						return TRUE
-			
+
 
 /datum/reagent/nanites/implant_medics/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(..())
@@ -138,7 +145,7 @@
 				else if (istype(organ, /obj/item/organ/internal) && organ.damage > 0 && BP_IS_ROBOTIC(organ))
 					organ.heal_damage((2 + organ.damage * 0.05)* effect_multiplier)
 					return
-				
+
 
 /datum/reagent/nanites/nantidotes
 	name = "Nantidotes"
@@ -171,9 +178,10 @@
 /datum/reagent/nanites/nanosymbiotes/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(..())
 		M.heal_organ_damage(1 * effect_multiplier, 1 * effect_multiplier, 3 * effect_multiplier, 3 * effect_multiplier)
-		M.adjustToxLoss(-((1 + (M.getToxLoss() * 0.03)) * effect_multiplier))
 		M.adjustCloneLoss(-(1 + (M.getCloneLoss() * 0.03)) * effect_multiplier)
 		M.adjustBrainLoss(-(1 + (M.getBrainLoss() * 0.03)) * effect_multiplier)
+	if(!M.species.reagent_tag == IS_CHTMANT) //If we are a Chtmant we dont heal are toxloss from nanites
+		M.adjustToxLoss(-((1 + (M.getToxLoss() * 0.03)) * effect_multiplier))
 
 /datum/reagent/nanites/oxyrush
 	name = "Oxyrush"


### PR DESCRIPTION

## About The Pull Request
Cht'mants when eating or injecting METAL or nanite based chems will have increased negative affects
For basic metal it will be small toxic harm, nothing to bad unless you never heal yourself or start guzzling down all 12 metals at once and then inject them - So not an issue

For nanites - they drain more blood, cant heal toxic damage and deal a small amount of toxic damage, nothing a little bit of anti-toxin and sugar cant fix!

## Changelog
:cl:
add: Cht'mants as pre lore dislike metals and will take really low amounts of toxic damage form them if injected or eaten. Nanites for cht'mants only will no longer heal toxins, and take even more blood then normal. Nanites only for Cht'mants will deal increased toxic damage in all cases.
/:cl:
