### PR TITLE
Categorizes Graphic Updates in Char Creation

### DIFF
--- a/code/modules/client/preference_setup/augmentation/01_modifications.dm
+++ b/code/modules/client/preference_setup/augmentation/01_modifications.dm
@@ -158,6 +158,7 @@
 	return
 
 /datum/category_item/player_setup_item/augmentation/modifications/OnTopic(var/href, list/href_list, mob/user)
+	pref.categoriesChanged = "Augmentation"
 	if(href_list["organ"])
 		pref.current_organ = href_list["organ"]
 		return TOPIC_REFRESH_UPDATE_PREVIEW

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -124,6 +124,7 @@
 
 /datum/category_item/player_setup_item/physical/basic/OnTopic(var/href,var/list/href_list, var/mob/user)
 	var/datum/species/S = all_species[pref.species]
+	pref.categoriesChanged = "Basic"
 
 	if(href_list["rename"])
 		var/raw_name = input(user, "Choose your character's name:", "Character Name", pref.real_name)  as text|null

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -97,6 +97,11 @@
 				pref.real_name = random_name(pref.gender, pref.species)
 	*/
 /datum/category_item/player_setup_item/physical/basic/content()
+	if(global.all_species[pref.species]?.obligate_name)
+		pref.custom_species = global.all_species[pref.species]
+	if ((pref.species == "Human") && (pref.custom_species in global.all_species))
+		pref.custom_species = "Human"
+
 	. = list()
 	. += "<style>span.color_holder_box{display: inline-block; width: 20px; height: 8px; border:1px solid #000; padding: 0px;}</style>"
 	. += "<span class='info' style='color:#0000cc;background-color:#ffffff;padding:5px;'> This is <b>[pref.real_name]</b>, <b><font color='[pref.species_color]'>a[pref.species_aan] [pref.custom_species]</font></b>!</span> <br>"

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -165,6 +165,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 /datum/category_item/player_setup_item/physical/body/OnTopic(var/href,var/list/href_list, var/mob/user)
 
+	pref.categoriesChanged = "Body"
 	var/datum/species/mob_species = all_species[pref.species]
 	var/datum/species_form/mob_species_form = GLOB.all_species_form_list[pref.species_form]
 	if(href_list["toggle_species_verbose"])

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -136,6 +136,7 @@
 	metadata["[bt]"] = new_metadata
 
 /datum/category_item/player_setup_item/physical/equipment/OnTopic(var/href,var/list/href_list, var/mob/user)
+	pref.categoriesChanged = "Equipment"
 	if(href_list["change_underwear"])
 		var/datum/category_group/underwear/UWC = GLOB.underwear.categories_by_name[href_list["change_underwear"]]
 		if(!UWC)

--- a/code/modules/client/preference_setup/general/06_furry.dm
+++ b/code/modules/client/preference_setup/general/06_furry.dm
@@ -114,6 +114,7 @@ datum/preferences
 		. += "<a href='?src=\ref[src];marking=[counter]'>[pref.body_markings[counter]]</a><br>"
 
 /datum/category_item/player_setup_item/physical/furry/OnTopic(var/href,var/list/href_list, var/mob/user)
