### PR TITLE
Remove the Roboticist's Spawn Toolbox

### DIFF
--- a/code/datums/outfits/jobs/science.dm
+++ b/code/datums/outfits/jobs/science.dm
@@ -35,7 +35,6 @@
 	pda_slot = slot_r_store
 	id_type = /obj/item/weapon/card/id/dkgrey
 	pda_type = /obj/item/modular_computer/pda/science/roboticist
-	l_hand = /obj/item/weapon/storage/toolbox/mechanical
 
 /decl/hierarchy/outfit/job/science/roboticist/New()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>
They already spawn with a full toolbelt, so the toolbox they spawn is obsolete because they already got the tools.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
del: Removed the toolbox that roboticists spawn with.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
