### PR TITLE
now properly checks melee armor

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/vox/thrown_items.dm
+++ b/code/modules/mob/living/carbon/superior_animal/vox/thrown_items.dm
@@ -4,6 +4,7 @@
 	agony = 12
 	armor_penetration = 5
 	step_delay = 0.75
+	check_armour = ARMOR_MELEE
 	can_ricochet = FALSE
 	embed = FALSE
 	sharp = FALSE
@@ -14,6 +15,7 @@
 	agony = 15
 	armor_penetration = 25
 	step_delay = 0.75
+	check_armour = ARMOR_MELEE
 	can_ricochet = FALSE
 	embed = TRUE
 	sharp = TRUE


### PR DESCRIPTION

## About The Pull Request
The birbs rocks and spears are balanced around melee armor and thus should use melee armor for is checks
## Changelog
:cl:
/:cl:
