### PR TITLE
Many drone QoLs/fixes

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -210,7 +210,7 @@
 	on_store_name = "Robotic Storage Oversight"
 	on_enter_occupant_message = "The storage unit broadcasts a sleep signal to you. Your systems start to shut down, and you enter low-power mode."
 	allow_occupant_types = list(/mob/living/silicon/robot)
-	disallow_occupant_types = list(/mob/living/silicon/robot/drone)
+//	disallow_occupant_types = list(/mob/living/silicon/robot/drone) We infact can put drones in storage.
 	applies_stasis = 0
 
 /obj/machinery/cryopod/elevator
@@ -228,7 +228,7 @@
 	time_till_despawn = 600 //1 minute. We want to be much faster then normal cryo, since waiting in an elevator for half an hour is a special kind of hell.
 
 	allow_occupant_types = list(/mob/living/silicon/robot,/mob/living/carbon/human)
-	disallow_occupant_types = list(/mob/living/silicon/robot/drone)
+//	disallow_occupant_types = list(/mob/living/silicon/robot/drone) Why would the lower colony not want us?!
 
 /obj/machinery/cryopod/dormitory
 	name = "Long Sleep Bed"

--- a/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
+++ b/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
@@ -15,6 +15,10 @@
 	real_name = "\"Blitzshell\" assault drone ([rand(100,999)])"
 	name = real_name
 
+/mob/living/silicon/robot/drone/blitzshell/init()
+	..()
+	locked = locked //No cheesing these ones.
+
 /mob/living/silicon/robot/drone/blitzshell/is_allowed_vent_crawl_item()
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request
Drones can now use the lift to leave the round, same as borgs
Drones can use robotic storage to leave the round, same as borg
Drones are killed by robotic Id swipe rather then a mix of Guild/Robotics (meaning like Marshal/Preimer only for some reason)
Drones maybe revive-able now Yay!
Drones (NOT BLITS) start unlocked for repairing/upgrading the cell/internals.
## Changelog
:cl:
/:cl:
