### PR TITLE
Fixes Ryetalyn unhusking dead people, for real this time!

### DIFF
--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -455,9 +455,9 @@
 	color = "#004000"
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1 // This is a mostly beneficial chem, it should show up on scanners
-	affects_dead = 1 //If it doesn't, how will it fix husking?
+	affects_dead = 1 //My guess is this flag makes the chem act on a cryotube regardless of mob life or not.
 
-/datum/reagent/medicine/ryetalyn/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+/datum/reagent/medicine/ryetalyn/on_mob_add(mob/living/carbon/M, alien, effect_multiplier) //on_mob_add allows it to act regardless if the human is dead or alive.
 	var/needs_update = M.mutations.len > 0
 
 	M.mutations = list()
@@ -468,6 +468,7 @@
 	if(needs_update && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.update_mutations()
+		H.update_body() //Don't let husks stay wrinkly all the time, we gotta fix them!
 
 /datum/reagent/medicine/negative_ling
 	name = "Negative Paragenetic Marker"


### PR DESCRIPTION
### About The Pull Request

Ryetalyn had no proper way to unhusk dead people (given the way husking works, you'd only find it as a mutation on dead people), even with the `affects_dead` flag, wich I'm assuming only meant that it would work while inside a Cryotube. ~~(Testing pending)~~
**Testing concluded:** Ryetalyn did not even work with the `affects_dead` flag inside a cryotube on a husked dead patient.
~~(Thanks Faxington)~~
<hr>

This PR changes the datum from an `affect_blood` into an `on_mob_add`, making it so that it acts the first time the chemical is added to the blood rather than the datum wich prevents chemicals from circulating on a dead body (and not necessarily having an entire separate use of Ryetalyn for just husks, and have it act normally for the rest of the mutations it heals)
This PR also adds an `update_body()` to properly refresh the human's appearance after certain mutations induce a change in them (green skin for Hulk, charred flesh for husk, etc...)
<hr>

This should accomplish what #543 failed to do.

## Changelog
:cl:DimmaDunk
fix: Ryetalyn should now properly remove husking on dead bodies.
/:cl: