### PR TITLE
Bug Fix/Adjustment: Adds in church painkiller chems + changes litanies

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -28,7 +28,7 @@
 		else
 			to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
 			H.vessel.remove_reagent("blood",blood_cost)
-	H.add_chemical_effect(CE_PAINKILLER, 30, TRUE)
+	H.reagents.add_reagent("anodyne", 10)
 	H.apply_effect(-30, AGONY, 0)
 	H.apply_effect(-30, HALLOSS, 0)
 	H.updatehealth()

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -47,7 +47,7 @@
 
 /datum/ritual/cruciform/tessellate/heal_heathen_special/proc/heal_other(mob/living/carbon/human/participant)
 		to_chat(participant, "<span class='info'>A sensation of relief bathes you, washing away your most of your pain in body and mind</span>")
-		participant.add_chemical_effect(CE_PAINKILLER, 100)
+		participant.reagents.add_reagent("anodyne", 10)
 		participant.adjustCloneLoss(-20)
 		participant.adjustBrainLoss(-20)
 		participant.updatehealth()
@@ -89,7 +89,7 @@
 
 /datum/ritual/cruciform/tessellate/heal_heathen_improved/proc/heal_other(mob/living/carbon/human/participant)
 		to_chat(participant, "<span class='info'>A sensation of relief bathes you, washing away your some of your pain</span>")
-		participant.add_chemical_effect(CE_PAINKILLER, 20)
+		participant.reagents.add_reagent("laudanum", 10)
 		participant.adjustBruteLoss(-20)
 		participant.adjustFireLoss(-20)
 		participant.adjustToxLoss(-20)
@@ -219,7 +219,7 @@
 		else
 			to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
 			H.vessel.remove_reagent("blood",blood_cost)
-	H.add_chemical_effect(CE_PAINKILLER, 10000, TRUE)
+	H.reagents.add_reagent("nepenthe", 10)
 	H.apply_effect(-200, AGONY, 0)
 	H.apply_effect(-200, HALLOSS, 0)
 	H.adjustBruteLoss(-10)

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -90,7 +90,7 @@
 			to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
 			H.vessel.remove_reagent("blood",blood_cost)
 	to_chat(H, "<span class='info'>A sensation of relief bathes you, washing away your pain</span>")
-	H.add_chemical_effect(CE_PAINKILLER, 20)
+	H.reagents.add_reagent("laudanum", 10)
 	H.adjustBruteLoss(-20)
 	H.adjustFireLoss(-20)
 	H.adjustToxLoss(-20)
@@ -143,7 +143,7 @@
 			to_chat(user, SPAN_DANGER("[H] is beyond your reach.."))
 			return
 		to_chat(H, "<span class='info'>A sensation of relief bathes you, washing away your pain</span>")
-		H.add_chemical_effect(CE_PAINKILLER, 20)
+		H.reagents.add_reagent("laudanum", 5)
 		H.adjustBruteLoss(-20)
 		H.adjustFireLoss(-20)
 		H.adjustToxLoss(-20)
@@ -191,7 +191,7 @@
 
 /datum/ritual/cruciform/priest/heal_heathen/proc/heal_other(mob/living/carbon/human/participant)
 		to_chat(participant, "<span class='info'>A sensation of relief bathes you, washing away your some of your pain</span>")
-		participant.add_chemical_effect(CE_PAINKILLER, 15)
+		participant.reagents.add_reagent("laudanum", 5)
 		participant.adjustBruteLoss(-15)
 		participant.adjustFireLoss(-15)
 		participant.adjustToxLoss(-15)
@@ -842,7 +842,7 @@
 	to_chat(T, SPAN_NOTICE("You feel slightly better as your pain eases."))
 	to_chat(user, SPAN_NOTICE("You ease the pain of [T.name]."))
 
-	T.add_chemical_effect(CE_PAINKILLER, 50)  // painkiller effect to target
+	T.reagents.add_reagent("anodyne", 10)
 
 	return TRUE
 
@@ -914,7 +914,7 @@
 	to_chat(T, SPAN_NOTICE("You feel weird as you progress through your addictions."))
 	to_chat(user, SPAN_NOTICE("You help [T.name] get rid of their addictions."))
 
-	T.add_chemical_effect(CE_PAINKILLER, 15)  // painkiller effect to target
+	T.reagents.add_reagent("laudanum", 10)
 
 	return TRUE
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -370,6 +370,52 @@
 	if(prob(5 - (2 * M.stats.getMult(STAT_TGH))))
 		M.Stun(5)
 
+/* Cruciform litany related painkillers */
+/datum/reagent/medicine/nepenthe  //Monomial super-painkiller
+	name = "Nepenthe"
+	id = "nepenthe"
+	description = "A gift from the Absolute, it allows the user to suffer through all hardships."
+	taste_description = "fading sorrow"
+	reagent_state = LIQUID
+	color = "#AA5656"
+	overdose = 0
+	scannable = 0
+	metabolism = 0.2
+	nerve_system_accumulations = 0
+
+/datum/reagent/medicine/nepenthe/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.add_chemical_effect(CE_PAINKILLER, 1000)
+
+/datum/reagent/medicine/anodyne //Standard used around
+	name = "Anodyne"
+	id = "anodyne"
+	description = "A gift from above to survive the present troubles."
+	taste_description = "numbness"
+	reagent_state = LIQUID
+	color = "#BAA845"
+	overdose = 0
+	scannable = 0
+	metabolism = 0.2
+	nerve_system_accumulations = 0
+
+/datum/reagent/medicine/anodyne/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.add_chemical_effect(CE_PAINKILLER, 40)
+
+/datum/reagent/medicine/laudanum //Weakest available
+	name = "Laudanum"
+	id = "laudanum"
+	description = "A weak painkiller. There to soothe only the most minor of wounds."
+	taste_description = "home"
+	reagent_state = LIQUID
+	color = "#488531"
+	overdose = 0
+	scannable = 0
+	metabolism = 0.5
+	nerve_system_accumulations = 0
+
+/datum/reagent/medicine/laudanum/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.add_chemical_effect(CE_PAINKILLER, 15)
+
 /* Other medicine */
 
 /datum/reagent/medicine/synaptizine


### PR DESCRIPTION
**To fix a bug regarding litanies regarding how the painkiller effects are handled,such as never going away, they are solved via this PR.**
What this PR does:
-Add in 3 different type of pain relief chems for use in this
-First chem is "Nepenthe"  which provides the massive pain removal for the monomial.
-Second chem is "Anodyne" which provides a medium pain relief.
-Third chem is "Laudanum" which provides a low pain relief
These chems: Do not show up on a scanner, process at twice the rate of normal painkillers (so 0.2 instead of 0.1), and have no overdose limit.
-All the litanies which provide a painkiller effect have been readjusted to these chems with what I feel is an appropriate amount, which is either giving 5 or 10 units of it to the individual(s).

This PR has been tested and everything works appropriately. Let me know if there is anything which should be adjusted.