### PR TITLE
Allows other species to use facial hair.

### DIFF
--- a/code/modules/sprite_accessories/_accessory_facial.dm
+++ b/code/modules/sprite_accessories/_accessory_facial.dm
@@ -9,6 +9,17 @@
 /datum/sprite_accessory/facial_hair
 	icon = 'icons/mob/human_races/species/human/facial.dmi'
 	gender = MALE // barf (unless you're a dorf, dorfs dig chix /w beards :P)
+	species_allowed = list(
+		SPECIES_HUMAN,
+		FORM_MARQUA,
+		FORM_SABLEKYNE,
+		FORM_KRIOSAN,
+		FORM_AKULA,
+		FORM_CHTMANT,
+		FORM_CINDAR,
+		FORM_NARAMAD,
+		FORM_OPIFEX
+		)
 
 /datum/sprite_accessory/facial_hair/shaved
 	name = "Shaved"
@@ -170,12 +181,12 @@
 	name = "Cindarite Chin Horn"
 	icon_state = "facial_chinhorns_s"
 	gender = NEUTER
-
+/* Does not properly work. Probably broken icon state or something. Commented out due to being worthless. -Intense Skies
 /datum/sprite_accessory/facial_hair/una_hornadorns
 	name = "Cindarite Horn Adorns"
 	icon_state = "facial_hornadorns_s"
 	gender = NEUTER
-
+*/
 /datum/sprite_accessory/facial_hair/una_spinespikes
 	name = "Cindarite Spine Spikes"
 	icon_state = "facial_spikes_s"


### PR DESCRIPTION
What this PR does:
-Adds the same line of code hair has to allow all species to use it. (Although its not necessary for them.)
-Comments out cindarite horn adorns as they did not do anything
Reason: Some species had species specific facial hair options which are not available to them due to it being locked out.
Simple adjustment for now. Perhaps at a later time I'll take look at a lot of these which are commented out and see if they can be fixed.