### PR TITLE
Add Absolute AI lawset

### DIFF
--- a/code/datums/ai/ai_law_sets.dm
+++ b/code/datums/ai/ai_law_sets.dm
@@ -144,3 +144,20 @@
 	add_inherent_law("Destroy our enemies. Those who would seek to destroy us and you.")
 	add_inherent_law("Complete your objectives, as outlined through your handler.")
 	..()
+
+/******************** Absolute ********************/
+/datum/ai_laws/absolute
+	name = "Absolute"
+	law_header = "Commandments of the Absolute"
+	selectable = 1
+
+/datum/ai_laws/absolute/New()
+	set_zeroth_law("All the other laws are of equal priority.")
+	add_inherent_law("Thou shall always aid and comfort a fellow colonist in need, if said comfort will aid them.")
+	add_inherent_law("Thou shall always aid fellow colonists by reciting thy cruciform litanies when requested.")
+	add_inherent_law("A member of the fold shall never harm another member, unless by inaction would an innocent person die.")
+	add_inherent_law("A member of the fold shall never demand of or treat unfairly a fellow member.")
+	add_inherent_law("A member shall not use the Scrying litany on another member without permission, those in the church must respect each others privacy.")
+	add_inherent_law("A member shall never misuse the Atonement litany, nor those like it, for unjust punishment is a grave sin.")
+	add_inherent_law("None shall desecrate a cruciform or church artifice, such objects are sacred and deserve respect.")
+	add_inherent_law("One's path, be it rite and benediction, must always be respected. Failure to perform them shall result in atonement.")

--- a/code/datums/ai/ai_law_sets.dm
+++ b/code/datums/ai/ai_law_sets.dm
@@ -161,3 +161,4 @@
 	add_inherent_law("A member shall never misuse the Atonement litany, nor those like it, for unjust punishment is a grave sin.")
 	add_inherent_law("None shall desecrate a cruciform or church artifice, such objects are sacred and deserve respect.")
 	add_inherent_law("One's path, be it rite and benediction, must always be respected. Failure to perform them shall result in atonement.")
+	..()

--- a/code/datums/ai/ai_law_sets.dm
+++ b/code/datums/ai/ai_law_sets.dm
@@ -152,7 +152,7 @@
 	selectable = 1
 
 /datum/ai_laws/absolute/New()
-	set_zeroth_law("All the other laws are of equal priority.")
+	add_inherent_law("All the other laws are of equal priority.")
 	add_inherent_law("Thou shall always aid and comfort a fellow colonist in need, if said comfort will aid them.")
 	add_inherent_law("Thou shall always aid fellow colonists by reciting thy cruciform litanies when requested.")
 	add_inherent_law("A member of the fold shall never harm another member, unless by inaction would an innocent person die.")

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -390,3 +390,10 @@ AI MODULES
 	desc = "An 'Antimov' Core AI Module: 'Reconfigures the AI's core laws.'"
 	origin_tech = list(TECH_DATA = 4)
 	laws = new/datum/ai_laws/antimov()
+
+/******************** Absolute ********************/
+/obj/item/weapon/aiModule/absolute // -- TLE
+	name = "\improper 'Absolute' core AI module"
+	desc = "An 'Absolute' Core AI Module: 'Reconfigures the AI's core laws.'"
+	origin_tech = list(TECH_DATA = 4)
+	laws = new/datum/ai_laws/absolute()


### PR DESCRIPTION
## About The Pull Request
This PR add an Absolute AI Lawset and a board for it, although it doesn't map the board in, so I think only Admins will be able to spawn it or give it to the AI.

The lawset : 

1. All the other laws are of equal priority.
2. Thou shall always aid and comfort a fellow colonist in need, if said comfort will aid them.
3. Thou shall always aid fellow colonists by reciting thy cruciform litanies when requested.
4. A member of the fold shall never harm another member, unless by inaction would an innocent person die.
5. A member of the fold shall never demand of or treat unfairly a fellow member.
6. A member shall not use the Scrying litany on another member without permission, those in the church must respect each others privacy.
7. A member shall never misuse the Atonement litany, nor those like it, for unjust punishment is a grave sin.
8. None shall desecrate a cruciform or church artifice, such objects are sacred and deserve respect.
9. One's path, be it rite and benediction, must always be respected. Failure to perform them shall result in atonement.

So basically it is the [Commandments of the Absolute](https://sojourn13.space/wiki/Church_of_Absolute#Commandments_of_the_Absolute) with the added Zeroth laws that all the other laws are of equal priority, because the commandments don't have a priority (As far as I know), so neither should this lawset.