### PR TITLE
Tweak/Modify explosive damage formula for mechs.

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -677,6 +677,13 @@ assassination method if you time it right*/
 		log_append_to_last("Took [damage] points of damage. Damage type: \"[type]\".",1)
 	return
 
+/obj/mecha/proc/take_flat_damage(amount, type="brute")
+	if(amount)
+		health -= amount
+		update_health()
+		log_append_to_last("Took [amount] points of damage.",1)
+	return
+
 /obj/mecha/proc/absorb_damage(damage,damage_type)
 	return damage*(listgetindex(damage_absorption,damage_type) || 1)
 
@@ -854,21 +861,11 @@ assassination method if you time it right*/
 	if(prob(src.deflect_chance))
 		severity++
 		src.log_append_to_last("Armor saved, changing severity to [severity].")
-	switch(severity)
-		if(1.0)
-			qdel(src)
-		if(2.0)
-			if (prob(30))
-				qdel(src)
-			else
-				src.take_damage(initial(src.health)/2)
-				src.check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),1)
-		if(3.0)
-			if (prob(5))
-				qdel(src)
-			else
-				src.take_damage(initial(src.health)/5)
-				src.check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),1)
+	// This formula is designed to one-shot anything less armored than a Phazon taking a severity 1 explosion.
+	// This formula does the same raw damage (aside from one-shotting) as the previous formula against a Durand, but deals more final damage due to being unmitigated by damage resistance.
+	var/damage_proportion = 1 / max(1, (severity + max(0, armor_level - 2)))
+	src.take_flat_damage(initial(src.health) * damage_proportion)
+	src.check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST,MECHA_INT_SHORT_CIRCUIT),1)
 	return
 
 /*Will fix later -Sieve


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Modifies the explosive damage formula for mechs, using armor level to calculate flat health damage.

The formula is, as a proportion of the mech's health: 1 / (severity + armor_level - 2).
Severity ranges from 1 to 3, with 1 being the most severe and 3 being the least.

With this new formula, a severity 1 explosion will instantly destroy any mech with an armor level of 2 or less, which includes Gygaxes, Firefighter APLUs, Ripley APLUs, Odysseuses, and Hover Pods.

Against a Durand, this formula means three severity 1 explosions will destroy it, or five severity 3 explosions.

I may make an ERA module for mechs at some point which modifies their armor level against explosions and weapon hits a certain number of times before exhausting its uses and needing replacement.

## Changelog
:cl:
tweak: changed the mech damage formula for explosions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
