### PR TITLE
Combo tool mods and tweaks!

### DIFF
--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -4,6 +4,64 @@
 	related_stats = list(STAT_COG)
 	avaliableToEveryone = FALSE
 
+/datum/craft_recipe/guild/ai_tool
+	name = "Tool Mod:Integrated Tool AI"
+	result = /obj/item/weapon/tool_upgrade/augment/guild_ai_tool
+	steps = list(
+		list(CRAFT_MATERIAL, 30, MATERIAL_STEEL, "time" = 60),
+		list(CRAFT_MATERIAL, 7, MATERIAL_SILVER, "time" = 60),
+		list(CRAFT_MATERIAL, 7, MATERIAL_GOLD, "time" = 60),
+		list(QUALITY_CUTTING, 20, "time" = 180),
+		list(QUALITY_SCREW_DRIVING, 30, "time" = 90),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 120),
+		list(/obj/item/stack/cable_coil, 2, "time" = 10),
+		list(/obj/item/device/aicard, 1, "time" = 360),
+		list(/obj/item/stack/cable_coil, 2, "time" = 10),
+		list(QUALITY_CUTTING, 30, "time" = 180),
+		list(QUALITY_SCREW_DRIVING, 40, "time" = 90),
+		list(QUALITY_BOLT_TURNING, 40, "time" = 120),
+		list(/obj/item/weapon/cell/small/moebius/nuclear, 1),
+		list(QUALITY_ADHESIVE, 15, 70, "time" = 10)
+	)
+
+/datum/craft_recipe/guild/oxy_fuel
+	name = "Tool Mod: Oxy Fuel"
+	result = /obj/item/weapon/tool_upgrade/combo/oxy_fuel
+	steps = list(
+		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTIC, "time" = 60),
+		list(QUALITY_WELDING, 40, "time" = 60),
+		list(/obj/item/weapon/tool_upgrade/productivity/oxyjet, 1, "time" = 15),
+		list(/obj/item/weapon/tool_upgrade/augment/fuel_tank, 1, "time" = 15),
+		list(QUALITY_SCREW_DRIVING, 40, "time" = 90),
+		list(QUALITY_BOLT_TURNING, 40, "time" = 20),
+		list(QUALITY_ADHESIVE, 15, 70, "time" = 10)
+	)
+
+/datum/craft_recipe/guild/sound_sink
+	name = "Tool Mod: Sound-Sunk"
+	result = /obj/item/weapon/tool_upgrade/combo/sound_sink
+	steps = list(
+		list(/obj/item/weapon/tool_upgrade/reinforcement/heatsink, 1, "time" = 60),
+		list(QUALITY_WELDING, 40, "time" = 60),
+		list(QUALITY_CUTTING, 30, "time" = 60),
+		list(/obj/item/weapon/tool_upgrade/augment/dampener, 1, "time" = 60),
+		list(QUALITY_HAMMERING, 20, "time" = 90),
+		list(QUALITY_SCREW_DRIVING, 30, "time" = 90),
+		list(QUALITY_ADHESIVE, 15, 70, "time" = 10)
+	)
+
+/datum/craft_recipe/guild/grip
+	name = "Tool Mod: Stabled Ergonomic Grip"
+	result = /obj/item/weapon/tool_upgrade/combo/supper_grip
+	steps = list(
+		list(/obj/item/weapon/tool_upgrade/productivity/ergonomic_grip, 1,"time" = 60),
+		list(QUALITY_WELDING, 40, "time" = 60),
+		list(QUALITY_CUTTING, 30, "time" = 60),
+		list(/obj/item/weapon/tool_upgrade/refinement/stabilized_grip, 1, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 30, "time" = 90),
+		list(QUALITY_ADHESIVE, 15, 70, "time" = 10)
+	)
+
 /datum/craft_recipe/guild/melee
 	name = "melee plating"
 	result = /obj/item/weapon/tool_upgrade/armor/melee

--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -169,7 +169,6 @@
 		list(QUALITY_ADHESIVE, 15, 70)
 	)
 
-
 /datum/craft_recipe/weapon/nailed_bat
 	name = "nailed bat"
 	result = /obj/item/weapon/tool/nailstick

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -32,6 +32,10 @@
 	)
 
 	known_recipes = list(
+			/datum/craft_recipe/guild/ai_tool,
+			/datum/craft_recipe/guild/oxy_fuel,
+			/datum/craft_recipe/guild/sound_sink,
+			/datum/craft_recipe/guild/grip,
 			/datum/craft_recipe/guild/melee,
 			/datum/craft_recipe/guild/bullet,
 			/datum/craft_recipe/guild/energy,
@@ -101,6 +105,10 @@
 	)
 
 	known_recipes = list(
+			//datum/craft_recipe/guild/ai_tool, //Only CRO and GM know this one
+			/datum/craft_recipe/guild/oxy_fuel,
+			/datum/craft_recipe/guild/sound_sink,
+			/datum/craft_recipe/guild/grip,
 			/datum/craft_recipe/guild/melee,
 			/datum/craft_recipe/guild/bullet,
 			/datum/craft_recipe/guild/energy,
@@ -112,6 +120,7 @@
 			/datum/craft_recipe/guild/technohelmet,
 			/datum/craft_recipe/guild/webbing
 			)
+
 
 	software_on_spawn = list(/datum/computer_file/program/power_monitor,
 							 /datum/computer_file/program/supermatter_monitor,

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -32,6 +32,11 @@
 		STAT_BIO = 25,
 	)
 
+	known_recipes = list(
+			/datum/craft_recipe/guild/ai_tool //Yes its "guild" but it fits for CRO
+			)
+
+
 	perks = list(/datum/perk/selfmedicated)
 
 	// TODO: enable after baymed

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -71,6 +71,7 @@
 	//Does not affect damage dealt to mobs
 
 	var/list/item_upgrades = list()
+	var/list/upgrade_type = list()
 	var/max_upgrades = 3
 	var/list/prefixes = list()
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -70,6 +70,9 @@
 	var/structure_damage_factor = STRUCTURE_DAMAGE_NORMAL	//Multiplier applied to the damage when attacking structures and machinery
 	//Does not affect damage dealt to mobs
 
+//What type of mod we are holding, used in checking.
+	var/list/tool_mod_index = list()
+
 	var/list/item_upgrades = list()
 	var/max_upgrades = 3
 	var/list/prefixes = list()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -71,7 +71,6 @@
 	//Does not affect damage dealt to mobs
 
 	var/list/item_upgrades = list()
-	var/list/upgrade_type = list()
 	var/max_upgrades = 3
 	var/list/prefixes = list()
 

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -26,9 +26,6 @@
 	//Actual effects of upgrades
 	var/list/upgrades = list() //variable name(string) -> num
 
-	//If the tool mod cant be removed
-	var/bolt = FALSE
-
 /datum/component/item_upgrade/Initialize()
 	RegisterSignal(parent, COMSIG_IATTACK, .proc/attempt_install)
 	RegisterSignal(parent, COMSIG_EXAMINE, .proc/on_examine)
@@ -96,20 +93,11 @@
 			if(T.cell)
 				to_chat(user, SPAN_WARNING("Remove the cell from the tool first!"))
 				return FALSE
-
 		//No using multiples of the same upgrade
 		for (var/obj/item/I in T.item_upgrades)
 			if (I.type == parent.type)
 				to_chat(user, SPAN_WARNING("An upgrade of this type is already installed!"))
 				return FALSE
-
-		//No using multiples types of the same upgrade
-		for (var/obj/item/I in T.upgrade_type)
-			if (I.upgrade_type == parent.upgrade_type)
-				to_chat(user, SPAN_WARNING("An upgrade of this type is already installed!"))
-				return FALSE
-
-
 		return TRUE
 	if (istype(A, /obj/item/clothing/suit/armor))
 		var/obj/item/clothing/suit/armor/T = A
@@ -153,13 +141,8 @@
 	A.refresh_upgrades()
 	return TRUE
 
-/datum/component/item_upgrade/proc/uninstall(var/obj/item/I, var/mob/living/user)
+/datum/component/item_upgrade/proc/uninstall(var/obj/item/I)
 	var/obj/item/P = parent
-
-	if(bolt)
-		to_chat(user, SPAN_WARNING("This tool mod is bolted to the tool!"))
-		return FALSE
-
 	I.item_upgrades -= P
 	P.forceMove(get_turf(I))
 	UnregisterSignal(I, COMSIG_APPVAL)
@@ -265,5 +248,3 @@
 	force = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_SMALL
 	price_tag = 200
-	//What type of upgrade is this? - Used to prevent same type mixing
-	var/list/upgrade_type = list()

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -26,6 +26,9 @@
 	//Actual effects of upgrades
 	var/list/upgrades = list() //variable name(string) -> num
 
+	//If the tool mod cant be removed
+	var/bolt = FALSE
+
 /datum/component/item_upgrade/Initialize()
 	RegisterSignal(parent, COMSIG_IATTACK, .proc/attempt_install)
 	RegisterSignal(parent, COMSIG_EXAMINE, .proc/on_examine)
@@ -93,11 +96,20 @@
 			if(T.cell)
 				to_chat(user, SPAN_WARNING("Remove the cell from the tool first!"))
 				return FALSE
+
 		//No using multiples of the same upgrade
 		for (var/obj/item/I in T.item_upgrades)
 			if (I.type == parent.type)
 				to_chat(user, SPAN_WARNING("An upgrade of this type is already installed!"))
 				return FALSE
+
+		//No using multiples types of the same upgrade
+		for (var/obj/item/I in T.upgrade_type)
+			if (I.upgrade_type == parent.upgrade_type)
+				to_chat(user, SPAN_WARNING("An upgrade of this type is already installed!"))
+				return FALSE
+
+
 		return TRUE
 	if (istype(A, /obj/item/clothing/suit/armor))
 		var/obj/item/clothing/suit/armor/T = A
@@ -141,8 +153,13 @@
 	A.refresh_upgrades()
 	return TRUE
 
-/datum/component/item_upgrade/proc/uninstall(var/obj/item/I)
+/datum/component/item_upgrade/proc/uninstall(var/obj/item/I, var/mob/living/user)
 	var/obj/item/P = parent
+
+	if(bolt)
+		to_chat(user, SPAN_WARNING("This tool mod is bolted to the tool!"))
+		return FALSE
+
 	I.item_upgrades -= P
 	P.forceMove(get_turf(I))
 	UnregisterSignal(I, COMSIG_APPVAL)
@@ -248,3 +265,5 @@
 	force = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_SMALL
 	price_tag = 200
+	//What type of upgrade is this? - Used to prevent same type mixing
+	var/list/upgrade_type = list()

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -105,9 +105,10 @@
 
 		//No using multiples types of the same upgrade
 		for (var/obj/item/I in T.upgrade_type)
-			if (I.type == parent.type)
+			if (I.upgrade_type == parent.upgrade_type)
 				to_chat(user, SPAN_WARNING("An upgrade of this type is already installed!"))
 				return FALSE
+
 
 		return TRUE
 	if (istype(A, /obj/item/clothing/suit/armor))
@@ -168,10 +169,6 @@
 		return
 	if(istype(holder, /obj/item/weapon/tool))
 		var/obj/item/weapon/tool/T = holder
-
-		if(upgrades[upgrade_type])
-			T.upgrade_added += upgrades[upgrade_added]
-
 		if(upgrades[UPGRADE_PRECISION])
 			T.precision += upgrades[UPGRADE_PRECISION]
 		if(upgrades[UPGRADE_WORKSPEED])
@@ -269,5 +266,4 @@
 	w_class = ITEM_SIZE_SMALL
 	price_tag = 200
 	//What type of upgrade is this? - Used to prevent same type mixing
-	var/list/upgrade_added = list()
-
+	var/list/upgrade_type = list()

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -105,10 +105,9 @@
 
 		//No using multiples types of the same upgrade
 		for (var/obj/item/I in T.upgrade_type)
-			if (I.upgrade_type == parent.upgrade_type)
+			if (I.type == parent.type)
 				to_chat(user, SPAN_WARNING("An upgrade of this type is already installed!"))
 				return FALSE
-
 
 		return TRUE
 	if (istype(A, /obj/item/clothing/suit/armor))
@@ -169,6 +168,10 @@
 		return
 	if(istype(holder, /obj/item/weapon/tool))
 		var/obj/item/weapon/tool/T = holder
+
+		if(upgrades[upgrade_type])
+			T.upgrade_added += upgrades[upgrade_added]
+
 		if(upgrades[UPGRADE_PRECISION])
 			T.precision += upgrades[UPGRADE_PRECISION]
 		if(upgrades[UPGRADE_WORKSPEED])
@@ -266,4 +269,5 @@
 	w_class = ITEM_SIZE_SMALL
 	price_tag = 200
 	//What type of upgrade is this? - Used to prevent same type mixing
-	var/list/upgrade_type = list()
+	var/list/upgrade_added = list()
+

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -22,7 +22,6 @@
 	I.upgrades = list(
 		UPGRADE_DEGRADATION_MULT = 0.65,
 		UPGRADE_FORCE_MOD = 1,
-		upgrade_type = list("stick")
 		)
 
 	I.required_qualities = list(QUALITY_BOLT_TURNING,QUALITY_PRYING, QUALITY_SAWING,QUALITY_SHOVELING,QUALITY_DIGGING,QUALITY_EXCAVATION)
@@ -40,31 +39,27 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
 		UPGRADE_DEGRADATION_MULT = 0.65,
-		UPGRADE_HEALTH_THRESHOLD = 10,
-		upgrade_type = list("heatsink")
+		UPGRADE_HEALTH_THRESHOLD = 10
 		)
 	I.prefix = "heatsunk"
 	I.req_fuel_cell = REQ_FUEL_OR_CELL
+
 
 /obj/item/weapon/tool_upgrade/reinforcement/plating
 	name = "reinforced plating"
 	desc = "A sturdy bit of plasteel that can be bolted onto any tool to protect it. Tough, but bulky."
 	icon_state = "plate"
-
-
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 2) //steel to compensate for metal rods used in crafting
 
 /obj/item/weapon/tool_upgrade/reinforcement/plating/New()
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-		UPGRADE_DEGRADATION_MULT = 0.55,
-		UPGRADE_FORCE_MOD = 1,
-		UPGRADE_PRECISION = -5,
-		UPGRADE_BULK = 1,
-		UPGRADE_HEALTH_THRESHOLD = 10,
-		upgrade_type = list("plating")
-		)
+	UPGRADE_DEGRADATION_MULT = 0.55,
+	UPGRADE_FORCE_MOD = 1,
+	UPGRADE_PRECISION = -5,
+	UPGRADE_BULK = 1,
+	UPGRADE_HEALTH_THRESHOLD = 10)
 	I.prefix = "reinforced"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 
