### PR TITLE
Cerebrix QoL Change

### DIFF
--- a/code/modules/psionics/psionic_items.dm
+++ b/code/modules/psionics/psionic_items.dm
@@ -382,13 +382,13 @@
 /obj/item/psi_injector
 	name = "cerebrix inhaler"
 	desc = "A modified inhaler which delivers over-saturated cerebrix diluted in water before being aerosolized. Unlike a direct injection or drinking, this method prevents overdosing or nasty side \
-	side effects at the cost of spending more cerebrix for what it returns."
+	side effects at the cost of spending more cerebrix for what it returns in essence."
 	icon = 'icons/obj/syringe.dmi'
 	icon_state = "psi_inhaler"
 	force = WEAPON_FORCE_HARMLESS
 	w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
-	var/use = 1 // Number of times it can be used.
+	var/use = 4 // Number of times it can be used.
 	var/point_per_use = 1 // Amount of points it give to a psion each use.
 
 /obj/item/psi_injector/update_icon()

--- a/code/modules/reagents/recipes/recipes.dm
+++ b/code/modules/reagents/recipes/recipes.dm
@@ -196,7 +196,7 @@
 
 /datum/chemical_reaction/psi_juice_inhaler
 	result = null
-	required_reagents = list("psi_juice" = 15, "water" = 15, "silicon" = 15)
+	required_reagents = list("psi_juice" = 40, "water" = 40, "silicon" = 40)
 	result_amount = 1
 	blacklist_containers = list(/mob, /obj/machinery/microwave)
 


### PR DESCRIPTION
-Cerebrix inhalers now take 40/40/40 cerebrix/water/silicon but now have 4 charges instead of one. Returns are now 50% instead of 33% (you get more essence per spent cerebrix on inhalers now).
-Wiki updated to reflect this change.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
