### PR TITLE
Runtime Fixes

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -338,75 +338,77 @@ SUBSYSTEM_DEF(job)
 		// EMAIL GENERATION
 		if(rank != "Robot" && rank != "AI")		//These guys get their emails later.
 			ntnet_global.create_email(H, H.real_name, pick(maps_data.usable_email_tlds))
+		// If they're head, give them the account info for their department
+
+		if(H.mind && (job.head_position || job.department_account_access))
+			var/remembered_info = ""
+			var/datum/money_account/department_account = department_accounts[job.department]
+			if(department_account)
+				remembered_info += "<b>Your department's account number is:</b> #[department_account.account_number]<br>"
+				remembered_info += "<b>Your department's account pin is:</b> [department_account.remote_access_pin]<br>"
+				remembered_info += "<b>Your department's account funds are:</b> [department_account.money][CREDS]<br>"
+
+				if(job.head_position)
+					//remembered_info += "<b>Your part of nuke code:</b> [SSticker.get_next_nuke_code_part()]<br>"
+					//we dont have a station nuke so this isn't needed
+					department_account.owner_name = H.real_name //Register them as the point of contact for this account
+
+			H.mind.store_memory(remembered_info)
+
+		var/alt_title = null
+		if(H.mind)
+			H.mind.assigned_role = rank
+		//	alt_title = H.mind.role_alt_title
+
+			switch(rank)
+				if("Robot")
+					return H.Robotize()
+				if("AI")
+					return H
+				if("Premier")
+					var/sound/announce_sound = (SSticker.current_state <= GAME_STATE_SETTING_UP)? null : sound('sound/misc/boatswain.ogg', volume=20)
+					captain_announcement.Announce("Premier [H.real_name] has signed in.", new_sound=announce_sound)
+
+		if(istype(H)) //give humans wheelchairs, if they need them.
+			var/obj/item/organ/external/l_leg = H.get_organ(BP_L_LEG)
+			var/obj/item/organ/external/r_leg = H.get_organ(BP_R_LEG)
+			if(!l_leg || !r_leg)
+				var/obj/structure/bed/chair/wheelchair/W = new /obj/structure/bed/chair/wheelchair(H.loc)
+				H.buckled = W
+				H.update_lying_buckled_and_verb_status()
+				W.set_dir(H.dir)
+				W.buckled_mob = H
+				W.add_fingerprint(H)
+
+		to_chat(H, "<B>You are [job.total_positions == 1 ? "the" : "a"] [alt_title ? alt_title : rank].</B>")
+
+		if(job.supervisors)
+			to_chat(H, "<b>As the [alt_title ? alt_title : rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
+
+		if(job.req_admin_notify)
+			to_chat(H, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
+
+		//Gives glasses to the vision impaired
+		if(H.disabilities & NEARSIGHTED)
+			var/equipped = H.equip_to_slot_or_del(new /obj/item/clothing/glasses/regular(H), slot_glasses)
+			if(equipped != 1)
+				var/obj/item/clothing/glasses/G = H.glasses
+				G.prescription = 1
+
+		var/obj/item/weapon/implant/core_implant/C = H.get_core_implant()
+		if(C)
+			C.install_default_modules_by_job(job)
+			C.access.Add(job.cruciform_access)
+			C.install_default_modules_by_path(job)
+
+		BITSET(H.hud_updateflag, ID_HUD)
+		BITSET(H.hud_updateflag, SPECIALROLE_HUD)
+		return H
 
 	else
 		to_chat(H, "Your job is [rank] and the game just can't handle it! Please report this bug to an administrator.")
 
-	// If they're head, give them the account info for their department
-	if(H.mind && (job.head_position || job.department_account_access))
-		var/remembered_info = ""
-		var/datum/money_account/department_account = department_accounts[job.department]
-		if(department_account)
-			remembered_info += "<b>Your department's account number is:</b> #[department_account.account_number]<br>"
-			remembered_info += "<b>Your department's account pin is:</b> [department_account.remote_access_pin]<br>"
-			remembered_info += "<b>Your department's account funds are:</b> [department_account.money][CREDS]<br>"
 
-			if(job.head_position)
-				//remembered_info += "<b>Your part of nuke code:</b> [SSticker.get_next_nuke_code_part()]<br>"
-				//we dont have a station nuke so this isn't needed
-				department_account.owner_name = H.real_name //Register them as the point of contact for this account
-
-		H.mind.store_memory(remembered_info)
-
-	var/alt_title = null
-	if(H.mind)
-		H.mind.assigned_role = rank
-	//	alt_title = H.mind.role_alt_title
-
-		switch(rank)
-			if("Robot")
-				return H.Robotize()
-			if("AI")
-				return H
-			if("Premier")
-				var/sound/announce_sound = (SSticker.current_state <= GAME_STATE_SETTING_UP)? null : sound('sound/misc/boatswain.ogg', volume=20)
-				captain_announcement.Announce("Premier [H.real_name] has signed in.", new_sound=announce_sound)
-
-	if(istype(H)) //give humans wheelchairs, if they need them.
-		var/obj/item/organ/external/l_leg = H.get_organ(BP_L_LEG)
-		var/obj/item/organ/external/r_leg = H.get_organ(BP_R_LEG)
-		if(!l_leg || !r_leg)
-			var/obj/structure/bed/chair/wheelchair/W = new /obj/structure/bed/chair/wheelchair(H.loc)
-			H.buckled = W
-			H.update_lying_buckled_and_verb_status()
-			W.set_dir(H.dir)
-			W.buckled_mob = H
-			W.add_fingerprint(H)
-
-	to_chat(H, "<B>You are [job.total_positions == 1 ? "the" : "a"] [alt_title ? alt_title : rank].</B>")
-
-	if(job.supervisors)
-		to_chat(H, "<b>As the [alt_title ? alt_title : rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
-
-	if(job.req_admin_notify)
-		to_chat(H, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
-
-	//Gives glasses to the vision impaired
-	if(H.disabilities & NEARSIGHTED)
-		var/equipped = H.equip_to_slot_or_del(new /obj/item/clothing/glasses/regular(H), slot_glasses)
-		if(equipped != 1)
-			var/obj/item/clothing/glasses/G = H.glasses
-			G.prescription = 1
-
-	var/obj/item/weapon/implant/core_implant/C = H.get_core_implant()
-	if(C)
-		C.install_default_modules_by_job(job)
-		C.access.Add(job.cruciform_access)
-		C.install_default_modules_by_path(job)
-
-	BITSET(H.hud_updateflag, ID_HUD)
-	BITSET(H.hud_updateflag, SPECIALROLE_HUD)
-	return H
 
 /proc/EquipCustomLoadout(var/mob/living/carbon/human/H, var/datum/job/job)
 	if(!H || !H.client)

--- a/code/controllers/subsystems/overlays.dm
+++ b/code/controllers/subsystems/overlays.dm
@@ -244,7 +244,9 @@ SUBSYSTEM_DEF(overlays)
 			cut_overlays()
 		return
 
-	var/list/cached_other = other.our_overlays
+	var/list/cached_other
+	if(other.our_overlays)
+		cached_other = other.our_overlays
 	if(cached_other)
 		if(cut_old || !overlays.len)
 			overlays = cached_other.Copy()

--- a/code/modules/client/preference_setup/options_popup.dm
+++ b/code/modules/client/preference_setup/options_popup.dm
@@ -76,45 +76,46 @@
 			dat += "<a href='?src=\ref[src];option_select=[option]' class='[option == get_pref_option() && "linkOn"] [img && "icon"]'>[img][option]</a><br>"
 
 	dat += "</td><td>"
-
-	dat += "<b>[selected_option]</b><br>"
-	dat += "[selected_option.desc]<br>"
-	dat += "<br>"
-
-	if(selected_option.stat_modifiers.len)
-		dat += "Stats:<br>"
-		for(var/stat in selected_option.stat_modifiers)
-			dat += "[stat] [selected_option.stat_modifiers[stat]]<br>"
+	if(selected_option)
+		dat += "<b>[selected_option]</b><br>"
+		dat += "[selected_option.desc]<br>"
 		dat += "<br>"
 
-	if(selected_option.restricted_jobs.len)
-		dat += "Restricted jobs:<br>"
-		for(var/job in selected_option.restricted_jobs)
-			var/datum/job/J = job
-			dat += "[initial(J.title)]<br>" //enjoy your byond magic
-		dat += "<br>"
+		if(selected_option.stat_modifiers.len)
+			dat += "Stats:<br>"
+			for(var/stat in selected_option.stat_modifiers)
+				dat += "[stat] [selected_option.stat_modifiers[stat]]<br>"
+			dat += "<br>"
 
-	if(selected_option.allowed_jobs.len)
-		dat += "Special jobs:<br>"
-		for(var/job in selected_option.allowed_jobs)
-			var/datum/job/J = job
-			dat += "[initial(J.title)]<br>"
-		dat += "<br>"
+		if(selected_option.restricted_jobs.len)
+			dat += "Restricted jobs:<br>"
+			for(var/job in selected_option.restricted_jobs)
+				var/datum/job/J = job
+				dat += "[initial(J.title)]<br>" //enjoy your byond magic
+			dat += "<br>"
 
-	if(selected_option.perks.len)
-		dat += "Perks:<br>"
-		for(var/perk in selected_option.perks)
-			var/datum/perk/P = perk
-			if(initial(P.icon))
-				preference_mob() << browse_rsc(icon(initial(P.icon),initial(P.icon_state)), "perk_[initial(P.name)].png")
-				dat += "<img style='vertical-align: middle;width=18px;height=18px;' src='perk_[initial(P.name)].png'/>"
-			dat += "[initial(P.name)]<br>"
-		dat += "<br>"
+		if(selected_option.allowed_jobs.len)
+			dat += "Special jobs:<br>"
+			for(var/job in selected_option.allowed_jobs)
+				var/datum/job/J = job
+				dat += "[initial(J.title)]<br>"
+			dat += "<br>"
 
-	if(!selected_option.allow_modifications)
-		dat += "Body augmentation disabled<br>"
-		dat += "<br>"
+		if(selected_option.perks.len)
+			dat += "Perks:<br>"
+			for(var/perk in selected_option.perks)
+				var/datum/perk/P = perk
+				if(initial(P.icon))
+					preference_mob() << browse_rsc(icon(initial(P.icon),initial(P.icon_state)), "perk_[initial(P.name)].png")
+					dat += "<img style='vertical-align: middle;width=18px;height=18px;' src='perk_[initial(P.name)].png'/>"
+				dat += "[initial(P.name)]<br>"
+			dat += "<br>"
 
+		if(!selected_option.allow_modifications)
+			dat += "Body augmentation disabled<br>"
+			dat += "<br>"
+	else
+		dat +="This should never be shown. If you see this, please report it. You managed to call /datum/category_item/player_setup_item/proc/show_popup without a selected option. Provide details of how you got here."
 	if(get_pref_option() == selected_option)
 		dat += "<a class='linkOff'>Selected</a>"
 	else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1198,14 +1198,15 @@ var/list/rank_prefix = list(\
 				new organ_type(src)
 
 		var/datum/category_item/setup_option/core_implant/I = Pref.get_option("Core implant")
-		if(I.implant_type)
-			var/obj/item/weapon/implant/core_implant/C = new I.implant_type
-			C.install(src)
-			C.activate()
-			if(mind)
-				C.install_default_modules_by_job(mind.assigned_job)
-				C.access.Add(mind.assigned_job.cruciform_access)
-				C.install_default_modules_by_path(mind.assigned_job)
+		if(I)
+			if(I.implant_type)
+				var/obj/item/weapon/implant/core_implant/C = new I.implant_type
+				C.install(src)
+				C.activate()
+				if(mind)
+					C.install_default_modules_by_job(mind.assigned_job)
+					C.access.Add(mind.assigned_job.cruciform_access)
+					C.install_default_modules_by_path(mind.assigned_job)
 
 	else
 		var/organ_type
@@ -1225,14 +1226,15 @@ var/list/rank_prefix = list(\
 			new organ_type(src)
 
 		if(checkprefcruciform)
-			var/datum/category_item/setup_option/core_implant/I = client.prefs.get_option("Core implant")
-			if(I.implant_type && (!mind || mind.assigned_role != "Robot"))
-				var/obj/item/weapon/implant/core_implant/C = new I.implant_type
-				C.install(src)
-				C.activate()
-				C.install_default_modules_by_job(mind.assigned_job)
-				C.access.Add(mind.assigned_job.cruciform_access)
-				C.install_default_modules_by_path(mind.assigned_job)
+			if(client)
+				var/datum/category_item/setup_option/core_implant/I = client.prefs.get_option("Core implant")
+				if(I.implant_type && (!mind || mind.assigned_role != "Robot"))
+					var/obj/item/weapon/implant/core_implant/C = new I.implant_type
+					C.install(src)
+					C.activate()
+					C.install_default_modules_by_job(mind.assigned_job)
+					C.access.Add(mind.assigned_job.cruciform_access)
+					C.install_default_modules_by_path(mind.assigned_job)
 
 	for(var/obj/item/organ/internal/carrion/C in organs_to_readd)
 		C.replaced(get_organ(C.parent_organ_base))

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -382,7 +382,7 @@ var/global/list/robot_modules = list(
 		S.update_icon()
 
 	if(src.modules)
-		var/obj/item/weapon/reagent_containers/spray/sterilizine/ST = src.modules //ST for STerilizine
+		var/obj/item/weapon/reagent_containers/spray/sterilizine/ST = locate() in src.modules //ST for STerilizine
 		ST.reagents.add_reagent("sterilizine", 2 * amount)
 	..()
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -35,7 +35,8 @@
 						ASSIGN_LIST_TO_COLORS(ReadRGB("#000000"), r_facial, g_facial, b_facial)
 				*/
 		if(current_form.appearance_flags & HAS_UNDERWEAR)
-			all_underwear.Cut()
+			if(all_underwear)
+				all_underwear.Cut()
 			for(var/datum/category_group/underwear/WRC in GLOB.underwear.categories)
 				var/datum/category_item/underwear/WRI = pick(WRC.items)
 				all_underwear[WRC.name] = WRI.name

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -528,11 +528,13 @@
 			hud_actions += action
 			if(istype(src.loc, /mob))
 				var/mob/user = src.loc
-				user.client.screen += action
+				if(user)
+					user.client.screen += action
 	else
 		if(istype(src.loc, /mob))
 			var/mob/user = src.loc
-			user.client.screen -= action
+			if(user)
+				user.client.screen -= action
 		hud_actions -= action
 		qdel(action)
 


### PR DESCRIPTION
Fixes several runtimes. Tested and no major problem appeared, or any problems as far as I could tell.

![image](https://user-images.githubusercontent.com/72584637/109385503-04f29d80-78fd-11eb-9d19-8a799535c6ad.png)

Runtime in gun.dm line 535: cannot read null.screen. Added sanity check when initializing scope. Scope initialization will run at gun initialization to properly set it up. Gun is not being held by anyone with a screen at the time though. Fix applied.

Runtime in glowing.dm line 34. Known issue. Glowing roaches runtime. Kept for later testing purposes. Fix can be done via eye check, but left in here in case we get the problem again where runtimes won't show up at all. 

Runtime in overlays.dm line 247: undefined variable /var/our_overlays. Added sanity check. If cut_overlays is ran before copy_overlays, it will destroy the list and cause this runtime. Need to check that it still exists. Cut will delete a list if it's done without arguments. Fix applied.

Runtime in atoms.dm line 773: gender_word has somehow resulted in a text gender despite get_gender result. Needs better error scoping. An object has its gender datum as plain text. Not a runtime here, but this is where the crash is generated. Not Fixed. Issue is at a different location, something has a problem with their gender datum definition.

Runtime in human.dm line 1228: Cannot read Null.prefs. *Should not happen*. We check to see if the client has a cruciform previously and then run this. checkprefcruciform should tell us if they have a cruciform or not. Somehow someone raced the clock here, being either deleted or removed in the meantime. Added an if statement check. Fix applied

Runtine in human.dm line 1201: Cannot read null.implant_type. We're rebuilding organs and looking to see what cruciform to give someone. However, we don't check to see if they actually selected one in the first place and initalized it. "pref.setup_options["Core implant"] = null" is how we initalize this. We're calling null.implant_type here. Fix applied.

Runtime in options_popup.dm line 71: Cannot read null.desc. Someone managed to call show_popup on a background list without actually selecting one, as even None will return something here. Congratulations to that person, I couldn't reproduce this in my server. Added a sanity check to keep this from happening. Fix applied. 

Runtime in callproc.dm line 151: bad proc. This was an admin called proc that somehow failed. Issue needs better scoping. What proc was called, what arguments were used? This was done by some admin. **Not fixed**.

Runtime in lighting_source.dm line 70: Atom space was a light source, but lacked a light source list. Issue needs better scoping. The exact runtime error returns the source atom that is the culprit. **Can't fix without knowning that atom**.

Runtine im preferences_setup.dm line 38: Cannot execute null.Cut(). We're checking if the person can wear underwear and then removing all their underwear. However, we don't check if they have underwear to begin with. We execute cut on a list that is null, so we're runtiming. Added sanity check. Fix applied. Can only be triggered by an admin using Respawn Character on someone who has no underwear. Someone did this this round.

Runtime in jobs.dm line 346: Cannot read null.head_position. Someone actually got the message "Your job is Assistant and the game just can't handle it! Please report this bug to an administrator" but did not report this. We check to see if the job exists and it doesn't, we'll run into this error and return that to the chat to that person. Can be replicated by running Respawn Character on someone with no job. Fix applied by moving the full initalization of a job's details to the former check we already had for most of it. 

Runtime in inventory.dm line 48: undefined proc or verb /obj/structure/railing/dropped(). Someone *somehow* managed to call put_in_hands on railing. Not sure how, couldn't replicate. Issue is that structures don't have a Dropped proc, why would they though? Applying a sanity check to the proc would be redundant, we should only be able to call it on items and we're give an item as a variable. Needs replication. **Not fixed.**

Runtine in robot_modules line 386: Cannot execute null.add reagent(). We weren't using 'locate' to find the proper cotainer to add reagents to. Changed that. This also fixes the issue where medical cyborgs could not recharge their sterilizine. Fix Applied.

Runtine in human_defense.dm line 255: Cannot read .len. There was an attack made with something that doesn't have attack_verb as a list. Couldn't find an item where this is the case. Modified item perhaps? Error can be reproduced by changing the attack_verb from a list to anything else. This needs root cause analysis rather than a validation check. **Not Fixed.**


