### PR TITLE
adds balaclava to loadout + custom name/descriptions for loadout items

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -331,3 +331,59 @@
 	if(ValidTeslaLinks[metadata[7]])
 		var/t = ValidTeslaLinks[metadata[7]]
 		I.tesla_link = new t(I)
+
+var/datum/gear_tweak/custom_name/gear_tweak_free_name = new()
+
+/datum/gear_tweak/custom_name
+	var/list/valid_custom_names
+
+/datum/gear_tweak/custom_name/New(var/list/valid_custom_names)
+	src.valid_custom_names = valid_custom_names
+	..()
+
+/datum/gear_tweak/custom_name/get_contents(var/metadata)
+	return "Name: [metadata]"
+
+/datum/gear_tweak/custom_name/get_default()
+	return ""
+
+/datum/gear_tweak/custom_name/get_metadata(var/user, var/metadata)
+	if(jobban_isbanned(user, "Custom loadout"))
+		to_chat(user, WARNING("You are banned from using custom loadout names/descriptions."))
+		return
+	if(valid_custom_names)
+		return input(user, "Choose an item name.", "Character Preference", metadata) as null|anything in valid_custom_names
+	return sanitize(input(user, "Choose the item's name. Leave it blank to use the default name.", "Item Name", metadata) as text|null, MAX_LNAME_LEN, extra = 0)
+
+/datum/gear_tweak/custom_name/tweak_item(var/obj/item/I, var/metadata)
+	if(!metadata)
+		return I.name
+	I.name = metadata
+
+/*
+Custom Description
+*/
+var/datum/gear_tweak/custom_desc/gear_tweak_free_desc = new()
+
+/datum/gear_tweak/custom_desc
+	var/list/valid_custom_desc
+
+/datum/gear_tweak/custom_desc/New(var/list/valid_custom_desc)
+	src.valid_custom_desc = valid_custom_desc
+	..()
+
+/datum/gear_tweak/custom_desc/get_contents(var/metadata)
+	return "Description: [metadata]"
+
+/datum/gear_tweak/custom_desc/get_default()
+	return ""
+
+/datum/gear_tweak/custom_desc/get_metadata(var/user, var/metadata)
+	if(valid_custom_desc)
+		return input(user, "Choose an item description.", "Character Preference", metadata) as null|anything in valid_custom_desc
+	return sanitize(input(user, "Choose the item's description. Leave it blank to use the default description.", "Item Description", metadata) as message|null, extra = 0)
+
+/datum/gear_tweak/custom_desc/tweak_item(var/obj/item/I, var/metadata)
+	if(!metadata)
+		return I.desc
+	I.desc = metadata

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -313,6 +313,7 @@ var/list/gear_datums = list()
 /datum/gear/New()
 	if(FLAGS_EQUALS(flags, GEAR_HAS_TYPE_SELECTION|GEAR_HAS_SUBTYPE_SELECTION))
 		CRASH("May not have both type and subtype selection tweaks")
+	gear_tweaks = list(gear_tweak_free_name, gear_tweak_free_desc)
 	if(!description)
 		var/obj/O = path
 		description = initial(O.desc)
@@ -322,6 +323,7 @@ var/list/gear_datums = list()
 		gear_tweaks += new/datum/gear_tweak/path/type(path)
 	if(flags & GEAR_HAS_SUBTYPE_SELECTION)
 		gear_tweaks += new/datum/gear_tweak/path/subtype(path)
+
 
 /datum/gear/proc/get_description(var/metadata)
 	. = description


### PR DESCRIPTION

## Why This Is Good For The Game

fluff is hrp

seriously it's actually great since you can now add fluff items without having to bloat code with them + it's still balanced because it's based on loadout items which should all be not-super-powergay anyways


## Changelog
:cl:
add: loadout now has a balaclava + you can now rename/change description of loadout items
/:cl:

