### PR TITLE
Removes Redundant getFlatIcon() calls

### DIFF
--- a/code/modules/client/preference_setup/augmentation/01_modifications.dm
+++ b/code/modules/client/preference_setup/augmentation/01_modifications.dm
@@ -2,7 +2,7 @@
 	var/list/modifications_data   = list()
 	var/list/modifications_colors = list()
 	var/current_organ = BP_TORSO
-	var/global/list/r_organs = list(BP_HEAD, BP_R_ARM, BP_CHEST, BP_R_LEG, BP_L_ARM, BP_GROIN, BP_L_LEG)
+	var/global/list/r_organs = list(BP_HEAD, BP_R_ARM, BP_R_LEG, BP_L_ARM, BP_GROIN, BP_L_LEG)
 	var/global/list/l_organs = list(BP_EYES, OP_HEART, OP_KIDNEY_LEFT, OP_KIDNEY_RIGHT, OP_STOMACH, BP_BRAIN, OP_LUNGS, OP_LIVER)
 	var/global/list/internal_organs = list("chest2", OP_HEART, OP_KIDNEY_LEFT, OP_KIDNEY_RIGHT, OP_STOMACH, BP_BRAIN, OP_LUNGS, OP_LIVER)
 
@@ -72,7 +72,7 @@
 		dat += "<br>[disp_name]<br>"
 
 	dat += "</td><td style='width:80px;'><center><img src=new_previewicon[pref.preview_dir].png height=64 width=64>"
-	dat += "<br><center><a href='?src=\ref[src];rotate=right'>&lt;&lt;</a> <a href='?src=\ref[src];rotate=left'>&gt;&gt;</a></center></td>"
+//	dat += "<br><center><a href='?src=\ref[src];rotate=right'>&lt;&lt;</a> <a href='?src=\ref[src];rotate=left'>&gt;&gt;</a></center></td>"
 	dat += "<td style='width:115px; text-align:left'>"
 
 	for(var/organ in pref.l_organs)

--- a/code/modules/client/preference_setup/augmentation/01_modifications.dm
+++ b/code/modules/client/preference_setup/augmentation/01_modifications.dm
@@ -33,15 +33,15 @@
 /datum/category_item/player_setup_item/augmentation/modifications/content(var/mob/user)
 	if(!pref.preview_icon)
 		pref.update_preview_icon(naked = TRUE)
-		if ((pref.preview_dir== EAST) && (!pref.preview_east))
-			pref.mannequin = get_mannequin(pref.client_ckey)
-			pref.mannequin.delete_inventory(TRUE)
-			if(SSticker.current_state > GAME_STATE_STARTUP)
-				pref.dress_preview_mob(pref.mannequin, TRUE)
-			pref.mannequin.dir = EAST
-			pref.preview_east = getFlatIcon(pref.mannequin, EAST)
-			pref.preview_east.Scale(pref.preview_east.Width() * 2, pref.preview_east.Height() * 2)
-			user << browse_rsc(pref.preview_east, "new_previewicon[EAST].png")
+	if ((pref.preview_dir== EAST) && (!pref.preview_east))
+		pref.mannequin = get_mannequin(pref.client_ckey)
+		pref.mannequin.delete_inventory(TRUE)
+		if(SSticker.current_state > GAME_STATE_STARTUP)
+			pref.dress_preview_mob(pref.mannequin, TRUE)
+		pref.mannequin.dir = EAST
+		pref.preview_east = getFlatIcon(pref.mannequin, EAST)
+		pref.preview_east.Scale(pref.preview_east.Width() * 2, pref.preview_east.Height() * 2)
+		user << browse_rsc(pref.preview_east, "new_previewicon[EAST].png")
 
 	if(pref.preview_north && pref.preview_south  && pref.preview_west)
 		user << browse_rsc(pref.preview_north, "new_previewicon[NORTH].png")
@@ -192,6 +192,7 @@
 			pref.preview_east = getFlatIcon(pref.mannequin, EAST)
 			pref.preview_east.Scale(pref.preview_east.Width() * 2, pref.preview_east.Height() * 2)
 			user << browse_rsc(pref.preview_east, "new_previewicon[EAST].png")
+
 		return TOPIC_REFRESH
 
 	return ..()

--- a/code/modules/client/preference_setup/augmentation/01_modifications.dm
+++ b/code/modules/client/preference_setup/augmentation/01_modifications.dm
@@ -33,10 +33,19 @@
 /datum/category_item/player_setup_item/augmentation/modifications/content(var/mob/user)
 	if(!pref.preview_icon)
 		pref.update_preview_icon(naked = TRUE)
-	if(pref.preview_north && pref.preview_south  && pref.preview_west /* && pref.preview_east */)
+		if ((pref.preview_dir== EAST) && (!pref.preview_east))
+			pref.mannequin = get_mannequin(pref.client_ckey)
+			pref.mannequin.delete_inventory(TRUE)
+			if(SSticker.current_state > GAME_STATE_STARTUP)
+				pref.dress_preview_mob(pref.mannequin, TRUE)
+			pref.mannequin.dir = EAST
+			pref.preview_east = getFlatIcon(pref.mannequin, EAST)
+			pref.preview_east.Scale(pref.preview_east.Width() * 2, pref.preview_east.Height() * 2)
+			user << browse_rsc(pref.preview_east, "new_previewicon[EAST].png")
+
+	if(pref.preview_north && pref.preview_south  && pref.preview_west)
 		user << browse_rsc(pref.preview_north, "new_previewicon[NORTH].png")
 		user << browse_rsc(pref.preview_south, "new_previewicon[SOUTH].png")
-	//	user << browse_rsc(pref.preview_east, "new_previewicon[EAST].png")
 		user << browse_rsc(pref.preview_west, "new_previewicon[WEST].png")
 
 	var/dat = list()
@@ -72,7 +81,7 @@
 		dat += "<br>[disp_name]<br>"
 
 	dat += "</td><td style='width:80px;'><center><img src=new_previewicon[pref.preview_dir].png height=64 width=64>"
-//	dat += "<br><center><a href='?src=\ref[src];rotate=right'>&lt;&lt;</a> <a href='?src=\ref[src];rotate=left'>&gt;&gt;</a></center></td>"
+	dat += "<br><center><a href='?src=\ref[src];rotate=right'>&lt;&lt;</a> <a href='?src=\ref[src];rotate=left'>&gt;&gt;</a></center></td>"
 	dat += "<td style='width:115px; text-align:left'>"
 
 	for(var/organ in pref.l_organs)
@@ -174,6 +183,15 @@
 			pref.preview_dir = turn(pref.preview_dir,-90)
 		else
 			pref.preview_dir = turn(pref.preview_dir,90)
+		if ((pref.preview_dir == EAST) && (!pref.preview_east))
+			pref.mannequin = get_mannequin(pref.client_ckey)
+			pref.mannequin.delete_inventory(TRUE)
+			if(SSticker.current_state > GAME_STATE_STARTUP)
+				pref.dress_preview_mob(pref.mannequin, TRUE)
+			pref.mannequin.dir = EAST
+			pref.preview_east = getFlatIcon(pref.mannequin, EAST)
+			pref.preview_east.Scale(pref.preview_east.Width() * 2, pref.preview_east.Height() * 2)
+			user << browse_rsc(pref.preview_east, "new_previewicon[EAST].png")
 		return TOPIC_REFRESH
 
 	return ..()

--- a/code/modules/client/preference_setup/augmentation/01_modifications.dm
+++ b/code/modules/client/preference_setup/augmentation/01_modifications.dm
@@ -33,10 +33,10 @@
 /datum/category_item/player_setup_item/augmentation/modifications/content(var/mob/user)
 	if(!pref.preview_icon)
 		pref.update_preview_icon(naked = TRUE)
-	if(pref.preview_north && pref.preview_south && pref.preview_east && pref.preview_west)
+	if(pref.preview_north && pref.preview_south  && pref.preview_west /* && pref.preview_east */)
 		user << browse_rsc(pref.preview_north, "new_previewicon[NORTH].png")
 		user << browse_rsc(pref.preview_south, "new_previewicon[SOUTH].png")
-		user << browse_rsc(pref.preview_east, "new_previewicon[EAST].png")
+	//	user << browse_rsc(pref.preview_east, "new_previewicon[EAST].png")
 		user << browse_rsc(pref.preview_west, "new_previewicon[WEST].png")
 
 	var/dat = list()

--- a/code/modules/client/preference_setup/preview.dm
+++ b/code/modules/client/preference_setup/preview.dm
@@ -14,8 +14,10 @@ datum/preferences/proc/update_preview_icon(var/naked = FALSE)
 	if(SSticker.current_state > GAME_STATE_STARTUP)
 		dress_preview_mob(mannequin, naked)
 
+	/*
 	mannequin.dir = EAST
 	preview_east = getFlatIcon(mannequin, EAST)
+	*/
 
 	mannequin.dir = WEST
 	var/icon/stamp = getFlatIcon(mannequin, WEST)
@@ -33,7 +35,7 @@ datum/preferences/proc/update_preview_icon(var/naked = FALSE)
 	preview_south = stamp
 
 	// Scaling here to prevent blurring in the browser.
-	preview_east.Scale(preview_east.Width() * 2, preview_east.Height() * 2)
+	//preview_east.Scale(preview_east.Width() * 2, preview_east.Height() * 2)
 	preview_west.Scale(preview_west.Width() * 2, preview_west.Height() * 2)
 	preview_north.Scale(preview_north.Width() * 2, preview_north.Height() * 2)
 	preview_south.Scale(preview_south.Width() * 2, preview_south.Height() * 2)

--- a/code/modules/client/preference_setup/preview.dm
+++ b/code/modules/client/preference_setup/preview.dm
@@ -5,9 +5,10 @@ datum/preferences
 	var/icon/preview_east  = null
 	var/icon/preview_west  = null
 	var/preview_dir = SOUTH	//for augmentation
+	var/mob/living/carbon/human/dummy/mannequin/mannequin = null
 
 datum/preferences/proc/update_preview_icon(var/naked = FALSE)
-	var/mob/living/carbon/human/dummy/mannequin/mannequin = get_mannequin(client_ckey)
+	mannequin = get_mannequin(client_ckey)
 	mannequin.delete_inventory(TRUE)
 	preview_icon = icon('icons/effects/96x64.dmi', bgstate)
 

--- a/code/modules/client/preference_setup/preview.dm
+++ b/code/modules/client/preference_setup/preview.dm
@@ -19,6 +19,7 @@ datum/preferences/proc/update_preview_icon(var/naked = FALSE)
 	mannequin.dir = EAST
 	preview_east = getFlatIcon(mannequin, EAST)
 	*/
+	preview_east = null
 
 	mannequin.dir = WEST
 	var/icon/stamp = getFlatIcon(mannequin, WEST)


### PR DESCRIPTION
CHANGELOG

Cleans up Character Creation a little, hopefully will reduce creation lag on the server.

-----------------------------------------

DEV EXPLANATION

`getFlatIcon()` is almost never called in the East direction. In fact, the only time a character's sprite will be seen facing East is in the Augmentations tab, and that is only if they are specifically rotated to face that way.

However, `getFlatIcon(EAST)` is called a LOT more than when it is actually used in that one circumstance.

This PR hopefully will reduce the number of proc calls in character creation drastically, hopefully reducing server load for people creating characters.