### PR TITLE
Alt Titles payroll/manifest fix

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -29,6 +29,10 @@ SUBSYSTEM_DEF(job)
 		occupations += job
 		occupations_by_name[job.title] = job
 
+		if(job.alt_titles)
+			for(var/alt_title in job.alt_titles)
+				occupations_by_name[alt_title] = job
+
 	if(!occupations.len)
 		to_chat(world, SPAN_WARNING("Error setting up jobs, no job datums found!"))
 		return FALSE
@@ -62,6 +66,8 @@ SUBSYSTEM_DEF(job)
 			Debug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
 			player.mind.assigned_role = rank
 			player.mind.assigned_job = job
+			if(job.alt_titles)
+				player.mind.role_alt_title = player.client.prefs.GetPlayerAltTitle(job)
 			unassigned -= player
 			job.current_positions++
 			return TRUE

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -82,7 +82,7 @@
 	supervisors = "the Chief Executive Officer"
 	difficulty = "Easy."
 	selection_color = "#dddddd"
-	//alt_titles = list("Hydroponicist")
+	alt_titles = list("Hydroponicist")
 	also_known_languages = list(LANGUAGE_CYRILLIC = 15, LANGUAGE_JIVE = 80)
 	access = list(access_hydroponics, access_bar, access_kitchen)
 	wage = WAGE_LABOUR_DUMB //The gardener can make money selling his fruits to the church or to the chef and bartender.
@@ -125,7 +125,7 @@
 	access = list(access_theatre)
 	outfit_type = /decl/hierarchy/outfit/job/cargo/artist
 	wage = WAGE_LABOUR_DUMB	//Barely a retaining fee. Actor can busk for credits to keep themselves fed
-	//alt_titles = list("Artist","Clown","Entertainer","Mime")
+	alt_titles = list("Artist","Clown","Entertainer","Mime")
 	stat_modifiers = list(
 		STAT_TGH = 30, //basically a punching bag, he can't robust anyone or shoot guns anyway
 	)
@@ -162,7 +162,7 @@
 	supervisors = "the Chief Executive Officer"
 	difficulty = "Easy."
 	selection_color = "#dddddd"
-	//alt_titles = list("Custodian","Sanitation Technician")
+	alt_titles = list("Custodian","Sanitation Technician")
 	access = list(access_janitor, access_maint_tunnels, access_morgue, access_hydroponics, access_bar, access_kitchen)
 	wage = WAGE_PROFESSIONAL
 	outfit_type = /decl/hierarchy/outfit/job/service/janitor

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -72,9 +72,8 @@
 	difficulty = "Medium."
 	selection_color = "#d5c88f"
 	wage = WAGE_PROFESSIONAL
-
 	outfit_type = /decl/hierarchy/outfit/job/engineering/engineer
-
+	alt_titles = list("Guild Novice")
 	access = list(
 		access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 		access_external_airlocks, access_construction, access_atmospherics

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -69,7 +69,7 @@
 	selection_color = "#a8b69a"
 	wage = WAGE_PROFESSIONAL
 	minimum_character_age = 25
-
+	alt_titles = list("Soteria Nurse", "Soteria Pharmacist", "Soteria Surgeon", "Soteria Medical Intern")
 	outfit_type = /decl/hierarchy/outfit/job/medical/doctor
 
 	access = list(
@@ -164,7 +164,7 @@
 	supervisors = "the Soteria Biolab Overseer"
 	difficulty = "Soul Crushing."
 	selection_color = "#a8b69a"
-
+	alt_titles = list("Soteria Psychologist")
 	outfit_type = /decl/hierarchy/outfit/job/medical/psychiatrist
 
 	access = list(

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -71,7 +71,7 @@
 	selection_color = "#bdb1bb"
 	wage = WAGE_PROFESSIONAL
 
-	//alt_titles = list("Moebius Xenobiologist")
+	alt_titles = list("Soteria Xenobiologist", "Soteria Xenoarcheologist", "Soteria Xenobotanist", "Soteria Research Assistant")
 	outfit_type = /decl/hierarchy/outfit/job/science/scientist
 
 	software_on_spawn = list(/datum/computer_file/program/signaller, /datum/computer_file/program/chem_catalog)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -327,7 +327,7 @@
 	spawn_positions = 4
 	supervisors = "the Blackshield Commander"
 	difficulty = "Hard."
-	//alt_titles = list("Blackshield Junior Trooper")
+	alt_titles = list("Blackshield Cadet")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
 
@@ -377,7 +377,7 @@
 	spawn_positions = 4
 	supervisors = "the Warrant Officer"
 	difficulty = "Hard."
-	//alt_titles = list("Marshal Junior Operative")
+	alt_titles = list("Marshal Junior Officer")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
 


### PR DESCRIPTION

Comments back in alt titles, along with adding a handful. Includes a fix to un-break their visibility and payroll courtesy of 
https://github.com/Occulus-Server/Occulus-Eris/pull/161
Additionally! This time it was actually tested and is working properly. 


Scientists -Soteria Xenobotanist, Soteria Xenoarcheologist, Soteria Xenobiologist
Doctors -Soteria Nurse, Soteria Surgeon, Soteria Pharmacist, Soteria Medical Intern
Adepts - Guild Novice
Officers - Marshal Junior Officer
Troopers - Blackshield Cadet

Update science.dm

Update medical.dm

Update engineering.dm

Update security.dm

Update engineering.dm

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
