### PR TITLE
Church Sword Sheath Adjustment + Printable church backpacks

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -37,9 +37,9 @@
 	name = "Cardboard"
 	build_path = /obj/item/stack/material/cardboard/random // I guess it depends on the protein content.
 */
-/datum/design/bioprinter/storage/sheath
-	name = "sheath"
-	build_path = /obj/item/weapon/storage/sheath
+/datum/design/bioprinter/leather/holster/saber/greatsword/churchprint
+	name = "Absolutist Sword Scabbard"
+	build_path = /obj/item/clothing/accessory/holster/saber/greatsword/churchprint
 
 /datum/design/bioprinter/wallet
 	name = "Wallet"
@@ -56,6 +56,18 @@
 /datum/design/bioprinter/leather/satchel
 	name = "Leather Satchel"
 	build_path = /obj/item/weapon/storage/backpack/satchel
+
+/datum/design/bioprinter/leather/storage/backpack/satchel/neotheology
+	name = "Cruciform  Satchel"
+	build_path = /obj/item/weapon/storage/backpack/satchel/neotheology
+
+/datum/design/bioprinter/leather/storage/backpack/neotheology
+	name = "Cruciform Backpack"
+	build_path = /obj/item/weapon/storage/backpack/neotheology
+
+/datum/design/bioprinter/leather/storage/backpack/sport/neotheology
+	name = "Cruciform Sport Backpack"
+	build_path = /obj/item/weapon/storage/backpack/sport/neotheology
 
 /datum/design/bioprinter/leather/leather_jacket
 	name = "Leather jacket"

--- a/code/game/objects/items/weapons/autolathe_disk/absolute_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/absolute_disks.dm
@@ -18,7 +18,6 @@
 		//general clothes
 		/datum/design/bioprinter/wallet,
 		/datum/design/bioprinter/botanic_leather,
-		/datum/design/bioprinter/leather/satchel,
 		/datum/design/bioprinter/leather/leather_jacket,
 		/datum/design/bioprinter/belt/utility,
 		/datum/design/bioprinter/belt/medical,
@@ -34,6 +33,10 @@
 		/datum/design/bioprinter/nt_clothes/hermes_shoes,
 		//medical
 		/datum/design/autolathe/firstaid/nt,
+		//backpacks
+		/datum/design/bioprinter/leather/storage/backpack/satchel/neotheology,
+		/datum/design/bioprinter/leather/storage/backpack/neotheology,
+		/datum/design/bioprinter/leather/storage/backpack/sport/neotheology,
 		//pouches
 		/datum/design/bioprinter/pouch/engineering_supply,
 		/datum/design/bioprinter/pouch/engineering_tools,
@@ -282,7 +285,7 @@
 		/datum/design/bioprinter/nt_clothes/hermes_shoes,
 		/datum/design/bioprinter/belt/security/neotheology,
 		//holsters
-		/datum/design/bioprinter/storage/sheath,
+		/datum/design/bioprinter/leather/holster/saber/greatsword/churchprint,
 		/datum/design/bioprinter/leather/holster,
 		/datum/design/bioprinter/leather/holster/armpit,
 		/datum/design/bioprinter/leather/holster/waist,

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -198,6 +198,28 @@ Sword holsters
 /obj/item/clothing/accessory/holster/saber/greatsword/occupied/Initialize()
 	holstered = new holstered_spawn
 
+//Subtype which is for printing from the biomachine
+/obj/item/clothing/accessory/holster/saber/greatsword/churchprint
+	name = "Absolutist Sword Scabbard"
+	desc = "A sturdy brown leather scabbard with gold trim. Perfectly designed for holding weapons to fight against the enemies of the Church."
+	icon_state = "crusader_holster"
+	overlay_state = "crusader"
+	can_hold = list(
+		/obj/item/weapon/tool/sword/nt,
+		/obj/item/weapon/tool/sword/crusader
+		)
+
+/obj/item/clothing/accessory/holster/saber/greatsword/churchprint/update_icon()
+	..()
+	cut_overlays()
+	if(contents.len)
+		add_overlay(image('icons/inventory/accessory/icon.dmi', "crusader_layer"))
+
+/obj/item/clothing/accessory/holster/saber/greatsword/churchprint/occupied
+	var/holstered_spawn = /obj/item/weapon/tool/sword/crusader
+
+/obj/item/clothing/accessory/holster/saber/greatsword/churchprint/occupied/Initialize()
+	holstered = new holstered_spawn
 
 
 


### PR DESCRIPTION
What this PR does:
-Removes the sheath storage from the bioprinter disk
-Adds a better version to it "Absolutist Sword Scabbard"
-Adds all of the cruciform backpack types (satchel, normal backpack, and sport) to the church bio printer disk
-Removes the plain black satchel from the bio printer disk
The better version has the following attributes:
--It goes on clothing like other holsters (why it was added)
--Holds NT swords
--Holds crusader sword
Reason for this change: The previous sword sheath was useless. Sword sheaths can only fit on belt slots. Swords can also fit on belt slots. There is no point to make one or use it at all. So this change make it useful with it fitting onto uniforms. 
All has been generally tested and works appropriately.