### PR TITLE
Fix the roach's taming chances.

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/riding.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/riding.dm
@@ -9,11 +9,11 @@
 /mob/living/carbon/superior_animal/roach/proc/try_tame(var/mob/living/carbon/user, var/obj/item/reagent_containers/food/snacks/grown/thefood)
 	if(!istype(thefood))
 		return FALSE
-	if(prob(40))
+	if(prob(40)) // Flat 40% chance to fail
 		visible_message("[src] hesitates for a moment...and then charges at [user]!")
-		return TRUE //Setting this to true because the only current usage is attack, and it says it hesitates.
+		return TRUE //Setting this to true because the only current usage is attack, and it says it hesitates. // TL;DR It will stop the current attack that called this proc, but not the others.
 	//fruits and veggies are not there own type, they are all the grown type and contain certain reagents. This is why it didnt work before
-	if(isnull(thefood.seed.chems["potato"]))
+	if(isnull(thefood.seed.chems["potato"])) // You need a potato. Roaches love potatoes.
 		return FALSE
 	visible_message("[src] scuttles towards [user], examining the [thefood] they have in their hand.")
 	can_buckle = TRUE
@@ -23,20 +23,26 @@
 			visible_message("[src] snaps out of its trance and rushes at [user]!")
 			return FALSE
 		visible_message("[src] bucks around wildly, trying to shake  [user] off!") //YEEEHAW
-		for(var/datum/language/L in user.languages)
-			if(!L.name == LANGUAGE_CHTMANT)
-				if(prob(40))
-					visible_message("[src] thrashes around, and throws [user] clean off!")
-					user.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
-					unbuckle_mob()
-					can_buckle = FALSE
-					return FALSE
-			else if(prob(10))
+
+		var/know_bug = FALSE // Do we know bug language?
+		for(var/datum/language/L in user.languages) // Check every language for the roach language
+			if(L.name == LANGUAGE_CHTMANT)
+				know_bug = TRUE // We speak roach!
+
+		if(know_bug) // If we speak roach, it is easier to make a fren.
+			if(prob(10))
 				visible_message("[src] thrashes around, and throws [user] clean off, despite their efforts to communicate with [src]!")
 				user.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
 				unbuckle_mob()
 				can_buckle = FALSE
 				return FALSE
+		else if(prob(40)) // We are not roach fren, it is harder to tame
+					visible_message("[src] thrashes around, and throws [user] clean off!")
+					user.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
+					unbuckle_mob()
+					can_buckle = FALSE
+					return FALSE
+
 		friends += user
 		colony_friend = TRUE
 		friendly_to_colony = TRUE

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
@@ -140,7 +140,7 @@ Has ability of every roach.
 		visible_message("[src] hesitates for a moment... and then charges at [user]!")
 		return TRUE //Setting this to true because the only current usage is attack, and it says it hesitates.
 	//fruits and veggies are not there own type, they are all the grown type and contain certain reagents. This is why it didnt work before
-	if(isnull(thefood.seed.chems["singulo"]))
+	if(isnull(thefood.seed.chems["singulo"])) // You need something injected with the 'Singulo' drink to tame this.
 		return FALSE
 	visible_message("[src] scuttles towards [user], examining the [thefood] they have in their hand.")
 	can_buckle = TRUE


### PR DESCRIPTION
## About The Pull Request
Refractor the roach taming code to *not* roll the dice for every language someone has.
Now you have a 40% to fail to tame a roach, no matter how many languages you know, unless one of those languages happen to be Cht'mant. Then you only have a 10% chance to fail.