### PR TITLE
Undo To Harmony Perk Nerf

### DIFF
--- a/code/modules/psionics/psion.dm
+++ b/code/modules/psionics/psion.dm
@@ -26,7 +26,7 @@
 		owner.stats.addPerk(PERK_PSION)
 
 	if(owner.stats.getPerk(PERK_PSI_HARMONY))
-		psi_max_bonus = 2
+		psi_max_bonus = 3
 
 	max_psi_points = round(clamp((owner.stats.getStat(STAT_COG) / 10), 1, 30)) + psi_max_bonus
 


### PR DESCRIPTION
After the big nerfs coming around and the upped costs a lot of the abilities won't be possible to do anymore. Plus there is already the longer recharge time.
-Changes the amount of points given from the Psionic Harmony perk from +2 to +3
Alternatively I'd advocate for this perk to give a quicker recharge but this is easier to do.