### PR TITLE
Change the roboticist loadout

### DIFF
--- a/code/datums/outfits/jobs/science.dm
+++ b/code/datums/outfits/jobs/science.dm
@@ -32,11 +32,11 @@
 	name = OUTFIT_JOB_NAME("Soteria - Roboticist")
 	uniform = /obj/item/clothing/under/rank/roboticist
 	suit = /obj/item/clothing/suit/storage/rank/robotech_jacket
-	belt = /obj/item/storage/belt/utility/full
+	belt = /obj/item/storage/belt/utility/roboticist
 	pda_slot = slot_r_store
 	id_type = /obj/item/card/id/dkgrey
 	pda_type = /obj/item/modular_computer/pda/science/roboticist
-	backpack_contents = list(/obj/item/device/robotanalyzer = 1)
+	backpack_contents = list(/obj/item/hydrogen_fuel_cell = 1)
 
 /decl/hierarchy/outfit/job/science/roboticist/New()
 	..()

--- a/code/datums/outfits/jobs/science.dm
+++ b/code/datums/outfits/jobs/science.dm
@@ -36,7 +36,7 @@
 	pda_slot = slot_r_store
 	id_type = /obj/item/card/id/dkgrey
 	pda_type = /obj/item/modular_computer/pda/science/roboticist
-	backpack_contents = list(/obj/item/hydrogen_fuel_cell = 1)
+	backpack_contents = list(/obj/item/hydrogen_fuel_cell = 1, /obj/item/stack/cable_coil = 1)
 
 /decl/hierarchy/outfit/job/science/roboticist/New()
 	..()

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -73,6 +73,33 @@
 /obj/item/storage/belt/utility/roboticist
 	name = "roboticist tool belt"
 	desc = "Can hold various tools."
+	can_hold = list(
+		/obj/item/tool,
+		/obj/item/tool_upgrade,
+		/obj/item/device/lightreplacer,
+		/obj/item/rcd,
+		/obj/item/device/lighting/toggleable/flashlight,
+		/obj/item/device/radio,
+		/obj/item/stack/cable_coil,
+		/obj/item/device/t_scanner,
+		/obj/item/device/scanner/gas,
+		/obj/item/taperoll/engineering,
+		/obj/item/device/robotanalyzer,
+		/obj/item/tool/minihoe,
+		/obj/item/tool/hatchet,
+		/obj/item/device/scanner/plant,
+		/obj/item/extinguisher/mini,
+		/obj/item/hand_labeler,
+		/obj/item/clothing/gloves,
+		/obj/item/clothing/glasses,
+		/obj/item/flame/lighter,
+		/obj/item/cell/small,
+		/obj/item/cell/medium,
+		/obj/item/grenade/chem_grenade/cleaner,
+		/obj/item/grenade/chem_grenade/antiweed,
+		/obj/item/grenade/chem_grenade/metalfoam,
+		/obj/item/gun/hydrogen/plasma_torch // Something that can hold a welder should be able to hold the same welder turned into a gun.
+	)
 
 /obj/item/storage/belt/utility/roboticist/populate_contents()
 	new /obj/item/tool/screwdriver/electric(src)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -70,6 +70,21 @@
 	new /obj/item/tool/wirecutters(src)
 	new /obj/item/stack/cable_coil/random(src)
 
+/obj/item/storage/belt/utility/roboticist
+	name = "roboticist tool belt"
+	desc = "Can hold various tools."
+	storage_slots = 8
+
+/obj/item/storage/belt/utility/roboticist/populate_contents()
+	new /obj/item/tool/screwdriver/electric(src)
+	new /obj/item/tool/wrench/big_wrench(src)
+	new /obj/item/tool/plasma_torch/loaded(src)
+	new /obj/item/tool/crowbar(src)
+	new /obj/item/tool/wirecutters(src)
+	new /obj/item/tool/multitool(src)
+	new /obj/item/stack/cable_coil(src)
+	new /obj/item/device/robotanalyzer(src)
+
 /obj/item/storage/belt/hunter
 	name = "hunting belt"
 	desc = "Can hold various tools fit for a lodge hunter."

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -73,7 +73,6 @@
 /obj/item/storage/belt/utility/roboticist
 	name = "roboticist tool belt"
 	desc = "Can hold various tools."
-	storage_slots = 8
 
 /obj/item/storage/belt/utility/roboticist/populate_contents()
 	new /obj/item/tool/screwdriver/electric(src)
@@ -82,7 +81,6 @@
 	new /obj/item/tool/crowbar(src)
 	new /obj/item/tool/wirecutters(src)
 	new /obj/item/tool/multitool(src)
-	new /obj/item/stack/cable_coil(src)
 	new /obj/item/device/robotanalyzer(src)
 
 /obj/item/storage/belt/hunter

--- a/code/modules/projectiles/guns/plasma/variant.dm
+++ b/code/modules/projectiles/guns/plasma/variant.dm
@@ -70,6 +70,7 @@
 	projectile_type = /obj/item/projectile/hydrogen/pistol/welder
 	twohanded = FALSE
 	init_firemodes = list()
+	var/obj/item/tool/plasma_torch/welder = null // Hold the welder the gun turns into.
 
 // This is where the gun turn into a welder
 /obj/item/gun/hydrogen/plasma_torch/verb/switch_to_welder()
@@ -77,12 +78,15 @@
 	set desc = "Enable the safeties, making the welder gun able to weld once more."
 	set category = "Object"
 
-	var/obj/item/tool/plasma_torch/welder = new /obj/item/tool/plasma_torch(src)
+	if(!welder) // Safety check if there isn't a welder.
+		welder = new /obj/item/tool/plasma_torch(src)
+		welder.gun = src
 	if(flask) // Give the welder the same flask the gun has, but only if there's a flask.
 		welder.flask = flask // Link the flask to the welder
 		flask.forceMove(welder) // Give the flask to the welder
 		flask = null // The gun has no more flask
