### PR TITLE
Admin Add and Remove Perks

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -555,6 +555,26 @@ ADMIN_VERB_ADD(/client/proc/man_up, R_ADMIN, FALSE)
 	log_admin("[key_name(usr)] told [key_name(T)] to man up and deal with it.")
 	message_admins("\blue [key_name_admin(usr)] told [key_name(T)] to man up and deal with it.", 1)
 
+ADMIN_VERB_ADD(/client/proc/perkadd, R_ADMIN, FALSE)
+/client/proc/perkadd(mob/T as mob in SSmobs.mob_list)
+	set category = "Fun"
+	set name = "Add Perk"
+	set desc = "Add a perk to a person."
+	var/perkname = input("What perk do you want to add?")
+	T.stats.addPerk("/datum/perk/[perkname]")
+	T.stats.addPerk("/datum/perk/oddity/[perkname]")
+	message_admins("\blue [key_name_admin(usr)] gave the perk [perkname] to [key_name(T)].", 1)
+
+ADMIN_VERB_ADD(/client/proc/perkremove, R_ADMIN, FALSE)
+/client/proc/perkremove(mob/T as mob in SSmobs.mob_list)
+	set category = "Fun"
+	set name = "Remove Perk"
+	set desc = "Remove a perk from a person."
+	var/perkname = input("What perk do you want to remove?")
+	T.stats.removePerk("/datum/perk/[perkname]")
+	T.stats.removePerk("/datum/perk/oddity/[perkname]")
+	message_admins("\blue [key_name_admin(usr)] removed the perk [perkname] from [key_name(T)].", 1)
+
 ADMIN_VERB_ADD(/client/proc/global_man_up, R_ADMIN, FALSE)
 /client/proc/global_man_up()
 	set category = "Fun"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -560,7 +560,12 @@ ADMIN_VERB_ADD(/client/proc/perkadd, R_ADMIN, FALSE)
 	set category = "Fun"
 	set name = "Add Perk"
 	set desc = "Add a perk to a person."
-	var/datum/perk/perkname = input("What perk do you want to add?") in subtypesof(/datum/perk/)
+	var/datum/perk/perkname = input("What perk do you want to add?") as null|anything in subtypesof(/datum/perk/)
+	if (!perkname)
+		return
+	if(QDELETED(T))
+		to_chat(usr, "Creature has been delete in the meantime.")
+		return
 	T.stats.addPerk(perkname)
 	message_admins("\blue [key_name_admin(usr)] gave the perk [perkname] to [key_name(T)].", 1)
 
@@ -572,7 +577,12 @@ ADMIN_VERB_ADD(/client/proc/perkremove, R_ADMIN, FALSE)
 	if (T.stats.perks.len ==0)
 		to_chat(usr, "Creature has no perks to remove")
 		return
-	var/datum/perk/perkname = input("What perk do you want to remove?") in T.stats.perks
+	var/datum/perk/perkname = input("What perk do you want to remove?") as null|anything in T.stats.perks
+	if (!perkname)
+		return
+	if(QDELETED(T))
+		to_chat(usr, "Creature has been delete in the meantime.")
+		return
 	T.stats.removePerk(perkname.type)
 	message_admins("\blue [key_name_admin(usr)] removed the perk [perkname] from [key_name(T)].", 1)
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -560,9 +560,8 @@ ADMIN_VERB_ADD(/client/proc/perkadd, R_ADMIN, FALSE)
 	set category = "Fun"
 	set name = "Add Perk"
 	set desc = "Add a perk to a person."
-	var/perkname = input("What perk do you want to add?")
-	T.stats.addPerk("/datum/perk/[perkname]")
-	T.stats.addPerk("/datum/perk/oddity/[perkname]")
+	var/datum/perk/perkname = input("What perk do you want to add?") in subtypesof(/datum/perk/)
+	T.stats.addPerk(perkname)
 	message_admins("\blue [key_name_admin(usr)] gave the perk [perkname] to [key_name(T)].", 1)
 
 ADMIN_VERB_ADD(/client/proc/perkremove, R_ADMIN, FALSE)
@@ -570,9 +569,11 @@ ADMIN_VERB_ADD(/client/proc/perkremove, R_ADMIN, FALSE)
 	set category = "Fun"
 	set name = "Remove Perk"
 	set desc = "Remove a perk from a person."
-	var/perkname = input("What perk do you want to remove?")
-	T.stats.removePerk("/datum/perk/[perkname]")
-	T.stats.removePerk("/datum/perk/oddity/[perkname]")
+	if (T.stats.perks.len ==0)
+		to_chat(usr, "Creature has no perks to remove")
+		return
+	var/datum/perk/perkname = input("What perk do you want to remove?") in T.stats.perks
+	T.stats.removePerk(perkname.type)
 	message_admins("\blue [key_name_admin(usr)] removed the perk [perkname] from [key_name(T)].", 1)
 
 ADMIN_VERB_ADD(/client/proc/global_man_up, R_ADMIN, FALSE)

--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -53,6 +53,8 @@
 		<option value='?_src_=vars;drop_everything=\ref[src]'>Drop Everything</option>
 
 		<option value='?_src_=vars;regenerateicons=\ref[src]'>Regenerate Icons</option>
+		<option value='?_src_=vars;perkadd=\ref[src]'>Add Perk</option>
+		<option value='?_src_=vars;perkremove=\ref[src]'>Remove Perk</option>
 		<option value='?_src_=vars;addlanguage=\ref[src]'>Add Language</option>
 		<option value='?_src_=vars;remlanguage=\ref[src]'>Remove Language</option>
 		<option value='?_src_=vars;addorgan=\ref[src]'>Add Organ</option>

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -236,9 +236,8 @@
 		if(!istype(S))
 			to_chat(usr, "This can only be done to instances of type /mob")
 			return
-		var/perkname = input("What perk do you want to add?")
-		S.stats.addPerk("/datum/perk/[perkname]")
-		S.stats.addPerk("/datum/perk/oddity/[perkname]")
+		var/datum/perk/perkname = input("What perk do you want to add?") in subtypesof(/datum/perk/)
+		S.stats.addPerk(perkname)
 		message_admins("\blue [key_name_admin(usr)] gave the perk [perkname] to [key_name(S)].", 1)
 		href_list["datumrefresh"] = href_list["perkadd"]
 
@@ -249,9 +248,11 @@
 		if(!istype(S))
 			to_chat(usr, "This can only be done to instances of type /mob")
 			return
-		var/perkname = input("What perk do you want to remove?")
-		S.stats.removePerk("/datum/perk/[perkname]")
-		S.stats.removePerk("/datum/perk/oddity/[perkname]")
+		if (S.stats.perks.len ==0)
+			to_chat(usr, "Creature has no perks to remove")
+			return
+		var/datum/perk/perkname = input("What perk do you want to remove?") in S.stats.perks
+		S.stats.removePerk(perkname.type)
 		message_admins("\blue [key_name_admin(usr)] removed the perk [perkname] from [key_name(S)].", 1)
 		href_list["datumrefresh"] = href_list["perkremove"]
 

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -236,7 +236,12 @@
 		if(!istype(S))
 			to_chat(usr, "This can only be done to instances of type /mob")
 			return
-		var/datum/perk/perkname = input("What perk do you want to add?") in subtypesof(/datum/perk/)
+		var/datum/perk/perkname = input("What perk do you want to add?") as null|anything in subtypesof(/datum/perk/)
+		if (!perkname)
+			return
+		if(QDELETED(S))
+			to_chat(usr, "Creature has been delete in the meantime.")
+			return
 		S.stats.addPerk(perkname)
 		message_admins("\blue [key_name_admin(usr)] gave the perk [perkname] to [key_name(S)].", 1)
 		href_list["datumrefresh"] = href_list["perkadd"]
@@ -251,7 +256,12 @@
 		if (S.stats.perks.len ==0)
 			to_chat(usr, "Creature has no perks to remove")
 			return
-		var/datum/perk/perkname = input("What perk do you want to remove?") in S.stats.perks
+		var/datum/perk/perkname = input("What perk do you want to remove?") as null|anything in S.stats.perks
+		if (!perkname)
+			return
+		if(QDELETED(S))
+			to_chat(usr, "Creature has been delete in the meantime.")
+			return
 		S.stats.removePerk(perkname.type)
 		message_admins("\blue [key_name_admin(usr)] removed the perk [perkname] from [key_name(S)].", 1)
 		href_list["datumrefresh"] = href_list["perkremove"]

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -229,6 +229,32 @@
 		src.holder.marked_datum_weak = weakref(D)
 		href_list["datumrefresh"] = href_list["mark_object"]
 
+	else if(href_list["perkadd"])
+		if(!check_rights(0))
+			return
+		var/mob/S = locate (href_list["perkadd"])
+		if(!istype(S))
+			to_chat(usr, "This can only be done to instances of type /mob")
+			return
+		var/perkname = input("What perk do you want to add?")
+		S.stats.addPerk("/datum/perk/[perkname]")
+		S.stats.addPerk("/datum/perk/oddity/[perkname]")
+		message_admins("\blue [key_name_admin(usr)] gave the perk [perkname] to [key_name(S)].", 1)
+		href_list["datumrefresh"] = href_list["perkadd"]
+
+	else if(href_list["perkremove"])
+		if(!check_rights(0))
+			return
+		var/mob/S = locate (href_list["perkremove"])
+		if(!istype(S))
+			to_chat(usr, "This can only be done to instances of type /mob")
+			return
+		var/perkname = input("What perk do you want to remove?")
+		S.stats.removePerk("/datum/perk/[perkname]")
+		S.stats.removePerk("/datum/perk/oddity/[perkname]")
+		message_admins("\blue [key_name_admin(usr)] removed the perk [perkname] from [key_name(S)].", 1)
+		href_list["datumrefresh"] = href_list["perkremove"]
+
 	else if(href_list["rotatedatum"])
 		if(!check_rights(0))	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Perk name is inputted manually, has to be the tailend of the path from https://github.com/sojourn-13/sojourn-station/blob/aca66e8cbbc9c32f48237728d838af8e87623db9/code/__DEFINES/perks.dm

So "sharp_mind" would be for the Sharpened Mind perk.

Might implement a list later, but this would require implementation with perks.dm to dynamically react when new perks are added. It's an admin command, doesn't need too much finesse at the moment.

Was tested in my own server, both direct command with Add-Perk and Remove-Perk work as well as using View Variables to add or remove perks. Not the most elegant picking as you have to type the perk name manually, but it'll work with any perk, both oddity and non-oddity ones. 

You're welcome, Kinni.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
