### PR TITLE
Fix scopes

### DIFF
--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -406,7 +406,6 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_OFFSET = 0.9,
-		GUN_UPGRADE_RECOIL = 1.1,
 		GUN_UPGRADE_ZOOM = 1.2
 		)
 	I.gun_loc_tag = GUN_SCOPE
@@ -422,7 +421,7 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_OFFSET = 0.7,
-		GUN_UPGRADE_RECOIL = 1.3,
+		GUN_UPGRADE_FIRE_DELAY_MULT = 1.4,
 		GUN_UPGRADE_ZOOM = 2
 		)
 	I.gun_loc_tag = GUN_SCOPE


### PR DESCRIPTION
I made so the contract killer scope increased fire delay instead of recoil, and deleted the guild scope's recoil, because what the fuck. No seriously, why would a scope increase recoil? At best you're gonna spend more time aiming, hence the fire delay, but why /recoil/? It essentially made them pointless besides the zoom itself. So here you go.


## Changelog
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things

