### PR TITLE
Boltgun Runtime Fix

### DIFF
--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -84,12 +84,12 @@
 	..()
 	if(bolt_training && user.stats.getPerk(PERK_BOLT_REFLECT) && loaded.len>0)
 		to_chat(user, SPAN_NOTICE("Your hands move instinctively to chamber a new round!"))
-		bolt_act(src)
-		bolt_act(src)
+		bolt_act(user)
+		bolt_act(user)
 		return
 	if(bolt_training && user.stats.getPerk(PERK_BOLT_REFLECT) && loaded.len==0)
 		to_chat(user, SPAN_NOTICE("You stop your hands from instinctively chambering a new round."))
-		bolt_act(src)
+		bolt_act(user)
 		return
 
 /obj/item/weapon/gun/projectile/boltgun/proc/bolt_act(mob/living/user)


### PR DESCRIPTION
Fixes an issue where a runtime would be generated every time a boltgun would be shot by someone with Boltgun Training.

Tested on my server and runs without an issue. 