### PR TITLE
mod and gun balance

### DIFF
--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -42,8 +42,8 @@
 		UPGRADE_HEALTH_THRESHOLD = 10
 		)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_FIRE_DELAY_MULT = 0.8,
-		GUN_UPGRADE_STEPDELAY_MULT = 0.8
+		GUN_UPGRADE_FIRE_DELAY_MULT = 0.9,
+		GUN_UPGRADE_STEPDELAY_MULT = 0.9
 	)
 	I.prefix = "heatsunk"
 	I.req_fuel_cell = REQ_FUEL_OR_CELL
@@ -104,8 +104,8 @@
 		UPGRADE_FUELCOST_MULT = 1.05
 		)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_FIRE_DELAY_MULT = 0.6,
-		GUN_UPGRADE_STEPDELAY_MULT = 0.6
+		GUN_UPGRADE_FIRE_DELAY_MULT = 0.8,
+		GUN_UPGRADE_STEPDELAY_MULT = 0.8
 	)
 	I.prefix = "plasma-cooled"
 	I.req_fuel_cell = REQ_FUEL_OR_CELL
@@ -180,8 +180,8 @@
 	UPGRADE_COLOR = "#FF4444"
 	)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_FIRE_DELAY_MULT = 0.8,
-		GUN_UPGRADE_STEPDELAY_MULT = 0.8,
+		GUN_UPGRADE_FIRE_DELAY_MULT = 0.75,
+		GUN_UPGRADE_STEPDELAY_MULT = 0.75,
 		GUN_UPGRADE_OFFSET = 7,
 		GUN_UPGRADE_RECOIL = 1.3,
 		UPGRADE_COLOR = "#FF4444"
@@ -202,7 +202,7 @@
 	I.tool_upgrades = list(
 	UPGRADE_WORKSPEED = 0.15,
 	UPGRADE_PRECISION = 5,
-	UPGRADE_FORCE_MULT = 1.15
+	UPGRADE_FORCE_MULT = 1.1
 	)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_MELEE_DAMAGE = 1.3,
@@ -225,7 +225,7 @@
 	I.tool_upgrades = list(
 	UPGRADE_WORKSPEED = 0.25,
 	UPGRADE_DEGRADATION_MULT = 0.85,
-	UPGRADE_FORCE_MULT = 1.10,
+	UPGRADE_FORCE_MULT = 1.1,
 	)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_MELEE_DAMAGE = 1.2,
@@ -247,7 +247,7 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.tool_upgrades = list(
 	UPGRADE_WORKSPEED = 0.20,
-	UPGRADE_FORCE_MULT = 1.15,
+	UPGRADE_FORCE_MULT = 1.1,
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_HEALTH_THRESHOLD = -10
 	)
@@ -266,7 +266,7 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.tool_upgrades = list(
 	UPGRADE_WORKSPEED = 0.5,
-	UPGRADE_FORCE_MULT = 1.15,
+	UPGRADE_FORCE_MULT = 1.1,
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_POWERCOST_MULT = 1.35,
 	UPGRADE_FUELCOST_MULT = 1.35,
@@ -323,7 +323,7 @@
 	UPGRADE_FUELCOST_MULT = 1.25
 	)
 	I.weapon_upgrades = list(
-	GUN_UPGRADE_DAMAGE_MULT = 1.25,
+	GUN_UPGRADE_DAMAGE_MULT = 1.20,
 	GUN_UPGRADE_CHARGECOST = 1.35
 	)
 	I.prefix = "boosted"
@@ -429,6 +429,8 @@
 	UPGRADE_HEALTH_THRESHOLD = 10
 	)
 	I.weapon_upgrades = list(
+		GUN_UPGRADE_FIRE_DELAY_MULT = 0.95,
+		GUN_UPGRADE_STEPDELAY_MULT = 0.95,
 		GUN_UPGRADE_MUZZLEFLASH = 0.8,
 		GUN_UPGRADE_RECOIL = 0.8,
 		GUN_UPGRADE_DAMAGE_MULT = 0.9
@@ -455,6 +457,8 @@
 	UPGRADE_BULK = 1
 	)
 	I.weapon_upgrades = list(
+		GUN_UPGRADE_FIRE_DELAY_MULT = 0.85,
+		GUN_UPGRADE_STEPDELAY_MULT = 0.85,
 		GUN_UPGRADE_MUZZLEFLASH = 0.6,
 		GUN_UPGRADE_RECOIL = 0.6,
 		GUN_UPGRADE_DAMAGE_MULT = 0.9
@@ -479,6 +483,8 @@
 	UPGRADE_ITEMFLAGPLUS = SILENT
 	)
 	I.weapon_upgrades = list(
+		GUN_UPGRADE_FIRE_DELAY_MULT = 0.65,
+		GUN_UPGRADE_STEPDELAY_MULT = 0.65,
 		GUN_UPGRADE_RECOIL = 0.5,
 	)
 	I.gun_loc_tag = GUN_GRIP
