### PR TITLE
Naramad Background Addition

### DIFF
--- a/code/datums/setup_option/backgrounds/origin.dm
+++ b/code/datums/setup_option/backgrounds/origin.dm
@@ -360,6 +360,25 @@
 		STAT_COG = -10
 	)
 
+/datum/category_item/setup_option/background/ethnicity/naramadnorth
+	name = "Northern Naramad"
+	desc = "The northern naramad has a more simplistic mind compared to its sister species. \
+			Having grown up in large communal families on Norian the northern naramadi hold a general if not extreme distrust of all non-Naramadi. \
+			And on the other end of the spectrum they bond more easily with fellow naramdi and will perform greater acts of self-sacrifice for each other. \
+			Northern naramdi are considered the best for manual within Sol Federation's military or alternatively within the rich mines upon their homeworld. \
+			Their simpler lives outside of their mandatory service is focused more farming, growing food, menial labor, and care for each other. \
+			Once their service is finished, it is rare for this group that is so dependant and comfortable around their own to not return home."
+
+	restricted_to_species = list(FORM_NARAMAD)
+
+	stat_modifiers = list(
+		STAT_ROB = 0,
+		STAT_TGH = 10,
+		STAT_VIG = -10,
+		STAT_BIO = 5,
+		STAT_MEC = 0,
+		STAT_COG = -5
+	)
 
 /datum/category_item/setup_option/background/ethnicity/naramadsouth
 	name = "Southern Naramad"


### PR DESCRIPTION
What this PR does:
-Adds in the Northern Naramad background including blurb, limitation to naramad, and stat changes.
Why? Its on the lore page so I don't see why it shouldn't be an in game thing.
Stat changes are rather simple:
+10 TGH
-10 VIG
+5 BIO
-5 COG
Rather light changes compared to others. Free to adjust at a later time but at least its in and can be picked.
Tested and works appropriately.