### PR TITLE
Makes cloakers a bit less harder on the eyes

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
@@ -15,7 +15,7 @@
 
 /mob/living/carbon/superior_animal/giant_spider/hunter/cloaker
 	desc = "Furry and black, it makes you shudder to look at it. This one has a chameleonic chitin that makes it hard to see."
-	alpha = 50
+	alpha = 80
 
 /mob/living/carbon/superior_animal/giant_spider/hunter/viper
 	desc = "Furry and black, it makes you shudder to look at it. This one has sparkling purple eyes and a large red splotch on its abdomen."


### PR DESCRIPTION

## About The Pull Request
Makes the spider hunter cloaker 80 aphla rathe rather then 50

being 50 is a bit to hard to see number imo to the point were you cant see one really at all with 100% lighting on the dirt roads or conflicting pallets. Camo only is meant to work if its same-ish. Still really hard to see in most cases in maints and the like but not as much when you have full lighting and the like 

## Changelog
:cl:
/:cl:
