### PR TITLE
Rebalances and tweaks some stashes

### DIFF
--- a/code/modules/stashes/stash_types/captain.dm
+++ b/code/modules/stashes/stash_types/captain.dm
@@ -23,7 +23,6 @@
 	/obj/item/clothing/mask/smokable/cigarette/cigar/havana = 15,
 	/obj/item/modular_computer/tablet/lease/preset/command = 25,
 	/obj/item/weapon/stamp/captain = 35,
-	/obj/item/weapon/disk/nuclear = 15,
 	/obj/item/weapon/hand_tele = 25,
 	/obj/item/weapon/bluespace_harpoon = 15,
 	/obj/item/weapon/reagent_containers/hypospray = 15,

--- a/code/modules/stashes/stash_types/excelsior.dm
+++ b/code/modules/stashes/stash_types/excelsior.dm
@@ -15,9 +15,19 @@
 	/obj/item/weapon/implantcase/excelsior/broken = 40,
 	/obj/item/clothing/suit/space/void/excelsior = 70,
 	/obj/item/weapon/gun/projectile/automatic/ak47 = 30,
-	/obj/item/weapon/gun/projectile/automatic/ak47 = 30,
+	/obj/item/weapon/gun/projectile/automatic/vintorez = 10,
+	/obj/item/weapon/gun/projectile/clarissa/makarov = 50,
+	/obj/item/weapon/gun/projectile/clarissa/makarov = 50,
 	/obj/item/ammo_magazine/lrifle = 50,
-	/obj/item/ammo_magazine/lrifle = 50,)
+	/obj/item/ammo_magazine/lrifle = 50,
+	/obj/item/weapon/stock_parts/capacitor/excelsior = 70,
+	/obj/item/weapon/stock_parts/scanning_module/excelsior = 70,
+	/obj/item/weapon/stock_parts/manipulator/excelsior = 70,
+	/obj/item/weapon/stock_parts/micro_laser/excelsior = 70,
+	/obj/item/weapon/stock_parts/matter_bin/excelsior = 70,
+	/obj/item/weapon/cell/large/excelsior = 60,
+	/obj/item/weapon/cell/medium/excelsior = 60,
+	/obj/item/weapon/cell/small/excelsior = 60,)
 	weight = 0.5
 
 /datum/stash/excelsior/shipyard

--- a/code/modules/stashes/stash_types/ninja.dm
+++ b/code/modules/stashes/stash_types/ninja.dm
@@ -14,7 +14,12 @@
 		/obj/item/weapon/material/star/uranium = 70,
 		/obj/item/weapon/tool/sword/katana = 20,
 		/obj/item/rig_module/chem_dispenser/ninja = 90, //Weakest chem dispenser rig
-		/obj/item/weapon/reagent_containers/food/drinks/bottle/pwine = 70,)
+		/obj/item/weapon/reagent_containers/food/drinks/bottle/pwine = 70,
+		/obj/item/device/spy_bug = 70,
+		/obj/item/device/spy_bug = 60,
+		/obj/item/device/spy_bug = 50,
+		/obj/item/weapon/silencer = 70,
+		/obj/item/weapon/pen/reagent = 20,)
 
 /datum/stash/ninja/haiku
 	lore = "Swift electric ghost<br>\

--- a/code/modules/stashes/stash_types/ninja.dm
+++ b/code/modules/stashes/stash_types/ninja.dm
@@ -11,7 +11,10 @@
 	contents_list_random = list(
 		/obj/item/weapon/storage/box/anti_photons = 60,
 		/obj/item/weapon/gun/projectile/silenced = 50,
-		/obj/item/weapon/material/star/uranium = 70)
+		/obj/item/weapon/material/star/uranium = 70,
+		/obj/item/weapon/tool/sword/katana = 20,
+		/obj/item/rig_module/chem_dispenser/ninja = 90, //Weakest chem dispenser rig
+		/obj/item/weapon/reagent_containers/food/drinks/bottle/pwine = 70,)
 
 /datum/stash/ninja/haiku
 	lore = "Swift electric ghost<br>\

--- a/code/modules/stashes/stash_types/valueables.dm
+++ b/code/modules/stashes/stash_types/valueables.dm
@@ -6,11 +6,9 @@
 	contents_list_base = list(/obj/random/credits/c5000 = 1)
 
 	contents_list_random = list(/obj/item/stack/material/diamond/random = 10,
-	/obj/item/stack/telecrystal/random = 5,
 	/obj/item/stack/material/platinum/random = 10,
 	/obj/item/stack/material/gold/random = 15,
 	/obj/item/stack/material/silver/random = 25,
-	/obj/item/weapon/moneybag/vault = 15,
 	/obj/random/credits/c5000 = 30,
 	/obj/random/credits/c1000 = 60,
 	/obj/random/credits/c500 = 90)


### PR DESCRIPTION
## About The Pull Request
Captains stash no longer gets a nuke disk
Ninja stash now can get
Weaker then basic chem dispender for rigs
Katana
Warlock Wine
Upto 3 cam bugs
A silencer
A fancy pen!

Weath/Money Stash 
No longer has TC
No longer has a bag of broken coins

Excelsior Stash
It can now spawn Excelsior handguns and vintorez 
It can now also spawn Excelsior stock parts and cells


## Changelog
:cl:
/:cl:
