### PR TITLE
makes bullet printer not shit

### DIFF
--- a/code/game/objects/items/weapons/tools/bonesetters.dm
+++ b/code/game/objects/items/weapons/tools/bonesetters.dm
@@ -18,4 +18,4 @@
 	degradation = 0.75
 
 /obj/item/tool/bonesetter/adv/si
-	icon_state = "retractor_SI"
+	icon_state = "bone setter_SI"


### PR DESCRIPTION

## About The Pull Request
Removes sleep checks on bullet printer to use the much more optimized spawn
swaps 1-0 to TRUE FALSE
Adds missing ammo
Makes printing things way better and more streamlined
Makes getting points via max stacks on materals way quicker
corrects adv bone setter sprites 