### PR TITLE
Runtime Fixes

### DIFF
--- a/code/controllers/subsystems/overlays.dm
+++ b/code/controllers/subsystems/overlays.dm
@@ -245,12 +245,13 @@ SUBSYSTEM_DEF(overlays)
 		return
 
 	var/list/cached_other
-	if(other.our_overlays)
-		cached_other = other.our_overlays
-	if(cached_other)
-		if(cut_old || !overlays.len)
-			overlays = cached_other.Copy()
-		else
-			overlays |= cached_other
-	else if(cut_old)
-		cut_overlays()
+	if("our_overlays" in other.vars)
+		if(other.our_overlays)
+			cached_other = other.our_overlays
+		if(cached_other)
+			if(cut_old || !overlays.len)
+				overlays = cached_other.Copy()
+			else
+				overlays |= cached_other
+		else if(cut_old)
+			cut_overlays()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -82,7 +82,7 @@
 	name = "plastic crate"
 	desc = "A rectangular plastic crate."
 	icon_state = "plasticcrate"
-	matter = list(MATERIAL_PLASIC = 10)
+	matter = list(MATERIAL_PLASTIC = 10)
 	price_tag = 10
 
 /obj/structure/closet/crate/internals

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -99,7 +99,8 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 			big_item = CATCH.get_item(/obj/random/pack/junk_machine/beacon)
 		else
 			big_item = CATCH.get_item(/obj/random/pack/junk_machine)
-		big_item.forceMove(src)
+		if(big_item) //Sanity check in case big_item is a null, as it may sometimes do.
+			big_item.forceMove(src)
 		if(prob(66))
 			big_item.make_old()
 		qdel(CATCH)


### PR DESCRIPTION
Runtime caused by non_existent material: PLASIC

Runtime caused by make_big_loot not having what loot to move.

Fixes runtime in overlays by making sure the variable our_overlays exists in the atom we're using. This will happen a lot during normal play.

Tested, nothing breaks on my server when running it.

