### PR TITLE
Add farming multitool

### DIFF
--- a/code/game/objects/items/devices/organ_module/active/multitool/farmer.dm
+++ b/code/game/objects/items/devices/organ_module/active/multitool/farmer.dm
@@ -1,0 +1,11 @@
+/obj/item/organ_module/active/multitool/farmer
+	name = "embedded farming multitool"
+	desc = "A specialized farming multitool. Includes everything a farmer would need, like a plant analyzer, a minihoe, a spade, a bucket, and a bag."
+	verb_name = "Deploy farming tool"
+	items = list(
+		/obj/item/device/scanner/plant,
+		/obj/item/weapon/tool/minihoe,
+		/obj/item/weapon/tool/shovel/spade,
+		/obj/item/weapon/reagent_containers/glass/bucket,
+		/obj/item/weapon/storage/bag/produce,
+	)

--- a/code/game/objects/items/devices/scanners/plant.dm
+++ b/code/game/objects/items/devices/scanners/plant.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "hydro"
 	item_state = "analyzer"
+	charge_per_use = 0 //It need to be 0 for the Green Thumb perk to work
 
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 

--- a/code/modules/research/designs/prosthesis_implants.dm
+++ b/code/modules/research/designs/prosthesis_implants.dm
@@ -120,6 +120,10 @@ the lims and such to pull out the internal bits for other people if needed
 	name = "Embedded Mining Multitool"
 	build_path = /obj/item/organ_module/active/multitool/miner
 
+/datum/design/research/item/mechfab/modules/multitool/farmer
+	name = "Embedded Farming Multitool"
+	build_path = /obj/item/organ_module/active/multitool/farmer
+
 //Implants
 /datum/design/research/item/implant
 	build_type = PROTOLATHE | MECHFAB

--- a/code/modules/research/nodes/biotech.dm
+++ b/code/modules/research/nodes/biotech.dm
@@ -279,6 +279,7 @@
 							/datum/design/research/item/mechfab/modules/multitool/surgical,
 							/datum/design/research/item/mechfab/modules/multitool/engineer,
 							/datum/design/research/item/mechfab/modules/multitool/miner,
+							/datum/design/research/item/mechfab/modules/multitool/farmer,
 							/datum/design/research/item/mechfab/prosthesis_moebius/r_arm,
 							/datum/design/research/item/mechfab/prosthesis_moebius/l_arm,
 							/datum/design/research/item/mechfab/prosthesis_moebius/r_leg,

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -905,6 +905,7 @@
 #include "code\game\objects\items\devices\organ_module\active\multitool.dm"
 #include "code\game\objects\items\devices\organ_module\active\pouch.dm"
 #include "code\game\objects\items\devices\organ_module\active\surgical.dm"
+#include "code\game\objects\items\devices\organ_module\active\multitool\farmer.dm"
 #include "code\game\objects\items\devices\organ_module\active\multitool\miner.dm"
 #include "code\game\objects\items\devices\organ_module\passive\armor.dm"
 #include "code\game\objects\items\devices\organ_module\passive\muscle.dm"


### PR DESCRIPTION
## About The Pull Request
In preparation to the Church FBP, this pr add a researchable implantable Farming Multitool.

It act like the mining multitool, with instead of a single omnitool like the Medical or Engineering implant, it got multiple tools you can choose from.

It got a plant scanner, a minihoe, a bucket, a plant bag and a spade.


I also profited of the occassion to clearly indicate in the code why the plant analyzer take no power.