### PR TITLE
Medical Rebalance Update.

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -69,6 +69,9 @@
 		go_out()
 
 /obj/machinery/atmospherics/unary/cryo_cell/attack_hand(mob/user)
+	if(!usr.stat_check(STAT_BIO, STAT_LEVEL_ADEPT))
+		to_chat(usr, SPAN_WARNING("Your biological understanding isn't enough to use this."))
+		return
 	ui_interact(user)
 
  /**

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -279,7 +279,7 @@
 /datum/ritual/cruciform/divisor/div_flash
 	name = "Ire"
 	phrase = "Fortitudo mea et laus mea Dominus, et sicut in omnibus divitiis."
-	desc = "Knocks over everybody without cruciform in your view range. Though the energy emitted is quite powerful, a vigilant person may resist it. This litany can only be used once every quarter hour."
+	desc = "Knocks over everybody without cruciform in your view range. Though the energy emitted is quite powerful, a vigilant person may resist it. This litany can only be used once every five minutes."
 	cooldown = TRUE
 	cooldown_time = 5 MINUTES
 	cooldown_category = "dflas"

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -637,7 +637,7 @@
 	power = 50
 	success_message = "On the verge of audibility you hear pleasant music, the alter slides open and a new cruciform slips out."
 
-/datum/ritual/cruciform/priest/new_cruciform_vinculum/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
+/datum/ritual/cruciform/priest/new_cruciform/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/list/OBJS = get_front(user)
 
 	var/obj/machinery/optable/altar = locate(/obj/machinery/optable/altar) in OBJS

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -224,7 +224,7 @@
 		return
 
 	var/rounded_vol
-	if( name == "syringe")
+	if(/obj/item/weapon/reagent_containers/syringe)
 		if(reagents && reagents.total_volume)
 			rounded_vol = CLAMP(round((reagents.total_volume / volume * 15),5), 1, 15)
 			var/image/filling_overlay = mutable_appearance('icons/obj/reagentfillings.dmi', "syringe[rounded_vol]")
@@ -245,7 +245,8 @@
 					injoverlay = "inject"
 			add_overlay(injoverlay)
 			update_wear_icon()
-	if( name == "Large syringe")
+
+	else if(/obj/item/weapon/reagent_containers/syringe/large)
 		if(reagents && reagents.total_volume)
 			rounded_vol = CLAMP(round((reagents.total_volume / volume * 15),5), 1, 15)
 			var/image/filling_overlay = mutable_appearance('icons/obj/reagentfillings.dmi', "syringe-[rounded_vol]")
@@ -339,7 +340,7 @@
 	..()
 
 /obj/item/weapon/reagent_containers/syringe/large
-	name = "Large syringe"
+	name = "large syringe"
 	desc = "A large syringe for those patients who needs a little more"
 	icon = 'icons/obj/syringe.dmi'
 	item_state = "syringe_-0"

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -1,6 +1,7 @@
 /* Drugs */
 /datum/reagent/drug
 	reagent_type = "Drug"
+	scannable = 1
 
 	var/sanity_gain
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -259,14 +259,15 @@ datum/reagent/medicine/respirodaxon/affect_blood(var/mob/living/carbon/M, var/al
 		M.add_chemical_effect(CE_PULSE, -2)
 
 /datum/reagent/medicine/clonexadone
-	name = "Clonexadone"
+	name = "Cronexidone"
 	id = "clonexadone"
-	description = "A liquid compound similar to that used in the cloning process. Can be used to 'finish' the cloning process when used in conjunction with a cryo tube."
+	description = "A liquid compound sthat is in all ways superior to cryoxadone. Can be used to treat severe clone damage, enetic mutation, and repair even dead bodies when used in conjunction with a cryo tube."
 	taste_description = "slime"
 	reagent_state = LIQUID
 	color = "#80BFFF"
 	metabolism = REM * 0.5
 	scannable = 1
+	affects_dead = 1 //This can even heal dead people.
 
 /datum/reagent/medicine/clonexadone/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(M.bodytemperature < 170)
@@ -719,7 +720,7 @@ datum/reagent/medicine/respirodaxon/affect_blood(var/mob/living/carbon/M, var/al
 /datum/reagent/medicine/kyphotorin
 	name = "Kyphotorin"
 	id = "kyphotorin"
-	description = "Allows patient to grow back limbs. Extremely painful to user and needs constant medical attention when applied."
+	description = "A strange chemical that allows a patient to regrow organic limbs, it may take awhile to work and requires use of a cryo pod. The process is extremely painful and may damage the body."
 	taste_description = "metal"
 	reagent_state = LIQUID
 	color = "#7d88e6"
@@ -727,7 +728,7 @@ datum/reagent/medicine/respirodaxon/affect_blood(var/mob/living/carbon/M, var/al
 
 /datum/reagent/medicine/kyphotorin/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	var/mob/living/carbon/human/H = M
-	if(istype(H))
+	if(istype(H) && (M.bodytemperature < 170))
 		if(prob(0.5 * effect_multiplier + dose) || dose == overdose)
 			var/list/missingLimbs = list()
 			for(var/name in BP_ALL_LIMBS)
@@ -739,7 +740,7 @@ datum/reagent/medicine/respirodaxon/affect_blood(var/mob/living/carbon/M, var/al
 				M.pain(luckyLimbName, 100, TRUE)
 				dose = 0
 	if(prob(10))
-		M.take_organ_damage(pick(0,5))
+		M.take_organ_damage(pick(0,15))
 
 /datum/reagent/medicine/kyphotorin/overdose(var/mob/living/carbon/M, var/alien)
 	M.adjustCloneLoss(4)

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -11,6 +11,7 @@
 	metabolism = REM * 0.05 // 0.01 by default. They last a while and slowly kill you.
 	var/strength = 0.05 // How much damage it deals per unit
 	reagent_type = "Toxin"
+	scannable = 1
 
 /datum/reagent/toxin/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(strength)

--- a/code/modules/surgery/old_encased.dm
+++ b/code/modules/surgery/old_encased.dm
@@ -109,7 +109,7 @@
 	affected.fracture()
 
 /datum/old_surgery_step/open_encased/close
-	requedQuality = QUALITY_RETRACTING
+	required_tool_quality = QUALITY_RETRACTING
 
 	duration = 30
 

--- a/code/modules/surgery/old_surgery.dm
+++ b/code/modules/surgery/old_surgery.dm
@@ -137,7 +137,7 @@ proc/do_old_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
 			H.update_surgery()
-		return	1	  												//don't want to do weapony things after surgery
+		return 1 //don't want to do weapony things after surgery
 
 	return 0
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -6,7 +6,7 @@
 	var/required_tool_quality = null
 	var/target_organ_type = /obj/item/organ/external
 
-	var/difficulty = FAILCHANCE_NORMAL
+	var/difficulty = FAILCHANCE_HARD
 	var/required_stat = STAT_BIO
 	var/duration = 60
 

--- a/code/modules/surgery/wound_repair.dm
+++ b/code/modules/surgery/wound_repair.dm
@@ -1,11 +1,11 @@
 // Wound repair surgeries.
-datum/old_surgery_step/external
+/datum/old_surgery_step/external
 	priority = 2 // Must be higher than /datum/old_surgery_step/internal
-	can_infect = 1
+	can_infect = TRUE
 
 	duration = 70
 
-/datum/old_surgery_step/external/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/external/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 
 	if (!hasorgans(target))
 		return 0
@@ -17,7 +17,7 @@ datum/old_surgery_step/external
 //					WOUND REPAIR SURGERY						//
 //////////////////////////////////////////////////////////////////
 
-/*datum/old_surgery_step/external/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/*datum/old_surgery_step/external/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -31,7 +31,7 @@ datum/old_surgery_step/external
 /datum/old_surgery_step/external/brute_heal
 	allowed_tools = list(/obj/item/stack/medical/advanced/bruise_pack = 100)
 
-/datum/old_surgery_step/external/brute_heal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/external/brute_heal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	var/tool_name = "\the [tool]"
 	if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
 		tool_name = "regenerative membrane"
@@ -43,12 +43,12 @@ datum/old_surgery_step/external
 	for(var/obj/item/organ/E in affected.internal_organs)
 		if (target.getBruteLoss() > 0)
 			user.visible_message(SPAN_NOTICE("[user] begins treating the brute damage to [target]'s body with the [tool_name]."), \
-			SPAN_NOTICE("You begin treating the brute damage to [target]'s body with the [tool_name].") )
+			SPAN_NOTICE("You begin treating the brute damage to [target]'s body with the [tool_name]."))
 
 	target.custom_pain("The pain in your [affected.name] is living hell!",1)
 	..()
 
-/datum/old_surgery_step/external/brute_heal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/external/brute_heal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	var/tool_name = "\the [tool]"
 	if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
 		tool_name = "regenerative membrane"
@@ -61,9 +61,10 @@ datum/old_surgery_step/external
 		if (target.getBruteLoss() > 0)
 			user.visible_message(SPAN_NOTICE("[user] treats the brute damage to [target]'s body with the [tool_name]."), \
 			SPAN_NOTICE("You treat the brute damage to [target]'s body with [tool_name].") )
-			target.adjustBruteLoss(-15)
+			if(tool.use(1))
+				target.adjustBruteLoss(-15)
 
-/datum/old_surgery_step/external/brute_heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/external/brute_heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 
 	if (!hasorgans(target))
 		return
@@ -90,7 +91,7 @@ datum/old_surgery_step/external
 /datum/old_surgery_step/external/burn_heal
 	allowed_tools = list(/obj/item/stack/medical/advanced/ointment = 100)
 
-/datum/old_surgery_step/external/burn_heal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/external/burn_heal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	var/tool_name = "\the [tool]"
 	if (istype(tool, /obj/item/stack/medical/advanced/ointment))
 		tool_name = "regenerative graft"
@@ -107,7 +108,7 @@ datum/old_surgery_step/external
 	target.custom_pain("The pain in your [affected.name] is living hell!",1)
 	..()
 
-/datum/old_surgery_step/external/burn_heal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/external/burn_heal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	var/tool_name = "\the [tool]"
 	if (istype(tool, /obj/item/stack/medical/advanced/ointment))
 		tool_name = "regenerative graft"
@@ -120,10 +121,11 @@ datum/old_surgery_step/external
 		if (target.getFireLoss() > 0)
 			user.visible_message(SPAN_NOTICE("[user] treats the burn damage to [target]'s body with the [tool_name]."), \
 			SPAN_NOTICE("You treat the burn damage to [target]'s body with [tool_name].") )
-			target.adjustFireLoss(-15)
+			if(tool.use(1))
+				target.adjustFireLoss(-15)
 
 
-/datum/old_surgery_step/external/burn_heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/external/burn_heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 
 	if (!hasorgans(target))
 		return
@@ -142,7 +144,7 @@ datum/old_surgery_step/external
 /datum/old_surgery_step/external/tox_heal
 	allowed_tools = list(/obj/item/stack/nanopaste = 100)
 
-/datum/old_surgery_step/external/tox_heal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/external/tox_heal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	var/tool_name = "\the [tool]"
 	if (istype(tool, /obj/item/stack/nanopaste))
 		tool_name = "nanite swarm"
@@ -159,7 +161,7 @@ datum/old_surgery_step/external
 	target.custom_pain("The pain in your [affected.name] is living hell!",1)
 	..()
 
-/datum/old_surgery_step/external/tox_heal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/external/tox_heal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	var/tool_name = "\the [tool]"
 	if (istype(tool, /obj/item/stack/nanopaste))
 		tool_name = "nanite swarm"
@@ -172,11 +174,12 @@ datum/old_surgery_step/external
 		if (target.getToxLoss() >= 0)
 			user.visible_message(SPAN_NOTICE("[user] finishess filtering out any toxins in [target]'s body and repairing any neural degradation with the [tool_name]."), \
 			SPAN_NOTICE("You finish filtering out any toxins to [target]'s body and repairing any neural degradation with the [tool_name].") )
-			target.adjustToxLoss(-200)
-			target.timeofdeath = 99999999
+			if(tool.use(1))
+				target.adjustToxLoss(-200)
+				target.timeofdeath = 99999999
 
 
-/datum/old_surgery_step/external/tox_heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/external/tox_heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 
 	if (!hasorgans(target))
 		return
@@ -200,7 +203,7 @@ datum/old_surgery_step/external
 
 	duration = 70
 /*
-/datum/old_surgery_step/fix_vein/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/fix_vein/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	if(!hasorgans(target))
 		return 0
 
@@ -213,7 +216,7 @@ datum/old_surgery_step/external
 
 	return affected.open >= 1 && internal_bleeding
 */
-/datum/old_surgery_step/fix_vein/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/fix_vein/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message(
 		"[user] starts patching the damaged vein in [target]'s [affected.name] with \the [tool].",
@@ -222,7 +225,7 @@ datum/old_surgery_step/external
 	target.custom_pain("The pain in [affected.name] is unbearable!",1)
 	..()
 
-/datum/old_surgery_step/fix_vein/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/fix_vein/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message(
 		"\blue [user] has patched the damaged vein in [target]'s [affected.name] with \the [tool].",
@@ -234,7 +237,7 @@ datum/old_surgery_step/external
 		affected.update_damages()
 	if (ishuman(user) && prob(40)) user:bloody_hands(target, 0)
 
-/datum/old_surgery_step/fix_vein/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/old_surgery_step/fix_vein/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message(
 		"\red [user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!",


### PR DESCRIPTION
-Fixed a typo with the ire litany to describe its cooldown accurately (5 minutes, not 15)
-Fixed an issue with the prayer of reunion with a pathing typo. It now works just fine.
-Many drugs and toxins can now be scanned and detected by scanners.
IMPORTANT! THE NEXT CHANGES VASTLY CHANGE GAMEPLAY
----Wound surgery now subtracts a charge per use when healing someone, for every 15 points of brute or burn healed you lose 1 charge and depending on the targeted body part the game will automatically use 3, 2, or 1 charges based on how many internal organs that area has (groin 3, chest 2, head 1).
----Surgery difficulty has been drastically heightened, non-mechanical surgery now has a 30% lowered success chance, self surgery or operation without being a doctor now have a much higher failure chance.
----Clonexadone has been renamed to cronexidone and has an updated description (it referenced cloning, which we don't have). It now can repair and restore dead bodies, making cryo actually useful, especially for healing someone before reviving them. Chemistry also now has a new task each shift to make this for the sake of reviving the greviously wounded.
Editor's note: I did not sleep last night and instead spent it coding. I wanted to re-add the steps to surgery for cutting through the ribcage and skull when opening those areas and prevent wound surgery step spam (ergo click 5 times to que 5 uses in rapid succession) Sadly both tasks proved more than my sleep depraved brain could handle, but the 5 charge hard cap now makes the click spam rather negligible. Unfortunately adding the previous steps back to surgery will require massive amounts of work, more than I want to devote really. We'll see what happens.
-Cryopods now require 25 biology to operate.
-Kyphotorin now only functions in a cryo pod and has slightly higher damage as a result, but hey it regrows limbs and its supposed to risky :V