### PR TITLE
Chem Dispenser Recharge Balance

### DIFF
--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -73,7 +73,8 @@
 
 /obj/machinery/chemical_dispenser/proc/recharge()
 	if(stat & (BROKEN|NOPOWER)) return
-	var/addenergy = cell.give(clamp(cell.maxcharge*cell.max_chargerate + (cell_charger_additon*20 / 2),0,cell.maxcharge))
+	//Calculates the charge rate. 800 battery starts at 48 which is high. So we pull that back a bit.
+	var/addenergy = cell.give(clamp((cell.maxcharge*cell.max_chargerate) / 2 + (cell_charger_additon*20 / 2),0,cell.maxcharge))
 	if(addenergy)
 		use_power(addenergy / CELLRATE)
 		SSnano.update_uis(src) // update all UIs attached to src


### PR DESCRIPTION
Balances chem_dispensers to have lower recharge rate.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Cuts the recharge rate from 48 to 24 for the inital recharge start (before capacitor fix it was 24) A 800 (the one it starts with) now starts at 24, 1000m becomes 40 and a 1600 goes up to 64, Those are without capacitor upgrades so if you really need super solution amounts upgrade the capacitor along with it.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
