### PR TITLE
Making the rigged laser more viable.

### DIFF
--- a/code/game/mecha/equipment/weapons/laser_weapons.dm
+++ b/code/game/mecha/equipment/weapons/laser_weapons.dm
@@ -25,7 +25,7 @@
 	fire_sound = 'sound/weapons/Laser.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/riggedlaser
-	equip_cooldown = 30
+	equip_cooldown = 15
 	name = "jury-rigged welder-laser"
 	desc = "While not regulation, this inefficient weapon can be attached to working exo-suits in desperate, or malicious, times."
 	icon_state = "mecha_laser"


### PR DESCRIPTION

## About The Pull Request
This PR aims to rebalance the inefficient laser weapon you can mount on exosuits, right now, the cooldown is absolutely enormous, making a shot perhaps every three or four seconds, while the laser-beam itself does twenty damage. For an exosuit mounted weapon, even an inefficient and improvised one, it remains extremely weak. This is even worse considering this is the only improvised ranged weapon that requires no ammo, and while this is an advantage, this is its only. You are better off with a Martin DPM wise.
This change simply halves the cooldown to a reasonable 15. Which should make about two seconds. For record, this is the cooldown of the /heavy/ exosuit laser, which does twice the damage.
## Changelog
:cl:
Welder-Laser exosuit weapon slightly buffed.
/:cl:


