### PR TITLE
WholeBody

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -70,3 +70,4 @@
 #define PERK_SECOND_SKIN /datum/perk/second_skin
 #define PERK_IRON_FLESH /datum/perk/iron_flesh
 #define PERK_SI_SCI /datum/perk/si_sci
+#define PERK_WHOLE_BODY /datum/perk/whole_body

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -437,3 +437,26 @@
 	name = "Channeling"
 	desc = "You know how to channel spiritual energy during rituals. You gain additional skill points \
 			during group rituals, and have an increased regeneration of cruciform energy."
+
+/datum/perk/whole_body
+	name = "Whole of Body and Mind"
+	desc = "Your chest is unburdened and your mind is clear. You feel as if your body \
+			and soul are stronger when not restrained by dogma or sucked dry by ideological implants."
+
+/datum/perk/whole_body/assign(mob/living/carbon/human/H)
+	..()
+	holder.stats.addTempStat(STAT_ROB, 12, INFINITY, "Whole Body")
+	holder.stats.addTempStat(STAT_TGH, 12, INFINITY, "Whole Body")
+	holder.stats.addTempStat(STAT_VIG, 12, INFINITY, "Whole Body")
+	holder.stats.addTempStat(STAT_BIO, 12, INFINITY, "Whole Body")
+	holder.stats.addTempStat(STAT_COG, 12, INFINITY, "Whole Body")
+	holder.stats.addTempStat(STAT_MEC, 12, INFINITY, "Whole Body")
+
+/datum/perk/whole_body/remove()
+	holder.stats.removeTempStat(STAT_ROB, "Whole Body")
+	holder.stats.removeTempStat(STAT_TGH, "Whole Body")
+	holder.stats.removeTempStat(STAT_VIG, "Whole Body")
+	holder.stats.removeTempStat(STAT_BIO, "Whole Body")
+	holder.stats.removeTempStat(STAT_COG, "Whole Body")
+	holder.stats.removeTempStat(STAT_MEC, "Whole Body")
+	..()

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -21,10 +21,12 @@ var/list/disciples = list()
 	if(.)
 		target.stats.addPerk(/datum/perk/sanityboost)
 		target.stats.addPerk(/datum/perk/unfinished_delivery)
+		target.stats.removePerk(/datum/perk/whole_body)
 
 /obj/item/weapon/implant/core_implant/cruciform/uninstall()
 	wearer.stats.removePerk(/datum/perk/sanityboost)
 	wearer.stats.addPerk(/datum/perk/unfinished_delivery)
+	wearer.stats.addPerk(/datum/perk/whole_body)
 	return ..()
 
 /obj/item/weapon/implant/core_implant/cruciform/get_mob_overlay(gender, form)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -55,7 +55,7 @@
 	make_blood()
 
 	sanity = new(src)
-
+	src.stats.addPerk(/datum/perk/whole_body)
 	AddComponent(/datum/component/fabric)
 
 /mob/living/carbon/human/Destroy()


### PR DESCRIPTION
Creates a new perk: Whole of Body and Mind.

Without the ideological burden of a cruciform and the strain put on the body by such an implant, people are stronger and can think better.
+12 in all stats while not having a cruciform, is removed when putting on one.

This changes nothing to the Church and simply gives people who choose not to wear a cruciform an incentive to do so. 