### PR TITLE
biomatter spills no longer hide under floors

### DIFF
--- a/code/modules/biomatter_manipulation/toxic_biomass.dm
+++ b/code/modules/biomatter_manipulation/toxic_biomass.dm
@@ -37,6 +37,7 @@
 	icon = 'icons/obj/bioreactor_misc.dmi'
 	icon_state = "biomass-1"
 	anchored = TRUE
+	layer = TURF_LAYER + 0.6
 
 
 /obj/effect/decal/cleanable/solid_biomass/Initialize()


### PR DESCRIPTION

## About The Pull Request
Did you know that if you spill biomatter on some floor tiles it vanishes! Cool right?
Well not for when people stop and stare at someone and then falls over dead

## Changelog
:cl:
/:cl:
