### PR TITLE
detective kit rebalance

### DIFF
--- a/code/modules/detectivework/tools/crimekit.dm
+++ b/code/modules/detectivework/tools/crimekit.dm
@@ -1,11 +1,12 @@
 //crime scene kit
 /obj/item/storage/briefcase/crimekit
 	name = "crime scene kit"
-	desc = "A stainless steel-plated carrycase for all your forensic needs. Feels heavy."
+	desc = "A stainless steel-plated carrycase for all your forensic needs. Feels heavy and has a hook on the back that allows for easy belt storage."
 	icon = 'icons/obj/forensics.dmi'
 	icon_state = "case"
 	item_state = "case"
-	storage_slots = 14
+	storage_slots = 12 //Techinnally better then a harness but, much bigger so no stacking them in bags
+	slot_flags = SLOT_BELT //This one is techinnally meant to be on a detective at all times
 	price_tag = 50
 
 /obj/item/storage/briefcase/crimekit/populate_contents()


### PR DESCRIPTION
Detective kit now holds 12 items rather then 14
Detective kits now can go on belt slots
they are well basiclly like a harness, have a major draw back in that you cant bag it to then put a larger item in its place
