### PR TITLE
Increase BIDON capacities tenfold

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -302,12 +302,12 @@
 	icon_state = "bidon"
 	reagent_flags = AMOUNT_VISIBLE
 	amount_per_transfer_from_this = 30
-	possible_transfer_amounts = list(10,30,60,120,200)
+	possible_transfer_amounts = list(10,30,60,120,200,300)
 	var/filling_states = list(10,20,30,40,50,60,70,80,100)
 	unacidable = 1
 	anchored = 0
 	density = TRUE
-	volume = 600
+	volume = 6000
 	var/lid = TRUE
 
 /obj/structure/reagent_dispensers/bidon/advanced
@@ -316,7 +316,7 @@
 	icon_state = "bidon_adv"
 	reagent_flags = TRANSPARENT
 	filling_states = list(20,40,60,80,100)
-	volume = 900
+	volume = 9000
 
 /obj/structure/reagent_dispensers/bidon/Initialize(mapload, ...)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Increasing BIDON capacity due to non-existant use, and no reason to use them
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
I increased the capacity of both BIDONs to ten times their current value, to 6000 and 9000 units respectively. They aren't used whatsoever, and given that the capacities are laughable two/three bluespace beakers, they seemed like a joke considering they can't be placed on tables, and you can put way more bluespace beakers visible on one turf square than is taken up by a BIDON.

This change would let them actually be used for mass storage purposes, be that medicine refills, poison storage, and perhaps even trading large amount of chemicals for credits without requiring god-tier micro to prevent insanity.
<hr>
</details>

## Changelog
:cl:
balance: Multiplied BIDON capacity by ten
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
