### PR TITLE
Word of Guidance litany bug fix & Entreaty stutter change

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -58,7 +58,7 @@
 			SPAN_NOTICE("The ritual book [H] is holding begins to emit light."),
 			SPAN_NOTICE("The ritual book you're holding begins to glow brightly.")
 		)
-		spawn(100) M.light_range = initial(M.light_range)
+		spawn(9000) M.light_range = initial(M.light_range)
 		successful = TRUE
 		set_personal_cooldown(H)
 	else

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -87,6 +87,7 @@
 	phrase = "Deus meus ut quid dereliquisti me."
 	desc = "Call for help, allowing other cruciform bearers to hear your cries."
 	power = 50
+	ignore_stuttering = TRUE
 
 /datum/ritual/cruciform/base/entreaty/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
 	for(var/mob/living/carbon/human/target in disciples)

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -50,15 +50,15 @@
 
 /datum/ritual/cruciform/base/glow_book/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
 	var/successful = FALSE
-	var/list/people_around = list()
 	if (istype(H.get_active_hand(), /obj/item/weapon/book/ritual/cruciform))
 		var/obj/item/weapon/book/ritual/cruciform/M = H.get_active_hand()
 		M.light_range = 5 //Slightly better than as a lantern since you can only hold it in hand or within the belt slot.
-		playsound(H.loc, 'sound/ambience/ambicha2.ogg', 50, 1)
-		for(var/mob/living/carbon/human/participant in people_around)
-			to_chat(participant, SPAN_NOTICE("The ritual book [H] is holding begins to glow with holy light!"))
-		to_chat(H, SPAN_NOTICE("The ritual book you are holding begins to glow with holy light!"))
-		spawn(9000) M.light_range = initial(M.light_range)
+		playsound(H.loc, 'sound/ambience/ambicha2.ogg', 75, 1)
+		H.visible_message(
+			SPAN_NOTICE("The ritual book [H] is holding begins to emit light."),
+			SPAN_NOTICE("The ritual book you're holding begins to glow brightly.")
+		)
+		spawn(100) M.light_range = initial(M.light_range)
 		successful = TRUE
 		set_personal_cooldown(H)
 	else


### PR DESCRIPTION
What this PR does:
For the Word of Guidance litany:
-Makes the litany properly display the message of your ritual book glowing to people around you. Previously it did not.
-This also increases the sound slightly since it was hard to hear.
For the Entreaty Litany:
-Added the bit where you can use it despite stuttering.
Reason: Considering the weight of using this litany where it lets every other cruciform bearer see where you are and that you're fucked its typically used at the last moment, at least in scenarios where I've have to do it. And during the last moments of being alive you're going to be stuttering. If you aren't stuttering, allowing you to use it, you're likely in a situation where you'll survive.
