### PR TITLE
Crafting Recipe for Jury-Rigged Heavy Pulse Rifle

### DIFF
--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -174,6 +174,21 @@
 		list(QUALITY_BOLT_TURNING, 40, "time" = 40)
 	)
 
+/datum/craft_recipe/guild/heavypulserifle
+	name = "Jury-Rigged EZ-13 MK2 Heavy Pulse Rifle"
+	result = /obj/item/weapon/gun/energy/laser/heavypulserifle
+	icon_state = "gun"
+	steps = list(
+		list(QUALITY_SAWING, 40, "time" = 60),
+		list(QUALITY_BOLT_TURNING, 40, "time" = 40),
+		list(/obj/item/stack/cable_coil, 30, "time" = 30),
+		list(QUALITY_WIRE_CUTTING, 40, 30),
+		list(/obj/item/stack/material/plasteel, 20, "time" = 30),
+		list(QUALITY_WELDING, 40, "time" = 40),
+		list(/obj/item/stack/material/silver, 10, "time" = 20),
+		list(QUALITY_SCREW_DRIVING, 40, "time" = 10)
+	)
+
 /datum/craft_recipe/guild/mace
 	name = "War Mace"
 	result = /obj/item/weapon/tool/hammer/mace

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -42,6 +42,7 @@
 			/datum/craft_recipe/guild/combat_shovel,
 			/datum/craft_recipe/guild/railgunpistol,
 			/datum/craft_recipe/guild/railgunrifle,
+			/datum/craft_recipe/guild/heavypulserifle,
 			/datum/craft_recipe/guild/mace,
 			/datum/craft_recipe/guild/claymore,
 			/datum/craft_recipe/guild/machete,

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -2344,6 +2344,7 @@
 #include "code\modules\projectiles\guns\energy\disco_vazer.dm"
 #include "code\modules\projectiles\guns\energy\egun.dm"
 #include "code\modules\projectiles\guns\energy\floragun.dm"
+#include "code\modules\projectiles\guns\energy\heavypulserifle.dm"
 #include "code\modules\projectiles\guns\energy\ionrifle.dm"
 #include "code\modules\projectiles\guns\energy\laser.dm"
 #include "code\modules\projectiles\guns\energy\laser_cannon.dm"


### PR DESCRIPTION
Adds crafting recipe for newly added handheld pulse rifle. Given to guild. May add crafting recipe to roboticist/science later for departmental balance reasons.

changelog

🆑
add: added crafting recipe
code: changed guild recipes to add new crafting recipe for heavy pulse rifle along with engineering job and made the heavy pulse rifle included in the code
/🆑

I could have chosen to turn this weapon into resources to build the colony but instead I chose violence
