### PR TITLE
massively increases toxins testing ability

### DIFF
--- a/code/game/machinery/vendor/tool_vendors.dm
+++ b/code/game/machinery/vendor/tool_vendors.dm
@@ -212,14 +212,14 @@
 /obj/machinery/vending/plasmaresearch
 	name = "Toximate 3000"
 	desc = "All the fine parts you need in one vending machine!"
-	products = list(/obj/item/clothing/under/rank/scientist = 6,
+	products = list(/obj/item/clothing/under/rank/scientist = 10,
 					/obj/item/clothing/suit/bio_suit = 6,
 					/obj/item/clothing/head/bio_hood = 6,
-					/obj/item/device/transfer_valve = 6,
-					/obj/item/device/assembly/timer = 6,
-					/obj/item/device/assembly/signaler = 6,
-					/obj/item/device/assembly/prox_sensor = 6,
-					/obj/item/device/assembly/igniter = 6)
+					/obj/item/device/transfer_valve = 60,
+					/obj/item/device/assembly/timer = 60,
+					/obj/item/device/assembly/signaler = 60,
+					/obj/item/device/assembly/prox_sensor = 60,
+					/obj/item/device/assembly/igniter = 60)
 	auto_price = FALSE
 
 //This one's from bay12


### PR DESCRIPTION

## About The Pull Request
Toxins venders now have amble amount of gear to test their ttv bombs with without having to wait 8 hours for round restart with many slight tweaks to their mixes

## Changelog
:cl:
/:cl: