### PR TITLE
Remove departemental restrictions on the prosthetics

### DIFF
--- a/code/modules/organs/body_modifications.dm
+++ b/code/modules/organs/body_modifications.dm
@@ -198,12 +198,14 @@ var/global/list/modifications_types = list(
 	replace_limb = /obj/item/organ/external/robotic/moebius
 	body_parts = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG)
 	icon = 'icons/mob/human_races/cyberlimbs/moebius.dmi'
+	department_specific = list(DEPARTMENT_MEDICAL, DEPARTMENT_SCIENCE)
 
 /datum/body_modification/limb/prosthesis/blackshield
 	id = "prosthesis_blackshield"
 	replace_limb = /obj/item/organ/external/robotic/blackshield
 	body_parts = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG)
 	icon = 'icons/mob/human_races/cyberlimbs/blackshield.dmi'
+	department_specific = list(DEPARTMENT_SECURITY)
 
 /datum/body_modification/limb/prosthesis/church
 	id = "prosthesis_church"

--- a/code/modules/organs/body_modifications.dm
+++ b/code/modules/organs/body_modifications.dm
@@ -197,21 +197,18 @@ var/global/list/modifications_types = list(
 	id = "prosthesis_moebius"
 	replace_limb = /obj/item/organ/external/robotic/moebius
 	body_parts = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG)
-	department_specific = list(DEPARTMENT_MEDICAL, DEPARTMENT_SCIENCE)
 	icon = 'icons/mob/human_races/cyberlimbs/moebius.dmi'
 
 /datum/body_modification/limb/prosthesis/blackshield
 	id = "prosthesis_blackshield"
 	replace_limb = /obj/item/organ/external/robotic/blackshield
 	body_parts = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG)
-	department_specific = list(DEPARTMENT_SECURITY)
 	icon = 'icons/mob/human_races/cyberlimbs/blackshield.dmi'
 
 /datum/body_modification/limb/prosthesis/church
 	id = "prosthesis_church"
 	replace_limb = /obj/item/organ/external/robotic/church
 	body_parts = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG)
-	department_specific = list(DEPARTMENT_CHURCH)
 	icon = 'icons/mob/human_races/cyberlimbs/church.dmi'
 
 /datum/body_modification/limb/mutation/New()


### PR DESCRIPTION
## About The Pull Request
Basically allow players to have Soteria Prosthetics while not in Soteria, Church limbs without being a vector or a prime, and Blackshield without being a trooper or an officer.

Because I really doubt that the factions would go out of their way to force players to change prosthetics simply because they want to cook one shift.