### PR TITLE
Update RCD.dm

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -110,37 +110,43 @@
 				build_turf =  /turf/simulated/floor/airless
 			if(gotFloor)
 				build_delay = 40
-				build_cost =  5
+				build_cost =  3
 				build_type =  "wall"
 				build_turf =  /turf/simulated/wall
 		if(2)
-			if(!gotBlocked)
+			if(gotBlocked)
+				return 0
+			if(gotSpace)
+				build_delay = 30
+				build_cost = 3
+				build_turf = /turf/simulated/floor/airless //there is always floor under low wall
 				build_type = "low wall"
 				build_object = /obj/structure/low_wall
-				if(gotSpace)
-					build_delay = 30
-					build_cost = 6
-					build_turf = /turf/simulated/floor/airless //there is always floor under low wall
-				if(gotFloor)
-					build_delay = 30
-					build_cost =  5
+			if(gotFloor)
+				build_type = "low wall"
+				build_object = /obj/structure/low_wall
+				build_delay = 30
+				build_cost =  2
 
 		if(3)
-			if(!gotBlocked)
+			if(gotBlocked)
+				return 0
+			if(gotSpace)
 				build_type = "airlock"
+				build_cost =  7
+				build_delay = 50
+				build_turf =  /turf/simulated/floor/airless
 				build_object = /obj/machinery/door/airlock
-				if(gotSpace)
-					build_cost =  11
-					build_delay = 50
-					build_turf =  /turf/simulated/floor/airless
-				if(gotFloor)
-					build_cost =  10
-					build_delay = 40
+			if(gotFloor)
+				build_type = "airlock"
+				build_cost =  6
+				build_delay = 40
+				build_object = /obj/machinery/door/airlock
 
 		if(4)
 			build_type =  "deconstruct"
 			if(gotFloor)
-				build_cost =  10
+				build_cost =  5
 				build_delay = 50
 				build_turf = get_base_turf_by_area(local_turf)
 			else if(istype(T,/obj/structure/low_wall))


### PR DESCRIPTION
By
Deal5

Fixed a little bug that allowed RCD to build low walls and airlocks inside other walls by clicking on them, and that doesnt spend any matter.

Also trying to make RCD's matter consumption a little more fair to the hand version since it's extremely unfun and feels unfair to use even in extreme situations. Tested how it affects borgs and rigs, the only problem might be the borgs since they can afford their cell charge to lose some energy and it might not even be that expensive for them but they are controlled by laws anyway, so what could go wrong?