### PR TITLE
Internal organs are edible.

### DIFF
--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -96,3 +96,28 @@
 		conditions_list.Add(list(condition))
 
 	return conditions_list
+
+// Organ eating
+/obj/item/organ/internal/proc/prepare_eat()
+	if(BP_IS_ROBOTIC(src))
+		return // No eating cybernetic implants!
+	var/obj/item/weapon/reagent_containers/food/snacks/organ/S = new
+	S.name = name
+	S.desc = desc
+	S.icon = icon
+	S.icon_state = icon_state
+	S.w_class = w_class
+
+	return S
+
+/obj/item/organ/internal/attack(mob/living/carbon/M, mob/user)
+	if(M == user && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/obj/item/weapon/reagent_containers/food/snacks/S = prepare_eat()
+		if(S)
+			H.drop_item()
+			H.put_in_active_hand(S)
+			S.attack(H, H)
+			qdel(src)
+	else
+		..()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3050,3 +3050,11 @@
 	nutriment_desc = list("bread" = 2, "sweetness" = 3)
 	nutriment_amt = 6
 
+/obj/item/weapon/reagent_containers/food/snacks/organ
+	name = "organ"
+	desc = "Technically qualifies as organic."
+	icon = 'icons/obj/surgery.dmi'
+	icon_state = "appendix"
+	filling_color = "#E00D34"
+	bitesize = 3
+	nutriment_amt = 5


### PR DESCRIPTION
## About The Pull Request
Another request from SynthNumeric.

![edibleOrgans](https://user-images.githubusercontent.com/47765135/94374722-39f38d80-00dc-11eb-96bb-e660fdf934f0.png)

Internal organs can be consumed. Weird, but okay.
Double checked to made sure it doesn't break surgery. Once a bite is taken out of the item, it can't be used for surgery anymore.

![surgeryWorks](https://user-images.githubusercontent.com/47765135/94374763-66a7a500-00dc-11eb-8dd5-4fc764064dda.png)


## Changelog
:cl:
add: Internal organs can now be eaten.
/:cl: