### PR TITLE
Fixes nurses spiders 2 hit combo

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -97,7 +97,7 @@
 				//first, check for potential food nearby to cocoon
 				var/list/cocoonTargets = new
 				for(var/mob/living/C in getObjectsInView())
-					if(C.stat != CONSCIOUS)
+					if(C.stat == DEAD) //We only want dead, no more cocooning living
 						cocoonTargets += C
 
 				cocoon_target = safepick(nearestObjectsInList(cocoonTargets,src,1))


### PR DESCRIPTION

## About The Pull Request
A spider that roles a lucky knockdown they can instantly cocoon a person or mob instantly killing them without any resistant making them unfairly good. This also works on other mobs like Queens, Xenos, Furheres that are not really fair.

## Changelog
:cl:
/:cl:
