### PR TITLE
Balance (stats) change for (some) weapons. 

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -19,7 +19,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
-	recoil_buildup = 8
+	recoil_buildup = 10
 	one_hand_penalty = 10 //automatic rifle level
 	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE, GUN_MAGWELL)
 
@@ -76,13 +76,13 @@
 /obj/item/weapon/gun/projectile/automatic/ak47/sa
 	name = "\"Kalashnikov\" carbine"
 	desc = "Weapon of the oppressed, oppressors, and extremists of all flavours. \
-		 A poor copy of the AKM pattern, shortened into a mid-length carbine and chambered in .257. The left arm of the unfree world."
+		 A copy of the AKM pattern, shortened into a mid-length carbine and chambered in .257. The left arm of the unfree world."
 	icon = 'icons/obj/guns/projectile/ak_wood.dmi'
 	icon_state = "AK"
 	item_state = "AK"
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
 	price_tag = 750
-	damage_multiplier = 0.9
+	damage_multiplier = 1
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	saw_off = TRUE
 	sawn = /obj/item/weapon/gun/projectile/automatic/ak47/sawn
@@ -90,7 +90,7 @@
 /obj/item/weapon/gun/projectile/automatic/ak47/sawn
 	name = "sawn-off \"Kalashnikov\" carbine"
 	desc = "Weapon of the oppressed, oppressors, and extremists of all flavours. \
-	A poor copy of the AKM pattern chambered in .257 and crudely sawed down to a shadow of its former self. Rifle was fine. Was."
+	A copy of the AKM pattern chambered in .257 and crudely sawed down to a shadow of its former self. Rifle was fine. Was."
 	icon = 'icons/obj/guns/projectile/sawnoff/ak.dmi'
 	icon_state = "AK"
 	item_state = "AK"
@@ -98,7 +98,7 @@
 	force = WEAPON_FORCE_NORMAL
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 5)
 	price_tag = 500
-	recoil_buildup = 10
+	recoil_buildup = 14
 	one_hand_penalty = 20
 	damage_multiplier = 0.8
 	saw_off = FALSE

--- a/code/modules/projectiles/guns/projectile/automatic/sts.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts.dm
@@ -17,8 +17,8 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
-	damage_multiplier = 1.1
-	recoil_buildup = 6
+	damage_multiplier = 1.2
+	recoil_buildup = 10
 	one_hand_penalty = 13 //automatic rifle level
 	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE, GUN_MAGWELL)
 
@@ -148,10 +148,10 @@
 	w_class = ITEM_SIZE_HUGE
 	caliber = CAL_HRIFLE
 	mag_well = MAG_WELL_HRIFLE
-	penetration_multiplier = 1
-	damage_multiplier = 1.3
-	recoil_buildup = 13
-	one_hand_penalty = 20
+	penetration_multiplier = 1.1
+	damage_multiplier = 1.1
+	recoil_buildup = 15
+	one_hand_penalty = 25
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/batrifle_cock.ogg'
 	saw_off = TRUE
@@ -168,7 +168,7 @@
 	item_state = "sts"
 	penetration_multiplier = 0.8
 	damage_multiplier = 1
-	recoil_buildup = 15
-	one_hand_penalty = 25
+	recoil_buildup = 20
+	one_hand_penalty = 30
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 6)
 	saw_off = FALSE

--- a/code/modules/projectiles/guns/projectile/boltgun/roe_sika.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/roe_sika.dm
@@ -9,7 +9,7 @@
 	recoil_buildup = 10
 	one_hand_penalty = 20 //maybe some trick shots
 	price_tag = 1000
-	damage_multiplier = 1
+	damage_multiplier = 1.25
 	sharp = FALSE
 	force = WEAPON_FORCE_PAINFUL
 	caliber = CAL_LRIFLE
@@ -45,7 +45,7 @@
 	one_hand_penalty = 20 //maybe some trick shots
 	zoom_factor = 2.0
 	price_tag = 1000
-	damage_multiplier = 1
+	damage_multiplier = 1.25
 	force = WEAPON_FORCE_PAINFUL
 	sharp = FALSE
 	caliber = CAL_LRIFLE

--- a/code/modules/projectiles/guns/projectile/boltgun/roe_sika.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/roe_sika.dm
@@ -6,7 +6,7 @@
 	item_state = "boltgun"
 	max_shells = 10
 	zoom_factor = 2.0
-	recoil_buildup = 10
+	recoil_buildup = 15
 	one_hand_penalty = 20 //maybe some trick shots
 	price_tag = 1000
 	damage_multiplier = 1.25

--- a/code/modules/projectiles/guns/projectile/boltgun/scout.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/scout.dm
@@ -1,12 +1,12 @@
 /obj/item/weapon/gun/projectile/boltgun/scout
 	name = "\"Scout\" heavy boltgun"
-	desc = "Weapon for hunting, sniping, and competition shooting. Chambered in .408 Heavy Rifle rounds, it packs the reach and accuracy for every occasion."
+	desc = "Weapon for hunting, sniping, and competition shooting. Chambered in .408 Heavy Rifle rounds, it packs the reach, the punch and the accuracy for every occasion, however saying it kicks like a mule would only be a plain understatement."
 	icon = 'icons/obj/guns/projectile/heavyboltgun.dmi'
 	icon_state = "boltgun"
 	item_state = "boltgun"
 	force = WEAPON_FORCE_PAINFUL
-	damage_multiplier = 1.3
-	penetration_multiplier  = 1.6
+	damage_multiplier = 1.5
+	penetration_multiplier  = 1.5
 	recoil_buildup = 30
 	max_shells = 5
 	zoom_factor = 2.0

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -159,7 +159,7 @@
 /// .257 Carbine///
 
 /obj/item/projectile/bullet/light_rifle_257
-	damage_types = list(BRUTE = 16)
+	damage_types = list(BRUTE = 20)
 	armor_penetration = 15
 	penetrating = 1
 	can_ricochet = TRUE
@@ -176,7 +176,7 @@
 	step_delay = 0.5
 
 /obj/item/projectile/bullet/light_rifle_257/hv
-	damage_types = list(BRUTE = 18)
+	damage_types = list(BRUTE = 22)
 	armor_penetration = 24
 	penetrating = 2
 	hitscan = TRUE
@@ -195,7 +195,7 @@
 
 /obj/item/projectile/bullet/light_rifle_257/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 18)
+	damage_types = list(BRUTE = 22)
 	agony = 20
 	armor_penetration = 5
 	penetrating = 0
@@ -205,7 +205,7 @@
 	step_delay = 0.6
 
 /obj/item/projectile/bullet/light_rifle_257/scrap
-	damage_types = list(BRUTE = 12)
+	damage_types = list(BRUTE = 16)
 
 /obj/item/projectile/bullet/light_rifle_257/nomuzzle
 	muzzle_type = null
@@ -264,7 +264,7 @@
 /// .408 OMNI ///
 
 /obj/item/projectile/bullet/heavy_rifle_408
-	damage_types = list(BRUTE = 20)
+	damage_types = list(BRUTE = 28)
 	armor_penetration = 30
 	penetrating = 2
 	can_ricochet = TRUE
@@ -294,14 +294,14 @@
 
 /obj/item/projectile/bullet/heavy_rifle_408/hv
 	name = "sabot penetrator"
-	damage_types = list(BRUTE = 24)
+	damage_types = list(BRUTE = 30)
 	armor_penetration = 40
 	penetrating = 3
 	hitscan = TRUE
 
 /obj/item/projectile/bullet/heavy_rifle_408/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 22)
+	damage_types = list(BRUTE = 30)
 	agony = 32
 	armor_penetration = 35
 	penetrating = 0
@@ -311,12 +311,12 @@
 	step_delay = 0.5
 
 /obj/item/projectile/bullet/heavy_rifle_408/scrap
