### PR TITLE
Fix the waring faction thing.

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/attack.dm
@@ -9,8 +9,11 @@
 
 	if(moved) damage *= move_attack_mult
 
-	if(waring_faction)
-		damage = damage*waring_faction_multy
+	if(istype(A, /mob))
+		var/mob/M
+		M = A
+		if(M.faction == waring_faction)
+			damage *= waring_faction_multy
 
 	. = A.attack_generic(src, damage, attacktext, environment_smash)
 


### PR DESCRIPTION
## About The Pull Request
Apparently superior mobs deal the waring faction damage bonus as long as they have a waring faction set.
This get fixed in this PR.