### PR TITLE
Craftable new scrap bot nades

### DIFF
--- a/code/datums/craft/recipes/clothing.dm
+++ b/code/datums/craft/recipes/clothing.dm
@@ -22,8 +22,6 @@
 		list(/obj/item/stack/cable_coil, 4)
 	)
 
-
-
 /datum/craft_recipe/clothing/balaclava
 	name = "balaclava"
 	result = /obj/item/clothing/mask/balaclava

--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -56,6 +56,19 @@
 		list(CRAFT_MATERIAL, 2, MATERIAL_STEEL)
 	)
 
+/datum/craft_recipe/weapon/kenny
+	name = "scrap bot deployer"
+	result = /obj/item/weapon/grenade/spawnergrenade/manhacks/junkbot
+	steps = list(
+		list(/obj/item/weapon/grenade/chem_grenade, 1),
+		list(/obj/item/clothing/head/space/void/riggedvoidsuit, 1),
+		list(/obj/item/weapon/computer_hardware/processor_unit, 1),
+		list(/obj/item/weapon/oddity, 1), //For the soul!
+		list(/obj/item/stack/cable_coil, 4),
+		list(/obj/item/clothing/suit/hooded/cloak/simple, 1),
+		list(/obj/item/weapon/scrap_lump, 1),
+		list(/obj/item/weapon/tool/tape_roll, 10, "time" = 10)
+	)
 /datum/craft_recipe/weapon/handmade_shield
 	name = "handmade shield"
 	result = /obj/item/weapon/shield/riot/handmade

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -5,11 +5,11 @@
 //Clockrigger 2019
 
 /obj/item/weapon/oddity
-	name = "Oddity"
+	name = "An Oddity"
 	desc = "Strange item of uncertain origin."
 	icon = 'icons/obj/oddities.dmi'
-	icon_state = "gift3"
-	item_state = "electronic"
+	icon_state = "techno_part3"
+	item_state = "techno_part3"
 	w_class = ITEM_SIZE_SMALL
 
 //You choose what stat can be increased, and a maximum value that will be added to this stat


### PR DESCRIPTION

## About The Pull Request
Scrap bots can now be made! Still keeing with the theme of them being trash they are made of bits and bobs and a way for propis to get a bit more use out of their oddities and scrap clothing by needing to craft up to a scrap bot if they want to.

## Changelog
:cl:
/:cl: