### PR TITLE
Make the prosthetic printer actually print prosthetic organs

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -12,7 +12,6 @@
 	icon_state = "bioprinter"
 	icon = 'icons/obj/surgery.dmi'
 
-	var/prints_prosthetics
 	var/stored_matter = 0
 	var/max_matter = 300
 	var/loaded_dna //Blood sample for DNA hashing.
@@ -26,11 +25,6 @@
 		OP_MUSCLE  =    	list(/obj/item/organ/internal/muscle,  20),
 		OP_NERVE  =	    	list(/obj/item/organ/internal/nerve,  10)
 		)
-
-/obj/machinery/bioprinter/prosthetics
-	name = "prosthetics fabricator"
-	desc = "It's a machine that prints prosthetic organs."
-	prints_prosthetics = 1
 
 /obj/machinery/bioprinter/examine(mob/user)
 	..()
@@ -64,9 +58,7 @@
 		var/new_organ = products[choice][1]
 		var/obj/item/organ/O = new new_organ(get_turf(src))
 
-		if(prints_prosthetics)
-			O.nature = MODIFICATION_SILICON
-		else if(loaded_dna)
+		if(loaded_dna)
 			visible_message("<span class='notice'>The printer injects the stored DNA into the biomass.</span>.")
 			O.transplant_data = list()
 			var/mob/living/carbon/C = loaded_dna["donor"]
@@ -82,7 +74,7 @@
 /obj/machinery/bioprinter/attackby(obj/item/weapon/W, mob/user)
 
 	// DNA sample from syringe.
-	if(!prints_prosthetics && istype(W,/obj/item/weapon/reagent_containers/syringe))
+	if(istype(W,/obj/item/weapon/reagent_containers/syringe))
 		var/obj/item/weapon/reagent_containers/syringe/S = W
 		var/datum/reagent/organic/blood/injected = locate() in S.reagents.reagent_list //Grab some blood
 		if(injected && injected.data)
@@ -90,16 +82,58 @@
 			to_chat(user, "<span class='info'>You inject the blood sample into the bioprinter.</span>")
 		return
 	// Meat for biomass.
-	if(!prints_prosthetics)
-		for(var/type in BIOMASS_TYPES)
-			if(istype(W,type))
-				stored_matter += BIOMASS_TYPES[type]
-				user.drop_item()
-				to_chat(user, "<span class='info'>\The [src] processes \the [W]. Levels of stored biomass now: [stored_matter]</span>")
-				qdel(W)
-				return
+	for(var/type in BIOMASS_TYPES)
+		if(istype(W,type))
+			stored_matter += BIOMASS_TYPES[type]
+			user.drop_item()
+			to_chat(user, "<span class='info'>\The [src] processes \the [W]. Levels of stored biomass now: [stored_matter]</span>")
+			qdel(W)
+			return
+
+	return ..()
+
+/obj/machinery/bioprinter/prosthetics
+	name = "prosthetics fabricator"
+	desc = "It's a machine that prints prosthetic organs."
+
+/obj/machinery/bioprinter/prosthetics/New()
+	..()
+	if(SSticker.current_state != GAME_STATE_PLAYING)
+		stored_matter = 200
+
+	products = list(
+		OP_HEART =  		list(/obj/item/organ/internal/heart/prosthetic,  50),
+		OP_LUNGS =  		list(/obj/item/organ/internal/lungs/prosthetic,  40),
+		OP_KIDNEYS = 		list(/obj/item/organ/internal/kidney/prosthetic, 20),
+		OP_EYES =    		list(/obj/item/organ/internal/eyes/prosthetic,   30),
+		OP_LIVER =   		list(/obj/item/organ/internal/liver/prosthetic,  50),
+		OP_BLOOD_VESSEL =    	list(/obj/item/organ/internal/blood_vessel,  10),
+		OP_MUSCLE  =    	list(/obj/item/organ/internal/muscle/robotic,  20),
+		OP_NERVE  =	    	list(/obj/item/organ/internal/nerve/robotic,  10)
+		)
+
+
+/obj/machinery/bioprinter/prosthetics/attack_hand(mob/user)
+
+	var/choice = input("What would you like to print?") as null|anything in products
+	if(!choice)
+		return
+
+	if(stored_matter >= products[choice][2])
+
+		stored_matter -= products[choice][2]
+		var/new_organ = products[choice][1]
+		var/obj/item/organ/O = new new_organ(get_turf(src))
+
+		O.nature = MODIFICATION_SILICON
+
+		visible_message("<span class='info'>The bioprinter spits out a new organ.</span>")
+	else
+		to_chat(user, SPAN_WARNING("There is not enough matter in the printer."))
+
+obj/machinery/bioprinter/prosthetics/attackby(obj/item/weapon/W, mob/user)
 	// Steel for matter.
-	if(prints_prosthetics && istype(W, /obj/item/stack/material) && W.get_material_name() == MATERIAL_STEEL)
+	if(istype(W, /obj/item/stack/material) && W.get_material_name() == MATERIAL_STEEL)
 		var/obj/item/stack/S = W
 		stored_matter += S.amount * 10
 		user.drop_item()
@@ -107,4 +141,5 @@
 		qdel(W)
 		return
 
-	return ..()
+
+

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -1,5 +1,6 @@
 /obj/item/organ/internal/eyes
 	name = "eyeballs"
+	desc = "Eyes. They allow you to see."
 	icon_state = "eyes"
 	gender = PLURAL
 	organ_efficiency = list(OP_EYES = 100)
@@ -16,6 +17,7 @@
 
 /obj/item/organ/internal/eyes/prosthetic
 	name = "prosthetic eyes"
+	desc = "Eyes. They allow you to see. These one are made of metal."
 	icon_state = "eyes-prosthetic"
 	price_tag = 100
 	nature = MODIFICATION_SILICON

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -17,7 +17,7 @@
 
 /obj/item/organ/internal/heart/prosthetic
 	name = "prosthetic heart"
-	desc = "synth board for drums."
+	desc = "A metal heart, doesn't beat like a normal heart, but do the same job."
 	icon_state = "heart-prosthetic"
 	dead_icon = "heart-prosthetic"
 	price_tag = 100

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -31,7 +31,7 @@
 	price_tag = 100
 	nature = MODIFICATION_SILICON
 	matter = list(MATERIAL_STEEL = 1)
-	organ_efficiency = list(OP_KIDNEYS = 150)
+	organ_efficiency = list(OP_KIDNEYS = 50)
 
 /obj/item/organ/internal/kidney/left
 /obj/item/organ/internal/kidney/right

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -24,3 +24,15 @@
 
 /obj/item/organ/internal/kidney/right/cindarite
 	icon_state = "kidney_right_cindar"
+
+/obj/item/organ/internal/kidney/prosthetic
+	name = "prosthetic kidneys"
+	icon_state = "kidneys-prosthetic"
+	price_tag = 100
+	nature = MODIFICATION_SILICON
+	matter = list(MATERIAL_STEEL = 1)
+	organ_efficiency = list(OP_KIDNEYS = 150)
+
+/obj/item/organ/internal/kidney/left
+/obj/item/organ/internal/kidney/right
+	icon_state = "kidneys-prosthetic2"

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -27,6 +27,7 @@
 
 /obj/item/organ/internal/kidney/prosthetic
 	name = "prosthetic kidneys"
+	desc = "Prosthetic kindeys, doesn't work as well as the real deal.
 	icon_state = "kidneys-prosthetic"
 	price_tag = 100
 	nature = MODIFICATION_SILICON

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -16,6 +16,7 @@
 
 /obj/item/organ/internal/liver/prosthetic
 	name = "prosthetic liver"
+	desc = "A liver made of metal. Does the same job as a normal liver, and just as well."
 	icon_state = "liver-prosthetic"
 	price_tag = 100
 	nature = MODIFICATION_SILICON

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -20,4 +20,4 @@
 	price_tag = 100
 	nature = MODIFICATION_SILICON
 	matter = list(MATERIAL_STEEL = 1)
-	organ_efficiency = list(OP_LIVER = 150)
+	organ_efficiency = list(OP_LIVER = 100)

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -13,3 +13,11 @@
 //We got it covered in Process with more detailed thing
 /obj/item/organ/internal/liver/handle_regeneration()
 	return
+
+/obj/item/organ/internal/liver/prosthetic
+	name = "prosthetic liver"
+	icon_state = "liver-prosthetic"
+	price_tag = 100
+	nature = MODIFICATION_SILICON
+	matter = list(MATERIAL_STEEL = 1)
+	organ_efficiency = list(OP_LIVER = 150)

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -18,3 +18,10 @@
 	organ_efficiency = list(OP_LUNGS = 133)
 	specific_organ_size = 3
 	breath_modulo = 8
+
+/obj/item/organ/internal/lungs/prosthetic
+	name = "prosthetic lungs"
+	icon_state = "lungs-prosthetic"
+	price_tag = 100
+	nature = MODIFICATION_SILICON
+	matter = list(MATERIAL_STEEL = 1)

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -21,6 +21,7 @@
 
 /obj/item/organ/internal/lungs/prosthetic
 	name = "prosthetic lungs"
+	desc = "Lungs made out of metal. Still work just as well as normal lungs."
 	icon_state = "lungs-prosthetic"
 	price_tag = 100
 	nature = MODIFICATION_SILICON

--- a/code/modules/organs/internal/muscles.dm
+++ b/code/modules/organs/internal/muscles.dm
@@ -11,7 +11,8 @@
 	w_class = ITEM_SIZE_SMALL
 
 /obj/item/organ/internal/muscle/robotic
-	name = "hydraulic"
+	name = "hydraulic muscles"
+	desc = "Hydraulic systems that act as muscles. Doesn't outperform their organic counterpart though."
 	icon_state = "robotic_muscle"
 	desc = "Expand and contract"
 	nature = MODIFICATION_SILICON

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -15,4 +15,4 @@
 	price_tag = 100
 	nature = MODIFICATION_SILICON
 	matter = list(MATERIAL_STEEL = 1)
-	organ_efficiency = list(OP_STOMACH = 150)
+	organ_efficiency = list(OP_STOMACH = 100)

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -11,6 +11,7 @@
 
 /obj/item/organ/internal/stomach/prosthetic
 	name = "prosthetic stomach"
+	desc = "A metal stomach, work just as well as a normal one."
 	//icon_state = "stomach-prosthetic" // No prosthetic stomach sprites.
 	price_tag = 100
 	nature = MODIFICATION_SILICON

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -8,3 +8,11 @@
 	max_blood_storage = 25
 	oxygen_req = 5
 	w_class = ITEM_SIZE_SMALL
+
+/obj/item/organ/internal/stomach/prosthetic
+	name = "prosthetic stomach"
+	//icon_state = "stomach-prosthetic" // No prosthetic stomach sprites.
+	price_tag = 100
+	nature = MODIFICATION_SILICON
+	matter = list(MATERIAL_STEEL = 1)
+	organ_efficiency = list(OP_STOMACH = 150)


### PR DESCRIPTION
## About The Pull Request
This PR separate the prosthetic printer and the organ printer with more than just a binary value, so its list of possible organs it can print will naturally be prosthetic organs.

However, due to the fact that several organs were missing prosthetic counterparts (And I was told that Character Creation put regular organs in instead of prosthetic), I added prosthetic lungs, stomachs, livers, and kidneys, based on the prosthetic eyes and heart and using the unutilized sprites. The only one that didn't already have a prosthetic sprite was the stomach, so it still looks the same.