### PR TITLE
Lazy Code

### DIFF
--- a/code/modules/mining/satchel_material_box.dm
+++ b/code/modules/mining/satchel_material_box.dm
@@ -1,0 +1,107 @@
+
+/**********************Material box**************************/
+
+/obj/structure/material_box
+	icon = 'icons/obj/mining.dmi'
+	icon_state = "orebox0"
+	name = "material box"
+	desc = "A heavy box used for storing materials."
+	density = 1
+	var/last_update = 0
+	var/list/stored_material = list()
+	var/stored_prices
+
+/obj/structure/material_box/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if (istype(W, /obj/item/stack/material))
+		user.remove_from_mob(W)
+		src.contents += W
+	if (istype(W, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/S = W
+		S.hide_from(usr)
+		if (locate(/obj/item/stack/material) in S.contents)
+			for(var/obj/item/stack/material/O in S.contents)
+				S.remove_from_storage(O, src) //This will move the item to this item's contents
+			playsound(loc, S.use_sound, 50, 1, -5)
+			user.visible_message(SPAN_NOTICE("[user.name] empties the [S] into the box"), SPAN_NOTICE("You empty the [S] into the box."), SPAN_NOTICE("You hear a rustling sound"))
+		else
+			to_chat(user, SPAN_WARNING("There's no material inside the [S] to empty into here"))
+	update_material_count()
+
+	return
+
+/obj/structure/material_box/proc/update_material_count()
+
+	stored_material = list()
+
+	for(var/obj/item/stack/material/O in contents)
+
+		if(stored_material[O.name])
+			stored_material[O.name]++
+		else
+			stored_material[O.name] = stored_material[O.name] + O.amount
+		stored_prices[O.name] = O.amount * O.price_tag + stored_prices[O.name]
+
+/obj/structure/material_box/examine(mob/user)
+	to_chat(user, "That's an [src].")
+	to_chat(user, desc)
+
+	// Borgs can now check contents too.
+	if((!ishuman(user)) && (!isrobot(user)))
+		return
+
+	if(!Adjacent(user)) //Can only check the contents of material boxes if you can physically reach them.
+		return
+
+	add_fingerprint(user)
+
+	if(!contents.len)
+		to_chat(user, "It is empty.")
+		return
+
+	if(world.time > last_update + 10)
+		update_material_count()
+		last_update = world.time
+
+	to_chat(user, "It holds:")
+	for(var/material in stored_material)
+		to_chat(user, "- [stored_material[material]] [material] worth [stored_prices[material]]")
+		//to_chat(user, "- [stored_material[material]] [material]")
+	return
+
+
+/obj/structure/material_box/verb/empty_box()
+	set name = "Empty Material Box"
+	set category = "Object"
+	set src in view(1)
+
+	if(!ishuman(usr)) //Only living, intelligent creatures with hands can empty material boxes.
+		to_chat(usr, "\red You are physically incapable of emptying the material box.")
+		return
+
+	if( usr.stat || usr.restrained() )
+		return
+
+	if(!Adjacent(usr)) //You can only empty the box if you can physically reach it
+		to_chat(usr, "You cannot reach the material box.")
+		return
+
+	add_fingerprint(usr)
+
+	if(contents.len < 1)
+		to_chat(usr, "\red The material box is empty")
+		return
+
+	for (var/obj/item/stack/material/O in contents)
+		contents -= O
+		O.loc = src.loc
+	to_chat(usr, "\blue You empty the material box")
+
+	return
+
+/obj/structure/material_box/ex_act(severity)
+	if(severity == 1.0 || (severity < 3.0 && prob(50)))
+		for (var/obj/item/stack/material/O in contents)
+			O.loc = src.loc
+			O.ex_act(severity++)
+		qdel(src)
+		return

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -18,7 +18,7 @@
 
 /obj/item/device/mmi
 	name = "man-machine interface"
-	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity."
+	desc = "The Warrior's bland acronym, MMI, obscures the true horror of this monstrosity. Under no circumstances should this be placed in anything except a cyborg chassis. Reminder, synthetic designs made by Soteria and the Artificer Guild are not cyborgs."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "mmi_empty"
 	w_class = ITEM_SIZE_NORMAL

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -20,6 +20,7 @@
 	price_tag = 100
 	nature = MODIFICATION_SILICON
 	matter = list(MATERIAL_STEEL = 1)
+	organ_efficiency = list(OP_EYES = 200)
 
 /obj/item/organ/internal/eyes/proc/get_icon()
 	var/icon/eyes_icon = new/icon('icons/mob/human_face.dmi', "eye_l")

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -1762,6 +1762,7 @@
 #include "code\modules\mining\money_bag.dm"
 #include "code\modules\mining\ore.dm"
 #include "code\modules\mining\ore_datum.dm"
+#include "code\modules\mining\satchel_material_box.dm"
 #include "code\modules\mining\satchel_ore_boxdm.dm"
 #include "code\modules\mining\drilling\drill.dm"
 #include "code\modules\mining\drilling\scanner.dm"


### PR DESCRIPTION
-Changed prosthetic eyes to have efficiency 200, making it so its quite difficult to get blurry eyes with robot eyes now. This should fix some issues with synths getting blurry vision.
-Added a description to MMI's specifically stating you should not put them in anything except cyborgs after discovering an amusing event revolving around someone putting an MMI in a sot-synth and turning the unlucky bastard into a potato.