+	pref.categoriesChanged = "Furry"
 	var/datum/species/cspecies = global.all_species[pref.species]
 	var/datum/species_form/cform = GLOB.all_species_form_list[pref.species_form]
 	if(href_list["blood_color"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -32,6 +32,7 @@
 	var/savefile/loaded_character
 	var/datum/category_collection/player_setup_collection/player_setup
 	var/datum/browser/panel
+	var/categoriesChanged = "All"
 
 /datum/preferences/New(client/C)
 	if(istype(C))
@@ -170,6 +171,87 @@
 
 /datum/preferences/proc/copy_to(mob/living/carbon/human/character, is_preview_copy = FALSE)
 	// Sanitizing rather than saving as someone might still be editing when copy_to occurs.
+
+	if(is_preview_copy && categoriesChanged != "All")
+
+		character.set_species(species) //2
+		character.set_form(species_form) //2
+		character.rebuild_organs(src) //7-8
+
+		switch(categoriesChanged)
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+			if("Basic")
+				categoriesChanged=null
+				if(be_random_name)   //1
+					real_name = random_name(gender,species)
+				if(config.humans_need_surnames)
+					var/firstspace = findtext(real_name, " ")
+					var/name_length = length(real_name)
+					if(!firstspace)	//we need a surname
+						real_name += " [pick(GLOB.last_names)]"
+					else if(firstspace == name_length)
+						real_name += "[pick(GLOB.last_names)]"
+				character.fully_replace_character_name(newname = real_name) //1
+				character.gender = gender //1
+				character.identifying_gender = gender_identity //1
+				character.age = age //1
+				character.b_type = b_type //1
+				character.species_aan = species_aan //1
+				character.species_color_key = species_color //1
+				character.species_name = custom_species //1
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+			if("Body")
+				categoriesChanged=null
+				character.h_style = h_style //2
+				character.f_style = f_style //2
+				character.eyes_color = eyes_color //2
+				character.hair_color = hair_color //2
+				character.facial_color = facial_color //2
+				character.skin_color = skin_color //2
+				character.s_tone = s_tone //2
+				character.grad_color = grad_color //2
+				character.grad_style = grad_style //2
+				character.update_hair(0) //2
+				character.force_update_limbs()//2
+	/////////////////////////////////////////////////////////////////////////////////////////////////
+			if("Equipment")
+				categoriesChanged=null
+				QDEL_NULL_LIST(character.worn_underwear) //4
+				character.worn_underwear = list() //4
+				for(var/underwear_category_name in all_underwear) //4
+					var/datum/category_group/underwear/underwear_category = GLOB.underwear.categories_by_name[underwear_category_name]
+					if(underwear_category)
+						var/underwear_item_name = all_underwear[underwear_category_name]
+						var/datum/category_item/underwear/UWD = underwear_category.items_by_name[underwear_item_name]
+						var/metadata = all_underwear_metadata[underwear_category_name]
+						var/obj/item/underwear/UW = UWD.create_underwear(character, metadata, character.form.underwear_icon)
+						if(UW)
+							UW.ForceEquipUnderwear(character, FALSE)
+					else
+						all_underwear -= underwear_category_name
+
+				character.update_underwear(0) //4
+				character.backpack_setup = new(backpack, backpack_metadata["[backpack]"]) //4
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+			if ("Furry",)
+				categoriesChanged=null
+				character.blood_color = blood_color //6
+				character.ears = GLOB.ears_styles_list[ears_style] //6
+				character.ears_colors = ears_colors
+				character.tail = GLOB.tail_styles_list[tail_style] //6
+				character.tail_colors = tail_colors
+				character.wings = GLOB.wings_styles_list[wings_style] //6
+				character.wings_colors = wings_colors
+				character.body_markings = body_markings //6
+			if ("Augmentation",)
+				categoriesChanged=null
+				character.update_implants(0) //7-8
+
+		character.update_body(0)
+		categoriesChanged = null
+		return
+
+
 	player_setup.sanitize_setup()
 	character.set_species(species) //2
 	character.set_form(species_form) //2
@@ -178,7 +260,6 @@
 
 	if(be_random_name)   //1
 		real_name = random_name(gender,species)
-
 	if(config.humans_need_surnames)
 		var/firstspace = findtext(real_name, " ")
 		var/name_length = length(real_name)
@@ -207,6 +288,8 @@
 	character.update_hair(0) //2
 	character.force_update_limbs()//2
 
+	QDEL_NULL_LIST(character.worn_underwear) //4
+	character.worn_underwear = list() //4
 	for(var/underwear_category_name in all_underwear) //4
 		var/datum/category_group/underwear/underwear_category = GLOB.underwear.categories_by_name[underwear_category_name]
 		if(underwear_category)
@@ -220,10 +303,6 @@
 			all_underwear -= underwear_category_name
 
 	character.update_underwear(0) //4
-
-	QDEL_NULL_LIST(character.worn_underwear)
-	character.worn_underwear = list()
-
 	character.backpack_setup = new(backpack, backpack_metadata["[backpack]"]) //4
 
 
@@ -238,24 +317,9 @@
 
 	character.update_implants(0) //7-8
 
-
-	// Build mob body from prefs
-
-
-
-
-
-
-
 	character.update_body(0)
 
 	character.update_mutations(0)
-
-
-
-
-	if(is_preview_copy)
-		return
 
 	character.update_icons()
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -171,10 +171,12 @@
 /datum/preferences/proc/copy_to(mob/living/carbon/human/character, is_preview_copy = FALSE)
 	// Sanitizing rather than saving as someone might still be editing when copy_to occurs.
 	player_setup.sanitize_setup()
-	character.set_species(species)
-	character.set_form(species_form)
+	character.set_species(species) //2
+	character.set_form(species_form) //2
+	character.rebuild_organs(src) //7-8
 
-	if(be_random_name)
+
+	if(be_random_name)   //1
 		real_name = random_name(gender,species)
 
 	if(config.humans_need_surnames)
@@ -184,45 +186,28 @@
 			real_name += " [pick(GLOB.last_names)]"
 		else if(firstspace == name_length)
 			real_name += "[pick(GLOB.last_names)]"
-	character.fully_replace_character_name(newname = real_name)
-	character.gender = gender
-	character.identifying_gender = gender_identity
-	character.age = age
-	character.b_type = b_type
+	character.fully_replace_character_name(newname = real_name) //1
+	character.gender = gender //1
+	character.identifying_gender = gender_identity //1
+	character.age = age //1
+	character.b_type = b_type //1
+	character.species_aan = species_aan //1
+	character.species_color_key = species_color //1
+	character.species_name = custom_species //1
 
-	character.h_style = h_style
-	character.f_style = f_style
+	character.h_style = h_style //2
+	character.f_style = f_style //2
+	character.eyes_color = eyes_color //2
+	character.hair_color = hair_color //2
+	character.facial_color = facial_color //2
+	character.skin_color = skin_color //2
+	character.s_tone = s_tone //2
+	character.grad_color = grad_color //2
+	character.grad_style = grad_style //2
+	character.update_hair(0) //2
+	character.force_update_limbs()//2
 
-	// Build mob body from prefs
-	character.rebuild_organs(src)
-
-	character.eyes_color = eyes_color
-	character.hair_color = hair_color
-	character.facial_color = facial_color
-	character.skin_color = skin_color
-
-	character.s_tone = s_tone
-
-	character.species_aan = species_aan
-	character.species_color_key = species_color
-	character.species_name = custom_species
-	character.blood_color = blood_color
-
-	character.ears = GLOB.ears_styles_list[ears_style]
-	character.ears_colors = ears_colors
-	character.tail = GLOB.tail_styles_list[tail_style]
-	character.tail_colors = tail_colors
-	character.wings = GLOB.wings_styles_list[wings_style]
-	character.wings_colors = wings_colors
-
-	character.body_markings = body_markings
-	character.grad_color = grad_color
-	character.grad_style = grad_style
-
-	QDEL_NULL_LIST(character.worn_underwear)
-	character.worn_underwear = list()
-
-	for(var/underwear_category_name in all_underwear)
+	for(var/underwear_category_name in all_underwear) //4
 		var/datum/category_group/underwear/underwear_category = GLOB.underwear.categories_by_name[underwear_category_name]
 		if(underwear_category)
 			var/underwear_item_name = all_underwear[underwear_category_name]
@@ -234,17 +219,40 @@
 		else
 			all_underwear -= underwear_category_name
 
-	character.backpack_setup = new(backpack, backpack_metadata["[backpack]"])
+	character.update_underwear(0) //4
 
-	character.force_update_limbs()
-	character.update_mutations(0)
-	character.update_implants(0)
+	QDEL_NULL_LIST(character.worn_underwear)
+	character.worn_underwear = list()
+
+	character.backpack_setup = new(backpack, backpack_metadata["[backpack]"]) //4
+
+
+	character.blood_color = blood_color //6
+	character.ears = GLOB.ears_styles_list[ears_style] //6
+	character.ears_colors = ears_colors
+	character.tail = GLOB.tail_styles_list[tail_style] //6
+	character.tail_colors = tail_colors
+	character.wings = GLOB.wings_styles_list[wings_style] //6
+	character.wings_colors = wings_colors
+	character.body_markings = body_markings //6
+
+	character.update_implants(0) //7-8
+
+
+	// Build mob body from prefs
+
+
+
+
+
 
 
 	character.update_body(0)
-	character.update_underwear(0)
 
-	character.update_hair(0)
+	character.update_mutations(0)
+
+
+
 
 	if(is_preview_copy)
 		return


### PR DESCRIPTION
Now instead of update_preview_icon sanitizing the entirety of the character every time, only the parts of the mob that belongs to the altered category is changed.

I am now officially out of ideas of how to better optimize the processes of creating a character.