### PR TITLE
Church Litanies General Nerf Added Cost (Trilby's PR but adjusted)

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -17,8 +17,17 @@
 	desc = "A short litany to relieve pain of the afflicted."
 	power = 50
 	ignore_stuttering = TRUE
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/cruciform/base/relief/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
+	//var/datum/reagent/bloodhold
+	if(H.species?.reagent_tag != IS_SYNTHETIC)
+		if(H.nutrition >= nutri_cost)
+			H.nutrition -= nutri_cost
+		else
+			to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			H.vessel.remove_reagent("blood",blood_cost)
 	H.add_chemical_effect(CE_PAINKILLER, 30, TRUE)
 	H.apply_effect(-30, AGONY, 0)
 	H.apply_effect(-30, HALLOSS, 0)
@@ -44,10 +53,18 @@
 	cooldown = TRUE
 	cooldown_time = 10 MINUTES
 	cooldown_category = "bglow"
+	nutri_cost = 10//low cost
+	blood_cost = 10//low cost
 
 /datum/ritual/cruciform/base/glow_book/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
 	var/successful = FALSE
 	if (istype(H.get_active_hand(), /obj/item/weapon/book/ritual/cruciform))
+		if(H.species?.reagent_tag != IS_SYNTHETIC)
+			if(H.nutrition >= nutri_cost)
+				H.nutrition -= nutri_cost
+			else
+				to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+				H.vessel.remove_reagent("blood",blood_cost)
 		var/obj/item/weapon/book/ritual/cruciform/M = H.get_active_hand()
 		M.set_light(5) //Slightly better than as a lantern since you can only hold it in hand or within the belt slot.
 		playsound(H.loc, 'sound/ambience/ambicha2.ogg', 75, 1)
@@ -70,8 +87,16 @@
 	cooldown = TRUE
 	cooldown_time = 2 MINUTES
 	cooldown_category = "flare"
+	nutri_cost = 10//low cost
+	blood_cost = 10//low cost
 
 /datum/ritual/cruciform/base/flare/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
+	if(H.species?.reagent_tag != IS_SYNTHETIC)
+		if(H.nutrition >= nutri_cost)
+			H.nutrition -= nutri_cost
+		else
+			to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			H.vessel.remove_reagent("blood",blood_cost)
 	playsound(H.loc, 'sound/effects/snap.ogg', 50, 1)
 	new /obj/effect/sparks(H.loc)
 	new /obj/effect/effect/smoke/illumination(H.loc, brightness=max(7), lifetime=12000) //Very bright light.
@@ -82,10 +107,18 @@
 	name = "Entreaty"
 	phrase = "Deus meus ut quid dereliquisti me."
 	desc = "Call for help, allowing other cruciform bearers to hear your cries."
-	power = 50
+	power = 25
 	ignore_stuttering = TRUE
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/cruciform/base/entreaty/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
+	if(H.species?.reagent_tag != IS_SYNTHETIC)
+		if(H.nutrition >= nutri_cost)
+			H.nutrition -= nutri_cost
+		else
+			to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			H.vessel.remove_reagent("blood",blood_cost)
 	for(var/mob/living/carbon/human/target in disciples)
 		if(target == H)
 			continue
@@ -102,9 +135,17 @@
 	phrase = "Et fumus tormentorum eorum ascendet in saecula saeculorum: nec habent requiem die ac nocte, qui adoraverunt bestiam, et imaginem ejus, et si quis acceperit caracterem nominis ejus."
 	desc = "Gain knowledge of your surroundings to reveal evil in people and places. This can tell you about hostile creatures around you, rarely can help you spot traps and sometimes let you sense a monster disguised as a person."
 	power = 35
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/cruciform/base/reveal/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
 	var/was_triggired = FALSE
+	if(H.species?.reagent_tag != IS_SYNTHETIC)
+		if(H.nutrition >= nutri_cost)
+			H.nutrition -= nutri_cost
+		else
+			to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			H.vessel.remove_reagent("blood",blood_cost)
 	log_and_message_admins("performed reveal litany")
 	if(prob(5)) //Aditional fail chance that hidded from user
 		to_chat(H, SPAN_NOTICE("There is nothing there. You feel safe."))
@@ -140,9 +181,17 @@
 	phrase = "Audit, me audit vocationem. Ego nuntius vobis."
 	desc = "Send a message anonymously through the void, straight into the mind of another disciple."
 	power = 30
+	nutri_cost = 10//low cost
+	blood_cost = 10//low cost
 
 /datum/ritual/cruciform/base/message/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C,list/targets)
 	var/mob/living/carbon/human/H = pick_disciple_global(user, TRUE)
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	if (!H)
 		return
 

--- a/code/modules/core_implant/cruciform/rituals/construction.dm
+++ b/code/modules/core_implant/cruciform/rituals/construction.dm
@@ -19,6 +19,8 @@ GLOBAL_LIST_INIT(nt_blueprints, init_nt_blueprints())
 	desc = "Building needs mainly faith but resources as well. Find out what it takes."
 	power = 5
 	category = "Construction"
+	nutri_cost = 10
+	blood_cost = 10
 
 /datum/ritual/cruciform/priest/blueprint_check/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C, list/targets)
 	var/construction_key = input("Select construction", "") as null|anything in GLOB.nt_blueprints
@@ -30,6 +32,12 @@ GLOBAL_LIST_INIT(nt_blueprints, init_nt_blueprints())
 			continue
 		listed_components += list("[blueprint.materials[placeholder]] [initial(placeholder.name)]")
 	to_chat(user, SPAN_NOTICE("[blueprint.name] requires: [english_list(listed_components)]."))
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 
 /datum/ritual/cruciform/priest/construction
 	name = "Manifestation"
@@ -37,6 +45,9 @@ GLOBAL_LIST_INIT(nt_blueprints, init_nt_blueprints())
 	desc = "Build and expand. Shape your faith into something more sensible."
 	power = 40
 	category = "Construction"
+	nutri_cost = 25
+	blood_cost = 25
+
 
 /datum/ritual/cruciform/priest/construction/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C, list/targets)
 	var/construction_key = input("Select construction", "") as null|anything in GLOB.nt_blueprints
@@ -50,6 +61,12 @@ GLOBAL_LIST_INIT(nt_blueprints, init_nt_blueprints())
 		return
 
 	user.visible_message(SPAN_NOTICE("You see as [user] passes his hands over something."),SPAN_NOTICE("You see your faith take physical form as you concentrate on [blueprint.name] image"))
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 
 	var/obj/effect/overlay/nt_construction/effect = new(target_turf, blueprint.build_time)
 

--- a/code/modules/core_implant/cruciform/rituals/crusader.dm
+++ b/code/modules/core_implant/cruciform/rituals/crusader.dm
@@ -8,9 +8,17 @@
 	name = "Eternal Brotherhood"
 	phrase = "Ita multi unum corpus sumus in Christo singuli autem alter alterius membra."
 	desc = "Reveals other disciples to speaker."
+	nutri_cost = 25//low cost
+	blood_cost = 25//low cost
 
 /datum/ritual/cruciform/crusader/brotherhood/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/datum/core_module/cruciform/neotheologyhud/hud_module = C.get_module(/datum/core_module/cruciform/neotheologyhud)
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	if(hud_module)
 		C.remove_module(hud_module)
 	else
@@ -25,9 +33,17 @@
 	cooldown_time = 10 MINUTES
 	cooldown_category = "battle call"
 	effect_time = 10 MINUTES
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/cruciform/crusader/battle_call/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/count = 0
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	for(var/mob/living/carbon/human/brother in view(user))
 		if(brother.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform))
 			count += 2
@@ -53,8 +69,16 @@
 	cooldown = TRUE
 	cooldown_time = 2 MINUTES
 	cooldown_category = "flash"
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/crusader/flash/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	if(prob(100 - user.stats.getStat(STAT_VIG)))
 		user.Weaken(10)
 		to_chat(user, SPAN_WARNING("The flux of psy-energy knocks over you!"))

--- a/code/modules/core_implant/cruciform/rituals/inquisitor.dm
+++ b/code/modules/core_implant/cruciform/rituals/inquisitor.dm
@@ -300,10 +300,18 @@
 	name = "Eternal Brotherhood"
 	phrase = "Ita multi unum corpus sumus in Christo singuli autem alter alterius membra."
 	desc = "Reveals other disciples to speaker."
+	nutri_cost = 10 //low cost
+	blood_cost = 10 //low cost
 
 
 /datum/ritual/cruciform/inquisitor/brotherhood/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/datum/core_module/cruciform/neotheologyhud/hud_module = C.get_module(/datum/core_module/cruciform/neotheologyhud)
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	if(hud_module)
 		C.remove_module(hud_module)
 	else
@@ -318,8 +326,16 @@
 	cooldown_time = 10 MINUTES
 	cooldown_category = "battle call"
 	effect_time = 10 MINUTES
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/cruciform/inquisitor/battle_call/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	var/count = 0
 	for(var/mob/living/carbon/human/brother in view(user))
 		if(brother.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform))
@@ -345,8 +361,16 @@
 	cooldown = TRUE
 	cooldown_time = 2 MINUTES
 	cooldown_category = "flash"
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/inquisitor/flash/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	if(prob(100 - user.stats.getStat(STAT_VIG)))
 		user.Weaken(10)
 		to_chat(user, SPAN_WARNING("The flux of psy-energy knocks over you!"))
@@ -378,6 +402,9 @@
 	cooldown = TRUE
 	cooldown_time = 12 HOURS
 	cooldown_category = "armaments"
+	nutri_cost = 50 //high cost
+	blood_cost = 50 //high cost
+
 
 /datum/ritual/targeted/cruciform/inquisitor/spawn_item/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C,list/targets)
 	new /obj/item/weapon/tool/sword/crusader(usr.loc)
@@ -385,4 +412,10 @@
 	new /obj/item/weapon/shield/riot/crusader(usr.loc)
 	new /obj/item/weapon/storage/belt/security/neotheology(usr.loc)
 	new /obj/item/clothing/suit/space/void/crusader(usr.loc)
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	set_personal_cooldown(user)

--- a/code/modules/core_implant/cruciform/rituals/machinery.dm
+++ b/code/modules/core_implant/cruciform/rituals/machinery.dm
@@ -5,7 +5,6 @@
 	fail_message = "The Cruciform feels cold against your chest."
 	category = "Machinery"
 
-
 /*
 //Cloning
 /datum/ritual/cruciform/machines/resurrection
@@ -37,13 +36,13 @@
 
 ////////////////////////BIOMATTER MANIPULATION MULTI MACHINES RITUALS
 
-
 ///////////////>Biogenerator manipulation rite</////////////////
 /datum/ritual/cruciform/machines/power_biogen_awake
 	name = "Power biogenerator song"
 	phrase = "Dixitque Deus: Fiat lux. Et facta est lux.  Et lux in tenebris lucet, et renebrae eam non comprehenderunt."
 	desc = "A ritual, that can activate or deactivate power biogenerator machine. You should be nearby its metrics screen."
-
+	nutri_cost = 10
+	blood_cost = 10
 
 /datum/ritual/cruciform/machines/power_biogen_awake/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
 	var/obj/machinery/multistructure/biogenerator_part/console/biogen_screen = locate() in range(4, H)
@@ -53,17 +52,24 @@
 			biogenerator.deactivate()
 		else
 			biogenerator.activate()
+		if(H.species?.reagent_tag != IS_SYNTHETIC)
+			if(H.nutrition >= nutri_cost)
+				H.nutrition -= nutri_cost
+			else
+				to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+				H.vessel.remove_reagent("blood",blood_cost)
 		return TRUE
 
-	fail("There are no any power biogenerator screen around you.", H, C)
+	fail("There is no power biogenerator screen near you.", H, C)
 	return FALSE
-
 
 
 ////////////////Bioreactor commands
 
 /datum/ritual/cruciform/machines/bioreactor
 	name = "Bioreactor command"
+	nutri_cost = 10
+	blood_cost = 10
 
 
 /datum/ritual/cruciform/machines/bioreactor/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
@@ -73,18 +79,21 @@
 		//to prevent any copypaste
 		//let's make it a bit better
 		var/success = perform_command(bioreactor)
+		if(H.species?.reagent_tag != IS_SYNTHETIC)
+			if(H.nutrition >= nutri_cost)
+				H.nutrition -= nutri_cost
+			else
+				to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+				H.vessel.remove_reagent("blood",blood_cost)
 		return success
 
-	fail("You should be near bioreactor metrics screen.", H, C)
+	fail("You should be near the bioreactor metrics screen.", H, C)
 	return FALSE
-
 
 //There we perform any manipulations with our bioreactor
 //Since console finder code is similar for both rituals
 /datum/ritual/cruciform/machines/bioreactor/proc/perform_command(datum/multistructure/bioreactor/bioreactor)
 	return
-
-
 
 ///////////////>Bioreactor pump solution ritual<//////////////////
 
@@ -93,14 +102,13 @@
 	phrase = "Nihil igitur fieri de nihilo posse putandum est."
 	desc = "This ritual pump in or pump out solution of bioreactor's chamber. You should stay nearby its screen."
 
-
 /datum/ritual/cruciform/machines/bioreactor/solution/perform_command(datum/multistructure/bioreactor/bioreactor)
 	if(!bioreactor.chamber_closed)
 		return FALSE
 	bioreactor.pump_solution()
 	var/obj/machinery/multistructure/bioreactor_part/console/bioreactor_console = bioreactor.metrics_screen
 	bioreactor_console.ping()
-	bioreactor_console.visible_message("Bioreactor produce echoing click and platforms pumps start buzzing.")
+	bioreactor_console.visible_message("Bioreactor produces an echoing click. The platforms pumps start buzzing.")
 	return TRUE
 
 
@@ -111,12 +119,10 @@
 	name = "Bioreactor chamber's words"
 	phrase = "Constituit quoque ianitores in portis domus Domini ut non ingrederetur eam inmundus in omni."
 	desc = "This ritual open or close bioreactor chamber. You should stay nearby its screen."
-
-
 /datum/ritual/cruciform/machines/bioreactor/chamber_doors/perform_command(datum/multistructure/bioreactor/bioreactor)
 	if(bioreactor.chamber_solution)
 		return FALSE
 	bioreactor.toggle_platform_door()
 	var/obj/machinery/multistructure/bioreactor_part/console/bioreactor_console = bioreactor.metrics_screen
 	bioreactor_console.ping()
-	bioreactor_console.visible_message("You hear a loud BANG. Then pause... Chamber's door mechanism start working quietly and softly.")
+	bioreactor_console.visible_message("You hear a loud BANG. Then a pause... The chamber's door mechanism moves its position with a quiet grace.")

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -18,9 +18,17 @@
 	cooldown_time = 15 MINUTES
 	cooldown_category = "grepose"
 	power = 60 //stronger healing higher cost
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/tessellate/heal_heathen_special/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/list/people_around = list()
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	for(var/mob/living/carbon/human/H in view(user))
 		if(H != user && !isdeaf(H))
 			people_around.Add(H)
@@ -52,9 +60,17 @@
 	power = 50
 	cooldown_time = 5 MINUTES
 	cooldown_category = "dhymn" //It shares a cooldown because it replaces divine hymn, not add atop it.
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/tessellate/heal_heathen_improved/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/list/people_around = list()
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	for(var/mob/living/carbon/human/H in view(user))
 		if(H != user && !isdeaf(H))
 			people_around.Add(H)
@@ -86,7 +102,6 @@
 	phrase = null
 	implant_type = /obj/item/weapon/implant/core_implant/cruciform/lemniscate
 	category = "Lemniscate"
-
 /datum/ritual/targeted/cruciform/lemniscate
 	name = "cruciform targeted"
 	phrase = null
@@ -103,6 +118,8 @@
 	cooldown_category = "short_boost"
 	category = "Lemniscate"
 	var/list/stats_to_boost = list()
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/lemniscate/long_boost/New()
 	..()
@@ -110,6 +127,12 @@
 
 /datum/ritual/cruciform/lemniscate/long_boost/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/list/people_around = list()
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	for(var/mob/living/carbon/human/H in view(user))
 		if(H != user && !isdeaf(H))
 			people_around.Add(H)
@@ -186,8 +209,16 @@
 	cooldown_time = 5 MINUTES
 	cooldown_category = "monopain"
 	ignore_stuttering = TRUE
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/monomial/ironskin/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
+	if(H.species?.reagent_tag != IS_SYNTHETIC)
+		if(H.nutrition >= nutri_cost)
+			H.nutrition -= nutri_cost
+		else
+			to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			H.vessel.remove_reagent("blood",blood_cost)
 	H.add_chemical_effect(CE_PAINKILLER, 10000, TRUE)
 	H.apply_effect(-200, AGONY, 0)
 	H.apply_effect(-200, HALLOSS, 0)
@@ -209,8 +240,16 @@
 	cooldown_category = "pself"
 	effect_time = 15 MINUTES
 	power = 90
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/monomial/perfect_self/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	user.stats.changeStat(STAT_TGH, 10)
 	user.stats.changeStat(STAT_ROB, 10)
 	user.stats.changeStat(STAT_VIG, 10)
@@ -250,12 +289,20 @@
 	cooldown = TRUE
 	cooldown_time = 4 HOURS
 	cooldown_category = "cdefn"
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/targeted/cruciform/divisor/spawn_con/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C,list/targets)
 	new /obj/item/weapon/gun/energy/taser(usr.loc)
 	new /obj/item/weapon/storage/belt/security/neotheology(usr.loc)
 	new /obj/item/clothing/head/rank/divisor(usr.loc)
 	new /obj/item/clothing/suit/greatcoat/divisor(usr.loc)
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	set_personal_cooldown(user)
 
 /datum/ritual/cruciform/divisor/div_flash
@@ -266,8 +313,16 @@
 	cooldown_time = 5 MINUTES
 	cooldown_category = "dflas"
 	power = 50
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/divisor/div_flash/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	playsound(user.loc, 'sound/effects/cascade.ogg', 65, 1)
 	log_and_message_admins("performed an ire litany")
 	for(var/mob/living/victim in view(user))

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -21,6 +21,8 @@
 	desc = "Imparts extreme pain on the target disciple. Does no actual harm. Use this on someone who performs a heretical act."
 	power = 35
 	category = "Devotion"
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/targeted/cruciform/priest/penance/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C,list/targets)
 	var/obj/item/weapon/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/weapon/implant/core_implant/cruciform)
@@ -42,6 +44,12 @@
 		return
 
 	user.visible_message("[user] places their hands upon [H] and utters a prayer", "You lay your hands upon [H] and begin speaking the words of penance")
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	if (do_after(user, 20, H, TRUE))
 		T = get_turf(user)
 		if (!(T.Adjacent(get_turf(H))))
@@ -71,8 +79,16 @@
 	cooldown_time = 300
 	power = 35 //Healing yourself is slightly easier than healing someone else
 	category = "Vitae"
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/priest/selfheal/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C,list/targets)
+	if(H.species?.reagent_tag != IS_SYNTHETIC)
+		if(H.nutrition >= nutri_cost)
+			H.nutrition -= nutri_cost
+		else
+			to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			H.vessel.remove_reagent("blood",blood_cost)
 	to_chat(H, "<span class='info'>A sensation of relief bathes you, washing away your pain</span>")
 	H.add_chemical_effect(CE_PAINKILLER, 20)
 	H.adjustBruteLoss(-20)
@@ -92,6 +108,8 @@
 	cooldown_time = 300
 	power = 45
 	category = "Vitae"
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/priest/heal_other/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C,list/targets)
 	var/obj/item/weapon/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/weapon/implant/core_implant/cruciform)
@@ -113,6 +131,12 @@
 		return
 
 	user.visible_message("[user] places their hands upon [H] and utters a prayer", "You lay your hands upon [H] and begin speaking the words of succor")
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	if (do_after(user, 40, H, TRUE))
 		T = get_turf(user)
 		if (!(T.Adjacent(get_turf(H))))
@@ -138,6 +162,8 @@
 	cooldown_category = "dhymn"
 	power = 50
 	category = "Vitae"
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/priest/heal_heathen/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/list/people_around = list()
@@ -146,6 +172,12 @@
 			people_around.Add(H)
 
 	if(people_around.len > 0)
+		if(user.species?.reagent_tag != IS_SYNTHETIC)
+			if(user.nutrition >= nutri_cost)
+				user.nutrition -= nutri_cost
+			else
+				to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+				user.vessel.remove_reagent("blood",blood_cost)
 		to_chat(user, SPAN_NOTICE("Your feel the air thrum with an inaudible vibration."))
 		playsound(user.loc, 'sound/machines/signal.ogg', 50, 1)
 		for(var/mob/living/carbon/human/participant in people_around)
@@ -177,6 +209,8 @@
 	desc = "Look into the world from the eyes of another believer. Strenuous and can only be maintained for half a minute. The target will sense they are being watched, but not by whom. This prayer requires power only primes and crusaders have."
 	power = 100
 	category = "Devotion"
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/priest/scrying/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C,list/targets)
 
@@ -200,6 +234,13 @@
 	eye.owner = eye
 	user.reset_view(eye)
 
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
+
 	//After 30 seconds, your view is forced back to yourself
 	addtimer(CALLBACK(user, .mob/proc/reset_view, user), 300)
 
@@ -215,6 +256,8 @@
 	name = "Epiphany"
 	phrase = "In nomine Patris et Filii et Spiritus sancti."
 	desc = "The Absolute's principal sacrament is a ritual of baptism and merging with cruciform. A body, relieved of clothes should be placed on Absolute's special altar."
+	nutri_cost = 10//low cost
+	blood_cost = 10//low cost
 
 /datum/ritual/cruciform/priest/epiphany/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/obj/item/weapon/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/weapon/implant/core_implant/cruciform, FALSE)
@@ -235,6 +278,12 @@
 		fail("It is too late for this one, the soul has already left the vessel", user, C)
 		return FALSE
 
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	log_and_message_admins("successfully baptized [CI.wearer]")
 	to_chat(CI.wearer, "<span class='info'>Your cruciform vibrates and warms up.</span>")
 
@@ -308,6 +357,8 @@
 	name = "Commitment"
 	phrase = "Unde ipse Dominus dabit vobis signum."
 	desc = "This litany will command a cruciform attach to person so you can perform an epiphany. Cruciform must lay near them."
+	nutri_cost = 10//low cost
+	blood_cost = 10//low cost
 
 /datum/ritual/cruciform/priest/install/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/mob/living/carbon/human/H = get_victim(user)
@@ -351,6 +402,12 @@
 		return FALSE
 
 	if(ishuman(H))
+		if(user.species?.reagent_tag != IS_SYNTHETIC)
+			if(user.nutrition >= nutri_cost)
+				user.nutrition -= nutri_cost
+			else
+				to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+				user.vessel.remove_reagent("blood",blood_cost)
 		var/mob/living/carbon/human/M = H
 		var/obj/item/organ/external/E = M.organs_by_name[BP_CHEST]
 		for (var/i = 0; i < 5;i++)
@@ -367,6 +424,8 @@
 	name = "Deprivation"
 	phrase = "Et revertatur pulvis in terram suam unde erat et spiritus redeat ad Deum qui dedit illum."
 	desc = "This litany will command a cruciform to detach from its bearer, if the one bearing it is dead."
+	nutri_cost = 10//low cost
+	blood_cost = 10//low cost
 
 /datum/ritual/cruciform/priest/ejection/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/obj/item/weapon/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/weapon/implant/core_implant/cruciform, FALSE)
@@ -382,6 +441,12 @@
 	var/mob/M = CI.wearer
 
 	if(ishuman(M) && M.is_dead())
+		if(user.species?.reagent_tag != IS_SYNTHETIC)
+			if(user.nutrition >= nutri_cost)
+				user.nutrition -= nutri_cost
+			else
+				to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+				user.vessel.remove_reagent("blood",blood_cost)
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/E = H.organs_by_name[BP_CHEST]
 		E.take_damage(15)
@@ -405,6 +470,8 @@
 	desc = "This litany will remove any upgrade from the target's cruciform implant. Usuable only by primes and crusaders."
 	power = 100
 	category = "Devotion"
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/priest/unupgrade/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/obj/item/weapon/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/weapon/implant/core_implant/cruciform)
@@ -422,6 +489,12 @@
 		return FALSE
 
 	for(var/obj/item/weapon/coreimplant_upgrade/CU in CI.upgrades)
+		if(user.species?.reagent_tag != IS_SYNTHETIC)
+			if(user.nutrition >= nutri_cost)
+				user.nutrition -= nutri_cost
+			else
+				to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+				user.vessel.remove_reagent("blood",blood_cost)
 		CU.remove()
 		log_and_message_admins("removed upgrade from [C] cruciform with asacris litany")
 
@@ -433,6 +506,8 @@
 	desc = "Request an upgrade kit to restore a vector or prime's cruciform to its devout stage. This litany requires you to stand next to an altar."
 	power = 50
 	success_message = "On the verge of audibility you hear pleasant music, the alter slides open and a devout upgrade circuit slips out."
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/targeted/cruciform/priest/upgrade_kit/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C,list/targets)
 	var/list/OBJS = get_front(user)
@@ -442,7 +517,12 @@
 	if(!altar)
 		fail("This is not your altar, the litany is useless.", user, C)
 		return FALSE
-
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	new /obj/item/weapon/coreimplant_upgrade/cruciform/priest(altar.loc)
 	set_personal_cooldown(user)
 
@@ -451,6 +531,8 @@
 	phrase = "Habe fiduciam in Domino ex toto corde tuo et ne innitaris prudentiae tuae, in omnibus viis tuis cogita illum et ipse diriget gressus tuos."
 	desc = "The second stage of granting a promotion to a disciple, upgrading them to a devout. The devout ascension kit is the first step."
 	power = 50
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/priest/initiation/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C,list/targets)
 	var/obj/item/weapon/implant/core_implant/CI = get_implant_from_victim(user, /obj/item/weapon/implant/core_implant/cruciform)
@@ -468,7 +550,12 @@
 	if(!PC)
 		fail("Target must have devout upgrade inside his cruciform.",user,C)
 		return FALSE
-
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	PC.activate()
 	log_and_message_admins("promoted disciple [C] to devout with initiation litany")
 
@@ -488,6 +575,8 @@
 	cooldown_category = "short_boost"
 	category = "Words of Power"
 	var/list/stats_to_boost = list()
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/priest/short_boost/New()
 	..()
@@ -500,6 +589,12 @@
 			people_around.Add(H)
 
 	if(people_around.len > 0)
+		if(user.species?.reagent_tag != IS_SYNTHETIC)
+			if(user.nutrition >= nutri_cost)
+				user.nutrition -= nutri_cost
+			else
+				to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+				user.vessel.remove_reagent("blood",blood_cost)
 		to_chat(user, SPAN_NOTICE("Your feel the air thrum with an inaudible vibration."))
 		playsound(user.loc, 'sound/machines/signal.ogg', 50, 1)
 		for(var/mob/living/carbon/human/participant in people_around)
@@ -573,6 +668,8 @@
 	desc = "Request a new cruciform in the event someone wishes to join the fold or the one they had was destroyed. Requires the speaker to stand next to an altar."
 	power = 50
 	success_message = "On the verge of audibility you hear pleasant music, the alter slides open and a new cruciform slips out."
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/priest/new_cruciform/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/list/OBJS = get_front(user)
@@ -587,18 +684,48 @@
 		var/response = input(user, "Which cruciform do you require?") in list("Lemniscate","Tessellate","Monomial","Divisor","No Path","Cancel Litany")
 		if (response == "Lemniscate")
 			new /obj/item/weapon/implant/core_implant/cruciform/lemniscate(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			return TRUE
 		if (response == "Tessellate")
 			new /obj/item/weapon/implant/core_implant/cruciform/tessellate(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			return TRUE
 		if (response == "Monomial")
 			new /obj/item/weapon/implant/core_implant/cruciform/monomial(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			return TRUE
 		if (response == "Divisor")
 			new /obj/item/weapon/implant/core_implant/cruciform/divisor(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			return TRUE
 		if (response == "No Path")
 			new /obj/item/weapon/implant/core_implant/cruciform(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			return TRUE
 		if (response == "Cancel Litany")
 			fail("You decide not to obtain a cruciform at this time.", user, C)
@@ -609,6 +736,8 @@
 	phrase = "Vetus moritur et onus hoc levaverit."
 	desc = "The ritual needed for the reactivation and repair of a cruciform that has been unwillingly separated from the body or destroyed by the bearer's death. The process requires an altar and the cruciform in question to be attached."
 	power = 50
+	nutri_cost = 50//high cost
+	blood_cost = 50//high cost
 
 /datum/ritual/cruciform/priest/reactivation/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/obj/item/weapon/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/weapon/implant/core_implant/cruciform, FALSE)
@@ -628,7 +757,12 @@
 	if (CI.wearer.stat == DEAD)
 		fail("The cruciform cannot be bound to a corpse.", user, C)
 		return FALSE
-
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	log_and_message_admins("successfully reconsecrated [CI.wearer]")
 	to_chat(CI.wearer, "<span class='info'>Your cruciform vibrates and warms up.</span>")
 
@@ -646,6 +780,8 @@
 	cooldown_category = "accelerated_growth"
 	power = 30
 	category = "Vitae"
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 	var/boost_value = 1.5  // How much the aging process of the plant is sped up
 
@@ -657,6 +793,12 @@
 			plants_around.Add(H.seed)
 
 	if(plants_around.len > 0)
+		if(user.species?.reagent_tag != IS_SYNTHETIC)
+			if(user.nutrition >= nutri_cost)
+				user.nutrition -= nutri_cost
+			else
+				to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+				user.vessel.remove_reagent("blood",blood_cost)
 		to_chat(user, SPAN_NOTICE("You feel the air thrum with an inaudible vibration."))
 		playsound(user.loc, 'sound/machines/signal.ogg', 50, 1)
 		for(var/datum/seed/S in plants_around)
@@ -683,13 +825,20 @@
 	desc = "Relieves the pain of a person in front of you."
 	power = 50
 	category = "Vitae"
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/cruciform/priest/mercy/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/mob/living/carbon/human/T = get_front_human_in_range(user, 1)
 	if(!T)
 		fail("No target in front of you.", user, C)
 		return FALSE
-
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	to_chat(T, SPAN_NOTICE("You feel slightly better as your pain eases."))
 	to_chat(user, SPAN_NOTICE("You ease the pain of [T.name]."))
 
@@ -703,12 +852,21 @@
 	desc = "Stabilizes the health of a person in front of you."
 	power = 50
 	category = "Vitae"
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/cruciform/priest/absolution/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C,list/targets)
 	var/mob/living/carbon/human/T = get_front_human_in_range(user, 1)
 	if(!T)
 		fail("No target in front of you.", user, C)
 		return FALSE
+
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 
 	to_chat(T, SPAN_NOTICE("You feel a soothing sensation in your veins."))
 	to_chat(user, SPAN_NOTICE("You stabilize [T.name]'s health."))
@@ -726,6 +884,8 @@
 	desc = "Addictions are common afflictions among colony denizens. This litany helps those people by easing or removing their addictions."
 	power = 50
 	category = "Vitae"
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/cruciform/priest/purging/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/mob/living/carbon/human/T = get_front_human_in_range(user, 1)
@@ -733,6 +893,12 @@
 		fail("No target in front of you.", user, C)
 		return FALSE
 
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
 	if(T.metabolism_effects.addiction_list.len)
 		for(var/addiction in T.metabolism_effects.addiction_list)
 			var/datum/reagent/R = addiction
@@ -758,6 +924,8 @@
 	desc = "This litany summon a prosthetic limb or implant to install on a follower."
 	power = 50
 	category = "Vitae"
+	nutri_cost = 25//med cost
+	blood_cost = 25//med cost
 
 /datum/ritual/cruciform/priest/prosthetic/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/list/OBJS = get_front(user)
@@ -773,26 +941,68 @@
 		var/response = input(user, "What limb do you require?") in list("Right Arm", "Left Arm", "Right Leg", "Left Leg", "Longsword", "Ritual Knife", "Bible", "Cancel Litany")
 		if (response == "Right Arm")
 			new /obj/item/organ/external/robotic/church/r_arm(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			return TRUE
 		if (response == "Left Arm")
 			new /obj/item/organ/external/robotic/church/l_arm(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			return TRUE
 		if (response == "Right Leg")
 			new /obj/item/organ/external/robotic/church/r_leg(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			return TRUE
 		if (response == "Left Leg")
 			new /obj/item/organ/external/robotic/church/l_leg(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			return TRUE
 		if (response == "Longsword")
 			new /obj/item/organ_module/active/simple/armblade/longsword(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			O = "longsword"
 			return TRUE
 		if (response == "Ritual Knife")
 			new /obj/item/organ_module/active/simple/armblade/ritual(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			O = "ritual knife"
 			return TRUE
 		if (response == "Bible")
 			new /obj/item/organ_module/active/simple/bible(altar.loc)
+			if(user.species?.reagent_tag != IS_SYNTHETIC)
+				if(user.nutrition >= nutri_cost)
+					user.nutrition -= nutri_cost
+				else
+					to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+					user.vessel.remove_reagent("blood",blood_cost)
 			O = "bible"
 			return TRUE
 		if (response == "Cancel Litany")

--- a/code/modules/core_implant/ritual.dm
+++ b/code/modules/core_implant/ritual.dm
@@ -12,6 +12,16 @@
 	var/implant_type = /obj/item/weapon/implant/core_implant
 	var/category = "???"
 
+
+	var/nutri_cost = 0 //The cost of the individual's nutrition value per spell cast
+	var/blood_cost = 0 //The cost of the individual's blood reagent per spell cast if nutrition cannot be used
+	//Nutrition cost is balanced as follows:
+	//50 for important spells (healing, knockdowns, buffs, etc)
+	//25 for all medium (pain relief, reveal, etc)
+	//10 for low importance. (Sending, light spells, etc)
+	//Blood cost when failing will be same as nutrition for now. Can be made more punishing in the future.
+	//Only given to normal spells. !Not given to group or construction!
+
 	var/cooldown = FALSE
 	var/cooldown_time = 0
 	var/cooldown_category = ""

--- a/code/modules/core_implant/ritual.dm
+++ b/code/modules/core_implant/ritual.dm
@@ -20,7 +20,6 @@
 	//25 for all medium (pain relief, reveal, etc)
 	//10 for low importance. (Sending, light spells, etc)
 	//Blood cost when failing will be same as nutrition for now. Can be made more punishing in the future.
-	//Only given to normal spells. !Not given to group or construction!
 
 	var/cooldown = FALSE
 	var/cooldown_time = 0


### PR DESCRIPTION
## About The Pull Request
(Accidentally closed my previous one.) <summary>
	Anyways this PR is the same as before.
-Makes all litanies (beside group ones) have a nutrition cost.
-Makes failing the nutrition cost take blood from the user but still successfully casts the litany
-Reduces the energy cost for entreaty litany from 50 to 25

Things of note: Humans have 400 max nutrition and 560 max blood.
So the nutrition cost for litanies has been balanced as follows:
50 for important spells (healing, knockdowns, buffs, etc)
25 for all medium (pain relief, reveal, etc)
10 for low importance. (Sending, light spells, etc)
There is also a cost of blood when you fail to cast a litany while lacking the proper nutrition.
Presently that blood cost is at the same level for whatever the nutrition cost of the litany is.
It has been given to all litanies (as best as possible) except for the group ones.
The nutrition cost is also only taken if you managed to properly cast a litany.

</summary>
<hr>

## Changelog
:cl:
<!---Makes all litanies (beside group ones) have a nutrition cost.
-Makes failing the nutrition cost take blood from the user but still successfully casts the litany
-Reduces the energy cost for entreaty litany from 50 to 25-->
/:cl: