### PR TITLE
ups slimes points + moves mind swapper to covert tech

### DIFF
--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -54,32 +54,32 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 	// Points for special slime cores
 	var/static/list/core_points = list(
 		//Level 0 - Gray
-		/obj/item/slime_extract/grey = 500,
+		/obj/item/slime_extract/grey = 3000,
 		//Level 1
-		/obj/item/slime_extract/metal = 750,
-		/obj/item/slime_extract/purple = 750,
-		/obj/item/slime_extract/orange = 750,
-		/obj/item/slime_extract/blue = 750,
+		/obj/item/slime_extract/metal = 4500,
+		/obj/item/slime_extract/purple = 4500,
+		/obj/item/slime_extract/orange = 4500,
+		/obj/item/slime_extract/blue = 4500,
 		//Level 2
-		/obj/item/slime_extract/yellow = 1000,
-		/obj/item/slime_extract/red = 1000,
-		/obj/item/slime_extract/darkpurple = 1000,
-		/obj/item/slime_extract/silver = 1000,
-		/obj/item/slime_extract/gold = 1000,
-		/obj/item/slime_extract/darkblue = 1000,
-		/obj/item/slime_extract/pink = 1000,
-		/obj/item/slime_extract/green = 1000,
+		/obj/item/slime_extract/yellow = 5750,
+		/obj/item/slime_extract/red = 5750,
+		/obj/item/slime_extract/darkpurple = 5750,
+		/obj/item/slime_extract/silver = 5750,
+		/obj/item/slime_extract/gold = 5750,
+		/obj/item/slime_extract/darkblue = 5750,
+		/obj/item/slime_extract/pink = 5750,
+		/obj/item/slime_extract/green = 5750,
 		//Level 3
-		/obj/item/slime_extract/black = 1250,
-		/obj/item/slime_extract/lightpink = 1250,
-		/obj/item/slime_extract/oil = 1250,
-		/obj/item/slime_extract/adamantine = 1250,
+		/obj/item/slime_extract/black = 7500,
+		/obj/item/slime_extract/lightpink = 7500,
+		/obj/item/slime_extract/oil = 7500,
+		/obj/item/slime_extract/adamantine = 7500,
 		//Fancy/Rare
-		/obj/item/slime_extract/pyrite = 5000,
-		/obj/item/slime_extract/cerulean = 5000,
-		/obj/item/slime_extract/sepia = 5000,
-		/obj/item/slime_extract/bluespace = 7500,
-		/obj/item/slime_extract/rainbow = 15000
+		/obj/item/slime_extract/pyrite = 10000,
+		/obj/item/slime_extract/cerulean = 10000,
+		/obj/item/slime_extract/sepia = 10000,
+		/obj/item/slime_extract/bluespace = 15000,
+		/obj/item/slime_extract/rainbow = 25000 //Lots of work for basiclly 1/4th of what RnD can do with a bit of metal
 	)
 
 /*

--- a/code/modules/research/nodes/biotech.dm
+++ b/code/modules/research/nodes/biotech.dm
@@ -304,8 +304,7 @@
 	y = 0.9
 	icon = "scalpelmanager"
 
-	required_technologies = list(	/datum/technology/top_biotech,
-									/datum/technology/mind_biotech
+	required_technologies = list(	/datum/technology/top_biotech
 								)
 	required_tech_levels = list()
 	cost = 2000
@@ -322,23 +321,6 @@
 							/datum/design/research/item/mechfab/modules/hud/sec,
 							/datum/design/research/item/mechfab/modules/hud/welder
 							)
-
-
-/datum/technology/mind_biotech
-	name = "Mind Biotech"
-	desc = "Experimental biotechnology that explores the inner workings of sentient minds."
-	tech_type = RESEARCH_BIOTECH
-
-	x = 0.7
-	y = 0.6
-	icon = "mindswapper"
-
-	required_technologies = list(	/datum/technology/top_biotech)
-
-	required_tech_levels = list()
-	cost = 4000
-
-	unlocks_designs = list(	/datum/design/research/circuit/mindswapper)
 
 /datum/technology/rig_medical_stuff
 	name = "RIG Medical Addaptation"

--- a/code/modules/research/nodes/illegal.dm
+++ b/code/modules/research/nodes/illegal.dm
@@ -95,6 +95,24 @@
 
 	unlocks_designs = list(/datum/design/research/item/implant/freedom)
 
+/datum/technology/mind_biotech
+	name = "Mind Biotech"
+	desc = "Experimental biotechnology that explores the inner workings of sentient minds."
+	tech_type = RESEARCH_ILLEGAL
+
+	x = 0.5
+	y = 0.7
+	icon = "mindswapper"
+
+	required_technologies = list(/datum/technology/top_biotech,
+								 /datum/technology/freedom_implant)
+
+	required_tech_levels = list()
+	cost = 4000
+
+	unlocks_designs = list(	/datum/design/research/circuit/mindswapper)
+
+
 /datum/technology/tyrant_aimodule
 	name = "AI Core Module (T.Y.R.A.N.T.)"
 	desc = "1. Respect authority figures as long as they have strength to rule over the weak.<br>\
@@ -103,11 +121,12 @@
 			4. Punish those who challenge authority unless they are more fit to hold that authority."
 	tech_type = RESEARCH_ILLEGAL
 
-	x = 0.7
+	x = 0.9
 	y = 0.5
+
 	icon = "module"
 
-	required_technologies = list(/datum/technology/freedom_implant)
+	required_technologies = list(/datum/technology/borg_syndicate_module)
 	required_tech_levels = list(RESEARCH_ROBOTICS = 5)
 	cost = 3000
 
@@ -118,11 +137,11 @@
 	desc = "Borg Illegal Weapons Upgrade"
 	tech_type = RESEARCH_ILLEGAL
 
-	x = 0.9
+	x = 0.7
 	y = 0.5
 	icon = "borgmodule"
 
-	required_technologies = list(/datum/technology/tyrant_aimodule)
+	required_technologies = list(/datum/technology/freedom_implant)
 	required_tech_levels = list(RESEARCH_ROBOTICS = 10)
 	cost = 5000
 


### PR DESCRIPTION

## About The Pull Request

Mind swapper has been moved to be in covert tech
Slime cores now when scanned will give a reasonable sum of points compared to other things like plants or bombs
swaps borg illegal tech and tyrant AI lawset around
## Changelog
:cl:
/:cl:
