### PR TITLE
Make the skeleton no longer dense

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -113,6 +113,7 @@
 	icon_state = "hangskele"
 	desc = "It's an anatomical model of a human skeletal system made of plaster."
 	anchored = 0
+	density = 0
 
 /obj/structure/showcase/horrific_experiment_cryo
 	name = "horrific experiment"


### PR DESCRIPTION
## About The Pull Request
This make the handing skeletong model no longer a dense object.

It was just annoying and in the way of the filling cabinet Medical use to store paperwork.