### PR TITLE
Makes the weighted spider spawn system be less tanky

### DIFF
--- a/code/game/objects/random/mob/spider.dm
+++ b/code/game/objects/random/mob/spider.dm
@@ -4,16 +4,16 @@
 	alpha = 128
 
 /obj/random/mob/spiders/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/giant_spider = 30,\
+	return pickweight(list(/mob/living/carbon/superior_animal/giant_spider = 35,\
 				/mob/living/carbon/superior_animal/giant_spider/nurse = 30,\
 				/mob/living/carbon/superior_animal/giant_spider/nurse/midwife = 15,\
 				/mob/living/carbon/superior_animal/giant_spider/nurse/queen = 5,\
-				/mob/living/carbon/superior_animal/giant_spider/nurse/recluse = 3,\
+				/mob/living/carbon/superior_animal/giant_spider/nurse/recluse = 4,\
 				/mob/living/carbon/superior_animal/giant_spider/tarantula/emperor = 1,\
-				/mob/living/carbon/superior_animal/giant_spider/hunter = 30,\
-				/mob/living/carbon/superior_animal/giant_spider/hunter/cloaker = 10,\
+				/mob/living/carbon/superior_animal/giant_spider/hunter = 35,\
+				/mob/living/carbon/superior_animal/giant_spider/hunter/cloaker = 20,\
 				/mob/living/carbon/superior_animal/giant_spider/hunter/viper = 15,\
-				/mob/living/carbon/superior_animal/giant_spider/tarantula = 15,\
+				/mob/living/carbon/superior_animal/giant_spider/tarantula = 10,\
 				))
 
 /obj/random/mob/spiders/low_chance


### PR DESCRIPTION

## About The Pull Request
Tanky spiders like fortress and guarden seem to be second/third most common type, this lowers it a small bit to allow more clockers and other types that are less tanky to spawn as well

## Changelog
:cl:
/:cl:
