### PR TITLE
Medical can no longer steal sci's jerb

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -69,3 +69,4 @@
 #define PERK_STAY_HYDRATED /datum/perk/stay_hydrated
 #define PERK_SECOND_SKIN /datum/perk/second_skin
 #define PERK_IRON_FLESH /datum/perk/iron_flesh
+#define PERK_SI_SCI /datum/perk/si_sci

--- a/code/controllers/subsystems/staverbs.dm
+++ b/code/controllers/subsystems/staverbs.dm
@@ -144,7 +144,7 @@ SUBSYSTEM_DEF(statverbs)
 /datum/statverb/fix_computer
 	name = "Fix computer"
 	required_stat = STAT_COG
-	minimal_stat  = STAT_LEVEL_ADEPT
+	minimal_stat  = STAT_LEVEL_PROF //We use what we at lest need to use this
 
 /datum/statverb/fix_computer/action(mob/user, obj/item/modular_computer/target)
 	if(target.hard_drive.damage < 100)

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -411,6 +411,10 @@
 	name = "Master Butcher"
 	desc = "Your skill as a butcher is unmatched, be it through your training or accumulated field experience. You can harvest additional valuable parts from animals you cut up, nothing shall be wasted."
 
+/datum/perk/si_sci
+	name = "SI Science Trainning"
+	desc = "You know how to use RnD core consoles and Exosuit Fabs."
+
 /datum/perk/greenthumb
 	name = "Green Thumb"
 	desc = "After growing plants for years (or at least being around those that do) you have become a botanical expert. You can get all information about plants, from stats \

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -30,7 +30,7 @@
 		STAT_COG = 25
 	)
 
-	perks = list(/datum/perk/medicalexpertise, /datum/perk/advanced_medical)
+	perks = list(/datum/perk/medicalexpertise, /datum/perk/advanced_medical, /datum/perk/si_sci)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/suit_sensors,

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -31,7 +31,7 @@
 		STAT_BIO = 25,
 	)
 
-	perks = list(/datum/perk/surgical_master, /datum/perk/robotics_expert)
+	perks = list(/datum/perk/surgical_master, /datum/perk/robotics_expert, /datum/perk/si_sci)
 
 	// TODO: enable after baymed
 	software_on_spawn = list(/datum/computer_file/program/comm,
@@ -80,6 +80,8 @@
 		access_robotics, access_tox, access_tox_storage, access_moebius, access_xenobiology, access_xenoarch, access_research_equipment,
 		access_genetics, access_medical_suits
 	)
+
+	perks = list(/datum/perk/si_sci)
 
 	stat_modifiers = list(
 		STAT_MEC = 20,
@@ -131,7 +133,7 @@
 		STAT_BIO = 25,
 	)
 
-	perks = list(/datum/perk/surgical_master, /datum/perk/robotics_expert)
+	perks = list(/datum/perk/surgical_master, /datum/perk/robotics_expert, /datum/perk/si_sci)
 
 	description = "The Roboticist is a specialized scientist with a busy workload - at the forefront of Soteria's service offerings.<br>\
 	You must maintain and upgrade the fleet of synthetics that keep the ship running, as well as constructing new ones on occasion.<br>\

--- a/code/game/machinery/autolathe/mechfab.dm
+++ b/code/game/machinery/autolathe/mechfab.dm
@@ -19,6 +19,12 @@
 	var/datum/research/files
 
 
+/obj/machinery/autolathe/mechfab/proc/check_user(mob/user)
+	if(user.stats?.getPerk(PERK_SI_SCI) || user.stat_check(STAT_MEC, 30)) //Needs same skill as it takes to maintain a mech
+		return TRUE
+	to_chat(user, SPAN_NOTICE("You don't know how to make the [src] work, you lack the training or mechanical skill."))
+	return FALSE
+
 /obj/machinery/autolathe/mechfab/Initialize()
 	. = ..()
 	files = new /datum/research(src)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -50,7 +50,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/obj/machinery/autolathe/rnd/protolathe/linked_lathe = null		//Linked Protolathe
 	var/obj/machinery/autolathe/rnd/imprinter/linked_imprinter = null	//Linked Circuit Imprinter
 
-	var/screen = SCREEN_MAIN	//Which screen is currently showing.
+	var/screen = SCREEN_LOCKED	//Which screen is currently showing.
 	var/id     = 0			//ID of the computer (for server restrictions).
 	var/sync   = 1		//If sync = 0, it doesn't show up on Server Control Console
 	var/can_research = TRUE   //Is this console capable of researching
@@ -380,7 +380,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	return designs_list
 
 /obj/machinery/computer/rdconsole/attack_hand(mob/user)
-	if(!usr.stat_check(STAT_COG, 20))
+	if(!user.stats?.getPerk(PERK_SI_SCI) && !usr.stat_check(STAT_COG, 60))
 		to_chat(usr, SPAN_WARNING("This is a bit beyond your cognitive understanding."))
 		return
 


### PR DESCRIPTION

## About The Pull Request
All rnd consoles can no longer start unlocked
Cog needed to hack the rnd console raised to 50 and useing it needs 60
Mech fabs needs 30 mech to use it, not that hard
Sci and CBO now get a perk to bypass these checks for stats
We cant have nice things


## Changelog
:cl:
/:cl: