### PR TITLE
Fix the psionic organ deleting held objects

### DIFF
--- a/code/modules/psionics/psion.dm
+++ b/code/modules/psionics/psion.dm
@@ -74,16 +74,13 @@
 			var/obj/item/organ/external/R = O
 			if(!BP_IS_ROBOTIC(R))
 				continue
-
-			if(R.owner != owner)
-				continue
 			owner.visible_message(SPAN_DANGER("[owner]'s [R.name] tears off."),
 			SPAN_DANGER("Your [R.name] tears off."))
 			R.droplimb()
 			if(ishuman(owner))
 				var/mob/living/carbon/human/H = owner
 				H.update_implants()
-	
+
 	for(var/obj/item/organ/O in owner.internal_organs)
 		if(istype(O, /obj/item/organ/internal))
 			var/obj/item/organ/internal/R = O

--- a/code/modules/psionics/psion.dm
+++ b/code/modules/psionics/psion.dm
@@ -69,7 +69,7 @@
 /obj/item/organ/internal/psionic_tumor/proc/remove_synthetics()
 	if(!owner)
 		return
-	for(var/obj/O in owner)
+	for(var/obj/item/organ/O in owner.organs)
 		if(istype(O, /obj/item/organ/external))
 			var/obj/item/organ/external/R = O
 			if(!BP_IS_ROBOTIC(R))
@@ -83,7 +83,8 @@
 			if(ishuman(owner))
 				var/mob/living/carbon/human/H = owner
 				H.update_implants()
-
+	
+	for(var/obj/item/organ/O in owner.internal_organs)
 		if(istype(O, /obj/item/organ/internal))
 			var/obj/item/organ/internal/R = O
 			if(!BP_IS_ROBOTIC(R))


### PR DESCRIPTION
## About The Pull Request
Make the psionic organ be a little more precise when checking for implants and prosthetics. Hopefully it fix the issue of held implants being deleted.