### PR TITLE
Makes food and drinks more likely for leveling up

### DIFF
--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -171,10 +171,10 @@
 /datum/sanity/proc/pick_desires()
 	desires.Cut()
 	var/list/candidates = list(
-		INSIGHT_DESIRE_FOOD,
-		INSIGHT_DESIRE_ALCOHOL,
-		INSIGHT_DESIRE_SMOKING,
-		INSIGHT_DESIRE_DRUGS,
+		INSIGHT_DESIRE_FOOD = 3,
+		INSIGHT_DESIRE_ALCOHOL = 3,
+		INSIGHT_DESIRE_SMOKING = 1,
+		INSIGHT_DESIRE_DRUGS = 2,
 	)
 	for(var/i = 0; i < INSIGHT_DESIRE_COUNT; i++)
 		var/desire = pick_n_take(candidates)


### PR DESCRIPTION

## About The Pull Request
Food and drink is now more likely to level you up with increased odds and likely options if it double roles into it
Drugs are also now more likely to pull form
This should make barkeep and cook more seeked after
## Changelog
:cl:
/:cl: