### PR TITLE
Legit Powergaming

### DIFF
--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -6,7 +6,6 @@
 	gloves = /obj/item/clothing/gloves/thick
 	pda_slot = slot_l_store
 	r_pocket = /obj/item/device/t_scanner
-	l_pocket =/obj/item/weapon/computer_hardware/hard_drive/portable/design/powerwork
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
 	backpack_contents = list(/obj/item/weapon/gun/matter/launcher/breaker = 1)
 
@@ -22,7 +21,6 @@
 	suit = /obj/item/clothing/suit/storage/hazardvest
 	l_ear = /obj/item/device/radio/headset/heads/ce
 	id_type = /obj/item/weapon/card/id/ce
-	l_pocket =/obj/item/weapon/computer_hardware/hard_drive/portable/design/powerwork/factory
 	pda_type = /obj/item/modular_computer/pda/heads/ce
 
 /decl/hierarchy/outfit/job/engineering/engineer
@@ -31,7 +29,6 @@
 	uniform = /obj/item/clothing/under/rank/engineer
 	suit = /obj/item/clothing/suit/storage/hazardvest
 	head = /obj/item/clothing/head/hardhat
-	l_pocket =/obj/item/weapon/computer_hardware/hard_drive/portable/design/powerwork //We always get a disk too
 	id_type = /obj/item/weapon/card/id/engie
 	pda_type = /obj/item/modular_computer/pda/engineering
 

--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -6,6 +6,7 @@
 	gloves = /obj/item/clothing/gloves/thick
 	pda_slot = slot_l_store
 	r_pocket = /obj/item/device/t_scanner
+	l_pocket =/obj/item/weapon/computer_hardware/hard_drive/portable/design/powerwork
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL
 	backpack_contents = list(/obj/item/weapon/gun/matter/launcher/breaker = 1)
 
@@ -21,6 +22,7 @@
 	suit = /obj/item/clothing/suit/storage/hazardvest
 	l_ear = /obj/item/device/radio/headset/heads/ce
 	id_type = /obj/item/weapon/card/id/ce
+	l_pocket =/obj/item/weapon/computer_hardware/hard_drive/portable/design/powerwork/factory
 	pda_type = /obj/item/modular_computer/pda/heads/ce
 
 /decl/hierarchy/outfit/job/engineering/engineer
@@ -29,6 +31,7 @@
 	uniform = /obj/item/clothing/under/rank/engineer
 	suit = /obj/item/clothing/suit/storage/hazardvest
 	head = /obj/item/clothing/head/hardhat
+	l_pocket =/obj/item/weapon/computer_hardware/hard_drive/portable/design/powerwork //We always get a disk too
 	id_type = /obj/item/weapon/card/id/engie
 	pda_type = /obj/item/modular_computer/pda/engineering
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1997,6 +1997,7 @@
 					 /obj/item/weapon/computer_hardware/hard_drive/portable/design/security = 5,
 					 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/cheap_guns = 5,
 					 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 10,
+					 /obj/item/weapon/computer_hardware/hard_drive/portable/design/powerwork = 3,
 					 /obj/item/weapon/circuitboard/autolathe = 3,
 					 /obj/item/weapon/circuitboard/vending = 10)
 	contraband = list(/obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_boxes_smallarms = 3)
@@ -2012,6 +2013,7 @@
 				  /obj/item/weapon/computer_hardware/hard_drive/portable/design/security = 600,
 				  /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/cheap_guns = 3000,
 				  /obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 700,
+				  /obj/item/weapon/computer_hardware/hard_drive/portable/design/powerwork = 600,
 				  /obj/item/weapon/circuitboard/autolathe = 700,
 				  /obj/item/weapon/circuitboard/vending = 500,
 				  /obj/item/weapon/computer_hardware/hard_drive/portable/design/ammo_boxes_smallarms = 1000)

--- a/code/game/objects/items/weapons/autolathe_disk/guild_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guild_disks.dm
@@ -103,6 +103,8 @@
 		/datum/design/autolathe/circuit/centrifuge,
 		/datum/design/autolathe/circuit/electrolyzer,
 		/datum/design/autolathe/circuit/reagentgrinder,
+		/datum/design/research/circuit/pacman,
+		/datum/design/research/circuit/diesel,
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/conveyors
@@ -194,3 +196,20 @@
 		/datum/design/research/item/weapon/toolmod/plasmablock,
 		)
 
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/powerwork
+	disk_name = "Artificer's KW-841 Power Setters"
+	icon_state = "technomancers"
+
+	license = -1
+	designs = list(
+	/datum/design/research/circuit/powermonitor,
+	/datum/design/research/circuit/solarcontrol,
+	/datum/design/research/circuit/miss,
+	/datum/design/research/circuit/superpacman,
+	/datum/design/research/circuit/mrspacman,
+	/datum/design/research/circuit/camp,
+	/datum/design/research/circuit/pacman,
+	/datum/design/research/circuit/diesel,
+	/datum/design/research/circuit/pacman/scrap,
+	/datum/design/research/structure/solar,
+	)

--- a/code/game/objects/items/weapons/autolathe_disk/guild_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guild_disks.dm
@@ -200,7 +200,7 @@
 	disk_name = "Artificer's KW-841 Power Setters"
 	icon_state = "technomancers"
 
-	license = -1
+	license = 10
 	designs = list(
 	/datum/design/research/circuit/powermonitor,
 	/datum/design/research/circuit/solarcontrol,
@@ -212,4 +212,15 @@
 	/datum/design/research/circuit/diesel,
 	/datum/design/research/circuit/pacman/scrap,
 	/datum/design/research/structure/solar,
+	/datum/design/research/circuit/smes_cell,
+	/datum/design/research/circuit/batteryrack,
+	/datum/design/research/circuit/breakerbox,
+	/datum/design/research/item/part/smes_coil,
+	/datum/design/research/item/part/smes_coil/weak,
+	/datum/design/research/item/part/smes_coil/super_io,
+	/datum/design/research/item/part/smes_coil/super_capacity,
 	)
+
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/powerwork/factory
+	disk_name = "Artificer's MW-841 Power Setters"
+	license = -1

--- a/code/game/objects/items/weapons/circuitboards/machinery/excelsior.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/excelsior.dm
@@ -37,8 +37,10 @@
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 3, TECH_POWER = 3, TECH_PLASMA = 3, TECH_ENGINEERING = 3, TECH_ILLEGAL = 2)
 	req_components = list(
-		/obj/item/weapon/stock_parts/manipulator = 1,
-		/obj/item/weapon/stock_parts/console_screen = 1
+		/obj/item/weapon/stock_parts/matter_bin = 1,
+		/obj/item/weapon/stock_parts/micro_laser = 1,
+		/obj/item/stack/cable_coil = 2,
+		/obj/item/weapon/stock_parts/capacitor = 1
 	)
 
 /obj/item/weapon/circuitboard/excelsior_boombox

--- a/code/game/objects/items/weapons/circuitboards/machinery/pacman.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/pacman.dm
@@ -20,6 +20,17 @@
 	build_path = /obj/machinery/power/port_gen/pacman/mrs
 	origin_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 5)
 
+/obj/item/weapon/circuitboard/pacman/camp
+	build_name = "CAMPMAN-type generator"
+	build_path = /obj/machinery/power/port_gen/pacman/camp
+	origin_tech = list(TECH_DATA = 1, TECH_POWER = 2, TECH_ENGINEERING = 3)
+
+/obj/item/weapon/circuitboard/pacman/miss
+	build_name = "MRSPACMAN-type generator"
+	build_path = /obj/machinery/power/port_gen/pacman/miss
+	origin_tech = list(TECH_DATA = 4, TECH_POWER = 6, TECH_ENGINEERING = 6)
+
+
 /*
 /obj/item/weapon/circuitboard/diesel
 	build_name = "diesel generator"

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -143,6 +143,8 @@
 				create_reagents(max_fuel_volume)
 		else if(istype(SP, /obj/item/weapon/stock_parts/micro_laser) || istype(SP, /obj/item/weapon/stock_parts/capacitor))
 			temp_rating += SP.rating
+	desc = "A power generator that runs on [fuel_name]. Rated for [(power_gen * max_safe_output) / 1000] kW max safe output."
+
 
 	power_gen = round(initial(power_gen) * (max(2, temp_rating) / 2))
 
@@ -472,3 +474,40 @@
 	//no special effects, but the explosion is pretty big (same as a supermatter shard).
 	explosion(src.loc, 3, 6, 12, 16, 1)
 	qdel(src)
+
+/obj/machinery/power/port_gen/pacman/camp
+	name = "C.A.M.P.E.R.P.A.C.M.A.N portable generator"
+	desc = "This pacman got its named form its low power rating of burning wood as fuel, tends to be used well people go out camping. Rated for 20 kW maximum safe output!"
+	icon_state = "portgen2"
+	sheet_path = /obj/item/stack/material/wood
+	sheet_name = "Wood Planks Fuel Sheets"
+
+	//Wood is everyware here, this is is rather weak
+	power_gen = 12000 //watts
+	time_per_fuel_unit = 80
+	temperature_gain = 20
+	circuit = /obj/item/weapon/circuitboard/pacman/camp
+
+/obj/machinery/power/port_gen/pacman/camp/explode()
+	//low explosion effects, this is rather safe.
+	explosion(src.loc, 0, 0, 3, 1)
+	qdel(src)
+
+/obj/machinery/power/port_gen/pacman/miss
+	name = "M.I.S.S.P.A.C.M.A.N portable generator"
+	desc = "Using a girls best friend. Rated for 200 kW maximum safe output!"
+	icon_state = "portgen2"
+	sheet_path = /obj/item/stack/material/diamond
+	sheet_name = "Diamond Sheet Fuel Sheets"
+
+	//diamonds are just as common as any other mat*
+	power_gen = 22500 //watts
+	time_per_fuel_unit = 284 //3x longer then plasma
+	temperature_gain = 70
+	circuit = /obj/item/weapon/circuitboard/pacman/miss
+
+/obj/machinery/power/port_gen/pacman/miss/explode()
+	//low explosion effects.
+	explosion(src.loc, 1, 1, 3, 3)
+	qdel(src)
+

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -64,8 +64,6 @@
 
 	update_icon()
 
-
-
 /obj/machinery/power/solar/attackby(obj/item/weapon/I, mob/user)
 
 	if(QUALITY_PRYING in I.tool_qualities)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -11,6 +11,7 @@
 	use_power = 0
 	idle_power_usage = 0
 	active_power_usage = 0
+	var/glass_power = 1 //How much are more are we getting from the glass?
 	var/id = 0
 	health = 10
 	var/obscured = 0
@@ -53,6 +54,14 @@
 	S.loc = src
 	if(S.glass_type == /obj/item/stack/material/glass/reinforced) //if the panel is in reinforced glass
 		health *= 2 								 //this need to be placed here, because panels already on the map don't have an assembly linked to
+		glass_power = 1.1 //33000
+	if(S.glass_type == /obj/item/stack/material/glass/plasmaglass) //if the panel is in plasma glass
+		health *= 2
+		glass_power = 1.2 //36000
+	if(S.glass_type == /obj/item/stack/material/glass/plasmarglass) //if the panel is in reinforced plasma glass
+		health *= 3
+		glass_power = 1.3 //39000
+
 	update_icon()
 
 
@@ -123,7 +132,7 @@
 		if(powernet == control.powernet)//check if the panel is still connected to the computer
 			if(obscured) //get no light from the sun, so don't generate power
 				return
-			var/sgen = SOLARGENRATE * sunfrac
+			var/sgen = SOLARGENRATE * sunfrac * glass_power
 			add_avail(sgen)
 			control.gen += sgen
 		else //if we're no longer on the same powernet, remove from control computer
@@ -246,7 +255,7 @@
 
 	if(anchored && isturf(loc))
 		log_debug("1")
-		if(istype(I, /obj/item/stack/material) && (I.get_material_name() == "glass" || I.get_material_name() == "rglass"))
+		if(istype(I, /obj/item/stack/material) && (I.get_material_name() == "glass" || I.get_material_name() == "rglass" || I.get_material_name() == "plasmaglass" || I.get_material_name() == "rplasmaglass"))
 			log_debug("2")
 			var/obj/item/stack/material/S = I
 			if(S.use(2))
@@ -549,8 +558,9 @@
 /obj/item/weapon/paper/solarsteup
 	name = "paper- 'Message from Tacitus, guild grand master.'"
 	info = "<h1>Greetings Adept</h1><p>Setting up the solar array is pretty straight forward, you just need to replace the wiring that transmits the most energy at the start of each shift \
-	and then go through all the existing wiring to cut off any frayed spots before recrimping it, this step is important as the frayed wires will cause power loss if not repaired. You'll \
-	notice the solar computer hooked up to the controller already, once you have it wired just perform a scan and the machines will do the rest of the work. If for any reason the solar \
+	and then go through all the existing wiring to cut off any frayed spots before recrimping it, this step is important as the frayed wires will cause power loss if not repaired. \
+	If your feeling fancy you can replace the solar pannles with better glass for more power, reinforced borosilicate glass gets the most power out of the sun well just reinforcing them will only help a little. \
+	You'll notice the solar computer hooked up to the controller already, once you have it wired just perform a scan and the machines will do the rest of the work. If for any reason the solar \
 	array doesn't detect the panels, try resetting the computer by taking it apart and putting it back together. Remember to walk instead of run on the under plating, wear \
 	insulated gloves, and wear some insulated work boots for protection. -Tacitus O'Connar.</p>"
 
@@ -558,8 +568,8 @@
 	name = "paper- 'Message from Augustine, church cartographer.'"
 	info = "<h1>Greetings</h1><p>For those unaware we have a small solar system set up here to help provide reserve power to the colony, be quite careful as while it is smaller, safer, and easier to \
 	maintain than what the artificer guild uses the wiring under the catwalk will fray over time and may shock you by electrifying the metal. If you find a pair of insulated gloves I \
-	highly suggest cutting any splicings and crimping the wires to make them safe and increase power production. If the colony ever has any brown outs or black outs the third SMES unit in the \
-	biogenerator room will charge from these solars and can be hooked up as a temporary solution.</p>"
+	highly suggest cutting any splicings and crimping the wires to make them safe and increase power production. If needed it may be usefull to upgrade the glass inside the pannles to harvest more power. \
+	If the colony ever has any brown outs or black outs the third SMES unit in the biogenerator room will charge from these solars and can be hooked up as a temporary solution.</p>"
 
 /obj/item/weapon/paper/solar
 	name = "paper- 'Going green! Setup your own solar array instructions.'"

--- a/code/modules/research/designs/cell.dm
+++ b/code/modules/research/designs/cell.dm
@@ -11,106 +11,86 @@
 	name = "Soteria \"Power-Geyser 2000L\""
 	build_type = PROTOLATHE | MECHFAB
 	build_path = /obj/item/weapon/cell/large/moebius
-	sort_string = "DAAAA"
 
 /datum/design/research/item/powercell/large/high
 	name = "Soteria \"Power-Geyser 7000L\""
 	build_type = PROTOLATHE | MECHFAB
 	build_path = /obj/item/weapon/cell/large/moebius/high
-	sort_string = "DAAAB"
 
 /datum/design/research/item/powercell/large/super
 	name = "Soteria \"Power-Geyser 13000L\""
 	build_path = /obj/item/weapon/cell/large/moebius/super
-	sort_string = "DAAAC"
 
 /datum/design/research/item/powercell/large/hyper
 	name = "Soteria \"Power-Geyser 18000L\""
 	build_path = /obj/item/weapon/cell/large/moebius/hyper
-	sort_string = "DAAAD"
 
 /datum/design/research/item/powercell/medium/basic
 	name = "Soteria \"Power-Geyser 700M\""
 	build_type = PROTOLATHE | MECHFAB
 	build_path = /obj/item/weapon/cell/medium/moebius
-	sort_string = "DAAAF"
 
 /datum/design/research/item/powercell/medium/high
 	name = "Soteria \"Power-Geyser 900M\""
 	build_type = PROTOLATHE | MECHFAB
 	build_path = /obj/item/weapon/cell/medium/moebius/high
-	sort_string = "DAAAI"
 
 /datum/design/research/item/powercell/medium/super
 	name = "Soteria \"Power-Geyser 1000M\""
 	build_path = /obj/item/weapon/cell/medium/moebius/super
-	sort_string = "DAAAO"
 
 /datum/design/research/item/powercell/medium/hyper
 	name = "Soteria \"Power-Geyser 1300M\""
 	build_path = /obj/item/weapon/cell/medium/moebius/hyper
-	sort_string = "DAAAP"
 
 /datum/design/research/item/powercell/small/basic
 	name = "Soteria \"Power-Geyser 120S\""
 	build_type = PROTOLATHE | MECHFAB
 	build_path = /obj/item/weapon/cell/small/moebius
-	sort_string = "DAAAQ"
 
 /datum/design/research/item/powercell/small/high
 	name = "Soteria \"Power-Geyser 250S\""
 	build_type = PROTOLATHE | MECHFAB
 	build_path = /obj/item/weapon/cell/small/moebius/high
-	sort_string = "DAAAV"
 
 /datum/design/research/item/powercell/small/super
 	name = "Soteria \"Power-Geyser 300S\""
 	build_path = /obj/item/weapon/cell/small/moebius/super
-	sort_string = "DAAAW"
 
 /datum/design/research/item/powercell/small/hyper
 	name = "Soteria \"Power-Geyser 400S\""
 	build_path = /obj/item/weapon/cell/small/moebius/hyper
-	sort_string = "DAAAX"
 
 /datum/design/research/item/powercell/large/omega
 	name = "Soteria \"Omega-Geyser 20000L\""
 	build_path = /obj/item/weapon/cell/large/moebius/omega
-	sort_string = "DAAAZ"
 
 /datum/design/research/item/powercell/medium/omega
 	name = "Soteria \"Omega-Geyser 1600M\""
 	build_path = /obj/item/weapon/cell/medium/moebius/omega
-	sort_string = "DAABA"
 
 /datum/design/research/item/powercell/small/omega
 	name = "Soteria \"Omega-Geyser 500S\""
 	build_path = /obj/item/weapon/cell/small/moebius/omega
-	sort_string = "DAABB"
 
 /datum/design/research/item/powercell/large/nuclear
 	name = "Soteria \"Atomcell 14000L\""
 	build_path = /obj/item/weapon/cell/large/moebius/nuclear
-	sort_string = "DAABC"
 
 /datum/design/research/item/powercell/medium/nuclear
 	name = "Soteria \"Atomcell 1000M\""
 	build_path = /obj/item/weapon/cell/medium/moebius/nuclear
-	sort_string = "DAABD"
 
 /datum/design/research/item/powercell/small/nuclear
 	name = "Soteria \"Atomcell 300S\""
 	build_path = /obj/item/weapon/cell/small/moebius/nuclear
-	sort_string = "DAABE"
 
 /datum/design/research/item/powercell/small/nuclear/pda
 	name = "Soteria \"Atomcell 50S\""
 	build_path = /obj/item/weapon/cell/small/moebius/pda
-	sort_string = "DAABF"
 
 //Hand crank for cells
 /datum/design/research/item/hand_charger
 	name = "Soteria \"Hand Crank\""
 	build_path = /obj/item/device/manual_charger
 	category = CAT_POWER
-	sort_string = "DAABG"

--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -20,13 +20,11 @@
 /datum/design/research/circuit/arcade_battle
 	name = "battle arcade machine"
 	build_path = /obj/item/weapon/circuitboard/arcade/battle
-	sort_string = "MAAAA"
 	category = CAT_MISC
 
 /datum/design/research/circuit/arcade_orion_trail
 	name = "orion trail arcade machine"
 	build_path = /obj/item/weapon/circuitboard/arcade/orion_trail
-	sort_string = "MABAA"
 	category = CAT_MISC
 
 /datum/design/research/circuit/secdata
@@ -38,127 +36,106 @@
 /datum/design/research/circuit/prisonmanage
 	name = "prisoner management console"
 	build_path = /obj/item/weapon/circuitboard/prisoner
-	sort_string = "DACAA"
 	category = CAT_COMP
 
 /datum/design/research/circuit/med_data
 	name = "medical records console"
 	build_path = /obj/item/weapon/circuitboard/med_data
-	sort_string = "FAAAA"
 	category = CAT_COMP
 
 /datum/design/research/circuit/operating
 	name = "patient monitoring console"
 	build_path = /obj/item/weapon/circuitboard/operating
-	sort_string = "FACAA"
 	category = CAT_COMP
 
 /datum/design/research/circuit/scan_console
 	name = "DNA machine"
 	build_path = /obj/item/weapon/circuitboard/scan_consolenew
-	sort_string = "FAGAA"
 	category = CAT_MEDI
 
 /datum/design/research/circuit/sleeper
 	name = "Sleeper"
 	build_path = /obj/item/weapon/circuitboard/sleeper
-	sort_string = "FAGAB"
 	category = CAT_MEDI
 
 /datum/design/research/circuit/clonepod
 	name = "clone pod"
 	build_path = /obj/item/weapon/circuitboard/clonepod
-	sort_string = "FAGAE"
 	category = CAT_MEDI
 
 /datum/design/research/circuit/clonescanner
 	name = "cloning scanner"
 	build_path = /obj/item/weapon/circuitboard/clonescanner
-	sort_string = "FAGAG"
 	category = CAT_MEDI
 
 /datum/design/research/circuit/chemmaster
 	name = "ChemMaster 3000"
 	build_path = /obj/item/weapon/circuitboard/chemmaster
-	sort_string = "FAHAA"
 	category = CAT_MEDI
 
 /datum/design/research/circuit/chem_heater
 	name = "Chemical Heater"
 	build_path = /obj/item/weapon/circuitboard/chem_heater
-	sort_string = "FAHAB"
 	category = CAT_MEDI
 
 /datum/design/research/circuit/chemical_dispenser
 	name = "Chemical Dispenser"
 	build_path = /obj/item/weapon/circuitboard/chemical_dispenser
-	sort_string = "FAHAC"
 	category = CAT_MEDI
 
 /datum/design/research/circuit/teleconsole
 	name = "teleporter control console"
 	build_path = /obj/item/weapon/circuitboard/teleporter
-	sort_string = "HAAAA"
 	category = CAT_BLUE
 
 /datum/design/research/circuit/robocontrol
 	name = "robotics control console"
 	build_path = /obj/item/weapon/circuitboard/robotics
-	sort_string = "HAAAB"
 	category = CAT_COMP
 
 /datum/design/research/circuit/mechacontrol
 	name = "exosuit control console"
 	build_path = /obj/item/weapon/circuitboard/mecha_control
-	sort_string = "HAAAC"
 	category = CAT_COMP
 
 /datum/design/research/circuit/rdconsole
 	name = "R&D control console"
 	build_path = /obj/item/weapon/circuitboard/rdconsole
-	sort_string = "HAAAE"
 	category = CAT_COMP
 
 /datum/design/research/circuit/aifixer
 	name = "AI integrity restorer"
 	build_path = /obj/item/weapon/circuitboard/aifixer
-	sort_string = "HAAAF"
 	category = CAT_COMP
 
 /datum/design/research/circuit/comm_monitor
 	name = "telecommunications monitoring console"
 	build_path = /obj/item/weapon/circuitboard/comm_monitor
-	sort_string = "HAACA"
 	category = CAT_TCOM
 
 /datum/design/research/circuit/comm_server
 	name = "telecommunications server monitoring console"
 	build_path = /obj/item/weapon/circuitboard/comm_server
-	sort_string = "HAACB"
 	category = CAT_TCOM
 
 /datum/design/research/circuit/message_monitor
 	name = "messaging monitor console"
 	build_path = /obj/item/weapon/circuitboard/message_monitor
-	sort_string = "HAACC"
 	category = CAT_TCOM
 
 /datum/design/research/circuit/aiupload
 	name = "AI upload console"
 	build_path = /obj/item/weapon/circuitboard/aiupload
-	sort_string = "HAABA"
 	category = CAT_COMP
 
 /datum/design/research/circuit/borgupload
 	name = "cyborg upload console"
 	build_path = /obj/item/weapon/circuitboard/borgupload
-	sort_string = "HAABB"
 	category = CAT_COMP
 
 /datum/design/research/circuit/destructive_analyzer
 	name = "destructive analyzer"
 	build_path = /obj/item/weapon/circuitboard/destructive_analyzer
-	sort_string = "HABAA"
 	category = CAT_COMP
 
 /datum/design/research/circuit/protolathe
@@ -170,179 +147,164 @@
 /datum/design/research/circuit/circuit_imprinter
 	name = "circuit imprinter"
 	build_path = /obj/item/weapon/circuitboard/circuit_imprinter
-	sort_string = "HABAC"
 	category = CAT_MACHINE
 
 /datum/design/research/circuit/autolathe
 	name = "autolathe"
 	build_path = /obj/item/weapon/circuitboard/autolathe
-	sort_string = "HABAD"
 	category = CAT_MACHINE
 
 /datum/design/research/circuit/rdservercontrol
 	name = "R&D server control console"
 	build_path = /obj/item/weapon/circuitboard/rdservercontrol
-	sort_string = "HABBA"
 	category = CAT_COMP
 
 /datum/design/research/circuit/rdserver
 	name = "R&D server"
 	build_path = /obj/item/weapon/circuitboard/rdserver
-	sort_string = "HABBB"
 	category = CAT_MACHINE
 
 /datum/design/research/circuit/mechfab
 	name = "exosuit fabricator"
 	build_path = /obj/item/weapon/circuitboard/mechfab
-	sort_string = "HABAE"
 	category = CAT_MACHINE
 
 /datum/design/research/circuit/mech_recharger
 	name = "mech recharger"
 	build_path = /obj/item/weapon/circuitboard/mech_recharger
-	sort_string = "HACAA"
 	category = CAT_MACHINE
 
 /datum/design/research/circuit/repair_station
 	name = "cyborg auto-repair platform"
 	build_path = /obj/item/weapon/circuitboard/repair_station
-	sort_string = "HACAE"
 	category = CAT_MACHINE
 
 /datum/design/research/circuit/recharge_station
 	name = "cyborg recharge station"
 	build_path = /obj/item/weapon/circuitboard/recharge_station
-	sort_string = "HACAC"
 	category = CAT_MACHINE
 
 /datum/design/research/circuit/recharger
 	name = "recharger"
 	build_path = /obj/item/weapon/circuitboard/recharger
-	sort_string = "HACAD"
 	category = CAT_POWER
 
 /datum/design/research/circuit/atmosalerts
 	name = "atmosphere alert console"
 	build_path = /obj/item/weapon/circuitboard/atmos_alert
-	sort_string = "JAAAA"
 	category = CAT_COMP
 
 /datum/design/research/circuit/air_management
 	name = "atmosphere monitoring console"
 	build_path = /obj/item/weapon/circuitboard/air_management
-	sort_string = "JAAAB"
 	category = CAT_COMP
 
 /datum/design/research/circuit/dronecontrol
 	name = "drone control console"
 	build_path = /obj/item/weapon/circuitboard/drone_control
-	sort_string = "JAAAD"
 	category = CAT_COMP
 
 /datum/design/research/circuit/powermonitor
 	name = "power monitoring console"
 	build_path = /obj/item/weapon/circuitboard/powermonitor
-	sort_string = "JAAAE"
 	category = CAT_COMP
 
 /datum/design/research/circuit/solarcontrol
 	name = "solar control console"
 	build_path = /obj/item/weapon/circuitboard/solar_control
-	sort_string = "JAAAF"
 	category = CAT_COMP
 
 /datum/design/research/circuit/pacman
 	name = "PACMAN-type generator"
 	build_path = /obj/item/weapon/circuitboard/pacman
-	sort_string = "JBAAA"
 	category = CAT_POWER
 
 /datum/design/research/circuit/superpacman
 	name = "SUPERPACMAN-type generator"
 	build_path = /obj/item/weapon/circuitboard/pacman/super
-	sort_string = "JBAAB"
 	category = CAT_POWER
 
 /datum/design/research/circuit/mrspacman
 	name = "MRSPACMAN-type generator"
 	build_path = /obj/item/weapon/circuitboard/pacman/mrs
-	sort_string = "JBAAC"
+	category = CAT_POWER
+
+/datum/design/research/circuit/miss
+	name = "MISS-PACMAN-type generator"
+	build_path = /obj/item/weapon/circuitboard/pacman/miss
+	category = CAT_POWER
+
+/datum/design/research/circuit/camp
+	name = "CAMP-PACMAN-type generator"
+	build_path = /obj/item/weapon/circuitboard/pacman/camp
+	category = CAT_POWER
+
+/datum/design/research/circuit/diesel
+	name = "diesel-type generator"
+	build_path = /obj/item/weapon/circuitboard/diesel
 	category = CAT_POWER
 
 /datum/design/research/circuit/batteryrack
 	name = "cell rack PSU"
 	build_path = /obj/item/weapon/circuitboard/batteryrack
-	sort_string = "JBABA"
 	category = CAT_POWER
 
 /datum/design/research/circuit/smes_cell
 	name = "'SMES' superconductive magnetic energy storage"
 	desc = "Allows for the construction of circuit boards used to build a SMES."
 	build_path = /obj/item/weapon/circuitboard/smes
-	sort_string = "JBABB"
 	category = CAT_POWER
 
 /datum/design/research/circuit/breakerbox
 	name = "breaker box"
 	build_path = /obj/item/weapon/circuitboard/breakerbox
-	sort_string = "JBABC"
 	category = CAT_POWER
 
 /datum/design/research/circuit/gas_heater
 	name = "gas heating system"
 	build_path = /obj/item/weapon/circuitboard/unary_atmos/heater
-	sort_string = "JCAAA"
 	category = CAT_MACHINE
 
 /datum/design/research/circuit/gas_cooler
 	name = "gas cooling system"
 	build_path = /obj/item/weapon/circuitboard/unary_atmos/cooler
-	sort_string = "JCAAB"
 	category = CAT_MACHINE
 
 /datum/design/research/circuit/secure_airlock
 	name = "secure airlock electronics"
 	desc =  "Allows for the construction of a tamper-resistant airlock electronics."
 	build_path = /obj/item/weapon/airlock_electronics/secure
-	sort_string = "JDAAA"
 	category = CAT_MISC
 
 /datum/design/research/circuit/ordercomp
 	name = "supply ordering console"
 	build_path = /obj/item/weapon/circuitboard/ordercomp
-	sort_string = "KAAAA"
 	category = CAT_COMP
 
 /datum/design/research/circuit/supplycomp
 	name = "supply control console"
 	build_path = /obj/item/weapon/circuitboard/supplycomp
-	sort_string = "KAAAB"
 	category = CAT_COMP
 
 /datum/design/research/circuit/biogenerator
 	name = "biogenerator"
 	build_path = /obj/item/weapon/circuitboard/biogenerator
-	sort_string = "KBAAA"
 	category = CAT_MACHINE
 
 /datum/design/research/circuit/miningdrill
 	name = "mining drill head"
 	build_path = /obj/item/weapon/circuitboard/miningdrill
-	sort_string = "KCAAA"
 	category = CAT_MINING
 
 /datum/design/research/circuit/miningdrillbrace
 	name = "mining drill brace"
 	build_path = /obj/item/weapon/circuitboard/miningdrillbrace
-	sort_string = "KCAAB"
 	category = CAT_MINING
 
 /datum/design/research/circuit/comconsole
 	name = "communications console"
 	build_path = /obj/item/weapon/circuitboard/communications
-	sort_string = "LAAAA"
 	category = CAT_COMP
-
 
 // Telecomms
 /datum/design/research/circuit/tcom
@@ -352,42 +314,34 @@
 /datum/design/research/circuit/tcom/server
 	name = "server mainframe"
 	build_path = /obj/item/weapon/circuitboard/telecomms/server
-	sort_string = "PAAAA"
 
 /datum/design/research/circuit/tcom/processor
 	name = "processor unit"
 	build_path = /obj/item/weapon/circuitboard/telecomms/processor
-	sort_string = "PAAAB"
 
 /datum/design/research/circuit/tcom/bus
 	name = "bus mainframe"
 	build_path = /obj/item/weapon/circuitboard/telecomms/bus
-	sort_string = "PAAAC"
 
 /datum/design/research/circuit/tcom/hub
 	name = "hub mainframe"
 	build_path = /obj/item/weapon/circuitboard/telecomms/hub
-	sort_string = "PAAAD"
 
 /datum/design/research/circuit/tcom/relay
 	name = "relay mainframe"
 	build_path = /obj/item/weapon/circuitboard/telecomms/relay
-	sort_string = "PAAAE"
 
 /datum/design/research/circuit/tcom/broadcaster
 	name = "subspace broadcaster"
 	build_path = /obj/item/weapon/circuitboard/telecomms/broadcaster
-	sort_string = "PAAAF"
 
 /datum/design/research/circuit/tcom/receiver
 	name = "subspace receiver"
 	build_path = /obj/item/weapon/circuitboard/telecomms/receiver
-	sort_string = "PAAAG"
 
 /datum/design/research/circuit/ntnet_relay
 	name = "NTNet Quantum Relay"
 	build_path = /obj/item/weapon/circuitboard/ntnet_relay
-	sort_string = "WAAAA"
 	category = CAT_TCOM
 
 // Shield Generators
@@ -398,13 +352,12 @@
 /datum/design/research/circuit/shield/hull
 	name = "hull"
 	build_path = /obj/item/weapon/circuitboard/shield_generator
-	sort_string = "VAAAB"
 /*
 /datum/design/research/circuit/shield/capacitor
 	name = "capacitor"
 	desc = "Allows for the construction of a shield capacitor circuit board."
 	build_path = /obj/item/weapon/circuitboard/shield_cap
-	sort_string = "VAAAC"*/
+*/
 
 //BS
 /datum/design/research/circuit/telesci/console
@@ -422,38 +375,37 @@
 /datum/design/research/circuit/bssilk/console
 	name = "Bluespace Snare Control Console"
 	build_path = /obj/item/weapon/circuitboard/bssilk_cons
-	sort_string = "VAAAK"
 	category = CAT_BLUE
 
 /datum/design/research/circuit/bssilk/hub
 	name = "Bluespace Snare Hub"
 	build_path = /obj/item/weapon/circuitboard/bssilk_hub
-	sort_string = "VAAAG"
 	category = CAT_BLUE
 
 //Experimental devices
 /datum/design/research/circuit/mindswapper
 	name = "experimental mind swapper"
 	build_path = /obj/item/weapon/circuitboard/mindswapper
-	sort_string = "WAAAA"
 	category = CAT_MACHINE
 
 //Industeral Printing
 
+/datum/design/research/circuit/industrial_chems
+	name = "Industrial Chem Dispenser"
+	build_path = /obj/item/weapon/circuitboard/industrial_grinder
+	category = CAT_MACHINE
+
 /datum/design/research/circuit/industrial_printer
 	name = "Industrial Printer"
 	build_path = /obj/item/weapon/circuitboard/autolathe_industrial
-	sort_string = "VAAAI"
 	category = CAT_MACHINE
 
 /datum/design/research/circuit/recharger_industrial
 	name = "Industrial Recharger"
 	build_path = /obj/item/weapon/circuitboard/recharger/industrial
-	sort_string = "VAAAJ"
 	category = CAT_POWER
 
 /datum/design/research/circuit/industrial_grinder
 	name = "Industrial Grinder"
 	build_path = /obj/item/weapon/circuitboard/industrial_grinder
-	sort_string = "VAAAK"
 	category = CAT_MACHINE

--- a/code/modules/research/designs/structures.dm
+++ b/code/modules/research/designs/structures.dm
@@ -18,3 +18,11 @@
 	build_path = /obj/structure/reagent_dispensers/bidon/advanced
 	category = "Medical"
 	materials = list(MATERIAL_STEEL = 25, MATERIAL_GLASS = 15)
+
+/datum/design/research/structure/solar
+	name = "solar assembly"
+	desc = "Simple but hard to produce solar assembly."
+	build_path = /obj/item/solar_assembly
+	build_type = AUTOLATHE
+	category = CAT_POWER
+	materials = list(MATERIAL_STEEL = 5, MATERIAL_GLASS = 5)

--- a/code/modules/research/nodes/engineering.dm
+++ b/code/modules/research/nodes/engineering.dm
@@ -367,7 +367,8 @@
 	required_tech_levels = list()
 	cost = 1000
 
-	unlocks_designs = list(/datum/design/research/item/part/high_micro_laser, /datum/design/research/item/part/adv_matter_bin)
+	unlocks_designs = list(/datum/design/research/item/part/high_micro_laser,
+							/datum/design/research/item/part/adv_matter_bin)
 
 /datum/technology/ultra_parts
 	name = "Super Parts"
@@ -382,7 +383,9 @@
 	required_tech_levels = list()
 	cost = 2000
 
-	unlocks_designs = list(/datum/design/research/item/part/ultra_micro_laser, /datum/design/research/item/part/super_matter_bin, /datum/design/research/item/medical/nanopaste)
+	unlocks_designs = list(/datum/design/research/item/part/ultra_micro_laser,
+						/datum/design/research/item/part/super_matter_bin,
+						/datum/design/research/item/medical/nanopaste)
 
 /datum/technology/super_adv_engineering
 	name = "Progressive Engineering"
@@ -397,7 +400,9 @@
 	required_tech_levels = list()
 	cost = 1500
 
-	unlocks_designs = list(/datum/design/research/item/part/RPED, /datum/design/research/circuit/secure_airlock, /datum/design/research/item/part/RPED/mini)
+	unlocks_designs = list(/datum/design/research/item/part/RPED,
+							 /datum/design/research/circuit/secure_airlock,
+							 /datum/design/research/item/part/RPED/mini)
 
 /datum/technology/industrial_printing
 	name = "Industrial Printing"
@@ -414,7 +419,8 @@
 
 	unlocks_designs = list(/datum/design/research/circuit/industrial_printer,
 							/datum/design/research/circuit/recharger_industrial,
-							/datum/design/research/circuit/industrial_grinder
+							/datum/design/research/circuit/industrial_grinder,
+							/datum/design/research/circuit/industrial_chems
 							)
 
 

--- a/code/modules/research/nodes/power.dm
+++ b/code/modules/research/nodes/power.dm
@@ -106,6 +106,7 @@
 	cost = 400
 
 	unlocks_designs = list(	/datum/design/research/circuit/solarcontrol,
+							/datum/design/research/circuit/camp,
 							/datum/design/research/circuit/pacman
 						)
 
@@ -122,7 +123,8 @@
 	required_tech_levels = list()
 	cost = 600
 
-	unlocks_designs = list(/datum/design/research/circuit/superpacman)
+	unlocks_designs = list(/datum/design/research/circuit/superpacman,
+							/datum/design/research/circuit/diesel)
 
 /datum/technology/advanced_power_generation
 	name = "Basic Fusion Power"
@@ -141,7 +143,7 @@
 
 /datum/technology/fusion_power_generation
 	name = "Fusion Power Generation"//"R-UST Mk. 8"
-	desc = "R-UST Tokamak MK 8"//"R-UST Mk. 8"
+	desc = "Using and harvesting fussion levels of power."//"R-UST Mk. 8" - get on that?
 	tech_type = RESEARCH_POWERSTORAGE
 
 	x = 0.6
@@ -149,7 +151,8 @@
 	icon = "rignuclearreactor"//"fusion"
 
 	required_technologies = list(/datum/technology/advanced_power_generation)
-	required_tech_levels = list()
+	required_tech_levels = list(/datum/design/research/circuit/miss,
+								/datum/design/research/structure/solar)
 	cost = 2000//5000
 
 	unlocks_designs = list()//"fusion_core_control", "fusion_fuel_compressor", "fusion_fuel_control", "gyrotron_control", "fusion_core", "fusion_injector", "gyrotron")

--- a/code/modules/scrap/scrap_burner.dm
+++ b/code/modules/scrap/scrap_burner.dm
@@ -1,17 +1,17 @@
 /obj/item/weapon/circuitboard/pacman/scrap
-	build_name = "PACMAN-type generator"
+	build_name = "S.C.R.A.P PACMAN-type generator"
 	build_path = /obj/machinery/power/port_gen/pacman/scrap
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 3, TECH_PLASMA = 3, TECH_ENGINEERING = 3)
 
 /datum/design/research/circuit/pacman/scrap
-	name = "PACMAN-type generator"
+	name = "S.C.R.A.P PACMAN-type generator"
 	build_path = /obj/item/weapon/circuitboard/pacman/scrap
-	sort_string = "JBAAD"
-	starts_unlocked = TRUE // i don't even know what this scrap pacman thing is supposed to be
+	starts_unlocked = TRUE //We want to be able to make these
 
 /obj/machinery/power/port_gen/pacman/scrap
 	name = "S.C.R.A.P.M.A.N portable generator"
+	desc = "An oldfashen power generator that runs on refined scrap. Rated for 80 kW maximum safe output!"
 	icon_state = "portgen1"                 // Get a spriter to do something with this perhaps.
 	sheet_name = "refined scrap"
 	sheet_path = /obj/item/stack/sheet/refined_scrap


### PR DESCRIPTION

## About The Pull Request
Solars can now be upgraded with glass, each glass type thats more exspestive then the last will give more power and have more health!
Guild techs now have a disk that allows them to make more SMES, coils and pacmans
2 new pacman types Wood based CAMPER(Its funny shut up) Miss uses diamonds(A girls best friend!)
RnD can now make industeral chem dispensers - as well as these new pacmans + diesel ones
diesel generator now has normal stock parts
Maybe fixes a bug with upgrading pacmans to properly state how much power they make
Makes SCRAPMAN pacman ya know... named correctly and tell you the correct fuel type...

## Changelog
:cl:
/:cl:
