### PR TITLE
crayon hot fix

### DIFF
--- a/code/game/objects/random/food.dm
+++ b/code/game/objects/random/food.dm
@@ -95,7 +95,7 @@
 	name = "random crayon rations"
 	icon_state = "food-green"
 
-/obj/random/rations/item_to_spawn()
+/obj/random/rations/crayon/item_to_spawn()
 	return pickweight(list(/obj/item/weapon/pen/crayon/red = 2,\
 				/obj/item/weapon/pen/crayon/orange = 2,\
 				/obj/item/weapon/pen/crayon/yellow = 2,\


### PR DESCRIPTION

## About The Pull Request
Normal food spawns are no longer crayons

## Changelog
:cl:
/:cl:

