### PR TITLE
Small changes to some projectiles' damage.

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -159,7 +159,7 @@
 /// .257 Carbine///
 
 /obj/item/projectile/bullet/light_rifle_257
-	damage_types = list(BRUTE = 16)
+	damage_types = list(BRUTE = 22)
 	armor_penetration = 15
 	penetrating = 1
 	can_ricochet = TRUE
@@ -176,7 +176,7 @@
 	step_delay = 0.5
 
 /obj/item/projectile/bullet/light_rifle_257/hv
-	damage_types = list(BRUTE = 18)
+	damage_types = list(BRUTE = 26)
 	armor_penetration = 24
 	penetrating = 2
 	hitscan = TRUE
@@ -195,7 +195,7 @@
 
 /obj/item/projectile/bullet/light_rifle_257/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 18)
+	damage_types = list(BRUTE = 24)
 	agony = 20
 	armor_penetration = 5
 	penetrating = 0
@@ -205,7 +205,7 @@
 	step_delay = 0.6
 
 /obj/item/projectile/bullet/light_rifle_257/scrap
-	damage_types = list(BRUTE = 12)
+	damage_types = list(BRUTE = 18)
 
 /obj/item/projectile/bullet/light_rifle_257/nomuzzle
 	muzzle_type = null
@@ -264,7 +264,7 @@
 /// .408 OMNI ///
 
 /obj/item/projectile/bullet/heavy_rifle_408
-	damage_types = list(BRUTE = 20)
+	damage_types = list(BRUTE = 28)
 	armor_penetration = 30
 	penetrating = 2
 	can_ricochet = TRUE
@@ -273,7 +273,7 @@
 /obj/item/projectile/bullet/heavy_rifle_408/rubber
 	name = "rubber bullet"
 	icon_state = "rubber"
-	damage_types = list(BRUTE = 8)
+	damage_types = list(BRUTE = 10)
 	agony = 32
 	check_armour = ARMOR_MELEE
 	armor_penetration = 0
@@ -294,14 +294,14 @@
 
 /obj/item/projectile/bullet/heavy_rifle_408/hv
 	name = "sabot penetrator"
-	damage_types = list(BRUTE = 24)
+	damage_types = list(BRUTE = 32)
 	armor_penetration = 40
 	penetrating = 3
 	hitscan = TRUE
 
 /obj/item/projectile/bullet/heavy_rifle_408/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 22)
+	damage_types = list(BRUTE = 30)
 	agony = 32
 	armor_penetration = 35
 	penetrating = 0
@@ -311,12 +311,12 @@
 	step_delay = 0.5
 
 /obj/item/projectile/bullet/heavy_rifle_408/scrap
-	damage_types = list(BRUTE = 16)
+	damage_types = list(BRUTE = 20)
 
 ///Snowflake caseless///
 
 /obj/item/projectile/bullet/c10x24
-	damage_types = list(BRUTE = 16)
+	damage_types = list(BRUTE = 18)
 	armor_penetration = 15
 	penetrating = 2
 	can_ricochet = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

For the purpose of re-balancing some weapons, mostly 257. ones, and making them worthwhile, I've decided to augment their damage values. Same with 408 (and 10x24 though minor), which despite being much, much rarer than 7.5 (with the exception of blackshield.), and having nearly no weapon disks that can print weapons using this ammunition, was actually weaker.
I also plan to modify some weapons' damage modifiers, notably the STS to be a 1.1x instead of 1.3x, along with some boltguns if this request passes through.
(First PR of mine. Pardon if anything's not up to par.)

Here are all the of the changes.

/obj/item/projectile/bullet/light_rifle_257 
damage_types = list(BRUTE = 22) (from 16)

/obj/item/projectile/bullet/light_rifle_257/hv
damage_types = list(BRUTE = 26) (from 18)

/obj/item/projectile/bullet/light_rifle_257/lethal
damage_types = list(BRUTE = 24) (from 18)

/obj/item/projectile/bullet/light_rifle_257/scrap
damage_types = list(BRUTE = 18) (from 12)

/obj/item/projectile/bullet/heavy_rifle_408
damage_types = list(BRUTE = 28) (from 20)

/obj/item/projectile/bullet/heavy_rifle_408/rubber
damage_types = list(BRUTE = 10) (from 8)

/obj/item/projectile/bullet/heavy_rifle_408/hv
damage_types = list(BRUTE = 32) (from 24)

/obj/item/projectile/bullet/heavy_rifle_408/scrap
damage_types = list(BRUTE = 20) (from 16)

/obj/item/projectile/bullet/c10x24
damage_types = list(BRUTE = 18) (from 16)

## Changelog
:cl:
balance: rebalanced something
code: changed some code (Damage values)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
