### PR TITLE
Exl teleporter name fixes

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disk/greyson_excelsior_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/greyson_excelsior_disks.dm
@@ -42,9 +42,10 @@
 
 	)
 
-// Excelsior
+// Excelsior We also replace "name" for spawning reasons
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/excelsior
-	disk_name = "Excelsior Means of Production"
+	name = "design disk Means of Production"
+	disk_name = "Excelsior"
 	desc = "The back has a machine etching: \"This struggle must be organised, according to \"all the rules of the art\", by people who are professionally engaged in revolutionary activity.\""
 	icon_state = "excelsior"
 
@@ -110,7 +111,8 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/excelsior_weapons
-	disk_name = "Excelsior Means of Revolution"
+	name = "design disk Means of Revolution"
+	disk_name = "Excelsior"
 	desc = "The back has a machine etching: \"We stand for organized terror - this should be frankly admitted. Terror is an absolute necessity during times of revolution.\""
 	icon_state = "excelsior"
 
@@ -145,7 +147,8 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/ex_parts
-	disk_name = "Excelsior - Stocking Revolution"
+	name = "design disk Stocking Revolution"
+	disk_name = "Excelsior"
 	desc = "The back has a machine etching: \"Everything can be apart of the revolution!\""
 	icon_state = "excelsior"
 
@@ -168,7 +171,8 @@
 
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/ex_cells
-	disk_name = "Excelsior - Means of Power"
+	name = "design disk Means of Power"
+	disk_name = "Excelsior"
 	desc = "The back has a machine etching: \"The power of the people!\""
 	icon_state = "excelsior"
 
@@ -180,7 +184,8 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ex_drozd
-	disk_name = "Excelsior - .35 Drozd SMG"
+	disk_name = "design disk .35 Drozd SMG"
+	disk_name = "Excelsior"
 	desc = "The back has a machine etching: \"Nobody is to be blamed for being born a slave; but a slave who not only eschews a striving for freedom but justifies and eulogies his slavery - such a slave is a lickspittle and a boor, who arouses a legitimate feeling of indignation, contempt, and loathing..\""
 	icon_state = "excelsior"
 
@@ -192,7 +197,8 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ex_makarov
-	disk_name = "Excelsior - Makarov"
+	name = "design disk Makarov"
+	disk_name = "Excelsior"
 	desc = "The back has a machine etching: \"The Equalizer that fits in your pocket.\""
 	icon_state = "excelsior"
 
@@ -204,7 +210,8 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ex_vintorez
-	disk_name = "Excelsior - Vintorez"
+	name = "design disk Vintorez"
+	disk_name = "Excelsior"
 	desc = "The back has a machine etching: \"The gun of long revolution.\""
 	icon_state = "excelsior"
 
@@ -216,7 +223,8 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ex_boltgun
-	disk_name = "Excelsior - Kardashev-Mosin"
+	name = "design disk Kardashev-Mosin"
+	disk_name = "Excelsior"
 	desc = "The back has a machine etching: \"The gun of endless revolution.\""
 	icon_state = "excelsior"
 
@@ -228,7 +236,8 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ex_ak
-	disk_name = "Excelsior - Kalashnikov"
+	name = "design disk Kalashnikov"
+	disk_name = "Excelsior"
 	desc = "The back has a machine etching: \"The gun of modern revolution.\""
 	icon_state = "excelsior"
 
@@ -241,7 +250,8 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ex_reclaimer
-	disk_name = "Excelsior - Reclaimer"
+	name = "design disk Reclaimer"
+	disk_name = "Excelsior"
 	desc = "The back has a machine etching: \"The gun of clean revolution.\""
 	icon_state = "excelsior"
 
@@ -251,7 +261,8 @@
 		)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ex_ppsh
-	disk_name = "Excelsior - Shpagin"
+	name = "design disk Shpagin"
+	disk_name = "Excelsior"
 	desc = "The back has a machine etching: \"The hammer to break the chains.\""
 	icon_state = "excelsior"
 

--- a/code/game/objects/items/weapons/circuitboards/machinery/excelsior.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/excelsior.dm
@@ -1,5 +1,8 @@
+
+//We override boards do to a spawner using the "name" rather then build name
 /obj/item/weapon/circuitboard/excelsiorshieldwallgen
-	build_name = "excelsior shield wall generator"
+	name = "circuit board excelsior shield wall generator"
+	build_name = ""
 	board_type = "machine"
 	build_path = /obj/machinery/shieldwallgen/excelsior
 	origin_tech = list(TECH_BLUESPACE = 3, TECH_MAGNET = 3, TECH_ILLEGAL = 2)
@@ -12,7 +15,8 @@
 	)
 
 /obj/item/weapon/circuitboard/excelsiorautolathe
-	build_name = "excelsior autolathe"
+	name = "circuit board excelsior autolathe"
+	build_name = ""
 	build_path = /obj/machinery/autolathe/excelsior
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2, TECH_ILLEGAL = 2)
@@ -22,6 +26,7 @@
 	)
 
 /obj/item/weapon/circuitboard/excelsiorreconstructor
+	name = "circuit board excelsior implant reconstructor"
 	build_name = "excelsior implant reconstructor"
 	build_path = /obj/machinery/complant_maker
 	board_type = "machine"
@@ -32,7 +37,8 @@
 	)
 
 /obj/item/weapon/circuitboard/diesel
-	build_name = "diesel generator"
+	name = "circuit board diesel generator"
+	build_name = " "
 	build_path = /obj/machinery/power/port_gen/pacman/diesel
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 3, TECH_POWER = 3, TECH_PLASMA = 3, TECH_ENGINEERING = 3, TECH_ILLEGAL = 2)
@@ -44,7 +50,8 @@
 	)
 
 /obj/item/weapon/circuitboard/excelsior_boombox
-	build_name = "excelsior boombox"
+	name = "circuit board excelsior boombox"
+	build_name = " "
 	build_path = /obj/machinery/excelsior_boombox
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 3, TECH_ILLEGAL = 1)
@@ -54,7 +61,8 @@
 	)
 
 /obj/item/weapon/circuitboard/excelsior_teleporter
-	build_name = "excelsior teleporter"
+	name = "circuit board excelsior teleporter"
+	build_name = ""
 	build_path = /obj/machinery/complant_teleporter
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 3, TECH_BLUESPACE = 3, TECH_ILLEGAL = 2)
@@ -65,7 +73,8 @@
 	)
 
 /obj/item/weapon/circuitboard/excelsior_turret
-	build_name = "excelsior turret"
+	name = "circuit board excelsior turret"
+	build_name = ""
 	build_path = /obj/machinery/porta_turret/excelsior
 	board_type = "machine"
 	origin_tech = list(TECH_COMBAT = 3, TECH_ILLEGAL = 2)


### PR DESCRIPTION

## About The Pull Request
Exl disks and boards now have their faction and such echted onto the board itself rather then being modular so that the teleporter can read the names correctly

## Changelog
:cl:
/:cl:
