### PR TITLE
Make the plant analyzer take power again

### DIFF
--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -421,7 +421,7 @@
 	        to harvest reagents, by examining them."
 	//icon_state = "greenthumb" // https://game-icons.net/1x1/delapouite/farmer.html
 
-	var/virtual_scanner = new /obj/item/device/scanner/plant
+	var/virtual_scanner = new /obj/item/device/scanner/plant/perk
 
 /datum/perk/greenthumb/assign(mob/living/carbon/human/H)
 	..()

--- a/code/game/objects/items/devices/organ_module/active/multitool/farmer.dm
+++ b/code/game/objects/items/devices/organ_module/active/multitool/farmer.dm
@@ -3,7 +3,7 @@
 	desc = "A specialized farming multitool. Includes everything a farmer would need, like a plant analyzer, minihoe, spade, bucket, produce bag, and of course soap for cleaning up fruit splatters."
 	verb_name = "Deploy farming tool"
 	items = list(
-		/obj/item/device/scanner/plant,
+		/obj/item/device/scanner/plant/perk,
 		/obj/item/weapon/tool/minihoe,
 		/obj/item/weapon/tool/shovel/spade,
 		/obj/item/weapon/reagent_containers/glass/bucket,

--- a/code/game/objects/items/devices/scanners/plant.dm
+++ b/code/game/objects/items/devices/scanners/plant.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "hydro"
 	item_state = "analyzer"
-	charge_per_use = 0 //It need to be 0 for the Green Thumb perk to work
+	charge_per_use = 2
 
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 
@@ -18,6 +18,9 @@
 	)
 	var/datum/seed/loaded_seed
 	var/datum/reagents/loaded_reagents
+
+/obj/item/device/scanner/plant/perk
+	charge_per_use = 0 //It need to be 0 for the Green Thumb perk to work
 
 /obj/item/device/scanner/plant/is_valid_scan_target(atom/O)
 	if(is_type_in_list(O, valid_targets))


### PR DESCRIPTION
## About The Pull Request
Make the plant analyzer take as much as the health analyzer instead of not taking any power at all.
Add a subtype of the plant analyzer that doesn't use power for use in perks or implants.
Change the green thumb perk from using the normal analyzer to the powerless version.