### PR TITLE
Comment out assisted organs.

### DIFF
--- a/code/modules/organs/body_modifications.dm
+++ b/code/modules/organs/body_modifications.dm
@@ -223,7 +223,7 @@ var/global/list/modifications_types = list(
 		return new replace_limb(holder)
 	else
 		return new organ(holder)
-
+/* Commented out due to no way to differenciate them.
 /datum/body_modification/organ/assisted
 	name = "Assisted organ"
 	short_name = "P: assisted"
@@ -237,7 +237,7 @@ var/global/list/modifications_types = list(
 	I.min_bruised_damage = 15
 	I.min_broken_damage = 35
 	return I
-
+*/
 
 /datum/body_modification/organ/robotize_organ
 	name = "Robotic organ"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Assisted organs are dumb. This remove Assisted Organs

They are repaired like prosthetic organs.
BUT
They aren't affected by EMP like prosthetic organs are.
AND
They get healed/hurt by chems like organic organs.

Not to mention that they aren't mentionned ANYWHERE in the code. Even the Prosthetic organs had 1-2 actual organs coded in.

If you have assisted organs on your characters, fear not! For it shall automatically revert them to organic organs. I tested it.
It will also prevent you from selecting them again.