### PR TITLE
ports an eris fix to roach revival 6245 - By Hatterhat 

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
@@ -15,14 +15,26 @@
 /datum/reagent/toxin/blattedin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(istype(M, /mob/living/carbon/superior_animal/roach))
 		var/mob/living/carbon/superior_animal/roach/bug = M
-		if(bug.stat == DEAD)
-			if((bug.blattedin_revives_left >= 0) && prob(70))//Roaches sometimes can come back to life from healing vapors
-				bug.blattedin_revives_left = max(0, bug.blattedin_revives_left - 1)
-				bug.rejuvenate()
-		else
-			bug.heal_organ_damage(heal_strength*removed)
+		bug.heal_organ_damage(heal_strength*removed)
 	else if(M.species?.reagent_tag == IS_CHTMANT)
 		M.adjustOxyLoss(-0.6)
 		M.heal_organ_damage(0.3)
 		M.adjustToxLoss(-0.3)
 		M.add_chemical_effect(CE_BLOODCLOT, 0.1)
+	else
+		. = ..()
+
+/datum/reagent/toxin/blattedin/on_mob_add(mob/living/L)
+	..()
+	if(istype(L, /mob/living/carbon/superior_animal/roach))
+		var/mob/living/carbon/superior_animal/roach/bug = L
+		if(bug.stat == DEAD)
+			if((bug.blattedin_revives_left >= 0) && prob(70))//Roaches sometimes can come back to life from healing vapors
+				bug.visible_message("<b>\The [bug.name]</b> twitches as it comes back to life!")
+				blattedin_revive(bug)
+
+/datum/reagent/toxin/blattedin/proc/blattedin_revive(var/mob/living/carbon/superior_animal/roach/bug)
+	bug.blattedin_revives_left = max(0, bug.blattedin_revives_left - 1)
+	bug.rejuvenate()
+
+


### PR DESCRIPTION

## About The Pull Request
About The Pull Request
did you know there was code that gave roaches a 70% chance to revive with blattedin...
but it didn't work because the code to run it would only run when the bug was alive, meaning that there was no way to revive with it

this fixes that.
idea: giving roaches a way to revive a few seconds after getting beat to shit if they have blattedin in their corpse (callback?)

Why It's Good For The Game
bugs about bugs should be fixed

Changelog
🆑
fix: Roaches now actually have their 70% chance to revive if they have blattedin injected into their corpses.
/🆑