### PR TITLE
Restores NTNet Functionality

### DIFF
--- a/maps/CEVEris/_map_data_Eris.dm
+++ b/maps/CEVEris/_map_data_Eris.dm
@@ -52,7 +52,7 @@
 	name = "Nadezhda Mountain Solars"
 	is_station_level = FALSE
 	is_player_level = TRUE
-	is_contact_level = FALSE
+	is_contact_level = TRUE
 	is_accessable_level = FALSE
 	is_sealed = TRUE
 	height = 1

--- a/maps/encounters/deeptunnels/deeptunnels.dm
+++ b/maps/encounters/deeptunnels/deeptunnels.dm
@@ -3,7 +3,7 @@
 /obj/map_data/nadezda_t
 	name = "Nadezhda Deep Tunnels"
 	is_player_level = TRUE
-	is_contact_level = FALSE
+	is_contact_level = TRUE
 	is_accessable_level = FALSE
 	generate_asteroid = TRUE
 	is_sealed = TRUE


### PR DESCRIPTION
Changes is_contact_level = TRUE on map of the mines as well as the solar panels.

This allows the NTNet to function on these maps provided they are either using an Advanced Network Card, or have a wired Ethernet card. This does nothing to affect computers using basic network cards.


