### PR TITLE
Church flare litany fix + nerf to it

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -44,12 +44,15 @@
 	phrase = "Lucerna pedibus meis verbum tuum, et lumen semitis meis."
 	desc = "Litany of pilgrims that creates a small light for about half an hour."
 	power = 30 //Cheap but not too cheap. Pretty powerful to light up a location for 30 mins.
+	cooldown = TRUE
+	cooldown_time = 1 MINUTES
+	cooldown_category = "flare"
 
 /datum/ritual/cruciform/base/flare/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
-	//var/mob/living/carbon/human/H = mob/living/carbon/human/user
 	playsound(H.loc, 'sound/effects/snap.ogg', 50, 1)
 	new /obj/effect/sparks(H.loc)
-	new /obj/effect/effect/smoke/illumination(H.loc, brightness=max(5), lifetime=30000) //About the same brightness as a lantern and its almost free!
+	new /obj/effect/effect/smoke/illumination(H.loc, brightness=max(6), lifetime=30000) //About the same brightness as a lantern and its almost free!
+	set_personal_cooldown(H)
 	return TRUE
 
 

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -42,7 +42,7 @@
 /datum/ritual/cruciform/base/flare
 	name = "Holy Light"
 	phrase = "Lucerna pedibus meis verbum tuum, et lumen semitis meis."
-	desc = "Litany of pilgrims that creates a small light for some time."
+	desc = "Litany of pilgrims that creates a small light for about half an hour."
 	power = 30 //Cheap but not too cheap. Pretty powerful to light up a location for 30 mins.
 
 /datum/ritual/cruciform/base/flare/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -39,19 +39,19 @@
 	H.adjustToxLoss(5)
 	return TRUE
 
-/* -Currently doesn't work, will spend more time fixing it later or replacing it with a more functional method. -Kaz
 /datum/ritual/cruciform/base/flare
 	name = "Holy Light"
 	phrase = "Lucerna pedibus meis verbum tuum, et lumen semitis meis."
 	desc = "Litany of pilgrims that creates a small light for some time."
-	power = 15 //Cheap but not tooo cheap
+	power = 30 //Cheap but not too cheap. Pretty powerful to light up a location for 30 mins.
 
 /datum/ritual/cruciform/base/flare/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
-	playsound(src, 'sound/effects/snap.ogg', 50, 1)
-	new /obj/effect/sparks(src)
-	new /obj/effect/effect/smoke/illumination(src, brightness=max(6), lifetime=30000) //Not as good as a flare or flare shell but its almost free!
+	//var/mob/living/carbon/human/H = mob/living/carbon/human/user
+	playsound(H.loc, 'sound/effects/snap.ogg', 50, 1)
+	new /obj/effect/sparks(H.loc)
+	new /obj/effect/effect/smoke/illumination(H.loc, brightness=max(5), lifetime=30000) //About the same brightness as a lantern and its almost free!
 	return TRUE
-*/
+
 
 /datum/ritual/cruciform/base/entreaty
 	name = "Entreaty"


### PR DESCRIPTION
What this PR does:
-Fixes a broken litany which was commented out.
-Slight description adjustment to give an idea for its duration.
-Also nerfs the litany with: 
   --Cost made greater with the original of 15 to new 30. 
   --And light level produced from 6 to 5. A lantern's light level is 4.
