### PR TITLE
Technically allow folken to see Infrared

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -58,7 +58,7 @@
 	var/radiation_mod = 1                    // Radiation modifier
 	var/flash_mod =     1                    // Stun from blindness modifier.
 	var/vision_flags = SEE_SELF              // Same flags as glasses.
-	var/see_infrared = FALSE
+	var/see_infrared = FALSE		 // Can the species see in infrared. (The BYOND kind of infrared, no custom infrared system)
 
 	var/list/hair_styles
 	var/list/facial_hair_styles

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -58,6 +58,7 @@
 	var/radiation_mod = 1                    // Radiation modifier
 	var/flash_mod =     1                    // Stun from blindness modifier.
 	var/vision_flags = SEE_SELF              // Same flags as glasses.
+	var/see_infrared = FALSE
 
 	var/list/hair_styles
 	var/list/facial_hair_styles
@@ -302,6 +303,8 @@
 	H.update_sight()
 	H.sight |= get_vision_flags(H)
 	H.sight |= H.equipment_vision_flags
+
+	H.see_infrared = see_infrared
 
 	if(H.stat == DEAD)
 		return 1

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -508,7 +508,8 @@
 	max_age = 200
 	burn_mod = 2						// Burn damage multiplier.
 	light_dam = 1 // Same threshold as the Nightcrawler perk
-	vision_flags = SEE_SELF
+	vision_flags = SEE_SELF | SEE_INFRA
+	see_infrared = TRUE
 	flags = NO_PAIN | IS_PLANT
 	taste_sensitivity = TASTE_NUMB
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -1,6 +1,7 @@
 /mob/living
 	see_in_dark = 2
 	see_invisible = SEE_INVISIBLE_LIVING
+	infra_luminosity = 10
 
 	//Health and life related vars
 	maxHealth = 100 //Maximum health that should be possible.


### PR DESCRIPTION
## About The Pull Request
This use BYOND's integrated infrared system to allow the folkens to see mobs in the dark!
However, I do not know if it work because for some reasons Folken (And maybe other mobs) are hardcoded to see in the dark the full way, and I can't edit it because it keep reseting itself because it is hardcoded and I can't find where it is hardcoded.
And even if it would allow itself to be lower, I still don't know if it would work with the custom darkness effect we use.