### PR TITLE
Biosiphon Anomaly buffs

### DIFF
--- a/code/game/objects/items/oddities_faction.dm
+++ b/code/game/objects/items/oddities_faction.dm
@@ -11,10 +11,10 @@
 	throw_speed = 1
 	throw_range = 2
 	price_tag = 20000
-	origin_tech = list(TECH_MATERIAL = 4, TECH_BLUESPACE = 9, TECH_POWER = 7)
+	origin_tech = list(TECH_MATERIAL = 4, TECH_BIO = 13, TECH_POWER = 7) //high bio as it works on making donuts!
 	matter = list(MATERIAL_PLASTIC = 6, MATERIAL_GLASS = 7)
 	var/last_produce = 0
-	var/cooldown = 2 HOURS
+	var/cooldown = 30 MINUTES
 
 /obj/item/biosyphon/New()
 	..()


### PR DESCRIPTION

## About The Pull Request
Biosiphon Anomaly now prints every 30 mins rather then 2 hours as no one uses these. And the case is itself a nerf on storage over a normal one for some reason
Removes Biosiphon Anomaly bluespace tech as its not teleporting anything

## Changelog
:cl:
/:cl:
