### PR TITLE
Fixes penance, improves the hands of mercy, nerfs the light producing litanies, and spelling fix

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -42,10 +42,10 @@
 /datum/ritual/cruciform/base/glow_book
 	name = "Word of Guidance"
 	phrase = "Legem pone mihi, Domine, in via tua, et dirige me in semitam rectam, propter inimicos meos."
-	desc = "A prayer to light your way. It makes the ritual book you're holding glow brightly for fifteen minutes. "
-	power = 15
+	desc = "A prayer to light your way. It makes the ritual book you're holding glow brightly for ten minutes. "
+	power = 10 //Cost correlates to duration
 	cooldown = TRUE
-	cooldown_time = 15 MINUTES
+	cooldown_time = 10 MINUTES
 	cooldown_category = "bglow"
 
 /datum/ritual/cruciform/base/glow_book/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
@@ -58,7 +58,7 @@
 			SPAN_NOTICE("The ritual book [H] is holding begins to emit light."),
 			SPAN_NOTICE("The ritual book you're holding begins to glow brightly.")
 		)
-		spawn(9000) M.light_range = initial(M.light_range)
+		spawn(6000) M.light_range = initial(M.light_range)
 		successful = TRUE
 		set_personal_cooldown(H)
 	else
@@ -68,16 +68,16 @@
 /datum/ritual/cruciform/base/flare
 	name = "Holy Light"
 	phrase = "Lucerna pedibus meis verbum tuum, et lumen semitis meis."
-	desc = "Litany of pilgrims that creates a small light for about half an hour."
-	power = 30 //Cheap but not too cheap. Pretty powerful to light up a location for 30 mins.
+	desc = "Litany of pilgrims that creates a small light for about twenty minutes."
+	power = 20 //Cost correlates to duration.
 	cooldown = TRUE
-	cooldown_time = 1 MINUTES
+	cooldown_time = 2 MINUTES
 	cooldown_category = "flare"
 
 /datum/ritual/cruciform/base/flare/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
 	playsound(H.loc, 'sound/effects/snap.ogg', 50, 1)
 	new /obj/effect/sparks(H.loc)
-	new /obj/effect/effect/smoke/illumination(H.loc, brightness=max(6), lifetime=30000) //About the same brightness as a lantern and its almost free!
+	new /obj/effect/effect/smoke/illumination(H.loc, brightness=max(6), lifetime=12000) //About the same brightness as a lantern and its almost free!
 	set_personal_cooldown(H)
 	return TRUE
 


### PR DESCRIPTION
What this PR does in a listed fashion:
1. Fixes a bug with the penance litany where it did not work.
2. Hands of Mercy aka Pain relief litany has its effect buffed. Previously it gave the pain killer effect of 15 making it effectively useless for a litany that only Devout get. Now it has been improved to give 50. For reference the self-pain relief any church member gets is only 30. 
3. The light up litanies have been both nerfed. The duration of Words of Guidance has been lowered from 15 to 10. The duration of Holy Light has been lowered from (mistakenly) 50 minutes to 20. The cost of these correlate to the duration.
4. Also a minor spelling mistake fixed.