### PR TITLE
Fixes double cost calculation in matterforge.

### DIFF
--- a/code/game/machinery/autolathe/matterforge.dm
+++ b/code/game/machinery/autolathe/matterforge.dm
@@ -497,12 +497,7 @@
 	next_file()
 
 /obj/machinery/matter_nanoforge/proc/consume_materials(datum/design/design)
-	for(var/material in design.materials)
-	// + 15 base cost for each material then * 2
-		design.materials[material] += ((1 - lst[material]) * 10) * 2
-		var/material_cost = design.adjust_materials ? SANITIZE_LATHE_COST(design.materials[material]): design.materials[material]
-		stored_material[MATERIAL_COMPRESSED_MATTER] = max(0, stored_material[MATERIAL_COMPRESSED_MATTER] - material_cost)
-
+	stored_material[MATERIAL_COMPRESSED_MATTER] = max(0, stored_material[MATERIAL_COMPRESSED_MATTER] - material_cost)
 	return TRUE
 
 #undef ERR_OK

--- a/code/game/machinery/autolathe/matterforge.dm
+++ b/code/game/machinery/autolathe/matterforge.dm
@@ -497,7 +497,7 @@
 	next_file()
 
 /obj/machinery/matter_nanoforge/proc/consume_materials(datum/design/design)
-	stored_material[MATERIAL_COMPRESSED_MATTER] = max(0, stored_material[MATERIAL_COMPRESSED_MATTER] - material_cost)
+	stored_material[MATERIAL_COMPRESSED_MATTER] = max(0, stored_material[MATERIAL_COMPRESSED_MATTER] - design.materials[MATERIAL_COMPRESSED_MATTER])
 	return TRUE
 
 #undef ERR_OK


### PR DESCRIPTION
Before my initial fixes: matter forge was altering the *apparent* cost of a recipe but not the actual cost.
After my initial fixes: matter forge was altering the actual cost properly.
Problem now: matter forge was not tweaked in my fix to no longer recalculate the real cost when needed.
Fix now: matter forge no longer calculates actual cost twice.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fix: Matterforge doing the cost-to-matter calculation on recipes twice.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
