### PR TITLE
Makes ore bomb proof

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -90,7 +90,7 @@
 		if(2.0)
 			mined_ore = 4 //Heavyer bomb, we lose some ore in this
 			GetDrilled()
-		if(severity => 3.0)
+		if(3.0)
 			mined_ore = 3 //Heavy bomb, we lose quite a bit of ore
 			GetDrilled()
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -90,7 +90,7 @@
 		if(2.0)
 			mined_ore = 4 //Heavyer bomb, we lose some ore in this
 			GetDrilled()
-		if(severity >= 3.0)
+		if(severity => 3.0)
 			mined_ore = 3 //Heavy bomb, we lose quite a bit of ore
 			GetDrilled()
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -84,12 +84,14 @@
 
 /turf/simulated/mineral/ex_act(severity)
 	switch(severity)
-		if(2.0)
-			if (prob(70))
-				mined_ore = 1 //some of the stuff gets blown up
-				GetDrilled()
 		if(1.0)
-			mined_ore = 2 //some of the stuff gets blown up
+			mined_ore = 5 //light bomb, were not lossing much ore
+			GetDrilled()
+		if(2.0)
+			mined_ore = 4 //Heavyer bomb, we lose some ore in this
+			GetDrilled()
+		if(severity >= 3.0)
+			mined_ore = 3 //Heavy bomb, we lose quite a bit of ore
 			GetDrilled()
 
 /turf/simulated/mineral/bullet_act(var/obj/item/projectile/Proj)
@@ -98,8 +100,8 @@
 	if(istype(Proj, /obj/item/projectile/beam/emitter))
 		emitter_blasts_taken++
 
-		if(emitter_blasts_taken > 2) // 3 blasts per tile
-			mined_ore = 1
+		if(emitter_blasts_taken > 1) // 2 blasts per tile
+			mined_ore = 4 //Were blasting away rock with high power lasers this takes quite a bit of time to set up and power.
 			GetDrilled()
 
 /turf/simulated/mineral/Bumped(AM)

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -8,6 +8,9 @@
 	var/material
 	var/sheet_amout = 1 //How many sheets do we give?
 
+/obj/item/weapon/ore/ex_act(severity)
+	return //We allow mining charges to not blow up ores
+
 /obj/item/weapon/ore/attackby(obj/item/I, mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(!istype(user.loc, /turf))


### PR DESCRIPTION
## About The Pull Request
Its really dumb that a toxin bomb cant be used to mine anything other then sand do to it blowing up the ore
Makes emitter mining not as trash - why do you lose so much ore?
Makes bombs mine legit amouts of ore rather then 1-2 as that is really dumb, also light bombing now digs out ore making you /want/ to use ligher bombs scattered around rather then one massive nuke
## Changelog
:cl:
/:cl: