### PR TITLE
name fixes

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_kits.dm
+++ b/code/modules/projectiles/ammunition/ammo_kits.dm
@@ -22,13 +22,13 @@
 
 	var/list/options = list()
 	options[".257 Rifle"] = "srifle"
-	options["7.5 Caseless Rifle"] = "clrifle"
+	options["7.5 Rifle"] = "clrifle"
 	options[".408 Rifle"] = "lrifle"
 	options[".35 Auto"] = "pistol"
 	options[".40 Magnum"] = "magnum"
-	options[".50 Shotgun Buckshot"] = "shot"
-	options[".50 Shotgun Beanbag"] = "bean"
-	options[".50 Shotgun Slug"] = "slug"
+	options[".20 Shotgun Buckshot"] = "shot"
+	options[".20 Shotgun Beanbag"] = "bean"
+	options[".20 Shotgun Slug"] = "slug"
 	options[".60 Anti-Material"] = "antim"
 
 	var/choice = input(user,"What ammo do you want to make?") as null|anything in options


### PR DESCRIPTION

## About The Pull Request
Scrap ammo now uses correct ammo names
## Changelog
:cl:
/:cl:
