### PR TITLE
reduces teh usefullness of flashes

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -67,7 +67,18 @@
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	var/flashfail = 0
 
-	if(iscarbon(M))
+	if(issuperioranimal(M))
+		if(M.stat!=DEAD)
+			var/flash_strength = 10
+			if(issuperioranimal(M))
+				var/mob/living/carbon/superior_animal/H = M
+				flash_strength -= H.flash_resistances
+			if(flash_strength > 0)
+				M.Weaken(flash_strength)
+			else
+				flashfail = 1
+
+	if(iscarbon(M) && !issuperioranimal(M)) //Just in case so we dont double flash are superioranimal friends
 		if(M.stat!=DEAD)
 			var/mob/living/carbon/C = M
 			var/safety = C.eyecheck()

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
@@ -94,6 +94,7 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 30
 	poison_per_bite = 4
+	flash_resistances = 3 //For balance against are speedy fello
 	poison_type = "party drops"
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/spider/emperor
 	//Giving the emperor spider his own meat that has party drops. Reducing dropped meat to 3 from 4.
@@ -117,6 +118,7 @@
 	turns_per_move = 1
 	melee_damage_lower = 40
 	melee_damage_upper = 50
+	flash_resistances = 10 //For balance against are speedy fello
 	poison_per_bite = 6
 	poison_type = "stoxin"
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/spider/reaper_spider

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -62,6 +62,7 @@
 	poison_type = "menace"
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/spider/queen
 	meat_amount = 3
+	flash_resistances = 5 //For balance against are speedy fello
 	//Giving the queen her own meat type which contains MENACE.
 	mob_size = MOB_LARGE
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
@@ -8,6 +8,9 @@
 	melee_damage_lower = 3
 	melee_damage_upper = 10
 	sanity_damage = 1
+
+	flash_resistances = 15 //We are the light
+
 	//spawn_blacklisted = TRUE
 	var/change_tele_to_mob = 25
 	var/chance_tele_to_eat = 25

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/fuhrer.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/fuhrer.dm
@@ -19,6 +19,8 @@
 	extra_burrow_chance = 100
 	blattedin_revives_left = 0 //He only lives once, cuz he's huge
 
+	flash_resistances = 5 //half stuns by flash, so we can still get up and be in the fight!
+
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/roachmeat/fuhrer
 	meat_amount = 6
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/glowing.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/glowing.dm
@@ -10,6 +10,8 @@
 	maxHealth = 45
 	health = 45
 
+	flash_resistances = 10 //We are the light
+
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/roachmeat/glowing
 
 	contaminant_immunity = TRUE

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
@@ -26,6 +26,8 @@ Has ability of every roach.
 	status_flags = 0
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 
+	flash_resistances = 9.9 // were not fully flash proof but almost...
+
 	var/distress_call_stage = 3
 
 	var/health_marker_1 = 1500

--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -32,6 +32,8 @@
 	var/stop_automated_movement = 0 //use this to temporarely stop random movement
 	var/stop_automated_movement_when_pulled = 0
 
+	var/flash_resistances = 0 //Normal flash done by a hand held is 10, 10+ is for bombs
+
 	var/toxin_immune = FALSE
 
 	var/contaminant_immunity = FALSE //if TRUE, mob is immune to harmful contaminants in air (plasma), skin contact, does not relate to breathing

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
@@ -19,7 +19,7 @@ var/datum/xenomorph/xenomorph_ai
 	health = 30
 	randpixel = 0
 	gibspawner = /obj/effect/gibspawner/xenomorph
-
+	flash_resistances = 0
 	attack_sound = list('sound/xenomorph/alien_claw_flesh1.ogg', 'sound/xenomorph/alien_claw_flesh2.ogg', 'sound/xenomorph/alien_claw_flesh3.ogg')
 	attack_sound_chance = 100
 	speak_emote = list("hisses", "screeches", "trills")

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/types/XenoImpressive.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/types/XenoImpressive.dm
@@ -5,7 +5,7 @@
 	icon_living = "crusher"
 	icon_dead = "crusher_dead"
 	icon_rest = "crusher_stunned"
-
+	flash_resistances = 7 //Crushers are meant to be tanks, let them tank!
 	maxHealth = 500
 	health = 500
 	attack_sound = list('sound/xenomorph/alien_footstep_charge1.ogg', 'sound/xenomorph/alien_footstep_charge2.ogg', 'sound/xenomorph/alien_footstep_charge3.ogg')
@@ -20,7 +20,7 @@
 	icon_living = "screecher"
 	icon_dead = "screecher_dead"
 	icon_rest = "screecher_stunned"
-
+	flash_resistances = 2 //For balance against are speedy fello
 	maxHealth = 400
 	health = 400
 
@@ -35,7 +35,7 @@
 	icon_living = "ravager"
 	icon_dead = "ravager_dead"
 	icon_rest = "ravager_stunned"
-
+	flash_resistances = 2 //For balance against are speedy fello
 	maxHealth = 450
 	health = 450
 
@@ -52,7 +52,7 @@
 	icon_living = "defiler"
 	icon_dead = "defiler_dead"
 	icon_rest = "defiler_stunned"
-
+	flash_resistances = 8 //One of the weakest ones and if they fall down likely will die quickly
 	maxHealth = 400
 	health = 400
 
@@ -68,7 +68,7 @@
 	icon_living = "hivelord"
 	icon_dead = "hivelord_dead"
 	icon_rest = "hivelord_stunned"
-
+	flash_resistances = 5 //Kinda slow, not really flash proof but has good amout of resistants
 	maxHealth = 900
 	health = 900
 

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/types/XenoMega.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/types/XenoMega.dm
@@ -9,7 +9,7 @@
 
 	maxHealth = 1600
 	health = 1600
-
+	flash_resistances = 9 //We are the second in command, lets not fall
 	melee_damage_lower = 40
 	melee_damage_upper = 50
 
@@ -25,7 +25,7 @@
 	icon_dead = "queen_dead"
 	icon_rest = "queen_stunned"
 	status_flags = 0
-
+	flash_resistances = 9.9 //Can mini stun to help make the queen want to attack the other people so it dosnt solo bullie one
 	maxHealth = 3000
 	health = 3000
 	poison_per_bite = 10

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/types/XenoRobust.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/types/XenoRobust.dm
@@ -9,7 +9,7 @@
 
 	maxHealth = 80
 	health = 80
-
+	flash_resistances = 8 //Weak xeno dies to like 3 hits of most things, lets not make it to easy
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 
@@ -21,7 +21,7 @@
 	icon_living = "defender"
 	icon_dead = "defender_dead"
 	icon_rest = "defender_stunned"
-
+	flash_resistances = 3 //Meant to be a weaker tank let them weakly tank
 	maxHealth = 200
 	health = 200
 
@@ -35,7 +35,7 @@
 
 	maxHealth = 40
 	health = 40
-
+	flash_resistances = 1 //Not really an issue to be flashing now is it?
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	var/cooldown_time = 30 SECONDS
@@ -106,7 +106,7 @@ var/datum/xenomorph/xeno_morph_ai
 	maxHealth = 120
 	health = 120
 	attack_sound = list('sound/xenomorph/alien_bite1.ogg', 'sound/xenomorph/alien_bite2.ogg')
-
+	flash_resistances = 3 //Meant to be a weaker tank let them weakly tank
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 
@@ -122,7 +122,7 @@ var/datum/xenomorph/xeno_morph_ai
 
 	maxHealth = 60
 	health = 60
-
+	flash_resistances = 20 //We are a evolved bomb, lets not get disarmed by a bit of electron trickery
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 


### PR DESCRIPTION

## About The Pull Request
Roaches changes with flash - 
Flashes against Furher are half affective
Flashes against Kaiser are not as affective
Flashes against Glowing ones are not affective
Flashes against Bluespace roaches are not affective
Spider changes with flashes - 
Flashes against Reaper spiders are not affective
Flashes against Emper are less affective
Flashes against Queens are less affective
Xeno Changes with flashes
Flashes against Queen/praetorian are not as affective
Flashes against Boilers are not affective
Flashes against most xenos has been reduced 
## Changelog
:cl:
/:cl:
