### PR TITLE
Fix Rejuvenation Proc ejecting augments

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -398,7 +398,7 @@ This function completely restores a damaged organ to perfect condition.
 
 	// remove embedded objects and drop them on the floor
 	for(var/obj/implanted_object in implants)
-		if(!istype(implanted_object,/obj/item/weapon/implant))	// We don't want to remove REAL implants. Just shrapnel etc.
+		if(!istype(implanted_object, /obj/item/weapon/implant) && !istype(implanted_object, /obj/item/organ_module))	// We don't want to remove REAL implants. Just shrapnel etc. // Also prevent the removal of augmentation.
 			implanted_object.loc = get_turf(src)
 			implants -= implanted_object
 


### PR DESCRIPTION
## About The Pull Request
So, turns out that while the rejuvenation proc **does** check if there's implants and make sure not to eject those, it doesn't give a single fuck about augments !

This just add an additional check that should have been made when augments were introduced.