### PR TITLE
Klutz no longer prevents naming papers

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -134,7 +134,14 @@
 
 	if((CLUMSY in usr.mutations) && prob(50))
 		to_chat(usr, SPAN_WARNING("You cut yourself on the paper."))
-		return
+
+		if(usr.hand == usr.l_hand) // Are we using the left arm?
+			usr.apply_damage(1, BRUTE, def_zone = BP_L_ARM)
+		if(usr.hand == usr.r_hand) // Are we using the right arm?
+			usr.apply_damage(1, BRUTE, def_zone = BP_R_ARM)
+		else //Were not using are hands so we damage are chest. As were always going to have this lim
+			usr.apply_damage(1, BRUTE, def_zone = BP_CHEST) //Hope no one does this well missing an arm...
+
 	var/n_name = sanitizeSafe(input(usr, "What would you like to label the paper?", "Paper Labelling", null)  as text, MAX_NAME_LEN)
 
 	// We check loc one level up, so we can rename in clipboards and such. See also: /obj/item/photo/rename()


### PR DESCRIPTION
Klutz now when renaming paper rather then prevent you, deals 1 damage.