### PR TITLE
Fixed funny bugs

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
@@ -89,7 +89,9 @@
 			help_shake_act(M)
 
 		if (I_GRAB)
-			if(!weakened)
+			if(!weakened && stat == CONSCIOUS)
+				if(M.stats.getPerk(PERK_ASS_OF_CONCRETE) || M.stats.getPerk(PERK_BRAWN))
+					return 1
 				M.Weaken(3)
 				visible_message(SPAN_WARNING("[src] breaks the grapple and uses its size to knock [M] over!"))
 				return 1
@@ -124,7 +126,9 @@
 				Weaken(3)
 
 				return 1
-			else
+			else if(!weakened && stat == CONSCIOUS)
+				if(M.stats.getPerk(PERK_ASS_OF_CONCRETE) || M.stats.getPerk(PERK_BRAWN))
+					return 1
 				M.visible_message("\red [src] knocks [M] to the ground!")
 				M.Weaken(3)
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
@@ -93,7 +93,7 @@
 				if(M.stats.getPerk(PERK_ASS_OF_CONCRETE) || M.stats.getPerk(PERK_BRAWN))
 					return 1
 				M.Weaken(3)
-				visible_message(SPAN_WARNING("[src] breaks the grapple and uses its size to knock [M] over!"))
+				visible_message(SPAN_WARNING("\red [src] breaks the grapple and uses its size to knock [M] over!"))
 				return 1
 			else
 				if(M == src || anchored)
@@ -215,3 +215,78 @@
 
 /mob/living/carbon/superior_animal/giant_spider/tarantula/emperor/reaper_spider/slip(var/slipped_on)
 	return FALSE
+
+/mob/living/carbon/superior_animal/giant_spider/tarantula/emperor/reaper_spider/attack_hand(mob/living/carbon/M as mob)
+	..()
+	var/mob/living/carbon/human/H = M
+
+	switch(M.a_intent)
+		if (I_HELP)
+			help_shake_act(M)
+
+		if (I_GRAB)
+			if(!weakened && stat == CONSCIOUS)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustOxyLoss(25)
+				M.Weaken(5)
+				visible_message(SPAN_WARNING("\red [src] immediately crushes [M] with its titan bulk when they stupidly try to grab it!"))
+				return 1
+			else
+				if(M == src || anchored)
+					return 0
+				for(var/obj/item/weapon/grab/G in src.grabbed_by)
+					if(G.assailant == M)
+						to_chat(M, SPAN_NOTICE("You already grabbed [src]."))
+						return
+
+				var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
+				if(buckled)
+					to_chat(M, SPAN_NOTICE("You cannot grab [src], \he is buckled in!"))
+				if(!G) //the grab will delete itself in New if affecting is anchored
+					return
+
+				M.put_in_active_hand(G)
+				G.synch()
+				LAssailant = M
+
+				M.do_attack_animation(src)
+				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+				visible_message(SPAN_WARNING("[M] has grabbed [src] passively!"))
+
+				return 1
+
+		if (I_DISARM)
+			if(!weakened && stat == CONSCIOUS)
+				M.visible_message("\red [src] hammers [M] to the ground!")
+				M.Weaken(5)
+				M.adjustBruteLoss(50)
+				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+
+			M.do_attack_animation(src)
+
+		if (I_HURT)
+			var/damage = 3
+			if ((stat == CONSCIOUS) && prob(10))
+				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+				M.visible_message("\red [M] missed \the [src]")
+			else
+				if (istype(H))
+					damage += max(0, (H.stats.getStat(STAT_ROB) / 10))
+					if (HULK in H.mutations)
+						damage *= 2
+
+				playsound(loc, "punch", 25, 1, -1)
+				M.visible_message("\red [M] has punched \the [src]")
+
+				adjustBruteLoss(damage)
+				updatehealth()
+				M.do_attack_animation(src)
+
+				return 1

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
@@ -94,8 +94,12 @@ var/datum/xenomorph/xenomorph_ai
 			help_shake_act(M)
 
 		if (I_GRAB)
-			if(!weakened)
-				M.visible_message("\red [src] breaks the grapple and impales [M] with its tail!")
+			if(!weakened && stat == CONSCIOUS)
+				if(M.stats.getPerk(PERK_ASS_OF_CONCRETE) || M.stats.getPerk(PERK_BRAWN))
+					M.visible_message("\red The [src] breaks the grapple and impales [M] with it's armor-piercing tail! [M] manages to stay standing!")
+					M.adjustBruteLoss(50)
+					return 1
+				M.visible_message("\red The [src] breaks the grapple and impales [M] with it's armor-piercing tail!")
 				M.adjustBruteLoss(50)
 				M.Weaken(3)
 				return 1
@@ -130,8 +134,12 @@ var/datum/xenomorph/xenomorph_ai
 				Weaken(3)
 
 				return 1
-			else
-				M.visible_message("\red [M] gets impaled by \the [src]'s tail!")
+			else if(!weakened && stat == CONSCIOUS)
+				if(M.stats.getPerk(PERK_ASS_OF_CONCRETE) || M.stats.getPerk(PERK_BRAWN))
+					M.visible_message("\red The [src] breaks the grapple and impales [M] with it's armor-piercing tail! [M] manages to stay standing!")
+					M.adjustBruteLoss(50)
+					return 1
+				M.visible_message("\red [M] gets impaled by \the [src]'s armor-piercing tail!")
 				M.adjustBruteLoss(50)
 				M.Weaken(3)
 				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
@@ -96,7 +96,7 @@ var/datum/xenomorph/xenomorph_ai
 		if (I_GRAB)
 			if(!weakened && stat == CONSCIOUS)
 				if(M.stats.getPerk(PERK_ASS_OF_CONCRETE) || M.stats.getPerk(PERK_BRAWN))
-					M.visible_message("\red The [src] breaks the grapple and impales [M] with it's armor-piercing tail! [M] manages to stay standing!")
+					M.visible_message("\red [src] breaks the grapple and impales [M] with it's armor-piercing tail! [M] manages to stay standing!")
 					M.adjustBruteLoss(50)
 					return 1
 				M.visible_message("\red The [src] breaks the grapple and impales [M] with it's armor-piercing tail!")
@@ -136,7 +136,7 @@ var/datum/xenomorph/xenomorph_ai
 				return 1
 			else if(!weakened && stat == CONSCIOUS)
 				if(M.stats.getPerk(PERK_ASS_OF_CONCRETE) || M.stats.getPerk(PERK_BRAWN))
-					M.visible_message("\red The [src] breaks the grapple and impales [M] with it's armor-piercing tail! [M] manages to stay standing!")
+					M.visible_message("\red [src] breaks the grapple and impales [M] with it's armor-piercing tail! [M] manages to stay standing!")
 					M.adjustBruteLoss(50)
 					return 1
 				M.visible_message("\red [M] gets impaled by \the [src]'s armor-piercing tail!")

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/types/XenoMega.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/types/XenoMega.dm
@@ -47,3 +47,78 @@
 			L.visible_message(SPAN_DANGER("\the [src] rams \the [L] off there feet!"))
 
 	. = ..()
+
+/mob/living/carbon/superior_animal/xenomorph/warrior/shrike/praetorian/queen/attack_hand(mob/living/carbon/M as mob)
+	..()
+	var/mob/living/carbon/human/H = M
+
+	switch(M.a_intent)
+		if (I_HELP)
+			help_shake_act(M)
+
+		if (I_GRAB)
+			if(!weakened && stat == CONSCIOUS)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustBruteLoss(25)
+				M.adjustOxyLoss(25)
+				M.Weaken(5)
+				visible_message(SPAN_WARNING("\red [src] immediately crushes [M] with its titan bulk when they stupidly try to grab it!"))
+				return 1
+			else
+				if(M == src || anchored)
+					return 0
+				for(var/obj/item/weapon/grab/G in src.grabbed_by)
+					if(G.assailant == M)
+						to_chat(M, SPAN_NOTICE("You already grabbed [src]."))
+						return
+
+				var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
+				if(buckled)
+					to_chat(M, SPAN_NOTICE("You cannot grab [src], \he is buckled in!"))
+				if(!G) //the grab will delete itself in New if affecting is anchored
+					return
+
+				M.put_in_active_hand(G)
+				G.synch()
+				LAssailant = M
+
+				M.do_attack_animation(src)
+				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+				visible_message(SPAN_WARNING("[M] has grabbed [src] passively!"))
+
+				return 1
+
+		if (I_DISARM)
+			if(!weakened && stat == CONSCIOUS)
+				M.visible_message("\red [src] slays [M] with an deadly impalement from its tail!")
+				M.Weaken(5)
+				M.adjustBruteLoss(250)
+				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+
+			M.do_attack_animation(src)
+
+		if (I_HURT)
+			var/damage = 3
+			if ((stat == CONSCIOUS) && prob(10))
+				playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+				M.visible_message("\red [M] missed \the [src]")
+			else
+				if (istype(H))
+					damage += max(0, (H.stats.getStat(STAT_ROB) / 10))
+					if (HULK in H.mutations)
+						damage *= 2
+
+				playsound(loc, "punch", 25, 1, -1)
+				M.visible_message("\red [M] has punched \the [src]")
+
+				adjustBruteLoss(damage)
+				updatehealth()
+				M.do_attack_animation(src)
+
+				return 1


### PR DESCRIPTION
-Xenomorphs no longer tail stab you when dead when you attempt to grab or disarm them.
-Spiders no longer knock you down if you attempt to grab or disarm them when they are dead.
-Perks DEFENSIVE_TRAINING and BRAWN are now considered when grappling or disarming spiders and xenomorphs. People with either can grab and choke hold any class spider and disarm knockdown is prevented. Against a xenomorph you are not knocked down, but the grapple is immediately broken and you still get tail shanked.
-Tail stab text updated to reflect its armor piercing qualities. The damage is 50 flat, unmitigated by armor.It's an 8 ft tail with an armor rending spike on the end, anything else doesn't make sense.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
