### PR TITLE
2 runtime fixes form eris

### DIFF
--- a/code/game/machinery/excelsior/ex_teleporter.dm
+++ b/code/game/machinery/excelsior/ex_teleporter.dm
@@ -85,6 +85,9 @@ var/global/excelsior_last_draft = 0
 	.=..()
 
 /obj/machinery/complant_teleporter/RefreshParts()
+	if (!component_parts.len)
+		error("[src] \ref[src] had no parts on refresh")
+		return //this has runtimed before
 	var/man_rating = 0
 	var/man_amount = 0
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -167,6 +167,10 @@
 		set_light(0)
 
 /obj/effect/plant/proc/refresh_icon()
+	if (growth_threshold == 0)
+		error("growth_threshold is somehow 0, probably never got redefined. Qdeling to prevent repeat logs")
+		qdel(src)
+		return
 	var/growth = max(1,min(max_growth,round(health/growth_threshold)))
 	var/at_fringe = dist3D(src,parent)
 	if(spread_distance > 5)


### PR DESCRIPTION

## About The Pull Request
From vode-code
removes three division by zero runtimes,one in ex_teleporter.dm RefreshParts(), one in spreading.dm refresh_icon()