### PR TITLE
[JTB] Fix people being unable to get back in

### DIFF
--- a/code/modules/dungeons/junk_tractor_beam.dm
+++ b/code/modules/dungeons/junk_tractor_beam.dm
@@ -3,7 +3,7 @@
 #define BEAM_STABILIZED  2
 #define BEAM_COOLDOWN    3
 
-#define JTB_EDGE     2
+#define JTB_EDGE     3
 #define JTB_MAXX   100
 #define JTB_MAXY   100
 #define JTB_OFFSET  10
@@ -514,10 +514,10 @@
 
 	// Make space outside the edge impassable to avoid fast moving object moving too fast through the barrier to be detected and wraped-around
 	edges = list()
-	edges += block(locate(1+JTB_OFFSET-JTB_EDGE-1, 1+JTB_OFFSET-JTB_EDGE, z), locate(1+JTB_OFFSET-JTB_EDGE-1, maxy+JTB_OFFSET+JTB_EDGE, z))  // Left border
-	edges |= block(locate(maxx+JTB_OFFSET+JTB_EDGE+1, 1+JTB_OFFSET-JTB_EDGE, z),locate(maxx+JTB_OFFSET+JTB_EDGE+1, maxy+JTB_OFFSET+JTB_EDGE, z))  // Right border
-	edges |= block(locate(1+JTB_OFFSET-JTB_EDGE-1, 1+JTB_OFFSET-JTB_EDGE-1, z), locate(maxx+JTB_OFFSET+JTB_EDGE+1, 1+JTB_OFFSET-JTB_EDGE-1, z))  // Bottom border
-	edges |= block(locate(1+JTB_OFFSET-JTB_EDGE-1, maxy+JTB_OFFSET+JTB_EDGE+1, z),locate(maxx+JTB_OFFSET+JTB_EDGE+1, maxy+JTB_OFFSET+JTB_EDGE+1, z))  // Top border
+	edges += block(locate(1+JTB_OFFSET-JTB_EDGE+1, 1+JTB_OFFSET-JTB_EDGE, z), locate(1+JTB_OFFSET-JTB_EDGE+1, maxy+JTB_OFFSET+JTB_EDGE, z))  // Left border
+	edges |= block(locate(maxx+JTB_OFFSET+JTB_EDGE-1, 1+JTB_OFFSET-JTB_EDGE, z),locate(maxx+JTB_OFFSET+JTB_EDGE-1, maxy+JTB_OFFSET+JTB_EDGE, z))  // Right border
+	edges |= block(locate(1+JTB_OFFSET-JTB_EDGE-1, 1+JTB_OFFSET-JTB_EDGE+1, z), locate(maxx+JTB_OFFSET+JTB_EDGE+1, 1+JTB_OFFSET-JTB_EDGE+1, z))  // Bottom border
+	edges |= block(locate(1+JTB_OFFSET-JTB_EDGE-1, maxy+JTB_OFFSET+JTB_EDGE-1, z),locate(maxx+JTB_OFFSET+JTB_EDGE+1, maxy+JTB_OFFSET+JTB_EDGE-1, z))  // Top border
 	for(var/turf/T in edges)
 		T.density = 1
 


### PR DESCRIPTION
Contributor
hyperioo
About The Pull Request
If people were teleported outside the JTB border because of a teleportation incident, they were unable to get out of there without admin intervention. Now they can just walk toward the edge and they will be teleported back inside.