### PR TITLE
Fixes a runtime in tools.dm

### DIFF
--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -647,12 +647,13 @@
 	if(!(L.len))	//If the tool has none of the required qualities, the list is empty and thus we exit out of the proc
 		return
 
-	if(L.len > 1)
-		for(var/i in L)
-			L[i] = image(icon = 'icons/mob/radial/tools.dmi', icon_state = i)
-		return show_radial_menu(user, use_on ? use_on : user, L, tooltips = TRUE, require_near = TRUE, custom_check = CB)
-	else
+	if(L.len == 1)
 		return L[1]
+
+	for(var/i in L)
+		L[i] = image(icon = 'icons/mob/radial/tools.dmi', icon_state = i)
+	return show_radial_menu(user, use_on ? use_on : user, L, tooltips = TRUE, require_near = TRUE, custom_check = CB)
+
 
 /obj/item/weapon/tool/proc/turn_on(var/mob/user)
 	if(use_power_cost)

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -644,6 +644,9 @@
 
 	var/list/L = required_qualities & tool_qualities
 
+	if(!(L.len))	//If the tool has none of the required qualities, the list is empty and thus we exit out of the proc
+		return
+
 	if(L.len > 1)
 		for(var/i in L)
 			L[i] = image(icon = 'icons/mob/radial/tools.dmi', icon_state = i)


### PR DESCRIPTION
## About The Pull Request

Fixes a runtime in _tools.dm that was caused by an empty list in get_tool_type().
This means for one that machetes can now hack apart a locker to get steel.

## Why Is It Good For The Game

Fixed a runtime - always good. Made a feature work again - quite good as well.