### PR TITLE
Chem changes for Cht'mants

### DIFF
--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -30,6 +30,9 @@
 	scannable = 1
 
 /datum/reagent/medicine/bicaridine/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
+	if(M.species?.reagent_tag == IS_CHTMANT)
+		M.heal_organ_damage(0.3 * effect_multiplier, 0, 5 * effect_multiplier)
+		return
 	M.heal_organ_damage(0.6 * effect_multiplier, 0, 5 * effect_multiplier)
 	M.add_chemical_effect(CE_BLOODCLOT, 0.15)
 
@@ -87,6 +90,8 @@
 	scannable = 1
 
 /datum/reagent/medicine/kelotane/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
+	if(M.species?.reagent_tag == IS_CHTMANT)
+		return
 	M.heal_organ_damage(0, 0.6 * effect_multiplier, 0, 3 * effect_multiplier)
 
 /datum/reagent/medicine/dermaline
@@ -168,6 +173,8 @@
 	scannable = 1
 
 /datum/reagent/medicine/dexalin/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
+	if(M.species?.reagent_tag == IS_CHTMANT)
+		return
 	M.adjustOxyLoss(-1.5 * effect_multiplier)
 	M.add_chemical_effect(CE_OXYGENATED, 1)
 	holder.remove_reagent("lexorin", 0.2 * effect_multiplier)
@@ -218,6 +225,8 @@ datum/reagent/medicine/respirodaxon/affect_blood(var/mob/living/carbon/M, var/al
 	overdose = REAGENTS_OVERDOSE
 
 /datum/reagent/medicine/tricordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
+	if(M.species?.reagent_tag == IS_CHTMANT)
+		return
 	M.adjustOxyLoss(-0.6 * effect_multiplier)
 	M.heal_organ_damage(0.3 * effect_multiplier, 0.3 * effect_multiplier)
 	M.adjustToxLoss(-0.3 * effect_multiplier)
@@ -406,6 +415,8 @@ datum/reagent/medicine/respirodaxon/affect_blood(var/mob/living/carbon/M, var/al
 	scannable = 1
 
 /datum/reagent/medicine/peridaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
+	if(M.species?.reagent_tag == IS_CHTMANT)
+		return
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -482,7 +482,12 @@
 /datum/reagent/toxin/diplopterum/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	..()
 	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_BASIC, STIM_TIME, "diplopterum")
-
+	if(M.species?.reagent_tag == IS_CHTMANT)
+		M.adjustOxyLoss(-1.5 * effect_multiplier)
+		M.add_chemical_effect(CE_OXYGENATED, 1)
+		holder.remove_reagent("lexorin", 0.2 * effect_multiplier)
+		M.adjustToxLoss(-0.1)
+		return
 /datum/reagent/toxin/diplopterum/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "diplopterum_w")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "diplopterum_w")
@@ -511,14 +516,14 @@
 	heating_products = list("radium", "ammonia", "sulfur", "nutriment")
 
 /datum/reagent/toxin/seligitillin/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.add_chemical_effect(CE_BLOODCLOT, 0.2)
-	M.heal_organ_damage(0.2 * effect_multiplier, 0, 3)
 	var/mob/living/carbon/human/H = M
 	for(var/obj/item/organ/external/E in H.organs)
 		for(var/datum/wound/W in E.wounds)
 			if(W.internal)
 				W.heal_damage(1 * effect_multiplier)
-
+	if(M.species?.reagent_tag == IS_CHTMANT)
+		M.heal_organ_damage(0, 0.6 * effect_multiplier, 0, 3 * effect_multiplier)
+		return
 /datum/reagent/toxin/seligitillin/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_ADEPT, STIM_TIME, "seligitillin_w")
 
@@ -548,7 +553,11 @@
 /datum/reagent/toxin/starkellin/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	..()
 	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_BASIC, STIM_TIME, "starkellin")
-
+	if(M.species?.reagent_tag == IS_CHTMANT)
+		M.heal_organ_damage(0.6 * effect_multiplier, 0, 5 * effect_multiplier)
+		M.add_chemical_effect(CE_BLOODCLOT, 0.15)
+		M.adjustToxLoss(-0.1)
+		return
 /datum/reagent/toxin/starkellin/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, STIM_TIME, "starkellin_w")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "starkellin_w")
@@ -572,7 +581,13 @@
 	..()
 	M.stats.addTempStat(STAT_ROB, STAT_LEVEL_BASIC, STIM_TIME, "gewaltine")
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "gewaltine")
-
+	if(M.species?.reagent_tag == IS_CHTMANT)
+		M.drowsyness = max(0, M.drowsyness - 0.6 * effect_multiplier)
+		M.adjust_hallucination(-0.9 * effect_multiplier)
+		M.adjustToxLoss(-((0.4 + (M.getToxLoss() * 0.05)) * effect_multiplier))
+		M.add_chemical_effect(CE_ANTITOX, 1)
+		holder.remove_reagent("pararein", 0.4 * effect_multiplier)
+		return
 /datum/reagent/toxin/gewaltine/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_ADEPT, STIM_TIME, "gewaltine_w")
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_BASIC, STIM_TIME, "gewaltine_w")
@@ -593,9 +608,17 @@
 	heating_point = 573
 	heating_products = list("radium", "mercury", "lithium", "nutriment")
 
+
+
 /datum/reagent/toxin/fuhrerole/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	M.faction = "roach"
+	if(M.species?.reagent_tag == IS_CHTMANT)
+		var/mob/living/carbon/human/H = M
 
+		for(var/obj/item/organ/I in H.internal_organs)
+			if((I.damage > 0) && !BP_IS_ROBOTIC(I)) //Peridaxon heals only non-robotic organs
+				I.heal_damage(((0.2 + I.damage * 0.05) * effect_multiplier), FALSE)
+		return
 /datum/reagent/toxin/fuhrerole/on_mob_delete(mob/living/L)
 	..()
 	L.faction = initial(L.faction)


### PR DESCRIPTION
All changes ONLY effect Cht'mants.
Diplopterum, acts as Dexalin.
Seligitillin acts as Kelotane
Starkellin acts as Bicaradine
Gewaltine acts as Dylovene
Fuhrerole acts as Peridaxon
Blattedin still acts as Tricordrazine.

Dexalin, Kelotane, Tricordrazine and Peridaxon now do NOTHING to
Cht'mants. Dermaline and Dexalin plus still do the same thing they do for everyone.
 Bicarardine heals for half as much brute damage as it does for others. Dylo remains untouched.
Alkysine and Imidazoline will still treat brain and eye damage as normal.
All roach chems have no od limit for cht'mants, and are not addictive or toxic to them. (or at least i hope this is my first code attempt ever and I tested alot but probably messed up some where) 

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
