### PR TITLE
Allow the welder to turn into a gun and back

### DIFF
--- a/code/game/objects/random/oddities.dm
+++ b/code/game/objects/random/oddities.dm
@@ -72,6 +72,7 @@
 				/obj/item/weapon/tool/wrench/big_wrench/freedom = 1,
 				/obj/item/weapon/tool/saw/hyper/doombringer = 1,
 				/obj/item/weapon/gun/projectile/that_gun = 1,
+				/obj/item/weapon/gun/hydrogen/incinerator = 1,
 				/obj/item/weapon/soap/bluespase = 0.5)) //Ye not a "gun" but still good for this
 
 /obj/random/uplink/low_chance

--- a/code/modules/projectiles/guns/plasma/hydrogen.dm
+++ b/code/modules/projectiles/guns/plasma/hydrogen.dm
@@ -76,7 +76,7 @@ Securing and unsecuring the flask is a long and hard task, and a failure when un
 /obj/item/weapon/gun/hydrogen/MouseDrop(over_object)
 	if(!connected)
 		if(secured)
-			to_chat(usr, "The cell is screwed to the gun. You cannot remove it.")
+			to_chat(usr, "The fuel cell is screwed to the gun. You cannot remove it.")
 		else if((src.loc == usr) && istype(over_object, /obj/screen/inventory/hand) && eject_item(flask, usr))
 			flask = null
 			update_icon()

--- a/code/modules/projectiles/guns/plasma/variant.dm
+++ b/code/modules/projectiles/guns/plasma/variant.dm
@@ -71,12 +71,18 @@
 
 // This is where the gun turn into a welder
 /obj/item/weapon/gun/hydrogen/plasma_torch/verb/switch_to_welder()
-	set name = "Switch to Welder"
-	set desc = "For when you need to work, this turn your gun into a welder."
+	set name = "Enable Safeties"
+	set desc = "Enable the safeties, making the welder gun able to weld once more."
 	set category = "Object"
 
-	var/obj/item/weapon/tool/plasma_torch/welder = new /obj/item/weapon/tool/plasma_torch(src.loc)
-	welder.flask = flask
-	flask.forceMove(welder)
-	flask = null
+	var/obj/item/weapon/tool/plasma_torch/welder = new /obj/item/weapon/tool/plasma_torch(src)
+	if(flask)
+		welder.flask = flask
+		flask.forceMove(welder)
+		flask = null
 	qdel(src)
+	usr.put_in_hands(welder)
+	usr.visible_message(
+						SPAN_NOTICE("[usr] activate the safeties of the [src.name]."),
+						SPAN_NOTICE("You activate the safeties of the [src.name].")
+						)

--- a/code/modules/projectiles/guns/plasma/variant.dm
+++ b/code/modules/projectiles/guns/plasma/variant.dm
@@ -58,3 +58,25 @@
 // Can't remove the cell
 /obj/item/weapon/gun/hydrogen/incinerator/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 	return
+
+/obj/item/weapon/gun/hydrogen/plasma_torch
+	name = "\improper Welder Gun"
+	desc = "A plasma welder converted to shoot plasma bolts. Has less range than a \"Classia\"-Pattern Plasma Pistol."
+	icon_state = "welder"
+	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_MHYDROGEN = 3, MATERIAL_OSMIUM = 2, MATERIAL_TRITIUM = 1)
+	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 7, TECH_PLASMA = 7)
+	projectile_type = /obj/item/projectile/hydrogen/pistol/welder
+	twohanded = FALSE
+	init_firemodes = list()
+
+// This is where the gun turn into a welder
+/obj/item/weapon/gun/hydrogen/plasma_torch/verb/switch_to_welder()
+	set name = "Switch to Welder"
+	set desc = "For when you need to work, this turn your gun into a welder."
+	set category = "Object"
+
+	var/obj/item/weapon/tool/plasma_torch/welder = new /obj/item/weapon/tool/plasma_torch(src.loc)
+	welder.flask = flask
+	flask.forceMove(welder)
+	flask = null
+	qdel(src)

--- a/code/modules/projectiles/guns/plasma/variant.dm
+++ b/code/modules/projectiles/guns/plasma/variant.dm
@@ -76,12 +76,12 @@
 	set category = "Object"
 
 	var/obj/item/weapon/tool/plasma_torch/welder = new /obj/item/weapon/tool/plasma_torch(src)
-	if(flask)
-		welder.flask = flask
-		flask.forceMove(welder)
-		flask = null
-	qdel(src)
-	usr.put_in_hands(welder)
+	if(flask) // Give the welder the same flask the gun has, but only if there's a flask.
+		welder.flask = flask // Link the flask to the welder
+		flask.forceMove(welder) // Give the flask to the welder
+		flask = null // The gun has no more flask
+	qdel(src) // Remove the original gun.
+	usr.put_in_hands(welder) // Put the welder in the user's hand.
 	usr.visible_message(
 						SPAN_NOTICE("[usr] activate the safeties of the [src.name]."),
 						SPAN_NOTICE("You activate the safeties of the [src.name].")

--- a/code/modules/projectiles/guns/plasma/welder.dm
+++ b/code/modules/projectiles/guns/plasma/welder.dm
@@ -120,12 +120,18 @@
 
 // This is where the welder transform into a gun
 /obj/item/weapon/tool/plasma_torch/verb/switch_to_gun()
-	set name = "Switch to Gun"
-	set desc = "For when you need to shoot, this turn your welder into a gun."
+	set name = "Disable Safeties"
+	set desc = "Disable the safeties, making the plasma torch able to shoot like a gun."
 	set category = "Object"
 
-	var/obj/item/weapon/gun/hydrogen/plasma_torch/da_gun = new /obj/item/weapon/gun/hydrogen/plasma_torch(src.loc)
-	da_gun.flask = flask
-	flask.forceMove(da_gun)
-	flask = null
+	var/obj/item/weapon/gun/hydrogen/plasma_torch/da_gun = new /obj/item/weapon/gun/hydrogen/plasma_torch(src)
+	if(flask)
+		da_gun.flask = flask
+		flask.forceMove(da_gun)
+		flask = null
 	qdel(src)
+	usr.put_in_hands(da_gun)
+	usr.visible_message(
+						SPAN_NOTICE("[usr] deactivate the safeties of the [src.name]."),
+						SPAN_NOTICE("You deactivate the safeties of the [src.name].")
+						)

--- a/code/modules/projectiles/guns/plasma/welder.dm
+++ b/code/modules/projectiles/guns/plasma/welder.dm
@@ -1,6 +1,6 @@
 // Welder that use plasma flasks
 /obj/item/weapon/tool/plasma_torch
-	name = "plasma welder"
+	name = "plasma torch"
 	desc = "A welder that uses a cryo-sealed hydrogen fuel cell to weld with the heat of a sun. While better than a conventional welders and even rivaling greyson prositronics its \
 	costly fuel supply and risks involved stopped the tool from ever seeing commercial success, a choice for a specialist and nobody else."
 	icon = 'icons/obj/guns/plasma/hydrogen.dmi'
@@ -19,10 +19,15 @@
 	var/use_plasma_cost = 1 // Active cost
 	var/passive_cost = 0.3 // Passive cost
 
+	var/gun_mode = FALSE // Determine if the welder act as a gun or not
+
+/obj/item/weapon/tool/plasma_torch/Initialize()
+	..()
+	flask = new /obj/item/weapon/hydrogen_fuel_cell(src) // Give the welder a new flask when mapped in.
+	update_icon()
+
 /obj/item/weapon/tool/plasma_torch/New()
 	..()
-	if(!flask)
-		flask = new /obj/item/weapon/hydrogen_fuel_cell(src)
 	update_icon()
 
 /obj/item/weapon/tool/plasma_torch/Process()
@@ -112,3 +117,15 @@
 	..()
 	if(flask)
 		add_overlay("[icon_state]_loaded")
+
+// This is where the welder transform into a gun
+/obj/item/weapon/tool/plasma_torch/verb/switch_to_gun()
+	set name = "Switch to Gun"
+	set desc = "For when you need to shoot, this turn your welder into a gun."
+	set category = "Object"
+
+	var/obj/item/weapon/gun/hydrogen/plasma_torch/da_gun = new /obj/item/weapon/gun/hydrogen/plasma_torch(src.loc)
+	da_gun.flask = flask
+	flask.forceMove(da_gun)
+	flask = null
+	qdel(src)

--- a/code/modules/projectiles/guns/plasma/welder.dm
+++ b/code/modules/projectiles/guns/plasma/welder.dm
@@ -125,12 +125,12 @@
 	set category = "Object"
 
 	var/obj/item/weapon/gun/hydrogen/plasma_torch/da_gun = new /obj/item/weapon/gun/hydrogen/plasma_torch(src)
-	if(flask)
-		da_gun.flask = flask
-		flask.forceMove(da_gun)
-		flask = null
-	qdel(src)
-	usr.put_in_hands(da_gun)
+	if(flask) // Give the gun the same flask the welder has, but only if there's a flask.
+		da_gun.flask = flask // Link the flask to the gun
+		flask.forceMove(da_gun) // Give the flask to the gun
+		flask = null // The Welder got no more flasks
+	qdel(src) // Delete the welder
+	usr.put_in_hands(da_gun) // Put the new gun in the user's hand
 	usr.visible_message(
 						SPAN_NOTICE("[usr] deactivate the safeties of the [src.name]."),
 						SPAN_NOTICE("You deactivate the safeties of the [src.name].")


### PR DESCRIPTION
## About The Pull Request
In 40k lore, plasma torchs are canonically able to be used as makeshift but powerful weapons.
> A Plasma Torch is a common tool utilised by Imperial engineers and Tech-priests, exploration teams who need to breach multiple barriers, and Space Marine Techmarines. Plasma Torches utilise a controlled plasma arc to make precise alterations when fixing Imperial technologies, although they are more commonly used to cut through impeding bulkheads within voidships. Plasma Torches are capable of cutting through adamantine plating that is up to 20 centimetres thick in a standard minute, and can cut thinner and weaker materials far faster. **Plasma Torches can also be fired as a weapon in a similar way to a Plasma Pistol, albeit at a shorter range and without the ability to fire on maximal mode. Many a foe who has come too close has been struck by a bolt of superheated plasma from a Plasma Torch.**

Since the hydrogen-plasma weaponry are very obviously inspired by 40k, it would be a shame not to add this function.
Also add the new bluecross gun to the bluecross spawns.