### PR TITLE
Armor rebalance

### DIFF
--- a/code/datums/craft/recipes/clothing.dm
+++ b/code/datums/craft/recipes/clothing.dm
@@ -151,11 +151,11 @@
 	result = /obj/item/clothing/suit/storage/scavengerarmor
 	steps = list(
 		list(/obj/item/clothing/under, 1),
-		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL),
-		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTIC),
-		list(QUALITY_ADHESIVE, 15, "time" = 60),
-		list(CRAFT_MATERIAL, 10, MATERIAL_GLASS),
-		list(QUALITY_WELDING, 10, 20)
+		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL), // Melee
+		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL), // Bullets
+		list(QUALITY_WELDING, 10, 20),
+		list(CRAFT_MATERIAL, 10, MATERIAL_GLASS), // Reflective plating?
+		list(QUALITY_ADHESIVE, 15, "time" = 60)
 	)
 
 /datum/craft_recipe/clothing/muzzle

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -279,7 +279,7 @@
 	name = "'Mark V' environmental protection helmet"
 	desc = "You feel like this helmet is rare, for some reason."
 	icon_state = "technohelmet"
-	armor = list(melee = 40, bullet = 40, energy = 40, bomb = 60, bio = 100, rad = 100) //Cant have armor mods
+	armor = list(melee = 45, bullet = 45, energy = 40, bomb = 60, bio = 100, rad = 100) //Cant have armor mods
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EARS
 	flash_protection = FLASH_PROTECTION_MAJOR

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -47,7 +47,7 @@
 	desc = "A pair of steel-toed utility workboots."
 	icon_state = "workboots"
 	item_state = "workboots"
-	armor = list(melee = 10, bullet = 0, energy = 10, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 15, bullet = 0, energy = 10, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0
 	can_hold_knife = 1
 

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -47,7 +47,7 @@
 	desc = "A pair of steel-toed utility workboots."
 	icon_state = "workboots"
 	item_state = "workboots"
-	armor = list(melee = 15, bullet = 0, energy = 10, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 10, bullet = 0, energy = 10, bomb = 0, bio = 0, rad = 0) //Worse than jackboots and reinforced boots due to granting shock immunity to legs
 	siemens_coefficient = 0
 	can_hold_knife = 1
 

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -89,7 +89,7 @@
 
 	armor = list(
 		melee = 40,
-		bullet = 15,
+		bullet = 20,
 		energy = 20,
 		bomb = 25,
 		bio = 100,
@@ -106,8 +106,8 @@
 	siemens_coefficient = 0.4
 	armor = list(
 		melee = 40,
-		bullet = 20,
-		energy = 20,
+		bullet = 40,
+		energy = 25,
 		bomb = 25,
 		bio = 100,
 		rad = 0
@@ -174,7 +174,7 @@
 		slot_r_hand_str = "medical_helm",
 		)
 	armor = list(
-		melee = 30,
+		melee = 20, // It's a literal glass cube
 		bullet = 10,
 		energy = 35,
 		bomb = 25,
@@ -195,7 +195,7 @@
 		/obj/item/roller
 	)
 	armor = list(
-		melee = 20,
+		melee = 35,
 		bullet = 10,
 		energy = 35,
 		bomb = 25,
@@ -440,7 +440,7 @@
 
 /obj/item/clothing/head/space/void/assault/void_wolf
 	name = "reaver assault helmet"
-	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has an additional layer of armor as well as a light built in. This one was made for a void wolf reaver."
+	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has an additional layer of armor as well as a light built in. This one was made for a Void Wolf Reaver."
 
 /obj/item/clothing/head/space/void/assault/void_wolf/New()
 	icon_state = "assault_wolf"
@@ -450,14 +450,14 @@
 	name = "reaver assault armor"
 	icon_state = "assault_wolf"
 	item_state = "assault_wolf"
-	desc = "Void wolves prey on Kriosan trade ships and frontier colonies all the time, in rare circumstances they engage military ships, with skilled and ballzy void wolf reavers succeeding \
-	and making off with expensive loot, such as this assault armor given a void wolf paint job."
+	desc = "Void Wolves prey on Kriosan trade ships and frontier colonies all the time, in rare circumstances they engage military ships, with skilled and ballsy Void Wolf Reavers succeeding \
+	and making off with expensive loot, such as this assault armor given a Void Wolf paint job."
 	helmet = /obj/item/clothing/head/space/void/assault/void_wolf
 
 /obj/item/clothing/suit/space/void/assault
 	name = "assault armor"
 	icon_state = "assaultsuit"
-	desc = "A specialty import from the kriosan confederacy, usually imported by the Lonestar thanks to the companies long standing trade agreement. It costs a kings ransom, albiet for a good reason \
+	desc = "A specialty import from the Kriosan Confederacy, usually imported by Lonestar LLC thanks to the companies' long standing trade agreement. It costs a king's ransom, albeit for a good reason \
 	given its sturdy craftmenship and reinforced armor layers."
 	item_state = "assaultsuit"
 	armor = list(
@@ -508,7 +508,7 @@
 	desc = "A suit of all purpose soteria medical void armor. Used for operations where oxygen is a rarity and protection is needed."
 	item_state = "armor_medical"
 	armor = list(
-		melee = 30,
+		melee = 35,
 		bullet = 35,
 		energy = 30,
 		bomb = 40,

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -106,8 +106,8 @@
 	siemens_coefficient = 0.4
 	armor = list(
 		melee = 40,
-		bullet = 40,
-		energy = 25,
+		bullet = 20,
+		energy = 20,
 		bomb = 25,
 		bio = 100,
 		rad = 0

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -78,8 +78,8 @@
 	icon_state = "armor_handmade"
 	armor = list(
 		melee = 30,
-		bullet = 25,
-		energy = 20,
+		bullet = 20,
+		energy = 15,
 		bomb = 10,
 		bio = 0,
 		rad = 0
@@ -94,8 +94,8 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	armor = list(
 		melee = 30,
-		bullet = 25,
-		energy = 20,
+		bullet = 20,
+		energy = 15,
 		bomb = 10,
 		bio = 0,
 		rad = 0
@@ -107,8 +107,8 @@
 	icon_state = "hm_armorvest_black"
 	armor = list(
 		melee = 30,
-		bullet = 25,
-		energy = 20,
+		bullet = 20,
+		energy = 15,
 		bomb = 10,
 		bio = 0,
 		rad = 0
@@ -123,8 +123,8 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	armor = list(
 		melee = 30,
-		bullet = 25,
-		energy = 20,
+		bullet = 20,
+		energy = 15,
 		bomb = 10,
 		bio = 0,
 		rad = 0
@@ -150,7 +150,7 @@
 	icon_state = "botanist"
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(melee = 30, bullet = 20, energy = 15, bomb = 20, bio = 100, rad = 80)
+	armor = list(melee = 30, bullet = 30, energy = 25, bomb = 20, bio = 100, rad = 80)
 	flags_inv = HIDEJUMPSUIT
 
 /obj/item/clothing/suit/armor/vest/botanist/verb/toggle_style()
@@ -499,7 +499,7 @@
 	icon_state = "platecarrier"
 	item_state = "platecarrier"
 	blood_overlay_type = "armor"
-	armor = list(melee = 40, bullet = 40, energy = 25, bomb = 10, bio = 0, rad = 0)
+	armor = list(melee = 35, bullet = 45, energy = 20, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/platecarrier/full
 	name = "full body plate carrier"
@@ -540,14 +540,14 @@
 	desc = "An armored vest carrying trauma plates and light ballistic meshes, this one is marked with corpsman liverly and has a stain resistant coating."
 	icon_state = "platecarrier_corpsman"
 	item_state = "platecarrier_corpsman"
-	armor = list(melee = 40, bullet = 40, energy = 20, bomb = 10, bio = 20, rad = 0)
+	armor = list(melee = 35, bullet = 45, energy = 20, bomb = 10, bio = 20, rad = 0)
 
 /obj/item/clothing/suit/armor/platecarrier/corpsman/full
 	name = "Corpsman full body plate carrier"
 	desc = "An armored vest carrying trauma plates and light ballistic meshes, this one is marked with corpsman liverly and has a stain resistant coating as well as additional shoulderpads and kneepads for added protection."
 	icon_state = "platecarrier_corpsman_fullbody"
 	item_state = "platecarrier_corpsman_fullbody"
-	armor = list(melee = 40, bullet = 40, energy = 20, bomb = 10, bio = 20, rad = 0) // Just in case it doesn't inherit armor qualities
+	armor = list(melee = 35, bullet = 45, energy = 20, bomb = 10, bio = 20, rad = 0) // Just in case it doesn't inherit armor qualities
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 
 /obj/item/clothing/suit/armor/platecarrier/green
@@ -593,7 +593,7 @@
 	blood_overlay_type = "armor"
 	price_tag = 250
 	slowdown = 0.5
-	armor = list(melee = 40, bullet = 45, energy = 20, bomb = 50, bio = 0, rad = 0)
+	armor = list(melee = 40, bullet = 40, energy = 20, bomb = 50, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/flackvest/full // Sic.
 	name = "full body flak vest"
@@ -601,7 +601,7 @@
 	icon_state = "flakvest_fullbody"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	slowdown = 0.6 // Bulkier due to protecting more
-	armor = list(melee = 40, bullet = 45, energy = 20, bomb = 50, bio = 0, rad = 0) // Again, in case it doesn't inherit
+	armor = list(melee = 40, bullet = 40, energy = 20, bomb = 50, bio = 0, rad = 0) // Again, in case it doesn't inherit
 
 /obj/item/clothing/suit/armor/flackvest/militia
 	name = "blackshield flak vest"
@@ -821,11 +821,11 @@ obj/item/clothing/suit/armor/commander/marshal_coat_ss
 	icon_state = "hm_woodvest"
 	item_state = "hm_woodvest"
 	armor = list(
-		melee = 30,
-		bullet = 25, // Justifying keeping somewhat decent values on bullet just because I changed the recipe to include steel. - Seb
-		energy = 15, // It's mostly made of wood, it will char easily.
+		melee = 25, //It's made of mostly wood and cloth, shittiest armor in the game easily, but does have bio and rad, giving it a rare but still possible boost over handmade. -Kaz
+		bullet = 15, // Justifying keeping somewhat decent values on bullet just because I changed the recipe to include steel. - Seb
+		energy = 10, // It's mostly made of wood, it will char easily.
 		bomb = 10,
-		bio = 0,
-		rad = 0
+		bio = 25,
+		rad = 25
 	)
 	price_tag = 50

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -27,9 +27,9 @@
 	item_state = "armor"
 	blood_overlay_type = "armor"
 	armor = list(
-		melee = 30,
-		bullet = 30,
-		energy = 30,
+		melee = 35,
+		bullet = 35,
+		energy = 35,
 		bomb = 10,
 		bio = 0,
 		rad = 0
@@ -78,8 +78,8 @@
 	icon_state = "armor_handmade"
 	armor = list(
 		melee = 30,
-		bullet = 20,
-		energy = 15,
+		bullet = 25,
+		energy = 20,
 		bomb = 10,
 		bio = 0,
 		rad = 0
@@ -94,8 +94,8 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	armor = list(
 		melee = 30,
-		bullet = 20,
-		energy = 15,
+		bullet = 25,
+		energy = 20,
 		bomb = 10,
 		bio = 0,
 		rad = 0
@@ -107,8 +107,8 @@
 	icon_state = "hm_armorvest_black"
 	armor = list(
 		melee = 30,
-		bullet = 20,
-		energy = 15,
+		bullet = 25,
+		energy = 20,
 		bomb = 10,
 		bio = 0,
 		rad = 0
@@ -123,8 +123,8 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	armor = list(
 		melee = 30,
-		bullet = 20,
-		energy = 15,
+		bullet = 25,
+		energy = 20,
 		bomb = 10,
 		bio = 0,
 		rad = 0
@@ -150,7 +150,7 @@
 	icon_state = "botanist"
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(melee = 30, bullet = 20, energy = 15, bomb = 25, bio = 100, rad = 80)
+	armor = list(melee = 30, bullet = 20, energy = 15, bomb = 20, bio = 100, rad = 80)
 	flags_inv = HIDEJUMPSUIT
 
 /obj/item/clothing/suit/armor/vest/botanist/verb/toggle_style()
@@ -182,7 +182,7 @@
 	icon_state = "acolyte"
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(melee = 30, bullet = 30, energy = 25, bomb = 25, bio = 100, rad = 80)
+	armor = list(melee = 30, bullet = 30, energy = 25, bomb = 20, bio = 100, rad = 80)
 	flags_inv = HIDEJUMPSUIT
 
 /obj/item/clothing/suit/armor/vest/acolyte/verb/toggle_style()
@@ -224,7 +224,7 @@
 	icon_state = "custodian"
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(melee = 30, bullet = 30, energy = 25, bomb = 25, bio = 100, rad = 80)
+	armor = list(melee = 35, bullet = 30, energy = 25, bomb = 25, bio = 100, rad = 80)
 	flags_inv = HIDEJUMPSUIT
 
 /obj/item/clothing/suit/armor/vest/custodian/verb/toggle_style()
@@ -266,7 +266,7 @@
 	icon_state = "technosuit"
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(melee = 35, bullet = 35, energy = 35, bomb = 50, bio = 100, rad = 100)
+	armor = list(melee = 40, bullet = 40, energy = 35, bomb = 50, bio = 100, rad = 100)
 	max_upgrades = 2
 	extra_allowed = list(/obj/item/weapon/extinguisher,
 						 /obj/item/weapon/tool,
@@ -286,7 +286,7 @@
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	max_upgrades = 2
-	armor = list(melee = 30, bullet = 20, energy = 20, bomb = 30, bio = 50, rad = 50)
+	armor = list(melee = 35, bullet = 25, energy = 25, bomb = 30, bio = 50, rad = 50)
 	extra_allowed = list(/obj/item/weapon/extinguisher,
 						 /obj/item/weapon/tool,
 						 /obj/item/weapon/tool_upgrade,
@@ -403,10 +403,10 @@
 	max_upgrades = 2
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	armor = list(
-		melee = 35,
+		melee = 40,
 		bullet = 35,
-		energy = 35,
-		bomb = 25,
+		energy = 40,
+		bomb = 30,
 		bio = 0,
 		rad = 0
 	)
@@ -499,7 +499,7 @@
 	icon_state = "platecarrier"
 	item_state = "platecarrier"
 	blood_overlay_type = "armor"
-	armor = list(melee = 35, bullet = 45, energy = 15, bomb = 10, bio = 0, rad = 0)
+	armor = list(melee = 40, bullet = 40, energy = 25, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/platecarrier/full
 	name = "full body plate carrier"
@@ -540,14 +540,14 @@
 	desc = "An armored vest carrying trauma plates and light ballistic meshes, this one is marked with corpsman liverly and has a stain resistant coating."
 	icon_state = "platecarrier_corpsman"
 	item_state = "platecarrier_corpsman"
-	armor = list(melee = 35, bullet = 35, energy = 15, bomb = 10, bio = 20, rad = 0)
+	armor = list(melee = 40, bullet = 40, energy = 20, bomb = 10, bio = 20, rad = 0)
 
 /obj/item/clothing/suit/armor/platecarrier/corpsman/full
 	name = "Corpsman full body plate carrier"
 	desc = "An armored vest carrying trauma plates and light ballistic meshes, this one is marked with corpsman liverly and has a stain resistant coating as well as additional shoulderpads and kneepads for added protection."
 	icon_state = "platecarrier_corpsman_fullbody"
 	item_state = "platecarrier_corpsman_fullbody"
-	armor = list(melee = 35, bullet = 35, energy = 15, bomb = 10, bio = 20, rad = 0) // Just in case it doesn't inherit armor qualities
+	armor = list(melee = 40, bullet = 40, energy = 20, bomb = 10, bio = 20, rad = 0) // Just in case it doesn't inherit armor qualities
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 
 /obj/item/clothing/suit/armor/platecarrier/green
@@ -583,7 +583,7 @@
 	item_state = "platecarrier_ih"
 	blood_overlay_type = "armor"
 	slowdown = 0.15
-	armor = list(melee = 40, bullet = 50, energy = 20, bomb = 10, bio = 0, rad = 0)
+	armor = list(melee = 50, bullet = 50, energy = 30, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/flackvest
 	name = "flak vest"
@@ -593,7 +593,7 @@
 	blood_overlay_type = "armor"
 	price_tag = 250
 	slowdown = 0.5
-	armor = list(melee = 40, bullet = 40, energy = 20, bomb = 50, bio = 0, rad = 0)
+	armor = list(melee = 40, bullet = 45, energy = 20, bomb = 50, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/flackvest/full // Sic.
 	name = "full body flak vest"
@@ -601,7 +601,7 @@
 	icon_state = "flakvest_fullbody"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	slowdown = 0.6 // Bulkier due to protecting more
-	armor = list(melee = 40, bullet = 40, energy = 20, bomb = 50, bio = 0, rad = 0) // Again, in case it doesn't inherit
+	armor = list(melee = 40, bullet = 45, energy = 20, bomb = 50, bio = 0, rad = 0) // Again, in case it doesn't inherit
 
 /obj/item/clothing/suit/armor/flackvest/militia
 	name = "blackshield flak vest"
@@ -821,9 +821,9 @@ obj/item/clothing/suit/armor/commander/marshal_coat_ss
 	icon_state = "hm_woodvest"
 	item_state = "hm_woodvest"
 	armor = list(
-		melee = 35,
-		bullet = 30,
-		energy = 25,
+		melee = 30,
+		bullet = 25, // Justifying keeping somewhat decent values on bullet just because I changed the recipe to include steel. - Seb
+		energy = 15, // It's mostly made of wood, it will char easily.
 		bomb = 10,
 		bio = 0,
 		rad = 0

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -182,7 +182,7 @@
 	icon_state = "acolyte"
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(melee = 30, bullet = 30, energy = 25, bomb = 20, bio = 100, rad = 80)
+	armor = list(melee = 30, bullet = 30, energy = 25, bomb = 25, bio = 100, rad = 80)
 	flags_inv = HIDEJUMPSUIT
 
 /obj/item/clothing/suit/armor/vest/acolyte/verb/toggle_style()
@@ -224,7 +224,7 @@
 	icon_state = "custodian"
 	item_flags = THICKMATERIAL | COVER_PREVENT_MANIPULATION
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	armor = list(melee = 35, bullet = 30, energy = 25, bomb = 25, bio = 100, rad = 80)
+	armor = list(melee = 30, bullet = 30, energy = 25, bomb = 25, bio = 100, rad = 80)
 	flags_inv = HIDEJUMPSUIT
 
 /obj/item/clothing/suit/armor/vest/custodian/verb/toggle_style()

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -364,9 +364,9 @@ obj/item/clothing/suit/fluff/kimono
 	icon_state = "outcast_cloak"
 	item_state = "outcast_cloak"
 	armor = list(
-		melee = 30,
+		melee = 25,
 		bullet = 25,
-		energy = 35, // Made of leather, following hunter's armor design logic
+		energy = 25, // Made of leather, following hunter's armor design logic
 		bomb = 10,
 		bio = 5,
 		rad = 5

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -311,12 +311,12 @@ obj/item/clothing/suit/fluff/kimono
 
 /obj/item/clothing/suit/storage/scavengerarmor
 	name = "scavenger armor"
-	desc = "A rigged yet sturdy scavenger armor. Strong and protective as most vests, it is made entirely from reclaimed materials."
+	desc = "A rigged yet sturdy scavenger armor. Strong and protective as most vests, it is made entirely from reclaimed materials. It even has pockets!"
 	icon_state = "scav_armor"
 	item_state = "scav_armor"
 	armor = list(
-		melee = 40,
-		bullet = 40,
+		melee = 35, //Not the best armor, but easily crafted and adds some utility with decent protection all round.
+		bullet = 35,
 		energy = 35,
 		bomb = 25,
 		bio = 0,
@@ -331,9 +331,9 @@ obj/item/clothing/suit/fluff/kimono
 	icon_state = "triadkillers"
 	item_state = "triadkillers"
 	armor = list(
-		melee = 25,
-		bullet = 25,
-		energy = 25,
+		melee = 15, //Loadout item with pockets, cool looking and decent protection but easily outclassed. -Kaz
+		bullet = 15,
+		energy = 15,
 		bomb = 15,
 		bio = 0,
 		rad = 0
@@ -360,13 +360,13 @@ obj/item/clothing/suit/fluff/kimono
 
 /obj/item/clothing/suit/storage/raggedcape
 	name = "outcast's cloak"
-	desc = "A haphazardly-made cloak made of reclaimed leather and other fiber materials, it's all you have for protection...for now."
+	desc = "A haphazardly-made cloak made of reclaimed leather and other fiber materials, it's all you have for protection... for now."
 	icon_state = "outcast_cloak"
 	item_state = "outcast_cloak"
 	armor = list(
-		melee = 25,
-		bullet = 25,
-		energy = 25, // Made of leather, following hunter's armor design logic
+		melee = 20,
+		bullet = 10,
+		energy = 20, //Decent starting armor but intentionally shitty because outsiders are hard mode. Scavenge better. Triumph or die! -Kaz
 		bomb = 10,
 		bio = 5,
 		rad = 5

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -311,12 +311,12 @@ obj/item/clothing/suit/fluff/kimono
 
 /obj/item/clothing/suit/storage/scavengerarmor
 	name = "scavenger armor"
-	desc = "A sturdy, rigged scavenger armor. strong and sturdy as most vests. made fully from junk."
+	desc = "A rigged yet sturdy scavenger armor. Strong and protective as most vests, it is made entirely from reclaimed materials."
 	icon_state = "scav_armor"
 	item_state = "scav_armor"
 	armor = list(
-		melee = 35,
-		bullet = 35,
+		melee = 40,
+		bullet = 40,
 		energy = 35,
 		bomb = 25,
 		bio = 0,
@@ -331,9 +331,9 @@ obj/item/clothing/suit/fluff/kimono
 	icon_state = "triadkillers"
 	item_state = "triadkillers"
 	armor = list(
-		melee = 35,
-		bullet = 35,
-		energy = 35,
+		melee = 25,
+		bullet = 25,
+		energy = 25,
 		bomb = 15,
 		bio = 0,
 		rad = 0
@@ -363,9 +363,16 @@ obj/item/clothing/suit/fluff/kimono
 	desc = "A haphazardly-made cloak made of reclaimed leather and other fiber materials, it's all you have for protection...for now."
 	icon_state = "outcast_cloak"
 	item_state = "outcast_cloak"
-	armor = list(melee = 20, bullet = 0, energy = 20, bomb = 0, bio = 5, rad = 5)
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
+	armor = list(
+		melee = 30,
+		bullet = 25,
+		energy = 35, // Made of leather, following hunter's armor design logic
+		bomb = 10,
+		bio = 5,
+		rad = 5
+		)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	cold_protection = UPPER_TORSO|LOWER_TORSO
 	min_cold_protection_temperature = T0C - 20
 	price_tag = 50
 	


### PR DESCRIPTION
## About The Pull Request

- Makes 35 protection the golden standard baseline of a standard security vest for melee/bullets/laser, every armor should have more (if better) or less (if poor) of those stats. Most of the rebalance here is based upon these numbers.
- Flak vests and plate carriers are now more specialized towards protecting against damage rather than being reskins of a  generic armor vest. Values against lasers mostly unchanged.
- Commander and WO vests are generally stronger, reflecting their uniqueness and importance of a faction leader
- Nerfs wooden armor down to handmade armor vest tier (a bit lower in fact) as its stats were TOO good for the materials it takes to make.
- Outsider cloak no longer protects arms and legs, I have no idea why it did but it shouldn't. Tweaked its stats to compromise so that it's a marginally worse leather hunter armor.
- Nerfs the Triad Outfit as it's a loadout option that took only 1 point and was technically a free armor vest (it still is pretty good for a piece of loadout clothing though, just not a free roundstart handmade armor anymore)
- Scavenger armor now requires steel instead of plastic to make, (change also reflected on the makeshift voidsuit due to taking 10 plasteel to make spaceproof)
- Rebalances Artificer's Guild's Mark V suit around numbers to not fall behind and become a glorified sec armor for the ammount of plasteel (and steps with high quality tools) it takes
- Nerfs melee protection of medical voidsuit as it's a literal reinforced glass helmet

Specialized suits (Ablative, bulletproof, Juggernaut, most voidsuits, etc) are all untouched as they are already good for their niches (and the coverage of damage types/bodyparts) and do not require improvement.

## Changelog
:cl:
tweak: Scavenger armor now requires 10 steel instead of plastic, changes order of steps, better stats to justify crafting over hunting for plate carriers (similar stats)
fix: Outsider robe no longer covers arms and legs, stats upped slightly to compensate
balance: Rebalanced armors/plate carriers/flak vests/etc to offer more protection, makes workboots have the same protection as reinforced boots since they also are steel laced, nerfs wooden armor as its stats *too* good for something made out of wood and some steel, nerfs the triad outfit as it was technically a free security armor, nerfs medical voidsuit's helmet's melee protection as it's just a reinforced glass dome over your head, balances certain armors on the materials they take to make (mostly plasteel)
/:cl: