### PR TITLE
mecha wreckage no longer hides

### DIFF
--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -10,7 +10,7 @@
 	density = 1
 	anchored = 0
 	opacity = 0
-	layer = BELOW_MOB_LAYER
+	layer = TURF_LAYER + 0.6
 	var/list/welder_salvage = list(/obj/item/stack/material/plasteel,/obj/item/stack/material/steel,/obj/item/stack/rods)
 	var/list/wirecutters_salvage = list(/obj/item/stack/cable_coil)
 	var/list/crowbar_salvage


### PR DESCRIPTION

## About The Pull Request
Mechs no longer when broke hide under things like catwalks or floors making an invisible shield basically 

## Changelog
:cl:
/:cl: