### PR TITLE
Bugfix/Allow monkeys to be humanized.

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -2,6 +2,19 @@
 // POWERS
 ///////////////////////////////////
 
+/datum/dna/gene/basic/monkey
+	name="Monkified"
+	activation_messages=list("You feel primitive")
+
+	New()
+		block=MONKEYBLOCK
+
+	deactivate(var/mob/M, var/connected, var/flags)
+		..(M,connected,flags)
+		if(istype(M, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = M
+			H.humanize()
+
 /datum/dna/gene/basic/nobreath
 	name="No Breathing"
 	activation_messages=list("You feel no need to breathe.")

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -7,6 +7,11 @@
 
 /mob/living/carbon/human/monkey/New(var/new_loc)
 	..(new_loc, "Monkey")
+	dna.SetSEValue(MONKEYBLOCK,0xFFF)
+	dna.b_type = RANDOM_BLOOD_TYPE
+	var/datum/dna/gene/G = new /datum/dna/gene/basic/monkey
+	active_genes |= G.type
+	update_icon = 1
 
 /mob/living/carbon/human/dummy/mannequin/Initialize()
 	. = ..()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -37,6 +37,37 @@
 	qdel(animation)
 	return src
 
+/mob/living/carbon/human/proc/humanize()
+	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))
+		return
+	ADD_TRANSFORMATION_MOVEMENT_HANDLER(src)
+	canmove = 0
+	stunned = 1
+	icon = null
+	invisibility = 101
+	var/atom/movable/overlay/animation = new /atom/movable/overlay( loc )
+	animation.plane = plane
+	animation.layer = ABOVE_MOB_LAYER
+	animation.icon_state = "blank"
+	animation.icon = 'icons/mob/mob.dmi'
+	animation.master = src
+	flick("h2monkey", animation)
+	sleep(48)
+	//animation = null
+
+	DEL_TRANSFORMATION_MOVEMENT_HANDLER(src)
+	stunned = 0
+
+	update_lying_buckled_and_verb_status()
+	invisibility = initial(invisibility)
+
+	set_species("Human")
+	dna.SetSEState(MONKEYBLOCK,0)
+
+	to_chat(src, "<B>You are now [species.name]. </B>")
+	qdel(animation)
+	return src
+
 /mob/new_player/AIize()
 	spawning = 1
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The start of making genetics better, this PR allows monkeys to be humanized in the DNA scanner by manipulating the monkey gene (Structural Enzyme 27). Importantly, this in a one-way transformation - humans still cannot be turned into monkeys, to avoid griefing with monkification activators.

* Allows monkeys to be humanized in the DNA scanner and with (de)activators.
* Does not allow humans to be monkified.
* Randomizes monkeys' blood type (requested by Sebastian)

## Changelog
:cl:
tweak: monkeys' blood type is now randomized.
fix: fixed DNA scanners being unable to humanize monkeys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
