### PR TITLE
Fixes the double do_after

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1023,10 +1023,6 @@ There are 9 wires.
 				playsound(src.loc, 'sound/items/keychainrattle.ogg', 30, 1, -2)
 			else
 				playsound(src.loc, 'sound/items/keychainrattle.ogg', 700, 1, -2)
-			if(!do_after(user, 300, src))
-				to_chat(user, SPAN_DANGER("Key code punch cancelled"))
-				used_now = FALSE
-				return
 			if(do_after(user, 300, src)) //in ms so half a min of sitting their trying
 				used_now = FALSE
 				if(locked)
@@ -1042,6 +1038,10 @@ There are 9 wires.
 				to_chat(user, SPAN_NOTICE("Damn wrong key!"))
 				key_odds += 1 //We dont try the same key over and over!
 				used_now = FALSE
+			else
+				to_chat(user, SPAN_DANGER("Key code punch cancelled"))
+				used_now = FALSE
+				return
 			used_now = FALSE
 			return
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Fixes the fact that, when using the janitor's keys to unlock a door, it'd do two do_after checks. Intended (according to a comment), is to have one check for a total of 30s.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fix: Fixed the janitor's keys taking twice as long as they should have.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
