### PR TITLE
Makes it so VIG isnt as op with bullets

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -285,7 +285,7 @@
 
 		projectile.multiply_projectile_damage(damage_multiplier)
 
-		projectile.multiply_projectile_penetration(penetration_multiplier + user.stats.getStat(STAT_VIG) * 0.2)
+		projectile.multiply_projectile_penetration(penetration_multiplier + user.stats.getStat(STAT_VIG) * 0.02) //every 10 points is 1 AP added on
 
 		projectile.multiply_pierce_penetration(pierce_multiplier)
 


### PR DESCRIPTION

## About The Pull Request
Turns out every vig stat is 1 AP on all bullets, meaning the commander nulls most armor round start with +30-40AP making their laser gun and bullet gun almost null armor. Lets make it so that this isnt a thing and armor be worth wile.

## Changelog
:cl:
/:cl: