### PR TITLE
Removes Redundant update_icons() call.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -245,10 +245,11 @@
 	character.update_underwear(0)
 
 	character.update_hair(0)
-	character.update_icons()
 
 	if(is_preview_copy)
 		return
+
+	character.update_icons()
 
 	for(var/lang in alternate_languages)
 		character.add_language(lang)


### PR DESCRIPTION
In the only instance that `copy_to(mob/living/carbon/human/character, is_preview_copy = FALSE)` is called with `is_preview_copy` being `TRUE`, `mannequin.update_icons()` is guaranteed to be called again in the stack. So placing the `is_preview_copy` check before eliminates a redundant `update_icons()` call.