### PR TITLE
Slightly more fair voting

### DIFF
--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -22,12 +22,12 @@
 
 /*To prevent abuse and rule-by-salt, the evac vote weights each player's vote based on a few parameters
 	If you are alive and have been for a while, then you have the normal 1 vote
-	If you are dead, or just spawned, you get only 0.3 votes
-	If you are an antag or a head of staff, you get 2 votes
+	If you are dead, or just spawned, you get only 0.6 votes
+	If you are an antag or a head of staff, you get 1.2 votes
 */
 #define VOTE_WEIGHT_LOW	0.6
 #define VOTE_WEIGHT_NORMAL	1
-#define VOTE_WEIGHT_HIGH	2
+#define VOTE_WEIGHT_HIGH	1.2 //To tie 2 dead votes but not over-rule 2 living
 #define MINIMUM_VOTE_LIFETIME	15 MINUTES
 
 /datum/poll/restart/get_vote_power(var/client/C)


### PR DESCRIPTION

## About The Pull Request
Heads of staff/"antags" now longer get 2+ in votes but 1.3
Why?
A head of staff can cancle out **3** dead votes and turn  2 living votes into a tie. Thats not good for voting...
This new way cancle outs 2 dead votes but only 1 living rather then tieing two making the dead vote/newcrew vote a bit more of a voting force.

## Changelog
:cl:
/:cl: