### PR TITLE
Disables Cthmant Augmentations

### DIFF
--- a/code/datums/setup_option/backgrounds/origin.dm
+++ b/code/datums/setup_option/backgrounds/origin.dm
@@ -373,6 +373,8 @@
 
 	perks = list(/datum/perk/scuttlebug)
 
+	allow_modifications = FALSE
+
 	stat_modifiers = list(
 		STAT_ROB = 4,
 		STAT_TGH = 3,
@@ -394,6 +396,8 @@
 	restricted_depts = SECURITY | PROSPECTOR
 
 	perks = list(/datum/perk/ichor)
+
+	allow_modifications = FALSE
 
 	stat_modifiers = list(
 		STAT_ROB = -8,
@@ -417,6 +421,8 @@
 	restricted_jobs = list(/datum/job/cmo, /datum/job/rd, /datum/job/smc, /datum/job/swo, /datum/job/cmo, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/paramedic, /datum/job/premier, /datum/job/pg, /datum/job/chief_engineer, /datum/job/chaplain, /datum/job/merchant)
 
 	perks = list(/datum/perk/chitinarmor)
+
+	allow_modifications = FALSE
 
 	stat_modifiers = list(
 		STAT_ROB = 15,

--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -16,6 +16,7 @@
 		)
 	allowed_depts = CHURCH
 	allow_modifications = TRUE
+	restricted_to_species = list(FORM_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_OPIFEX, FORM_CINDAR)
 
 /datum/category_item/setup_option/core_implant/cruciform/tessellate
 	name = "Tessellate Cruciform"


### PR DESCRIPTION
No longer allows Cthmants to alter their bodies in Character Setup.

Disables the Cruciform "Background" for Cthmants in Character Setup.


I do not know what will happen to any Cthmants with augmentations already saved to their loadouts.

I do not know what will happen if someone decides to try and install a Cruciform (or metal appendage) during the course of gameplay.