### PR TITLE
Make Omega-Geysers way cheaper

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -60,7 +60,7 @@
 	name = "Soteria \"Omega-Geyser 20000L\""
 	desc = "Soteria Institute-brand rechargeable L-standardized power cell. This one being part of the Omega line, making it the be-all-end-all power cell of its type, yet to hit the open market."
 	icon_state = "meb_b_omega"
-	matter = list(MATERIAL_STEEL = 12, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3, MATERIAL_GOLD = 6)
+	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3, MATERIAL_GOLD = 6)
 	origin_tech = list(TECH_POWER = 7)
 	maxcharge = 20000
 
@@ -178,7 +178,7 @@
 	name = "Soteria \"Omega-Geyser 1600M\""
 	desc = "Soteria Institute branded rechargeable M-standardized power cell. This one being part of the Omega line, making it the be-all-end-all power cell of its type, yet to hit the open market."
 	icon_state = "meb_m_omega"
-	matter = list(MATERIAL_STEEL = 9, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_GOLD = 4)
+	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_GOLD = 4)
 	origin_tech = list(TECH_POWER = 7)
 	maxcharge = 1600
 

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -60,7 +60,7 @@
 	name = "Soteria \"Omega-Geyser 20000L\""
 	desc = "Soteria Institute-brand rechargeable L-standardized power cell. This one being part of the Omega line, making it the be-all-end-all power cell of its type, yet to hit the open market."
 	icon_state = "meb_b_omega"
-	matter = list(MATERIAL_STEEL = 12, MATERIAL_PLASTIC = 12, MATERIAL_SILVER = 9, MATERIAL_GOLD = 6) //DEAR LOAD WHAT ARE THOSE COSTS?
+	matter = list(MATERIAL_STEEL = 12, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3, MATERIAL_GOLD = 6)
 	origin_tech = list(TECH_POWER = 7)
 	maxcharge = 20000
 
@@ -178,7 +178,7 @@
 	name = "Soteria \"Omega-Geyser 1600M\""
 	desc = "Soteria Institute branded rechargeable M-standardized power cell. This one being part of the Omega line, making it the be-all-end-all power cell of its type, yet to hit the open market."
 	icon_state = "meb_m_omega"
-	matter = list(MATERIAL_STEEL = 9, MATERIAL_PLASTIC = 9, MATERIAL_SILVER = 6, MATERIAL_GOLD = 3) //DEAR LOAD WHAT ARE THOSE COSTS?
+	matter = list(MATERIAL_STEEL = 9, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_GOLD = 4)
 	origin_tech = list(TECH_POWER = 7)
 	maxcharge = 1600
 
@@ -274,7 +274,7 @@
 	name = "Soteria \"Omega-Geyser 500S\""
 	desc = "Soteria Institute branded rechargeable S-standardized power cell. This one being part of the Omega line making it the be-all-end-all power cell of its type, yet to hit the open market."
 	icon_state = "meb_s_omega"
-	matter = list(MATERIAL_STEEL = 5, MATERIAL_PLASTIC = 5, MATERIAL_SILVER = 3, MATERIAL_GOLD = 1) //DEAR LOAD WHAT ARE THOSE COSTS?
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1, MATERIAL_GOLD = 2)
 	origin_tech = list(TECH_POWER = 7)
 	maxcharge = 500
 


### PR DESCRIPTION
## About The Pull Request
Makes the Omega-Geysers power cell material cost more inline with the other power cell instead of the massive cost.

Small Cell : 1 Steel, 1 Plastic, 1 Silver.
Small Atomcell : 1 Steel. 1 Plastic, 1 Silver, 2 Uranium
Previous Small Omega-Geyser : 5 Steel, 5 Plastic, 3 Silver 1 Gold

Medium Cell : 2 Steel, 2 Plastic, 2 Silver.
Medium Atomcell : 2 Steel. 2 Plastic, 2 Silver, 4 Uranium
Previous Medium Omega-Geyser : 9 Steel, 9 Plastic, 6 Silver 3 Gold

Large Cell : 3 Steel, 3 Plastic, 3 Silver.
Large Atomcell : 3 Steel. 3 Plastic, 3 Silver, 6 Uranium
Previous Large Omega-Geyser : 12 Steel, 12 Plastic, 9 Silver 6 Gold

Which is just exagerated when it only give 2000/200/100 comparted to the cheaper L/M/S cells that only need silver.

New Omega-Geyser Cell cost, those follow the same convention as the atoms and posi : 
Small : 1 Steel. 1 Plastic, 1 Silver, 2 Gold.
Medium : 2 Steel. 2 Plastic, 2 Silver, 4 Gold.
Large : 3 Steel. 3 Plastic, 3 Silver, 6 Gold.