### PR TITLE
Disk correction ADMs - tested to work

### DIFF
--- a/code/modules/maint_expeditions/adms.dm
+++ b/code/modules/maint_expeditions/adms.dm
@@ -261,10 +261,9 @@
 		to_chat(usr, SPAN_NOTICE("No disk is inside."))
 		return
 
-	if(inserted_disk)
-		inserted_disk.forceMove(drop_location())
-		component_parts -= inserted_disk
-		to_chat(usr, SPAN_NOTICE("You remove \the [inserted_disk] from \the [src]."))
+	inserted_disk.forceMove(drop_location())
+	component_parts -= inserted_disk
+	to_chat(usr, SPAN_NOTICE("You remove \the [inserted_disk] from \the [src]."))
 
 	inserted_disk = null
 	inserted_disk_file = null

--- a/code/modules/maint_expeditions/adms.dm
+++ b/code/modules/maint_expeditions/adms.dm
@@ -262,6 +262,8 @@
 		inserted_disk.loc = get_turf(src)
 		inserted_disk = null
 		inserted_disk_file = null
+		component_parts -= inserted_disk
+
 /obj/machinery/exploration/adms/update_icon()
 	if(active)
 		icon_state = "adms-on"

--- a/code/modules/maint_expeditions/adms.dm
+++ b/code/modules/maint_expeditions/adms.dm
@@ -254,15 +254,29 @@
 
 	update_icon()
 
+
+//Handles ejecting the data disk, when able, will place and hand
+/obj/machinery/exploration/adms/proc/eject_disk_action(mob/living/user)
+	if(!inserted_disk)
+		to_chat(usr, SPAN_NOTICE("No disk is inside."))
+		return
+
+	if(inserted_disk)
+		inserted_disk.forceMove(drop_location())
+		component_parts -= inserted_disk
+		to_chat(usr, SPAN_NOTICE("You remove \the [inserted_disk] from \the [src]."))
+
+	inserted_disk = null
+	inserted_disk_file = null
+
 /obj/machinery/exploration/adms/verb/eject_disk()
 	set name = "Eject Disk"
 	set category = "Object"
 	set src in view(1)
 	if(inserted_disk)
-		inserted_disk.loc = get_turf(src)
-		inserted_disk = null
-		inserted_disk_file = null
-		component_parts -= inserted_disk
+		eject_disk_action()
+	else
+		to_chat(usr, SPAN_NOTICE("No disk is inside."))
 
 /obj/machinery/exploration/adms/update_icon()
 	if(active)


### PR DESCRIPTION
## About The Pull Request
Corrects disks when ejected staying in the content list in a ADM meaning when you deconned it, it would teleport back to its spot