### PR TITLE
Fixes grenade launchers taking grenade 

### DIFF
--- a/code/modules/projectiles/guns/matter/launcher.dm
+++ b/code/modules/projectiles/guns/matter/launcher.dm
@@ -7,17 +7,17 @@
 
 //This normally uses a proc on projectiles and our ammo is not strictly speaking a projectile.
 /obj/item/weapon/gun/matter/launcher/can_hit(mob/living/target, mob/living/user)
-	return 1
+	return TRUE
 
 /obj/item/weapon/gun/matter/launcher/handle_suicide(mob/living/user)
 	to_chat(user, SPAN_WARNING("Shooting yourself with \a [src] is pretty tricky. You can't seem to manage it."))
 	return
 
 /obj/item/weapon/gun/matter/launcher/proc/update_release_force(obj/item/projectile)
-	return 0
+	return FALSE
 
 /obj/item/weapon/gun/matter/launcher/process_projectile(obj/item/projectile, mob/user, atom/target)
 	update_release_force(projectile)
 	projectile.loc = get_turf(user)
 	projectile.throw_at(target, throw_distance, release_force, user)
-	return 1
+	return TRUE

--- a/code/modules/projectiles/guns/projectile/other/protector.dm
+++ b/code/modules/projectiles/guns/projectile/other/protector.dm
@@ -22,6 +22,7 @@
 	var/release_force = 5
 	twohanded = TRUE
 
+/* We no longer fire grenades like this. As we now use internal ammo
 /obj/item/weapon/gun/projectile/grenade/proc/load_grenade(obj/item/weapon/grenade/A, mob/user)  //For loading hand grenades, not ammo
 	if(!A.loadable)
 		to_chat(user, SPAN_WARNING("\The [A] doesn't seem to fit in \the [src]!"))
@@ -40,7 +41,7 @@
 	if(istype(A, /obj/item/weapon/grenade))
 		load_grenade(A, user)
 	else
-		..()
+		..()*/
 
 
 //revolves the magazine, allowing players to choose between multiple grenade types


### PR DESCRIPTION

## About The Pull Request
When porting over the new and fancy grenade launchers we forgot to disable their now broken grenade loading and firing for hand grenades such as smoke bombs, frag, and other hand held ones that should have been disabled.
## Changelog
:cl:
/:cl:
