### PR TITLE
Buff the plasma weaponry

### DIFF
--- a/code/game/objects/items/weapons/hydrogen_fuel_cell.dm
+++ b/code/game/objects/items/weapons/hydrogen_fuel_cell.dm
@@ -49,8 +49,8 @@
 	contained_sprite = TRUE
 	item_state_slots = list(slot_back_str = "plasmapack_back", slot_l_hand_str = "plasma_can_left", slot_r_hand_str = "plasma_can_right")
 
-	plasma = 2000
-	max_plasma = 2000
+	plasma = 5000
+	max_plasma = 5000
 	slot_flags = SLOT_BACK
 	w_class = ITEM_SIZE_HUGE
 	var/obj/item/weapon/gun/hydrogen/the_gun = null

--- a/code/modules/cargo/packs_medsci.dm
+++ b/code/modules/cargo/packs_medsci.dm
@@ -229,7 +229,7 @@
 		/obj/item/weapon/hydrogen_fuel_cell,
 		/obj/item/weapon/hydrogen_fuel_cell
 	)
-	cost = 2000 // Not cheap
+	cost = 3000 // Not cheap, but basically 1$ per unit of hydrogen-plasma, this crate contain 3000 hydrogen-plasma
 	crate_name = "cryo-sealed hydrogen crate"
 	group = "Medical / Science"
 	containertype = /obj/structure/closet/crate
@@ -239,7 +239,7 @@
 	contains = list(
 		/obj/item/weapon/hydrogen_fuel_cell/backpack
 	)
-	cost = 5000 // Not cheap
+	cost = 5000 // Not cheap, but basically 1$ per unit of hydrogen-plasma, this crate contain 5000 hydrogen-plasma
 	crate_name = "cryo-sealed hydrogen crate"
 	group = "Medical / Science"
 	containertype = /obj/structure/closet/crate

--- a/code/modules/projectiles/guns/plasma/hydrogen.dm
+++ b/code/modules/projectiles/guns/plasma/hydrogen.dm
@@ -40,8 +40,8 @@ Securing and unsecuring the flask is a long and hard task, and a failure when un
 	var/secured = TRUE // Is the flask secured?
 	var/heat_level = 0 // Current heat level of the gun
 	var/vent_level = 50 // Threshold at which is automatically vent_level
-	var/vent_timer = 0 // Keep track of the timer
-	var/vent_level_timer = 50 // Timer in second before the next venting can happen
+	var/vent_timer = 0 // Keep track of the timer, decrease by 1 every 5 second
+	var/vent_level_timer = 6 // Timer in 5 second before the next venting can happen. A value of 6 mean that it will take 30 seconds before the gun can vent itself again.
 	var/overheat = 100 // Max heat before overheating.
 
 	// Damage dealt when overheating

--- a/code/modules/projectiles/projectile/hydrogen.dm
+++ b/code/modules/projectiles/projectile/hydrogen.dm
@@ -3,7 +3,7 @@
 	icon_state = "plasma_bolt"
 	mob_hit_sound = list('sound/effects/gore/sear.ogg')
 	hitsound_wall = 'sound/weapons/guns/misc/laser_searwall.ogg'
-	damage_types = list(BURN = 40)
+	damage_types = list(BURN = 100)
 	armor_penetration = 30
 	check_armour = ARMOR_ENERGY
 	muzzle_type = /obj/effect/projectile/plasma/muzzle
@@ -11,7 +11,7 @@
 	kill_count = 15 // How long until they disapear
 
 /obj/item/projectile/hydrogen/on_impact(atom/target)
-	explosion(loc, 0, 0, 1) // Smallest possible explosion
+	explosion(loc, 0, 0, 2) // Smallest possible explosion
 	set_light(0)
 	return TRUE
 
@@ -31,14 +31,14 @@
 
 // Overcharged Shots
 /obj/item/projectile/hydrogen/max
-	damage_types = list(BURN = 75)
+	damage_types = list(BURN = 150)
 	armor_penetration = 50
 
 
 /obj/item/projectile/hydrogen/pistol/max
-	damage_types = list(BURN = 75)
+	damage_types = list(BURN = 150)
 	armor_penetration = 50
 
 /obj/item/projectile/hydrogen/cannon/max
-	damage_types = list(BURN = 75)
+	damage_types = list(BURN = 150)
 	armor_penetration = 50


### PR DESCRIPTION
## About The Pull Request
This make the plasma weaponry more powerful to justify the risks and the cost.

- Boost the damage output from 40 burn (Barely 10 more than the Church's plasma guns) to 100 burn (enough to 3-shot a trapdoor spider.)
- Boost the overclock damage output from 75 burn damage to 150.
- Boost the shot's explosion from 1 power, to 2 power. Doesn't seem that much, but it mean the explosion will actually hurt the target, and not just break the tile in front of them.
- Reduce the automatic cooling time from 250 seconds (or ~4 minutes) to 30 seconds. It still won't keep up with the heat gain if you shoot it constantly.
- Buff the cryo-sealed hydrogen pack to hold enough hydrogen-plasma for 500 shots rather than just 200.
- Made the crates cost 1$ per plasma unit. So the hydrogen pack cost 5000$, and the flasks crate cost 3000$.
As a side-note, the cryo-sealed flask crate hold 20 flasks, each flask holding 150u of hydrogen-plasma, or enough for 15 shots. That's a total of 300 shots.

Overall, it make Soteria's hydrogen-plasma weapons more fitting of their description of 'Competing and Exceeding the Church's plasma weaponry by being dangerous.' because just 10 more damage isn't a lot.