### PR TITLE
Psi Armor

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -28,10 +28,10 @@
 	diary << "\[[time_stamp()]] [game_id] [category]: [text][log_end]"
 
 /proc/log_admin(text)
-	admin_log.Add(text)
+/*	admin_log.Add(text)
 	lobby_message(message = text, color = "#FFA500")
 	if (config.log_admin)
-		game_log("ADMIN", text)
+		game_log("ADMIN", text)*/
 
 /proc/log_debug(text)
 	if (config.log_debug)

--- a/code/game/objects/items/animal_parts.dm
+++ b/code/game/objects/items/animal_parts.dm
@@ -1,3 +1,4 @@
+// Most sprites here can be attributed to scar#1579 who provided either the sprite itself or the base sprite.
 /obj/item/animal_part
 	name = "animal part"
 	desc = "A chunk of an animal taken from the body during the butchering process. How the fuck did you find this?"
@@ -77,3 +78,5 @@
 	item_state = "wolf_tooth"
 	price_tag = 300
 	w_class = ITEM_SIZE_TINY
+
+// End of scar#1579's sprites.

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -10,13 +10,13 @@ var/global/floorIsLava = 0
 
 ////////////////////////////////
 /proc/message_admins(var/msg, tag = "admin_log", tagtext = "ADMIN LOG")
-	lobby_message(message = msg, color = "#FFA500")
+	/*lobby_message(message = msg, color = "#FFA500")
 	var/m = "<span class=\"log_message\"><span class=\"prefix\">[tagtext]:</span> <span class=\"message\">[msg]</span></span>"
 	log_adminwarn(m)
 	for(var/client/C in admins)
 		m = "<span class=\"log_message\"><span class=\"prefix\">[create_text_tag(tag, "[tagtext]:", C)]</span> <span class=\"message\">[msg]</span></span>"
 		if(check_rights(R_ADMIN, 0, C.mob))
-			to_chat(C, m)
+			to_chat(C, m)*/
 
 /proc/msg_admin_attack(var/text, tag = "attack", tagtext = "ATTACK:") //Toggleable Attack Messages
 	log_attack(text)

--- a/code/modules/mob/living/carbon/superior_animal/lodge/types/cerberus.dm
+++ b/code/modules/mob/living/carbon/superior_animal/lodge/types/cerberus.dm
@@ -1,4 +1,4 @@
-//Cerberus, a domesticated hell diver that can be bred for hunting.
+//Cerberus, a domesticated hell diver that can be bred for hunting. Credit to BigBimmer#2319 for the sprite.
 /mob/living/carbon/superior_animal/lodge/cerberus
 	name = "cerberus"
 	desc = "A domesticated hell diver kept fat, happy, and loyal by the local hunting lodge that breed them as hunting allies and guard animals. Favored especially for their asexual \
@@ -43,7 +43,7 @@
 	else
 		..()
 
-//Chimera, a rare spawn beast of a cerberus
+//Chimera, a rare spawn beast of a cerberus. Credit to scar#1579 for the sprite.
 /mob/living/carbon/superior_animal/lodge/cerberus/chimera
 	name = "chimera"
 	desc = "A mutated strain of a domesticated cerberus, rarely appearing and much sleeker than their lesser cousins. Chimera are faster, better armored, and much more lethal than a cerberus \
@@ -72,7 +72,7 @@
 	pixel_x = -16
 
 //Baby cerberus
-//Grows into a cerberus or chimera
+//Grows into a cerberus or chimera. Credit to BigBimmer#2319 for the sprite.
 /mob/living/carbon/superior_animal/lodge/baby_cerberus
 	name = "\improper cerberus gruntling"
 	desc = "Adorable! A chubby little pig rat thing, largely defenseless until it finally grows up."

--- a/code/modules/mob/living/carbon/superior_animal/lodge/types/clucker.dm
+++ b/code/modules/mob/living/carbon/superior_animal/lodge/types/clucker.dm
@@ -1,5 +1,5 @@
 //clucker
