### PR TITLE
Cindarite purge-toxin adjustment

### DIFF
--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -1240,7 +1240,7 @@
 	scannable = 1
 
 /datum/reagent/medicine/cindpetamol/affect_blood(mob/living/carbon/M, alien, effect_multiplier, var/removed)
-	M.adjustToxLoss(-5)
+	M.adjustToxLoss(-8)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/liver/L = H.random_organ_by_process(OP_LIVER)


### PR DESCRIPTION
I got little idea on the fuckery of code which exists for medicine so I'm just doing a small fix which provides actual toxin removal for cindarites. The tox adjust for cindpetamol seemed to be beyond useless so I just removed the var/removed multiplier and it works fine now. Previously it would do **nothing** and I'd just pass out for 10 minutes to wake up with MORE toxins in me for some reason. _Which makes it really, really bad to use and downright stupid when dylovene, a common chem, does the same job and better._