### PR TITLE
advanced turret now take 1 second to shoot

### DIFF
--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -51,7 +51,7 @@
 
 	ailock = TRUE
 	use_power = NO_POWER_USE
-	shot_delay = 5
+	shot_delay = 10
 	auto_repair = TRUE
 
 /obj/machinery/turretid/Destroy()


### PR DESCRIPTION
Well still cheating the advanced turret now shoots ever second rather then .5 seconds