### PR TITLE
Balance/Add stat scaling (and a perk) for mec and bio skills.

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -55,7 +55,9 @@
 #define PERK_BORN_WARRIOR /datum/perk/born_warrior
 #define PERK_SCUTTLEBUG /datum/perk/scuttlebug
 #define PERK_MARKET_PROF /datum/perk/market_prof
+#define PERK_MEDICAL_EXPERT /datum/perk/selfmedicated
 #define PERK_SURGICAL_MASTER /datum/perk/surgical_master
+#define PERK_ADVANCED_MEDICAL /datum/perk/advanced_medical
 #define PERK_ARTIST /datum/perk/job/artist
 #define PERK_BOLT_REFLECT /datum/perk/job/bolt_reflect
 #define PERK_JINGLE_JANGLE /datum/perk/job/jingle_jangle

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -368,6 +368,10 @@
 	name = "Surgical Master"
 	desc = "When it comes to surgery most in your field are experts, while you may not know the more advanced medical procedures you can perform surgery with ease."
 
+/datum/perk/advanced_medical
+	name = "Advanced Medical Techniques"
+	desc = "Your advanced medical training has taught you special techniques for treating patients, enabling you to make more effective and efficient use of your resources."
+
 /datum/perk/job/bolt_reflect
 	name = "Bolt Action Rifle Training"
 	desc = "Through your training with bolt action rifles and repeaters, after firing you will always chamber a new round instantly."

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -30,7 +30,7 @@
 		STAT_COG = 25
 	)
 
-	perks = list(/datum/perk/selfmedicated)
+	perks = list(/datum/perk/selfmedicated, /datum/perk/advanced_medical)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/suit_sensors,
@@ -82,7 +82,7 @@
 		STAT_COG = 10
 	)
 
-	perks = list(/datum/perk/selfmedicated)
+	perks = list(/datum/perk/selfmedicated, /datum/perk/advanced_medical)
 
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,
 							/datum/computer_file/program/chem_catalog,

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -953,12 +953,13 @@ assassination method if you time it right*/
 					if(src.health<initial(src.health))
 						var/missing_health = initial(src.health) - src.health
 						user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+						var/user_mec = max(0, user.stats.getStat(STAT_MEC))
 						if(state == 3)
 							to_chat(user, SPAN_NOTICE("You are able to repair more damage to [src.name] from the inside."))
-							src.health += min(initial(src.health) / 4, missing_health)
+							src.health += min(initial(src.health) * (user_mec / 100), missing_health)
 						else
 							to_chat(user, SPAN_NOTICE("You repair some damage to [src.name]."))
-							src.health += min(10, missing_health)
+							src.health += min(user.stats.getStat(STAT_MEC) * 2, missing_health)
 					return
 			return
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -299,3 +299,16 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 		return chair && chair.buckled_mob == M
 
 	return M.lying && (locate(/obj/machinery/optable, M.loc) || (locate(/obj/structure/bed, M.loc)) || locate(/obj/structure/table, M.loc))
+
+// Returns a bonus to apply to flat surgery values for various stat levels.
+// Soft caps at 80 bio, providing only 1/10 of the stat value exceeding 80.
+proc/calculate_expert_surgery_bonus(mob/living/user)
+	var/user_stat = user.stats.getStat(STAT_BIO)
+	var/stat_bonus = 0
+	if(user_stat > STAT_LEVEL_EXPERT && user_stat <= STAT_LEVEL_PROF)
+		stat_bonus = user_stat - STAT_LEVEL_EXPERT
+	else if(user_stat > STAT_LEVEL_PROF && user_stat <= STAT_LEVEL_GODLIKE)
+		stat_bonus = 20 + (user_stat - STAT_LEVEL_PROF) * 0.5
+	else if(user_stat > STAT_LEVEL_GODLIKE)
+		stat_bonus = 30 + (user_stat - STAT_LEVEL_GODLIKE) * 0.1
+	return stat_bonus

--- a/code/modules/surgery/wound_repair.dm
+++ b/code/modules/surgery/wound_repair.dm
@@ -42,10 +42,9 @@
 		return
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
-	for(var/obj/item/organ/E in affected.internal_organs)
-		if (target.getBruteLoss() > 0)
-			user.visible_message(SPAN_NOTICE("[user] begins treating the brute damage to [target]'s body with the [tool_name]."), \
-			SPAN_NOTICE("You begin treating the brute damage to [target]'s body with the [tool_name]."))
+	if (target.getBruteLoss() > 0)
+		user.visible_message(SPAN_NOTICE("[user] begins treating the brute damage to [target]'s body with the [tool_name]."), \
+		SPAN_NOTICE("You begin treating the brute damage to [target]'s body with the [tool_name]."))
 
 	target.custom_pain("The pain in your [affected.name] is living hell!",1)
 	..()
