### PR TITLE
drasticly lows food intake when healing damaged organs

### DIFF
--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -89,7 +89,7 @@
 	if(!damage || BP_IS_ROBOTIC(src) || !owner || owner.chem_effects[CE_TOXIN] || owner.is_asystole() || !current_blood)
 		return
 	if(damage < 0.1*max_damage)
-		owner.adjustNutrition(-(nutriment_req * 10))
+		owner.adjustNutrition(-(nutriment_req))
 		heal_damage(0.1)
 
 /obj/item/organ/internal/examine(mob/user)


### PR DESCRIPTION

## About The Pull Request
Taking upwards of 1000 food units to heal the heat 1 damage (max you can have i 500) is really really high... 
## Changelog
:cl:
/:cl:
