### PR TITLE
Wow coils are brokenly good. One of many balance changes aimed at people that abuse endless mats

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -521,13 +521,15 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	w_class = ITEM_SIZE_SMALL
 	throw_speed = 2
 	throw_range = 5
-	matter = list(MATERIAL_STEEL = 0.15, MATERIAL_PLASTIC = 0.15)
+	matter = null //Cant have nice things, peole abused it way to much. Thank you players.
+	//matter = list(MATERIAL_STEEL = 0.15, MATERIAL_PLASTIC = 0.15) less then 1 vaules make for endless mats in some places - Namely matterforge.
+	//matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1) Eris vaules, broken do to 30 x 3-4 per eletrical box making mechs in wires...
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	item_state = "coil"
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
 	stacktype = /obj/item/stack/cable_coil
-	preloaded_reagents = list("copper" = 8, "plasticide" = 2)
+	preloaded_reagents = list("copper" = 12, "plasticide" = 6) //Normal is 8 copper 2 plastic
 
 /obj/item/stack/cable_coil/cyborg
 	name = "cable coil synthesizer"


### PR DESCRIPTION

## About The Pull Request
You know whats fun? Getting a small bit of scrap form 1 or 2 of cells or 10 coil to get some camera film.
You know what people do? Abuse the heck out of everything to maxium abuse to powergame. We can have nice things ever thanks to them. If you are personally affected by this more then a minor annoyance then your apart of the problem and you should rethink why you are here and playing to win. Were HRP and endless matter creation for ever. single. round. ruins are more gimmicy or fun things that add a bit of unrealistic qol.
    P.S This is why we cant have fun, or QoL.

## Changelog
:cl:
/:cl:
