### PR TITLE
Make the Stasis Bidon work correctly.

### DIFF
--- a/code/modules/reagents/reagent_containers/bidon.dm
+++ b/code/modules/reagents/reagent_containers/bidon.dm
@@ -19,7 +19,7 @@
 	name = "stasis B.I.D.O.N. canister"
 	desc = "An advanced B.I.D.O.N. canister with stasis function."
 	icon_state = "bidon_adv"
-	reagent_flags = TRANSPARENT
+	reagent_flags = TRANSPARENT | NO_REACT // It's a stasis BIDON, shouldn't allow chems to react inside it.
 	filling_states = list(20,40,60,80,100)
 	volume = 9000
 


### PR DESCRIPTION
Make the Stasis Bidon work correctly.
For some reason it never has the NO_REACT flag which is what prevent chemical reactions from occuring which is the main point of the Stasis beakers & stuff