### PR TITLE
Simple Pouch Changes

### DIFF
--- a/code/datums/craft/recipes/lodge.dm
+++ b/code/datums/craft/recipes/lodge.dm
@@ -345,21 +345,12 @@
 		list(QUALITY_CUTTING, 15, "time" = 50)
 	)
 
-/datum/craft_recipe/lodge/leather_small_pouch
-	name = "small leather pouch"
-	result = /obj/item/storage/pouch/small_generic/leather
-	icon_state = "clothing"
-	steps = list(
-		list(CRAFT_MATERIAL, 2, MATERIAL_LEATHER, "time" = 30),
-		list(QUALITY_ADHESIVE, 10, "time" = 60)
-	)
-
 /datum/craft_recipe/lodge/leather_medium_pouch
 	name = "medium leather pouch"
 	result = /obj/item/storage/pouch/medium_generic/leather
 	icon_state = "clothing"
 	steps = list(
-		list(CRAFT_MATERIAL, 6, MATERIAL_LEATHER, "time" = 30),
+		list(CRAFT_MATERIAL, 4, MATERIAL_LEATHER, "time" = 30),
 		list(QUALITY_ADHESIVE, 10, "time" = 60)
 	)
 
@@ -368,6 +359,6 @@
 	result = /obj/item/storage/pouch/large_generic/leather
 	icon_state = "clothing"
 	steps = list(
-		list(CRAFT_MATERIAL, 12, MATERIAL_LEATHER, "time" = 30),
+		list(CRAFT_MATERIAL, 8, MATERIAL_LEATHER, "time" = 30),
 		list(QUALITY_ADHESIVE, 10, "time" = 60)
 	)

--- a/code/datums/craft/recipes/storage.dm
+++ b/code/datums/craft/recipes/storage.dm
@@ -109,6 +109,15 @@
 	)
 	related_stats = list(STAT_COG)
 
+/datum/craft_recipe/lodge/leather_small_pouch
+	name = "small leather pouch"
+	result = /obj/item/storage/pouch/small_generic/leather
+	icon_state = "clothing"
+	steps = list(
+		list(CRAFT_MATERIAL, 2, MATERIAL_LEATHER, "time" = 30),
+		list(QUALITY_ADHESIVE, 10, "time" = 60)
+	)
+
 /datum/craft_recipe/box/adv
 	icon_state = "clothing"
 	avaliableToEveryone = FALSE

--- a/code/datums/craft/recipes/storage.dm
+++ b/code/datums/craft/recipes/storage.dm
@@ -109,7 +109,7 @@
 	)
 	related_stats = list(STAT_COG)
 
-/datum/craft_recipe/lodge/leather_small_pouch
+/datum/craft_recipe/storage/leather_small_pouch
 	name = "small leather pouch"
 	result = /obj/item/storage/pouch/small_generic/leather
 	icon_state = "clothing"

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -53,6 +53,7 @@
 /obj/item/storage/pouch/small_generic/leather
 	icon_state = "small_leather"
 	item_state = "small_leather"
+	price_tag = 150
 
 /obj/item/storage/pouch/medium_generic
 	name = "medium generic pouch"
@@ -67,6 +68,7 @@
 /obj/item/storage/pouch/medium_generic/leather
 	icon_state = "medium_leather"
 	item_state = "medium leather"
+	price_tag = 300
 
 /obj/item/storage/pouch/medium_generic/opifex
 	name = "opifex smuggle pouch"
@@ -88,9 +90,10 @@
 	price_tag = 1000
 
 /obj/item/storage/pouch/large_generic/leather
-	desc = "A mini satchel made of leather.Can hold a fair bit, but it won't fit in your pocket"
+	desc = "A mini satchel made of leather. Can hold a fair bit, but it won't fit in your pocket"
 	icon_state = "large_leather"
 	item_state = "large_leather"
+	price_tag = 700
 
 /obj/item/storage/pouch/medical_supply
 	name = "medical supply pouch"


### PR DESCRIPTION
What this PR does:

- Re-adds the small leather pouch to be a craft available for everyone.
-  Lowers the cost of crafting for the medium and large pouches.
- Adds a space for proper grammar.
- Lowers the credits worth of leather pouches a bit.

Reasons why I changed this:

Nobody will make a small pouch when they can make a medium or a large. And the leather small pouches look nice, so I want them to be used, somehow. Allowing it to be crafted by everyone means that colonists and outsiders will have a way to make a simple storage container, through appropriate effort, which still doesn't beat the best.

The crafting cost change was simply too high, so I lowered it. Credits worth has been lowered slightly, if that is considered to be an issue.

Let me know what/how/why things are good or bad about this PR.