### PR TITLE
Allows clients to set an FPS value in preferences

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -399,12 +399,10 @@
 	set category = "OOC"
 	if(prefs)
 		prefs.ShowChoices(usr)
-/*
-/client/proc/apply_fps(var/client_fps)
-	if(world.byond_version >= 511 && byond_version >= 511 && client_fps >= CLIENT_MIN_FPS && client_fps <= CLIENT_MAX_FPS)
-		vars["fps"] = prefs.clientfps
 
-*/
+/client/proc/apply_fps(var/client_fps)
+	if(world.byond_version >= 511 && byond_version >= 511 && client_fps >= 0 && client_fps <= 240)
+		vars["fps"] = prefs.clientfps
 
 // Byond seemingly calls stat, each tick.
 // Calling things each tick can get expensive real quick.

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -1,5 +1,5 @@
 /datum/preferences
-	//var/clientfps = 0
+	var/clientfps = 0
 		//game-preferences
 	var/ooccolor = "#010000"			//Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color
 	var/UI_style = "ErisStyle"
@@ -17,21 +17,21 @@
 	S["UI_style_color"]	>> pref.UI_style_color
 	S["UI_style_alpha"]	>> pref.UI_style_alpha
 	S["ooccolor"]		>> pref.ooccolor
-	//S["clientfps"]		>> pref.clientfps
+	S["clientfps"]		>> pref.clientfps
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(var/savefile/S)
 	S["UI_style"]		<< pref.UI_style
 	S["UI_style_color"]	<< pref.UI_style_color
 	S["UI_style_alpha"]	<< pref.UI_style_alpha
 	S["ooccolor"]		<< pref.ooccolor
-	//S["clientfps"]		<< pref.clientfps
+	S["clientfps"]		<< pref.clientfps
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
 	pref.UI_style		= sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
 	pref.UI_style_color	= sanitize_hexcolor(pref.UI_style_color, initial(pref.UI_style_color))
 	pref.UI_style_alpha	= sanitize_integer(pref.UI_style_alpha, 0, 255, initial(pref.UI_style_alpha))
 	pref.ooccolor		= sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
-	//pref.clientfps	    = sanitize_integer(pref.clientfps, CLIENT_MIN_FPS, CLIENT_MAX_FPS, initial(pref.clientfps))
+	pref.clientfps	    = sanitize_integer(pref.clientfps, 0, 240, initial(pref.clientfps))
 
 /datum/category_item/player_setup_item/player_global/ui/content(var/mob/user)
 	. += "<b>UI Settings</b><br>"
@@ -45,7 +45,7 @@
 			. += "<a href='?src=\ref[src];select_ooc_color=1'><b>Using Default</b></a><br>"
 		else
 			. += "<a href='?src=\ref[src];select_ooc_color=1'><b>[pref.ooccolor]</b></a> <table style='display:inline;' bgcolor='[pref.ooccolor]'><tr><td>__</td></tr></table> <a href='?src=\ref[src];reset=ooc'>reset</a><br>"
-	//. += "<b>Client FPS:</b> <a href='?src=\ref[src];select_fps=1'><b>[pref.clientfps]</b></a><br>"
+	. += "<b>Client FPS:</b> <a href='?src=\ref[src];select_fps=1'><b>[pref.clientfps]</b></a><br>"
 
 
 /datum/category_item/player_setup_item/player_global/ui/OnTopic(var/href,var/list/href_list, var/mob/user)
@@ -76,7 +76,6 @@
 			pref.ooccolor = new_ooccolor
 			return TOPIC_REFRESH
 
-	/*
 	else if(href_list["select_fps"])
 		var/version_message
 		if (user.client && user.client.byond_version < 511)
@@ -85,13 +84,13 @@
 			version_message += "\nThis server does not currently support client side fps. You can set now for when it does."
 		var/new_fps = input(user, "Choose your desired fps.[version_message]\n(0 = synced with server tick rate (currently:[world.fps]))", "Global Preference") as num|null
 		if (isnum(new_fps) && CanUseTopic(user))
-			pref.clientfps = CLAMP(new_fps, CLIENT_MIN_FPS, CLIENT_MAX_FPS)
+			pref.clientfps = CLAMP(new_fps, 0, 240)
 
 			var/mob/target_mob = preference_mob()
 			if(target_mob && target_mob.client)
 				target_mob.client.apply_fps(pref.clientfps)
 			return TOPIC_REFRESH
-	*/
+
 	else if(href_list["reset"])
 		switch(href_list["reset"])
 			if("ui")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Allows clients to set client FPS value in global preferences. Defaults to 0, which syncs to server tick rate. This feature already existed, it was just commented out for some reason.

![image](https://user-images.githubusercontent.com/62350255/121567033-1a8f5d00-c9ec-11eb-9fa5-c571892fc7f9.png)


</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
add: Client FPS option in global preferences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
