### PR TITLE
Fixes Synthetic Batteries

### DIFF
--- a/code/modules/organs/internal/machine.dm
+++ b/code/modules/organs/internal/machine.dm
@@ -53,11 +53,12 @@
 	var/cost = get_servo_cost()
 	if(world.time - owner.l_move_time < 15)
 		cost *= 2
+	/*
 	if(!use(cost))
 		if(!owner.lying && !owner.buckled)
 			to_chat(owner, SPAN_WARNING("You don't have enough energy to function!"))
 		owner.Paralyse(3)
-
+	*/ // Since atom cells don't recharge, this will keep triggering over and over, paralizing the user and knocking them over every minute or so.
 /obj/item/organ/internal/cell/emp_act(severity)
 	..()
 	if(cell)


### PR DESCRIPTION
The simplest solution is often the best. We simply no longer drop you for 3 seconds in case you run out of charge. Because nuclear cells no longer recharge while in use, this keeps happening after an hour or two of walking around and doing stuff as a synthetic.

This fixes it. Tested it on my own server, everything seemed to work just fine. 