### PR TITLE
Slight Adjustments

### DIFF
--- a/code/game/objects/items/weapons/tools/mods/_defines.dm
+++ b/code/game/objects/items/weapons/tools/mods/_defines.dm
@@ -109,6 +109,7 @@
 #define GUN_GRIP "grip slot"
 #define GUN_KNIFE "knife slot"
 #define GUN_MAGWELL "magwell slot"
+#define GUN_SIGHT "sight slot"
 
 //Whitelist Tag defines
 #define GUN_SILENCABLE "silencable"

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -291,7 +291,7 @@
 	UPGRADE_FUELCOST_MULT = 1.25
 	)
 	I.weapon_upgrades = list(
-	GUN_UPGRADE_DAMAGE_MULT = 1.2,
+	GUN_UPGRADE_DAMAGE_MULT = 1.25,
 	GUN_UPGRADE_CHARGECOST = 1.35
 	)
 	I.prefix = "boosted"
@@ -333,6 +333,7 @@
 	UPGRADE_PRECISION = 10)
 	I.weapon_upgrades = list(
 	GUN_UPGRADE_RECOIL = 0.9)
+	I.gun_loc_tag = GUN_SIGHT
 	I.prefix = "laser-guided"
 
 //Fits onto generally small tools that require precision, especially surgical tools
@@ -571,6 +572,7 @@
 	GUN_UPGRADE_FIRE_DELAY_MULT = 1.2,
 	GUN_UPGRADE_MOVE_DELAY_MULT = 1.2,
 	GUN_UPGRADE_CHARGECOST = 0.8)
+	I.gun_loc_tag = GUN_MECHANISM
 	I.prefix = "sanctified"
 	I.req_fuel_cell = REQ_FUEL_OR_CELL
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -499,8 +499,13 @@
 	else
 		to_chat(user, SPAN_NOTICE("The safety is off."))
 
-	if(one_hand_penalty)
+	if(can_dual == TRUE)
+		to_chat(user, SPAN_NOTICE("This gun can be duel-wielded effectively, if you're skilled enough."))
+
+	if(one_hand_penalty && !user.stats.getPerk(PERK_PERFECT_SHOT))
 		to_chat(user, SPAN_WARNING("This gun needs to be wielded in both hands to be used most effectively."))
+	else if((one_hand_penalty && user.stats.getPerk(PERK_PERFECT_SHOT)))
+		to_chat(user, SPAN_NOTICE("This gun would need to be wielded in both hands, if you weren't such a skilled shot."))
 
 /obj/item/weapon/gun/proc/initialize_firemodes()
 	QDEL_CLEAR_LIST(firemodes)

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -115,9 +115,9 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_DAMAGE_MULT = 1.3,
-		GUN_UPGRADE_CHARGECOST = 1.4
+		GUN_UPGRADE_CHARGECOST = 1.15
 		)
-	I.gun_loc_tag = GUN_MECHANISM
+	I.gun_loc_tag = GUN_BARREL
 	I.req_gun_tags = list(GUN_ENERGY)
 
 /obj/item/weapon/gun_upgrade/trigger


### PR DESCRIPTION
-Guns now have the sight slot (currently only used by laser sights)
-Booster now increases laser damage by 25%, up from 20%.
-Sanctifier now fits the gun mechanism slot instead of free slot.
-Excruciator now fits the barrel slot instead of mechanism. Charge cost is now 15%, down from 40%.
-Kriosans with the instinctual skill perk now get plain text when inspecting fire arms they negate the 1 handed penalty too.
-All firearms capable of being dual wielded now display text stating so when examined.