### PR TITLE
Spawnpoints no longer sleep you

### DIFF
--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -193,7 +193,7 @@
 		C.set_occupant(M, FALSE)
 
 		//When spawning in cryo, you start off asleep for a few moments and wake up
-		M.Paralyse(2)
+		//M.Paralyse(2) we were asleep, now awake. No need to paralyse! - Also lasted longer then a few moments do to MC 
 
 		//You can get yourself out of the cryopod, or it will auto-eject after one minute
 		spawn(600)


### PR DESCRIPTION

## About The Pull Request
The lift, long bed and cryo pod when spawning into them no longer sleep you.

Lasts for to long, annoying and harms RP as when you come up/wake up you might want to talk to the people that are greeting you.
## Changelog
:cl:
/:cl: