### PR TITLE
Fix the sawn-off heavy STS size

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/sts.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts.dm
@@ -166,6 +166,7 @@
 	icon = 'icons/obj/guns/projectile/sts40.dmi'
 	icon_state = "sts"
 	item_state = "sts"
+	w_class = ITEM_SIZE_BULKY
 	penetration_multiplier = 0.8
 	damage_multiplier = 1
 	recoil_buildup = 20


### PR DESCRIPTION
What this PR does : Give you a reason to saw off the STS Heavy Rifle, as before it didn't change the gun's size. Which is the whole reason why you saw a part of it off.