### PR TITLE
bugfix/Make cleanbots less laggy

### DIFF
--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -78,25 +78,26 @@
 
 	var/found_spot
 	var/target_in_view = FALSE
-	search_loop:
-		for(var/i=0, i <= maximum_search_range, i++)
-			for(var/obj/effect/decal/cleanable/D in view(i, src))
-				if(D in ignorelist)
-					continue
-				for(var/T in target_types)
-					if(istype(D, T))
-						target = D
-						found_spot = handle_target()
-						if (found_spot)
-							break search_loop
-						else
-							target_in_view = TRUE
-							target = null
-							continue // no need to check the other types
+	if(world.time > give_up_cooldown)
+		search_loop:
+			for(var/i=0, i <= maximum_search_range, i++)
+				for(var/obj/effect/decal/cleanable/D in view(i, src))
+					if(D in ignorelist)
+						continue
+					for(var/T in target_types)
+						if(istype(D, T))
+							target = D
+							found_spot = handle_target()
+							if (found_spot)
+								break search_loop
+							else
+								target_in_view = TRUE
+								target = null
+								continue // no need to check the other types
 
 	if(!found_spot && target_in_view && world.time > give_up_cooldown)
 		visible_message("[src] can't reach the target and is giving up.")
-		give_up_cooldown = world.time + 300
+		give_up_cooldown = world.time + rand(300, 600)
 
 
 /mob/living/bot/cleanbot/UnarmedAttack(var/obj/effect/decal/cleanable/D, var/proximity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes cleanbots cancel pathfinding for their timeout period when they can't find a path so that they don't constantly spam it every chance they get. Also randomizes the timeout between 30 and 60 seconds to prevent multiple cleanbots from ending up on the same tick forever and lagging the server every time their timeout comes up.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>

## Changelog
:cl:
fix: Made cleanbots less laggy when unable to path to a dirty tile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
