### PR TITLE
Mob Armor

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -95,6 +95,16 @@
 
 	var/fleshcolor = "#666600"
 	var/bloodcolor = "#666600"
+	//Armor values for the mob. Works like normal armor values.
+	var/armor = list(
+		melee = 0,
+		bullet = 0,
+		energy = 0,
+		bomb = 0,
+		bio = 0,
+		rad = 0,
+		agony = 0
+	)
 
 /mob/living/carbon/superior_animal/New()
 	..()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -17,7 +17,14 @@
 	var/effective_damage = damage - guaranteed_damage_red
 
 	if(damagetype == HALLOSS)
-		effective_damage = round(effective_damage * max(0.5, (get_specific_organ_efficiency(OP_NERVE, def_zone) / 100)))
+		if(istype(src,/mob/living/simple_animal/) || istype(src,/mob/living/carbon/superior_animal/))
+			effective_damage = round ( effective_damage * ( 100 - src.getarmor(def_zone, "agony") ) / 100 )
+		else
+			effective_damage = round(effective_damage * max(0.5, (get_specific_organ_efficiency(OP_NERVE, def_zone) / 100)))
+	//Simple and superior mobs have a different way of dealing with agony damage.
+	if(damagetype == AGONY)
+		if(istype(src,/mob/living/simple_animal/) || istype(src,/mob/living/carbon/superior_animal/))
+			effective_damage = round ( effective_damage * ( 100 - src.getarmor(def_zone, "agony") ) / 100 )
 
 	if(effective_damage <= 0)
 		show_message(SPAN_NOTICE("Your armor absorbs the blow!"))
@@ -67,6 +74,11 @@
 /mob/living/proc/getarmor(var/def_zone, var/type)
 	return 0
 
+/mob/living/simple_animal/getarmor(var/def_zone, var/type)
+	return src.armor[type]
+
+/mob/living/carbon/superior_animal/getarmor(var/def_zone, var/type)
+	return src.armor[type]
 
 /mob/living/proc/hit_impact(damage, dir)
 	if(incapacitated(INCAPACITATION_DEFAULT|INCAPACITATION_BUCKLED_PARTIALLY))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -107,6 +107,16 @@
 	var/scan_range = 6//How far around the animal will look for food
 	var/foodtarget = 0
 	//Used to control how often ian scans for nearby food
+	//Armor values for the mob. Works like normal armor values.
+	var/armor = list(
+		melee = 0,
+		bullet = 0,
+		energy = 0,
+		bomb = 0,
+		bio = 0,
+		rad = 0,
+		agony = 0
+	)
 
 	mob_classification = CLASSIFICATION_ORGANIC
 
@@ -335,11 +345,13 @@
 /mob/living/simple_animal/gib()
 	..(icon_gib,1)
 
-/mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
+/mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj, var/def_zone = null)
 	if(!Proj || Proj.nodamage)
 		return
 
-	adjustBruteLoss(Proj.get_total_damage())
+	for(var/damage_type in Proj.damage_types)
+		var/damage = Proj.damage_types[damage_type]
+		damage_through_armor(damage, damage_type, def_zone, Proj.check_armour, armour_pen = Proj.armor_penetration, used_weapon = Proj, sharp=is_sharp(Proj), edge=has_edge(Proj))
 	return 0
 
 /mob/living/simple_animal/rejuvenate()


### PR DESCRIPTION
Tested thoroughly, didn't see a runtime or anything breaking. 
Adds the ability for mobs to have armor. Armor value calculation is done by the procs already in place for normal armor. 

Every part is pretty much self-explanatory except for the agony one. Agony armor only applies to agony dealt from projectiles like hollow point bullets. Tasers, arcwelders and stun gloves fall under 'energy'. Because of this, you may need to set it to much higher values than normal to feel an effect.

Redefine the list under the mob and change the values to anything you want. 

Here are some tests I did:
0 Vigilance, on a Fuhrer, using Lamia 50kurtz
No armor:
regular - 6 shots
hollow point - 3 shots
high velocity - 5 shots
rubber - 5 shots

50 bullet armor:
regular - 8 shots
hollow point - 5 shots
high velocity - 6 shots
rubber - 6 shots

50 bullet armor and 50 agony armor:
regular - 8 shots
hollow point - 6 shots
high velocity - 6 shots
rubber - 9 shots

extra test: 50 bullet armor, 150 agony armor. Hollow point takes 8 shots
extra test: 100 bullet armor but character has 100 vigilance. Normal takes 11 shots.
extra test: 100 bullet armor but character has 0 vigilance. Normal takes 14 shots.