### PR TITLE
Give all superior mobs the Follower AI

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/ai.dm
@@ -96,3 +96,23 @@
 				if (istype(obstacle, /obj/structure/window) || istype(obstacle, /obj/structure/closet) || istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/grille) || istype(obstacle, /obj/structure/low_wall) || istype(obstacle, /obj/structure/railing) || istype(obstacle, /obj/mecha) || istype(obstacle, /obj/structure/girder))
 					obstacle.attack_generic(src,rand(melee_damage_lower,melee_damage_upper),attacktext)
 					return
+
+/mob/living/carbon/superior_animal/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol, speech_volume)
+	..()
+	if(obey_friends) // Are we only obeying friends?
+		if(speaker in friends) // Is the one talking a friend?
+			if(findtext(message, "Follow") && findtext(message, "[src.name]") && !following) // Is he telling us to follow?
+				following = speaker
+				visible_emote("[follow_message]")
+
+			if(findtext(message, "Stop") && findtext(message, "[src.name]") && following) // Else, is he telling us to stop?
+				following = null
+				visible_emote("[stop_message]")
+	else // We are obeying everyone
+		if(findtext(message, "Follow") && findtext(message, "[src.name]") && !following) // Is he telling us to follow?
+			following = speaker
+			visible_emote("[follow_message]")
+
+		if(findtext(message, "Stop") && findtext(message, "[src.name]") && following) // Else, is he telling us to stop?
+			following = null
+			visible_emote("[stop_message]")

--- a/code/modules/mob/living/carbon/superior_animal/drone/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/drone/ai.dm
@@ -6,14 +6,6 @@
 
 /mob/living/carbon/superior_animal/handmade/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol, speech_volume)
 	..()
-	if(speaker in friends) // Is the one talking a friend?
-		if(message == "Follow." && !following) // Is he telling us to follow?
-			following = speaker
-			visible_emote("state, \"Beginning Escort Protocol on [speaker.name].\"")
-
-		if(message == "Stop." && following) // Else, is he telling us to stop?
-			following = null
-			visible_emote("state, \"Ending Escort Protocol.\"")
 
 	if(speaker in creator) // Is it the creator speaking?
 

--- a/code/modules/mob/living/carbon/superior_animal/drone/handmade_drone.dm
+++ b/code/modules/mob/living/carbon/superior_animal/drone/handmade_drone.dm
@@ -33,7 +33,8 @@
 	friendly_to_colony = TRUE
 
 	var/obj/item/weapon/cell/large/cell = new /obj/item/weapon/cell/large/moebius // Hold the drone's power cell, default to a cheap one.
-	var/mob/following = null // Who are we following?
+	follow_message = "state, \"Beginning Escort Protocol.\""
+	stop_message = "state, \"Ending Escort Protocol.\""
 	var/list/creator = list() // Who's the bot's creator.
 
 /mob/living/carbon/superior_animal/handmade/examine(mob/user)

--- a/code/modules/mob/living/carbon/superior_animal/drone/life.dm
+++ b/code/modules/mob/living/carbon/superior_animal/drone/life.dm
@@ -1,8 +1,2 @@
-/mob/living/carbon/superior_animal/lodge/Life()
+/mob/living/carbon/superior_animal/handmade/Life()
 	. = ..()
-
-	if((following) && !(findTarget())) // Are we following someone and not attacking something?
-		walk_to(src, following, 3, move_to_delay) // Follow the mob referenced in 'following' and stand almost next to them.
-
-	if(!following && !(findTarget())) // Stop following
-		walk_to(src, 0)

--- a/code/modules/mob/living/carbon/superior_animal/fungi/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/fungi/ai.dm
@@ -1,13 +1,5 @@
 /mob/living/carbon/superior_animal/fungi/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol, speech_volume)
 	..()
-	if(speaker in friends) // Is the one talking a friend?
-		if(message == "Follow." && !following) // Is he telling us to follow?
-			following = speaker
-			visible_emote("says, \"I follow friend, [speaker.name].\"")
-
-		if(message == "Stop." && following) // Else, is he telling us to stop?
-			following = null
-			visible_emote("says, \"I stop follow friend.\"")
 
 /mob/living/carbon/superior_animal/fungi/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/reagent_containers/food/snacks))

--- a/code/modules/mob/living/carbon/superior_animal/fungi/fungi.dm
+++ b/code/modules/mob/living/carbon/superior_animal/fungi/fungi.dm
@@ -36,7 +36,8 @@
 	break_stuff_probability = 0
 	leather_amount = 0
 	bones_amount = 0
-	var/mob/following = null // Who are we following?
+	follow_message = "says, \"I follow friend.\""
+	stop_message ="says, \"I stop follow friend.\""
 
 /mob/living/carbon/superior_animal/fungi/New()
 	..()

--- a/code/modules/mob/living/carbon/superior_animal/fungi/life.dm
+++ b/code/modules/mob/living/carbon/superior_animal/fungi/life.dm
@@ -1,10 +1,2 @@
 /mob/living/carbon/superior_animal/fungi/Life()
 	..()
-
-	// Start following.
-	if(following && !findTarget()) // Are we following someone and not attacking something?
-		walk_to(src, following, 2, move_to_delay) // Follow the mob referenced in 'following' and stand almost next to them.
-
-	// Stop following if we got no one to follow and no ennemies nearby
-	if(!following && !findTarget())
-		walk_to(src, 0)

--- a/code/modules/mob/living/carbon/superior_animal/life.dm
+++ b/code/modules/mob/living/carbon/superior_animal/life.dm
@@ -75,6 +75,12 @@
 	if(speak_chance && prob(speak_chance))
 		visible_emote(emote_see)
 
+	if((following) && !(findTarget())) // Are we following someone and not attacking something?
+		walk_to(src, following, follow_distance, move_to_delay) // Follow the mob referenced in 'following' and stand almost next to them.
+
+	if(!following && !(findTarget())) // Stop following
+		walk_to(src, 0)
+
 /mob/living/carbon/superior_animal/handle_chemicals_in_body()
 	if(reagents)
 		chem_effects.Cut()

--- a/code/modules/mob/living/carbon/superior_animal/lodge/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/lodge/ai.dm
@@ -1,9 +1,2 @@
 /mob/living/carbon/superior_animal/lodge/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol, speech_volume)
 	..()
-	if(message == "Follow." && !following) // Is he telling us to follow?
-		following = speaker
-		visible_emote("nods and start following [speaker.name].")
-
-	if(message == "Stop." && following) // Else, is he telling us to stop?
-		following = null
-		visible_emote("nods and stop following [speaker.name].")

--- a/code/modules/mob/living/carbon/superior_animal/lodge/lodge.dm
+++ b/code/modules/mob/living/carbon/superior_animal/lodge/lodge.dm
@@ -10,4 +10,5 @@
 	stop_automated_movement_when_pulled = TRUE
 	colony_friend = TRUE
 	friendly_to_colony = TRUE
-	var/mob/following = null // Who are we following?
+	obey_friends = FALSE
+	follow_distance = 3

--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -129,6 +129,13 @@
 	var/rounds_per_fire = 1 //how many bullets do we eat per shot, NOTE: rapid fire will use rounds_per_fire * 3
 	var/reload_message = "Performs a tactical reload!" //Are reload message.
 
+	// Variables for the following AI
+	var/obey_friends = TRUE // Do we obey only friends ?
+	var/mob/following = null // Who are we following?
+	var/follow_distance = 2 // How close do we stay?
+	var/follow_message = "nods and start following." // Message that the mob emote when they start following. Include the name of the one who follow at the end
+	var/stop_message = "nods and stop following." // Message that the mob emote when they stop following. Include the name of the one who follow at the end
+
 /mob/living/carbon/superior_animal/New()
 	..()
 	if(!icon_living)


### PR DESCRIPTION
## About The Pull Request
It give *all* the superior mobs the Follower AI that the Hunting Lodge's pet, the Shroomling and Soteria's handmade bots already had, while changing it to be a bit more streamlined with a few more vars for customization.
- The `obey_friend` var determine if the superior mob only listen to the mobs in its `friends` var or to anyone. By default it is set to TRUE, but the Hunting Lodge's pets have it set to FALSE.
- `following` is simply the mob they are currently running after.
- `follow_distance` is how close do they try to stay from the one they are following, By default it is 2, but the Hunting Lodge's pets have it set to 3.
- `follow_message` & `stop_message` are self-explanatory, it is the message that the mob emote when receiving the order.
- The AI as a whole is less finicky and more precise. Instead of having to say "Follow.", and it not working if the F wasn't capitalized or the '.' was missing. Now it will follow you if the message contain the mob's name and 'Follow'.

As a side-note, that mean that you can make the roach you tamed with ambrosia follow you around, though it doesn't make it anymore friendly to the colony.