### PR TITLE
Does this fix the crashes? - Disables notes in stashes

### DIFF
--- a/code/modules/stashes/stash_spawner.dm
+++ b/code/modules/stashes/stash_spawner.dm
@@ -26,7 +26,7 @@
 		return INITIALIZE_HINT_QDEL
 
 	datum.spawn_stash()
-	datum.spawn_note(loc)
+	// datum.spawn_note(loc) // - Test to see if this fixes the crashes
 
 	//Aaaand we are done -- would've never guessed that
 	return INITIALIZE_HINT_QDEL


### PR DESCRIPTION
Revert this when either BYOND is fixed or the crashing keeps happening.