### PR TITLE
Add The Tesla Shotgun

### DIFF
--- a/code/modules/projectiles/guns/energy/tesla_shotgun.dm
+++ b/code/modules/projectiles/guns/energy/tesla_shotgun.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/energy/tesla_shotgun
-	name = "Tesla Shotgun"
-	desc = "An energy shotgun that drain power from a nearby APC."
+	name = "\"Nikolai's Fervor\" tesla shotgun"
+	desc = "An energy shotgun that drains power from a nearby APC to shoot electric blasts. May take time to charge and piss off your local guild adept."
 	icon = 'icons/obj/guns/energy/slimegun.dmi'
 	icon_state = "slimepistol"
 	item_state = "slimepistol"
@@ -20,8 +20,8 @@
 	use_external_power = TRUE
 
 /obj/item/gun/energy/tesla_shotgun/manual
-	name = "Manual Tesla Shotgun"
-	desc = "An energy shotgun that drain power from a nearby APC. This one can be pumped to charge faster."
+	name = "\"Edison's Lament\" tesla shotgun"
+	desc = "An energy shotgun that drains power from a nearby APC. This one can be pumped to charge faster. Is it really better?"
 	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 5, MATERIAL_GOLD = 2.5)
 
 // Charge the cell by pumping it.
@@ -37,15 +37,15 @@
 		cell.give(charge_cost / 2) // Only charge half of a shot per pump.
 
 /obj/item/gun/energy/tesla_shotgun/high_damage
-	name = "High-Output Tesla Shotgun"
-	desc = "An energy shotgun that drain power from a nearby APC. This one shoot a stronger beam."
+	name = "\"Modern Solutions\" tesla shotgun"
+	desc = "An energy shotgun that drains power from a nearby APC. This one shoots a stronger beam than others."
 	charge_cost = 200
 	projectile_type = /obj/item/projectile/beam/shotgun/strong
 	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 5, MATERIAL_PLASMA = 2.5)
 
 /obj/item/gun/energy/tesla_shotgun/atomic
-	name = "Atomic Tesla Shotgun"
-	desc = "An energy shotgun that drain power from a nearby APC. This one doesn't need an APC to charge thanks to an Atomcell."
+	name = "\"Atom Bomb\" tesla shotgun"
+	desc = "An energy shotgun that drains power from a nearby APC. This one doesn't need an APC to charge thanks to an atomic power cell. Oh baby!"
 	cell_type = /obj/item/cell/medium/moebius/nuclear
 	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 5, MATERIAL_URANIUM = 2.5)
 

--- a/code/modules/projectiles/guns/energy/tesla_shotgun.dm
+++ b/code/modules/projectiles/guns/energy/tesla_shotgun.dm
@@ -43,7 +43,7 @@
 	projectile_type = /obj/item/projectile/beam/shotgun/strong
 	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 5, MATERIAL_PLASMA = 2.5)
 
-/obj/item/gun/energy/tesla_shotgun/atom
+/obj/item/gun/energy/tesla_shotgun/atomic
 	name = "Atomic Tesla Shotgun"
 	desc = "An energy shotgun that drain power from a nearby APC. This one doesn't need an APC to charge thanks to an Atomcell."
 	cell_type = /obj/item/cell/medium/moebius/nuclear

--- a/code/modules/projectiles/guns/energy/tesla_shotgun.dm
+++ b/code/modules/projectiles/guns/energy/tesla_shotgun.dm
@@ -11,6 +11,7 @@
 	suitable_cell = /obj/item/cell/medium
 	cell_type = /obj/item/cell/medium/moebius
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
+	twohanded = TRUE
 	can_dual = FALSE
 	projectile_type = /obj/item/projectile/beam/shotgun
 	charge_meter = FALSE

--- a/code/modules/projectiles/guns/energy/tesla_shotgun.dm
+++ b/code/modules/projectiles/guns/energy/tesla_shotgun.dm
@@ -1,0 +1,69 @@
+/obj/item/gun/energy/tesla_shotgun
+	name = "Tesla Shotgun"
+	desc = "An energy shotgun that drain power from a nearby APC."
+	icon = 'icons/obj/guns/energy/slimegun.dmi'
+	icon_state = "slimepistol"
+	item_state = "slimepistol"
+	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 5)
+	price_tag = 500
+	charge_cost = 100
+	fire_sound = 'sound/weapons/Taser.ogg'
+	suitable_cell = /obj/item/cell/medium
+	cell_type = /obj/item/cell/medium/moebius
+	slot_flags = SLOT_BELT|SLOT_HOLSTER
+	can_dual = FALSE
+	projectile_type = /obj/item/projectile/beam/shotgun
+	charge_meter = FALSE
+	item_charge_meter = FALSE
+	self_recharge = TRUE
+	use_external_power = TRUE
+
+/obj/item/gun/energy/tesla_shotgun/manual
+	name = "Manual Tesla Shotgun"
+	desc = "An energy shotgun that drain power from a nearby APC. This one can be pumped to charge faster."
+
+// Charge the cell by pumping it.
+/obj/item/gun/energy/tesla_shotgun/manual/attack_self(mob/user as mob)
+	if(!cell) // Check if we have a cell to charge.
+		to_chat(user, "The [src.name] doesn't have a cell to charge.")
+		return FALSE
+	else if(cell.charge >= cell.maxcharge) // Does the cell need charging?
+		to_chat(user, "The [src.name] is already charged.")
+		return FALSE
+	else if(do_after(user, WORKTIME_NEAR_INSTANT, src)) // Charge the cell.
+		to_chat(user, "You pump the [src.name].")
+		cell.give(charge_cost / 5) // Only charge a fifth of a shot per pump.
+
+/obj/item/gun/energy/tesla_shotgun/high_damage
+	name = "High-Output Tesla Shotgun"
+	desc = "An energy shotgun that drain power from a nearby APC. This one shoot a stronger beam."
+	charge_cost = 200
+	projectile_type = /obj/item/projectile/beam/shotgun/strong
+
+/obj/item/gun/energy/tesla_shotgun/atom
+	name = "Atomic Tesla Shotgun"
+	desc = "An energy shotgun that drain power from a nearby APC. This one doesn't need an APC to charge thanks to an Atomcell."
+	cell_type = /obj/item/cell/medium/moebius/nuclear
+
+/obj/item/gun/energy/tesla_shotgun/Process()
+	if(self_recharge) //Every [recharge_time] ticks, recharge a shot for the cyborg
+		charge_tick++
+		if(charge_tick < recharge_time) return 0
+		charge_tick = 0
+
+		if(!cell || cell.charge >= cell.maxcharge)
+			return 0 // check if we actually need to recharge
+
+		if(use_external_power)
+			if(drain_apc(charge_cost)) //Take power from the APC...
+				cell.give(charge_cost) //... to recharge the shot
+				update_icon()
+	return 1
+
+/obj/item/gun/energy/tesla_shotgun/proc/drain_apc(var/power_usage)
+	var/area/A = get_area(src)
+	if(!istype(A) || !A.powered(STATIC_EQUIP))
+		return FALSE
+
+	A.use_power(power_usage, STATIC_EQUIP)
+	return TRUE

--- a/code/modules/projectiles/guns/energy/tesla_shotgun.dm
+++ b/code/modules/projectiles/guns/energy/tesla_shotgun.dm
@@ -21,6 +21,7 @@
 /obj/item/gun/energy/tesla_shotgun/manual
 	name = "Manual Tesla Shotgun"
 	desc = "An energy shotgun that drain power from a nearby APC. This one can be pumped to charge faster."
+	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 5, MATERIAL_GOLD = 2.5)
 
 // Charge the cell by pumping it.
 /obj/item/gun/energy/tesla_shotgun/manual/attack_self(mob/user as mob)
@@ -39,11 +40,13 @@
 	desc = "An energy shotgun that drain power from a nearby APC. This one shoot a stronger beam."
 	charge_cost = 200
 	projectile_type = /obj/item/projectile/beam/shotgun/strong
+	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 5, MATERIAL_PLASMA = 2.5)
 
 /obj/item/gun/energy/tesla_shotgun/atom
 	name = "Atomic Tesla Shotgun"
 	desc = "An energy shotgun that drain power from a nearby APC. This one doesn't need an APC to charge thanks to an Atomcell."
 	cell_type = /obj/item/cell/medium/moebius/nuclear
+	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 5, MATERIAL_URANIUM = 2.5)
 
 /obj/item/gun/energy/tesla_shotgun/Process()
 	if(self_recharge) //Every [recharge_time] ticks, recharge a shot for the cyborg

--- a/code/modules/projectiles/guns/energy/tesla_shotgun.dm
+++ b/code/modules/projectiles/guns/energy/tesla_shotgun.dm
@@ -31,9 +31,9 @@
 	else if(cell.charge >= cell.maxcharge) // Does the cell need charging?
 		to_chat(user, "The [src.name] is already charged.")
 		return FALSE
-	else if(do_after(user, WORKTIME_NEAR_INSTANT, src)) // Charge the cell.
+	else if(do_after(user, WORKTIME_INSTANT, src)) // Charge the cell.
 		to_chat(user, "You pump the [src.name].")
-		cell.give(charge_cost / 5) // Only charge a fifth of a shot per pump.
+		cell.give(charge_cost / 2) // Only charge half of a shot per pump.
 
 /obj/item/gun/energy/tesla_shotgun/high_damage
 	name = "High-Output Tesla Shotgun"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -54,6 +54,10 @@
 	damage_types = list(BURN = 35) //Normal slugs deal 45
 	armor_penetration = 10
 
+/obj/item/projectile/beam/shotgun/strong
+	damage_types = list(BURN = 54) // Default slug (/obj/item/projectile/bullet/shotgun) deal 54 damage
+	armor_penetration = 10
+
 /obj/item/projectile/beam/practice
 	name = "laser"
 	icon_state = "laser"

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -2429,6 +2429,7 @@
 #include "code\modules\projectiles\guns\energy\sst.dm"
 #include "code\modules\projectiles\guns\energy\stun.dm"
 #include "code\modules\projectiles\guns\energy\temperature.dm"
+#include "code\modules\projectiles\guns\energy\tesla_shotgun.dm"
 #include "code\modules\projectiles\guns\energy\xray.dm"
 #include "code\modules\projectiles\guns\launcher\crossbow.dm"
 #include "code\modules\projectiles\guns\launcher\makeshift.dm"


### PR DESCRIPTION
## About The Pull Request
Add a series of shotguns that use tesla relays to drain power from the nearby APCs to recharge their powercell. Come in four variations : 
Normal : Default gun, charge overtime as long as it is in a room with a powered APC.
Manual : Same as normal, but you can pump it to charge 1/5th of a shot.
High-Power : Same as normal, but deal more damage.
Atomic : Same as normal, but has an atomcell instead for when you don't have an APC nearby.

Names and descriptions are subject to change. Sprites **will** change.