### PR TITLE
Mini hoes no longer cost plasteel

### DIFF
--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -107,7 +107,7 @@
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "hoe"
 	item_state = "hoe"
-	matter = list(MATERIAL_PLASTEEL = 2, MATERIAL_PLASTIC = 2)
+	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2)
 	force = WEAPON_FORCE_WEAK
 	throwforce = WEAPON_FORCE_WEAK
 	max_upgrades = 2


### PR DESCRIPTION
## About The Pull Request
They're called "steel mini hoes" should cost steel, not plasteel
Also quality shoveling 10 for two sheets of plasteel is a **scam**.
<hr>

## Changelog
:cl:
fix: Mini-hoes cost steel instead of plasteel to make, as intended
/:cl: