### PR TITLE
lowers turrets shooting rate

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -72,6 +72,7 @@
 /obj/machinery/porta_turret/One_star
 	name = "greyson positronic turret"
 	installation = /obj/item/gun/energy/cog
+	shot_delay = 20 //2 seconds between each shot, its older and the like
 
 /obj/machinery/porta_turret/crescent
 	enabled = FALSE

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -48,10 +48,9 @@
 	check_access = TRUE //Respects access
 	check_anomalies = FALSE //We dont attack simples
 	check_synth = FALSE //so dont shoot are own
-
+	shot_delay = 20		//2 seconds between each shot, its a heavy laser and thats what the gun in the turret is meant to be delayed by 
 	ailock = TRUE
 	use_power = NO_POWER_USE
-	shot_delay = 5
 	auto_repair = TRUE
 
 /obj/machinery/turretid/Destroy()


### PR DESCRIPTION
Grayson turrets now shoots every 2 seconds
Prepper turrets now need 2 seconds per shot do to being a heavy laser