### PR TITLE
Lowers Gluhand roaches spawn

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/types/roachling.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/roachling.dm
@@ -30,7 +30,7 @@
 					/mob/living/carbon/superior_animal/roach/tank = 4,
 					/mob/living/carbon/superior_animal/roach/toxic = 6,
 					/mob/living/carbon/superior_animal/roach/nanite = 0.5,
-					/mob/living/carbon/superior_animal/roach/glowing = 2,
+					/mob/living/carbon/superior_animal/roach/glowing = 1,
 					/mob/living/carbon/superior_animal/roach/hunter = 2,
 					/mob/living/carbon/superior_animal/roach/support = 6,
 					/mob/living/carbon/superior_animal/roach/fuhrer = 2))
@@ -39,7 +39,7 @@
 					/mob/living/carbon/superior_animal/roach/tank = 2,
 					/mob/living/carbon/superior_animal/roach/toxic = 2,
 					/mob/living/carbon/superior_animal/roach/nanite = 2,
-					/mob/living/carbon/superior_animal/roach/glowing = 4,
+					/mob/living/carbon/superior_animal/roach/glowing = 1,
 					/mob/living/carbon/superior_animal/roach/hunter = 4,
 					/mob/living/carbon/superior_animal/roach/support = 4,
 					/mob/living/carbon/superior_animal/roach/fuhrer = 0.5))


### PR DESCRIPTION

## About The Pull Request
Lowers the gluhand roach spawns as they are better then toxic ones and have a flash built into their attacks that reck most spiders making roaches only need around 12 to kill a queen do to likelyhoold of stunlocks
Also uranium is inside them making it a bit to easy to get chem warfare against people with rads
## Changelog
:cl:
/:cl:

