### PR TITLE
Repair Plateform Fix & Buff

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -286,8 +286,13 @@
 	var/mob/living/silicon/robot/repairing
 
 	var/repair_amount = 100 //How much we can heal something for.
+	var/repair_amount = 0 //How much we can heal something for.
 	var/repair_rate = 5 //How much HP we restore per second
 	var/repair_complexity = REPAIR_HULL //How complex we get regarding repairing things
+
+/obj/machinery/repair_station/Initialize()
+	..()
+	repair_amount = 500
 
 /obj/machinery/repair_station/examine(mob/user)
 	..()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -332,6 +332,14 @@
 		visible_message("\The [src] buzzes \"Insufficient material remaining to continue repairs.\".")
 		stop_repairing()
 		return
+
+	for(var/V in repairing.components)
+		var/datum/robot_component/C = repairing.components[V]
+		if(C.brute_damage + C.electronics_damage >= C.max_damage)
+			visible_message("\The [src] buzzes \"[C.name] too damaged to repair, aborting.\".")
+			stop_repairing()
+			return
+
 	var/repair_count = 0
 	if(repair_complexity & REPAIR_HULL && (repairing.getBruteLoss() || repairing.getFireLoss()))
 		var/amount_to_heal = min(repair_amount, repair_rate)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -285,7 +285,6 @@
 
 	var/mob/living/silicon/robot/repairing
 
-	var/repair_amount = 100 //How much we can heal something for.
 	var/repair_amount = 0 //How much we can heal something for.
 	var/repair_rate = 5 //How much HP we restore per second
 	var/repair_complexity = REPAIR_HULL //How complex we get regarding repairing things


### PR DESCRIPTION
## About The Pull Request
- Buff the starting repair platforms by giving them an extra 400 starting repair points, for the grand total of 500 points, or the equivalent of 20 steel sheet compared to the previous 4.
- Remove an exploit, Repair platforms started with a 100 repair points when made, so when they ran out you could just deconstruct and reassemble them.
- Added a check to prevent the repair plateform from spending all its repair points trying to repair a destroyed component that it can't fix.