### PR TITLE
Doubles scrap beacon pre-cooldown to not take 1 hour form shift to start it

### DIFF
--- a/code/modules/scrap/scrap_beacon.dm
+++ b/code/modules/scrap/scrap_beacon.dm
@@ -11,7 +11,7 @@
 	var/impact_speed = 3
 	var/impact_prob = 100
 	var/impact_range = 2
-	var/last_summon = -36000
+	var/last_summon = -72000
 	var/active = 0
 
 /obj/structure/scrap_beacon/attack_hand(mob/user)


### PR DESCRIPTION

## About The Pull Request
Doubles scrap beacon pre-cooldown to not take 1 hour form shift to start it

## Changelog
:cl:
/:cl:
