### PR TITLE
Fixes Lag

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -756,11 +756,12 @@ its easier to just keep the beam vertical.
 /atom/proc/get_sex()
 	return gender
 
+//RETURNS A DATUM
 /atom/proc/get_gender()
 	return GLOB.gender_datums[gender]
 
 /atom/proc/gender_word(var/position, var/gen = null) //So you can suggest an alternative gender if needed.
-	var/datum/gender/G = GLOB.gender_datums["neuter"]
+	var/datum/gender/G = get_gender()
 	if(istype(gen, /datum/gender))
 		//Use as given.
 		G = gen
@@ -768,7 +769,4 @@ its easier to just keep the beam vertical.
 	else if(istext(gen))
 		G = GLOB.gender_datums[gen] //Convert to the gender using the name given.
 		if(istext(G)) CRASH("gender_word has somehow resulted in a text gender despite list extraction") //TODO: REMOVE THIS ONCE FIXED
-	else
-		G = get_gender() //Otherwise, default to this thing's gender.
-		if(istext(G)) CRASH("gender_word has somehow resulted in a text gender despite get_gender result") //TODO: REMOVE THIS ONCE FIXED
 	return G.word(position)

--- a/code/modules/mob/gender.dm
+++ b/code/modules/mob/gender.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_EMPTY(gender_datums)
 		if("gender")					return key
 		if("Gender")					return gender2text(key)
 		else
-			CRASH("Genderword proc called with invalid position.")
+			CRASH("Genderword proc called with invalid position. ([position])")
 
 /datum/gender/male
 	key  = "male"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -242,9 +242,6 @@
 
 			playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
-/mob/living/carbon/proc/eyecheck()
-	return 0
-
 // ++++ROCKDTBEN++++ MOB PROCS -- Ask me before touching.
 // Stop! ... Hammertime! ~Carn
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -59,13 +59,13 @@
 				use_sound = 'sound/machines/synth_no.ogg'
 			else if(act == "rcough")
 				display_msg = "emits a robotic cough"
-				if(get_gender() == FEMALE)
+				if(get_sex() == FEMALE)
 					use_sound = pick('sound/effects/mob_effects/f_machine_cougha.ogg','sound/effects/mob_effects/f_machine_coughb.ogg')
 				else
 					use_sound = pick('sound/effects/mob_effects/m_machine_cougha.ogg','sound/effects/mob_effects/m_machine_coughb.ogg', 'sound/effects/mob_effects/m_machine_coughc.ogg')
 			else if(act == "rsneeze")
 				display_msg = "emits a robotic sneeze"
-				if(get_gender() == FEMALE)
+				if(get_sex() == FEMALE)
 					use_sound = 'sound/effects/mob_effects/machine_sneeze.ogg'
 				else
 					use_sound = 'sound/effects/mob_effects/f_machine_sneeze.ogg'
@@ -239,7 +239,7 @@
 				if (!muzzled)
 					message = "chuckles."
 					m_type = 2
-					if(get_gender() == FEMALE)
+					if(get_sex() == FEMALE)
 						playsound(src, 'sound/voice/womanlaugh.ogg', 70)
 					else
 						playsound(src, 'sound/voice/manlaugh1.ogg', 70)
@@ -270,7 +270,7 @@
 				if (!muzzled)
 					message = "coughs!"
 					m_type = 2
-					if(get_gender() == FEMALE)
+					if(get_sex() == FEMALE)
 						switch(pick("1", "2"))
 							if("1")
 								playsound(src, 'sound/effects/mob_effects/f_cougha.ogg', 70)
@@ -329,7 +329,7 @@
 				if (!muzzled)
 					message = "giggles."
 					m_type = 2
-					if(get_gender() == FEMALE)
+					if(get_sex() == FEMALE)
 						playsound(src, 'sound/voice/womanlaugh.ogg', 70)
 					else
 						playsound(src, 'sound/voice/manlaugh1.ogg', 70)
@@ -420,7 +420,7 @@
 				if (!muzzled)
 					message = "laughs."
 					m_type = 2
-					if(get_gender() == FEMALE)
+					if(get_sex() == FEMALE)
 						playsound(src, 'sound/voice/womanlaugh.ogg', 70)
 					else
 						playsound(src, 'sound/voice/manlaugh1.ogg', 70)
@@ -547,7 +547,7 @@
 				if (!muzzled)
 					message = "sneezes."
 					m_type = 2
-					if(get_gender() == FEMALE)
+					if(get_sex() == FEMALE)
 						playsound(loc, 'sound/effects/mob_effects/f_sneeze.ogg', 70, 1)
 					else
 						playsound(loc, 'sound/effects/mob_effects/sneeze.ogg', 70, 0) //Please don't give it variance, you sneeze like Barry White 80% of the time.
@@ -662,7 +662,7 @@
 					m_type = 2
 					if(prob(1))
 						playsound(loc, 'sound/voice/wilhelm_scream.ogg', 80, 1)
-					else if(get_gender() == FEMALE)
+					else if(get_sex() == FEMALE)
 						switch(pick("1", "2", "3", "4", "5"))
 							if("1")
 								playsound(loc, 'sound/voice/femalescream_1.ogg', 80, 1)
@@ -690,17 +690,17 @@
 					message = "makes a very loud noise."
 					m_type = 2
 			cloud_emote = "cloud-scream"
-		
+
 		if("urah") //Emoting will NOT give you the perk's bonuses, but anyone who knows the emote can at least use it for flavor value.
 			if (miming)
 				message = "acts out a battlecry!"
 				m_type = 1
 			else if (!muzzled)
-				message = "releases a heroic roar, inspiring everyone around [get_gender() == MALE ? "him" : get_visible_gender() == FEMALE ? "her" : "them"]! URA!"
+				message = "releases a heroic roar, inspiring everyone around [gender_word("him")]! URA!"
 				m_type = 2
-				if(get_gender() == MALE)
+				if(get_sex() == MALE)
 					playsound(loc, 'sound/voice/ura.ogg', 80, 1) //URAH!!!
-				else if(get_gender() == FEMALE || PLURAL || NEUTER)
+				else if(get_sex() == FEMALE || PLURAL || NEUTER)
 					playsound(loc, 'sound/voice/femalewarcry.ogg', 80, 1)
 			else
 				message = "makes a very loud noise."

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -835,3 +835,6 @@ default behaviour is:
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/proc/drip_blood(var/amt as num)
 	blood_splatter(src,src)
+
+/mob/living/proc/eyecheck()
+	return 0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -604,9 +604,6 @@
 /mob/proc/is_ready()
 	return client && !!mind
 
-/mob/get_gender()
-	return gender
-
 /mob/proc/see(message)
 	if(!is_active())
 		return 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -447,7 +447,7 @@
 
 /mob/new_player/get_gender()
 	if(!client || !client.prefs) ..()
-	return client.prefs.gender
+	return GLOB.gender_datums[client.prefs.gender]
 
 /mob/new_player/is_ready()
 	return ready && ..()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -102,6 +102,19 @@
 /obj/item/weapon/cell/proc/check_charge(var/amount)
 	return (charge >= amount)
 
+//Convenience proc for objects which may use or give
+/obj/item/weapon/cell/proc/transfer(var/amount)
+	if(amount >= 0)
+		return give(amount)
+	else
+		return -use(-amount)
+
+/obj/item/weapon/cell/proc/checked_transfer(var/amount)
+	if(amount >= 0)
+		return give(amount)
+	else
+		return -checked_use(-amount)
+
 // use power from a cell, returns the amount actually used
 /obj/item/weapon/cell/proc/use(var/amount)
 	if(rigged && amount > 0)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -104,16 +104,18 @@
 
 //Convenience proc for objects which may use or give
 /obj/item/weapon/cell/proc/transfer(var/amount)
-	if(amount >= 0)
+	if(amount > 0)
 		return give(amount)
-	else
+	else if(amount < 0)
 		return -use(-amount)
+	return 0
 
 /obj/item/weapon/cell/proc/checked_transfer(var/amount)
-	if(amount >= 0)
+	if(amount > 0)
 		return give(amount)
-	else
+	else if(amount < 0)
 		return -checked_use(-amount)
+	return 0
 
 // use power from a cell, returns the amount actually used
 /obj/item/weapon/cell/proc/use(var/amount)
@@ -130,8 +132,7 @@
 /obj/item/weapon/cell/proc/checked_use(var/amount)
 	if(!check_charge(amount))
 		return 0
-	use(amount)
-	return 1
+	return use(amount) //This'll be nonzero if successful anyway.
 
 // recharge the cell
 /obj/item/weapon/cell/proc/give(var/amount)


### PR DESCRIPTION
Adds a function transfer() to cells which gives power to the cell if positive, and takes if negative.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fix: The horrible thing that was older apc code has been optimized.
fix: get_gender() no longer returns strings
fix: audible emotes now depend on the 'gender' var, not the result of get_gender()
fix: eyecheck() is now a living mob proc, not a carbon mob proc. Used to runtime when a roach tried to blind a mouse.
tweak: power cells checked_use now returns the amount used, rather than 1 if it happens.
add: transfer and checked_transfer procs added to power cells. Positive numbers charge the battery, negatives drain.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
