### PR TITLE
Guns manufacture and naming lore tweaks

### DIFF
--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -60,7 +60,7 @@
 	build_path = /obj/item/weapon/gun/projectile/ladon/sa
 
 /datum/design/autolathe/gun/rafale
-	name = "SM SHG .40 \"Rafale\""
+	name = "GmbH SHG .40 \"Rafale\""
 	build_path = /obj/item/weapon/gun/projectile/silenced
 
 /datum/design/autolathe/gun/mk58_wood
@@ -129,7 +129,7 @@
 	build_path = /obj/item/weapon/gun/projectile/automatic/straylight
 
 /datum/design/autolathe/gun/wirbelwind
-	name = "SM SMG ,35 \"Wirbelwind\""
+	name = "GmbH SMG ,35 \"Wirbelwind\""
 	build_path = /obj/item/weapon/gun/projectile/automatic/wirbelwind
 
 /datum/design/autolathe/gun/drozd
@@ -205,7 +205,7 @@
 	build_path = /obj/item/weapon/gun/projectile/automatic/pitbull
 
 /datum/design/autolathe/gun/ostwind
-	name = "SM AR .257 \"Ostwind\""
+	name = "GmbH AR .257 \"Ostwind\""
 	build_path = /obj/item/weapon/gun/projectile/automatic/ostwind
 
 /datum/design/autolathe/gun/sts25
@@ -236,7 +236,7 @@
 	build_path = /obj/item/weapon/gun/projectile/automatic/vintorez
 
 /datum/design/autolathe/gun/nordwind
-	name = "SM DMR - 7.5mm  \"Nordwind\""
+	name = "GmbH DMR - 7.5mm  \"Nordwind\""
 	build_path = /obj/item/weapon/gun/projectile/automatic/nordwind
 
 /datum/design/autolathe/gun/sts30
@@ -314,7 +314,7 @@
 	build_path = /obj/item/weapon/gun/projectile/automatic/dp
 
 /datum/design/autolathe/gun/survivalrifle
-	name = "SM SAS .10mm Caseless \"Bond\" Rifle"
+	name = "SAS .10mm Caseless \"Bond\" Rifle"
 	build_path = /obj/item/weapon/gun/projectile/automatic/survivalrifle
 
 //L A U N C H E R S

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -11,22 +11,22 @@
 	name = "turret"
 	icon = 'icons/obj/turrets.dmi'
 	icon_state = "turretCover"
-	anchored = 1
+	anchored = TRUE
 
-	density = 0
+	density = FALSE
 	use_power = IDLE_POWER_USE				//this turret uses and requires power
 	idle_power_usage = 50		//when inactive, this turret takes up constant 50 Equipment power
 	active_power_usage = 300	//when active, this turret takes up constant 300 Equipment power
 	power_channel = EQUIP	//drains power from the EQUIPMENT channel
 
-	var/raised = 0			//if the turret cover is "open" and the turret is raised
-	var/raising= 0			//if the turret is currently opening or closing its cover
+	var/raised = FALSE			//if the turret cover is "open" and the turret is raised
+	var/raising= FALSE			//if the turret is currently opening or closing its cover
 	health = 80			//the turret's health
 	maxHealth = 80		//turrets maximal health.
 	var/resistance = RESISTANCE_FRAGILE 		//reduction on incoming damage
-	var/auto_repair = 0		//if 1 the turret slowly repairs itself.
-	var/locked = 1			//if the turret's behaviour control access is locked
-	var/controllock = 0		//if the turret responds to control panels
+	var/auto_repair = FALSE		//if 1 the turret slowly repairs itself.
+	var/locked = TRUE			//if the turret's behaviour control access is locked
+	var/controllock = FALSE		//if the turret responds to control panels
 
 	var/obj/item/weapon/gun/energy/installation = /obj/item/weapon/gun/energy/gun	//the weapon that's installed. Store as path to initialize a new gun on creation.
 	var/projectile = null	//holder for bullettype
@@ -38,19 +38,19 @@
 	var/last_fired = 0		//1: if the turret is cooling down from a shot, 0: turret is ready to fire
 	var/shot_delay = 15		//1.5 seconds between each shot
 
-	var/check_arrest = 1	//checks if the perp is set to arrest
-	var/check_records = 1	//checks if a security record exists at all
-	var/check_weapons = 0	//checks if it can shoot people that have a weapon they aren't authorized to have
-	var/check_access = 1	//if this is active, the turret shoots everything that does not meet the access requirements
-	var/check_anomalies = 1	//checks if it can shoot at unidentified lifeforms (ie xenos)
-	var/check_synth	 = 0 	//if active, will shoot at anything not an AI or cyborg
-	var/ailock = 0 			// AI cannot use this
+	var/check_arrest = TRUE	//checks if the perp is set to arrest
+	var/check_records = TRUE	//checks if a security record exists at all
+	var/check_weapons = FALSE	//checks if it can shoot people that have a weapon they aren't authorized to have
+	var/check_access = TRUE	//if this is active, the turret shoots everything that does not meet the access requirements
+	var/check_anomalies = TRUE	//checks if it can shoot at unidentified lifeforms (ie xenos)
+	var/check_synth	 = FALSE 	//if active, will shoot at anything not an AI or cyborg
+	var/ailock = FALSE 			// AI cannot use this
 
-	var/attacked = 0		//if set to 1, the turret gets pissed off and shoots at people nearby (unless they have sec access!)
+	var/attacked = FALSE		//if set to 1, the turret gets pissed off and shoots at people nearby (unless they have sec access!)
 
-	var/enabled = 1				//determines if the turret is on
-	var/lethal = 0			//whether in lethal or stun mode
-	var/disabled = 0
+	var/enabled = TRUE				//determines if the turret is on
+	var/lethal = FALSE			//whether in lethal or stun mode
+	var/disabled = FALSE
 
 	var/shot_sound 			//what sound should play when the turret fires
 	var/eshot_sound			//what sound should play when the emagged turret fires
@@ -60,40 +60,40 @@
 	var/wrenching = 0
 	var/last_target					//last target fired at, prevents turrets from erratically firing at all valid targets in range
 
-	var/hackfail = 0				//if the turret has gotten pissed at someone who tried to hack it, but failed, it will immediately reactivate and target them.
-	var/debugopen = 0				//if the turret's debug functions are accessible through the control panel
+	var/hackfail = FALSE				//if the turret has gotten pissed at someone who tried to hack it, but failed, it will immediately reactivate and target them.
+	var/debugopen = FALSE				//if the turret's debug functions are accessible through the control panel
 	var/list/registered_names = list() 		//holder for registered IDs for the turret to ignore
 	var/list/access_occupy = list()
-	var/overridden = 0				//if the security override is 0, security protocols are on. if 1, protocols are broken.
+	var/overridden = FALSE				//if the security override is 0, security protocols are on. if 1, protocols are broken.
 
 /obj/machinery/porta_turret/One_star
 	name = "greyson positronic turret"
 	installation = /obj/item/weapon/gun/energy/retro
 
 /obj/machinery/porta_turret/crescent
-	enabled = 0
-	ailock = 1
-	check_synth	 = 0
-	check_access = 1
-	check_arrest = 1
-	check_records = 1
-	check_weapons = 1
-	check_anomalies = 1
+	enabled = FALSE
+	ailock = TRUE
+	check_synth	 = FALSE
+	check_access = TRUE
+	check_arrest = TRUE
+	check_records = TRUE
+	check_weapons = TRUE
+	check_anomalies = TRUE
 
 /obj/machinery/porta_turret/gate
 	name = "colony defense turret"
 	desc = "Decent firepower, slow rate of fire, only has a lethal mode. The kind of defense the colony can afford."
-	check_synth	 = 0
-	check_access = 0
-	check_arrest = 1
-	check_records = 0
-	check_weapons = 0
-	check_anomalies = 1
-	installation = /obj/item/weapon/gun/energy/laser
+	check_synth	 = FALSE
+	check_access = FALSE
+	check_arrest = TRUE
+	check_records = FALSE
+	check_weapons = FALSE
+	check_anomalies = TRUE
+	installation = /obj/item/weapon/gun/energy/retro
 
 /obj/machinery/porta_turret/stationary
-	ailock = 1
-	lethal = 1
+	ailock = TRUE
+	lethal = TRUE
 	installation = /obj/item/weapon/gun/energy/laser
 
 /obj/machinery/porta_turret/New()

--- a/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
@@ -472,7 +472,7 @@
 		)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/rafale
-	disk_name = "SM - .40 Auto-Mag Rafale"
+	disk_name = "GmbH - .40 Auto-Mag Rafale"
 	icon_state = "frozenstar"
 
 	license = 8
@@ -630,7 +630,7 @@
 // SMGs
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/wirbelwind
-	disk_name = "SM - .35 Wirbelwind SMG"
+	disk_name = "GmbH - .35 Wirbelwind SMG"
 	icon_state = "frozenstar"
 
 	license = 12
@@ -701,7 +701,7 @@
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/ostwind
-	disk_name = "SM - .257 Ostwind Carbine"
+	disk_name = "GmbH - .257 Ostwind Carbine"
 	icon_state = "frozenstar"
 
 	license = 16
@@ -996,7 +996,7 @@ obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/china
 	)
 
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/survivalrifle
-	disk_name = "SM SAS - 10mm Caseless /'Bond/' Rifle"
+	disk_name = "SAS - 10mm Caseless /'Bond/' Rifle"
 	icon_state = "black"
 
 	license = 10 //2 guns 2 mags and 1 box

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -263,7 +263,7 @@
 
 /obj/item/weapon/gun/energy/lasercannon
 	name = "\"Titanica\" laser cannon"
-	desc = "A bulky design for an energy weapon that allows for it to shoot condenced laser beams to really burn a whole in anything."
+	desc = "A bulky outdated and now abandoned H&S design for an energy weapon that allows for it to shoot condenced laser beams to really burn a whole in anything. At its time it was compared to the \"Bull\" as one of the worst personal defence laser firearms created."
 	icon = 'icons/obj/guns/energy/lascannon.dmi'
 	icon_state = "lasercannon"
 	item_state = "lasercannon"
@@ -280,13 +280,14 @@
 	one_hand_penalty = 5
 	twohanded = TRUE
 	init_firemodes = list(
-		WEAPON_NORMAL,
+		WEAPON_NORMAL
 		)
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 
 /obj/item/weapon/gun/energy/lasercannon/rnd
 	name = "\"Solaris\" laser cannon"
-	desc = "A new design for an energy weapon created by Soteria Institute. The lasing medium is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. This incredible technology may help YOU achieve high excitation rates with small laser volumes!"
+	desc = "A outdated and abandoned design for an energy weapon, revamped by Soteria Institute. The lasing medium is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. \
+		This incredible technology packed inside let it stand on it's own has one of the markets best laser cannon for turret defense and firepower! "
 	matter = list(MATERIAL_STEEL = 25, MATERIAL_SILVER = 4, MATERIAL_URANIUM = 1)
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
 	price_tag = 1500

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -262,8 +262,8 @@
 	twohanded = FALSE
 
 /obj/item/weapon/gun/energy/lasercannon
-	name = "\"Titanica\" laser cannon"
-	desc = "A new design for an energy weapon. The lasing medium is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. This incredible technology may help YOU achieve high excitation rates with small laser volumes!"
+	name = "\"Solaris\" laser cannon"
+	desc = "A new design for an energy weapon created by Soteria Institute. The lasing medium is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. This incredible technology may help YOU achieve high excitation rates with small laser volumes!"
 	icon = 'icons/obj/guns/energy/lascannon.dmi'
 	icon_state = "lasercannon"
 	item_state = "lasercannon"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -262,28 +262,38 @@
 	twohanded = FALSE
 
 /obj/item/weapon/gun/energy/lasercannon
-	name = "\"Solaris\" laser cannon"
-	desc = "A new design for an energy weapon created by Soteria Institute. The lasing medium is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. This incredible technology may help YOU achieve high excitation rates with small laser volumes!"
+	name = "\"Titanica\" laser cannon"
+	desc = "A bulky design for an energy weapon that allows for it to shoot condenced laser beams to really burn a whole in anything."
 	icon = 'icons/obj/guns/energy/lascannon.dmi'
 	icon_state = "lasercannon"
 	item_state = "lasercannon"
 	item_charge_meter = TRUE
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
-	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
+	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 3) //Shows that its not as high tech but still rather smartly designed
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BELT|SLOT_BACK
 	projectile_type = /obj/item/projectile/beam/heavylaser
 	charge_cost = 100
 	fire_delay = 20
-	matter = list(MATERIAL_STEEL = 25, MATERIAL_SILVER = 4, MATERIAL_URANIUM = 1)
-	price_tag = 1500
+	matter = list(MATERIAL_STEEL = 25, MATERIAL_SILVER = 6)
+	price_tag = 500
 	one_hand_penalty = 5
 	twohanded = TRUE
 	init_firemodes = list(
 		WEAPON_NORMAL,
-		WEAPON_CHARGE
 		)
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
+
+/obj/item/weapon/gun/energy/lasercannon/rnd
+	name = "\"Solaris\" laser cannon"
+	desc = "A new design for an energy weapon created by Soteria Institute. The lasing medium is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. This incredible technology may help YOU achieve high excitation rates with small laser volumes!"
+	matter = list(MATERIAL_STEEL = 25, MATERIAL_SILVER = 4, MATERIAL_URANIUM = 1)
+	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
+	price_tag = 1500
+	init_firemodes = list(
+		WEAPON_NORMAL,
+		WEAPON_CHARGE
+		)
 
 /obj/item/weapon/gun/energy/lasercannon/mounted
 	name = "mounted laser cannon"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/energy/taser
 	name = "\"Counselor\" stun gun"
-	desc = "The OT SP \"Counselor\" is a taser gun used for non-lethal takedowns. Originally produced by the Old Testament as a non-lethal and safe alternative to plasma or ballistics."
+	desc = "The OT SP \"Counselor\" is a taser gun used for non-lethal takedowns. Originally developed by the Seinemetall Defense GmbH before being sold off to Old Testament as a non-lethal and safe alternative to plasma or ballistics."
 	icon = 'icons/obj/guns/energy/taser.dmi'
 	icon_state = "taser"
 	item_state = null	//so the human update icon uses the icon_state instead.
@@ -43,7 +43,8 @@
 
 /obj/item/weapon/gun/energy/stunrevolver
 	name = "\"Zeus\" stun revolver"
-	desc = "Also know as stun revolver. Older and less precise H&S solution for non-lethal takedowns. This gun has a smaller capacity in exchange for S-cells use."
+	desc = "Also know as stun revolver. Seinemetall Defense GmbH with Soteria Institute solution for non-lethal takedowns, its rather simple deisign has a smaller capacity in exchange for S-cells use. \
+			The now outdated design was the base for the much more successfull \"Counselor\"."
 	icon = 'icons/obj/guns/energy/stunrevolver.dmi'
 	icon_state = "stunrevolver"
 	item_state = "stunrevolver"

--- a/code/modules/projectiles/guns/projectile/automatic/battlerifle.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/battlerifle.dm
@@ -105,7 +105,7 @@
 /obj/item/weapon/gun/projectile/automatic/omnirifle/fancy
 	name = "\"Osprey\" precision rifle"
 	desc = "Classic, elegant sporting rifle based on proven military technology. \
-		 A civilian model of the venerable M13A1 Special Purpose Rifle manufactured on Earth by Seinemetall for both sportsmen and counter-terror agents, it fires a variety of utility and specialized munitions. \
+		 A civilian model of the venerable M13A1 Special Purpose Rifle manufactured on Earth by Seinemetall Defense GmbH for both sportsmen and counter-terror agents, it fires a variety of utility and specialized munitions. \
 		 Chambered in .408, its gaping bore allows virtually any imaginable payload, however the recoil and magazine suffer for it. \
 		 This example is fitted with an high-zoom optic, elegant wood furnishing, and is limited to semiautomatic."
 	icon = 'icons/obj/guns/projectile/Osprey.dmi'

--- a/code/modules/projectiles/guns/projectile/automatic/nordwind.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/nordwind.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/automatic/nordwind
 	name = "\"Nordwind\" precision rifle"
-	desc = "A \"Nordwind\" high-end police-grade marksman rifle manufactured by Seinemetall Defense. Primarily used by law enforcement, counter-terror units, and private security. Uses 7.5mm Rifle rounds."
+	desc = "A \"Nordwind\" high-end police-grade marksman rifle manufactured by Seinemetall Defense GmbH. Primarily used by law enforcement, counter-terror units, and private security. Uses 7.5mm Rifle rounds."
 	icon = 'icons/obj/guns/projectile/nordwind.dmi'
 	icon_state = "nordwind"
 	item_state = "nordwind"

--- a/code/modules/projectiles/guns/projectile/automatic/ostwind.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ostwind.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/automatic/ostwind
 	name = "\"Ostwind\" carbine"
-	desc = "An \"Ostwind\" high-end police-grade assault rifle manufactured by Seinemetall Defense. Primarily used by law enforcement, counter-terror units, and private security. Uses .257 Carbine rounds."
+	desc = "An \"Ostwind\" high-end police-grade assault rifle manufactured by Seinemetall Defense GmbH. Primarily used by law enforcement, counter-terror units, and private security. Uses .257 Carbine rounds."
 	icon = 'icons/obj/guns/projectile/ostwind.dmi'
 	icon_state = "ostwind"
 	item_state = "ostwind"

--- a/code/modules/projectiles/guns/projectile/automatic/wirbelwind.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wirbelwind.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/automatic/wirbelwind
 	name = "\"Wirbelwind\" SMG"
-	desc = "A compact and lightweight law enforcement PDW produced by Seinemetall. Uses .35 Auto."
+	desc = "A compact and lightweight law enforcement PDW produced by Seinemetall Defense GmbH. Uses .35 Auto."
 	icon = 'icons/obj/guns/projectile/wirbelwind.dmi'
 	icon_state = "wirbelwind"
 	item_state = "wirbelwind"

--- a/code/modules/research/designs/weapon.dm
+++ b/code/modules/research/designs/weapon.dm
@@ -26,7 +26,7 @@
 /datum/design/research/item/weapon/lasercannon
 	name = "\"Solaris\" Laser Cannon"
 	desc = "The lasing medium of this prototype is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core."
-	build_path = /obj/item/weapon/gun/energy/lasercannon
+	build_path = /obj/item/weapon/gun/energy/lasercannon/rnd
 
 /datum/design/research/item/weapon/c20r
 	name = "Lightweight C20R"


### PR DESCRIPTION
## About The Pull Request
All cases of Seinemetall Defense GmbH being called SM have been replaced by GmhH
All cases of just Seinemtall, and Seinemetall Defense have been replaced with Seinemetall Defense GmbH
Correrts name and manufactory of the Solaris
The stun revolver now shows that it was made by Seinemetall Defense GmbH with SI help
The consoler now has better lore on why it was made as a non-lethal take down weapon.
The laser cannon inside of turrets at preppers is now its own type of laser gun, only differentce from RnD's is that it dosnt have a charge mode nor uranium inside as well as more lore on why no one ever makes them anymore (bad marketing)
colony turrets now have Cogs inside them as they were meant to.
## Changelog
:cl:
/:cl:
