### PR TITLE
Ups airlock health

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -6,6 +6,8 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 	icon_state = "door_closed"
 	power_channel = STATIC_ENVIRON
 
+	maxhealth = 400 //Makes it so you need to really shoot open a door
+
 	explosion_resistance = 10
 
 	var/aiControlDisabled = 0


### PR DESCRIPTION
Contributor
zombiemimic
More or less makes glass doors weaker then normal doors + makes shooting most doors less viable to help get people to do none shooty into roomy!
