### PR TITLE
Update artifact_harvester.dm

### DIFF
--- a/code/modules/research/xenoarchaeology/machinery/artifact_harvester.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_harvester.dm
@@ -14,13 +14,18 @@
 	var/obj/machinery/artifact_scanpad/owned_scanner = null
 	var/last_process = 0
 
+//Upon creation attempt to connect to scan pad.
 /obj/machinery/artifact_harvester/New()
 	..()
-	//connect to a nearby scanner pad
+	reconnect_scanner()
+
+//Allows us to reconnect to nearby scanner pads if we arn't connected.
+/obj/machinery/artifact_harvester/proc/reconnect_scanner()
 	owned_scanner = locate(/obj/machinery/artifact_scanpad) in get_step(src, dir)
 	if(!owned_scanner)
 		owned_scanner = locate(/obj/machinery/artifact_scanpad) in orange(1, src)
 
+//Battery Insert Segment.
 /obj/machinery/artifact_harvester/attackby(var/obj/I as obj, var/mob/user as mob)
 	if(istype(I,/obj/item/weapon/anobattery))
 		if(!inserted_battery)
@@ -44,8 +49,12 @@
 	user.set_machine(src)
 	var/dat = "<B>Artifact Power Harvester</B><BR>"
 	dat += "<HR><BR>"
-	//
-	if(owned_scanner)
+	//Scanner Pad connection check, Flows into user interface of battery charge.
+	if(!owned_scanner)
+		reconnect_scanner()
+	if(!owned_scanner)
+		dat += "<B><font color=red>Unable to locate analysis pad.</font><BR></b>"
+	else if(owned_scanner)
 		if(harvesting)
 			if(harvesting > 0)
 				dat += "Please wait. Harvesting in progress ([round((inserted_battery.stored_charge/inserted_battery.capacity)*100)]%).<br>"
@@ -62,8 +71,6 @@
 
 			else
 				dat += "No battery inserted.<BR>"
-	else
-		dat += "<B><font color=red>Unable to locate analysis pad.</font><BR></b>"
 	//
 	dat += "<HR>"
 	dat += "<A href='?src=\ref[src];refresh=1'>Refresh</A> <A href='?src=\ref[src];close=1'>Close<BR>"


### PR DESCRIPTION
Causes Xeno-Arch's harvesters to use the same search style as Xeno-Arch's analyzers. They search for scan pads if they are not connected to one, when used. Instead of just looking one time when they are made.