### PR TITLE
why do I have to squint to see things?

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/big.dm
+++ b/code/modules/mob/living/simple_animal/hostile/big.dm
@@ -197,7 +197,7 @@
 	move_to_delay = 2
 	speak_emote = list("chitters", "sharpens its claws")
 	attack_sound = 'sound/xenomorph/alien_bite1.ogg'
-	alpha = 15
+	alpha = 80
 	faction = "stalker"
 
 /mob/living/simple_animal/hostile/nightmare/MoveToTarget()
@@ -215,11 +215,7 @@
 
 /mob/living/simple_animal/hostile/nightmare/LoseTarget()
 	..()
-	alpha = 15
-
-/mob/living/simple_animal/hostile/nightmare/LostTarget()
-	..()
-	alpha = 15
+	alpha = 80
 
 /mob/living/simple_animal/hostile/nightmare/death()
 	..()


### PR DESCRIPTION
## About The Pull Request
More eye QoL/ Mob cheats nerfs makes these frankly massive things camo in full daylight, that has conflicting pallets be see able without needing to use safety squints. Like really, its less about "just get gud" when they already decloak to attack and shit, this just makes it so I dont have eye stain form trying to play the game
Nightmarks aplha is now 80 from, 15

## Changelog
:cl:
/:cl: