### PR TITLE
Map requests

### DIFF
--- a/maps/CEVEris/_Nadezhda_Colony_Underground.dmm
+++ b/maps/CEVEris/_Nadezhda_Colony_Underground.dmm
@@ -13878,6 +13878,8 @@
 "aKe" = (
 /obj/machinery/door/airlock/centcom,
 /obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "aKf" = (
@@ -25156,6 +25158,7 @@
 "bnB" = (
 /obj/random/contraband/low_chance,
 /mob/living/simple_animal/hostile/mimic/crate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "bnC" = (
@@ -53170,15 +53173,27 @@
 /area/nadezhda/crew_quarters/bar)
 "cCl" = (
 /obj/structure/table/marble,
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar";
+	name = "glass shutter"
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/bar)
 "cCm" = (
 /obj/structure/table/marble,
 /obj/item/weapon/storage/fancy/cigarettes,
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar";
+	name = "glass shutter"
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/bar)
 "cCn" = (
 /obj/structure/table/marble,
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar";
+	name = "glass shutter"
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/bar)
 "cCo" = (
@@ -54060,10 +54075,16 @@
 /area/nadezhda/quartermaster/miningdock)
 "cEu" = (
 /obj/machinery/smartfridge/drinks,
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar";
+	name = "glass shutter"
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/bar)
 "cEv" = (
-/obj/machinery/vending/boozeomat,
+/obj/machinery/vending/boozeomat{
+	req_access = list(25)
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/bar)
 "cEw" = (
@@ -54829,6 +54850,12 @@
 /obj/item/weapon/reagent_containers/food/drinks/shaker,
 /obj/machinery/light,
 /obj/structure/table/marble,
+/obj/machinery/button/remote/blast_door{
+	id = "bar";
+	name = "bar access";
+	pixel_y = -28;
+	req_access = list(25)
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/bar)
 "cGq" = (
@@ -55796,6 +55823,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/item/clothing/head/fedora/feathered{
+	pixel_y = 16;
+	pixel_x = -6
+	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/barbackroom)
 "cIJ" = (
@@ -55976,6 +56007,7 @@
 "cJg" = (
 /obj/random/junkfood/rotten/low_chance,
 /obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cJh" = (
@@ -61731,6 +61763,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar";
+	name = "glass shutter"
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/bar)
 "cWN" = (
@@ -62698,10 +62734,13 @@
 /obj/structure/bed/chair/sofa/teal/corner{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZp" = (
 /obj/structure/bed/chair/sofa/teal,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZq" = (
@@ -62709,10 +62748,12 @@
 /obj/machinery/holoposter{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZr" = (
 /obj/machinery/disposal,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZs" = (
@@ -62722,6 +62763,8 @@
 /obj/machinery/atm{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZt" = (
@@ -62729,10 +62772,12 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZu" = (
 /obj/machinery/media/jukebox,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZv" = (
@@ -62745,6 +62790,7 @@
 	pixel_y = 32
 	},
 /obj/item/device/lighting/glowstick/random,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZx" = (
@@ -62752,10 +62798,13 @@
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZy" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZz" = (
 /obj/structure/table/bar_special,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/plushie/spider,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZA" = (
@@ -62779,6 +62828,7 @@
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZD" = (
 /obj/structure/cyberplant,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZE" = (
@@ -62789,9 +62839,12 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZF" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZG" = (
@@ -62802,6 +62855,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZH" = (
@@ -62812,6 +62868,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZI" = (
@@ -62820,6 +62879,10 @@
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZJ" = (
 /obj/item/device/lighting/glowstick/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZK" = (
@@ -62828,6 +62891,7 @@
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZL" = (
 /obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZM" = (
@@ -62843,12 +62907,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZO" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZP" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZQ" = (
@@ -62857,6 +62923,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZR" = (
@@ -62865,6 +62935,10 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZS" = (
@@ -62872,12 +62946,14 @@
 	dir = 4;
 	icon_state = "bar_chair"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZT" = (
 /obj/structure/table/bar_special,
 /obj/machinery/floor_light,
 /obj/item/device/lighting/glowstick/random,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZU" = (
@@ -62888,14 +62964,18 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZV" = (
 /obj/item/weapon/stool/custom/bar_special,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZW" = (
 /obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZX" = (
@@ -62906,19 +62986,23 @@
 "cZY" = (
 /obj/structure/table/bar_special,
 /obj/machinery/floor_light,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "cZZ" = (
 /obj/structure/cyberplant,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "daa" = (
 /obj/structure/table/bar_special,
 /obj/item/device/lighting/glowstick/random,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "dab" = (
 /obj/structure/bed/chair/custom/bar_special,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "dac" = (
@@ -62926,6 +63010,7 @@
 	dir = 8;
 	icon_state = "bar_chair"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "dad" = (
@@ -62936,6 +63021,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "dae" = (
@@ -62957,19 +63043,24 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "dah" = (
-/obj/machinery/vending/boozeomat,
+/obj/machinery/vending/boozeomat{
+	auto_price = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "dai" = (
 /obj/structure/table/bar_special,
 /obj/machinery/chemical_dispenser/beer,
 /obj/machinery/floor_light,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "daj" = (
 /obj/structure/table/bar_special,
 /obj/machinery/chemical_dispenser/soda,
 /obj/machinery/floor_light,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "dak" = (
@@ -64761,6 +64852,7 @@
 "ddY" = (
 /obj/structure/scrap/food,
 /obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "ddZ" = (
@@ -67896,6 +67988,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "dlj" = (
@@ -68066,6 +68159,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "dlD" = (
@@ -83412,6 +83506,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
 /area/derelict/medical/chapel)
+"fjl" = (
+/obj/structure/bed/chair/sofa/teal/left,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "fjD" = (
 /obj/machinery/light_switch{
 	pixel_x = 0;
@@ -83475,6 +83574,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
+"fxP" = (
+/obj/machinery/button/remote/blast_door{
+	id = "bar";
+	name = "bar access";
+	pixel_y = -28;
+	req_access = list(25)
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/crew_quarters/barbackroom)
 "fyj" = (
 /obj/machinery/light_switch{
 	pixel_x = 0;
@@ -83563,6 +83671,10 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor1oldgarden)
+"fTH" = (
+/obj/item/weapon/material/shard,
+/turf/simulated/floor/wood,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "fWq" = (
 /obj/machinery/light_switch{
 	pixel_x = 28
@@ -83761,6 +83873,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
+"hpg" = (
+/obj/structure/bed/chair/custom/bar_special{
+	dir = 4;
+	icon_state = "bar_chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "hpP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -83790,6 +83911,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/derelict/medical/chapel)
+"hxV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "hzy" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "CEO2"
@@ -83812,6 +83938,13 @@
 	},
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"hHG" = (
+/obj/item/weapon/material/shard,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/tool/broken_bottle,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "hNz" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/structure/disposalpipe/segment{
@@ -83916,6 +84049,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
+"ifK" = (
+/obj/machinery/door/airlock/centcom,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
+"ifV" = (
+/obj/random/lowkeyrandom,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "ijv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83982,6 +84126,11 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/engineering/foyer)
+"itM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/mop,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "iuO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -84016,6 +84165,12 @@
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/medical/medbay3)
+"iJP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/circuitboard/broken,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "iMA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/extinguisher_cabinet{
@@ -84120,6 +84275,11 @@
 /mob/living/simple_animal/hostile/roomba/slayer,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor2south)
+"jfB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/tool/broken_bottle,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "jgy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -84179,6 +84339,13 @@
 	},
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/medical/medbay2)
+"jqD" = (
+/obj/structure/bed/chair/sofa/teal/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "jsS" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -84254,6 +84421,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"jZd" = (
+/obj/structure/bed/chair/sofa/teal/right{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "jZM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84382,6 +84556,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
+"lfp" = (
+/obj/machinery/door/airlock/centcom,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "lhx" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel/monofloor,
@@ -84393,6 +84573,11 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/medbay3)
+"lkz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/spiderling_remains,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "lov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84505,6 +84690,14 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/engineering/foyer)
+"lSv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/soap{
+	desc = "An unbranded bar of soap, smells of cobwebs.";
+	name = "old soap"
+	},
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "lSV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -84733,6 +84926,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
+"mTD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "mVy" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -84816,6 +85018,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
+/obj/item/weapon/material/shard,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/tool/broken_bottle,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "nhZ" = (
@@ -84870,6 +85076,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/derelict/medical/chapel)
+"nHe" = (
+/obj/random/junk/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2south)
+"nIM" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "nKm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84901,6 +85116,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/medbreak)
+"nUm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/tool/broken_bottle,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
+"nUR" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/wood,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "ocD" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -84944,6 +85171,8 @@
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "ong" = (
@@ -85107,12 +85336,25 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/nadezhda/crew_quarters/podrooms)
+"pdB" = (
+/obj/random/junk/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "pdO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/toilet/public)
+"peD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "pjU" = (
 /obj/machinery/light_switch{
 	pixel_y = 30
@@ -85191,6 +85433,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/security/checkpoint/cryo)
+"pGC" = (
+/obj/item/weapon/material/shard,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/tool/broken_bottle,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "pHQ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/blucarpet,
@@ -85237,6 +85486,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/cbo)
+"pTJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "pTM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -85306,6 +85562,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/atmos/monitoring)
+"qck" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "qey" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -85561,6 +85822,11 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/turret_protected/ai_upload)
+"rkh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/spiderling_remains,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "rrk" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -85644,6 +85910,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section4)
+"rOD" = (
+/obj/structure/table/bar_special,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/broken_robot_part,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
+"rRA" = (
+/obj/random/mob/roaches/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "rVh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -85672,6 +85949,22 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/hallway/side/f2section2)
+"rZf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2south)
+"sak" = (
+/obj/item/weapon/material/shard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/tool/broken_bottle,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
+"sbd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/tool/broken_bottle,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "set" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
@@ -85806,6 +86099,17 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/circuitlab)
+"tuc" = (
+/obj/structure/table/bar_special,
+/obj/structure/cyberplant{
+	emagged = 1;
+	name = "holodancer";
+	pixel_y = 12
+	},
+/obj/machinery/floor_light,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "txr" = (
 /obj/machinery/light{
 	dir = 4
@@ -85908,6 +86212,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/library)
+"uer" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "ufv" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -85990,6 +86301,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/captain/quarters)
+"uAx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "uBg" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
@@ -86003,6 +86319,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/docking)
+"uFE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/circuitboard/broken,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "uGN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86048,6 +86369,12 @@
 /obj/structure/table/woodentable,
 /obj/random/rations,
 /turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2south)
+"uNn" = (
+/obj/item/weapon/material/shard,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/tool/broken_bottle,
+/turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor2south)
 "uNP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -86115,6 +86442,11 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/enginehallway)
+"vkB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/storage/box/lights/mixed,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "vwk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -86129,6 +86461,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/circuitlab)
+"vxn" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/maintenance/undergroundfloor2south)
+"vyA" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "vyD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -86261,6 +86606,14 @@
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2south)
+"vYw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/plushie/spider,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "vZG" = (
 /obj/machinery/newscaster{
 	dir = 8;
@@ -86384,6 +86737,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"xhE" = (
+/obj/random/junk/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "xjO" = (
 /obj/machinery/papershredder,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -86391,6 +86749,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
+"xns" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "xrh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -86427,6 +86790,11 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/cbo)
+"xxj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank/derelict,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "xxY" = (
 /obj/machinery/light_switch{
 	pixel_y = 30
@@ -86442,6 +86810,19 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/atmos/monitoring)
+"xBn" = (
+/obj/structure/cyberplant,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
+"xBC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "xGb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -86490,6 +86871,11 @@
 "xQe" = (
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/hallway/side/f2section2)
+"xSs" = (
+/obj/structure/table/bar_special,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "yaG" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white/cyancorner,
@@ -86509,6 +86895,10 @@
 "ygC" = (
 /obj/structure/table/marble,
 /obj/machinery/recharger,
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar";
+	name = "glass shutter"
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/bar)
 "yhm" = (
@@ -86520,6 +86910,12 @@
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/command/cro/quarters)
+"yiu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/spiderling_remains,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/nadezhda/maintenance/undergroundfloor2south)
 "yjP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -111722,9 +112118,9 @@ aQZ
 cYb
 blP
 cSn
-cSn
-bmy
-cSn
+cKe
+dmu
+cKe
 dmv
 cYb
 cSq
@@ -111737,12 +112133,12 @@ cXf
 cXf
 cXf
 cXf
-cSn
+cKc
 dIG
 dak
 cKe
 cKe
-cSn
+cKc
 cYb
 cYb
 aac
@@ -111927,8 +112323,8 @@ bmn
 bmy
 bmn
 cSn
-cRX
-cSq
+rRA
+cTR
 cSn
 boF
 boO
@@ -111936,15 +112332,15 @@ cSn
 cXf
 cZO
 cZS
-cZS
+hpg
 cXf
 cXf
-cSn
+cKc
 cSn
 dal
 cSn
 cSn
-cSn
+cKc
 cYb
 cYb
 aac
@@ -112124,12 +112520,12 @@ bbL
 dOx
 dOZ
 vYt
-cSn
-cIY
+cKe
+dme
+nUR
 cSq
-cSq
 cIY
-cIY
+nIM
 cYb
 cSf
 bmy
@@ -112326,10 +112722,10 @@ dOF
 aRc
 aQZ
 cYb
-cSn
-cSq
+cKe
+cTR
 cRX
-cSq
+fTH
 cIY
 dmv
 cYb
@@ -112346,7 +112742,7 @@ cXf
 bot
 bot
 dal
-cSn
+cKc
 cSn
 cSn
 cYb
@@ -112530,7 +112926,7 @@ aQZ
 cYb
 cPE
 cSq
-cIY
+dme
 cIY
 cIY
 bnw
@@ -112540,15 +112936,15 @@ cYb
 cYb
 cYb
 cXf
-cZO
-nhu
+rZf
+uer
 cZZ
 cXf
 cXf
 cXf
 cXf
 cXf
-cSn
+cKc
 cSn
 cSn
 cYb
@@ -112732,7 +113128,7 @@ aRc
 cYb
 cPE
 cSq
-cSq
+cTR
 cSb
 cIY
 cSb
@@ -112933,9 +113329,9 @@ aRc
 aRc
 cYb
 blQ
-cSq
-cSq
-cSb
+fTH
+vxn
+ifV
 bne
 bnx
 cXf
@@ -112947,7 +113343,7 @@ cZD
 cZO
 cZD
 cXf
-cZO
+rZf
 cZF
 cZS
 cXf
@@ -113136,19 +113532,19 @@ aRc
 cYb
 cPE
 dmv
-cSq
-cIY
+cTR
+dme
 bnf
 bnA
 cXf
 bZr
 cZn
+hxV
+lfp
+hxV
+pGC
 cZO
-cZB
-cZO
-cZO
-cZO
-cZB
+ifK
 cZW
 dab
 cZY
@@ -113338,17 +113734,17 @@ aRc
 cYb
 cRD
 dmv
-ugs
-cSq
-dmv
+vyA
+cTR
+xhE
 bnB
 aKe
 cZO
 nhu
-cZO
+rZf
 cXf
 cZE
-cZO
+lkz
 cZL
 cXf
 cZP
@@ -113356,7 +113752,7 @@ cZF
 dac
 cXf
 cXf
-cKe
+uAx
 cSn
 cSn
 dpx
@@ -113550,7 +113946,7 @@ cXf
 cXf
 cXf
 cXf
-cZB
+ifK
 cXf
 cXf
 cXf
@@ -113558,7 +113954,7 @@ cXf
 cXf
 cXf
 cXf
-cKe
+uAx
 cSn
 cSn
 dpx
@@ -113749,10 +114145,10 @@ aQZ
 cYb
 cXf
 cZo
-cOi
+jZd
 cZZ
 cZF
-cZO
+iJP
 cZZ
 cZF
 cZy
@@ -113951,14 +114347,14 @@ aQZ
 cYb
 cXf
 cZp
-cZn
+tuc
 cZO
 cZO
+hxV
 cZO
 cZO
-cZO
-cZO
-cZy
+lkz
+sak
 cZY
 cZT
 cXf
@@ -114152,12 +114548,12 @@ dPc
 aQZ
 cYb
 cXf
-bZr
+fjl
 cZy
-cZO
+jfB
 cZG
-cZF
-cZF
+mTD
+peD
 cZQ
 cZO
 cZy
@@ -114355,16 +114751,16 @@ aQZ
 cYb
 cXf
 cZq
-cZy
+sak
 cZO
-cZF
-cZF
-cZF
-cZF
+xBC
+nUm
+pTJ
+peD
 cZO
 cZy
 cZr
-cZZ
+xBn
 cXf
 dps
 cKe
@@ -114559,10 +114955,10 @@ cXf
 cZr
 cZy
 cZO
-cZF
+xBC
 cZJ
-cZF
-cZF
+vYw
+peD
 cZO
 cZy
 dad
@@ -114762,11 +115158,11 @@ cZs
 cZy
 cZO
 cZH
-cZF
-cZF
+peD
+peD
 cZR
-cZO
-cZy
+uFE
+lSv
 cZY
 cZY
 cXf
@@ -114961,12 +115357,12 @@ aQZ
 cYb
 cXf
 cZt
-cZy
+rkh
+uFE
 cZO
 cZO
-cZO
-cZO
-cZO
+uNn
+vkB
 cZO
 cZy
 cZU
@@ -114974,7 +115370,7 @@ cZU
 cXf
 dpv
 cSn
-cKe
+uAx
 cYb
 cYb
 cYb
@@ -115164,19 +115560,19 @@ cYb
 cXf
 cZu
 cZy
+sbd
 cZy
 cZy
 cZy
-cZy
-cZy
-cZy
+itM
+xxj
 cZy
 cZy
 cZF
 dho
 atn
 cSn
-cSn
+cKc
 cYb
 cYb
 aac
@@ -115369,11 +115765,11 @@ cZv
 cZv
 cZI
 cZy
+qck
+yiu
 cZy
 cZy
-cZy
-cZy
-cZy
+sbd
 cZF
 cZK
 atn
@@ -115566,8 +115962,8 @@ aUP
 aQZ
 cYb
 cXf
-cZo
-cOi
+jqD
+jZd
 cZZ
 cZv
 cZy
@@ -115575,8 +115971,8 @@ cZy
 cZV
 cZY
 daa
-cZz
-cZz
+rOD
+xSs
 cXf
 dpw
 cSn
@@ -115769,18 +116165,18 @@ aQZ
 cYb
 cXf
 cZp
-cZn
+tuc
 cZO
-cZF
+xns
 cZy
 cZy
 cZV
-cZz
-cZO
+xSs
+uFE
 cZO
 olM
 cXf
-cSn
+cKc
 cSn
 cSn
 cYb
@@ -115970,14 +116366,14 @@ aUP
 aQZ
 cYb
 cXf
-bZr
+fjl
 cZO
 cZO
-cZF
+xns
 cZy
-cZy
+hHG
 cZV
-cZz
+xSs
 cZO
 cZO
 dah
@@ -116177,7 +116573,7 @@ cZz
 cZr
 cZv
 cZy
-cZy
+qck
 cZV
 daa
 cZO
@@ -116382,7 +116778,7 @@ cZF
 cZF
 cZV
 cZY
-nhu
+uer
 cZO
 daj
 cXf
@@ -116590,7 +116986,7 @@ cXf
 cXf
 cSn
 cSn
-cSn
+cKc
 cYb
 cYb
 aac
@@ -116781,8 +117177,8 @@ cQL
 cYb
 cYb
 cZC
-cSn
-cSn
+cKc
+cKc
 cSn
 cRj
 cSn
@@ -116792,7 +117188,7 @@ cSn
 cSn
 cSn
 cSn
-cSn
+cKc
 cYb
 cYb
 aac
@@ -116990,8 +117386,8 @@ cRj
 cSn
 cSn
 cSn
-cSn
-cSn
+cKc
+cKc
 cSn
 cSn
 cSn
@@ -150298,8 +150694,8 @@ abi
 abi
 abi
 abi
-cNk
-cOQ
+dIF
+cMd
 cOm
 cQG
 cYb
@@ -150500,8 +150896,8 @@ cIF
 cGF
 cKL
 cSn
-cSn
-cOQ
+cKe
+cMd
 bHI
 dmb
 cYb
@@ -150702,8 +151098,8 @@ cIH
 cGF
 cKL
 cSn
-cSn
-cOQ
+cKe
+cMd
 cHY
 cYb
 cYb
@@ -150905,7 +151301,7 @@ cGF
 beX
 cSn
 ddC
-cGK
+nHe
 dlT
 cYb
 cYb
@@ -151102,7 +151498,7 @@ dmI
 cGF
 cGF
 nbw
-cRu
+fxP
 cGF
 cKL
 cSn
@@ -151511,7 +151907,7 @@ cGF
 cSn
 cSn
 cSn
-cSn
+cKe
 cHY
 cYb
 cYb
@@ -151713,7 +152109,7 @@ bGS
 cOQ
 cOQ
 cOQ
-cOQ
+cMd
 cOB
 cTk
 vYt
@@ -153339,8 +153735,8 @@ cGP
 cGP
 dmw
 dmN
-cGK
-cPE
+nHe
+pdB
 cYb
 cYb
 aac
@@ -153541,8 +153937,8 @@ cGP
 cGP
 dmx
 dmO
-cPE
-cPE
+pdB
+pdB
 cYb
 cYb
 aac

--- a/maps/CEVEris/_Nadezhda_Colony_Underground.dmm
+++ b/maps/CEVEris/_Nadezhda_Colony_Underground.dmm
@@ -47572,11 +47572,11 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/hallway/side/f2section4)
 "cpw" = (
-/obj/machinery/smartfridge,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics)
 "cpx" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
@@ -50585,7 +50585,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/small/lavarock2,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/rnd/scient)
 "cwn" = (
@@ -52206,6 +52205,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/machinery/reagentgrinder/industrial,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "czU" = (
@@ -60774,6 +60774,7 @@
 /obj/machinery/button/windowtint{
 	id = "RD"
 	},
+/obj/item/weapon/stamp/rd,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/command/cro)
 "cUL" = (
@@ -65856,12 +65857,9 @@
 	},
 /area/nadezhda/hallway/side/f2section2)
 "dgk" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/reagentgrinder/industrial,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/crew_quarters/kitchen)
+/obj/machinery/smartfridge,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/hydroponics)
 "dgl" = (
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/dark,
@@ -68836,11 +68834,8 @@
 	},
 /obj/item/weapon/aiModule/paladin,
 /obj/machinery/door/window{
-	base_state = "left";
-	dir = 4;
-	icon_state = "left";
 	name = "High-Risk Modules";
-	req_access = list(20)
+	req_access = list(16)
 	},
 /obj/item/weapon/aiModule/freeform,
 /obj/item/weapon/aiModule/oxygen,
@@ -70931,7 +70926,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/weapon/stamp/rd,
 /obj/item/device/eftpos{
 	eftpos_name = "Soteria Biolabs EFTPOS scanner"
 	},
@@ -75125,7 +75119,6 @@
 /area/nadezhda/medical/reception)
 "dBr" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
 "dBs" = (
@@ -85361,6 +85354,9 @@
 /obj/structure/table/marble,
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
@@ -152714,7 +152710,7 @@ dSK
 cyr
 czh
 czT
-dgk
+cta
 qob
 diY
 dsb
@@ -152916,7 +152912,7 @@ bGH
 cpw
 cvJ
 bGH
-bGH
+dgk
 bGH
 bGH
 bGH


### PR DESCRIPTION
## About The Pull Request
Removed the 2 Bar/RnD advertisement holopads - people were confused why they were their
Moved down the cook room food storer thing, added a window in place, moved up the grinder.
AI case glass thing as been correct by its access lock to now open if you have AI Upload access - Turns out this was a mapping oversight
Moved RD stamp 1 tile - to prevent new CRO's from getting confused on were the samp is located

Bar stuff - Added glass shutters to the bar tables same unlock as normal bar keep stuff
Made the club below much more to clean and such, more trash and the like really
Make the vendor in club need credits rather then vending all its stuff for free cuz you jumped over a table - Things that are normally free are still free iirc only really makes the booze and drinks costs credits if that.
added a hat to the barkeep room for the hat rack
## Changelog
:cl:
/:cl: