### PR TITLE
flame changes to spider stuff and mobs

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -48,8 +48,12 @@
 
 
 /obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel
+	name = "plasma mist"
+	desc = "A small, low mist of the blue gas..."
 	icon_state = "mustard"
+	alpha = 150 //Less seeable
 	anchored = 0
+	color = "#9D14DB" // RGB (157, 20, 219)
 	var/turf/origin
 
 /obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel/New(newLoc, _amount = 1, d = 0, var/turf/_origin)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -45,7 +45,7 @@
 		qdel(src)
 
 /obj/effect/spider/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(exposed_temperature > 300 + T0C)
+	if(exposed_temperature > T0C + 50) //Weak to fire, windows take T0C + 100.
 		health -= 5
 		healthCheck()
 
@@ -56,6 +56,11 @@
 		if(prob(50))
 			icon_state = "stickyweb2"
 		..()
+
+/obj/effect/spider/stickyweb/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(exposed_temperature > T0C + 25) //Webs are even weaker to fire
+		health -= 5
+		healthCheck()
 
 /obj/effect/spider/stickyweb/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0)) return 1

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -29,7 +29,6 @@
 
 	return ..()
 
-
 /obj/item/weapon/flamethrower/Process()
 	if(ptank.air_contents.gas["plasma"] < 1)
 		lit = FALSE
@@ -46,7 +45,6 @@
 	if(isturf(location)) //start a fire if possible
 		location.hotspot_expose(700, 2)
 	return
-
 
 /obj/item/weapon/flamethrower/update_icon()
 	cut_overlays()
@@ -83,7 +81,6 @@
 	..()
 	return
 
-
 /obj/item/weapon/flamethrower/attack_self(mob/user as mob)
 	if(user.stat || user.restrained() || user.lying)	return
 	user.set_machine(src)
@@ -91,7 +88,6 @@
 	user << browse(dat, "window=flamethrower;size=340x160")
 	onclose(user, "flamethrower")
 	return
-
 
 /obj/item/weapon/flamethrower/Topic(href,href_list[])
 	if(href_list["close"])
@@ -130,7 +126,6 @@
 	update_icon()
 	return
 
-
 //Called from turf.dm turf/dblclick
 /obj/item/weapon/flamethrower/proc/flame_turf(var/list/turflist)
 	if(!lit || operating)	return
@@ -151,7 +146,6 @@
 		if((M.client && M.machine == src))
 			attack_self(M)
 	return
-
 
 /obj/item/weapon/flamethrower/proc/ignite_turf(turf/target)
 	//TODO: DEFERRED Consider checking to make sure tank pressure is high enough before doing this...

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -353,6 +353,11 @@
 
 	if (thermal_protection < 1 && bodytemperature < burn_temperature)
 		bodytemperature += round(BODYTEMP_HEATING_MAX*(1-thermal_protection), 1)
+	if(stat == DEAD)
+		spawn(900)//how much time it takes to dust a corpse, in tenths of second
+		//90 seconds || 1min 30seconds
+		if(stat == DEAD) //Double check were not dusting something that has been revived
+			dust()
 
 /mob/living/carbon/superior_animal/update_fire()
 	cut_overlay(image("icon"='icons/mob/OnFire.dmi', "icon_state"="Standing"))


### PR DESCRIPTION
## About The Pull Request
if a superior animal mob is dead for 90 seconds and on fire, they will dust.
spider based things now only need 50~c to take harm
spider cobwebs now only need around 25c to take damage
flamer fule no longer calls itself "welding fuel" but plasma mist, looks more blue and is harder to see (for traps)

## Changelog
:cl:
/:cl: