### PR TITLE
Church obelisk now use biomatter as ammo

### DIFF
--- a/code/modules/core_implant/cruciform/machinery/obelisk.dm
+++ b/code/modules/core_implant/cruciform/machinery/obelisk.dm
@@ -68,7 +68,7 @@
 		if (B.amount)
 			var/sheets_amount_to_transphere = input(user, "How many sheets you want to load?", "Biomatter melting", 1) as num
 			if (sheets_amount_to_transphere > B.amount ) //No cheating!
-				to_chat(user, SPAN_WARNING("You don't that many [B.name]"))
+				to_chat(user, SPAN_WARNING("You don't have that many [B.name]"))
 				return
 			if(sheets_amount_to_transphere)
 				B.use(sheets_amount_to_transphere)

--- a/code/modules/core_implant/cruciform/rituals/construction.dm
+++ b/code/modules/core_implant/cruciform/rituals/construction.dm
@@ -121,6 +121,7 @@ GLOBAL_LIST_INIT(nt_blueprints, init_nt_blueprints())
 	materials = list(
 		/obj/item/stack/material/plasteel = 10,
 		/obj/item/stack/material/gold = 5,
+		/obj/item/stack/material/biomatter = 50, //so we dont doup biomatter
 		/CRUCIFORM_TYPE = 1
 	)
 	build_time = 8 SECONDS
@@ -133,6 +134,7 @@ GLOBAL_LIST_INIT(nt_blueprints, init_nt_blueprints())
 		/obj/item/stack/material/biomatter = 10,
 		/obj/item/stack/material/gold = 5,
 		/obj/item/stack/material/diamond = 3,
+		/obj/item/stack/material/biomatter = 120, //so we dont doup biomatter
 		/CRUCIFORM_TYPE = 1
 	)
 	build_time = 15 SECONDS


### PR DESCRIPTION

## About The Pull Request
This pr is rather simple, yet works!
Church obelisk now can be made and placed all over meaning theirs never a reason to not spam them around maints or during events for that bit more fire support. Well now you got to fuel them with biomatter!
Anyone can fuel them for the time and it even tells you how much it has on look.
Round start the church obelisk that spawn in the church have 50 shots
Making obelisk now costs the biomatter that they have stored inside
This is no max amout of shots you can load into a obelisk meaning if you stuff 5000 sheets you got 5000 shots!
This has been tested and all should work flawlessly!

## Changelog
:cl:
/:cl:
