### PR TITLE
Fix relay chat not letting held and non-held computers communicate

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -71,7 +71,8 @@
 		var/channel_title = sanitizeSafe(input(user,"Enter channel name or leave blank to cancel:") as text|null, 64)
 		if(!channel_title)
 			return
-		var/datum/ntnet_conversation/C = new/datum/ntnet_conversation(computer.z)
+		var/turf/computer_turf = get_turf(computer)
+		var/datum/ntnet_conversation/C = new/datum/ntnet_conversation(computer_turf.z)
 		C.add_client(src)
 		C.operator = src
 		channel = C
@@ -164,8 +165,8 @@
 /datum/computer_file/program/chatclient/process_tick()
 
 	..()
-
-	if(channel && !(channel.source_z in GetConnectedZlevels(computer.z)))
+	var/turf/computer_turf = get_turf(computer)
+	if(channel && !(channel.source_z in GetConnectedZlevels(computer_turf.z)))
 		channel.remove_client(src)
 		channel = null
 
@@ -224,7 +225,8 @@
 
 	else // Channel selection screen
 		var/list/all_channels[0]
-		var/list/connected_zs = GetConnectedZlevels(C.computer.z)
+		var/turf/computer_turf = get_turf(C.computer)
+		var/list/connected_zs = GetConnectedZlevels(computer_turf.z)
 		for(var/datum/ntnet_conversation/conv in ntnet_global.chat_channels)
 			if(conv && conv.title && (conv.source_z in connected_zs))
 				all_channels.Add(list(list(

--- a/html/changelogs/MeghanRossi-RelayChatFix.yml
+++ b/html/changelogs/MeghanRossi-RelayChatFix.yml
@@ -1,0 +1,4 @@
+author: Meghan Rossi
+delete-after: True
+changes: 
+  - bugfix: "Fixed a bug where computers and pdas held in a person's hand or inventory slots couldn't see relay chat channels created by computers and pdas lying on the ground and vice versa."


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
This fixes a bug where computers and pdas held in a person's hand or inventory slots couldn't see relay chat channels created by computers and pdas lying on the ground and vice versa.
</summary>
</details>

## Changelog
:cl:
fix: Fixed a bug where computers and pdas held in a person's hand or inventory slots couldn't see relay chat channels created by computers and pdas lying on the ground and vice versa.
/:cl:
