### PR TITLE
You can't holster an MG SST

### DIFF
--- a/code/modules/projectiles/guns/energy/sst.dm
+++ b/code/modules/projectiles/guns/energy/sst.dm
@@ -86,6 +86,7 @@
 	can_dual = FALSE
 	price_tag = 3200
 	charge_meter = FALSE
+	slot_flags = SLOT_BACK
 	charge_cost = 450
 	suitable_cell = /obj/item/weapon/cell/large
 	recoil_buildup = 2


### PR DESCRIPTION
Title says it all. No longer will you be able to holster a machinegun. Can't believe I have to make this.