### PR TITLE
New Church Litany: Word of Guidance aka Glow Book + Ritual book storage adjustment

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -39,6 +39,32 @@
 	H.adjustToxLoss(5)
 	return TRUE
 
+/datum/ritual/cruciform/base/glow_book
+	name = "Word of Guidance"
+	phrase = "Legem pone mihi, Domine, in via tua, et dirige me in semitam rectam, propter inimicos meos."
+	desc = "A prayer to light your way. It makes the ritual book you're holding glow brightly for fifteen minutes. "
+	power = 15
+	cooldown = TRUE
+	cooldown_time = 15 MINUTES
+	cooldown_category = "bglow"
+
+/datum/ritual/cruciform/base/glow_book/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
+	var/successful = FALSE
+	var/list/people_around = list()
+	if (istype(H.get_active_hand(), /obj/item/weapon/book/ritual/cruciform))
+		var/obj/item/weapon/book/ritual/cruciform/M = H.get_active_hand()
+		M.light_range = 5 //Slightly better than as a lantern since you can only hold it in hand or within the belt slot.
+		playsound(H.loc, 'sound/ambience/ambicha2.ogg', 50, 1)
+		for(var/mob/living/carbon/human/participant in people_around)
+			to_chat(participant, SPAN_NOTICE("The ritual book [H] is holding begins to glow with holy light!"))
+		to_chat(H, SPAN_NOTICE("The ritual book you are holding begins to glow with holy light!"))
+		spawn(9000) M.light_range = initial(M.light_range)
+		successful = TRUE
+		set_personal_cooldown(H)
+	else
+		to_chat(H, SPAN_DANGER("You need to be holding a ritual book to perfom this rite."))
+	return successful
+
 /datum/ritual/cruciform/base/flare
 	name = "Holy Light"
 	phrase = "Lucerna pedibus meis verbum tuum, et lumen semitis meis."

--- a/code/modules/core_implant/ritual_book.dm
+++ b/code/modules/core_implant/ritual_book.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/library.dmi'
 	icon_state = "book"
 	var/has_reference = FALSE
-
+	slot_flags = SLOT_BELT
 	var/expanded_group = null
 	var/current_category = "Common"
 	var/reference_mode = FALSE


### PR DESCRIPTION
What this PR adds:

1. A base litany that any cruciform bearer can access.
-Makes the book they are holding light up with light level 5
-Costs 15 energy, has 15 min cd, and lasts for 15 minutes
2. Allows the church's ritual book fit within the belt storage slot
Balance thoughts: The closest and easiest comparison is to a lantern. A lantern is easy to get, is slightly dimmer, but it fits into your pocket or the back slot of something you're wearing. The ritual book only fits into your belt slot, where a common tool belt or webbing would go, or has to be held in your hand. 
General thoughts: In general I think its a nice church-flavored addition which provides something useful+cool. If there is any thoughts/ideas/concerns let me know. It has been tested nearly entirely except for the AoE message. But I'm pretty certain that works as its mostly copied code. Other then that small thing everything else has been checked.