@@ -72,7 +67,6 @@
 	name = "metal guard"
 	desc = "A bent piece of metal that wraps around sensitive parts of a tool, protecting it from impacts, debris, and stray fingers."
 	icon_state = "guard"
-
 	matter = list(MATERIAL_PLASTEEL = 5)
 
 /obj/item/weapon/tool_upgrade/reinforcement/guard/New()
@@ -81,8 +75,7 @@
 	I.upgrades = list(
 	UPGRADE_DEGRADATION_MULT = 0.75,
 	UPGRADE_PRECISION = 5,
-	UPGRADE_HEALTH_THRESHOLD = 10,
-	upgrade_type = list("guard")
+	UPGRADE_HEALTH_THRESHOLD = 10
 	)
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_DRILLING, QUALITY_SAWING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_WELDING, QUALITY_HAMMERING)
 	I.prefix = "shielded"
@@ -99,8 +92,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_WORKSPEED = 0.15,
-	upgrade_type = list("ergonomic_grip")
+	UPGRADE_WORKSPEED = 0.15
 	)
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 	I.prefix = "ergonomic"
@@ -115,8 +107,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_WORKSPEED = 0.25,
-	upgrade_type = list("ratchet")
+	UPGRADE_WORKSPEED = 0.25
 	)
 	I.required_qualities = list(QUALITY_BOLT_TURNING,QUALITY_SCREW_DRIVING)
 	I.prefix = "ratcheting"
@@ -133,8 +124,7 @@
 	I.upgrades = list(
 	UPGRADE_WORKSPEED = 0.20,
 	UPGRADE_PRECISION = -10,
-	UPGRADE_COLOR = "#FF4444",
-	upgrade_type = list("red_paint")
+	UPGRADE_COLOR = "#FF4444"
 	)
 	I.prefix = "red"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
@@ -151,8 +141,7 @@
 	I.upgrades = list(
 	UPGRADE_WORKSPEED = 0.15,
 	UPGRADE_PRECISION = 5,
-	UPGRADE_FORCE_MULT = 1.15,
-	upgrade_type = list("whetstone")
+	UPGRADE_FORCE_MULT = 1.15
 	)
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_SAWING, QUALITY_SHOVELING, QUALITY_WIRE_CUTTING)
 	I.prefix = "sharpened"
@@ -171,7 +160,6 @@
 	UPGRADE_WORKSPEED = 0.25,
 	UPGRADE_DEGRADATION_MULT = 0.85,
 	UPGRADE_FORCE_MULT = 1.10,
-	upgrade_type = list("diamond_blade")
 	)
 	I.required_qualities = list(QUALITY_CUTTING, QUALITY_SHOVELING, QUALITY_SAWING, QUALITY_WIRE_CUTTING, QUALITY_PRYING)
 	I.negative_qualities = list(QUALITY_WELDING, QUALITY_LASER_CUTTING)
@@ -190,8 +178,7 @@
 	UPGRADE_WORKSPEED = 0.20,
 	UPGRADE_FORCE_MULT = 1.15,
 	UPGRADE_DEGRADATION_MULT = 1.15,
-	UPGRADE_HEALTH_THRESHOLD = -10,
-	upgrade_type = list("oxyjet")
+	UPGRADE_HEALTH_THRESHOLD = -10
 	)
 	I.required_qualities = list(QUALITY_WELDING)
 	I.prefix = "oxyjet"
@@ -213,8 +200,7 @@
 	UPGRADE_POWERCOST_MULT = 1.35,
 	UPGRADE_FUELCOST_MULT = 1.35,
 	UPGRADE_PRECISION = -10,
-	UPGRADE_HEALTH_THRESHOLD = -10,
-	upgrade_type = list("motor")
+	UPGRADE_HEALTH_THRESHOLD = -10
 	)
 	I.required_qualities = list(QUALITY_SCREW_DRIVING, QUALITY_DRILLING, QUALITY_SAWING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_HAMMERING)
 	I.prefix = "high-power"
@@ -232,9 +218,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_PRECISION = 10,
-	upgrade_type = list("laserguide"),
-	)
+	UPGRADE_PRECISION = 10)
 	I.prefix = "laser-guided"
 
 //Fits onto generally small tools that require precision, especially surgical tools
@@ -250,9 +234,7 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
 	UPGRADE_PRECISION = 10,
-	UPGRADE_HEALTH_THRESHOLD = 10,
-	upgrade_type = list("stabilizer_grip")
-	)
+	UPGRADE_HEALTH_THRESHOLD = 10)
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_WIRE_CUTTING, QUALITY_SCREW_DRIVING, QUALITY_WELDING,QUALITY_PULSING, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_BONE_SETTING, QUALITY_LASER_CUTTING)
 	I.prefix = "stabilized"
 
@@ -266,8 +248,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_PRECISION = 10,
-	upgrade_type = list("magbit")
+	UPGRADE_PRECISION = 10
 	)
 	I.required_qualities = list(QUALITY_SCREW_DRIVING, QUALITY_BOLT_TURNING, QUALITY_CLAMPING, QUALITY_BONE_SETTING)
 	I.prefix = "magnetic"
@@ -284,8 +265,7 @@
 	UPGRADE_PRECISION = 12,
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_BULK = 1,
-	UPGRADE_HEALTH_THRESHOLD = 10,
-	upgrade_type = list("ported_barrel")
+	UPGRADE_HEALTH_THRESHOLD = 10
 	)
 	I.required_qualities = list(QUALITY_WELDING)
 	I.prefix = "ported"
@@ -307,8 +287,7 @@
 	UPGRADE_BULK = 1,
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_HEALTH_THRESHOLD = -10,
-	UPGRADE_CELLPLUS = 1,
-	upgrade_type = list("cell_mount")
+	UPGRADE_CELLPLUS = 1
 	)
 	I.prefix = "medium-cell"
 	I.req_fuel_cell = REQ_CELL
@@ -327,9 +306,7 @@
 	UPGRADE_BULK = 1,
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_HEALTH_THRESHOLD = -10,
-	UPGRADE_MAXFUEL = 100,
-	upgrade_type = list("fuel_tank", "holding_tank")
-	)
+	UPGRADE_MAXFUEL = 100)
 	I.prefix = "expanded"
 	I.req_fuel_cell = REQ_FUEL
 
@@ -347,8 +324,7 @@
 	UPGRADE_BULK = 1,
 	UPGRADE_DEGRADATION_MULT = 1.30,
 	UPGRADE_HEALTH_THRESHOLD = -20,
-	UPGRADE_MAXFUEL = 600,
-	upgrade_type = list("holding_tank", "fuel_tank") //Cant mix fuel tanks for over 700
+	UPGRADE_MAXFUEL = 600
 	)
 	I.prefix = "holding"
 	I.req_fuel_cell = REQ_FUEL
@@ -357,7 +333,7 @@
 /obj/item/weapon/tool_upgrade/augment/expansion
 	name = "expansion port"
 	icon_state = "expand"
-	desc = "A bulky bolted adapter which more modifications to be attached to the tool.  A bit fragile but you can compensate."
+	desc = "A bulky adapter which more modifications to be attached to the tool.  A bit fragile but you can compensate."
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 1)
 
 /obj/item/weapon/tool_upgrade/augment/expansion/New()
@@ -368,9 +344,7 @@
 	UPGRADE_DEGRADATION_MULT = 1.3,
 	UPGRADE_PRECISION = -10,
 	UPGRADE_HEALTH_THRESHOLD = -20,
-	UPGRADE_MAXUPGRADES = 3,
-	upgrade_type = list("expansion"),
-	bolt = TRUE
+	UPGRADE_MAXUPGRADES = 3
 	)
 	I.prefix = "custom"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
@@ -390,8 +364,7 @@
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_WORKSPEED = -0.15,
 	UPGRADE_HEALTH_THRESHOLD = -10,
-	UPGRADE_SHARP = TRUE,
-	upgrade_type = list("spikes")
+	UPGRADE_SHARP = TRUE
 	)
 	I.prefix = "spiked"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
@@ -410,7 +383,6 @@
 	UPGRADE_WORKSPEED = -0.5,
 	UPGRADE_HEALTH_THRESHOLD = 5,
 	tool_qualities = list(QUALITY_HAMMERING = 10)
-	upgrade_type = list("hammer")
 	)
 	I.prefix = "flattened"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
@@ -428,8 +400,7 @@
 	I.upgrades = list(
 	UPGRADE_COLOR = "#AAAAAA",
 	UPGRADE_HEALTH_THRESHOLD = -10,
-	UPGRADE_ITEMFLAGPLUS = SILENT,
-	upgrade_type = list("dampener")
+	UPGRADE_ITEMFLAGPLUS = SILENT
 	)
 	I.prefix = "silenced"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
@@ -449,7 +420,6 @@
 	UPGRADE_PRECISION = 14,
 	UPGRADE_WORKSPEED = 14,
 	UPGRADE_HEALTH_THRESHOLD = -10,
-	upgrade_type = list("ai", "repair_nano")
 	)
 	I.prefix = "intelligent"
 	I.req_fuel_cell = REQ_CELL
@@ -465,14 +435,9 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
 	UPGRADE_DEGRADATION_MULT = 0.01,
-	UPGRADE_HEALTH_THRESHOLD = 10,
-	upgrade_type = list("ai", "repair_nano")
+	UPGRADE_HEALTH_THRESHOLD = 10
 	)
 	I.prefix = "self-healing"
-
-// 		Armor: Upgrades armor
-//------------------------------------------------
-
 
 //Armor mods
 /obj/item/weapon/tool_upgrade/armor/melee
@@ -485,8 +450,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_MELEE_ARMOR = 20,
-	upgrade_type = list("melee")
+	UPGRADE_MELEE_ARMOR = 20
 	)
 	I.prefix = "reinforced"
 	I.required_qualities = list(QUALITY_ARMOR)
@@ -501,8 +465,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_BALLISTIC_ARMOR = 20,
-	upgrade_type = list("bullet")
+	UPGRADE_BALLISTIC_ARMOR = 20
 	)
 	I.prefix = "kevlar-plated"
 	I.required_qualities = list(QUALITY_ARMOR)
@@ -517,8 +480,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_ENERGY_ARMOR = 20,
-	upgrade_type = list("energy")
+	UPGRADE_ENERGY_ARMOR = 20
 	)
 	I.prefix = "ablative-plated"
 	I.required_qualities = list(QUALITY_ARMOR)
@@ -533,53 +495,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_BOMB_ARMOR = 40,
-	upgrade_type = list("bomb")
+	UPGRADE_BOMB_ARMOR = 40
 	)
 	I.prefix = "bomb-proofed"
 	I.required_qualities = list(QUALITY_ARMOR)
-
-
-// 		MIXED: Mixing tool mods to save space but are less affective
-//------------------------------------------------------------------
-
-
-//Sound n Heatsink can be attached to any tool that uses fuel or power
-/obj/item/weapon/tool_upgrade/reinforcement/sound_sink
-	name = "soundsink"
-	desc = "An array of plasteel fins mixed in with sound dampers to dissipates heat, reducing damage, extending the lifespan and soften sounds of power tools."
-	icon_state = "heatsink"
-	matter = list(MATERIAL_PLASTEEL = 6, MATERIAL_PLASTIC = 1, MATERIAL_PLATINUM = 1)
-
-/obj/item/weapon/tool_upgrade/reinforcement/heatsink/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
-	I.upgrades = list(
-		UPGRADE_DEGRADATION_MULT = 0.45,
-		UPGRADE_HEALTH_THRESHOLD = 5,
-		UPGRADE_ITEMFLAGPLUS = SILENT,
-		upgrade_type = list("heatsink", "dampener")
-		)
-	I.prefix = "soundsunk"
-	I.req_fuel_cell = REQ_FUEL_OR_CELL
-
-//Stores moar fuel and speeds up
-/obj/item/weapon/tool_upgrade/augment/fuel_oxy
-	name = "expanded fuel tank"
-	desc = "An auxiliary tank which stores 30 extra units of fuel at the cost of degradation."
-	icon_state = "canister"
-	matter = list(MATERIAL_PLASTEEL = 4, MATERIAL_PLASTIC = 1)
-
-/obj/item/weapon/tool_upgrade/augment/fuel_tank/New()
-	..()
-	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
-	I.upgrades = list(
-	UPGRADE_BULK = 1,
-	UPGRADE_DEGRADATION_MULT = 1.15,
-	UPGRADE_HEALTH_THRESHOLD = -10,
-	UPGRADE_MAXFUEL = 100,
-	upgrade_type = list("fuel_tank", "holding_tank")
-	)
-	I.prefix = "expanded"
-	I.req_fuel_cell = REQ_FUEL
-

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -22,8 +22,9 @@
 	I.upgrades = list(
 		UPGRADE_DEGRADATION_MULT = 0.65,
 		UPGRADE_FORCE_MOD = 1,
+		upgrade_type = list("stick")
 		)
-	I.upgrade_type = list("stick")
+
 	I.required_qualities = list(QUALITY_BOLT_TURNING,QUALITY_PRYING, QUALITY_SAWING,QUALITY_SHOVELING,QUALITY_DIGGING,QUALITY_EXCAVATION)
 	I.prefix = "braced"
 
@@ -49,6 +50,7 @@
 	name = "reinforced plating"
 	desc = "A sturdy bit of plasteel that can be bolted onto any tool to protect it. Tough, but bulky."
 	icon_state = "plate"
+
 
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 2) //steel to compensate for metal rods used in crafting
 
@@ -134,7 +136,6 @@
 	UPGRADE_COLOR = "#FF4444",
 	upgrade_type = list("red_paint")
 	)
-	I.bolt = TRUE
 	I.prefix = "red"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 
@@ -153,7 +154,6 @@
 	UPGRADE_FORCE_MULT = 1.15,
 	upgrade_type = list("whetstone")
 	)
-	I.bolt = TRUE
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_SAWING, QUALITY_SHOVELING, QUALITY_WIRE_CUTTING)
 	I.prefix = "sharpened"
 
@@ -370,8 +370,8 @@
 	UPGRADE_HEALTH_THRESHOLD = -20,
 	UPGRADE_MAXUPGRADES = 3,
 	upgrade_type = list("expansion"),
+	bolt = TRUE
 	)
-	I.bolt = TRUE
 	I.prefix = "custom"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -22,9 +22,8 @@
 	I.upgrades = list(
 		UPGRADE_DEGRADATION_MULT = 0.65,
 		UPGRADE_FORCE_MOD = 1,
-		upgrade_type = list("stick")
 		)
-
+	I.upgrade_type = list("stick")
 	I.required_qualities = list(QUALITY_BOLT_TURNING,QUALITY_PRYING, QUALITY_SAWING,QUALITY_SHOVELING,QUALITY_DIGGING,QUALITY_EXCAVATION)
 	I.prefix = "braced"
 
@@ -50,7 +49,6 @@
 	name = "reinforced plating"
 	desc = "A sturdy bit of plasteel that can be bolted onto any tool to protect it. Tough, but bulky."
 	icon_state = "plate"
-
 
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 2) //steel to compensate for metal rods used in crafting
 
@@ -136,6 +134,7 @@
 	UPGRADE_COLOR = "#FF4444",
 	upgrade_type = list("red_paint")
 	)
+	I.bolt = TRUE
 	I.prefix = "red"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 
@@ -154,6 +153,7 @@
 	UPGRADE_FORCE_MULT = 1.15,
 	upgrade_type = list("whetstone")
 	)
+	I.bolt = TRUE
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_SAWING, QUALITY_SHOVELING, QUALITY_WIRE_CUTTING)
 	I.prefix = "sharpened"
 
@@ -370,8 +370,8 @@
 	UPGRADE_HEALTH_THRESHOLD = -20,
 	UPGRADE_MAXUPGRADES = 3,
 	upgrade_type = list("expansion"),
-	bolt = TRUE
 	)
+	I.bolt = TRUE
 	I.prefix = "custom"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -23,7 +23,7 @@
 		UPGRADE_DEGRADATION_MULT = 0.65,
 		UPGRADE_FORCE_MOD = 1,
 		)
-
+	I.tool_mod_type = list("stick")
 	I.required_qualities = list(QUALITY_BOLT_TURNING,QUALITY_PRYING, QUALITY_SAWING,QUALITY_SHOVELING,QUALITY_DIGGING,QUALITY_EXCAVATION)
 	I.prefix = "braced"
 
@@ -41,6 +41,7 @@
 		UPGRADE_DEGRADATION_MULT = 0.65,
 		UPGRADE_HEALTH_THRESHOLD = 10
 		)
+	I.tool_mod_type = list("heatsink")
 	I.prefix = "heatsunk"
 	I.req_fuel_cell = REQ_FUEL_OR_CELL
 
@@ -60,6 +61,7 @@
 	UPGRADE_PRECISION = -5,
 	UPGRADE_BULK = 1,
 	UPGRADE_HEALTH_THRESHOLD = 10)
+	I.tool_mod_type = list("plating")
 	I.prefix = "reinforced"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 
@@ -77,6 +79,7 @@
 	UPGRADE_PRECISION = 5,
 	UPGRADE_HEALTH_THRESHOLD = 10
 	)
+	I.tool_mod_type = list("guard")
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_DRILLING, QUALITY_SAWING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_WELDING, QUALITY_HAMMERING)
 	I.prefix = "shielded"
 
@@ -94,6 +97,7 @@
 	I.upgrades = list(
 	UPGRADE_WORKSPEED = 0.15
 	)
+	I.tool_mod_type = list("ergomomic_grip")
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 	I.prefix = "ergonomic"
 
@@ -109,6 +113,7 @@
 	I.upgrades = list(
 	UPGRADE_WORKSPEED = 0.25
 	)
+	I.tool_mod_type = list("ratchet")
 	I.required_qualities = list(QUALITY_BOLT_TURNING,QUALITY_SCREW_DRIVING)
 	I.prefix = "ratcheting"
 
@@ -126,6 +131,8 @@
 	UPGRADE_PRECISION = -10,
 	UPGRADE_COLOR = "#FF4444"
 	)
+	I.tool_mod_type = list("paint")
+	I.bolt = TRUE
 	I.prefix = "red"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 
@@ -143,6 +150,8 @@
 	UPGRADE_PRECISION = 5,
 	UPGRADE_FORCE_MULT = 1.15
 	)
+	I.tool_mod_type = list("whetstone")
+	I.bolt = TRUE
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_SAWING, QUALITY_SHOVELING, QUALITY_WIRE_CUTTING)
 	I.prefix = "sharpened"
 
@@ -161,6 +170,7 @@
 	UPGRADE_DEGRADATION_MULT = 0.85,
 	UPGRADE_FORCE_MULT = 1.10,
 	)
+	I.tool_mod_type = list("diamond_blade")
 	I.required_qualities = list(QUALITY_CUTTING, QUALITY_SHOVELING, QUALITY_SAWING, QUALITY_WIRE_CUTTING, QUALITY_PRYING)
 	I.negative_qualities = list(QUALITY_WELDING, QUALITY_LASER_CUTTING)
 	I.prefix = "diamond-edged"
@@ -180,6 +190,7 @@
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_HEALTH_THRESHOLD = -10
 	)
+	I.tool_mod_type = list("oxyjet")
 	I.required_qualities = list(QUALITY_WELDING)
 	I.prefix = "oxyjet"
 
@@ -202,6 +213,7 @@
 	UPGRADE_PRECISION = -10,
 	UPGRADE_HEALTH_THRESHOLD = -10
 	)
+	I.tool_mod_type = list("moter") //Brrrrr
 	I.required_qualities = list(QUALITY_SCREW_DRIVING, QUALITY_DRILLING, QUALITY_SAWING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_HAMMERING)
 	I.prefix = "high-power"
 	I.req_fuel_cell = REQ_FUEL_OR_CELL
@@ -218,7 +230,9 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_PRECISION = 10)
+	UPGRADE_PRECISION = 10
+	)
+	I.tool_mod_type = list("laserpointer")
 	I.prefix = "laser-guided"
 
 //Fits onto generally small tools that require precision, especially surgical tools
@@ -235,6 +249,7 @@
 	I.upgrades = list(
 	UPGRADE_PRECISION = 10,
 	UPGRADE_HEALTH_THRESHOLD = 10)
+	I.tool_mod_type = list("stabilized_grip")
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_WIRE_CUTTING, QUALITY_SCREW_DRIVING, QUALITY_WELDING,QUALITY_PULSING, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_BONE_SETTING, QUALITY_LASER_CUTTING)
 	I.prefix = "stabilized"
 
@@ -250,6 +265,7 @@
 	I.upgrades = list(
 	UPGRADE_PRECISION = 10
 	)
+	I.tool_mod_type = list("magbit")
 	I.required_qualities = list(QUALITY_SCREW_DRIVING, QUALITY_BOLT_TURNING, QUALITY_CLAMPING, QUALITY_BONE_SETTING)
 	I.prefix = "magnetic"
 
@@ -267,6 +283,7 @@
 	UPGRADE_BULK = 1,
 	UPGRADE_HEALTH_THRESHOLD = 10
 	)
+	I.tool_mod_type = list("ported_barrel")
 	I.required_qualities = list(QUALITY_WELDING)
 	I.prefix = "ported"
 
@@ -289,6 +306,7 @@
 	UPGRADE_HEALTH_THRESHOLD = -10,
 	UPGRADE_CELLPLUS = 1
 	)
+	I.tool_mod_type = list("cell_sizer")
 	I.prefix = "medium-cell"
 	I.req_fuel_cell = REQ_CELL
 
@@ -307,6 +325,7 @@
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_HEALTH_THRESHOLD = -10,
 	UPGRADE_MAXFUEL = 100)
+	I.tool_mod_type = list("fuel_tank", "fuel_holder")
 	I.prefix = "expanded"
 	I.req_fuel_cell = REQ_FUEL
 
@@ -326,6 +345,7 @@
 	UPGRADE_HEALTH_THRESHOLD = -20,
 	UPGRADE_MAXFUEL = 600
 	)
+	I.tool_mod_type = list("fuel_holder", "fuel_tank")
 	I.prefix = "holding"
 	I.req_fuel_cell = REQ_FUEL
 
@@ -346,6 +366,8 @@
 	UPGRADE_HEALTH_THRESHOLD = -20,
 	UPGRADE_MAXUPGRADES = 3
 	)
+	I.bolt = TRUE
+	I.tool_mod_type = list("expansionport")
 	I.prefix = "custom"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 
@@ -366,6 +388,7 @@
 	UPGRADE_HEALTH_THRESHOLD = -10,
 	UPGRADE_SHARP = TRUE
 	)
+	I.tool_mod_type = list("spikes")
 	I.prefix = "spiked"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 
@@ -384,9 +407,11 @@
 	UPGRADE_HEALTH_THRESHOLD = 5,
 	tool_qualities = list(QUALITY_HAMMERING = 10)
 	)
+	I.tool_mod_type = list("hammer")
 	I.prefix = "flattened"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 */
+
 //Vastly reduces tool sounds, for stealthy hacking
 /obj/item/weapon/tool_upgrade/augment/dampener
 	name = "aural dampener"
@@ -402,6 +427,7 @@
 	UPGRADE_HEALTH_THRESHOLD = -10,
 	UPGRADE_ITEMFLAGPLUS = SILENT
 	)
+	I.tool_mod_type = list("dampener")
 	I.prefix = "silenced"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 
@@ -421,7 +447,30 @@
 	UPGRADE_WORKSPEED = 14,
 	UPGRADE_HEALTH_THRESHOLD = -10,
 	)
+	I.tool_mod_type = list("ai", "nano")
 	I.prefix = "intelligent"
+	I.req_fuel_cell = REQ_CELL
+
+/obj/item/weapon/tool_upgrade/augment/guild_ai_tool
+	name = "micro-integrated AI"
+	desc = "Smart AI will integrate itself into this tool with the aid of micro-technology and improve it.\
+	Do to its integrated laws, it fights against its user in combat."
+	icon_state = "ai_tool"
+	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_PLASTEEL = 1, MATERIAL_PLATINUM = 1)
+
+/obj/item/weapon/tool_upgrade/augment/guild_ai_tool/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.upgrades = list(
+	UPGRADE_BULK = 1,
+	UPGRADE_POWERCOST_MULT = 3.20,
+	UPGRADE_PRECISION = 5,
+	UPGRADE_WORKSPEED = 2,
+	UPGRADE_HEALTH_THRESHOLD = -60,
+	UPGRADE_FORCE_MULT = 0.10, //These AIs hate harm...
+	)
+	I.tool_mod_type = list("ai", "nano")
+	I.prefix = "smart"
 	I.req_fuel_cell = REQ_CELL
 
 /obj/item/weapon/tool_upgrade/augment/repair_nano
@@ -437,7 +486,67 @@
 	UPGRADE_DEGRADATION_MULT = 0.01,
 	UPGRADE_HEALTH_THRESHOLD = 10
 	)
+	I.tool_mod_type = list("nano", "ai")
 	I.prefix = "self-healing"
+
+// COMBO MODS
+// Two mods that are hacked together to save space but at a cost!
+/obj/item/weapon/tool_upgrade/combo/sound_sink
+	name = "sound-sunk"
+	desc = "An array of plasteel fins which dissipates heat mixed in with an aural dampener to both make the tool more quiet well helping with tool life."
+	icon_state = "heatsink"
+	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_PLASTEEL = 6, MATERIAL_PLATINUM = 1)
+
+/obj/item/weapon/tool_upgrade/augment/sound_sink/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.upgrades = list(
+	UPGRADE_DEGRADATION_MULT = 0.75,
+	UPGRADE_WORKSPEED = -0.05, //Balance
+	UPGRADE_HEALTH_THRESHOLD = -3,
+	UPGRADE_COLOR = "#AAAAAA",
+	UPGRADE_ITEMFLAGPLUS = SILENT
+	)
+	I.tool_mod_type = list("heatsink", "dampener")
+	I.prefix = "soundsunk"
+
+/obj/item/weapon/tool_upgrade/combo/oxy_fuel
+	name = "oxy fuel"
+	desc = "Combing fuel storage with a oxyjet tank."
+	icon_state = "oxyjet"
+	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_PLASTEEL = 6)
+
+/obj/item/weapon/tool_upgrade/augment/oxy_fuel/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.upgrades = list(
+	UPGRADE_BULK = 2,
+	UPGRADE_DEGRADATION_MULT = 3.15,
+	UPGRADE_FORCE_MULT = 1.10,
+	UPGRADE_WORKSPEED = 0.15,
+	UPGRADE_HEALTH_THRESHOLD = -30,
+	UPGRADE_MAXFUEL = 60) //40/60
+	I.tool_mod_type = list("fuel_tank", "fuel_holder", "oxyjet")
+	I.prefix = "oxyjet expanded"
+	I.req_fuel_cell = REQ_FUEL
+
+/obj/item/weapon/tool_upgrade/combo/supper_grip
+	name = "stabled ergonomic grip"
+	desc = "Combing fuel storage with a oxyjet tank."
+	icon_state = "ergonomic"
+	matter = list(MATERIAL_PLASTIC = 8)
+
+/obj/item/weapon/tool_upgrade/augment/supper_grip/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.upgrades = list(
+	UPGRADE_WORKSPEED = 0.15,
+	UPGRADE_PRECISION = 3,
+	UPGRADE_HEALTH_THRESHOLD = 3
+	)
+	I.tool_mod_type = list("ergomomic_grip", "stabilized_grip")
+	I.prefix = "stabled gripped"
+	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 
 //Armor mods
 /obj/item/weapon/tool_upgrade/armor/melee

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -22,6 +22,7 @@
 	I.upgrades = list(
 		UPGRADE_DEGRADATION_MULT = 0.65,
 		UPGRADE_FORCE_MOD = 1,
+		upgrade_type = list("stick")
 		)
 
 	I.required_qualities = list(QUALITY_BOLT_TURNING,QUALITY_PRYING, QUALITY_SAWING,QUALITY_SHOVELING,QUALITY_DIGGING,QUALITY_EXCAVATION)
@@ -39,27 +40,31 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
 		UPGRADE_DEGRADATION_MULT = 0.65,
-		UPGRADE_HEALTH_THRESHOLD = 10
+		UPGRADE_HEALTH_THRESHOLD = 10,
+		upgrade_type = list("heatsink")
 		)
 	I.prefix = "heatsunk"
 	I.req_fuel_cell = REQ_FUEL_OR_CELL
-
 
 /obj/item/weapon/tool_upgrade/reinforcement/plating
 	name = "reinforced plating"
 	desc = "A sturdy bit of plasteel that can be bolted onto any tool to protect it. Tough, but bulky."
 	icon_state = "plate"
+
+
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 2) //steel to compensate for metal rods used in crafting
 
 /obj/item/weapon/tool_upgrade/reinforcement/plating/New()
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_DEGRADATION_MULT = 0.55,
-	UPGRADE_FORCE_MOD = 1,
-	UPGRADE_PRECISION = -5,
-	UPGRADE_BULK = 1,
-	UPGRADE_HEALTH_THRESHOLD = 10)
+		UPGRADE_DEGRADATION_MULT = 0.55,
+		UPGRADE_FORCE_MOD = 1,
+		UPGRADE_PRECISION = -5,
+		UPGRADE_BULK = 1,
+		UPGRADE_HEALTH_THRESHOLD = 10,
+		upgrade_type = list("plating")
+		)
 	I.prefix = "reinforced"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 
@@ -67,6 +72,7 @@
 	name = "metal guard"
 	desc = "A bent piece of metal that wraps around sensitive parts of a tool, protecting it from impacts, debris, and stray fingers."
 	icon_state = "guard"
+
 	matter = list(MATERIAL_PLASTEEL = 5)
 
 /obj/item/weapon/tool_upgrade/reinforcement/guard/New()
@@ -75,7 +81,8 @@
 	I.upgrades = list(
 	UPGRADE_DEGRADATION_MULT = 0.75,
 	UPGRADE_PRECISION = 5,
-	UPGRADE_HEALTH_THRESHOLD = 10
+	UPGRADE_HEALTH_THRESHOLD = 10,
+	upgrade_type = list("guard")
 	)
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_DRILLING, QUALITY_SAWING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_WELDING, QUALITY_HAMMERING)
 	I.prefix = "shielded"
@@ -92,7 +99,8 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_WORKSPEED = 0.15
+	UPGRADE_WORKSPEED = 0.15,
+	upgrade_type = list("ergonomic_grip")
 	)
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
 	I.prefix = "ergonomic"
@@ -107,7 +115,8 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_WORKSPEED = 0.25
+	UPGRADE_WORKSPEED = 0.25,
+	upgrade_type = list("ratchet")
 	)
 	I.required_qualities = list(QUALITY_BOLT_TURNING,QUALITY_SCREW_DRIVING)
 	I.prefix = "ratcheting"
@@ -124,7 +133,8 @@
 	I.upgrades = list(
 	UPGRADE_WORKSPEED = 0.20,
 	UPGRADE_PRECISION = -10,
-	UPGRADE_COLOR = "#FF4444"
+	UPGRADE_COLOR = "#FF4444",
+	upgrade_type = list("red_paint")
 	)
 	I.prefix = "red"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
@@ -141,7 +151,8 @@
 	I.upgrades = list(
 	UPGRADE_WORKSPEED = 0.15,
 	UPGRADE_PRECISION = 5,
-	UPGRADE_FORCE_MULT = 1.15
+	UPGRADE_FORCE_MULT = 1.15,
+	upgrade_type = list("whetstone")
 	)
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_SAWING, QUALITY_SHOVELING, QUALITY_WIRE_CUTTING)
 	I.prefix = "sharpened"
@@ -160,6 +171,7 @@
 	UPGRADE_WORKSPEED = 0.25,
 	UPGRADE_DEGRADATION_MULT = 0.85,
 	UPGRADE_FORCE_MULT = 1.10,
+	upgrade_type = list("diamond_blade")
 	)
 	I.required_qualities = list(QUALITY_CUTTING, QUALITY_SHOVELING, QUALITY_SAWING, QUALITY_WIRE_CUTTING, QUALITY_PRYING)
 	I.negative_qualities = list(QUALITY_WELDING, QUALITY_LASER_CUTTING)
@@ -178,7 +190,8 @@
 	UPGRADE_WORKSPEED = 0.20,
 	UPGRADE_FORCE_MULT = 1.15,
 	UPGRADE_DEGRADATION_MULT = 1.15,
-	UPGRADE_HEALTH_THRESHOLD = -10
+	UPGRADE_HEALTH_THRESHOLD = -10,
+	upgrade_type = list("oxyjet")
 	)
 	I.required_qualities = list(QUALITY_WELDING)
 	I.prefix = "oxyjet"
@@ -200,7 +213,8 @@
 	UPGRADE_POWERCOST_MULT = 1.35,
 	UPGRADE_FUELCOST_MULT = 1.35,
 	UPGRADE_PRECISION = -10,
-	UPGRADE_HEALTH_THRESHOLD = -10
+	UPGRADE_HEALTH_THRESHOLD = -10,
+	upgrade_type = list("motor")
 	)
 	I.required_qualities = list(QUALITY_SCREW_DRIVING, QUALITY_DRILLING, QUALITY_SAWING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_HAMMERING)
 	I.prefix = "high-power"
@@ -218,7 +232,9 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_PRECISION = 10)
+	UPGRADE_PRECISION = 10,
+	upgrade_type = list("laserguide"),
+	)
 	I.prefix = "laser-guided"
 
 //Fits onto generally small tools that require precision, especially surgical tools
@@ -234,7 +250,9 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
 	UPGRADE_PRECISION = 10,
-	UPGRADE_HEALTH_THRESHOLD = 10)
+	UPGRADE_HEALTH_THRESHOLD = 10,
+	upgrade_type = list("stabilizer_grip")
+	)
 	I.required_qualities = list(QUALITY_CUTTING,QUALITY_WIRE_CUTTING, QUALITY_SCREW_DRIVING, QUALITY_WELDING,QUALITY_PULSING, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_BONE_SETTING, QUALITY_LASER_CUTTING)
 	I.prefix = "stabilized"
 
@@ -248,7 +266,8 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_PRECISION = 10
+	UPGRADE_PRECISION = 10,
+	upgrade_type = list("magbit")
 	)
 	I.required_qualities = list(QUALITY_SCREW_DRIVING, QUALITY_BOLT_TURNING, QUALITY_CLAMPING, QUALITY_BONE_SETTING)
 	I.prefix = "magnetic"
@@ -265,7 +284,8 @@
 	UPGRADE_PRECISION = 12,
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_BULK = 1,
-	UPGRADE_HEALTH_THRESHOLD = 10
+	UPGRADE_HEALTH_THRESHOLD = 10,
+	upgrade_type = list("ported_barrel")
 	)
 	I.required_qualities = list(QUALITY_WELDING)
 	I.prefix = "ported"
@@ -287,7 +307,8 @@
 	UPGRADE_BULK = 1,
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_HEALTH_THRESHOLD = -10,
-	UPGRADE_CELLPLUS = 1
+	UPGRADE_CELLPLUS = 1,
+	upgrade_type = list("cell_mount")
 	)
 	I.prefix = "medium-cell"
 	I.req_fuel_cell = REQ_CELL
@@ -306,7 +327,9 @@
 	UPGRADE_BULK = 1,
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_HEALTH_THRESHOLD = -10,
-	UPGRADE_MAXFUEL = 100)
+	UPGRADE_MAXFUEL = 100,
+	upgrade_type = list("fuel_tank", "holding_tank")
+	)
 	I.prefix = "expanded"
 	I.req_fuel_cell = REQ_FUEL
 
@@ -324,7 +347,8 @@
 	UPGRADE_BULK = 1,
 	UPGRADE_DEGRADATION_MULT = 1.30,
 	UPGRADE_HEALTH_THRESHOLD = -20,
-	UPGRADE_MAXFUEL = 600
+	UPGRADE_MAXFUEL = 600,
+	upgrade_type = list("holding_tank", "fuel_tank") //Cant mix fuel tanks for over 700
 	)
 	I.prefix = "holding"
 	I.req_fuel_cell = REQ_FUEL
@@ -333,7 +357,7 @@
 /obj/item/weapon/tool_upgrade/augment/expansion
 	name = "expansion port"
 	icon_state = "expand"
-	desc = "A bulky adapter which more modifications to be attached to the tool.  A bit fragile but you can compensate."
+	desc = "A bulky bolted adapter which more modifications to be attached to the tool.  A bit fragile but you can compensate."
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 1)
 
 /obj/item/weapon/tool_upgrade/augment/expansion/New()
@@ -344,7 +368,9 @@
 	UPGRADE_DEGRADATION_MULT = 1.3,
 	UPGRADE_PRECISION = -10,
 	UPGRADE_HEALTH_THRESHOLD = -20,
-	UPGRADE_MAXUPGRADES = 3
+	UPGRADE_MAXUPGRADES = 3,
+	upgrade_type = list("expansion"),
+	bolt = TRUE
 	)
 	I.prefix = "custom"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
@@ -364,7 +390,8 @@
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_WORKSPEED = -0.15,
 	UPGRADE_HEALTH_THRESHOLD = -10,
-	UPGRADE_SHARP = TRUE
+	UPGRADE_SHARP = TRUE,
+	upgrade_type = list("spikes")
 	)
 	I.prefix = "spiked"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
@@ -383,6 +410,7 @@
 	UPGRADE_WORKSPEED = -0.5,
 	UPGRADE_HEALTH_THRESHOLD = 5,
 	tool_qualities = list(QUALITY_HAMMERING = 10)
+	upgrade_type = list("hammer")
 	)
 	I.prefix = "flattened"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
@@ -400,7 +428,8 @@
 	I.upgrades = list(
 	UPGRADE_COLOR = "#AAAAAA",
 	UPGRADE_HEALTH_THRESHOLD = -10,
-	UPGRADE_ITEMFLAGPLUS = SILENT
+	UPGRADE_ITEMFLAGPLUS = SILENT,
+	upgrade_type = list("dampener")
 	)
 	I.prefix = "silenced"
 	I.required_qualities = list(QUALITY_BOLT_TURNING, QUALITY_PULSING, QUALITY_PRYING, QUALITY_WELDING, QUALITY_SCREW_DRIVING, QUALITY_WIRE_CUTTING, QUALITY_SHOVELING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_RETRACTING, QUALITY_DRILLING, QUALITY_HAMMERING, QUALITY_SAWING, QUALITY_CUTTING)
@@ -420,6 +449,7 @@
 	UPGRADE_PRECISION = 14,
 	UPGRADE_WORKSPEED = 14,
 	UPGRADE_HEALTH_THRESHOLD = -10,
+	upgrade_type = list("ai", "repair_nano")
 	)
 	I.prefix = "intelligent"
 	I.req_fuel_cell = REQ_CELL
@@ -435,9 +465,14 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
 	UPGRADE_DEGRADATION_MULT = 0.01,
-	UPGRADE_HEALTH_THRESHOLD = 10
+	UPGRADE_HEALTH_THRESHOLD = 10,
+	upgrade_type = list("ai", "repair_nano")
 	)
 	I.prefix = "self-healing"
+
+// 		Armor: Upgrades armor
+//------------------------------------------------
+
 
 //Armor mods
 /obj/item/weapon/tool_upgrade/armor/melee
@@ -450,7 +485,8 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_MELEE_ARMOR = 20
+	UPGRADE_MELEE_ARMOR = 20,
+	upgrade_type = list("melee")
 	)
 	I.prefix = "reinforced"
 	I.required_qualities = list(QUALITY_ARMOR)
@@ -465,7 +501,8 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_BALLISTIC_ARMOR = 20
+	UPGRADE_BALLISTIC_ARMOR = 20,
+	upgrade_type = list("bullet")
 	)
 	I.prefix = "kevlar-plated"
 	I.required_qualities = list(QUALITY_ARMOR)
@@ -480,7 +517,8 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_ENERGY_ARMOR = 20
+	UPGRADE_ENERGY_ARMOR = 20,
+	upgrade_type = list("energy")
 	)
 	I.prefix = "ablative-plated"
 	I.required_qualities = list(QUALITY_ARMOR)
@@ -495,7 +533,53 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.upgrades = list(
-	UPGRADE_BOMB_ARMOR = 40
+	UPGRADE_BOMB_ARMOR = 40,
+	upgrade_type = list("bomb")
 	)
 	I.prefix = "bomb-proofed"
 	I.required_qualities = list(QUALITY_ARMOR)
+
+
+// 		MIXED: Mixing tool mods to save space but are less affective
+//------------------------------------------------------------------
+
+
+//Sound n Heatsink can be attached to any tool that uses fuel or power
+/obj/item/weapon/tool_upgrade/reinforcement/sound_sink
+	name = "soundsink"
+	desc = "An array of plasteel fins mixed in with sound dampers to dissipates heat, reducing damage, extending the lifespan and soften sounds of power tools."
+	icon_state = "heatsink"
+	matter = list(MATERIAL_PLASTEEL = 6, MATERIAL_PLASTIC = 1, MATERIAL_PLATINUM = 1)
+
+/obj/item/weapon/tool_upgrade/reinforcement/heatsink/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.upgrades = list(
+		UPGRADE_DEGRADATION_MULT = 0.45,
+		UPGRADE_HEALTH_THRESHOLD = 5,
+		UPGRADE_ITEMFLAGPLUS = SILENT,
+		upgrade_type = list("heatsink", "dampener")
+		)
+	I.prefix = "soundsunk"
+	I.req_fuel_cell = REQ_FUEL_OR_CELL
+
+//Stores moar fuel and speeds up
+/obj/item/weapon/tool_upgrade/augment/fuel_oxy
+	name = "expanded fuel tank"
+	desc = "An auxiliary tank which stores 30 extra units of fuel at the cost of degradation."
+	icon_state = "canister"
+	matter = list(MATERIAL_PLASTEEL = 4, MATERIAL_PLASTIC = 1)
+
+/obj/item/weapon/tool_upgrade/augment/fuel_tank/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.upgrades = list(
+	UPGRADE_BULK = 1,
+	UPGRADE_DEGRADATION_MULT = 1.15,
+	UPGRADE_HEALTH_THRESHOLD = -10,
+	UPGRADE_MAXFUEL = 100,
+	upgrade_type = list("fuel_tank", "holding_tank")
+	)
+	I.prefix = "expanded"
+	I.req_fuel_cell = REQ_FUEL
+


### PR DESCRIPTION
## About The Pull Request
Makes some tool mods no longer be able to be taken off - like paint, ports and wetstones
Makes some mods no longer stack, such as 2 fuel add ons or such

Adds 4 new tool mods
New AI tool mod that the GM and CRO can make, this being a integrated AI into any cell based tool!
3 Combo Mods All Guild only crafting cuz power creep
Sound-Sunk - Heat sink + sound sink
Supper grip -  Grip + padding
Oxy Fuel - Fuel tank + oxy jet

Now you might be wondering `omg thats like mega pow pow creep!`
And to that I state, no. Flat out no
These combo mods are really not flat better then if you were to ad them onto a tool
They are infact /much worst/ if you combine them from the time it takes to the property you use/lose from the tools
They are good at saving space, on tools that are needed for and now with some tool mods bolting onto a tool it might be worth it to think harder what your doing.

## Changelog
:cl:
/:cl: