### PR TITLE
Bugfix/Fix big knife robot upgrade and some typos.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_dogborgs.dm
+++ b/code/modules/mob/living/silicon/robot/robot_dogborgs.dm
@@ -69,7 +69,7 @@
 	channels = list("Medical" = 1)
 	networks = list(NETWORK_MEDICAL)
 	can_be_pushed = 0
-	supported_upgrades = list(/obj/item/borg/upgrade/hypospray/medical,/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/stachle_of_holding_for_borgs)
+	supported_upgrades = list(/obj/item/borg/upgrade/hypospray/medical,/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/satchel_of_holding_for_borgs)
 	health = 85 //Fragile
 	speed_factor = 1.0 //Kinda slow
 	power_efficiency = 0.7 //Very poor, shackled to a charger
@@ -161,7 +161,7 @@
 					)
 	channels = list("Service" = 1)
 	can_be_pushed = 0
-	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/stachle_of_holding_for_borgs)
+	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/satchel_of_holding_for_borgs)
 
 	health = 175 //Bulky
 	speed_factor = 1.1 //Slow
@@ -223,7 +223,7 @@
 					)
 	channels = list("Science" = 1)
 	can_be_pushed = 0
-	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/stachle_of_holding_for_borgs)
+	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/satchel_of_holding_for_borgs)
 
 	health = 115 //Weak
 	speed_factor = 1.3 //Average

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -764,7 +764,7 @@ var/global/list/robot_modules = list(
 	speed_factor = 1.15 //Fast
 	power_efficiency = 0.8 //Poor
 
-	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/stachle_of_holding_for_borgs)
+	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/satchel_of_holding_for_borgs)
 
 
 	stat_modifiers = list(
@@ -845,7 +845,7 @@ var/global/list/robot_modules = list(
 		STAT_TGH = 30,
 		STAT_MEC = 30
 	)
-	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/stachle_of_holding_for_borgs)
+	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/satchel_of_holding_for_borgs)
 
 /obj/item/weapon/robot_module/service/New(var/mob/living/silicon/robot/R)
 	src.modules += new /obj/item/weapon/tool/crowbar/robotic(src)
@@ -928,7 +928,7 @@ var/global/list/robot_modules = list(
 		STAT_BIO = 25,
 		STAT_COG = 25
 	)
-	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/stachle_of_holding_for_borgs)
+	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/satchel_of_holding_for_borgs)
 
 	desc = "Built for digging anywhere, excavating the ores and materials to keep the colony running, \
 	this is heavy and powerful unit with a fairly singleminded purpose. It needs to withstand impacts \
@@ -973,7 +973,7 @@ var/global/list/robot_modules = list(
 	desc = "Built for working in a well-equipped lab, and designed to handle a wide variety of research \
 	duties, this module prioritises flexibility over efficiency. Capable of working in R&D, Toxins, \
 	chemistry, xenobiology and robotics."
-	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/stachle_of_holding_for_borgs)
+	supported_upgrades = list(/obj/item/borg/upgrade/jetpack,/obj/item/borg/upgrade/satchel_of_holding_for_borgs)
 
 	stat_modifiers = list(
 		STAT_BIO = 30,

--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -279,14 +279,14 @@
 		return TRUE
 
 
-/obj/item/borg/upgrade/stachle_of_holding_for_borgs
-	name = "stachle of holding equipment module"
-	desc = "Mounts a unstable bluespace stachle of holding borgs"
+/obj/item/borg/upgrade/satchel_of_holding_for_borgs
+	name = "satchel of holding equipment module"
+	desc = "Mounts a unstable bluespace satchel of holding borgs"
 	icon_state = "cyborg_upgrade2"
 	matter = list(MATERIAL_STEEL = 12, MATERIAL_GOLD = 6, MATERIAL_DIAMOND = 2, MATERIAL_URANIUM = 2)
 	require_module = TRUE
 
-/obj/item/borg/upgrade/bigknife/action(var/mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/satchel_of_holding_for_borgs/action(var/mob/living/silicon/robot/R)
 	if(..()) return FALSE
 
 	if(!R.module || !(type in R.module.supported_upgrades))

--- a/code/modules/research/designs/robot_parts.dm
+++ b/code/modules/research/designs/robot_parts.dm
@@ -149,7 +149,7 @@
 	desc = "Allows for the construction of lethal upgrades for sec-based bots."
 	build_path = /obj/item/borg/upgrade/bigknife
 
-/datum/design/research/item/robot_upgrade/stachle_of_holding_for_borgs
-	name = "Stachle of holding equipment upgrade"
+/datum/design/research/item/robot_upgrade/satchel_of_holding_for_borgs
+	name = "Satchel of holding equipment upgrade"
 	desc = "Allows for the construction of lethal upgrades for sec-based bots."
-	build_path = /obj/item/borg/upgrade/stachle_of_holding_for_borgs
+	build_path = /obj/item/borg/upgrade/satchel_of_holding_for_borgs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Fixes the big knife robot upgrade behaving oddly when used on a robot.
* Also fixes some typos in the mining cyborg's satchel of holding upgrade.

## Changelog
:cl:
fix: Fixed robots' big knife upgrade behaving strangely when applied.
spellcheck: Fixed a few typos in robots' ore satchel of holding upgrade.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
