### PR TITLE
Buffs RnD points form things outside of bluespace/illegal tech

### DIFF
--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -8,15 +8,15 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 	var/saved_best_explosion = 0
 
 	var/static/list/tech_points = list(
-		TECH_MATERIAL = 200,
-		TECH_ENGINEERING = 250,
-		TECH_PLASMA = 500,
-		TECH_POWER = 300,
+		TECH_MATERIAL = 300,
+		TECH_ENGINEERING = 400,
+		TECH_PLASMA = 550,
+		TECH_POWER = 370,
 		TECH_BLUESPACE = 1000,
-		TECH_BIO = 300,
-		TECH_COMBAT = 500,
-		TECH_MAGNET = 350,
-		TECH_DATA = 400,
+		TECH_BIO = 350,
+		TECH_COMBAT = 570,
+		TECH_MAGNET = 450,
+		TECH_DATA = 500,
 		TECH_ILLEGAL = 5000,
 	)
 


### PR DESCRIPTION

## About The Pull Request
Raises the points you get for most things other then bluespace/illegal tech to help make the two not the epic meme stuff that you shoot for all at once to max RnD without wanting to wast time/mats on other techs

## Changelog
:cl:
balance: RnD points from levels is a small bit easyer. Meaning Rng and illegal tech are no longer the way to go
/:cl:
