### PR TITLE
More QoL changes

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -20,8 +20,8 @@
 	var/list/level1 = list("tricordrazine" ="Tricordrazine")
 	var/list/level2 = list("spaceacillin" = "Spaceacillin")
 	var/list/level3 = list("alkysine" = "Alkysine")
-	var/list/level4 = list("leporazine" = "Leporazine")
-	var/list/level5 = list("oxycodone" = "Oxycodone")
+	var/list/level4 = list("hyronalin" = "Hyronalin")
+	var/list/level5 = list("arithrazine" = "Arithrazine")
 
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 15
@@ -36,7 +36,7 @@
 	color = "#a4bdba"
 	circuit = /obj/item/weapon/circuitboard/sleeper/hyper
 	level0 = list(
-		"inaprovaline" = "Inaprovaline", "chloralhydrate" = "Chloral Hydrate", "tramadol" = "Tramadol", "carthatoline" = "Carthatoline", "dexalinp" = "Dexalin Plus", "bicaridine" = "Bicaridine", "dermaline" = "Dermaline")
+		"tricordrazine" ="Tricordrazine", "tramadol" = "Tramadol", "dexalinp" = "Dexalin Plus", "bicaridine" = "Bicaridine", "dermaline" = "Dermaline", "carthatoline" = "Carthatoline", "peridaxon" = "Peridaxon")
 
 /obj/machinery/sleeper/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -109,7 +109,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/zippomes = "USER lights NAME with FLAME"
 	var/weldermes = "USER lights NAME with FLAME"
 	var/ignitermes = "USER lights NAME with FLAME"
-//	preloaded_reagents = list("nicotine" = 5)
+//	preloaded_reagents = list("nicotineplus" = 5)
 
 /obj/item/clothing/mask/smokable/Initialize()
 	reagent_flags |= NO_REACT // so it doesn't react until you light it
@@ -386,7 +386,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "cigaroff"
 	smoketime = 800
 	chem_volume = 25
-	preloaded_reagents = list("nicotine" = 14)
+	preloaded_reagents = list("nicotineplus" = 14)
 	quality_multiplier = 2
 	matchmes = "<span class='notice'>USER lights their NAME with their FLAME.</span>"
 	lightermes = "<span class='notice'>USER manages to offend their NAME by lighting it with FLAME.</span>"
@@ -400,6 +400,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "cigar2off"
 	icon_on = "cigar2on"
 	icon_off = "cigar2off"
+	smoketime = 1000
+	chem_volume = 45
+	preloaded_reagents = list("nicotineplus" = 20, "coffee" = 10)
 
 /obj/item/clothing/mask/smokable/cigarette/cigar/havana
 	name = "premium havanian cigar"
@@ -409,7 +412,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "cigar2off"
 	smoketime = 1100
 	chem_volume = 35
-	preloaded_reagents = list("nicotine" = 20)
+	preloaded_reagents = list("nicotineplus" = 20)
 	quality_multiplier = 3
 
 /obj/item/trash/cigbutt
@@ -487,7 +490,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	chem_volume = 50
 	w_class = ITEM_SIZE_SMALL
 	preloaded_reagents = list("nicotine" = 1)
-	matchmes = "<span class='notice'>USER lights their NAME with their FLAME.</span>"
+	matchmes = "<span class='notice'>USER lights their NAME with their FLAME in a very classy move.</span>"
 	lightermes = "<span class='notice'>USER manages to light their NAME with FLAME.</span>"
 	zippomes = "<span class='rose'>With much care, USER lights their NAME with their FLAME.</span>"
 	weldermes = "<span class='notice'>USER recklessly lights NAME with FLAME.</span>"

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -39,7 +39,7 @@
 	name = "Serotrotium"
 	id = "serotrotium"
 	description = "A chemical compound that promotes concentrated production of the serotonin neurotransmitter in humans."
-	taste_description = "bitterness"
+	taste_description = "pure happiness"
 	reagent_state = LIQUID
 	color = "#202040"
 	metabolism = REM * 0.25
@@ -158,11 +158,11 @@
 	name = "Nicotine"
 	id = "nicotine"
 	description = "A highly addictive stimulant extracted from the tobacco plant."
-	taste_description = "pepper"
+	taste_description = "tobacco"
 	reagent_state = LIQUID
 	color = "#181818"
 	overdose = REAGENTS_OVERDOSE
-	addiction_chance = 0
+	addiction_chance = 0.05
 	nerve_system_accumulations = 10
 
 /datum/reagent/drug/nicotine/overdose(mob/living/carbon/M, alien, effect_multiplier)
@@ -176,8 +176,35 @@
 /datum/reagent/drug/nicotine/overdose(var/mob/living/carbon/M, var/alien)
 	M.add_side_effect("Headache", 11)
 	if(prob(5))
-		M.vomit()
+		M.emote("cough")
+	M.adjustOxyLoss(0.5)
 	M.adjustToxLoss(0.5)
+
+/datum/reagent/drug/nicotineplus
+	name = "Nicotine"
+	id = "nicotine"
+	description = "A highly addictive and strong stimulant extracted from the tobacco plant, found on the finest of cigars."
+	taste_description = "fine tobacco"
+	reagent_state = LIQUID
+	color = "#181818"
+	overdose = REAGENTS_OVERDOSE
+	addiction_chance = 0.1
+	nerve_system_accumulations = 15
+
+/datum/reagent/drug/nicotineplus/overdose(mob/living/carbon/M, alien, effect_multiplier)
+	..()
+	M.add_chemical_effect(CE_PULSE, 1)
+	M.add_chemical_effect(CE_PAINKILLER, 10 * effect_multiplier)
+	if(M.stats.getPerk(PERK_CHAINGUN_SMOKER))
+		M.add_chemical_effect(CE_ANTITOX, 10 * effect_multiplier)
+		M.heal_organ_damage(0.2 * effect_multiplier, 0.2 * effect_multiplier)
+
+/datum/reagent/drug/nicotine/overdose(var/mob/living/carbon/M, var/alien)
+	M.add_side_effect("Headache", 11)
+	if(prob(5))
+		M.emote("cough")
+	M.adjustOxyLoss(1)
+	M.adjustToxLoss(1)
 
 /datum/reagent/drug/hyperzine
 	name = "Hyperzine"

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -181,8 +181,8 @@
 	M.adjustToxLoss(0.5)
 
 /datum/reagent/drug/nicotineplus
-	name = "Nicotine"
-	id = "nicotine"
+	name = "Fine Nicotine"
+	id = "nicotineplus"
 	description = "A highly addictive and strong stimulant extracted from the tobacco plant, found on the finest of cigars."
 	taste_description = "fine tobacco"
 	reagent_state = LIQUID

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -302,7 +302,7 @@
 	color = "#C8A5DC"
 	overdose = 60
 	scannable = 1
-	metabolism = 0.02
+	metabolism = 0.1 // Who thought it was a good idea for such a mild painkiller to last a lifetime?
 
 /datum/reagent/medicine/paracetamol/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_PAINKILLER, 50, TRUE)
@@ -436,9 +436,9 @@
 		var/mob/living/carbon/human/H = M
 
 		for(var/obj/item/organ/I in H.internal_organs)
-			if((I.damage > 0) && !BP_IS_ROBOTIC(I)) //Peridaxon heals only non-robotic organs
+			if((I.damage > 0) && !BP_IS_ROBOTIC(I) && !istype(/obj/item/organ/internal/bone)) //Stop healing bones, bones are not organs!
 				I.heal_damage(((0.2 + I.damage * 0.05) * effect_multiplier), FALSE)
-		var/obj/item/organ/internal/nerve/N = H.random_organ_by_process(OP_NERVE )
+		var/obj/item/organ/internal/nerve/N = H.random_organ_by_process(OP_NERVE)
 		if(H && istype(H))
 			if(BP_IS_ROBOTIC(N))
 				return
@@ -453,22 +453,26 @@
 	taste_description = "acid"
 	reagent_state = SOLID
 	color = "#004000"
+	metabolism = REM * 1.5
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1 // This is a mostly beneficial chem, it should show up on scanners
 	affects_dead = 1
 
+/datum/reagent/medicine/ryetalyn/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+    src.on_mob_add(M, alien, effect_multiplier) //I'm going with this to make it both affect dead people for unhusking, and to update on every life tick. Thanks Hydro!
+
 /datum/reagent/medicine/ryetalyn/on_mob_add(mob/living/carbon/M, alien, effect_multiplier) //on_mob_add allows it to act regardless if the human is dead or alive.
-	var/needs_update = M.mutations.len > 0
+    var/needs_update = M.mutations.len > 0
 
-	M.mutations = list()
-	M.disabilities = 0
-	M.sdisabilities = 0
+    M.mutations = list()
+    M.disabilities = 0
+    M.sdisabilities = 0
 
-	// Might need to update appearance for hulk etc.
-	if(needs_update && ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.update_mutations()
-		H.update_body() //Don't let husks stay wrinkly all the time, we gotta fix them!
+    // Might need to update appearance for hulk etc.
+    if(needs_update && ishuman(M))
+        var/mob/living/carbon/human/H = M
+        H.update_mutations()
+        H.update_body() //Don't let husks stay wrinkly all the time, we gotta fix them!
 
 /datum/reagent/medicine/negative_ling
 	name = "Negative Paragenetic Marker"
@@ -761,6 +765,8 @@
 /datum/reagent/medicine/noexcutite/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.make_jittery(-50)
 
+/datum/reagent/medicine/noexcutite/overdose(mob/living/carbon/M, alien)
+	M.paralysis = max(M.paralysis, 5)
 
 /datum/reagent/medicine/kyphotorin
 	name = "Kyphotorin"


### PR DESCRIPTION
## About The Pull Request
- Sleepers have more attractive chems as upgrades
- Hyper sleeper has even more amazing selection of chems to justify their rarity
- Tobacco now tastes like tobacco, with a distinction between cigar's fine tobacco and cigarette tobacco
- Makes Peridaxon no longer heal bones too
- Fixes to Ryetalyn so that it continues to proc the mutations cleanup on every life tick
- Fixes Paracetamol taking ages to metabolize
- Adds an overdose effect for Noexcutite
- Changes Peridaxon so that it no longers heals bones, to justify making Ossisine (also Peri shouldn't heal bones!)

## Changelog
:cl:DimmaDunk
add: Added Fine Nicotin for the expensive cigars
add: Added Noexcutite overdose effect
tweak: Peridaxon no longer heals bones, only internal organs
balance: Changed the Sleeper's unlockable chems by tier, as well as the Hyper Sleeper's chemical selection
fix: Ryetalyn should now also work on every life tick instead of having to wait for it to metabolize out, then re-dose for it to affect only when first added to the system
/:cl: