### PR TITLE
Gun tag correction

### DIFF
--- a/code/modules/projectiles/guns/projectile/boltgun/flaregun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/flaregun.dm
@@ -18,7 +18,7 @@
 	saw_off = FALSE
 	bolt_training = FALSE
 	eject_animatio = FALSE //TODO: this
-
+	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE) //We cant be overshooter or sharpened, but we can take a scope!
 
 
 /obj/item/gun/projectile/boltgun/flare_gun/update_icon()


### PR DESCRIPTION
Disallows Dazzlation on getting overshooters, baynet sharpening and silencing 