### PR TITLE
Re-balance for the AK to be more special.

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -82,7 +82,8 @@
 	item_state = "AK"
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
 	price_tag = 750
-	damage_multiplier = 1
+	damage_multiplier = 1.2
+	recoil_buildup = 14
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	saw_off = TRUE
 	sawn = /obj/item/weapon/gun/projectile/automatic/ak47/sawn
@@ -98,7 +99,7 @@
 	force = WEAPON_FORCE_NORMAL
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 5)
 	price_tag = 500
-	recoil_buildup = 14
+	recoil_buildup = 16
 	one_hand_penalty = 20
 	damage_multiplier = 0.8
 	saw_off = FALSE


### PR DESCRIPTION
The AK in this change is now made into a high recoil-high damage option instead of before, to make it a more distinct option compared to other weapons. It's less accurate, but does more damage now. (Which'd be more accurate to the real life counterpart too, as it uses a round with more power and more recoil than other assault rifles chambered in 5.56 and the likes, the sooner being known to overpenetrate a lot.)


## Changelog
:cl:
<!--add: Added new things
tweak: tweaked a few things
/:cl: