### PR TITLE
Adds a second combat surgery kit to the Blackshield Corpsman room

### DIFF
--- a/maps/CEVEris/_Nadezhda_Colony_Surface.dmm
+++ b/maps/CEVEris/_Nadezhda_Colony_Surface.dmm
@@ -199,7 +199,7 @@
 "adQ" = (/obj/machinery/atmospherics/pipe/manifold/visible/cyan{dir = 8},/turf/simulated/floor/tiled/white/brown_perforated,/area/nadezhda/engineering/atmos/surface)
 "adR" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/structure/closet/secure_closet/personal/corpsman,/turf/simulated/floor/tiled/dark/gray_platform,/area/nadezhda/security/triage)
 "adS" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/obj/machinery/light_switch{pixel_y = 30},/obj/machinery/light{dir = 4},/obj/structure/closet/secure_closet/personal/corpsman,/turf/simulated/floor/tiled/dark/gray_platform,/area/nadezhda/security/triage)
-"adT" = (/obj/structure/table/standard,/obj/machinery/light_switch{pixel_x = -20},/obj/item/weapon/storage/deferred/surgery,/turf/simulated/floor/tiled/dark/gray_platform,/area/nadezhda/security/triage)
+"adT" = (/obj/structure/table/standard,/obj/machinery/light_switch{pixel_x = -20},/obj/item/weapon/storage/deferred/surgery,/obj/item/weapon/storage/deferred/surgery,/turf/simulated/floor/tiled/dark/gray_platform,/area/nadezhda/security/triage)
 "adU" = (/obj/structure/table/standard,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/white/cyancorner,/area/nadezhda/security/triage)
 "adV" = (/obj/effect/decal/cleanable/dirt,/obj/landmark/join/start/medspec,/turf/simulated/floor/tiled/white/cyancorner,/area/nadezhda/security/triage)
 "adW" = (/obj/item/weapon/storage/firstaid/adv,/obj/item/weapon/storage/firstaid/toxin,/obj/item/weapon/storage/firstaid/regular,/obj/structure/table/rack/shelf,/obj/random/medical,/turf/simulated/floor/tiled/dark/gray_platform,/area/nadezhda/security/triage)


### PR DESCRIPTION
### Changes
- Adds a second combat surgery kit to the Blackshield Corpsman room.

### Reasoning
We have two Corpsman slots, and some people often cryo with the only surgery kit. This lets both Corpsmen be able to perform surgery, and also helps buffer against people cryoing with vital equipment. This is something that an active Corpsman player requested of me to add.

### Screenshots of map changes
Corpsman prep area: https://gyazo.com/19f7bfed73c138053c5315721a77d8b7