### PR TITLE
Scrap code changes and fixes

### DIFF
--- a/code/datums/autolathe/circuits.dm
+++ b/code/datums/autolathe/circuits.dm
@@ -83,3 +83,11 @@
 /datum/design/autolathe/circuit/sorter
 	name = "sorter"
 	build_path = /obj/item/weapon/circuitboard/sorter
+
+/datum/design/autolathe/circuit/recycler
+	name = "recycler"
+	build_path = /obj/item/weapon/circuitboard/recycler
+
+/datum/design/autolathe/circuit/pile_ripper
+	name = "pile ripper"
+	build_path = /obj/item/weapon/circuitboard/pile_ripper

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -49,12 +49,22 @@
 			if(locate(/mob/living) in O)
 				occupant_message(SPAN_WARNING("You can't load living things into the cargo compartment."))
 				return
-			if(O.anchored && (!istype(O, /obj/structure/scrap) && !istype(O, /obj/structure/salvageable)))
+			if(O.anchored && !istype(O, /obj/structure/salvageable))
 				occupant_message(SPAN_WARNING("[target] is firmly secured."))
 				return
 			if(cargo_holder.cargo.len >= cargo_holder.cargo_capacity)
 				occupant_message(SPAN_WARNING("Not enough room in cargo compartment."))
 				return
+
+			if(istype(target, /obj/structure/scrap))
+				occupant_message(SPAN_NOTICE("\The [chassis] begins compressing \the [O] with \the [src]."))
+				if(do_after_cooldown(O))
+					if(istype(O, /obj/structure/scrap))
+						var/obj/structure/scrap/S = O
+						S.make_cube()
+						occupant_message(SPAN_NOTICE("\The [chassis] compresses \the [O] into a cube with \the [src]."))
+				return
+
 
 			occupant_message("You lift [target] and start to load it into cargo compartment.")
 			playsound(src,'sound/mecha/hydraulic.ogg',100,1)

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -88,6 +88,7 @@
 				new /obj/item/stack/material/plastic(get_turf(src), 1 ? 30 : 2)
 				new /obj/item/stack/material/plasteel(get_turf(src), 1 ? 20 : 2)
 				new /obj/item/stack/material/glass(get_turf(src), 1 ? 10 : 2)
+				new /obj/item/stack/sheet/refined_scrap(get_turf(src), 1 ? 30 : 2)
 				to_chat(user, SPAN_NOTICE("You cut up the mech."))
 				qdel(src)
 			return

--- a/code/game/objects/items/weapons/autolathe_disk/guild_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guild_disks.dm
@@ -120,7 +120,9 @@
 		/datum/design/autolathe/conveyor = 0,
 		/datum/design/autolathe/conveyor_switch = 0,
 		///datum/design/autolathe/circuit/smelter = 3, //Balance, no more rnd/guild abuse
-		/datum/design/autolathe/circuit/sorter = 3
+		/datum/design/autolathe/circuit/sorter = 3,
+		/datum/design/autolathe/circuit/recycler = 1,
+		/datum/design/autolathe/circuit/pile_ripper = 1,
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/engineering
@@ -181,6 +183,8 @@
 		/datum/design/autolathe/circuit/centrifuge,
 		/datum/design/autolathe/circuit/smelter, //Ok some guild abuse
 		/datum/design/autolathe/circuit/sorter,
+		/datum/design/autolathe/circuit/recycler,
+		/datum/design/autolathe/circuit/pile_ripper,
 		// From tool mods
 		/datum/design/autolathe/part/laserguide,
 		/datum/design/autolathe/part/diamondblade,
@@ -337,6 +341,8 @@
 	/datum/design/research/circuit/smes_cell,
 	/datum/design/research/circuit/batteryrack,
 	/datum/design/research/circuit/breakerbox,
+	/datum/design/autolathe/circuit/recycler,
+	/datum/design/autolathe/circuit/pile_ripper,
 	//Stock Parts, and SMES coils
 	/datum/design/autolathe/part/consolescreen,
 	/datum/design/research/item/part/basic_capacitor,

--- a/code/game/objects/random/junk.dm
+++ b/code/game/objects/random/junk.dm
@@ -6,6 +6,7 @@
 	var/list/items = list(
 		/obj/item/weapon/material/shard = 5,
 		/obj/item/weapon/material/shard/shrapnel = 8,
+		/obj/item/weapon/scrap_lump = 1,
 		/obj/item/weapon/reagent_containers/pill/floorpill = 8,
 		/obj/item/stack/material/cardboard = 3,
 		/obj/item/weapon/storage/box/lights/mixed = 3,

--- a/code/game/objects/random/purerandom.dm
+++ b/code/game/objects/random/purerandom.dm
@@ -6,6 +6,7 @@
 /obj/random/lowkeyrandom/item_to_spawn()
 	return pickweight(list(
 				/obj/item/ammo_magazine/ammobox/shotgun/beanbags = 1,
+				/obj/item/weapon/scrap_lump = 2,
 				/obj/item/weapon/storage/box/matches = 3,
 				/obj/item/stack/material/cardboard = 2,
 				/obj/item/weapon/cell/large = 3,

--- a/code/game/objects/structures/salvageable.dm
+++ b/code/game/objects/structures/salvageable.dm
@@ -22,9 +22,21 @@
 				to_chat(user, SPAN_NOTICE("Thanks to your training on salvaging machines you find additional materials in \the [src]."))
 				new /obj/random/material_handyman(src.loc)
 				new /obj/item/stack/sheet/refined_scrap/random(src.loc) //So we can fuel scap-pacmans
+				if(prob(50))
+					new /obj/item/weapon/scrap_lump(src.loc)
+				if(prob(25))
+					new /obj/item/weapon/scrap_lump(src.loc)
+				if(prob(5))
+					new /obj/item/weapon/scrap_lump(src.loc)
 			else if(user.stats.getPerk(PERK_HANDYMAN))
 				to_chat(user, SPAN_NOTICE("You don't find any additional rare materials, but you do manage to salvage some refined scrap from \the [src]."))
 				new /obj/item/stack/sheet/refined_scrap/random(src.loc)
+				if(prob(50))
+					new /obj/item/weapon/scrap_lump(src.loc)
+				if(prob(25))
+					new /obj/item/weapon/scrap_lump(src.loc)
+				if(prob(5))
+					new /obj/item/weapon/scrap_lump(src.loc)
 			qdel(src)
 			return
 
@@ -35,6 +47,11 @@
 	icon_state = "machine"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 80,
+		/obj/item/weapon/scrap_lump = 70,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 20,
+		/obj/item/weapon/scrap_lump = 10,
+		/obj/item/weapon/scrap_lump = 5,
 		/obj/item/stack/cable_coil{amount = 5} = 80,
 		/obj/item/trash/material/circuit = 60,
 		/obj/item/trash/material/metal = 60,
@@ -69,6 +86,9 @@
 	icon_state = "computer"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 80,
+		/obj/item/weapon/scrap_lump = 70,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 20,
 		/obj/item/stack/cable_coil{amount = 5} = 90,
 		/obj/item/stack/material/glass{amount = 5} = 90,
 		/obj/item/trash/material/circuit = 60,
@@ -95,6 +115,11 @@ obj/structure/salvageable/computer/Initialize()
 	icon_state = "autolathe"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 80,
+		/obj/item/weapon/scrap_lump = 70,
+		/obj/item/weapon/scrap_lump = 60,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 30,
 		/obj/item/stack/cable_coil{amount = 5} = 80,
 		/obj/item/trash/material/circuit = 60,
 		/obj/item/trash/material/metal = 60,
@@ -130,6 +155,10 @@ obj/structure/salvageable/computer/Initialize()
 	icon_state = "implant-container"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 80,
+		/obj/item/weapon/scrap_lump = 70,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 30,
+		/obj/item/weapon/scrap_lump = 10,
 		/obj/item/stack/cable_coil{amount = 5} = 80,
 		/obj/item/trash/material/circuit = 60,
 		/obj/item/trash/material/metal = 60,
@@ -168,6 +197,9 @@ obj/structure/salvageable/implant_container/Initialize()
 	icon_state = "data"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 80,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 30,
 		/obj/item/stack/cable_coil{amount = 5} = 90,
 		/obj/item/stack/material/glass{amount = 5} = 90,
 		/obj/item/trash/material/circuit = 60,
@@ -196,6 +228,10 @@ obj/structure/salvageable/data/Initialize()
 	icon_state = "server"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 80,
+		/obj/item/weapon/scrap_lump = 60,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 40,
 		/obj/item/stack/cable_coil{amount = 5} = 90,
 		/obj/item/stack/material/glass{amount = 5} = 90,
 		/obj/item/trash/material/circuit = 60,
@@ -226,6 +262,8 @@ obj/structure/salvageable/server/Initialize()
 	icon_state = "personal"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 90,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 30,
 		/obj/item/stack/cable_coil{amount = 5} = 90,
 		/obj/item/weapon/computer_hardware/led = 40,
 		/obj/item/weapon/computer_hardware/led/adv = 40,
@@ -289,6 +327,12 @@ obj/structure/salvageable/bliss/Initialize()
 	icon_state = "os-machine"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 80,
+		/obj/item/weapon/scrap_lump = 60,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 30,
 		/obj/item/stack/cable_coil{amount = 5} = 80,
 		/obj/item/weapon/stock_parts/capacitor/one_star = 40,
 		/obj/item/weapon/stock_parts/capacitor/one_star = 40,
@@ -311,6 +355,12 @@ obj/structure/salvageable/bliss/Initialize()
 	icon_state = "os_autolathe"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 80,
+		/obj/item/weapon/scrap_lump = 90,
+		/obj/item/weapon/scrap_lump = 70,
+		/obj/item/weapon/scrap_lump = 60,
+		/obj/item/weapon/scrap_lump = 60,
+		/obj/item/weapon/scrap_lump = 60,
+		/obj/item/weapon/scrap_lump = 50,
 		/obj/item/stack/cable_coil{amount = 5} = 80,
 		/obj/item/weapon/stock_parts/capacitor/one_star = 20,
 		/obj/item/weapon/stock_parts/capacitor/one_star = 20,
@@ -347,6 +397,12 @@ obj/structure/salvageable/bliss/Initialize()
 	icon_state = "os-computer"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 80,
+		/obj/item/weapon/scrap_lump = 60,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 30,
 		/obj/item/stack/cable_coil{amount = 5} = 90,
 		/obj/item/stack/material/glass{amount = 5} = 90,
 		/obj/item/weapon/stock_parts/capacitor/one_star = 60,
@@ -364,6 +420,12 @@ obj/structure/salvageable/bliss/Initialize()
 	icon_state = "os-container"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 80,
+		/obj/item/weapon/scrap_lump = 60,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 30,
 		/obj/item/stack/cable_coil{amount = 5} = 80,
 		/obj/item/weapon/implant/death_alarm = 30,
 		/obj/item/weapon/implant/explosive = 20,
@@ -388,6 +450,12 @@ obj/structure/salvageable/bliss/Initialize()
 	icon_state = "os-data"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 90,
+		/obj/item/weapon/scrap_lump = 60,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 30,
 		/obj/item/stack/cable_coil{amount = 5} = 90,
 		/obj/item/stack/material/glass{amount = 5} = 90,
 		/obj/item/weapon/computer_hardware/processor_unit/adv = 60,
@@ -404,6 +472,12 @@ obj/structure/salvageable/bliss/Initialize()
 	icon_state = "os-server"
 	salvageable_parts = list(
 		/obj/item/weapon/stock_parts/console_screen = 80,
+		/obj/item/weapon/scrap_lump = 60,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 30,
 		/obj/item/stack/cable_coil{amount = 5} = 90,
 		/obj/item/stack/material/glass{amount = 5} = 90,
 		/obj/item/weapon/computer_hardware/network_card/wired = 40,
@@ -430,6 +504,12 @@ obj/structure/salvageable/bliss/Initialize()
 	salvageable_parts = list(
 		/obj/item/weapon/computer_hardware/hard_drive/portable/research_points = 60,
 		/obj/item/weapon/computer_hardware/hard_drive/portable/research_points/rare = 25,
+		/obj/item/weapon/scrap_lump = 30,
+		/obj/item/weapon/scrap_lump = 25,
+		/obj/item/weapon/scrap_lump = 20,
+		/obj/item/weapon/scrap_lump = 20,
+		/obj/item/weapon/scrap_lump = 20,
+		/obj/item/weapon/scrap_lump = 10,
 		/obj/item/stack/cable_coil{amount = 5} = 90,
 		/obj/item/weapon/stock_parts/console_screen = 80,
 		/obj/item/weapon/stock_parts/capacitor/one_star = 60,
@@ -448,6 +528,13 @@ obj/structure/salvageable/bliss/Initialize()
 	salvageable_parts = list(
 		/obj/item/weapon/computer_hardware/hard_drive/portable/research_points = 30,
 		/obj/item/weapon/computer_hardware/hard_drive/portable/research_points/rare = 15,
+		/obj/item/weapon/scrap_lump = 60,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 50,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 40,
+		/obj/item/weapon/scrap_lump = 30,
 		/obj/item/stack/cable_coil{amount = 5} = 90,
 		/obj/item/weapon/stock_parts/console_screen = 80,
 		/obj/item/weapon/stock_parts/capacitor/one_star = 60,

--- a/code/modules/scrap/scrap_pileripper.dm
+++ b/code/modules/scrap/scrap_pileripper.dm
@@ -17,7 +17,7 @@
 	density = TRUE
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 300
-
+	circuit = /obj/item/weapon/circuitboard/pile_ripper
 	var/safety_mode = FALSE // Temporality stops the machine if it detects a mob
 	var/icon_name = "grinder-b"
 	var/blood = 0

--- a/code/modules/scrap/scrap_refine.dm
+++ b/code/modules/scrap/scrap_refine.dm
@@ -30,7 +30,7 @@
 	desc = "This thing is messed up beyond any recognition. Into the grinder it goes!"
 	icon = 'icons/obj/structures/scrap/refine.dmi'
 	icon_state = "unrefined"
-	w_class = ITEM_SIZE_BULKY
+	w_class = ITEM_SIZE_TINY //so we can fit more then 2 in a bag
 
 /obj/item/weapon/scrap_lump/Initialize()
 	. = ..()

--- a/code/modules/scrap/scrap_refinery.dm
+++ b/code/modules/scrap/scrap_refinery.dm
@@ -18,22 +18,20 @@
 	var/safety_mode = FALSE // Temporality stops the machine if it detects a mob
 	var/grinding = FALSE
 	var/icon_name = "grinder-o"
+	circuit = /obj/item/weapon/circuitboard/recycler
 	var/blood = FALSE
 	var/eat_dir = WEST
-	var/chance_to_recycle = 1
+	var/chance_to_recycle = 33
 
 /obj/machinery/recycler/Initialize()
 	// On us
 	. = ..()
-	component_parts = list()
-	component_parts += new /obj/item/weapon/circuitboard/recycler(null)
-	component_parts += new /obj/item/weapon/stock_parts/manipulator(null)
 	RefreshParts()
 	update_icon()
 
 /obj/machinery/recycler/RefreshParts()
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
-		chance_to_recycle = 25 * M.rating //% of materials salvaged
+		chance_to_recycle = 33 * M.rating //% of materials salvaged level 3 parts is 99%
 	chance_to_recycle = min(100, chance_to_recycle)
 
 /obj/machinery/recycler/examine(mob/user)
@@ -110,10 +108,10 @@
 
 	if(sound)
 		playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
-	var/chance_mod = 1
+	var/chance_mod = 1 //Unused
 	if(!istype(I, /obj/item/weapon/scrap_lump))
-		chance_mod = 5
-	if(prob(chance_to_recycle / chance_mod))
+		chance_mod = 1 //Unused
+	if(prob(chance_to_recycle / chance_mod)) //change_mod here is not used, - divieds by one, prevents warning
 		new /obj/item/stack/sheet/refined_scrap(loc)
 	qdel(I)
 


### PR DESCRIPTION
## About The Pull Request
Clamping scrap piles now cube them hopefully
taking apat things now gives unrefined scrap, you get more as guild
unrefined scrap is now a common trash item
unrefined scrap is now in trash piles
Drasticlly highers the odd of the scrapper into refined scrap
fixes the missing boards in the thingys that do the things with the boards and the parts
adds 2 more boards to the logistic disk making it /work getting/ maybe
## Changelog
:cl:
/:cl:

