### PR TITLE
Surgeons can now control wound repair

### DIFF
--- a/code/modules/surgery/wound_repair.dm
+++ b/code/modules/surgery/wound_repair.dm
@@ -64,12 +64,8 @@
 			heal_amount -= calculate_expert_surgery_bonus(user)
 		user.visible_message(SPAN_NOTICE("[user] [advanced_medical ? "expertly" : ""] treats the brute damage to [target]'s body with the [tool_name]."), \
 		SPAN_NOTICE("You treat the brute damage to [target]'s body with [tool_name].") )
-		var/charges_needed = target.getBruteLoss() / (heal_amount * -1)
-		// Take the ceiling of charges_needed as required_uses
-		var/required_uses = round(charges_needed) == charges_needed ? charges_needed : round(charges_needed + 1)
-		for(var/i = 0; i < required_uses; i++)
-			if(tool.use(1))
-				target.adjustBruteLoss(heal_amount)
+		if(target.getBruteLoss() > 0 && tool.use(1))
+			target.adjustBruteLoss(heal_amount)
 
 /datum/old_surgery_step/external/brute_heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 
@@ -132,10 +128,8 @@
 			heal_amount -= calculate_expert_surgery_bonus(user)
 		user.visible_message(SPAN_NOTICE("[user] [advanced_medical ? "expertly" : ""] treats the burn damage to [target]'s body with the [tool_name]."), \
 			SPAN_NOTICE("You treat the burn damage to [target]'s body with [tool_name].") )
-		var/charges_needed = target.getFireLoss() / (heal_amount * -1)
-		for(var/i = 0; i <= charges_needed; i++)
-			if(tool.use(1))
-				target.adjustFireLoss(heal_amount)
+		if(target.getFireLoss() > 0 && tool.use(1))
+			target.adjustFireLoss(heal_amount)
 
 
 /datum/old_surgery_step/external/burn_heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
@@ -191,13 +185,9 @@
 			heal_amount -= calculate_expert_surgery_bonus(user) * 2
 		user.visible_message(SPAN_NOTICE("[user] finishes [advanced_medical ? "expertly" : ""] filtering out any toxins in [target]'s body and repairing any neural degradation with the [tool_name]."), \
 		SPAN_NOTICE("You finish filtering out any toxins to [target]'s body and repairing any neural degradation with the [tool_name].") )
-		var/charges_needed = target.getToxLoss() / (heal_amount * -1)
-		if(needs_regeneration && charges_needed <= 0) // Use at least one charge to repair neural degradation
-			charges_needed = 1
-		for(var/i = 0; i <= charges_needed; i++)
-			if(tool.use(1))
-				target.adjustToxLoss(heal_amount)
-				target.timeofdeath = 99999999
+		if((needs_regeneration || target.getToxLoss() > 0) && tool.use(1))
+			target.adjustToxLoss(heal_amount)
+			target.timeofdeath = 99999999
 
 
 /datum/old_surgery_step/external/tox_heal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)


### PR DESCRIPTION
Wound repair no longer consumes the maximum amount of brute packs, burn packs, or nanopaste.
Instead, they use one pack if needed.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: wound repair surgeries now act only once per run
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
