### PR TITLE
Xenofloral Biogenerator Fixes

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -7,6 +7,7 @@
 	anchored = 1
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 40
+	circuit = /obj/item/weapon/circuitboard/biogenerator
 	var/processing = 0
 	var/obj/item/weapon/reagent_containers/glass/beaker = null
 	var/points = 0
@@ -41,8 +42,8 @@
 			list(name="Wallet", cost=100, path=/obj/item/weapon/storage/wallet),
 			list(name="Botanical gloves", cost=250, path=/obj/item/clothing/gloves/botanic_leather),
 			list(name="Utility belt", cost=300, path=/obj/item/weapon/storage/belt/utility),
-			list(name="Leather Satchel", cost=400, path=/obj/item/weapon/storage/backpack/satchel),
-			list(name="Leather jacket", cost=400, /obj/item/clothing/suit/storage/toggle/leather),
+			list(name="Leather Satchel", cost=400, path=/obj/item/weapon/storage/backpack/satchel/leather),
+			list(name="Leather Jacket", cost=400, path=/obj/item/clothing/suit/storage/toggle/leather),
 			list(name="Cash Bag", cost=400, path=/obj/item/weapon/storage/bag/money),
 			list(name="Medical belt", cost=300, path=/obj/item/weapon/storage/belt/medical),
 			list(name="Security belt", cost=300, path=/obj/item/weapon/storage/belt/security),

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -7,7 +7,6 @@
 	anchored = 1
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 40
-	circuit = /obj/item/weapon/circuitboard/biogenerator
 	var/processing = 0
 	var/obj/item/weapon/reagent_containers/glass/beaker = null
 	var/points = 0
@@ -42,8 +41,8 @@
 			list(name="Wallet", cost=100, path=/obj/item/weapon/storage/wallet),
 			list(name="Botanical gloves", cost=250, path=/obj/item/clothing/gloves/botanic_leather),
 			list(name="Utility belt", cost=300, path=/obj/item/weapon/storage/belt/utility),
-			list(name="Leather Satchel", cost=400, path=/obj/item/weapon/storage/backpack/satchel/leather),
-			list(name="Leather Jacket", cost=400, path=/obj/item/clothing/suit/storage/toggle/leather),
+			list(name="Leather Satchel", cost=400, path=/obj/item/weapon/storage/backpack/satchel),
+			list(name="Leather jacket", cost=400, /obj/item/clothing/suit/storage/toggle/leather),
 			list(name="Cash Bag", cost=400, path=/obj/item/weapon/storage/bag/money),
 			list(name="Medical belt", cost=300, path=/obj/item/weapon/storage/belt/medical),
 			list(name="Security belt", cost=300, path=/obj/item/weapon/storage/belt/security),


### PR DESCRIPTION
Fixes bug where round spawn Xenofloral Biogenerators could not be upgraded or deconstructed.

Fixes bug where choosing Leather Jacket caused Biogenerator to seize up and brick itself.

Makes Leather Satchel actually produce a leather satchel as opposed to a standard grey satchel.