### PR TITLE
No Shrinking / Growing during damage

### DIFF
--- a/code/__HELPERS/matrices.dm
+++ b/code/__HELPERS/matrices.dm
@@ -2,7 +2,11 @@
 	. = new_angle - old_angle
 	Turn(.) //BYOND handles cases such as -270, 360, 540 etc. DOES NOT HANDLE 180 TURNS WELL, THEY TWEEN AND LOOK LIKE SHIT
 
-
+/mob/living/carbon/human/shake_animation(var/intensity = 8) //Special Snowflake shake_animation redifining for players because of how scaling works.
+	var/init_px = pixel_x
+	var/shake_dir = pick(-1, 1)
+	animate(src, transform=turn(matrix(), intensity*shake_dir)*size_multiplier, pixel_x=init_px + 2*shake_dir, time=1)
+	animate(transform=matrix().Translate(0,16*(size_multiplier-1))*size_multiplier, pixel_x=init_px, time=6, easing=ELASTIC_EASING) //We're using the size multiplier on a matrix translated to make sure we are *all* on the same height on a tile.
 
 /atom/proc/shake_animation(var/intensity = 8)
 	var/init_px = pixel_x


### PR DESCRIPTION
When we take damage while standing we'll call the shake_animation procedure normally.

Created a new procedure specifically for players that will take into account the size multiplier. 

The math now includes using the size multiplier as well as translating the matrix upward so that we retain the same footing as before / as everyone else.

Currently this implementation may make the model to appear just a tad different, with the difference only visible after the model is updated with update_icons, this is due to how animate works in byond.

If that is too noticeable / becomes an issue, we can use update_icons at the end of the proc, but at the moment it's not included since calling it every time we're hit would just add more unnecessary matrix calculations into the mix. 