-	damage_types = list(BRUTE = 16)
+	damage_types = list(BRUTE = 20)
 
 ///Snowflake caseless///
 
 /obj/item/projectile/bullet/c10x24
-	damage_types = list(BRUTE = 16)
+	damage_types = list(BRUTE = 18)
 	armor_penetration = 15
 	penetrating = 2
 	can_ricochet = TRUE
@@ -341,7 +341,7 @@
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	icon_state = "slug"
-	damage_types = list(BRUTE = 55) //normal would be 45
+	damage_types = list(BRUTE = 45) //normal would be 45
 	armor_penetration = 10
 	knockback = 0 //Bug doups hits
 	step_delay = 0.9
@@ -497,7 +497,7 @@
 /obj/item/projectile/bullet/crossbow_bolt
 	name = "bolt"
 	icon_state = "bolt"
-	damage_types = list(BRUTE = 55) //normal would be 45
+	damage_types = list(BRUTE = 45) //normal would be 45
 	armor_penetration = 10
 	knockback = 0 //Bug doups hits
 	step_delay = 0.9

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -159,7 +159,7 @@
 /// .257 Carbine///
 
 /obj/item/projectile/bullet/light_rifle_257
-	damage_types = list(BRUTE = 20)
+	damage_types = list(BRUTE = 22)
 	armor_penetration = 15
 	penetrating = 1
 	can_ricochet = TRUE
@@ -176,7 +176,7 @@
 	step_delay = 0.5
 
 /obj/item/projectile/bullet/light_rifle_257/hv
-	damage_types = list(BRUTE = 22)
+	damage_types = list(BRUTE = 26)
 	armor_penetration = 24
 	penetrating = 2
 	hitscan = TRUE
@@ -195,7 +195,7 @@
 
 /obj/item/projectile/bullet/light_rifle_257/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 22)
+	damage_types = list(BRUTE = 24)
 	agony = 20
 	armor_penetration = 5
 	penetrating = 0
@@ -205,7 +205,7 @@
 	step_delay = 0.6
 
 /obj/item/projectile/bullet/light_rifle_257/scrap
-	damage_types = list(BRUTE = 16)
+	damage_types = list(BRUTE = 18)
 
 /obj/item/projectile/bullet/light_rifle_257/nomuzzle
 	muzzle_type = null
@@ -294,7 +294,7 @@
 
 /obj/item/projectile/bullet/heavy_rifle_408/hv
 	name = "sabot penetrator"
-	damage_types = list(BRUTE = 30)
+	damage_types = list(BRUTE = 32)
 	armor_penetration = 40
 	penetrating = 3
 	hitscan = TRUE

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -341,7 +341,7 @@
 /obj/item/projectile/bullet/shotgun
 	name = "slug"
 	icon_state = "slug"
-	damage_types = list(BRUTE = 45) //normal would be 45
+	damage_types = list(BRUTE = 54)
 	armor_penetration = 10
 	knockback = 0 //Bug doups hits
 	step_delay = 0.9
@@ -497,7 +497,7 @@
 /obj/item/projectile/bullet/crossbow_bolt
 	name = "bolt"
 	icon_state = "bolt"
-	damage_types = list(BRUTE = 45) //normal would be 45
+	damage_types = list(BRUTE = 54)
 	armor_penetration = 10
 	knockback = 0 //Bug doups hits
 	step_delay = 0.9


### PR DESCRIPTION
About The Pull Request : 
(Now fixed.)
This is the change that was announced after modifying 257. and 408. stats, after an awful fight with my poor coding skills, I've managed to put all of those changes in a single PR. However, the fact it can't merged together automatically might be because some projectile values are the same. 
(Despite being a change from the forked version of sojourn, which was somehow different from the version the server uses on SS13.)
Some weapons have also been modified, like the Scout and SA AKM to actually be relevant now.
🆑
Weapon balance.
/🆑