### PR TITLE
Add Nanites Powers

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -93,8 +93,7 @@
 #define PERK_NANITE_REGEN /datum/perk/nanite_regen
 #define PERK_NANITE_MUSCLE /datum/perk/nanite_muscle
 #define PERK_NANITE_ARMOR /datum/perk/nanite_armor
-#define PERK_NANITE_KNIFE /datum/perk/nanite_knife
-#define PERK_NANITE_TOOL /datum/perk/nanite_tool
+#define PERK_NANITE_AMMO /datum/perk/nanite_ammo
 
 // Nanite Chem Perks.
 #define PERK_NANITE_CHEM /datum/perk/nanite_chem

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -36,7 +36,7 @@
 
 /datum/perk/nanite_chem
 	name = "Nanite Chemicals"
-	desc = "You program and set aside a specific subset of nanites who have a singular purpose that you can call upon at any time to engage their effect, but this only works once."
+	desc = "You programmed and set aside a specific subset of nanites who have a singular purpose that you can call upon at any time to engage their effect, but this only works once."
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
 	active = FALSE
 	passivePerk = FALSE
@@ -76,3 +76,23 @@
 /datum/perk/nanite_chem/nantidotes
 	name = "Nantidotes"
 	chem_id = "nantidotes"
+
+/datum/perk/nanite_ammo
+	name = "Nanite Ammunition"
+	desc = "You programmed and set aside a specific subset of nanites who have a singular purpose that you can call upon at any time to engage their effect."
+	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
+	active = FALSE
+	passivePerk = FALSE
+	var/cooldown = 30 MINUTES
+
+/datum/perk/nanite_ammo/activate()
+	if(world.time < cooldown_time)
+		to_chat(usr, SPAN_NOTICE("Your nanites didn't ready an ammo box yet."))
+		return FALSE
+
+	var/list/ammo_boxes = typesof(/obj/item/ammo_magazine/ammobox)
+	ammo_boxes -= /obj/item/ammo_magazine/ammobox
+	var/obj/item/choice = input(usr, "Which type of ammo do you want?", "Ammo Choice", null) as null|anything in ammo_boxes
+	usr.put_in_hands(new choice(usr.loc))
+	cooldown_time = world.time + cooldown
+	return ..()

--- a/code/modules/organs/internal/nanogate.dm
+++ b/code/modules/organs/internal/nanogate.dm
@@ -88,6 +88,8 @@ obj/item/organ/internal/nanogate
 		/obj/item/organ/internal/nanogate/proc/nanite_muscle,
 		/obj/item/organ/internal/nanogate/proc/nanite_armor,
 		/obj/item/organ/internal/nanogate/proc/nanite_chem,
+		/obj/item/organ/internal/nanogate/proc/nanite_mod,
+		/obj/item/organ/internal/nanogate/proc/nanite_ammo,
 
 		// Rig Upgrades
 		/obj/item/organ/internal/nanogate/proc/nanite_rig,

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -676,7 +676,7 @@
 	desc = "The mechanism that loads bullets into the chamber has jammed, one would be lucky the gun didn't explode if this was shot."
 	icon_state = "Reverse_loader"
 
-/obj/item/gun_upgrade/faulty_trapped/New()
+/obj/item/gun_upgrade/mechanism/faulty_trapped/New()
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(


### PR DESCRIPTION
## About The Pull Request
- Add a check that prevent synths from using the nanite chem power that they wouldn't gain any benefit from.
- Make the faulty mechanism work again.
- Add two nanites power : 
- Ammo Box : For 1 point, give the user a perk that allow them to spawn an ammo box every 30 minutes. They can choose the type of box that spawn.
- Modifications : For 1 point, allow the user to spawn a designated tool/gun mod, with the exception of AIs, Greyson, Bluespace and Faulty stuff. It is the only power that is usable more than once, costing 1 point per activation.