### PR TITLE
corrects spender fed amout per egg laying and perks

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -53,7 +53,7 @@
 		man_amount++
 	man_rating -= man_amount
 
-	available_chemicals = level0.Copy() 
+	available_chemicals = level0.Copy()
 
 			//We start out (2 - 2) for are man_rating
 
@@ -106,7 +106,7 @@
 	icon_state = "sleeper_[occupant ? "1" : "0"]"
 
 /obj/machinery/sleeper/attack_hand(var/mob/user)
-	if(!usr.stat_check(STAT_BIO, STAT_LEVEL_ADEPT))
+	if(user.stats?.getPerk(PERK_MEDICAL_EXPERT) !usr.stat_check(STAT_BIO, STAT_LEVEL_ADEPT))
 		to_chat(usr, SPAN_WARNING("Your biological understanding isn't enough to use this."))
 		return
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -106,7 +106,7 @@
 	icon_state = "sleeper_[occupant ? "1" : "0"]"
 
 /obj/machinery/sleeper/attack_hand(var/mob/user)
-	if(user.stats?.getPerk(PERK_MEDICAL_EXPERT) !usr.stat_check(STAT_BIO, STAT_LEVEL_ADEPT))
+	if(user.stats?.getPerk(PERK_MEDICAL_EXPERT) || !usr.stat_check(STAT_BIO, STAT_LEVEL_ADEPT))
 		to_chat(usr, SPAN_WARNING("Your biological understanding isn't enough to use this."))
 		return
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -69,7 +69,7 @@
 		go_out()
 
 /obj/machinery/atmospherics/unary/cryo_cell/attack_hand(mob/user)
-	if(!usr.stat_check(STAT_BIO, STAT_LEVEL_ADEPT))
+	if(user.stats?.getPerk(PERK_MEDICAL_EXPERT) || !usr.stat_check(STAT_BIO, STAT_LEVEL_ADEPT))
 		to_chat(usr, SPAN_WARNING("Your biological understanding isn't enough to use this."))
 		return
 	ui_interact(user)

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -20,7 +20,7 @@
 	charge_per_use = 0
 
 /obj/item/device/scanner/health/afterattack(atom/A, mob/user, proximity)
-	if(user.stats.getStat(STAT_BIO) > STAT_LEVEL_EXPERT)
+	if(user.stats?.getPerk(PERK_ADVANCED_MEDICAL) || user.stats.getStat(STAT_BIO) > STAT_LEVEL_EXPERT)
 		use_delay = 0 // Instant use for skilled users
 	..()
 	use_delay = initial(use_delay) // Reset use_delay so unskilled users don't get the bonus

--- a/code/game/objects/items/devices/scanners/reagents.dm
+++ b/code/game/objects/items/devices/scanners/reagents.dm
@@ -12,7 +12,7 @@
 	var/recent_fail = 0
 
 /obj/item/device/scanner/reagent/is_valid_scan_target(obj/O)
-	if(user.stats?.getPerk(PERK_ADVANCED_MEDICAL) || !usr.stat_check(STAT_COG, STAT_LEVEL_BASIC))
+	if(usr.stats?.getPerk(PERK_ADVANCED_MEDICAL) || !usr.stat_check(STAT_COG, STAT_LEVEL_BASIC))
 		to_chat(usr, SPAN_WARNING("Your cognitive understanding isn't high enough to use this!"))
 		return
 

--- a/code/game/objects/items/devices/scanners/reagents.dm
+++ b/code/game/objects/items/devices/scanners/reagents.dm
@@ -12,7 +12,7 @@
 	var/recent_fail = 0
 
 /obj/item/device/scanner/reagent/is_valid_scan_target(obj/O)
-	if(!usr.stat_check(STAT_COG, STAT_LEVEL_BASIC))
+	if(user.stats?.getPerk(PERK_ADVANCED_MEDICAL) || !usr.stat_check(STAT_COG, STAT_LEVEL_BASIC))
 		to_chat(usr, SPAN_WARNING("Your cognitive understanding isn't high enough to use this!"))
 		return
 

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -131,7 +131,7 @@
 							if(busy == LAYING_EGGS)
 								if(!(locate(/obj/effect/spider/eggcluster) in get_turf(src)))
 									new /obj/effect/spider/eggcluster(loc, src)
-									fed--
+									fed -= 2
 									update_openspace()
 								busy = 0
 								stop_automated_movement = 0

--- a/code/modules/reagents/machinery/centrifuge.dm
+++ b/code/modules/reagents/machinery/centrifuge.dm
@@ -125,7 +125,7 @@
 
 
 /obj/machinery/centrifuge/attack_hand(mob/user)
-	if(!usr.stat_check(STAT_BIO, STAT_LEVEL_BASIC))
+	if(user.stats?.getPerk(PERK_MEDICAL_EXPERT) || !usr.stat_check(STAT_BIO, STAT_LEVEL_BASIC))
 		to_chat(usr, SPAN_WARNING("Your biological understanding isn't enough to use this."))
 		return
 

--- a/code/modules/reagents/machinery/chem_heater.dm
+++ b/code/modules/reagents/machinery/chem_heater.dm
@@ -101,7 +101,7 @@
 	..()
 
 /obj/machinery/chem_heater/attack_hand(mob/user)
-	if(!usr.stat_check(STAT_BIO, STAT_LEVEL_BASIC))
+	if(user.stats?.getPerk(PERK_MEDICAL_EXPERT) || !usr.stat_check(STAT_BIO, STAT_LEVEL_BASIC))
 		to_chat(usr, SPAN_WARNING("Your biological understanding isn't enough to use this."))
 		return
 

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -249,7 +249,7 @@
 	if(inoperable())
 		return
 
-	if(!usr.stat_check(STAT_BIO, STAT_LEVEL_BASIC) && !simple_machinery)
+	if(user.stats?.getPerk(PERK_MEDICAL_EXPERT) || !usr.stat_check(STAT_BIO, STAT_LEVEL_BASIC) && !simple_machinery)
 		to_chat(usr, SPAN_WARNING("Your biological understanding isn't enough to use this."))
 		return
 

--- a/code/modules/reagents/machinery/electrolyzer.dm
+++ b/code/modules/reagents/machinery/electrolyzer.dm
@@ -145,7 +145,7 @@
 
 
 /obj/machinery/electrolyzer/attack_hand(mob/user)
-	if(!usr.stat_check(STAT_BIO, STAT_LEVEL_BASIC))
+	if(user.stats?.getPerk(PERK_MEDICAL_EXPERT) || !usr.stat_check(STAT_BIO, STAT_LEVEL_BASIC))
 		to_chat(usr, SPAN_WARNING("Your biological understanding isn't enough to use this."))
 		return
 


### PR DESCRIPTION

## About The Pull Request
Pushes the fix for spider fixes
Makes it so all medical gear stat can be bypassed by perks that sci and medical gets
All medical stuff is medical perk only
The sci stuff is sci perk and medical perk bypassable

## Changelog
:cl:
/:cl:
