### PR TITLE
Allow cruciform cell charging to stop when moving.

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -373,6 +373,8 @@
 			if(do_after(user, charge_rate)) // Small delay where the user must stand still
 				C.power -= charge_used // We use some juicy cruciform power
 				P.give(charge_used * 10) // Charge the power cell
+			else
+				break // Leave the loop if we interrupt.
 		to_chat(user, "You finish charging the [P.name]. It is now [P.percent()]% charged.")
 	else
 		fail("You need a power cell in your active hand to charge it.", user, C)

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -368,6 +368,8 @@
 		var/obj/item/weapon/cell/P = inhand
 		to_chat(user, "You start charging the [P.name].")
 		while(C.power >= charge_used) // Keep going until we run out of power
+			if(!istype(/obj/item/weapon/cell, user.get_active_hand())) // Check if we're still holding a cell. Because rigged cell explode when charging.
+				break
 			if(P.fully_charged()) // Leave the loop if the cell is charged.
 				break
 			if(do_after(user, charge_rate)) // Small delay where the user must stand still


### PR DESCRIPTION
## About The Pull Request
If you move while charging the cell, stop charging the cell.
It will also help with rigged cells because it will constantly check if the cell is in your active hand, so if it disappear, it will stop charging it.