-	qdel(src) // Remove the original gun.
+	usr.remove_from_mob(src) // Remove the gun from the user
+	src.forceMove(welder) // Move the gun into the welder
 	usr.put_in_hands(welder) // Put the welder in the user's hand.
 	usr.visible_message(
 						SPAN_NOTICE("[usr] activate the safeties of the [src.name]."),

--- a/code/modules/projectiles/guns/plasma/variant.dm
+++ b/code/modules/projectiles/guns/plasma/variant.dm
@@ -69,6 +69,7 @@
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 7, TECH_PLASMA = 7)
 	projectile_type = /obj/item/projectile/hydrogen/pistol/welder
 	twohanded = FALSE
+	w_class = ITEM_SIZE_SMALL
 	init_firemodes = list()
 	safety = FALSE // It's a welder turned into a gun, it doesn't have any nifty safeties, and even if it did, the player had to deactivate them to turn the welder into a gun in the first place.
 	restrict_safety = TRUE // Can't change the safety on something that doesn't have any. Look here ^ - R4d6

--- a/code/modules/projectiles/guns/plasma/variant.dm
+++ b/code/modules/projectiles/guns/plasma/variant.dm
@@ -70,6 +70,8 @@
 	projectile_type = /obj/item/projectile/hydrogen/pistol/welder
 	twohanded = FALSE
 	init_firemodes = list()
+	safety = FALSE // It's a welder turned into a gun, it doesn't have any nifty safeties, and even if it did, the player had to deactivate them to turn the welder into a gun in the first place.
+	restrict_safety = TRUE // Can't change the safety on something that doesn't have any. Look here ^ - R4d6
 	var/obj/item/tool/plasma_torch/welder = null // Hold the welder the gun turns into.
 
 // This is where the gun turn into a welder

--- a/code/modules/projectiles/guns/plasma/welder.dm
+++ b/code/modules/projectiles/guns/plasma/welder.dm
@@ -19,7 +19,7 @@
 	var/use_plasma_cost = 1 // Active cost
 	var/passive_cost = 0.3 // Passive cost
 
-	var/gun_mode = FALSE // Determine if the welder act as a gun or not
+	var/obj/item/gun/hydrogen/plasma_torch/gun = null // Hold the gun the welder turns into.
 
 /obj/item/tool/plasma_torch/Initialize()
 	..()
@@ -29,6 +29,9 @@
 /obj/item/tool/plasma_torch/New()
 	..()
 	update_icon()
+	if(!gun)
+		gun = new /obj/item/gun/hydrogen/plasma_torch(src)
+		gun.welder = src
 
 /obj/item/tool/plasma_torch/loaded/New()
 	flask = new /obj/item/hydrogen_fuel_cell(src)
@@ -128,13 +131,16 @@
 	set desc = "Disable the safeties, making the plasma torch able to shoot like a gun."
 	set category = "Object"
 
-	var/obj/item/gun/hydrogen/plasma_torch/da_gun = new /obj/item/gun/hydrogen/plasma_torch(src)
+	if(!gun) // Safety check if somehow there isn't a gun.
+		gun = new /obj/item/gun/hydrogen/plasma_torch(src)
+		gun.welder = src
 	if(flask) // Give the gun the same flask the welder has, but only if there's a flask.
-		da_gun.flask = flask // Link the flask to the gun
-		flask.forceMove(da_gun) // Give the flask to the gun
+		gun.flask = flask // Link the flask to the gun
+		flask.forceMove(gun) // Give the flask to the gun
 		flask = null // The Welder got no more flasks
-	qdel(src) // Delete the welder
-	usr.put_in_hands(da_gun) // Put the new gun in the user's hand
+	usr.remove_from_mob(src) // Remove the welder from the user
+	src.forceMove(gun) // Move the welder into the gun
+	usr.put_in_hands(gun) // Put the gun in the user's hand
 	usr.visible_message(
 						SPAN_NOTICE("[usr] deactivate the safeties of the [src.name]."),
 						SPAN_NOTICE("You deactivate the safeties of the [src.name].")

--- a/code/modules/projectiles/guns/plasma/welder.dm
+++ b/code/modules/projectiles/guns/plasma/welder.dm
@@ -30,6 +30,10 @@
 	..()
 	update_icon()
 
+/obj/item/tool/plasma_torch/loaded/New()
+	flask = new /obj/item/hydrogen_fuel_cell(src)
+	..()
+
 /obj/item/tool/plasma_torch/Process()
 	..()
 	if(switched_on)

--- a/code/modules/projectiles/projectile/hydrogen.dm
+++ b/code/modules/projectiles/projectile/hydrogen.dm
@@ -19,7 +19,7 @@
 	kill_count = 10
 
 /obj/item/projectile/hydrogen/pistol/welder
-	kill_count = 7
+	kill_count = 5
 
 /obj/item/projectile/hydrogen/cannon
 	kill_count = 12


### PR DESCRIPTION
## About The Pull Request
Since Soteria is all about high-tech stuff, give Roboticists a bit of a new loadout consisting of :
- Electric Screwdriver
- Big Wrench
- Hydrogen-Plasma Welder
- Normal Crowbar
- Normal Wirecutters
- Normal Multitool
- RoboAnalyzer

In addition, it move the cable coil from their belt to their bag, with their analyzer going the opposite way, and adding an hydrogen fuel flask to their bag too. Wouldn't want them to be unable to use their fancy new welders.


*Also I used this occasion to fix a few things with the hydrogen welder, in preparation of allowing them to have toolmods installed.