### PR TITLE
QoL Minor

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -360,7 +360,7 @@
 
 /obj/item/weapon/storage/fancy/cigar
 	name = "cigar case"
-	desc = "A case for holding your cigars when you are not smoking them, made of steel and designed to hold only classy cigars."
+	desc = "A case for holding your cigars when you are not smoking them, made of steel and designed to hold only classy cigars and equally classy zippo lighters."
 	icon_state = "cigarcase"
 	item_state = "cigarcase"
 	icon = 'icons/obj/cigarettes.dmi'
@@ -368,7 +368,7 @@
 	throwforce = WEAPON_FORCE_HARMLESS
 	slot_flags = SLOT_BELT
 	storage_slots = 7
-	can_hold = list(/obj/item/clothing/mask/smokable/cigarette/cigar)
+	can_hold = list(/obj/item/clothing/mask/smokable/cigarette/cigar, /obj/item/weapon/flame/lighter/zippo)
 	icon_type = "cigar"
 	reagent_flags = REFILLABLE | NO_REACT
 	var/open = FALSE

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -34,6 +34,7 @@
 	armor = list(melee = 20, bullet = 10, energy = 25, bomb = 10, bio = 10, rad = 0)
 	item_flags = NOSLIP
 	siemens_coefficient = 0.4
+	can_hold_knife = 1
 
 /obj/item/clothing/shoes/sandal
 	desc = "A pair of rather plain, wooden sandals."
@@ -52,7 +53,7 @@
 
 /obj/item/clothing/shoes/cult
 	name = "boots"
-	desc = "A pair of boots worn by the followers of Nar-Sie."
+	desc = "A pair of boots worn by the followers of ... something."
 	icon_state = "cult"
 	item_state = "cult"
 	force = WEAPON_FORCE_WEAK


### PR DESCRIPTION
-Cigar cases can now hold zippos and only zippos in addition to cigars.
-Combat boots can now hold knives, side note for prospectors, combat boots have the NO_SLIP tag, making them a direct upgrade in all scenrios involving footwear except speed effecting boots.