### PR TITLE
[FIX&REBALANCE]Revival Sickness

### DIFF
--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -265,22 +265,22 @@
 	..()
 	initial_time = world.time
 	cooldown_time = world.time + 30 MINUTES
-	holder.brute_mod_perk += 0.15
-	holder.burn_mod_perk += 0.15
-	holder.oxy_mod_perk += 0.15
-	holder.toxin_mod_perk += 0.15
-	holder.stats.changeStat(STAT_ROB, -15)
-	holder.stats.changeStat(STAT_TGH, -15)
-	holder.stats.changeStat(STAT_VIG, -15)
+	holder.brute_mod_perk += 0.10
+	holder.burn_mod_perk += 0.10
+	holder.oxy_mod_perk += 0.10
+	holder.toxin_mod_perk += 0.10
+	holder.stats.changeStat(STAT_ROB, -10)
+	holder.stats.changeStat(STAT_TGH, -10)
+	holder.stats.changeStat(STAT_VIG, -10)
 
 /datum/perk/rezsickness/remove()
-	holder.brute_mod_perk -= 0.15
-	holder.burn_mod_perk -= 0.15
-	holder.oxy_mod_perk -= 0.15
-	holder.toxin_mod_perk -= 0.15
-	holder.stats.changeStat(STAT_ROB, 15)
-	holder.stats.changeStat(STAT_TGH, 15)
-	holder.stats.changeStat(STAT_VIG, 15)
+	holder.brute_mod_perk -= 0.10
+	holder.burn_mod_perk -= 0.10
+	holder.oxy_mod_perk -= 0.10
+	holder.toxin_mod_perk -= 0.10
+	holder.stats.changeStat(STAT_ROB, 10)
+	holder.stats.changeStat(STAT_TGH, 10)
+	holder.stats.changeStat(STAT_VIG, 10)
 	..()
 
 /datum/perk/rezsickness/severe
@@ -289,19 +289,19 @@
 
 /datum/perk/rezsickness/severe/assign(mob/living/carbon/human/H)
 	..()
-	holder.brute_mod_perk += 0.10
-	holder.burn_mod_perk += 0.10
-	holder.oxy_mod_perk += 0.10
-	holder.toxin_mod_perk += 0.10
+	holder.brute_mod_perk += 0.15
+	holder.burn_mod_perk += 0.15
+	holder.oxy_mod_perk += 0.15
+	holder.toxin_mod_perk += 0.15
 	holder.stats.changeStat(STAT_COG, -15)
 	holder.stats.changeStat(STAT_MEC, -15)
 	holder.stats.changeStat(STAT_BIO, -15)
 
 /datum/perk/rezsickness/severe/remove()
-	holder.brute_mod_perk -= 0.10
-	holder.burn_mod_perk -= 0.10
-	holder.oxy_mod_perk -= 0.10
-	holder.toxin_mod_perk -= 0.10
+	holder.brute_mod_perk -= 0.15
+	holder.burn_mod_perk -= 0.15
+	holder.oxy_mod_perk -= 0.15
+	holder.toxin_mod_perk -= 0.15
 	holder.stats.changeStat(STAT_COG, 15)
 	holder.stats.changeStat(STAT_MEC, 15)
 	holder.stats.changeStat(STAT_BIO, 15)
@@ -317,24 +317,24 @@
 	holder.burn_mod_perk += 0.25
 	holder.oxy_mod_perk += 0.25
 	holder.toxin_mod_perk += 0.25
-	holder.stats.changeStat(STAT_ROB, -15)
-	holder.stats.changeStat(STAT_TGH, -15)
-	holder.stats.changeStat(STAT_VIG, -15)
-	holder.stats.changeStat(STAT_COG, -15)
-	holder.stats.changeStat(STAT_MEC, -15)
-	holder.stats.changeStat(STAT_BIO, -15)
+	holder.stats.changeStat(STAT_ROB, -20)
+	holder.stats.changeStat(STAT_TGH, -20)
+	holder.stats.changeStat(STAT_VIG, -20)
+	holder.stats.changeStat(STAT_COG, -20)
+	holder.stats.changeStat(STAT_MEC, -20)
+	holder.stats.changeStat(STAT_BIO, -20)
 
 /datum/perk/rezsickness/severe/fatal/remove()
 	holder.brute_mod_perk -= 0.25
 	holder.burn_mod_perk -= 0.25
 	holder.oxy_mod_perk -= 0.25
 	holder.toxin_mod_perk -= 0.25
-	holder.stats.changeStat(STAT_ROB, 15)
-	holder.stats.changeStat(STAT_TGH, 15)
-	holder.stats.changeStat(STAT_VIG, 15)
-	holder.stats.changeStat(STAT_COG, 15)
-	holder.stats.changeStat(STAT_MEC, 15)
-	holder.stats.changeStat(STAT_BIO, 15)
+	holder.stats.changeStat(STAT_ROB, 20)
+	holder.stats.changeStat(STAT_TGH, 20)
+	holder.stats.changeStat(STAT_VIG, 20)
+	holder.stats.changeStat(STAT_COG, 20)
+	holder.stats.changeStat(STAT_MEC, 20)
+	holder.stats.changeStat(STAT_BIO, 20)
 	..()
 
 /datum/perk/rezsickness/on_process()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Fixes Revival Sickness to be properly scaled with the severity of it.
</summary>
<hr>
This was a rather strange thing to come across - Revival sickness used to be extremely strange on how it worked, going from a -15 debuff, to a -10, to a -25 in terms of damage modifiers. This corrects that, and the stat-loss.

While this actually does nothing in terms of damage incoming, it now further reduces skills.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
Tweak: Revival sickness now scales with its tier, along with applying lesser/much worse stat debuffs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
