### PR TITLE
Make the mining bot have to be manually activated

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/mining/mining_drone.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/mining/mining_drone.dm
@@ -41,6 +41,11 @@
 		if(istype(target, /obj/item/ore && !pickup))
 			target = null // reset the target
 
+
+		// We shouldn't target the floor
+		if(istype(target, /turf/simulated/floor))
+			target = null // reset the target
+
 		if(target) // Do we have a destination?
 			walk_to(src, target, 1, move_to_delay) // Go there
 		else

--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/mining/mining_drone.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/mining/mining_drone.dm
@@ -41,7 +41,6 @@
 		if(istype(target, /obj/item/ore && !pickup))
 			target = null // reset the target
 
-
 		// We shouldn't target the floor
 		if(istype(target, /turf/simulated/floor))
 			target = null // reset the target
@@ -125,7 +124,7 @@
 
 // Pick an ore and put it in the contents.
 /mob/living/carbon/superior_animal/robot/mining/proc/pick_ore(var/obj/item/ore/O)
-	visible_message("[src] pick up [O]") // Visible message
+	//visible_message("[src] pick up [O]") // For some reasons the messages do not combine and spam the chat.
 	O.forceMove(src) // Pick up the item
 	return TRUE
 

--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/mining/types/colony.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/mining/types/colony.dm
@@ -11,7 +11,7 @@
 	friendly_to_colony = TRUE
 	obey_friends = FALSE // We follow everyone who ask
 
-	// The vars start deactivated so that it doesn't fuck off as soon as it spawn
+	// The vars start deactivated so that it doesn't leave as soon as it spawn
 	wandering = FALSE
 	pickup = FALSE
 	mining = FALSE

--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/mining/types/colony.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/mining/types/colony.dm
@@ -11,4 +11,7 @@
 	friendly_to_colony = TRUE
 	obey_friends = FALSE // We follow everyone who ask
 
-	wandering = FALSE // We don't wander automatically
+	// The vars start deactivated so that it doesn't fuck off as soon as it spawn
+	wandering = FALSE
+	pickup = FALSE
+	mining = FALSE


### PR DESCRIPTION
## About The Pull Request
Make the aether mining bot have to be manually activated so that it doesn't move as soon as the game start.