### PR TITLE
Halves scrap beacon cooldown

### DIFF
--- a/code/modules/scrap/scrap_beacon.dm
+++ b/code/modules/scrap/scrap_beacon.dm
@@ -7,7 +7,7 @@
 	anchored = TRUE
 	density = TRUE
 	layer = MOB_LAYER + 1
-	var/summon_cooldown = 120 MINUTES
+	var/summon_cooldown = 60 MINUTES
 	var/impact_speed = 3
 	var/impact_prob = 100
 	var/impact_range = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The relocation of the scrap beacon to the outside of the colony now poses a greater challenge to the acquisition of essential materials by the Church. The removal of the obelisks makes killing the roaches a much harder task (Especially in the start of a shift) and having to wait for Blackshield or for a Marshall to show up to the gate adds yet another delay, especially in low-pop rounds, not to mention the greater time needed to move piles of roach meat and scrap metal back to the bioreactor.

Halving the scrap beacon's recharge rate does not subtract from this new element of difficult, and instead allows for a more rewarding and fun experience to Vectors who are still willing to excavate through piles of debris amidst the increased danger, especially now that their operation has the potential of being significantly delayed or even jeopardized by simplemobs and other players.

As always, I am open to feedback. I enjoy the added challenge but I believe this increase in difficulty should be properly balanced with a more rewarding experience, and many other church players share this sentiment.

<hr>
</details>

## Changelog
:cl:Kaksisilma
tweak: The Scrap Beacon cooldown is now set to 60 minutes
/:cl: