### PR TITLE
AI Drone Control

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/_drone.dm
@@ -33,14 +33,14 @@ var/list/mob_hat_cache = list()
 	braintype = "Robot"
 	lawupdate = 0
 	density = FALSE
-	req_access = list(access_robotics)
+	req_access = list(access_robotics) //We are robotics based!
 	integrated_light_power = 3
 	local_transmit = 1
 	possession_candidate = 1
 	speed = -0.25
 
-	can_pull_size = ITEM_SIZE_NORMAL
-	can_pull_mobs = MOB_PULL_SMALLER
+//	can_pull_size = ITEM_SIZE_NORMAL SoJ change, we can drag normal things around to not get soft lock/QoL
+//	can_pull_mobs = MOB_PULL_SMALLER SoJ change, we can drag mobs that need to be dragged, QoL
 
 	mob_bump_flag = SIMPLE_ANIMAL
 	mob_swap_flags = SIMPLE_ANIMAL
@@ -104,8 +104,8 @@ var/list/mob_hat_cache = list()
 	module_type = /obj/item/weapon/robot_module/drone/construction
 	hat_x_offset = 1
 	hat_y_offset = -12
-//	can_pull_size = ITEM_SIZE_HUGE
-//	can_pull_mobs = MOB_PULL_SAME
+//	can_pull_size = ITEM_SIZE_HUGE Soj chnge, same as base
+//	can_pull_mobs = MOB_PULL_SAME Soj chnge, same as base
 
 /mob/living/silicon/robot/drone/New()
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_remote_control.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_remote_control.dm
@@ -1,0 +1,111 @@
+/mob/living/silicon/ai
+	var/mob/living/silicon/robot/drone/controlling_drone
+
+/mob/living/silicon/robot/drone
+	var/mob/living/silicon/ai/controlling_ai
+	var/obj/item/device/radio/drone_silicon_radio
+
+/mob/living/silicon/robot/drone/attack_ai(var/mob/living/silicon/ai/user)
+
+	if(!istype(user) || controlling_ai || !config.allow_drone_spawn)
+		return
+
+	if(stat != 2 || client || key)
+		to_chat(user, "<span class='warning'>You cannot take control of an autonomous, active drone.</span>")
+		return
+
+	if(health < -35 || emagged)
+		to_chat(user, "<span class='notice'><b>WARNING:</b> connection timed out.</span>")
+		return
+
+	assume_control(user)
+
+/mob/living/silicon/robot/drone/proc/assume_control(var/mob/living/silicon/ai/user)
+	user.controlling_drone = src
+	controlling_ai = user
+	verbs += /mob/living/silicon/robot/drone/proc/release_ai_control_verb
+	local_transmit = FALSE
+	languages = controlling_ai.languages.Copy()
+
+	//give controlled drone access to AI radio
+	drone_silicon_radio = silicon_radio
+	silicon_radio = new /obj/item/device/radio/headset/heads/ai_integrated(src)
+	//silicon_radio.recalculateChannels()
+
+	default_language = controlling_ai.default_language
+
+	stat = CONSCIOUS
+	if(user.mind)
+		user.mind.transfer_to(src)
+	else
+		key = user.key
+	updatename()
+	to_chat(src, "<span class='notice'><b>You have shunted your primary control loop into \a [initial(name)].</b> Use the <b>Release Control</b> verb to return to your core.</span>")
+
+/obj/machinery/drone_fabricator/attack_ai(var/mob/living/silicon/ai/user)
+
+	if(!istype(user) || user.controlling_drone || !config.allow_drone_spawn)
+		return
+
+	if(stat & NOPOWER)
+		to_chat(user, "<span class='warning'>\The [src] is unpowered.</span>")
+		return
+
+	if(!produce_drones)
+		to_chat(user, "<span class='warning'>\The [src] is disabled.</span>")
+		return
+
+	if(drone_progress < 100)
+		to_chat(user, "<span class='warning'>\The [src] is not ready to produce a new drone.</span>")
+		return
+
+	if(count_drones() >= config.max_maint_drones)
+		to_chat(user, "<span class='warning'>The drone control subsystems are tasked to capacity; they cannot support any more drones.</span>")
+		return
+
+	var/mob/living/silicon/robot/drone/new_drone = new drone_type(get_turf(src))
+	new_drone.assume_control(user)
+
+
+/mob/living/silicon/robot/drone/death(gibbed)
+	if(controlling_ai)
+		release_ai_control("<b>WARNING: remote system failure.</b> Connection timed out.")
+	drone_silicon_radio = null
+	. = ..(gibbed)
+
+/mob/living/silicon/ai/death(gibbed)
+	if(controlling_drone)
+		controlling_drone.release_ai_control("<b>WARNING: Primary control loop failure.</b> Session terminated.")
+	. = ..(gibbed)
+
+/mob/living/silicon/ai/Life()
+	. = ..()
+	if(controlling_drone && stat != CONSCIOUS)
+		controlling_drone.release_ai_control("<b>WARNING: Primary control loop failure.</b> Session terminated.")
+
+/mob/living/silicon/robot/drone/proc/release_ai_control_verb()
+	set name = "Release Control"
+	set desc = "Release control of a remote drone."
+	set category = "Silicon Commands"
+
+	release_ai_control("Remote session terminated.")
+
+/mob/living/silicon/robot/drone/proc/release_ai_control(var/message = "Connection terminated.")
+
+	if(controlling_ai)
+		if(mind)
+			mind.transfer_to(controlling_ai)
+		else
+			controlling_ai.key = key
+		to_chat(controlling_ai, "<span class='notice'>[message]</span>")
+		controlling_ai.controlling_drone = null
+		controlling_ai = null
+	//releases controlled drone access to AI radio
+	QDEL_NULL(silicon_radio)
+	silicon_radio = drone_silicon_radio
+	drone_silicon_radio = null
+
+	verbs -= /mob/living/silicon/robot/drone/proc/release_ai_control_verb
+	full_law_reset()
+	updatename()
+	death()

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -1978,6 +1978,7 @@
 #include "code\modules\mob\living\silicon\robot\drone\drone_damage.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_items.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_manufacturer.dm"
+#include "code\modules\mob\living\silicon\robot\drone\drone_remote_control.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_say.dm"
 #include "code\modules\mob\living\simple_animal\parrot.dm"
 #include "code\modules\mob\living\simple_animal\simple_animal.dm"


### PR DESCRIPTION
The AI can not do the following:**

- Click on a drone fabricator to create a new drone shell for themselves and enter it.
- Leave and enter drone bodies whenever they want by clicking uncopied drone shells. Release-Control is the verb to leave a drone, available under Silicon Commands
- If a drone is destroyed while controled, control is simply turned back to the old AI core.**

Enjoy. Tested on my server. No runtime, runs as expected.