-//Basically a mutant chicken that produces feathers, meat, and a single bit of bones if butchered by a hunter.
+//Basically a mutant chicken that produces feathers, meat, and a single bit of bones if butchered by a hunter. Credit to scar#1579 for the sprite.
 /mob/living/carbon/superior_animal/lodge/clucker
 	name = "\improper clucker"
 	desc = "A clucker, the affectionately nick named chickens that escaped the colony and somehow survived in the wild before mutating. While mostly without feathers, a single blood engorged one \
@@ -69,7 +69,7 @@
 		STOP_PROCESSING(SSobj, src)
 
 //Baby Clucker
-//Looks nearly the same as a regular chick.
+//Looks nearly the same as a regular chick. Credit to scar#1579 for the sprite.
 /mob/living/carbon/superior_animal/lodge/chick_clucker
 	name = "\improper clucker chick"
 	desc = "Adorable! They make such a racket though."

--- a/code/modules/mob/living/carbon/superior_animal/lodge/types/tatonka.dm
+++ b/code/modules/mob/living/carbon/superior_animal/lodge/types/tatonka.dm
@@ -1,5 +1,5 @@
 //tatonka
-//Two headed cow that produces milk+
+//Two headed cow that produces milk+ Credit to scar#1579 for the sprite.
 /mob/living/carbon/superior_animal/lodge/tatonka
 	name = "tatonka"
 	desc = "When cows brought by the colony escape into the wilds they tend to mutate rapidly, the most stable strain growing a second head and losing much of its coloration. Useful for the \
@@ -97,7 +97,7 @@
 	pixel_x = -16
 
 //Baby Tatonka
-//Grows into a tatonka or a tangu
+//Grows into a tatonka or a tangu. Credit to scar#1579 for the sprite.
 /mob/living/carbon/superior_animal/lodge/baby_tatonka
 	name = "\improper tatonka calf"
 	desc = "Adorable! Four sets of big brown eyes and cute little horns."
@@ -135,7 +135,7 @@
 	default_pixel_x = -16
 	pixel_x = -16
 
-//Tangu, the improved version of tatonka and thus rarer to produce.
+//Tangu, the improved version of tatonka and thus rarer to produce. Credit to scar#1579 for the sprite.
 /mob/living/carbon/superior_animal/lodge/tatonka/tangu
 	name = "tangu"
 	desc = "Tangu are a mutant strand of tatonka who have grown larger with thick shaggy coats. While rarer than tatonka they are highly prized for their more robust milk and for their horns, \

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -81,6 +81,7 @@
 	melee_damage_upper = 40
 	special_parts = list(/obj/item/animal_part/wolf_tooth,/obj/item/animal_part/wolf_tooth)
 
+// Credit to scar#1579 for the sprite.
 /mob/living/simple_animal/hostile/bear/mukwah
 	name = "mukwah"
 	desc = "A bear that escaped from the abandoned zoo labs before mutating into a creature known as a mukwah. Unlike a standard bear, a mukwah is much more powerful, a heavy hitter that is \

--- a/code/modules/mob/living/simple_animal/hostile/big.dm
+++ b/code/modules/mob/living/simple_animal/hostile/big.dm
@@ -289,6 +289,7 @@
 	icon_state = "leaper"
 	icon_living = "leaper"
 
+// Credit to SlapDrink#0083 for the sprite.
 /mob/living/simple_animal/hostile/hell_pig
 	name = "hell pig"
 	desc = "The venerable evolution of a tengolo charger, morphing into a violent and destructive beast hostile to all but its own berserk kind. Hell pigs represent the end of a charger's life \
@@ -335,6 +336,7 @@
 	has_special_parts = TRUE
 	special_parts = list(/obj/item/animal_part/wolf_tooth,/obj/item/animal_part/wolf_tooth)
 
+// Credit to scar#1579 for the sprite.
 /mob/living/simple_animal/hostile/hell_pig/slepnir
 	name = "slepnir"
 	desc = "The venerable evolution of a tengolo charger, morphing into a violent and destructive beast hostile to all but its own berserk kind. The slepnir, unlike its other berserk kin, only attacks \

--- a/code/modules/mob/living/simple_animal/hostile/misc.dm
+++ b/code/modules/mob/living/simple_animal/hostile/misc.dm
@@ -345,6 +345,7 @@
 	mob_size = 20
 	resistance = 15
 
+// Credit to scar#1579 for the sprite.
 /mob/living/simple_animal/hostile/retaliate/tahca
 	name = "tahca"
 	desc = "A cervine creature, surprisingly native to this planet, that resembles a two-headed deer. Despite what one would expect, while docile in nature, it is more than willing to fight if attacked. Hunters value \

--- a/code/modules/organs/internal/psionic.dm
+++ b/code/modules/organs/internal/psionic.dm
@@ -42,5 +42,5 @@
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_call,
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_banish,
 		/obj/item/organ/internal/psionic_tumor/proc/journey_to_nowhere,
-		///obj/item/organ/internal/psionic_tumor/proc/psionic_armor
+		/obj/item/organ/internal/psionic_tumor/proc/psionic_armor
 	)

--- a/code/modules/psionics/psionic_items.dm
+++ b/code/modules/psionics/psionic_items.dm
@@ -540,7 +540,7 @@
 	icon_state = "gloves"
 	icon_override = 'icons/obj/psionic/occmob.dmi'
 	slot_flags = SLOT_GLOVES
-	siemens_coefficient = 1 //Insulated! You can't take them off so I don't think it's an issue.
+	siemens_coefficient = 1 //Insulated!
 	matter = list()
 	armor = list(
 		melee = 35,
@@ -590,6 +590,7 @@
 		rad = 50
 	)
 	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL|AIRTIGHT|NOSLIP //make these like spacesuit so it can be a real spacesuit
+	siemens_coefficient = 1 //Insulated!
 	var/mob/living/carbon/human/occultist
 	var/pointgranted = 0 //Did we give you your cog?
 

--- a/code/modules/psionics/psionic_items.dm
+++ b/code/modules/psionics/psionic_items.dm
@@ -427,12 +427,12 @@
 	item_state = "armor"
 	icon = 'icons/obj/psionic/occicon.dmi'
 	icon_override = 'icons/obj/psionic/occmob.dmi'
-	desc = "A black fabric robe inset with hardened plates, shaped from the mind of a psion. It is durable, capable of surviving space and protecting one from many of the things that would do one harm. \
+	desc = "A black fabric robe inset with hardened bronze plates, shaped from the mind of a psion. It is durable, capable of surviving space and protecting one from many of the things that would do one harm. \
 	Is it durable because the mind is the last thing to die? Why must it appear so, if it is but a reflection of our thoughts?"
 	w_class = ITEM_SIZE_NORMAL
 	slot_flags = SLOT_OCLOTHING
 	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL
-	matter = list(MATERIAL_STEEL = 10, MATERIAL_LEATHER = 5)
+	matter = list()
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS //It has gloves, hood, and shoes for the rest of them
 	slowdown = 0.3 //Slightly faster than the red suit. Maybe do it at 0.2?
 	armor = list(
@@ -448,19 +448,11 @@
 	supporting_limbs = list()
 	flags_inv = HIDEJUMPSUIT|HIDETAIL //Removed hide shoes and gloves because we want this so that you can see the shoes and stuff while keeping the spacesuit tags. Yes this is terrible, no there isn't a better way.
 	//var/list/supporting_limbs = list(
-	var/mob/living/carbon/holder
 
-/obj/item/clothing/suit/space/occultist/New(var/loc, var/mob/living/carbon/Maker)
+/obj/item/clothing/suit/space/occultist/dropped()
 	..()
-	holder = loc
-	START_PROCESSING(SSobj, src)
-
-/obj/item/clothing/suit/space/occultist/Process()
-	..()
-	if(loc != SLOT_OCLOTHING) // We're no longer in the psionic's hand.
-		visible_message("The [src.name] fades into nothingness.")
-		qdel(src)
-		return
+	spawn(5)
+	qdel(src)
 
 /obj/item/clothing/head/space/occulthood
 	name = "psion hood"
@@ -468,10 +460,10 @@
 	item_state = "hood"
 	icon = 'icons/obj/psionic/occicon.dmi'
 	icon_override = 'icons/obj/psionic/occmob.dmi'
-	desc = "A black fabric hood inset with hardened plates, shaped from the mind of a psion. It is durable, capable of surviving space and protecting one from many of the things that would do one harm. \
+	desc = "A black fabric hood inset with hardened bronze plates, shaped from the mind of a psion. It is durable, capable of surviving space and protecting one from many of the things that would do one harm. \
 	Strange, it seems to have far more room on the inside than one would think."
 	slot_flags = SLOT_HEAD
-	matter = list(MATERIAL_STEEL = 5, MATERIAL_GLASS = 10)
+	matter = list()
 	armor = list(
 		melee = 35,
 		bullet = 35,
@@ -483,28 +475,17 @@
 	siemens_coefficient = 0.4
 	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL|AIRTIGHT
 
-	action_button_name = "Toggle Light" //reflavor this so I can make it purple to go in line with the guns - Sigma
+	action_button_name = "Toggle Witchlight" //reflavor this so I can make it purple to go in line with the guns - Sigma
 	light_overlay = "helmet_light_occult" //Sadly this has to go in icons/obj/light_overlays because I can't figure out how to point it to a different one.
 										  //Currently it's located in the icons/obj/light_overlays folder, proc is at /obj/item/clothing/head/on_update_icon(mob/user) -Sigma
-	var/mob/living/carbon/holder
 
-/obj/item/clothing/head/space/occulthood/New(var/loc, var/mob/living/carbon/Maker)
+/obj/item/clothing/head/space/occulthood/dropped()
 	..()
-	holder = loc
-	START_PROCESSING(SSobj, src)
-
-/obj/item/clothing/head/space/occulthood/Process()
-	..()
-	if(loc != holder) // We're no longer in the psionic's hand.
-		visible_message("The [src.name] fades into nothingness.")
-		qdel(src)
-		return
+	spawn(5)
+	qdel(src)
 
 /obj/item/clothing/head/space/occulthood/attack_self(mob/user) //Reflavoring because this is light from a place that does not know it.
 	if(brightness_on)
-		if(!isturf(user.loc))
-			to_chat(user, "Your hood cannot hear you while it is in this [user.loc]")
-			return
 		on = !on
 		to_chat(user, "With a single thought and urging of your psychic power, you [on ? "enkindle" : "extinguish"] the hood's unnatural light.")
 		update_occult_flashlight(user)
@@ -523,7 +504,7 @@
 
 /obj/item/clothing/gloves/occultgloves //We want them to not be snippable. Maybe make it some kind of rigsuit?
 	name = "psion gloves"
-	desc = "A black fabric pair of gloves inset with hardened plates, shaped from the mind of a psion. It is durable, capable of surviving space and protecting one from many of the things that \
+	desc = "A black fabric pair of gloves inset with hardened bronze plates, shaped from the mind of a psion. It is durable, capable of surviving space and protecting one from many of the things that \
 	would do one harm. It does one well to protect their hands."
 	icon = 'icons/obj/psionic//occicon.dmi'
 	item_state = "gloves"
@@ -531,7 +512,7 @@
 	icon_override = 'icons/obj/psionic/occmob.dmi'
 	slot_flags = SLOT_GLOVES
 	siemens_coefficient = 1 //Insulated! You can't take them off so I don't think it's an issue.
-	matter = list(MATERIAL_LEATHER = 10, MATERIAL_STEEL = 2)
+	matter = list()
 	armor = list(
 		melee = 35,
 		bullet = 35,
@@ -541,20 +522,11 @@
 		rad = 50
 	)
 	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL|AIRTIGHT //make these like spacesuit so it can be a real spacesuit
-	var/mob/living/carbon/holder
 
-/obj/item/clothing/gloves/occultgloves/New(var/loc, var/mob/living/carbon/Maker)
+/obj/item/clothing/gloves/occultgloves/dropped()
 	..()
-	holder = loc
-	START_PROCESSING(SSobj, src)
-
-/obj/item/clothing/gloves/occultgloves/Process()
-	..()
-	if(loc != holder) // We're no longer in the psionic's hand.
-		visible_message("The [src.name] fades into nothingness.")
-		qdel(src)
-		return
-
+	spawn(5)
+	qdel(src)
 
 /obj/item/clothing/gloves/occultgloves/attackby(obj/item/W, mob/user) //Overwrite the gloves clip proc because we don't want these clipped off at all.
 	if(istype(W, /obj/item/tool/wirecutters) || istype(W, /obj/item/tool/scalpel)) //Same check as normal gloves.
@@ -562,14 +534,14 @@
 
 /obj/item/clothing/shoes/occultgreaves
 	name = "psion greaves"
-	desc = "A black fabric set of greaves inset with hardened plates, shaped from the mind of a psion. It is durable, capable of surviving space and protecting one from many of the things that would do one harm. \
+	desc = "A black fabric set of greaves inset with hardened bronze plates, shaped from the mind of a psion. It is durable, capable of surviving space and protecting one from many of the things that would do one harm. \
 	Is it durable because the mind is the last thing to die? Why must it appear so, if it is but a reflection of our thoughts?"
 	icon = 'icons/obj/psionic/occicon.dmi'
 	item_state = "shoes"
 	icon_state = "shoes"
 	icon_override = 'icons/obj/psionic/occmob.dmi'
 	slot_flags = SLOT_FEET
-	matter = list(MATERIAL_STEEL = 6, MATERIAL_LEATHER = 3)
+	matter = list()
 	armor = list(
 		melee = 35,
 		bullet = 35,
@@ -579,16 +551,8 @@
 		rad = 50
 	)
 	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL|AIRTIGHT|NOSLIP //make these like spacesuit so it can be a real spacesuit
-	var/mob/living/carbon/holder
 
-/obj/item/clothing/shoes/occultgreaves/New(var/loc, var/mob/living/carbon/Maker)
+/obj/item/clothing/shoes/occultgreaves/dropped()
 	..()
-	holder = loc
-	START_PROCESSING(SSobj, src)
-
-/obj/item/clothing/shoes/occultgreaves/Process()
-	..()
-	if(loc != holder) // We're no longer in the psionic's hand.
-		visible_message("The [src.name] fades into nothingness.")
-		qdel(src)
-		return
+	spawn(5)
+	qdel(src)

--- a/code/modules/psionics/psionic_items.dm
+++ b/code/modules/psionics/psionic_items.dm
@@ -486,6 +486,9 @@
 
 /obj/item/clothing/head/space/occulthood/attack_self(mob/user) //Reflavoring because this is light from a place that does not know it.
 	if(brightness_on)
+		if(!isturf(user.loc))
+			to_chat(user, "Your cannot hear your thoughts while in this [user.loc]")
+			return
 		on = !on
 		to_chat(user, "With a single thought and urging of your psychic power, you [on ? "enkindle" : "extinguish"] the hood's unnatural light.")
 		update_occult_flashlight(user)

--- a/code/modules/psionics/psionic_items.dm
+++ b/code/modules/psionics/psionic_items.dm
@@ -427,7 +427,8 @@
 	item_state = "armor"
 	icon = 'icons/obj/psionic/occicon.dmi'
 	icon_override = 'icons/obj/psionic/occmob.dmi'
-	desc = "A black fabric robe inset with hardened bronze plates, shaped from the mind of a psion. It is durable, capable of surviving space and protecting one from many of the things that would do one harm. \
+	desc = "A black fabric robe inset with hardened bronze plates, shaped from the mind of a psion. Wearing the complete set is said to enhance the cognitive powers of a psion. \
+	It is durable, capable of surviving space and protecting one from many of the things that would do one harm. \
 	Is it durable because the mind is the last thing to die? Why must it appear so, if it is but a reflection of our thoughts?"
 	w_class = ITEM_SIZE_NORMAL
 	slot_flags = SLOT_OCLOTHING
@@ -448,11 +449,22 @@
 	supporting_limbs = list()
 	flags_inv = HIDEJUMPSUIT|HIDETAIL //Removed hide shoes and gloves because we want this so that you can see the shoes and stuff while keeping the spacesuit tags. Yes this is terrible, no there isn't a better way.
 	//var/list/supporting_limbs = list(
+	var/mob/living/carbon/human/occultist //This is so we know who is wearing it.
+	var/pointgranted = 0 //Did we give you your cog?
 
 /obj/item/clothing/suit/space/occultist/dropped()
 	..()
+	occultist.stats.changeStat(STAT_COG, -5)
 	spawn(5)
 	qdel(src)
+
+
+/obj/item/clothing/suit/space/occultist/equipped(var/mob/M)
+	.=..()
+	occultist = M
+	if(!pointgranted)
+		occultist.stats.changeStat(STAT_COG, 5)
+		pointgranted = 1
 
 /obj/item/clothing/head/space/occulthood
 	name = "psion hood"
@@ -474,6 +486,11 @@
 	)
 	siemens_coefficient = 0.4
 	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL|AIRTIGHT
+	brightness_on = 5
+	on = 0
+	light_applied = 0
+	var/mob/living/carbon/human/occultist
+	var/pointgranted = 0 //Did we give you your cog?
 
 	action_button_name = "Toggle Witchlight" //reflavor this so I can make it purple to go in line with the guns - Sigma
 	light_overlay = "helmet_light_occult" //Sadly this has to go in icons/obj/light_overlays because I can't figure out how to point it to a different one.
@@ -481,8 +498,10 @@
 
 /obj/item/clothing/head/space/occulthood/dropped()
 	..()
+	occultist.stats.changeStat(STAT_COG, -5)
 	spawn(5)
 	qdel(src)
+
 
 /obj/item/clothing/head/space/occulthood/attack_self(mob/user) //Reflavoring because this is light from a place that does not know it.
 	if(brightness_on)
@@ -505,6 +524,13 @@
 	update_icon(user)
 	user.update_action_buttons()
 
+/obj/item/clothing/head/space/occulthood/equipped(var/mob/M)
+	.=..()
+	occultist = M
+	if(!pointgranted)
+		occultist.stats.changeStat(STAT_COG, 5)
+		pointgranted = 1
+
 /obj/item/clothing/gloves/occultgloves //We want them to not be snippable. Maybe make it some kind of rigsuit?
 	name = "psion gloves"
 	desc = "A black fabric pair of gloves inset with hardened bronze plates, shaped from the mind of a psion. It is durable, capable of surviving space and protecting one from many of the things that \
@@ -525,11 +551,21 @@
 		rad = 50
 	)
 	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL|AIRTIGHT //make these like spacesuit so it can be a real spacesuit
+	var/mob/living/carbon/human/occultist
+	var/pointgranted = 0 //Did we give you your cog?
 
 /obj/item/clothing/gloves/occultgloves/dropped()
 	..()
+	occultist.stats.changeStat(STAT_COG, -5)
 	spawn(5)
 	qdel(src)
+
+/obj/item/clothing/gloves/occultgloves/equipped(var/mob/M)
+	.=..()
+	occultist = M
+	if(!pointgranted)
+		occultist.stats.changeStat(STAT_COG, 5)
+		pointgranted = 1
 
 /obj/item/clothing/gloves/occultgloves/attackby(obj/item/W, mob/user) //Overwrite the gloves clip proc because we don't want these clipped off at all.
 	if(istype(W, /obj/item/tool/wirecutters) || istype(W, /obj/item/tool/scalpel)) //Same check as normal gloves.
@@ -554,8 +590,18 @@
 		rad = 50
 	)
 	item_flags = STOPPRESSUREDAMAGE|THICKMATERIAL|AIRTIGHT|NOSLIP //make these like spacesuit so it can be a real spacesuit
+	var/mob/living/carbon/human/occultist
+	var/pointgranted = 0 //Did we give you your cog?
 
 /obj/item/clothing/shoes/occultgreaves/dropped()
 	..()
+	occultist.stats.changeStat(STAT_COG, -5)
 	spawn(5)
 	qdel(src)
+
+/obj/item/clothing/shoes/occultgreaves/equipped(var/mob/M)
+	.=..()
+	occultist = M
+	if(!pointgranted)
+		occultist.stats.changeStat(STAT_COG, 5)
+		pointgranted = 1


### PR DESCRIPTION
-Added a Psi armor power, which costs 4 essence to use. Psi armor is decent all round armor that can't be punctured, functions as a space suit, has a built in light, and comes with some nifty minor benefits.
Suit Specifics:
--Armor 35/35/35/30/100/50 for melee/bullet/energy/bomb/bio/radiation.
--Reduces shock damage by 40% when hit in the chest.
--Gloves are insulated. Prevents shocks on arms/hands.
--Shoes are no slip and insulated. Prevents shocks on legs/feet.
--Hood has a light built into it.
--For every 2 pieces you have equipped, your cognition increases by 5. For a total of +10.
--When used, it permanently destroys any clothing or items in the suit, hands, head, or boots.
--Removing any piece causes it to disappear instantly. You also lose the set bonuses.
--The armor cannot be punctured or damaged like a void suit and functions as one in space, preventing pressure damage and offer some temperature effects.
--The chest piece does give minor slowdown when worn. 