### PR TITLE
Replace the Trauma Team's LMG with a Bullpip

### DIFF
--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -46,8 +46,8 @@
 	back = /obj/item/storage/backpack/duffelbag
 	l_pocket = /obj/item/device/flash
 	r_pocket = /obj/item/handcuffs
-	backpack_contents = list(/obj/item/rig/trauma_suit/equipped = 1, /obj/item/handcuffs = 1, /obj/item/clothing/suit/straight_jacket = 1, /obj/item/storage/firstaid/soteria/large = 1, /obj/item/gun/energy/sst/formatbound = 1, /obj/item/cell/large/moebius/high = 1, /obj/item/cell/medium/moebius/high = 1)
-	suit_store = /obj/item/gun/energy/sst/systemcost
+	backpack_contents = list(/obj/item/rig/trauma_suit/equipped = 1, /obj/item/handcuffs = 1, /obj/item/clothing/suit/straight_jacket = 1, /obj/item/storage/firstaid/soteria/large = 1, /obj/item/gun/energy/sst/formatbound = 1, /obj/item/cell/medium/moebius/high = 1, /obj/item/ammo_magazine/smg_35 = 3)
+	suit_store = /obj/item/gun/projectile/automatic/c20r/sci
 
 /decl/hierarchy/outfit/job/medical/psychiatrist
 	name = OUTFIT_JOB_NAME("Soteria - Psychiatrist")


### PR DESCRIPTION
## About The Pull Request
Replace the Trauma Team's SST LMG with a Bullpip.
The Trauma Team's main object require them to fight non-colonist hostiles, and while the LMG is great against a single target or three, it's high energy consumption and low damage mean it is unsuited for facing hordes of roaches or spiders.
As such their LMG is now replaced by Soteria's Bullpip .35 SMG and 3 magazines, with RnD being able to print more with a bit of research. The Trauma Team still keep their Format-Bound to quickly incapacitate colonists and other people.