### PR TITLE
Cruciform no longer protects against Exl

### DIFF
--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -121,8 +121,7 @@ var/list/disciples = list()
 			wearer.visible_message(SPAN_DANGER("[wearer]'s [R.name] tears off."),
 			SPAN_DANGER("Your [R.name] tears off."))
 			R.droplimb()
-*/
-//This is the function to remove excelsior implants for cruciform bearers. Should only make cruciform bearers react badly to excelsior implants. -Kaz
+
 		if(istype(O, /obj/item/weapon/implant/excelsior))
 			if(O == src)
 				continue
@@ -136,6 +135,7 @@ var/list/disciples = list()
 			R.part.take_damage(rand(20,40))
 			R.uninstall()
 			R.malfunction = MALFUNCTION_PERMANENT
+*/
 	if(ishuman(wearer))
 		var/mob/living/carbon/human/H = wearer
 		H.update_implants()


### PR DESCRIPTION

## About The Pull Request
Implants and metal lims are not rejected by the church at all, so why does Exl's? This makes it so that if we ever do have exl events were they are to convert people they can more easily do so and take over parts of each faction without having to worry about needing to vet the person for a curciform.
Exl QoL basiclly
## Changelog
:cl:
/:cl:
