### PR TITLE
Bomb code, bomb code never changes

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -8,7 +8,14 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 			return
 		//So we still get RnD points for this
 		for(var/obj/item/device/radio/beacon/explosion_watcher/W in GLOB.explosion_watcher_list)
-			var/power = devastation_range * 2 + heavy_impact_range + light_impact_range //The ranges add up, ie light 14 includes both heavy 7 and devestation 3. So this calculation means devestation counts for 4, heavy for 2 and light for 1 power, giving us a cap of 27 power.
+			var/power = devastation_range + heavy_impact_range + light_impact_range
+			//The ranges add up to give us RnD points
+			// ie light 14 includes both heavy 7 and devestation 3.
+			// So this calculation means devestation counts for 2,
+			// heavy for 2
+			// light for 1 power
+			// giving us a cap of 25 power.
+
 			if(get_dist(W, epicenter) < 10)
 				W.react_explosion(epicenter, power)
 

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -6,6 +6,11 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 			var/power = devastation_range * 2 + heavy_impact_range + light_impact_range //The ranges add up, ie light 14 includes both heavy 7 and devestation 3. So this calculation means devestation counts for 4, heavy for 2 and light for 1 power, giving us a cap of 27 power.
 			explosion_rec(epicenter, power)
 			return
+		//So we still get RnD points for this
+		for(var/obj/item/device/radio/beacon/explosion_watcher/W in GLOB.explosion_watcher_list)
+			var/power = devastation_range * 2 + heavy_impact_range + light_impact_range //The ranges add up, ie light 14 includes both heavy 7 and devestation 3. So this calculation means devestation counts for 4, heavy for 2 and light for 1 power, giving us a cap of 27 power.
+			if(get_dist(W, epicenter) < 10)
+				W.react_explosion(epicenter, power)
 
 		var/start = world.timeofday
 		epicenter = get_turf(epicenter)

--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -180,7 +180,7 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 // Grants research points when explosion happens nearby
 /obj/item/device/radio/beacon/explosion_watcher
 	name = "Kinetic Energy Scanner"
-	desc = "Scans the level of kinetic energy from explosions"
+	desc = "Scans the level of kinetic energy from explosions. This beacon, is in fact bomb proof and to use it properly you must use the bomb within 10 tiles of this scanner."
 
 	channels = list("Science" = 1)
 


### PR DESCRIPTION
## About The Pull Request
That was painful.
Makes bombs legit count for RnD, like they are meant to but we had the wrong check for a bomb code that uses one thats disabled. Moves the code in case we enable it to a slighted nerfed version 

Is tested.

If you go out of your way to waste time and such on making a bomb, then tada, it will get you points like its meant to.

## Changelog
:cl:
trilbyspaseclone creating an admin explosion at the Toxins Mixing Room.
 [Science] Kinetic Energy Scanner states, "Detected explosion with power level 7, received 7000 research points"
ADMIN LOG: Explosion with size (1, 2, 3) in area Toxins Mixing Room (45,20,1) (JMP)

[Science] Kinetic Energy Scanner states, "Detected explosion with power level 7, received 1400 research points"
ADMIN LOG: Explosion with size (7) in area Toxins Mixing Room (45,20,1)
/:cl:
