### PR TITLE
Take a drag off that cig! +Energy Melee weapons now sound like energy weapons

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -102,6 +102,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/type_butt = null
 	var/chem_volume = 0
 	var/smoketime = 0
+	var/last_drag = 0
 	var/quality_multiplier = 1 // Used for sanity and insight gain
 	var/matchmes = "USER lights NAME with FLAME"
 	var/lightermes = "USER lights NAME with FLAME"
@@ -355,6 +356,20 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(lit == 1)
 		user.visible_message(SPAN_NOTICE("[user] calmly drops and treads on the lit [src], putting it out instantly."))
 		die(1)
+	return ..()
+
+/obj/item/clothing/mask/smokable/cigarette/attack(mob/living/carbon/human/H, mob/user, def_zone)
+	if(lit && H == user && istype(H))
+		var/obj/item/blocked = H.check_mouth_coverage()
+		if(blocked)
+			to_chat(H, SPAN_WARNING("\The [blocked] is in the way!"))
+			return 1
+		if(last_drag <= world.time - 30) //No chainsmoking.
+			last_drag = world.time
+			H.visible_message("<span class='notice'>[H.name] takes a drag of their [name].</span>")
+			playsound(H, 'sound/items/cigs_lighters/inhale.ogg', 50, 0, -1)
+			reagents.trans_to_mob(H, (rand(10,20)/10), CHEM_INGEST)
+			return 1
 	return ..()
 
 ////////////

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -10,6 +10,7 @@
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
 	heat = 3800
 	embed_mult = 0 //No physical matter to catch onto things
+	hitsound = sound/weapons/blade1.ogg //Make these lightsaber thingies do the sound they're intended to do on attack.
 
 /obj/item/weapon/melee/energy/is_hot()
 	if (active)


### PR DESCRIPTION
## About The Pull Request

- Energy melee weapons now properly do their corresponding swing sound instead of the stock hit by blunt weapons
- You can now take drags off your cigarette by holding it on your hand and clicking your character's sprite, with sound!

## Changelog
:cl:/DimmaDunk
add: You can take drags off cigarettes and cigars now.
soundadd: Not really adding sounds, just properly assigning them for their intended use.
/:cl: