### PR TITLE
re-balance scrap trade + misc corrections

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disk/greyson_excelsior_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/greyson_excelsior_disks.dm
@@ -143,7 +143,7 @@
 		/datum/design/autolathe/circuit/reconstructor_excelsior,
 		/datum/design/autolathe/circuit/diesel_excelsior,
 		/datum/design/autolathe/circuit/turret_excelsior,
-		/datum/design/autolathe/circuit/autolathe_disk_cloner = 3,
+		/datum/design/autolathe/circuit/autolathe_disk_cloner,
 		/datum/design/research/item/part/micro_mani,				//machine parts
 		/datum/design/research/item/part/subspace_amplifier,
 		/datum/design/research/item/part/subspace_crystal,

--- a/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
@@ -59,6 +59,7 @@
 		/datum/design/autolathe/gun/grenade_launcher_lenar = 6,
 		//sniper
 		/datum/design/autolathe/gun/nordwind = 14, //basic uses the whole disk...
+		/datum/design/autolathe/device/landmine = 0,
 		)
 
 //Blackshield
@@ -90,6 +91,7 @@
 		/datum/design/autolathe/gun/sts25,
 		/datum/design/autolathe/gun/sts30,
 		/datum/design/autolathe/gun/sts40,
+		/datum/design/autolathe/device/landmine = 0,
 		)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshieldammo

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -127,6 +127,7 @@
 	icon_state = "c_tube"
 	throwforce = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_SMALL
+	matter = list(MATERIAL_CARDBOARD = 1)
 	throw_speed = 4
 	throw_range = 5
 
@@ -135,7 +136,7 @@
 	desc = "You can use this to wrap items in."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "wrap_paper"
-	matter = list(MATERIAL_BIOMATTER = 4)
+	matter = list(MATERIAL_BIOMATTER = 4, MATERIAL_CARDBOARD = 1)
 	var/amount = 20.0
 
 /obj/item/wrapping_paper/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -321,6 +321,7 @@
 	item_flags = THICKMATERIAL
 	flags_inv = HIDEEARS|BLOCKHAIR
 	siemens_coefficient = 1
+	price_tag = 160
 	armor = list(
 		melee = 15,
 		bullet = 15,

--- a/code/modules/economy/price_list.dm
+++ b/code/modules/economy/price_list.dm
@@ -1137,6 +1137,11 @@
 /obj/item/robot_parts/robot_component/armour/exosuit/combat/price_tag = 1000
 
 /obj/item/mech_component/price_tag = 150
+
+/obj/item/mecha_parts/mecha_equipment/tool/safety_clamp/price_tag = 600
+
+/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp/price_tag = 200
+
 /obj/item/mech_equipment/price_tag = 200
 
 /obj/item/gun/launcher/grenade/price_tag = 1500
@@ -1146,3 +1151,19 @@
 /obj/item/inflatable/price_tag = 40
 
 /obj/item/tool/knife/dagger/bluespace/price_tag = 400
+
+/obj/item/ammo_casing/antim/lethal/prespawned/price_tag = 500
+
+/obj/item/ammo_casing/antim/lethal/prespawned/get_item_cost(export)
+	. = ..()
+	. = amount * 100
+
+/obj/item/ammo_casing/antim/lethal/price_tag = 100
+
+/obj/item/storage/photo_album/price_tag = 30
+
+/obj/item/device/toner/price_tag = 10
+
+/obj/item/wrapping_paper/price_tag = 32
+
+/obj/item/packageWrap/price_tag = 45

--- a/code/modules/trade/datums/trade_stations_presets/cybernetics.dm
+++ b/code/modules/trade/datums/trade_stations_presets/cybernetics.dm
@@ -56,3 +56,20 @@
 		/obj/item/organ_module/active/simple/taser
 	)
 
+/obj/item/organ/external/robotic/moebius
+	price_tag = 450 //Has plasteel
+
+/obj/item/organ/external/robotic/blackshield
+	price_tag = 750 //Has blackmarket
+
+/obj/item/organ/external/robotic/one_star
+	price_tag = 1250 //Has legit the best in the game
+
+/obj/item/organ/external/robotic/technomancer
+	price_tag = 375 //basic
+
+/obj/item/organ/external/robotic/serbian
+	price_tag = 375 //basic
+
+/obj/item/organ/external/robotic/frozen_star
+	price_tag = 375 //basic

--- a/code/modules/trade/datums/trade_stations_presets/hellcat.dm
+++ b/code/modules/trade/datums/trade_stations_presets/hellcat.dm
@@ -51,7 +51,10 @@
 			/obj/item/clothing/suit/armor/vest/security,
 			/obj/item/clothing/suit/armor/vest/detective,
 			/obj/item/clothing/suit/storage/vest,
-			/obj/item/clothing/head/armor/helmet,
+			/obj/item/clothing/head/armor/helmet/tanker,
+			/obj/item/clothing/head/armor/helmet/tanker/green,
+			/obj/item/clothing/head/armor/helmet/tanker/brown,
+			/obj/item/clothing/head/armor/helmet/tanker/gray,
 			/obj/item/clothing/suit/armor/bulletproof,
 			/obj/item/clothing/suit/armor/laserproof
 		),

--- a/code/modules/trade/datums/trade_stations_presets/nt_cruisers.dm
+++ b/code/modules/trade/datums/trade_stations_presets/nt_cruisers.dm
@@ -41,7 +41,7 @@
 			/obj/item/gun/projectile/mk58/wood,
 			/obj/item/gun/projectile/revolver/lemant,
 			/obj/item/gun/projectile/shotgun/pump/combat,
-			/obj/item/gun/launcher/grenade
+			/obj/item/gun/projectile/grenade
 		),
 	)
 

--- a/code/modules/trade/datums/trade_stations_presets/trash_refine.dm
+++ b/code/modules/trade/datums/trade_stations_presets/trash_refine.dm
@@ -2,10 +2,14 @@
 	name_pool = list("IRS 'Lancer'" = "IRS Trash Railgun 'Lancer'. They're sending a message. \"Hoho, you want some Trash?\"")
 	offer_amout_devider_of_wanted_goods = 6 //less items do to cubes being really hard to stack and rather long to make food items
 	assortiment = list(
-		"Trash" = list(/obj/random/scrap/dense_even = custom_good_amount_range(list(6, 80))),
+		"Trash" = list(/obj/random/scrap/dense_weighted = custom_good_amount_range(list(2, 5)),
+				/obj/random/scrap/dense_even = custom_good_amount_range(list(4, 8)),
+				/obj/random/scrap/sparse_even = custom_good_amount_range(list(5, 9)),
+				/obj/random/scrap/sparse_weighted = custom_good_amount_range(list(6, 10)),
+				)
 		"Scrap Lump" = list(/obj/item/scrap_lump = custom_good_amount_range(list(80, 100))),
 		"Salvageable Machines" = list(
-			/obj/structure/salvageable/computer = custom_good_amount_range(list(50, 75)),
+			/obj/structure/salvageable/computer = custom_good_amount_range(list(5, 15)),
 			/obj/structure/salvageable/personal = custom_good_amount_range(list(0, 8)),
 			/obj/structure/salvageable/server = custom_good_amount_range(list(6, 12)),
 			/obj/structure/salvageable/data = custom_good_amount_range(list(6, 10)),
@@ -22,6 +26,18 @@
 	)
 //imo way better place of doing the whole list to be in same file as the ship - Trilby
 /obj/random/scrap
+	price_tag = 50
+
+/obj/random/scrap/dense_weighted
+	price_tag = 150
+
+/obj/random/scrap/dense_even
+	price_tag = 125
+
+/obj/random/scrap/sparse_even
+	price_tag = 100
+
+/obj/random/scrap/sparse_weighted
 	price_tag = 50
 
 /obj/structure/scrap_cube

--- a/code/modules/trade/datums/trade_stations_presets/trash_refine.dm
+++ b/code/modules/trade/datums/trade_stations_presets/trash_refine.dm
@@ -6,7 +6,7 @@
 				/obj/random/scrap/dense_even = custom_good_amount_range(list(4, 8)),
 				/obj/random/scrap/sparse_even = custom_good_amount_range(list(5, 9)),
 				/obj/random/scrap/sparse_weighted = custom_good_amount_range(list(6, 10)),
-				)
+				),
 		"Scrap Lump" = list(/obj/item/scrap_lump = custom_good_amount_range(list(80, 100))),
 		"Salvageable Machines" = list(
 			/obj/structure/salvageable/computer = custom_good_amount_range(list(5, 15)),


### PR DESCRIPTION
The scrap ship now dosnt get as much trash piles
But has more trash random spawner types and prices depending on the type
Corrects a ton 0 price items
Corrects bad lists
Corrects wrong guns


Marshals and blackshield disks now have landmines
exl disk cloner can now be printed by the exl disk