### PR TITLE
Time Tracking 2.0

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -631,16 +631,16 @@ SUBSYSTEM_DEF(job)
 
 //Forces a job to be accessible regardless of time played, or disables it if 'enable' is set false.
 /datum/controller/subsystem/job/proc/JobTimeForce(ckey, job_key, enable = TRUE)
-	var/datum/playtime/P = JobTimeGetDatum(ckey)
+	var/datum/playtime/P = JobTimeGetDatum(ckey, job_key)
 	P.forced = enable
-	JobTimeSetDatum(ckey)
+	JobTimeSetDatum(ckey, job_key, P)
 
 /* Procs that read the save */
 
 //Returns true if either the job from job_key has been forced, or the sum of all jobs in the list exceeds req_time
 /datum/controller/subsystem/job/proc/JobTimeAutoCheck(ckey, job_key, jobs, req_time)
 	if(JobTimeAllowCheck(ckey, job_key)) return TRUE
-	return JobTimeCheck(ckey, req_time) >= req_time
+	return JobTimeCheck(ckey, jobs) >= req_time
 
 //Returns the sum of all times in the list of jobs provided.
 //If 'jobs' is not a list, it will be encapsulated in one.

--- a/code/game/jobs/department.dm
+++ b/code/game/jobs/department.dm
@@ -10,8 +10,7 @@
 	var/account_number = 0
 	var/account_pin
 	var/account_initial_balance = 3500	//How much money this account starts off with
-
-
+	var/list/jobs_in_department = list()
 
 	//Account Funding
 	/*
@@ -45,7 +44,6 @@
 	pending_wage_total = 0
 	for (var/a in pending_wages)
 		pending_wage_total += pending_wages[a]
-
 
 /*************
 	Command

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -13,6 +13,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	difficulty = "Very Hard."
 	selection_color = "#ccccff"
 	req_admin_notify = 1
+	playtimerequired = 1200
 	wage = WAGE_COMMAND
 
 	ideal_character_age = 50 // Old geezer captains ftw
@@ -75,6 +76,7 @@ Treat your command officers with respect, and listen to their council. Try not t
 	difficulty = "Hard."
 	selection_color = "#ddddff"
 	req_admin_notify = 1
+	playtimerequired = 1200
 	wage = WAGE_COMMAND
 	ideal_character_age = 35
 	minimum_character_age = 30

--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -12,6 +12,7 @@
 	selection_color = "#ecd37d"
 	ideal_character_age = 40
 	minimum_character_age = 30
+	playtimerequired = 1200
 	also_known_languages = list(LANGUAGE_LATIN = 100)
 
 	access = list(

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -11,6 +11,7 @@
 	difficulty = "Medium."
 	selection_color = "#c7b97b"
 	req_admin_notify = 1
+	playtimerequired = 1200
 	wage = WAGE_COMMAND
 	ideal_character_age = 50
 	minimum_character_age = 30

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -19,6 +19,7 @@
 	)
 	ideal_character_age = 40
 	minimum_character_age = 30
+	playtimerequired = 1200
 
 	stat_modifiers = list(
 		STAT_ROB = 10,

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -139,6 +139,27 @@
 /datum/job/proc/get_access()
 	return src.access.Copy()
 
+/datum/job/proc/is_experienced_enough(client/C) //This can be reimplemented if you want to have special requirements for jobs.
+	var/are_we_experienced_enough = FALSE //We start under the assumption of NO!
+	var/list/jobs_in_department = list() //What jobs are in this department?
+	for(var/job in joblist)
+		var/datum/job/J = joblist[job]
+		if(department_flag == COMMAND)
+			if(department_flag & J.department_flag)
+				jobs_in_department += "[J.type]"
+		else
+			if(department == J.department)
+				jobs_in_department += "[J.type]"
+	if(playtimerequired > 0)
+		if(SSjob.JobTimeAutoCheck(C.ckey, "[type]", jobs_in_department, playtimerequired))
+			are_we_experienced_enough = TRUE //We are experienced enough, hurray.
+	if(coltimerequired > 0)
+		if(SSjob.JobTimeAutoCheck(C.ckey, "[type]", "/datum/job/assistant", coltimerequired))
+			are_we_experienced_enough = TRUE //We are experienced enough as a colonist, hurray.
+	if(playtimerequired == 0 && coltimerequired == 0)
+		are_we_experienced_enough = TRUE //We're doing a job that requires 0 experience, hurray.
+	return are_we_experienced_enough
+
 /datum/job/proc/apply_fingerprints(var/mob/living/carbon/human/target)
 	if(!istype(target))
 		return 0
@@ -173,6 +194,9 @@
 		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age].</span>")
 		return TRUE
 
+	if(!is_experienced_enough(prefs.client))
+		to_chat(feedback, "<span class='boldannounce'>Not experienced enough. This job requires that you play [coltimerequired] minutes of colonist and [playtimerequired] in the [department] department.</span>")
+		return TRUE
 	//Disabled since I rewrote the system to be more granular. Will need later work.
 	/*if(coltimerequired)
 		if(coltimerequired > prefs.playtime["Civilian"])
@@ -247,4 +271,3 @@
 	//The string processing is necessary so that string queries can return too.
 	//For some reason, /datum/job/hydro and "/datum/job/hydro" are not considered the same string.
 	SSjob.JobTimeAdd(C.ckey, "[type]", amount)
-	

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -23,6 +23,7 @@
 
 	ideal_character_age = 40
 	minimum_character_age = 30
+	playtimerequired = 1200
 
 	stat_modifiers = list(
 		STAT_BIO = 50,

--- a/code/game/jobs/job/offcolony.dm
+++ b/code/game/jobs/job/offcolony.dm
@@ -25,7 +25,7 @@
 		STAT_MEC = 5,
 		STAT_COG = 0
 	)
-
+	playtimerequired = 1200
 	description = "You are not apart of the colony, at least currently, having decided to take a shift with the local lodge hunters either temporarily or permanently. As the hunt \
 	master your job is to lead your fledgling hunters on expeditions and generally work towards keeping them alive while thriving in your lodge. You are not nearly as well \
 	equipped as the colony is, but special training by the lodge has given you the ability to live off the land."

--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -15,7 +15,7 @@
 	department_account_access = TRUE
 
 	outfit_type = /decl/hierarchy/outfit/job/foreman
-
+	playtimerequired = 1200
 	access = list(
 		access_prospector, access_foreman, access_external_airlocks, access_eva, access_heads, access_sec_doors,
 		access_RC_announce, access_keycard_auth, access_maint_tunnels, access_medical_suits //for locating scav team dead bodies

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -14,7 +14,7 @@
 	wage = WAGE_COMMAND
 
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
-
+	playtimerequired = 1200
 	access = list(
 		access_rd, access_heads, access_tox, access_genetics, access_morgue,
 		access_tox_storage, access_teleporter, access_sec_doors,

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -15,6 +15,7 @@
 	ideal_character_age = 40
 	minimum_character_age = 30
 	department_account_access = TRUE
+	playtimerequired = 1200
 
 	outfit_type = /decl/hierarchy/outfit/job/security/smc
 
@@ -76,6 +77,7 @@
 	ideal_character_age = 40
 	minimum_character_age = 30
 	department_account_access = TRUE
+	playtimerequired = 1200
 
 	outfit_type = /decl/hierarchy/outfit/job/security/swo
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -584,7 +584,7 @@ ADMIN_VERB_ADD(/client/proc/playtimebypass, R_ADMIN|R_MOD|R_DEBUG, FALSE)
 	if(!J) return
 	var/mode = input("Enable, or disable?") in list("Enable", "Disable")
 	if(!mode) return
-	SSjob.JobTimeForce(ckey, initial(J.title), (mode=="Enable"))
+	SSjob.JobTimeForce(ckey, "[J]", (mode=="Enable"))
 	message_admins("\blue [key_name_admin(usr)] [lowertext(mode)]d [key]'s [J] job bypass.", 1)
 	log_admin("[key_name_admin(usr)] [lowertext(mode)]d [key]'s [J] job bypass.")
 

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -141,6 +141,12 @@
 				bad_message = "\[MINIMUM PLAYTIME AS A COLONIST: [job.coltimerequired] Minutes]" *///People may need to play colonist before playing this job.
 		else if(user.client && job.is_setup_restricted(user.client.prefs.setup_options))
 			bad_message = "\[SETUP RESTRICTED]"
+		else if(job.playtimerequired && user.client)
+			if(!job.is_experienced_enough(user.client))
+				bad_message = "\[MINIMUM PLAYTIME: [job.playtimerequired] Minutes]"
+		else if(job.coltimerequired && user.client)
+			if(!job.is_experienced_enough(user.client))
+				bad_message = "\[MINIMUM COLONIST PLAYTIME: [job.coltimerequired] Minutes]"
 		if(("Assistant" in pref.job_low) && (rank != "Assistant"))
 			. += "<a href='?src=\ref[src];set_skills=[rank]'><font color=grey>[rank]</font></a></td><td></td></tr>"
 			continue

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1302,3 +1302,14 @@ mob/proc/yank_out_object()
 /mob/proc/set_stat(var/new_stat)
 	. = stat != new_stat
 	stat = new_stat
+
+/client/verb/showplaytime()
+	set name = "Show All Playtime"
+	set category = "IC"
+	var/timeinjob = 0
+	log_debug("[src.ckey] just looked at his playtime.")
+	for(var/job in joblist)
+		var/datum/job/J = joblist[job]
+		timeinjob = SSjob.JobTimeCheck(usr.ckey, "[J.type]")
+		if(timeinjob > 0)
+			to_chat(src, "You have spent [timeinjob] minutes playing as [J.title].")


### PR DESCRIPTION
We now enable the last part of time tracking, namely the locking. You can check how much time you've played in each job under IC. Currently need to have played 20 hours in that department to be able to play the head of staff, or 20 in the council in general to play Premier and Steward.

Tested in my own test environment (a lot of times). Things should work as expected.