### PR TITLE
Premier Can't Have Cruciform

### DIFF
--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -12,7 +12,8 @@
 		/datum/job/supsec,
 		/datum/job/inspector,
 		/datum/job/officer,
-		/datum/job/smc
+		/datum/job/smc,
+		/datum/job/premier
 		)
 	allowed_depts = CHURCH
 	allow_modifications = TRUE


### PR DESCRIPTION
The Premier is supposed to be as impartial as possible and can influence the outcome of events.

Much how every other council position outside of the Prime themselves can't have a cruciform, the Premier should also have this restriction. Church duties can easily conflict with the Premier's duties.

Tested and runs, works just as intended.