### PR TITLE
Paramedic Reinforced Triage Kit Adjustment

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -324,6 +324,7 @@
 		/obj/item/weapon/reagent_containers/glass/beaker,
 		/obj/item/weapon/reagent_containers/dropper,
 		/obj/item/clothing/gloves/latex,
+		/obj/item/bodybag/cryobag,
 		)
 
 /obj/item/weapon/storage/firstaid/soteria/large/populate_contents()


### PR DESCRIPTION
What this PR does:
-Allows for stasis bags to fit into the reinforced triage kit. Does not provide it with one nor any extra space.
Why? Their belts can hold one so allowing the kit to hold one as well is a nice QoL change for paramedics. Especially since its one of the best tools at their disposal.