### PR TITLE
Gun Price Fixes & Minor Recoil Rebalance

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -100,7 +100,7 @@
 
 /obj/item/weapon/gun/energy/firestorm
 	name = "\"Firestorm\" assault SMG"
-	desc = "A front loading laser SMG made more close quarters, compactness and its high rate of fire. Its downside revolves around its usage of small batteries.\
+	desc = "A front loading laser SMG made more close quarters, compactness and its high rate of fire. Luckily it appears to make up for its charge usage by taking medium cell batteries.\
 	On the side of the gun under the barrel appears to be an 'H&S' marking. Surprising considering the quality of the weapon!"
 	icon = 'icons/obj/guns/energy/firestorm.dmi'
 	icon_state = "firestorm"

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -59,7 +59,7 @@
 	force = WEAPON_FORCE_NORMAL
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_PLASTIC = 10, MATERIAL_SILVER = 10, MATERIAL_GOLD = 5)
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_MAGNET = 3, TECH_POWER = 5)
-	price_tag = 600
+	price_tag = 1000
 	recoil_buildup = 3
 	one_hand_penalty = 10
 	damage_multiplier = 1
@@ -81,9 +81,9 @@
 	icon_state = "AK"
 	item_state = "AK"
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
-	price_tag = 750
+	price_tag = 1000
 	damage_multiplier = 1.2
-	recoil_buildup = 14
+	recoil_buildup = 7
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	saw_off = TRUE
 	sawn = /obj/item/weapon/gun/projectile/automatic/ak47/sawn
@@ -98,8 +98,8 @@
 	w_class = ITEM_SIZE_NORMAL
 	force = WEAPON_FORCE_NORMAL
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 5)
-	price_tag = 500
-	recoil_buildup = 16
+	price_tag = 650
+	recoil_buildup = 13
 	one_hand_penalty = 20
 	damage_multiplier = 0.8
 	saw_off = FALSE

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -14,12 +14,12 @@
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_STANMAG
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 10)
-	price_tag = 1750
+	price_tag = 1500
 	fire_sound = 'sound/weapons/guns/fire/ltrifle_fire.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
-	recoil_buildup = 10
+	recoil_buildup = 5
 	one_hand_penalty = 10 //automatic rifle level
 	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE, GUN_MAGWELL)
 

--- a/code/modules/projectiles/guns/projectile/automatic/basstet.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/basstet.dm
@@ -9,7 +9,7 @@
 	price_tag = 800
 	damage_multiplier = 0.9 //Cheaer AK basiclly
 	w_class = ITEM_SIZE_NORMAL
-	recoil_buildup = 10
+	recoil_buildup = 8
 	caliber = CAL_LRIFLE
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_STANMAG

--- a/code/modules/projectiles/guns/projectile/automatic/bren.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/bren.dm
@@ -13,13 +13,13 @@
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_STANMAG
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 3, MATERIAL_WOOD = 12)
-	price_tag = 1250
+	price_tag = 1100
 	damage_multiplier = 0.9
 	fire_sound = 'sound/weapons/guns/fire/ltrifle_fire.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
-	recoil_buildup = 12
+	recoil_buildup = 8
 	one_hand_penalty = 10 //automatic rifle level
 	twohanded = TRUE
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL)

--- a/code/modules/projectiles/guns/projectile/automatic/bulldog.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/bulldog.dm
@@ -13,7 +13,7 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 12)
 	price_tag = 1650
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	recoil_buildup = 10
+	recoil_buildup = 7
 	one_hand_penalty = 5 //bullpup rifle (this one is smaller and carbine, so it's 5)
 	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE, GUN_MAGWELL)
 

--- a/code/modules/projectiles/guns/projectile/automatic/dp.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dp.dm
@@ -20,7 +20,7 @@
 	reload_sound 	= 'sound/weapons/guns/interact/lmg_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/lmg_cock.ogg'
 	fire_sound = 'sound/weapons/guns/fire/dp_fire.ogg'
-	recoil_buildup = 3
+	recoil_buildup = 3.5
 	twohanded = TRUE
 	one_hand_penalty = 30 //not like it's used anyway, but LMG level
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG)

--- a/code/modules/projectiles/guns/projectile/automatic/luger.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/luger.dm
@@ -12,7 +12,7 @@
 	price_tag = 650
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_35)
 	damage_multiplier = 1
-	recoil_buildup = 2
+	recoil_buildup = 5
 	one_hand_penalty = 20
 	load_method = MAGAZINE
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/automatic/mac.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/mac.dm
@@ -14,7 +14,7 @@
 	matter = list(MATERIAL_PLASTEEL = 16, MATERIAL_PLASTIC = 4)
 	price_tag = 1000
 	damage_multiplier = 0.9
-	recoil_buildup = 5
+	recoil_buildup = 4
 	gun_tags = list(GUN_PROJECTILE,GUN_SILENCABLE, GUN_CALIBRE_35, GUN_MAGWELL)
 	one_hand_penalty = 5 //smg level
 

--- a/code/modules/projectiles/guns/projectile/automatic/nordwind.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/nordwind.dm
@@ -42,7 +42,7 @@
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 10, MATERIAL_WOOD = 10)
 	price_tag = 750
 	zoom_factor = 0.5
-	recoil_buildup = 20
+	recoil_buildup = 14
 	damage_multiplier = 0.9
 	one_hand_penalty = 25
 	auto_eject = FALSE

--- a/code/modules/projectiles/guns/projectile/automatic/ppsh.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ppsh.dm
@@ -16,7 +16,7 @@
 	matter = list(MATERIAL_PLASTEEL = 28, MATERIAL_PLASTIC = 10)
 	price_tag = 1500
 	penetration_multiplier = 1.2
-	recoil_buildup = 5
+	recoil_buildup = 3.5
 	fire_sound = 'sound/weapons/guns/fire/grease_fire.ogg'
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_35)
 	one_hand_penalty = 20
@@ -48,6 +48,6 @@
 	price_tag = 1200
 	damage_multiplier = 0.9
 	penetration_multiplier = 1.0
-	recoil_buildup = 10
+	recoil_buildup = 5
 	one_hand_penalty = 20
 	auto_eject = 0

--- a/code/modules/projectiles/guns/projectile/automatic/sts.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts.dm
@@ -18,7 +18,7 @@
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
 	damage_multiplier = 1.2
-	recoil_buildup = 10
+	recoil_buildup = 7
 	one_hand_penalty = 13 //automatic rifle level
 	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE, GUN_MAGWELL)
 


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	I noticed after looking through gun values that things such as the Kalash had higher prices than guns with similar if not the same stats despite having a high recoil. In turn I've lowered most STS and Kalash recoils to be more on-par with certain guns like the Pitbull or the 'PKM' LMG (which only has a recoil of 3.5.) Also modified some other weapons as well to fix their values. This will require tweaking and testing as we get feedback but overall prospectors, security members and others have mentioned certain guns such as the AK were objectively inferior due to high recoil. This should hopefully fix and balance that somewhat.
</summary>
<hr>
</details>

## Changelog
:cl:
tweak: Adjusted STS, AK, Kalashnabren, DP (by .5) and other guns stats to balance them
tweak: Adjusted STS, AK and other guns pricing to allow for fairer selling at Lonestar.
/:cl: