### PR TITLE
Make all mechs construction need 5 cables instead of 4.

### DIFF
--- a/code/game/mecha/mecha_construction/durand.dm
+++ b/code/game/mecha/mecha_construction/durand.dm
@@ -270,7 +270,7 @@
 						"[usr] removes the wiring from [holder].", \
 						"You remove the wiring from [holder]."
 					)
-					new /obj/item/stack/cable_coil (get_turf(holder), 4)
+					new /obj/item/stack/cable_coil (get_turf(holder), 5)
 					holder.icon_state = "durand2"
 			if(21)
 				if(diff==FORWARD)

--- a/code/game/mecha/mecha_construction/firefighter.dm
+++ b/code/game/mecha/mecha_construction/firefighter.dm
@@ -229,7 +229,7 @@
 						"[usr] removes the wiring from [holder].", \
 						"You remove the wiring from [holder]."
 					)
-					new /obj/item/stack/cable_coil (get_turf(holder), 4)
+					new /obj/item/stack/cable_coil (get_turf(holder), 5)
 					holder.icon_state = "firefighter2"
 			if(16)
 				if(diff==FORWARD)

--- a/code/game/mecha/mecha_construction/gygax.dm
+++ b/code/game/mecha/mecha_construction/gygax.dm
@@ -267,7 +267,7 @@
 						"[usr] removes the wiring from [holder].", \
 						"You remove the wiring from [holder]."
 					)
-					new /obj/item/stack/cable_coil (get_turf(holder), 4)
+					new /obj/item/stack/cable_coil (get_turf(holder), 5)
 					holder.icon_state = "gygax2"
 			if(21)
 				if(diff==FORWARD)

--- a/code/game/mecha/mecha_construction/odysseus.dm
+++ b/code/game/mecha/mecha_construction/odysseus.dm
@@ -198,7 +198,7 @@
 						"[usr] removes the wiring from [holder].", \
 						"You remove the wiring from [holder]."
 					)
-					new /obj/item/stack/cable_coil (get_turf(holder), 4)
+					new /obj/item/stack/cable_coil (get_turf(holder), 5)
 					holder.icon_state = "odysseus2"
 			if(14)
 				if(diff==FORWARD)
@@ -347,7 +347,7 @@
 						"[usr] removes wire form [holder].", \
 						"You unscrews and take out wiring from [holder]."
 					)
-					new /obj/item/stack/cable_coil (get_turf(holder), 4)
+					new /obj/item/stack/cable_coil (get_turf(holder), 5)
 					holder.icon_state = "odysseus11"
 			if(3)
 				if(diff==FORWARD)

--- a/code/game/mecha/mecha_construction/phazon.dm
+++ b/code/game/mecha/mecha_construction/phazon.dm
@@ -177,7 +177,7 @@
 						"[usr] removes the wiring from the [holder].", \
 						"You remove the wiring from [holder]."
 					)
-					new /obj/item/stack/cable_coil (get_turf(holder), 4)
+					new /obj/item/stack/cable_coil (get_turf(holder), 5)
 					holder.icon_state = "phazon2"
 			if(20)
 				if(diff==FORWARD)

--- a/code/game/mecha/mecha_construction/ripley.dm
+++ b/code/game/mecha/mecha_construction/ripley.dm
@@ -221,7 +221,7 @@
 						"[usr] removes the wiring from [holder].", \
 						"You remove the wiring from [holder]."
 					)
-					new /obj/item/stack/cable_coil (get_turf(holder), 4)
+					new /obj/item/stack/cable_coil (get_turf(holder), 5)
 					holder.icon_state = "ripley2"
 			if(14)
 				if(diff==FORWARD)


### PR DESCRIPTION
## About The Pull Request
ALL, and I say all, of the other resources needed to make mechs are 5 sheets. Steel, Plasteel, Gold, Silver, if it was a stackable material, then you needed 5 sheet of it for that step.

So why the hell did you need 4 cable coils?! WHY?!

Anyway now each step that need cable now need five cable coils instead of the previous four.