### PR TITLE
Fixes for nanogate and sword

### DIFF
--- a/code/modules/nanogate/nanogate_powers.dm
+++ b/code/modules/nanogate/nanogate_powers.dm
@@ -13,17 +13,19 @@ List of powers in this page :
 
 /obj/item/organ/internal/nanogate/proc/nanite_message()
 	set category = "Nanogate Powers"
-	set name = "Message"
+	set name = "Nanite Message"
 	set desc = "Send a message to someone else that has a nanogate."
 	nano_point_cost = 0 // It's free.
 
-	var/list/creatures = list() // Who we can talk to
+	var/list/mob/living/carbon/human/target_list = list() // Who we can talk to
 	for(var/mob/living/carbon/human/h in world) // Check every players in the game
-		for(var/organ_inside in h.internal_organs)
-			if(istype(organ_inside, /obj/item/organ/internal/nanogate))
-				creatures += h // Add the player to the list we can talk to
-				continue
-	var/mob/target = input("Who do you want to project your mind to ?") as null|anything in creatures
+		if(ishuman(h) && !h.is_mannequin)
+			for(var/organ_inside in h.internal_organs)
+				if(istype(organ_inside, /obj/item/organ/internal/nanogate))
+					target_list += h // Add the player to the list we can talk to
+					break
+	target_list -= owner
+	var/mob/target = input("Who do you want to project your mind to ?") as null|anything in target_list
 	if (isnull(target))
 		return
 


### PR DESCRIPTION
## About The Pull Request
- Make the Nanogate 'Message' power compatible with non-deadmins admins.
- Make the Nanogate 'Message' power ceck for manniquins and remove the user of the power from the list.
- Give the Hydrogen Sword a sound effect when hitting something.
- Make the Hydrogen Sword & Grenade have a special effect when exploding.
- Nerf the Hydrogen Sword Heat Wave range from 2 to 1.
- Nerf the Hydrogen Grenade Heat Wave range from 3 to 2.
- Buff the Hydrogen Grenade's throw range from 5 to 7.
- Make the Hydrogen Sword a tool with 25 Welding, 25 Cauterizing and 50 Cutting when turned on.
- Make the Hydrogen Grenade play a sound when being armed.