### PR TITLE
sometimes good things can not be had

### DIFF
--- a/code/modules/reagents/recipes/recipes.dm
+++ b/code/modules/reagents/recipes/recipes.dm
@@ -417,7 +417,7 @@
 
 /datum/chemical_reaction/explosion_potassium/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
-	e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
+	e.set_up(round (created_volume/45, 1), holder.my_atom, 0, 0) // 600/45 = 13.3 , 13/3 = 4-3 light-range , slightly weaker than a cracker.
 	if(isliving(holder.my_atom))
 		e.amount *= 0.5
 		var/mob/living/L = holder.my_atom
@@ -480,7 +480,7 @@
 
 /datum/chemical_reaction/nitroglycerin/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/datum/effect/effect/system/reagents_explosion/e = new()
-	e.set_up(round (created_volume/2, 1), holder.my_atom, 0, 0)
+	e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
 	if(isliving(holder.my_atom))
 		e.amount *= 0.5
 		var/mob/living/L = holder.my_atom


### PR DESCRIPTION

## About The Pull Request
Eris had this one right
MLGTASTICa - Water/Pot reaction explosions now get divided by 45 instead of 10 , at 600 reaction amount (bluespace beakers) resulting in a explosion slightly weaker than a cracker.
Trilby - Now makes it so nytro bombs devide by 10 rather then 2 making it not as easy to spam 127 tile bombs

## Changelog
:cl:
/:cl:
