### PR TITLE
Fix the Cube

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -1057,7 +1057,9 @@ I said no!
 	items = list(/obj/item/organ/internal/brain)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/braincake
 
-/datum/recipe/cube/roach
+//Roach cubes
+
+/datum/recipe/cube/
 	fruit = list("potato" = 1)
 	reagents = list("protein" = 10)
 	items = list(/obj/item/weapon/reagent_containers/food/snacks/meat/roachmeat)


### PR DESCRIPTION
Re-creates the class so that it's the parent class instead of /roach one, much like the cake. We need a default class first before we can go straight into a sub-class.