### PR TITLE
Fix blackshield ammo disk

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
@@ -90,6 +90,8 @@
 		/datum/design/autolathe/ammo/magnum_ammobox,
 		/datum/design/autolathe/ammo/magnum_ammobox_rubber,
 		/datum/design/autolathe/ammo/magnum_ammobox_practice = 0,
+		/datum/design/autolathe/ammo/rifle,
+		/datum/design/autolathe/ammo/rifle_ammobox,
 		/datum/design/autolathe/ammo/lrifle_ammobox,
 		/datum/design/autolathe/ammo/lrifle_ammobox_rubber,
 		/datum/design/autolathe/ammo/hrifle_ammobox,


### PR DESCRIPTION
The blackshield ammo disk couldn't produce 7.5 ammo for some reason, so here it is.

fix: fixed a few things


