### PR TITLE
Bugfixes, Death penaltie increase

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -116,7 +116,7 @@
 /obj/item/weapon/spider_shadow_trap/proc/ambush(var/mob/living/M)
 	triggered = 1
 	playsound(src.loc, 'sound/sanity/screech.ogg', 300, 1)
-	M.Weaken(8)
+	M.Weaken(3)
 	new /mob/living/carbon/superior_animal/giant_spider/tarantula/emperor(src.loc)
 	qdel(src)
 
@@ -141,7 +141,7 @@
 /obj/item/weapon/spider_shadow_trap/burrowing/ambush(var/mob/living/M)
 	triggered = 1
 	playsound(src.loc, 'sound/effects/impacts/rumble2.ogg', 300, 1)
-	M.Weaken(8)
+	M.Weaken(3)
 	new /mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing(src.loc)
 	qdel(src)
 

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -516,8 +516,16 @@
 	M.updatehealth()
 	apply_brain_damage(M, deadtime)
 
+	if(!M.stats.getPerk(/datum/perk/rezsickness))
+		M.stats.changeStat(STAT_MEC, -15)
+		M.stats.changeStat(STAT_BIO, -15)
+		M.stats.changeStat(STAT_COG, -15)
+		M.stats.changeStat(STAT_ROB, -15)
+		M.stats.changeStat(STAT_TGH, -15)
+		M.stats.changeStat(STAT_VIG, -15)
+
 	switch(M.stats.getStat(STAT_TGH))
-		if(0 to 40)
+		if(-200 to 40)
 			M.stats.addPerk(/datum/perk/rezsickness/severe/fatal)
 			log_debug("Try to add mild rez sickness.")
 		if(40 to 60)

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -259,7 +259,7 @@
 	max_upgrades = 4
 
 /obj/item/weapon/tool/knife/dagger/bluespace
-	name = "/improper Soteria \"Displacement Dagger\""
+	name = "\improper Soteria \"Displacement Dagger\""
 	desc = "A teleportation matrix attached to a dagger, for sending things you stab it into very far away."
 	icon_state = "bluespace_dagger"
 	item_state = "bluespace_dagger"
@@ -563,6 +563,7 @@
 	desc = "A battery powered hydraulic combat gauntlet designed for extended operations where close combat and muscles matter most."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "powerfist"
+	item_state = "powerfist"
 	toggleable = TRUE
 	worksound = WORKSOUND_HAMMER
 	switched_on_force = WEAPON_FORCE_BRUTAL

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -283,7 +283,7 @@
 	log_and_message_admins("performed an ire litany")
 	for(var/mob/living/victim in view(user))
 		if(!victim.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform))
-			if(prob(100 - victim.stats.getStat(STAT_VIG)))
+			if(prob(100 - (victim.stats.getStat(STAT_VIG) * 3)))
 				to_chat(victim, SPAN_WARNING("You feel a blast of energy that knocks you down!"))
 				victim.Stun(3)
 				victim.Weaken(3)

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -1330,8 +1330,8 @@
 
 /datum/seed/shand
 	name = "shand"
-	seed_name = "Mercy's hand"
-	display_name = "Mercy's hand leaves"
+	seed_name = "mercy's hand"
+	display_name = "mercy's hand leaves"
 	chems = list("bicaridine" = list(1,10), "anti_toxin" = list(1,10))
 	kitchen_tag = "shand"
 
@@ -1350,8 +1350,8 @@
 
 /datum/seed/mtear
 	name = "mtear"
-	seed_name = "Sun tear"
-	display_name = "Sun tear leaves"
+	seed_name = "sun tear"
+	display_name = "sun tear leaves"
 	chems = list("honey" = list(1,10), "kelotane" = list(3,5))
 	kitchen_tag = "mtear"
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -14,9 +14,9 @@
 		var/turf/T = loc
 		if(T.get_lumcount() < 0.6)
 			if(stats.getPerk(PERK_NIGHTCRAWLER))
-				tally += 0.5
+				tally -= 0.5
 			else if(see_invisible != SEE_INVISIBLE_NOLIGHTING)
-				tally += 0.5
+				tally -= 0.5
 	if(stats.getPerk(PERK_FAST_WALKER))
 		tally -= 0.5
 	if(stats.getPerk(PERK_SCUTTLEBUG))
@@ -26,9 +26,10 @@
 
 	var/health_deficiency = (maxHealth - health)
 	var/hunger_deficiency = (MOB_BASE_MAX_HUNGER - nutrition)
-	if(!species.reagent_tag == IS_SYNTHETIC)
-		if(hunger_deficiency >= 200) tally += (hunger_deficiency / 100) //If youre starving, movement slowdown can be anything up to 4.
-	if(health_deficiency >= 40) tally += (health_deficiency / 25)
+	if((hunger_deficiency >= 200) && species.reagent_tag != IS_SYNTHETIC)
+		tally += (hunger_deficiency / 100) //If youre starving, movement slowdown can be anything up to 4.
+	if(health_deficiency >= 40)
+		tally += (health_deficiency / 25)
 
 	if (!(species && (species.flags & NO_PAIN)))
 		if(halloss >= 10) tally += (halloss / 20) //halloss shouldn't slow you down if you can't even feel it

--- a/code/modules/projectiles/guns/oddity_items.dm
+++ b/code/modules/projectiles/guns/oddity_items.dm
@@ -118,7 +118,7 @@
 	desc = "An anomalous weapon created by an unknown person (or group?), their work marked by a blue cross, these weapons are known to vanish and reappear when left alone. \
 			The weapon's loading port seems skillfully enlarged to allow larger rounds to be loaded into the rifle of .06-06 caliber! \
 			Wild-west styled antimaterial rifle.. who would have thought?"
-	iocn = 'icons/obj/guns/projectile/lever.dmi'
+	icon = 'icons/obj/guns/projectile/lever.dmi'
 	icon_state = "armstrong"
 	item_state = "armstrong"
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_SCOPE)


### PR DESCRIPTION
-Nerfed knockdown timers on spider traps. Now its 3, down from 8.
-Ire litany is now immensely more easy to resist, with the math being 100% - Vigilance * 3 (minimum 34 to be immune).
-Corrected some typos's in seed datums and bluespace daggers.
-Dying without the rez sickness perk now gives you a permanant -15 to all stats before assigning rez sickness.
-Added an experimental untested function that should fix the issue with low nutrition not slowing you down.
-Powerfist now has a working in-hand sprite when turned on.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
