### PR TITLE
Roaches now wait 15 mins to DNR rather then 5

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/life.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/life.dm
@@ -36,8 +36,8 @@
 					stop_automated_movement = 1
 					src.visible_message(SPAN_NOTICE("\The [src] begins to eat \the [eat_target]."))
 					walk(src,0)
-					spawn(3000) // how much time it takes to it a corpse, in tenths of second
-					    // Set to 5 minutes to let the crew enough time to get the corpse
+					spawn(9000) // how much time it takes to it a corpse, in tenths of second
+					    // Set to 15 minutes to let the crew enough time to get the corpse
 						// Several roaches eating at the same time do not speed up the process
 						// If disturbed the roach has to start back from 0
 						if(busy == EATING_TARGET)


### PR DESCRIPTION

## About The Pull Request
This is really unforgiving well trying to get someone when on lower pops, and getting lost.
I think and after first and seeing a failer to save someone that died in a basic area and got DNR it should be upped to give people time. Imagine dieing in a coroner and a basic roach eat the body do to sci/med unable to fine them is just not fun to deal with by any party 

## Changelog
:cl:
balance: Ups Roaches timer to eat bodys from 5 mins to 15mins to give us time to eat the body
/:cl:
