### PR TITLE
Makes Assisted organs able to be mended through surgery [WIP]

### DIFF
--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -89,8 +89,8 @@
 			)
 		else if(BP_IS_ASSISTED(src))
 			condition = list(
-				"name" = "Damage"
-				"fix_name" = "Fix"
+				"name" = "Damage",
+				"fix_name" = "Fix",
 				"step" = /datum/surgery_step/assisted/fix_organ,
 				"organ" = "\ref[src]"
 			)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -33,6 +33,8 @@
 /obj/item/organ/internal/proc/take_internal_damage(amount, var/silent=0)
 	if(BP_IS_ROBOTIC(src))
 		damage = between(0, src.damage + (amount * 0.8), max_damage)
+	elseif(BP_IS_ASSISTED(src))
+		damage = between(0, src.damage + (amount * 1.2), max_damage) //Assisted organs are more easily damaged.
 	else
 		damage = between(0, src.damage + amount, max_damage)
 
@@ -83,6 +85,13 @@
 				"name" = "Damage",
 				"fix_name" = "Repair",
 				"step" = /datum/surgery_step/robotic/fix_organ,
+				"organ" = "\ref[src]"
+			)
+		elseif(BP_IS_ASSISTED(src))
+			condition = list(
+				"name" = "Damage"
+				"fix_name" = "Fix"
+				"step" = /datum/surgery_step/assisted/fix_organ,
 				"organ" = "\ref[src]"
 			)
 		else

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -87,7 +87,7 @@
 				"step" = /datum/surgery_step/robotic/fix_organ,
 				"organ" = "\ref[src]"
 			)
-		elseif(BP_IS_ASSISTED(src))
+		else if(BP_IS_ASSISTED(src))
 			condition = list(
 				"name" = "Damage"
 				"fix_name" = "Fix"

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -33,7 +33,7 @@
 /obj/item/organ/internal/proc/take_internal_damage(amount, var/silent=0)
 	if(BP_IS_ROBOTIC(src))
 		damage = between(0, src.damage + (amount * 0.8), max_damage)
-	elseif(BP_IS_ASSISTED(src))
+	else if(BP_IS_ASSISTED(src))
 		damage = between(0, src.damage + (amount * 1.2), max_damage) //Assisted organs are more easily damaged.
 	else
 		damage = between(0, src.damage + amount, max_damage)

--- a/code/modules/organs/surgery_helpers.dm
+++ b/code/modules/organs/surgery_helpers.dm
@@ -37,6 +37,7 @@
 	status_data["dead"] = status & ORGAN_DEAD
 	status_data["mutated"] = status & ORGAN_MUTATED
 	status_data["robotic"] = BP_IS_ROBOTIC(src)
+	status_data["assisted"] = BP_IS_ASSISTED(src)
 
 	return status_data
 

--- a/code/modules/surgery/assisted_damage.dm
+++ b/code/modules/surgery/assisted_damage.dm
@@ -1,0 +1,55 @@
+// Here we finally see a solution for assisted organ damage fixing.
+
+/datum/surgery_step/assisted
+	difficulty = FAILCHANCE_NORMAL
+	inflict_agony = 60
+
+/datum/surgery_step/assisted/fix_organ
+	target_organ_type = /obj/item/organ/internal
+	required_tool_quality = QUALITY_SCREW_DRIVING
+	allowed_tools = list(
+		/obj/item/stack/medical/advanced/bruise_pack = 100,
+		/obj/item/stack/medical/bruise_pack = 20,
+		/obj/item/stack/nanopaste = 100,
+	)
+
+	duration = 80
+
+/datum/surgery_step/assisted/fix_organ/require_tool_message(mob/living/user)
+	to_chat(user, SPAN_WARNING("You need a tool capable of [required_tool_quality], any kind of bruise pack, or some Nanopaste to complete this step."))
+	
+/datum/surgery_step/assisted/fix_organ/proc/get_tool_name(obj/item/stack/tool)
+	var/tool_name = "\the [tool]"
+	if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
+		tool_name = "regenerative membrane"
+	if (istype(tool, /obj/item/stack/medical/bruise_pack))
+		tool_name = "the bandaid"
+	if (istype(tool, /obj/item/stack/nanopaste))
+		tool_name = "the nanopaste"
+	return tool_name
+
+/datum/surgery_step/assisted/fix_organ/can_use(mob/living/user, obj/item/organ/internal/organ, obj/item/tool)
+	return ..() && organ.is_open() && organ.damage > 0
+
+/datum/surgery_step/assisted/fix_organ/begin_step(mob/living/user, obj/item/organ/internal/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] starts mending the damage to [organ.get_surgery_name()]."),
+		SPAN_NOTICE("You start mending the damage to [organ.get_surgery_name()].")
+	)
+
+/datum/surgery_step/assisted/fix_organ/end_step(mob/living/user, obj/item/organ/internal/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] fixes [organ.get_surgery_name()] with [tool]."),
+		SPAN_NOTICE("You fix [organ.get_surgery_name()] with [tool].")
+	)
+	organ.damage = 0
+	if(istype(tool, /obj/item/stack/nanopaste))
+		var/obj/item/stack/S = tool
+		S.use(1)
+
+/datum/surgery_step/assisted/fix_organ/fail_step(mob/living/user, obj/item/organ/internal/organ, obj/item/tool)
+	user.visible_message(
+		SPAN_WARNING("[user]'s hand slips, damaging the integrity of [organ.get_surgery_name()] with [tool]!"),
+		SPAN_WARNING("Your hand slips, damaging the integrity of [organ.get_surgery_name()] with [tool]!")
+	)
+	organ.take_damage(7, 0) //They're hanging by a thread! Be careful with assisted organs!

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -2602,6 +2602,7 @@
 #include "code\modules\stashes\stash_types\valueables.dm"
 #include "code\modules\stashes\stash_types\weapons.dm"
 #include "code\modules\surgery\_defines.dm"
+#include "code\modules\surgery\assisted_damage.dm"
 #include "code\modules\surgery\autodoc.dm"
 #include "code\modules\surgery\hardsuit.dm"
 #include "code\modules\surgery\internal.dm"


### PR DESCRIPTION
## About The Pull Request

Assisted organs had no way to be treated through surgery, and a hole in programming let them be cathegorized by default as organic (for intents and purposes of, say, Peridaxon/Cryoxadone/Cronexidone healing them), yet no tool nor bruise pack nor nanopaste ever worked to fix them directly through normal surgical procedures.
This PR aims to make them more succeptible to organ damage (since they're supposed to be a fleshy organ that needs something like, say a LVAD for the heart), while making its repair by means of either screwdriver or bruise packs.

<hr>

**Currently, this PR as-is has bugged all NanoUI windows when tested locally. I'm leaving it as a draft and asking advice on how to fix this, if I forgot to edit any files (most probably NanoUI ones), etcetera, as I'm at an impasse on how to solve this. PLEASE DO NOT MERGE YET!!!**
	
<hr>

## Changelog
:cl:DimmaDunk
balance: Assisted organs are now 20% more easily damaged
fix: Assisted organs are now treatable through surgery
/:cl: