### PR TITLE
RuntimeFix225

### DIFF
--- a/code/controllers/subsystems/inactivity.dm
+++ b/code/controllers/subsystems/inactivity.dm
@@ -26,7 +26,9 @@ SUBSYSTEM_DEF(inactivity)
 				var/mob/living/carbon/human/SMan = C.mob
 				if(istype(SMan, /mob/living/carbon/human))
 					if(SMan.job)
-						SMan.mind.assigned_job.change_playtime(C, 1)
+						if(SMan.mind)
+							if(SMan.mind.assigned_job)
+								SMan.mind.assigned_job.change_playtime(C, 1)
 
 		if (MC_TICK_CHECK)
 			return

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -151,11 +151,13 @@
 			if(department == J.department)
 				jobs_in_department += "[J.type]"
 	if(playtimerequired > 0)
-		if(SSjob.JobTimeAutoCheck(C.ckey, "[type]", jobs_in_department, playtimerequired))
-			are_we_experienced_enough = TRUE //We are experienced enough, hurray.
+		if(C.ckey)
+			if(SSjob.JobTimeAutoCheck(C.ckey, "[type]", jobs_in_department, playtimerequired))
+				are_we_experienced_enough = TRUE //We are experienced enough, hurray.
 	if(coltimerequired > 0)
-		if(SSjob.JobTimeAutoCheck(C.ckey, "[type]", "/datum/job/assistant", coltimerequired))
-			are_we_experienced_enough = TRUE //We are experienced enough as a colonist, hurray.
+		if(C.ckey)
+			if(SSjob.JobTimeAutoCheck(C.ckey, "[type]", "/datum/job/assistant", coltimerequired))
+				are_we_experienced_enough = TRUE //We are experienced enough as a colonist, hurray.
 	if(playtimerequired == 0 && coltimerequired == 0)
 		are_we_experienced_enough = TRUE //We're doing a job that requires 0 experience, hurray.
 	return are_we_experienced_enough

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -326,7 +326,7 @@
 		. += 0.5
 
 	var/muscle_eff = owner.get_specific_organ_efficiency(OP_MUSCLE, organ_tag)
-	muscle_eff = muscle_eff - (muscle_eff/(owner.get_specific_organ_efficiency(OP_NERVE, organ_tag)/100)) //Need more nerves to control those new muscles
+	muscle_eff = muscle_eff - (muscle_eff/CLAMP((owner.get_specific_organ_efficiency(OP_NERVE, organ_tag)/100),0.01,100)) //Need more nerves to control those new muscles
 	. += max(-(muscle_eff/ 100)/4, MAX_MUSCLE_SPEED)
 
 	. += tally


### PR DESCRIPTION
Fixes the following runtimes:
1. A runtime in inactivity where we were calling on null.
2. A runtime in job.dm where we were calling on a null ckey
3. A runtime in organs where a muscle that was fully destroyed would divide by 0
Tested and all that, shouldn't cause issues. 