### PR TITLE
Carth Buff, Loadout Additions, Map adjustments

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/clothing.dm
+++ b/code/modules/client/preference_setup/loadout/lists/clothing.dm
@@ -57,11 +57,6 @@
 	slot = slot_wear_mask
 	flags = GEAR_HAS_TYPE_SELECTION
 
-/datum/gear/clothing/mask/costume/halloween
-	display_name = "Halloween mask selection"
-	path = /obj/item/clothing/mask/costume/halloween
-	flags = GEAR_HAS_TYPE_SELECTION
-
 /datum/gear/clothing/mask/gas/clown
 	display_name = "Clown mask selection"
 	slot = slot_wear_mask

--- a/code/modules/client/preference_setup/loadout/lists/clothing.dm
+++ b/code/modules/client/preference_setup/loadout/lists/clothing.dm
@@ -44,3 +44,66 @@
 	path = /obj/item/clothing/mask/gas/industrial
 	slot = slot_wear_mask
 	cost = 2
+
+/datum/gear/clothing/mask/costume/history/plaguedoctor
+	display_name = "Plague Doctor mask"
+	path = /obj/item/clothing/mask/costume/history/plaguedoctor
+	slot = slot_wear_mask
+	cost = 2 //Same cost as gasmasks because it provides the same benefit (actually better for this one)
+
+/datum/gear/clothing/mask/costume/animal
+	display_name = "Animal mask selection"
+	path = /obj/item/clothing/mask/costume/animal/
+	slot = slot_wear_mask
+	flags = GEAR_HAS_TYPE_SELECTION
+
+/datum/gear/clothing/mask/costume/halloween
+	display_name = "Halloween mask selection"
+	path = /obj/item/clothing/mask/costume/halloween
+	flags = GEAR_HAS_TYPE_SELECTION
+
+/datum/gear/clothing/mask/gas/clown
+	display_name = "Clown mask selection"
+	slot = slot_wear_mask
+	path = /obj/item/clothing/mask/gas/dal
+	cost = 2 //Same cost as gasmasks because it provides the same benefit
+
+/datum/gear/clothing/mask/gas/clown/New()
+	..()
+	var/gas = list(
+		"professional clown mask"		=	/obj/item/clothing/mask/gas/dal,
+		"psychopathic clown mask"		=	/obj/item/clothing/mask/gas/wolf,
+		"prisoner clown mask"			=	/obj/item/clothing/mask/gas/hox,
+		"daredevil clown mask"			=	/obj/item/clothing/mask/gas/cha,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(gas)
+
+/datum/gear/clothing/mask/costume/halloween
+	display_name = "Halloween mask selection"
+	slot = slot_wear_mask
+	path = /obj/item/clothing/mask/costume/halloween/demon
+
+/datum/gear/clothing/mask/costume/halloween/New()
+	..()
+	var/halloween = list(
+		"demon mask"			=	/obj/item/clothing/mask/costume/halloween/demon,
+		"scarecrow sack"		=	/obj/item/clothing/mask/costume/halloween/scarecrow,
+		"mummy bandages"		=	/obj/item/clothing/mask/costume/halloween/mummy,
+		"goblin mask"			=	/obj/item/clothing/mask/costume/halloween/goblin,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(halloween)
+
+datum/gear/clothing/mask/tiki
+	display_name = "Tiki mask selection"
+	slot = slot_wear_mask
+	path = /obj/item/clothing/mask/costume/misc/tiki/
+
+datum/gear/clothing/mask/tiki/New()
+	..()
+	var/tiki = list(
+		"startled tiki mask"			=	/obj/item/clothing/mask/costume/misc/tiki,
+		"angry tiki mask"				=	/obj/item/clothing/mask/costume/misc/tiki/angry,
+		"confused tiki mask"			=	/obj/item/clothing/mask/costume/misc/tiki/confused,
+		"happy tiki mask"				=	/obj/item/clothing/mask/costume/misc/tiki/happy,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(tiki)

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -139,7 +139,7 @@
 	color = "#225722"
 	scannable = 1
 
-/datum/reagent/medicine/carthatoline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed = REM)
+/datum/reagent/medicine/carthatoline/affect_blood(var/mob/living/carbon/M, var/alien, effect_multiplier, var/removed = REM)
 	M.adjustToxLoss(-8 * removed)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -149,6 +149,12 @@
 				return
 			if(L.damage > 0)
 				L.damage = max(L.damage - 2 * removed, 0)
+	holder.remove_reagent("pararein", 0.8 * effect_multiplier)
+	holder.remove_reagent("carpotoxin", 0.4 * effect_multiplier) // Gonna be good for fish recipes
+	holder.remove_reagent("toxin", 0.4 * effect_multiplier)
+	holder.remove_reagent("stoxin", 0.4 * effect_multiplier)     //Fuck mobs and injectables
+	holder.remove_reagent("zombiepowder", 0.4 * effect_multiplier)
+	holder.remove_reagent("xenotoxin", 0.4 * effect_multiplier)
 
 /datum/reagent/medicine/cordradaxon
 	name = "Cordradaxon"

--- a/maps/CEVEris/_Nadezhda_Colony_Underground.dmm
+++ b/maps/CEVEris/_Nadezhda_Colony_Underground.dmm
@@ -31935,9 +31935,9 @@
 	desc = "A remote control-switch for the AI core maintenance door.";
 	id = "AICore";
 	name = "AI Maintenance Hatch";
+	pixel_y = -32;
 	req_access = newlist();
-	req_one_access = newlist();
-	pixel_y = -32
+	req_one_access = newlist()
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cro)
@@ -38938,6 +38938,12 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/captain/quarters)
+"iiS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/constructable_frame/machine_frame,
+/obj/item/circuitboard/biogenerator,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/maintenance/undergroundfloor1south)
 "ija" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -73551,7 +73557,7 @@ aHa
 aRq
 aHa
 aRq
-aRQ
+iiS
 aQj
 aHa
 aQj

--- a/maps/encounters/deeptunnels/_Nadezhda_Deep_Tunnels.dmm
+++ b/maps/encounters/deeptunnels/_Nadezhda_Deep_Tunnels.dmm
@@ -818,10 +818,10 @@
 /obj/structure/table/rack,
 /obj/item/gun/projectile/shotgun/doublebarrel,
 /obj/item/gun/projectile/shotgun/doublebarrel,
-/obj/item/ammo_magazine/ammobox,
-/obj/item/ammo_magazine/ammobox,
 /obj/item/beartrap,
 /obj/item/beartrap,
+/obj/item/ammo_magazine/ammobox/shotgun/flashshells,
+/obj/item/ammo_magazine/ammobox/shotgun/flashshells,
 /obj/item/ammo_magazine/ammobox/shotgun/flashshells,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/mine/lockers)


### PR DESCRIPTION
What this PR does:
-Buffs Carthatoline to purge the following chems: 
The ones dylo does:
--pararein
--carpotoxin
--toxin
EXTRA PURGES Carth also gets:
--stoxin (sleep toxin aka soporific)
--zombiepowder
--xenotoxin

The one thing carth will be lacking though, compared to dylo, is the anti-sleepy effects. **But** it purges the chems and more so that means its better. It IS supposed to be the upgraded version... Let me know if there are any other common animal toxins that I've missed in adding. (Did this because people whined and are too lazy to do it themselves.)

-Loadout additions
A variety of masks have been added to loadout. Several animal types that carry no mechanical benefit, all of them costing a single point. The eris clown gasmasks (costing 2 points much like normal gasmasks), plague doctor mask which costs two points, and then some halloween masks that carry no mechanical benefit.
Once again, let me know if you want more added.

-Map changes
--Removes a bad ammo spawn in the mining outpost (was the parent spawn of ammunition) and in its place just puts more flash shells.
--Adds a biogenerator board into one of the maintenance tunnels dungeon.