### PR TITLE
Cht'mants can't be cultists

### DIFF
--- a/code/datums/setup_option/backgrounds/origin.dm
+++ b/code/datums/setup_option/backgrounds/origin.dm
@@ -477,7 +477,7 @@
 			knew what was needed for their purpose and literally nothing else."
 
 	restricted_to_species = list(FORM_CHTMANT)
-
+	allow_modifications = FALSE
 	perks = list(/datum/perk/scuttlebug)
 
 	stat_modifiers = list(
@@ -499,7 +499,7 @@
 
 	restricted_to_species = list(FORM_CHTMANT)
 	restricted_depts = SECURITY | PROSPECTOR
-
+	allow_modifications = FALSE
 	perks = list(/datum/perk/ichor)
 
 	stat_modifiers = list(
@@ -519,7 +519,7 @@
 			rely on winning battles by sheer weight of numbers or pure attrition. The severe lack of intelligence they exhibit also bars them from most medical roles and all of science, engineering, and command roles."
 
 	restricted_to_species = list(FORM_CHTMANT)
-
+	allow_modifications = FALSE
 	restricted_depts = SCIENCE | ENGINEERING
 	restricted_jobs = list(/datum/job/cmo, /datum/job/rd, /datum/job/smc, /datum/job/swo, /datum/job/cmo, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/paramedic, /datum/job/premier, /datum/job/pg, /datum/job/chief_engineer, /datum/job/chaplain, /datum/job/merchant)
 

--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -16,6 +16,7 @@
 		)
 	allowed_depts = CHURCH
 	allow_modifications = TRUE
+	restricted_to_species = list(FORM_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_OPIFEX, FORM_CINDAR)
 
 /datum/category_item/setup_option/core_implant/cruciform/tessellate
 	name = "Tessellate Cruciform"

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -186,6 +186,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 			pref.setup_options["Homeworld"] = null
 			pref.setup_options["Upbringing"] = null
 			pref.setup_options["Ethnicity"] = null
+			pref.setup_options["Core implant"] = null
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["reset_form"])

--- a/code/modules/core_implant/core_implant.dm
+++ b/code/modules/core_implant/core_implant.dm
@@ -2,8 +2,8 @@
 	name = "core implant"
 	icon = 'icons/obj/device.dmi'
 	w_class = ITEM_SIZE_SMALL
-	origin_tech = list(TECH_MATERIAL=9, TECH_BIO=9, TECH_DATA= 9, TECH_ENGINEERING=12, TECH_COMBAT = 8, TECH_BLUESPACE  = 7, TECH_PLASMA = 6)
-	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1, MATERIAL_BIOMATTER = 3, MATERIAL_DIAMOND = 10)
+	origin_tech = list(TECH_MATERIAL = 9, TECH_BIO = 9, TECH_DATA = 9, TECH_ENGINEERING = 12, TECH_COMBAT = 8, TECH_BLUESPACE  = 7, TECH_PLASMA = 6)
+	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_GOLD = 4, MATERIAL_SILVER = 4, MATERIAL_PLASTIC = 2, MATERIAL_PLASMA = 3, MATERIAL_URANIUM = 5, MATERIAL_GLASS = 1, MATERIAL_BIOMATTER = 3, MATERIAL_DIAMOND = 10)
 	external = TRUE
 	var/implant_type = /obj/item/weapon/implant/core_implant
 	var/active = FALSE


### PR DESCRIPTION
-Cht'mants can't be cultists anymore, so sayeth the cht'mant lore dev. Selecting a cht'mant as a race clears your cruciform and disables the option. Selecting an ethnicity also disables augments now, which you shouldn't be taking augments as a cht'mant unless you want to die quickly.