@@ -57,14 +56,19 @@
 
 	if (!hasorgans(target))
 		return
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
-	for(var/obj/item/organ/E in affected.internal_organs)
-		if (target.getBruteLoss() > 0)
-			user.visible_message(SPAN_NOTICE("[user] treats the brute damage to [target]'s body with the [tool_name]."), \
-			SPAN_NOTICE("You treat the brute damage to [target]'s body with [tool_name].") )
+	if(target.getBruteLoss() > 0)
+		var/heal_amount = -15
+		if(user.stats.getPerk(PERK_ADVANCED_MEDICAL))
+			heal_amount -= calculate_expert_surgery_bonus(user)
+		user.visible_message(SPAN_NOTICE("[user] treats the brute damage to [target]'s body with the [tool_name]."), \
+		SPAN_NOTICE("You treat the brute damage to [target]'s body with [tool_name].") )
+		var/charges_needed = target.getBruteLoss() / (heal_amount * -1)
+		// Take the ceiling of charges_needed as required_uses
+		var/required_uses = round(charges_needed) == charges_needed ? charges_needed : round(charges_needed + 1)
+		for(var/i = 0; i < required_uses; i++)
 			if(tool.use(1))
-				target.adjustBruteLoss(-15)
+				target.adjustBruteLoss(heal_amount)
 
 /datum/old_surgery_step/external/brute_heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 
@@ -102,12 +106,12 @@
 
 	if (!hasorgans(target))
 		return
+
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
-	for(var/obj/item/organ/E in affected.internal_organs)
-		if (target.getFireLoss() > 0)
-			user.visible_message(SPAN_NOTICE("[user] begins treating the burn damage to [target]'s body with the [tool_name]."), \
-			SPAN_NOTICE("You begin treating the burn damage to [target]'s body with the [tool_name].") )
+	if (target.getFireLoss() > 0)
+		user.visible_message(SPAN_NOTICE("[user] begins treating the burn damage to [target]'s body with the [tool_name]."), \
+		SPAN_NOTICE("You begin treating the burn damage to [target]'s body with the [tool_name].") )
 
 	target.custom_pain("The pain in your [affected.name] is living hell!",1)
 	..()
@@ -119,14 +123,19 @@
 
 	if (!hasorgans(target))
 		return
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
-	for(var/obj/item/organ/E in affected.internal_organs)
-		if (target.getFireLoss() > 0)
-			user.visible_message(SPAN_NOTICE("[user] treats the burn damage to [target]'s body with the [tool_name]."), \
+	if(target.getFireLoss() > 0)
+		var/heal_amount = -15
+		if(user.stats.getPerk(PERK_ADVANCED_MEDICAL))
+			heal_amount -= calculate_expert_surgery_bonus(user)
+		user.visible_message(SPAN_NOTICE("[user] treats the burn damage to [target]'s body with the [tool_name]."), \
 			SPAN_NOTICE("You treat the burn damage to [target]'s body with [tool_name].") )
+		var/charges_needed = target.getFireLoss() / (heal_amount * -1)
+		// Take the ceiling of charges_needed as required_uses
+		var/required_uses = round(charges_needed) == charges_needed ? charges_needed : round(charges_needed + 1)
+		for(var/i = 0; i <= charges_needed; i++)
 			if(tool.use(1))
-				target.adjustFireLoss(-15)
+				target.adjustFireLoss(heal_amount)
 
 
 /datum/old_surgery_step/external/burn_heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds some stat scaling (and a medical perk) to make the mechanical and biology stats more impactful. I'll be expanding on this more in future PRs.

* Adds an Advanced Medical Techniques perk for Doctors and the CBO, which allows them to use their Biology stat to scale the amount of damage healed by ATKs and ABKs in reconstructive surgery. Will be adding to this perk more later.
* Reworks reconstructive surgery to only use the number of kits necessary for the amount of damage the patient has.
* Adds stat scaling to welders repairing mechs, both for external and internal repairs.

## Changelog
:cl:
add: Added a perk to Doctors and the CBO allowing them to scale the amount healed by ATKs and ABKs during reconstructive surgery.
balance: Added stat scaling to repairing mechs and reconstructive surgery (w/perk)
fix: Fixed reconstructive surgery using more ATKs and ABKs than necessary.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
