### PR TITLE
Fixes Rnd printer being unable to use biomatter

### DIFF
--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -7,7 +7,6 @@
 	layer = BELOW_OBJ_LAYER
 	use_power = IDLE_POWER_USE
 	var/obj/machinery/computer/rdconsole/linked_console
-	unsuitable_materials = list() //So we can use biomatter and others
 
 /obj/machinery/r_n_d/attack_hand(mob/user)
 	return
@@ -38,6 +37,7 @@
 	desc = "A machine used for construction of advanced prototypes. Operated from an R\&D console."
 	icon_state = "protolathe"
 	circuit = /obj/item/weapon/circuitboard/protolathe
+	unsuitable_materials = list() //So we can use biomatter and others
 
 	build_type = PROTOLATHE
 	storage_capacity = 120

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -7,6 +7,7 @@
 	layer = BELOW_OBJ_LAYER
 	use_power = IDLE_POWER_USE
 	var/obj/machinery/computer/rdconsole/linked_console
+	unsuitable_materials = list() //So we can use biomatter and others
 
 /obj/machinery/r_n_d/attack_hand(mob/user)
 	return


### PR DESCRIPTION

## About The Pull Request
Makes it so the printer in Rnd can use biomatter to make things like kits and goggles for people and the church when trading for things...
## Changelog
:cl:
fix: Rnd can now use biomatter to print things that they need biomatter for
/:cl:
