### PR TITLE
coffee dispender fix & cargo pack

### DIFF
--- a/code/modules/cargo/packs_hospitality.dm
+++ b/code/modules/cargo/packs_hospitality.dm
@@ -226,3 +226,15 @@
 	containertype = /obj/structure/closet/crate/freezer
 	crate_name = "pizza crate"
 	group = "Hospitality"
+
+/datum/supply_pack/hospitality_dispenser
+	name = "Hospitality Dispenser (Booze/Soda/Coffie Dispensers Boards)"
+	contains = list(/obj/item/weapon/circuitboard/chemical_dispenser/coffee_master,
+					/obj/item/weapon/circuitboard/chemical_dispenser/beer,
+					/obj/item/weapon/circuitboard/chemical_dispenser/soda,
+					/obj/item/weapon/storage/box/drinkingglasses,
+					/obj/item/weapon/storage/box/drinkingglasses)
+	cost = 850
+	containertype = /obj/structure/closet/crate
+	crate_name = "hospitality dispenser"
+	group = "Hospitality"

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -263,7 +263,7 @@
 	density = FALSE
 	level0 = list(
 		"coffee","cream","tea","greentea","sugar","hot_coco","espresso")
-
+	hacked_reagents = list("ice")
 	level1 = list("cappuccino")
 	level2 = list("macchiato")
 	level3 = list("soymilk") //Commie stock part gives this


### PR DESCRIPTION
## About The Pull Request
Fixes cofffee master when hacked giving normal chem dispender chems + 14 glasses
Added a new cargo crate with each soda/booze/coffee board in it to make them
## Changelog
:cl:
/:cl:
