### PR TITLE
Adds stunbatons to sec disk

### DIFF
--- a/code/datums/autolathe/security.dm
+++ b/code/datums/autolathe/security.dm
@@ -38,3 +38,7 @@
 /datum/design/autolathe/sec/hailer
 	name = "hailer"
 	build_path = /obj/item/device/hailer
+
+/datum/design/autolathe/sec/stunbaton
+	name = "stunbaton"
+	build_path = /obj/item/weapon/melee/baton

--- a/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
@@ -21,6 +21,7 @@
 		/datum/design/autolathe/sec/hailer,
 		/datum/design/research/item/medical/autopsy_scanner,
 		/datum/design/autolathe/gun/cop_mod = 0,
+		/datum/design/autolathe/sec/stunbaton = 5, //balance, we can only make 10
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/security/hos

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -21,6 +21,7 @@
 	var/obj/item/weapon/cell/starting_cell = /obj/item/weapon/cell/medium/high
 	var/suitable_cell = /obj/item/weapon/cell/medium
 	structure_damage_factor = STRUCTURE_DAMAGE_BLUNT
+	matter = list(MATERIAL_STEEL = 10, MATERIAL_GLASS = 1, MATERIAL_PLASTIC = 10)
 
 /obj/item/weapon/melee/baton/Initialize()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Stunbatons can now be deconstructed into mats
Stunbatons can now be made in the sec disk
As a reminder, you can make for FAR less, in crafting menu
## Changelog
:cl:
/:cl:
