### PR TITLE
Lonestar Handgun Ammo

### DIFF
--- a/code/modules/cargo/packs_security.dm
+++ b/code/modules/cargo/packs_security.dm
@@ -14,7 +14,7 @@
 	crate_name = "special ops crate"
 	group = "Security"
 	hidden = TRUE
-/*
+
 /datum/supply_pack/sts_lrifle
 	name = "STS Carbine(.257) Weapons Crate"
 	contains = list(/obj/item/weapon/gun/projectile/automatic/sts/lrifle,
@@ -44,8 +44,7 @@
 	containertype = /obj/structure/closet/crate/secure/weapon
 	crate_name = "STS Heavy Rifle(.408) Weapons Crate"
 	group = "Security"
-*/
-//STS rifles are no longer vended out here. Lonestar is switching to handguns.
+
 /datum/supply_pack/thirtyfive_ammo
 	name = "HS .35 Handgun Ammunition Crate"
 	contains = list(/obj/item/ammo_magazine/ammobox/pistol_35,

--- a/code/modules/cargo/packs_security.dm
+++ b/code/modules/cargo/packs_security.dm
@@ -14,7 +14,7 @@
 	crate_name = "special ops crate"
 	group = "Security"
 	hidden = TRUE
-
+/*
 /datum/supply_pack/sts_lrifle
 	name = "STS Carbine(.257) Weapons Crate"
 	contains = list(/obj/item/weapon/gun/projectile/automatic/sts/lrifle,
@@ -43,6 +43,97 @@
 	cost = 4000
 	containertype = /obj/structure/closet/crate/secure/weapon
 	crate_name = "STS Heavy Rifle(.408) Weapons Crate"
+	group = "Security"
+*/
+//STS rifles are no longer vended out here. Lonestar is switching to handguns.
+/datum/supply_pack/thirtyfive_ammo
+	name = "HS .35 Handgun Ammunition Crate"
+	contains = list(/obj/item/ammo_magazine/ammobox/pistol_35,
+					/obj/item/ammo_magazine/ammobox/pistol_35,
+					/obj/item/ammo_magazine/ammobox/pistol_35,
+					/obj/item/ammo_magazine/pistol_35,
+					/obj/item/ammo_magazine/pistol_35,
+					/obj/item/ammo_magazine/pistol_35,
+					/obj/item/ammo_magazine/speed_loader_pistol_35,
+					/obj/item/ammo_magazine/speed_loader_pistol_35,
+					/obj/item/ammo_magazine/speed_loader_pistol_35)
+	cost = 650
+	crate_name = "HS .35 ammunition crate"
+	group = "Security"
+
+/datum/supply_pack/thirtyfive_ammo_nl
+	name = "HS .35 Handgun Non-Lethal Ammunition Crate"
+	contains = list(/obj/item/ammo_magazine/ammobox/pistol_35/rubber,
+					/obj/item/ammo_magazine/ammobox/pistol_35/rubber,
+					/obj/item/ammo_magazine/ammobox/pistol_35/rubber,
+					/obj/item/ammo_magazine/pistol_35/rubber,
+					/obj/item/ammo_magazine/pistol_35/rubber,
+					/obj/item/ammo_magazine/pistol_35/rubber,
+					/obj/item/ammo_magazine/speed_loader_pistol_35/rubber,
+					/obj/item/ammo_magazine/speed_loader_pistol_35/rubber,
+					/obj/item/ammo_magazine/speed_loader_pistol_35/rubber)
+	cost = 450
+	crate_name = "HS .35 Non-Lethal ammunition crate"
+	group = "Security"
+
+/datum/supply_pack/fourty_ammo
+	name = "HS .40 Ammunition Crate"
+	contains = list(/obj/item/ammo_magazine/ammobox/magnum_40,
+					/obj/item/ammo_magazine/ammobox/magnum_40,
+					/obj/item/ammo_magazine/ammobox/magnum_40,
+					/obj/item/ammo_magazine/magnum_40,
+					/obj/item/ammo_magazine/magnum_40,
+					/obj/item/ammo_magazine/magnum_40,
+					/obj/item/ammo_magazine/speed_loader_magnum_40,
+					/obj/item/ammo_magazine/speed_loader_magnum_40,
+					/obj/item/ammo_magazine/speed_loader_magnum_40)
+	cost = 750
+	crate_name = "HS .40 ammunition crate"
+	group = "Security"
+
+/datum/supply_pack/fourty_ammo_nl
+	name = "HS .40 Non-Lethal Ammunition Crate"
+	contains = list(/obj/item/ammo_magazine/ammobox/magnum_40/rubber,
+					/obj/item/ammo_magazine/ammobox/magnum_40/rubber,
+					/obj/item/ammo_magazine/ammobox/magnum_40/rubber,
+					/obj/item/ammo_magazine/magnum_40/rubber,
+					/obj/item/ammo_magazine/magnum_40/rubber,
+					/obj/item/ammo_magazine/magnum_40/rubber,
+					/obj/item/ammo_magazine/speed_loader_magnum_40/rubber,
+					/obj/item/ammo_magazine/speed_loader_magnum_40/rubber,
+					/obj/item/ammo_magazine/speed_loader_magnum_40/rubber)
+	cost = 550
+	crate_name = "HS .40 Non-Lethal ammunition crate"
+	group = "Security"
+
+/datum/supply_pack/kurtz_ammo
+	name = "HS .50 Kurtz Ammunition Crate"
+	contains = list(/obj/item/ammo_magazine/ammobox/kurtz_50,
+					/obj/item/ammo_magazine/ammobox/kurtz_50,
+					/obj/item/ammo_magazine/ammobox/kurtz_50,
+					/obj/item/ammo_magazine/kurtz_50,
+					/obj/item/ammo_magazine/kurtz_50,
+					/obj/item/ammo_magazine/kurtz_50,
+					/obj/item/ammo_magazine/speed_loader_kurtz_50,
+					/obj/item/ammo_magazine/speed_loader_kurtz_50,
+					/obj/item/ammo_magazine/speed_loader_kurtz_50)
+	cost = 950
+	crate_name = "HS .50 Kurtz ammunition crate"
+	group = "Security"
+
+/datum/supply_pack/kurtz_ammo_nl
+	name = "HS .50 Kurtz Non-Lethal Ammunition Crate"
+	contains = list(/obj/item/ammo_magazine/ammobox/kurtz_50,
+					/obj/item/ammo_magazine/ammobox/kurtz_50,
+					/obj/item/ammo_magazine/ammobox/kurtz_50,
+					/obj/item/ammo_magazine/kurtz_50,
+					/obj/item/ammo_magazine/kurtz_50,
+					/obj/item/ammo_magazine/kurtz_50,
+					/obj/item/ammo_magazine/speed_loader_kurtz_50,
+					/obj/item/ammo_magazine/speed_loader_kurtz_50,
+					/obj/item/ammo_magazine/speed_loader_kurtz_50)
+	cost = 750
+	crate_name = "HS .50 Kurtz Non-Lethal ammunition crate"
 	group = "Security"
 
 /datum/supply_pack/fsenergy


### PR DESCRIPTION
Allows Lonestar to order Handgun ammunition, either normal or rubber, in 35, 40 and 50 Kurtz. Removed the STS rifles from cargo ordering. 