### PR TITLE
Direct Control Hostile Mobs Can Now Shoot

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/big.dm
+++ b/code/modules/mob/living/simple_animal/hostile/big.dm
@@ -23,6 +23,7 @@
 	icon = 'icons/mob/deathclaw.dmi'
 	icon_state = "deathclaw"
 	icon_living = "deathclaw"
+	icon_rest = "deathclaw_sleep"
 	icon_dead = "deathclaw_dead"
 	icon_gib = "deathclaw_gib"
 	speed = 18
@@ -185,6 +186,7 @@
 	icon = 'icons/mob/64x64.dmi'
 	icon_state = "arachnid"
 	icon_living = "arachnid"
+	icon_rest = "arachnid_sleeping"
 	icon_dead = "arachnid_dead"
 	melee_damage_lower = 30
 	melee_damage_upper = 35

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -269,6 +269,11 @@ var/list/mydirs = list(NORTH, SOUTH, EAST, WEST, SOUTHWEST, NORTHWEST, NORTHEAST
 	var/def_zone = get_exposed_defense_zone(target)
 	A.launch(target, def_zone)
 
+/mob/living/simple_animal/MiddleClickOn(mob/targetDD as mob) //Letting Mobs Fire when middle clicking as someone controlling it.
+	var /mob/living/simple_animal/hostile/shooter = src
+	if(shooter.ranged ==1)
+		shooter.OpenFire(targetDD)
+
 /mob/living/simple_animal/hostile/proc/DestroySurroundings()
 	if(istype(src, /mob/living/simple_animal/hostile/megafauna))
 		set_dir(get_dir(src,target_mob))

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -104,6 +104,7 @@
 	ranged = 1
 	rapid = 1
 	minimum_distance = 4
+	projectiletype = /obj/item/projectile/beam
 	weapon1 = /obj/item/weapon/gun/energy/retro
 	weapon2 = null
 


### PR DESCRIPTION
Allows directly controlled mobs to fire their guns by pressing Middle-Click. A mob controlled will trigger its firing routine if it has one.

Known Issue: Greysons Mech will not work properly due to its special attack pattern where it chooses what to do based on a chance. You can still fire, but there is an unpredictability as to which direction and other stuff.

Also fixed minor bug: aero-trooper not firing and two big mobs missing their resting animations.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Allows admins (or anyone else directly controlling a hostile mob with a ranged attack) to fire that attack.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