@@ -580,7 +586,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.tool_upgrades = list(
-	UPGRADE_FORCE_MOD = 4,
+	UPGRADE_FORCE_MOD = 3,
 	UPGRADE_PRECISION = -5,
 	UPGRADE_DEGRADATION_MULT = 1.15,
 	UPGRADE_WORKSPEED = -0.15,
@@ -670,8 +676,8 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.tool_upgrades = list(
 	UPGRADE_POWERCOST_MULT = 1.20,
-	UPGRADE_PRECISION = 14,
-	UPGRADE_WORKSPEED = 14,
+	UPGRADE_PRECISION = 12,
+	UPGRADE_WORKSPEED = 3,
 	UPGRADE_HEALTH_THRESHOLD = -10,
 	)
 	I.weapon_upgrades = list(
@@ -825,7 +831,7 @@
 	UPGRADE_HEALTH_THRESHOLD = rand(-10,10),
 	UPGRADE_WORKSPEED = rand(-1,3),
 	UPGRADE_PRECISION = rand(-20,20),
-	UPGRADE_FORCE_MOD = rand(-20,20),
+	UPGRADE_FORCE_MOD = rand(-10,10),
 	UPGRADE_BULK = rand(-1,2),
 	UPGRADE_COLOR = "#3366ff"
 	)

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -86,7 +86,7 @@
 	armor_penetration = ARMOR_PEN_SHALLOW
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_SAWING = 60, QUALITY_CUTTING = 50, QUALITY_WIRE_CUTTING = 20) //not the best choice to cut wires
-	max_upgrades = 4
+	max_upgrades = 3
 	use_fuel_cost = 0.1
 	max_fuel = 80
 
@@ -101,7 +101,7 @@
 	armor_penetration = ARMOR_PEN_SHALLOW
 	matter = list(MATERIAL_SILVER = 2, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 3)
 	tool_qualities = list(QUALITY_SAWING = 60, QUALITY_CUTTING = 50, QUALITY_WIRE_CUTTING = 20)
-	max_upgrades = 4
+	max_upgrades = 2
 	degradation = 0.7
 	use_power_cost = 1
 	suitable_cell = /obj/item/weapon/cell/medium

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -115,7 +115,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_DAMAGE_MULT = 1.3,
+		GUN_UPGRADE_DAMAGE_MULT = 1.2,
 		GUN_UPGRADE_CHARGECOST = 1.15
 		)
 	I.gun_loc_tag = GUN_BARREL
@@ -134,7 +134,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_FIRE_DELAY_MULT = 0.8,
+		GUN_UPGRADE_FIRE_DELAY_MULT = 0.9,
 		GUN_UPGRADE_FORCESAFETY = FALSE,
 		)
 	I.gun_loc_tag = GUN_TRIGGER
@@ -251,9 +251,9 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-	GUN_UPGRADE_RECOIL = 2,
+	GUN_UPGRADE_RECOIL = 1.5,
 	GUN_UPGRADE_FIRE_DELAY_MULT = 1.5,
-	GUN_UPGRADE_DAMAGE_MULT = 2,
+	GUN_UPGRADE_DAMAGE_MULT = 1.5,
 	GUN_UPGRADE_CHARGECOST = 2)
 	I.req_fuel_cell = REQ_CELL
 	I.gun_loc_tag = GUN_MECHANISM
@@ -367,7 +367,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_DAMAGE_BRUTE = 10,
+		GUN_UPGRADE_DAMAGE_BRUTE = 5,
 		GUN_UPGRADE_PEN_MULT = 1.2,
 		GUN_UPGRADE_PIERC_MULT = 1,
 		GUN_UPGRADE_FIRE_DELAY_MULT = 1.2,
@@ -443,7 +443,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-	GUN_UPGRADE_FIRE_DELAY_MULT = 1.50,
+	GUN_UPGRADE_FIRE_DELAY_MULT = 1.20,
 	GUN_UPGRADE_AUTOEJECT = TRUE)
 	I.gun_loc_tag = GUN_MAGWELL
 

--- a/code/modules/projectiles/guns/oddity_items.dm
+++ b/code/modules/projectiles/guns/oddity_items.dm
@@ -45,6 +45,7 @@
 	penetration_multiplier = 2
 	recoil_buildup = 75
 	one_hand_penalty = 50
+	gun_tags = list(GUN_PROJECTILE)
 
 /obj/item/weapon/gun/energy/ntpistol/mana
 	name = "\"Mana from Heaven\" energy pistol"
@@ -94,7 +95,7 @@
 	icon = 'icons/obj/guns/projectile/bluecross.dmi'
 	icon_state = "bluecross"
 	item_state = "bluecross"
-	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_SCOPE)
+	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE)
 	force = WEAPON_FORCE_DANGEROUS
 	bolt_training = FALSE
 	damage_multiplier = 2.5 //basic shot will 67.6~ damage
@@ -185,7 +186,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	armor_penetration = ARMOR_PEN_HALF
 	structure_damage_factor = STRUCTURE_DAMAGE_DESTRUCTIVE
-	max_upgrades = 5
+	max_upgrades = 3
 	tool_qualities = list(QUALITY_HAMMERING = 100)
 
 /obj/item/weapon/tool/knife/dagger/assassin/ubersaw
@@ -214,7 +215,7 @@
 	structure_damage_factor = STRUCTURE_DAMAGE_DESTRUCTIVE
 	throwforce = WEAPON_FORCE_PAINFUL
 	degradation = 0.7
-	max_upgrades = 4
+	max_upgrades = 2
 
 /obj/item/weapon/tool/saw/hyper/doombringer
 	name = "\"Doombringer\" chainsword"
@@ -228,7 +229,7 @@
 	armor_penetration = ARMOR_PEN_HALF
 	matter = list(MATERIAL_SILVER = 2, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 3)
 	tool_qualities = list(QUALITY_SAWING = 70, QUALITY_CUTTING = 60, QUALITY_WIRE_CUTTING = 30)
-	max_upgrades = 4
+	max_upgrades = 2
 	degradation = 0.1
 	use_power_cost = 1
 	suitable_cell = /obj/item/weapon/cell/medium

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -22,7 +22,7 @@
 	var/bolt_open = 0
 	zoom_factor = 2.0
 	twohanded = TRUE
-	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG)
+	gun_tags = list(GUN_PROJECTILE)
 
 /obj/item/weapon/gun/projectile/heavysniper/update_icon()
 	..()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -115,9 +115,9 @@
 	icon_state = "xray"
 	damage_types = list(BURN = 50)
 	armor_penetration = 40
-	stun = 3
-	weaken = 3
-	stutter = 3
+//	stun = 3
+//	weaken = 3
+//	stutter = 3
 
 	muzzle_type = /obj/effect/projectile/xray/muzzle
 	tracer_type = /obj/effect/projectile/xray/tracer

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -487,13 +487,13 @@
 		M.adjust_fire_stacks(fire_stacks)
 		M.IgniteMob()
 
-//Should do about 68 damage at 1 tile distance (adjacent), and 40 damage at 3 tiles distance.
+//Should do about 51 damage at 1 tile distance (adjacent), and 30 damage at 3 tiles distance.
 //Overall less damage than slugs in exchange for more damage at very close range and more embedding
 /obj/item/projectile/bullet/pellet/shotgun
 	name = "shrapnel"
 	icon_state = "birdshot-1"
 	damage_types = list(BRUTE = 18)
-	pellets = 4
+	pellets = 3
 	range_step = 1
 	spread_step = 10
 	knockback = 0 //We do not knockback do to issues with bullet douping


### PR DESCRIPTION
## About The Pull Request
Thundershotgun, ARM and Krag Jørgensen no longer can be over-loaded
Shotgun petters have been nerfed by having 1 less pellet
Most damage based tool and gun mods have been nerfed a slight bit
Hypersaws and chainsaws get less tool upgrade slots
Most gun mods that heavilly affect recoil make guns bullets shoot slower
Sant and Valkery laser snipers no longer hardstun
## Changelog
