### PR TITLE
Bugfix: Mad Scientist Costume Kit

### DIFF
--- a/code/game/objects/items/weapons/storage/costume.dm
+++ b/code/game/objects/items/weapons/storage/costume.dm
@@ -214,9 +214,9 @@
 	desc = "A box containing a mad scientist costume."
 
 /obj/item/weapon/storage/box/costume/madscientist/populate_contents()
-	new /obj/item/clothing/head/costume/halloween/mad
-	new /obj/item/clothing/suit/costume/halloween/madscientist
-	new /obj/item/clothing/under/scrubs/purple
+	new /obj/item/clothing/head/costume/halloween/mad(src)
+	new /obj/item/clothing/suit/costume/halloween/madscientist(src)
+	new /obj/item/clothing/under/scrubs/purple(src)
 
 /obj/item/weapon/storage/box/costume/mailman
 	name = "mailman costume kit"


### PR DESCRIPTION
What this PR does:
-Fixes the Mad Scientist Costume kit (purchaseable from the Portable Stage vendor).
Previously it did not get the items in it. Now it works properly and gets the contents.