### PR TITLE
Big boy rebalance

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -92,7 +92,7 @@
 			return 1
 
 		if (I_DISARM)
-			if (!weakened && (prob(30) + (H.stats.getStat(STAT_ROB) * 0.1)))
+			if (!weakened && (prob(30 + (H.stats.getStat(STAT_ROB) * 0.1))))
 				M.visible_message("\red [M] has knocked \the [src] over!")
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 				Weaken(3)

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
@@ -80,6 +80,77 @@
 
 	. = ..()
 
+/mob/living/carbon/superior_animal/giant_spider/tarantula/attack_hand(mob/living/carbon/M as mob)
+	..()
+	var/mob/living/carbon/human/H = M
+
+	switch(M.a_intent)
+		if (I_HELP)
+			help_shake_act(M)
+
+		if (I_GRAB)
+			if(!weakened)
+				M.Weaken(3)
+				visible_message(SPAN_WARNING("[src] breaks the grapple and uses its size to knock [M] over!"))
+				return 1
+			else
+				if(M == src || anchored)
+					return 0
+				for(var/obj/item/weapon/grab/G in src.grabbed_by)
+					if(G.assailant == M)
+						to_chat(M, SPAN_NOTICE("You already grabbed [src]."))
+						return
+
+				var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
+				if(buckled)
+					to_chat(M, SPAN_NOTICE("You cannot grab [src], \he is buckled in!"))
+				if(!G) //the grab will delete itself in New if affecting is anchored
+					return
+
+				M.put_in_active_hand(G)
+				G.synch()
+				LAssailant = M
+
+				M.do_attack_animation(src)
+				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+				visible_message(SPAN_WARNING("[M] has grabbed [src] passively!"))
+
+				return 1
+
+		if (I_DISARM)
+			if (!weakened && (prob(10 + (H.stats.getStat(STAT_ROB) * 0.1))))
+				M.visible_message("\red [M] has knocked \the [src] over!")
+				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+				Weaken(3)
+
+				return 1
+			else
+				M.visible_message("\red [src] knocks [M] to the ground!")
+				M.Weaken(3)
+				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+
+			M.do_attack_animation(src)
+
+		if (I_HURT)
+			var/damage = 3
+			if ((stat == CONSCIOUS) && prob(10))
+				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+				M.visible_message("\red [M] missed \the [src]")
+			else
+				if (istype(H))
+					damage += max(0, (H.stats.getStat(STAT_ROB) / 10))
+					if (HULK in H.mutations)
+						damage *= 2
+
+				playsound(loc, "punch", 25, 1, -1)
+				M.visible_message("\red [M] has punched \the [src]")
+
+				adjustBruteLoss(damage)
+				updatehealth()
+				M.do_attack_animation(src)
+
+				return 1
+
 /mob/living/carbon/superior_animal/giant_spider/tarantula/ogre
 	name = "ogre spider"
 	desc = "Furry and tan, it makes you shudder to look at it. An absolute unit of a spider with the same strength and durability of a fortress spider combined with the toxins and speed of a hunter."

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
@@ -84,3 +84,76 @@ var/datum/xenomorph/xenomorph_ai
 	verbs -= /mob/verb/observe
 	pixel_x = 0
 	pixel_y = 0
+
+/mob/living/carbon/superior_animal/xenomorph/attack_hand(mob/living/carbon/M as mob)
+	..()
+	var/mob/living/carbon/human/H = M
+
+	switch(M.a_intent)
+		if (I_HELP)
+			help_shake_act(M)
+
+		if (I_GRAB)
+			if(!weakened)
+				M.visible_message("\red [src] breaks the grapple and impales [M] with its tail!")
+				M.adjustBruteLoss(50)
+				M.Weaken(3)
+				return 1
+			else
+				if(M == src || anchored)
+					return 0
+				for(var/obj/item/weapon/grab/G in src.grabbed_by)
+					if(G.assailant == M)
+						to_chat(M, SPAN_NOTICE("You already grabbed [src]."))
+						return
+
+				var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
+				if(buckled)
+					to_chat(M, SPAN_NOTICE("You cannot grab [src], \he is buckled in!"))
+				if(!G) //the grab will delete itself in New if affecting is anchored
+					return
+
+				M.put_in_active_hand(G)
+				G.synch()
+				LAssailant = M
+
+				M.do_attack_animation(src)
+				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+				visible_message(SPAN_WARNING("[M] has grabbed [src] passively!"))
+
+				return 1
+
+		if (I_DISARM)
+			if (!weakened && (prob(10 + (H.stats.getStat(STAT_ROB) * 0.1))))
+				M.visible_message("\red [M] has knocked \the [src] over!")
+				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+				Weaken(3)
+
+				return 1
+			else
+				M.visible_message("\red [M] gets impaled by \the [src]'s tail!")
+				M.adjustBruteLoss(50)
+				M.Weaken(3)
+				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+
+			M.do_attack_animation(src)
+
+		if (I_HURT)
+			var/damage = 3
+			if ((stat == CONSCIOUS) && prob(10))
+				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+				M.visible_message("\red [M] missed \the [src]")
+			else
+				if (istype(H))
+					damage += max(0, (H.stats.getStat(STAT_ROB) / 10))
+					if (HULK in H.mutations)
+						damage *= 2
+
+				playsound(loc, "punch", 25, 1, -1)
+				M.visible_message("\red [M] has punched \the [src]")
+
+				adjustBruteLoss(damage)
+				updatehealth()
+				M.do_attack_animation(src)
+
+				return 1


### PR DESCRIPTION
-Xenomorphs now impale you with their tail (50 brute) and stun you if you attempt to grapple or disarm them.
-Tarantulae class spiders (fortress, ogre, emperor, and reaper) now stun you if you attempt to grapple or disarm them.
-The math for pushdowns is now correct, as a slight mistype made it so it was far too easy to knock down superior mobs. All mobs have 30 + 10% robustness. Tarantula class spiders and xenomorphs have 10 + 10% robustness as their fucking huge and failing has a severe penalty as well.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
