### PR TITLE
Opifex Belt Perk Rework (+typo fixes)

### DIFF
--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -218,6 +218,45 @@
 	new /obj/item/weapon/storage/belt/utility/opifex/full(usr.loc)
 	return ..()
 
+/datum/perk/opifex_backup_medical
+	name = "Smuggled Medicine"
+	desc = "You retrieve your custom kitted medical webbing hidden on your person somewhere, along with the opifex-made black webbing vest that holds them. As every opifex is told, never go anywhere without your kit. This tool belt is yours alone and you should not allow any non-opifex to use it."
+	active = FALSE
+	passivePerk = FALSE
+
+/datum/perk/opifex_backup_medical/activate()
+	var/mob/living/carbon/human/user = usr
+	if(!istype(user))
+		return ..()
+	if(world.time < cooldown_time)
+		to_chat(usr, SPAN_NOTICE("You've already retrieved your set of back up meds. You didn't lose them, did you?"))
+		return FALSE
+	cooldown_time = world.time + 12 HOURS
+	to_chat(usr, SPAN_NOTICE("You discretely and stealthily slip your back up webbing out from their hiding place, the webbing unfolds as it quietly flops to the floor."))
+	log_and_message_admins("used their [src] perk.")
+	new /obj/item/weapon/storage/belt/medical/opifex/full(usr.loc)
+	return ..()
+
+
+/datum/perk/opifex_backup_combat
+	name = "Smuggled Armaments"
+	desc = "You retrieve your custom kitted combat belt hidden on your person somewhere, along with the opifex-made black webbing vest that holds them. As every opifex is told, never go anywhere without your kit. This tool belt is yours alone and you should not allow any non-opifex to use it, nor the weapons within."
+	active = FALSE
+	passivePerk = FALSE
+
+/datum/perk/opifex_backup_combat/activate()
+	var/mob/living/carbon/human/user = usr
+	if(!istype(user))
+		return ..()
+	if(world.time < cooldown_time)
+		to_chat(usr, SPAN_NOTICE("You've already retrieved your set of back up weapons. You didn't lose them, did you?"))
+		return FALSE
+	cooldown_time = world.time + 12 HOURS
+	to_chat(usr, SPAN_NOTICE("You discretely and stealthily slip your back up belt out from their hiding place, the webbing unfolds as it quietly flops to the floor."))
+	log_and_message_admins("used their [src] perk.")
+	new /obj/item/weapon/storage/belt/security/tactical/opifex/full(usr.loc)
+	return ..()
+
 /datum/perk/opifex_turret
 	name = "Smuggled Circuit"
 	desc = "Opifex are scavengers at heart and rely heavily on machines and AI as a result, as such, each opifex keeps a specially designed circuit on their person to build a make shift defense platform when needed to secure their safety. Sadly, you only managed to smuggle the circuit on your person."

--- a/code/datums/setup_option/backgrounds/origin.dm
+++ b/code/datums/setup_option/backgrounds/origin.dm
@@ -301,14 +301,36 @@
 		STAT_COG = 15
 	)
 
+/datum/category_item/setup_option/background/ethnicity/opifex_mechanist
+	name = "Mechanist"
+	desc = "You are one of the many opifex trained in the ways of your craft by your scavenger fleet. Like your brothers you have a knack for adapting to new situations and using all things \
+	mechanical. Sadly, seperated from your fleet you do not have access to the many useful robots that make life so much easier. That said, you always keep your various tools stowed away in a \
+	webbing smuggled on your person. As a rank and file you represent the best of the opifex ability and wear your tools with pride."
+
+	restricted_to_species = list(FORM_OPIFEX)
+
+	perks = list(/datum/perk/opifex_backup)
+
+	stat_modifiers = list(
+		STAT_ROB = 0,
+		STAT_TGH = 0,
+		STAT_VIG = 0,
+		STAT_BIO = 0,
+		STAT_MEC = 5,
+		STAT_COG = 5
+	)
+
 /datum/category_item/setup_option/background/ethnicity/opifexbiomech
 	name = "Biomechanist"
 	desc = "While all opifex are trained in the workings of machines some are reserved for the biological aspect of their respective scavenger fleet. \
 			This training is usually towards the goal of maintaining the bio-mechanical augmentations used by the opifex, from installing nano-gates to replacing lost limbs with synthetic copies. \
 			The additional biological training, while helpful, does hamper the average opifexes ability to study machines, lessening their ability to quickly adapt to situations and new \
-			technology. After all, to the average opifex a biological entity is far less complex and nuisanced than even the most basic of robots."
+			technology. After all, to the average opifex a biological entity is far less complex and nuisanced than even the most basic of robots. Out of habit you always keep your trusty \
+			medical webbing stowed on your person with various useful chemicals and devices stored within."
 
 	restricted_to_species = list(FORM_OPIFEX)
+
+	perks = list(/datum/perk/opifex_backup_medical)
 
 	stat_modifiers = list(
 		STAT_ROB = 0,
@@ -324,9 +346,12 @@
 	desc = "Some opifex are assigned the tasks of dealing with the hostile entities aboard ships they loot, be it creatures living on space hulks, machines still defending lost ships, \
 			or the crew of a recently boarded ship being mercilessly slaughtered so they can peacefully strip the shuttles tech. Combat technicians favor the use of range weaponry, often \
 			times supported by combat drones with which they lead into conflict. Their skills towards repairing and salvaging technology isn't as good as the average opifex, but their concern \
-			is only on making areas safe for the lesser technicians to do the grunt labors."
+			is only on making areas safe for the lesser technicians to do the grunt labors. You don't take chances though, always making sure to keep your tactical belt smuggled on your person with \
+			a spare energy pistol, some manhack grenades, and other various combat tools."
 
 	restricted_to_species = list(FORM_OPIFEX)
+
+	perks = list(/datum/perk/opifex_backup_combat)
 
 	stat_modifiers = list(
 		STAT_ROB = 0,
@@ -388,8 +413,8 @@
 
 	restricted_to_species = list(FORM_CHTMANT)
 
-	restricted_depts = SCIENCE | ENGINEERING | COMMAND
-	restricted_jobs = list(/datum/job/cmo, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/paramedic)
+	restricted_depts = SCIENCE | ENGINEERING
+	restricted_jobs = list(/datum/job/cmo, /datum/job/rd, /datum/job/smc, /datum/job/swo, /datum/job/cmo, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/paramedic, /datum/job/premier, /datum/job/pg, /datum/job/chief_engineer, /datum/job/chaplain, /datum/job/merchant)
 
 	perks = list(/datum/perk/chitinarmor)
 

--- a/code/game/objects/items/weapons/grenades/emgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/emgrenade.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/grenade/empgrenade
-	name = "FS EMPG \"Frye\""
+	name = "HS EMPG \"Frye\""
 	desc = "EMP grenade, designed to disable electronics, augmentations and energy weapons."
 	icon_state = "emp"
 	item_state = "empgrenade"
@@ -13,7 +13,7 @@
 	return
 
 /obj/item/weapon/grenade/empgrenade/low_yield
-	name = "FS EMPG \"Frye\" - C"
+	name = "HS EMPG \"Frye\" - C"
 	desc = "A weaker variant of the \"Frye\" emp grenade, with lesser radius."
 	icon_state = "lyemp"
 	item_state = "empgrenade"

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/grenade/flashbang
-	name = "FS FBG \"Serra\""
-	desc = "A \"Frozen Star\" flashbang grenade. If in any doubt - use it."
+	name = "HS FBG \"Serra\""
+	desc = "A \"Holland and Sullivan\" flashbang grenade. If in any doubt - use it."
 	icon_state = "flashbang"
 	item_state = "flashbang"
 	origin_tech = list(TECH_MATERIAL = 2, TECH_COMBAT = 1)

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -39,6 +39,10 @@
 	deliveryamt = 5
 	origin_tech = list(TECH_MATERIAL = 3, TECH_MAGNET = 4, TECH_ILLEGAL = 4)
 
+/obj/item/weapon/grenade/spawnergrenade/manhacks/opifex
+	name = "opifex manhack grenade"
+	desc = "Deploys a swarm of floating robots that will attack animals and non-colony humanoids nearby. Due to targeting issues the manhacks will attack cht'mants and be shot by colony defense turrets be they opifex, guild, laser, or church defense grids, use with caution."
+	spawner_type = /mob/living/simple_animal/hostile/viscerator/opifex
 
 /obj/item/weapon/grenade/spawnergrenade/blob
 	name = "bioweapon sample"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -116,6 +116,27 @@
 	new /obj/item/weapon/tool/wrench/big_wrench(src)
 	new /obj/item/weapon/tool/knife/dagger(src)
 
+/obj/item/weapon/storage/belt/medical/opifex
+	name = "opifex black medical webbing"
+	desc = "A black webbing made specifically for opifex to prevent any pulling or ruffling of feathers, slightly uncomfortable for anyone else but none can deny its quality. This harness is built specifically for medical supplies, limiting its versatility."
+	icon_state = "webbing_black"
+	item_state = "webbing_black"
+	storage_slots = 12
+
+/obj/item/weapon/storage/belt/medical/opifex/full/populate_contents()
+	new /obj/item/device/scanner/health(src)
+	new /obj/item/weapon/reagent_containers/syringe/hyperzine(src)
+	new /obj/item/weapon/reagent_containers/syringe/tricordrazine(src)
+	new /obj/item/weapon/reagent_containers/syringe/inaprovaline(src)
+	new /obj/item/weapon/storage/pill_bottle/tramadol(src)
+	new /obj/item/weapon/storage/pill_bottle/prosurgeon(src)
+	new /obj/item/weapon/storage/pill_bottle/bicaridine(src)
+	new /obj/item/weapon/storage/pill_bottle/dermaline(src)
+	new /obj/item/weapon/storage/pill_bottle/dexalin_plus(src)
+	new /obj/item/weapon/storage/pill_bottle/antitox(src)
+	new /obj/item/bodybag/cryobag(src)
+	new /obj/item/weapon/extinguisher/mini(src)
+
 /obj/item/weapon/storage/belt/medical
 	name = "medical belt"
 	desc = "Can hold various medical equipment."
@@ -200,11 +221,13 @@
 		/obj/item/device/hailer,
 		/obj/item/device/megaphone,
 		/obj/item/weapon/melee,
-		//obj/item/weapon/gun/projectile/mk58, //too big, use holster
+		/obj/item/weapon/tool/knife,
+		/obj/item/weapon/gun/projectile/mk58,
+		/obj/item/weapon/gun/energy/gun,
 		/obj/item/weapon/gun/projectile/clarissa,
 		/obj/item/weapon/gun/projectile/giskard,
-		//obj/item/weapon/gun/projectile/olivaw, //too big, use holster
-		//obj/item/weapon/gun/projectile/revolver/detective, //too big, use holster
+		/obj/item/weapon/gun/projectile/olivaw,
+		/obj/item/weapon/gun/projectile/revolver/detective,
 		/obj/item/weapon/gun/energy/gun/martin,
 		/obj/item/taperoll
 	)
@@ -245,6 +268,24 @@
 	desc = "Can hold various military and security equipment, more so than a standard belt or web harness."
 	icon_state = "tactical"
 	storage_slots = 12
+
+/obj/item/weapon/storage/belt/security/tactical/opifex
+	name = "opifex tactical belt"
+	desc = "A black tactical belt made specifically for opifex to prevent any pulling or ruffling of feathers, slightly uncomfortable for anyone else but none can deny its quality. This harness is built specifically for combat, limiting its versatility."
+
+/obj/item/weapon/storage/belt/security/tactical/opifex/full/populate_contents()
+	new /obj/item/weapon/reagent_containers/spray/pepper(src)
+	new /obj/item/weapon/tool/crowbar(src)
+	new /obj/item/device/flash(src)
+	new /obj/item/device/lighting/toggleable/flashlight/heavy(src)
+	new /obj/item/weapon/gun/energy/gun(src)
+	new /obj/item/weapon/cell/medium/high(src)
+	new /obj/item/weapon/cell/medium/high(src)
+	new /obj/item/weapon/tool/knife/dagger/assassin(src)
+	new /obj/item/weapon/grenade/spawnergrenade/manhacks/opifex(src)
+	new /obj/item/weapon/grenade/spawnergrenade/manhacks/opifex(src)
+	new /obj/item/weapon/grenade/smokebomb(src)
+	new /obj/item/weapon/grenade/chem_grenade/teargas(src)
 
 /obj/item/weapon/storage/belt/security/neotheology
 	name = "tactical absolutism belt"

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -394,5 +394,4 @@
 		H.faction = "roach"
 		H.add_language(LANGUAGE_CHTMANT)
 	if(H.species.reagent_tag == IS_OPIFEX)
-		H.faction = "vox"
 		H.add_language(LANGUAGE_OPIFEXEE)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -319,7 +319,7 @@
 		"Feathered Wings, Large"
 		)
 
-	perks = list(/datum/perk/opifex_backup,/datum/perk/opifex_turret,/datum/perk/opifex_patchkit)
+	perks = list(/datum/perk/opifex_turret,/datum/perk/opifex_patchkit)
 
 /datum/species/vox/get_bodytype()
 	return "Opifex"

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -220,6 +220,11 @@
 	..(null,"is smashed into pieces!")
 	qdel(src)
 
+/mob/living/simple_animal/hostile/viscerator/opifex
+	name = "opifex viscerator"
+	desc = "A small, twin-bladed machine capable of inflicting very deadly lacerations. This one is an opifex model and thus targets non-colony humanoids, animals, and cht'mants."
+	faction = "neutral"
+
 
 /mob/living/simple_animal/hostile/elitemercenary
 	name = "\improper Elite operative"


### PR DESCRIPTION
Opifex belts are now sorted by ethnicity and give you equipment based on background. Mechanists gain the standard toolbelt, biomechanists get a medical webbing, and combat techs get a tactical belt. All of which are loaded with genuinely useful items. 
-Mechanist focused opifex get an additional +5 mechanical and cognition. 
-Manhacks allied to the colonists are now a thing.
-Fixed some grenade typos referencing frozen star (old eris company replaced by Holland and Sullivan)

Copied from the code for ease of reading:
-Medical belt gets
        Health scanner
	Syringe (Hyperzine 15u)
	Syringe (Tricord15u)
	Syringe (Inaprov15u)
	Pill bottle (Tramadol)
	Pill bottle (Dylo)
	Pill bottle (Bica)
	Pill bottle (Derma)
	Pill bottle (Dex+)
	Pill bottle (Prosurgeon)
	Cryobag
	Mini fire extinguisher

-Combat belt gets
	Pepperspray
	Crowbar
	Flash
	Heavy duty flashlight
	Spider rose energy pistol
	Cell (Medium, 800w)
	Cell (Medium, 800w)
	Hypo dagger (assassin)
	Opifex manhack grenade
	Opifex manhack grenade
	Smokebomb
	Tear gas grenade

Toolbelt is the same.