### PR TITLE
hunter cross bow can no longer be sawn down

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun/hunter_crossbow.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/hunter_crossbow.dm
@@ -15,6 +15,7 @@
 	price_tag = 750
 	recoil_buildup = 1
 	one_hand_penalty = 14
+	saw_off = FALSE
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_SCOPE)
 
 /obj/item/weapon/gun/projectile/shotgun/pump/hunter_crossbow/pump(mob/M as mob)


### PR DESCRIPTION

## About The Pull Request
As funny as it is, you no longer can saw down bolt lancers into pump action 20mm grizzles 

## Changelog
:cl:
/:cl:

