### PR TITLE
Add filter effects, holy glow to litanies and more.

### DIFF
--- a/code/__HELPERS/filters_effects.dm
+++ b/code/__HELPERS/filters_effects.dm
@@ -1,0 +1,27 @@
+/* 	This is for adding & removing filter effects from mobs. (See : http://www.byond.com/docs/ref/#/{notes}/filters )
+	[user] is the mob to add the filter effect to.
+	[effect] is the filter effect you want to add.
+	[duration] is if you want the effect to disappear after some time, values are in deciseconds (1/10th of a second)
+	[fade_delay] is how long the fade out of the effect in decisecond is.
+
+	The defines are pre-made filters effect for ease of copy-paste.
+*/
+
+#define FILTER_HOLY_GLOW filter(type="drop_shadow", x=0, y=0, size=5, offset=2, color=rgb(255,255,170))
+#define FILTER_RIPPLE filter(type="ripple", x=0, y=0, size=5)
+#define FILTER_HOLY_RAY filter(type="ray", x=0, y=0, size=32, offset=2, color=rgb(255,255,170))
+
+/proc/add_effect(var/mob/user, var/dm_filter/effect, var/duration)
+	if(user && effect)
+		user.filters += effect
+		if(duration)
+			spawn(duration)
+				remove_effect(user, filter_fx, fade_delay)
+		return TRUE
+	return FALSE
+
+/proc/remove_effect(var/mob/user, var/dm_filter/effect)
+	if(user && effect)
+		user.filters -= filter_fx
+		return TRUE
+	return FALSE

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -32,6 +32,7 @@
 	H.apply_effect(-30, AGONY, 0)
 	H.apply_effect(-30, HALLOSS, 0)
 	H.updatehealth()
+	add_effect(H, FILTER_HOLY_GLOW, 25)
 	return TRUE
 
 /datum/ritual/cruciform/base/soul_hunger
@@ -43,6 +44,7 @@
 /datum/ritual/cruciform/base/soul_hunger/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/C)
 	H.nutrition += 100
 	H.adjustToxLoss(5)
+	add_effect(H, FILTER_HOLY_GLOW, 25)
 	return TRUE
 
 /datum/ritual/cruciform/base/glow_book
@@ -128,6 +130,7 @@
 
 		if((istype(CI) && CI.get_module(CRUCIFORM_PRIEST)) || prob(50))
 			to_chat(target, SPAN_DANGER("[H], faithful cruciform follower, cries for salvation at [t.name]!"))
+	add_effect(H, FILTER_HOLY_GLOW, 25)
 	return TRUE
 
 /datum/ritual/cruciform/base/reveal
@@ -174,12 +177,13 @@
 				break
 	if (!was_triggired)
 		to_chat(H, SPAN_NOTICE("There is nothing here. You feel safe."))
+	add_effect(H, FILTER_HOLY_GLOW, 25)
 	return TRUE
 
 /datum/ritual/cruciform/base/message
 	name = "Sending"
 	phrase = "Audit, me audit vocationem. Ego nuntius vobis."
-	desc = "Send a message anonymously through the void, straight into the mind of another disciple."
+	desc = "Send a message through the void, straight into the mind of another disciple."
 	power = 30
 	nutri_cost = 10//low cost
 	blood_cost = 10//low cost
@@ -206,3 +210,5 @@
 	log_and_message_admins("[user.real_name] sent a message to [H] with text \"[text]\"")
 	playsound(user.loc, 'sound/machines/signal.ogg', 50, 1)
 	playsound(H, 'sound/machines/signal.ogg', 50, 1)
+	add_effect(user, FILTER_HOLY_GLOW, 25)
+	add_effect(H, FILTER_HOLY_GLOW, 25)

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -39,6 +39,7 @@
 		for(var/mob/living/carbon/human/participant in people_around)
 			to_chat(participant, SPAN_NOTICE("You hear a silent signal..."))
 			heal_other(participant)
+			add_effect(participant, FILTER_HOLY_GLOW, 25)
 		set_personal_cooldown(user)
 		return TRUE
 	else
@@ -81,6 +82,7 @@
 		for(var/mob/living/carbon/human/participant in people_around)
 			to_chat(participant, SPAN_NOTICE("You hear a silent signal..."))
 			heal_other(participant)
+			add_effect(participant, FILTER_HOLY_GLOW, 25)
 		set_personal_cooldown(user)
 		return TRUE
 	else
@@ -143,6 +145,7 @@
 		for(var/mob/living/carbon/human/participant in people_around)
 			to_chat(participant, SPAN_NOTICE("You hear a silent signal..."))
 			give_boost(participant)
+			add_effect(participant, FILTER_HOLY_GLOW, 25)
 		set_global_cooldown()
 		return TRUE
 	else
@@ -229,6 +232,7 @@
 	H.adjustBrainLoss(-5)
 	H.updatehealth()
 	set_personal_cooldown(H)
+	add_effect(H, FILTER_HOLY_GLOW, 25)
 	return TRUE
 
 /datum/ritual/cruciform/monomial/perfect_self
@@ -259,6 +263,7 @@
 	to_chat(user, SPAN_NOTICE("You feel at peace with yourself, your body and mind going beyond its limits."))
 	set_personal_cooldown(user)
 	addtimer(CALLBACK(src, .proc/discard_effect, user), src.cooldown_time)
+	add_effect(user, FILTER_HOLY_GLOW, 25)
 	return TRUE
 
 /datum/ritual/cruciform/monomial/perfect_self/proc/discard_effect(mob/living/carbon/human/user, amount)
@@ -304,6 +309,7 @@
 			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
 			user.vessel.remove_reagent("blood",blood_cost)
 	set_personal_cooldown(user)
+	add_effect(user, FILTER_HOLY_GLOW, 25)
 
 /datum/ritual/cruciform/divisor/div_flash
 	name = "Ire"
@@ -334,6 +340,7 @@
 			else
 				to_chat(victim, SPAN_NOTICE("Your legs feel numb, but you managed to stay on your feet!"))
 	set_personal_cooldown(user)
+	add_effect(user, FILTER_HOLY_GLOW, 25)
 	return TRUE
 
 /datum/ritual/cruciform/factorial
@@ -370,6 +377,7 @@
 			fail("This type of cell cannot be charged.", user, C)
 			return
 		to_chat(user, "You start charging the [P.name].")
+		add_effect(user, FILTER_HOLY_GLOW, 25)
 		while(C.power >= charge_used) // Keep going until we run out of power
 			if(!istype(user.get_active_hand(), /obj/item/cell)) // Check if we're still holding a cell. Because rigged cell explode when charging.
 				break
@@ -408,6 +416,7 @@
 		if(augmentic.nature == MODIFICATION_SILICON) // Are the organ made of metal?
 			augmentic.rejuvenate() // Repair the organ
 	to_chat(user, "Your mechanical organs knit themselves back together.")
+	add_effect(user, FILTER_HOLY_GLOW, 25)
 
 // Mass-Repair
 /datum/ritual/cruciform/factorial/mass_repair
@@ -429,8 +438,9 @@
 			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
 			user.vessel.remove_reagent("blood",blood_cost)
 	set_personal_cooldown(user)
-	for(var/mob/living/carbon/human/H in view(user)) // Affect everyone the user can see.
+	for(var/mob/living/carbon/human/H in oview(user)) // Affect everyone the user can see.
 		for(var/obj/item/organ/augmentic in H) // Run this loop for every organ the person has
 			if(augmentic.nature == MODIFICATION_SILICON) // Are the organ made of metal?
 				augmentic.rejuvenate() // Repair the organ
 				to_chat(H, "Your [augmentic.name] repair itself!")
+				add_effect(H, FILTER_HOLY_GLOW, 25)

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -98,6 +98,7 @@
 	H.adjustBrainLoss(-5)
 	H.updatehealth()
 	set_personal_cooldown(H)
+	add_effect(user, FILTER_HOLY_GLOW, 25)
 	return TRUE
 
 /datum/ritual/cruciform/priest/heal_other
@@ -151,6 +152,7 @@
 		H.adjustBrainLoss(-5)
 		H.updatehealth()
 		set_personal_cooldown(user)
+		add_effect(H, FILTER_HOLY_GLOW, 25)
 		return TRUE
 
 /datum/ritual/cruciform/priest/heal_heathen
@@ -183,6 +185,7 @@
 		for(var/mob/living/carbon/human/participant in people_around)
 			to_chat(participant, SPAN_NOTICE("You hear a silent signal..."))
 			heal_other(participant)
+			add_effect(participant, FILTER_HOLY_GLOW, 25)
 		set_personal_cooldown(user)
 		return TRUE
 	else
@@ -286,6 +289,7 @@
 			user.vessel.remove_reagent("blood",blood_cost)
 	log_and_message_admins("successfully baptized [CI.wearer]")
 	to_chat(CI.wearer, "<span class='info'>Your cruciform vibrates and warms up.</span>")
+	add_effect(CI.wearer, FILTER_HOLY_GLOW, 25)
 
 	CI.activate()
 
@@ -417,6 +421,7 @@
 		M.custom_pain("You feel the nails of the cruciform drive into your ribs!",1)
 		M.update_implants()
 		M.updatehealth()
+		add_effect(M, FILTER_HOLY_GLOW, 25)
 
 	return TRUE
 
@@ -568,7 +573,7 @@
 /datum/ritual/cruciform/priest/short_boost
 	name = "Short boost ritual"
 	phrase = null
-	desc = "This litany boosts the stats of everyone who's hear you on the short time. "
+	desc = "This litany boosts the stats of everyone who is near you on the short time. "
 	cooldown = TRUE
 	cooldown_time = 2 MINUTES
 	effect_time = 10 MINUTES
@@ -600,6 +605,7 @@
 		for(var/mob/living/carbon/human/participant in people_around)
 			to_chat(participant, SPAN_NOTICE("You hear a silent signal..."))
 			give_boost(participant)
+			add_effect(user, FILTER_HOLY_GLOW, 25)
 		set_global_cooldown()
 		return TRUE
 	else
@@ -660,6 +666,7 @@
 
 	if(altar)
 		new /obj/item/paper/neopaper(altar.loc, disciples.Join("\n"), "Church Record")
+		add_effect(user, FILTER_HOLY_GLOW, 25)
 	return TRUE
 
 /datum/ritual/cruciform/priest/new_cruciform
@@ -813,6 +820,7 @@
 		for(var/datum/seed/S in plants_around)
 			give_boost(S)
 		set_global_cooldown()
+		add_effect(user, FILTER_HOLY_GLOW, 25)
 		return TRUE
 	else
 		fail("There is no plant around to hear your song.", user, C)
@@ -852,6 +860,7 @@
 	to_chat(user, SPAN_NOTICE("You ease the pain of [T.name]."))
 
 	T.reagents.add_reagent("anodyne", 10)
+	add_effect(T, FILTER_HOLY_GLOW, 25)
 
 	return TRUE
 
@@ -884,6 +893,7 @@
 	R.add_reagent("holyinaprovaline", 10)
 	R.add_reagent("holydexalinp", 10)
 	R.trans_to_mob(T, 20, CHEM_BLOOD)
+	add_effect(T, FILTER_HOLY_GLOW, 25)
 
 	return TRUE
 
@@ -924,6 +934,7 @@
 	to_chat(user, SPAN_NOTICE("You help [T.name] get rid of their addictions."))
 
 	T.reagents.add_reagent("laudanum", 10)
+	add_effect(T, FILTER_HOLY_GLOW, 25)
 
 	return TRUE
 

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -83,6 +83,7 @@
 #include "code\__HELPERS\bluespace_entropy.dm"
 #include "code\__HELPERS\delays.dm"
 #include "code\__HELPERS\files.dm"
+#include "code\__HELPERS\filters_effects.dm"
 #include "code\__HELPERS\functional.dm"
 #include "code\__HELPERS\game.dm"
 #include "code\__HELPERS\global_lists.dm"


### PR DESCRIPTION
## About The Pull Request
- Add a proc to easily add timed [Filter Effects](http://www.byond.com/docs/ref/#/{notes}/filters) to mobs.
- Most of the Church's litanies now make the affected people glow for 2.5 seconds.
- Removed the 'anonymous' part of the message litany because it wasn't.
- Change the Factorial's mass repair litany to no longer affect the Factorial. You got a separate litany for that, use it.