### PR TITLE
Implementing Backstabbing

### DIFF
--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -113,6 +113,18 @@
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	slot_flags = SLOT_BELT
 	structure_damage_factor = STRUCTURE_DAMAGE_BLADE
+	var/backstab_damage = 8
+
+/obj/item/weapon/tool/knife/resolve_attackby(atom/target, mob/user)
+	..()
+	if(iscarbon(target) && get_turf(target) == get_step(user, user.dir) && target.stat!=2 && user.dir == target.dir) //Detect that we're attacking a carbon target, that we're behind it as well.
+		var/mob/living/carbon/M = target
+		M.apply_damages(backstab_damage,0,0,0,0,0,user.targeted_organ)
+		visible_message("<span class='danger'>[user] backstabs [target] with [src]!</span>")
+		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been backstabbed by [user.name] ([user.ckey])</font>")
+		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Backstabbed [M.name] ([M.ckey])</font>")
+	//Uses regular call to deal damage
+	//Is affected by mob armor*
 
 /obj/item/weapon/tool/knife/boot
 	name = "boot knife"
@@ -122,6 +134,7 @@
 	item_state = "knife"
 	matter = list(MATERIAL_PLASTEEL = 2, MATERIAL_PLASTIC = 1)
 	force = WEAPON_FORCE_PAINFUL
+	backstab_damage = 12
 	tool_qualities = list(QUALITY_CUTTING = 20,  QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 15)
 
 /obj/item/weapon/tool/knife/hook
@@ -131,6 +144,7 @@
 	item_state = "hook_knife"
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 2)
 	force = WEAPON_FORCE_DANGEROUS
+	backstab_damage = 6
 	armor_penetration = ARMOR_PEN_EXTREME //Should be countered be embedding
 	embed_mult = 1.5 //This is designed for embedding
 
@@ -140,6 +154,7 @@
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "render"
 	force = WEAPON_FORCE_PAINFUL
+	backstab_damage = 12
 
 /obj/item/weapon/tool/knife/butch
 	name = "butcher's cleaver"
@@ -147,6 +162,7 @@
 	desc = "A huge thing used for chopping and chopping up meat. This includes roaches and roach-by-products."
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_NORMAL
+	backstab_damage = 6
 	armor_penetration = ARMOR_PEN_MODERATE
 	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	matter = list(MATERIAL_STEEL = 5, MATERIAL_PLASTIC = 1)
@@ -168,6 +184,7 @@
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "tacknife_guard"
 	item_state = "knife"
+	backstab_damage = 12
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2)
 	force = WEAPON_FORCE_PAINFUL
 	tool_qualities = list(QUALITY_CUTTING = 20,  QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 5,  QUALITY_SAWING = 5)
@@ -182,6 +199,7 @@
 	item_state = "dagger"
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2)
 	force = WEAPON_FORCE_NORMAL
+	backstab_damage = 15
 	armor_penetration = ARMOR_PEN_DEEP
 
 /obj/item/weapon/tool/knife/dagger/ceremonial
@@ -203,6 +221,7 @@
 	toggleable = TRUE
 	use_power_cost = 0.4
 	passive_power_cost = 0.4
+	backstab_damage = 6
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2, TECH_BLUESPACE = 4)
 	var/mob/living/embedded
 	var/last_teleport


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Implementing backstabbing. Building upon what was initially discussed with Lily. We use the method resolve_attackby to test whether we're stabbing from behind and stabbing a living carbon thing. If we do, we add some more damage via a regular call to apply_damages and write to the admin attack log for logging purposes. 

Damage numbers are subject to change. Can be changed with the changing of numbers. 

Was tested on my own server. 

An unintended effect is that if the target stumbles (is moved around) by the attack, which it has a chance to do so, the backstab will fail because the target no longer meets the requirements. Initially unintended, this actually works well in-character, as it gives a chance of failure to do the backstab damage with the explanation that your attack pushed them aside rather than digging in deep.

You could implement a check for stumbling, but that over-complicates things. 
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
