### PR TITLE
Hydroelectric fix2

### DIFF
--- a/code/modules/power/hydroelectric.dm
+++ b/code/modules/power/hydroelectric.dm
@@ -227,7 +227,7 @@
 
 /obj/machinery/power/hydroelectric_control/proc/togglegate()
 	working = !working
-	malfnumber = malfnumber + 5
+	malfnumber = malfnumber + 10
 
 /obj/machinery/power/hydroelectric_control/attack_hand(mob/user)
 	ui_interact(user)

--- a/code/modules/power/hydroelectric.dm
+++ b/code/modules/power/hydroelectric.dm
@@ -179,6 +179,7 @@
 				var/malftrigger = rand(1,workingturbines)
 				connected_turbines[malftrigger].Malfunction()
 				malfnumber = 0
+			tidechange = 0
 		return
 
 	if(waterheld >= 10000 && !announced)
@@ -226,7 +227,7 @@
 
 /obj/machinery/power/hydroelectric_control/proc/togglegate()
 	working = !working
-	malfnumber = malfnumber + 1
+	malfnumber = malfnumber + 5
 
 /obj/machinery/power/hydroelectric_control/attack_hand(mob/user)
 	ui_interact(user)


### PR DESCRIPTION
Changing the Hydroelectric Dam.

Due to a missing line in the initial release, the counter to check if the die would change would always spill over and only trigger once per round. This made malfunctioning a near impossibility.

It will now function as desired. Before, it was stuck at the lowest possible filling setting. Not will randomly choose between a few numbers of settings. 

To balance out the potential for faster filling, the chance to malfunction (which now it will) goes up 10% each time the dam is turned on.