### PR TITLE
QoL and Bugfixes

### DIFF
--- a/code/datums/setup_option/backgrounds/origin_akula.dm
+++ b/code/datums/setup_option/backgrounds/origin_akula.dm
@@ -4,11 +4,9 @@
 			While the common akula is strong, most gangers train themselves in the 'honorable' way of fighting, favoring melee. Fixing up their bikes so often has also given them some mechanical knack.  \
 			Days and weeks of patching themselves up after a bar fight or gang-land style shooting have made most pretty self reliant but, sadly even the clever gangers eventually get caught. \
 			While criminal backgrounds are often overlooked, yours is one of public record and far more brutal than most, made known by either your boasting, tattoos, or records. \
-			Because of that security has no interest in hiring you, even as a militia grunt."
+			Security is still willing to hire you, but your records should note your history."
 
 	restricted_to_species = list(FORM_AKULA)
-
-	restricted_depts = SECURITY
 
 	perks = list(/datum/perk/chem_contraband)
 

--- a/code/datums/setup_option/backgrounds/origin_career.dm
+++ b/code/datums/setup_option/backgrounds/origin_career.dm
@@ -3,9 +3,8 @@
 	desc = "Early on in your life you became a pirate for personal reasons. You may have been a void wolf or apart of a named group of space raiders, regardless of your decisions you spent a \
 	period attacking other ships, frontier colonies, and looting the aftermaths of battles for anything of value. For whatever reason you gave up that life to become an honest \
 	(or dishonest) citizen of the colony. One benefit at least of your raider life style is you got good at getting in and out quickly, regardless of any barriers in your way. Sadly your past is \
-	a known factor and while here on the frontier security can overlook a checkered past, command positions are still barred for you."
+	a known factor and while here on the frontier security can overlook a checkered past, your records should contain a detailed and accurate report of your history."
 
-	restricted_depts = COMMAND
 	perks = list(/datum/perk/parkour, /datum/perk/chem_contraband)
 
 	stat_modifiers = list(
@@ -149,11 +148,10 @@
 /datum/category_item/setup_option/background/career/criminal
 	name = "Former Criminal"
 	desc = "Maybe you were a low tier ganger, a mafioso, or a professional with a criminal syndicate. Whatever you were it wasn't honest, nor was it something any good person could take pride in. \
-	Your former connections, for they are former as you've left that life behind, still haunt you as your record is known by security. As such you are barred from command positions, though not from \
-	security itself, after all, its the frontier and the colony can't be as picky as bigger empires. But that life has at least gifted you with some broad if boorish skills and a quick fingered \
+	Your former connections, for they are former as you've left that life behind, still haunt you as your record is known by security. As such your records should contain a detailed list of \
+	your past and history, after all, its the frontier and the colony can't be as picky as bigger empires. But that life has at least gifted you with some broad if boorish skills and a quick fingered \
 	disposition for snatching objects off of people without them noticing."
 
-	restricted_depts = COMMAND
 	perks = list(/datum/perk/fast_fingers, /datum/perk/chem_contraband)
 
 	stat_modifiers = list(

--- a/code/datums/setup_option/backgrounds/origin_chtmant.dm
+++ b/code/datums/setup_option/backgrounds/origin_chtmant.dm
@@ -24,14 +24,15 @@
 			usually have less than ten at most and use them to perform primitive medical care, research, and genetic alterations to  \
 			the rest of their hives. Being pre stone age at the time, their research mostly consisted of consuming any and  \
 			everything to unravel its genetic code. Because of this the Ru brain and body was, and still is, a complex mystery. \
-			Due to the physical weakness of the Ru caste they are barred from taking roles as security and due to their importance to their respective hive restricted from work as prospectors."
+			Due to the physical weakness of the Ru caste they are barred from taking roles as security, as their importance to their relative hive structure makes them far more suited in other roles.."
 
 	restricted_to_species = list(FORM_CHTMANT)
-	restricted_depts = SECURITY | PROSPECTOR
+	restricted_depts = SECURITY
+
 	allow_modifications = FALSE
 	perks = list(/datum/perk/ichor)
 	racial_implants = (/obj/item/organ_module/active/simple/surgical/cht_mant)
-
+	restricted_jobs = list(/datum/job/pro)
 
 	stat_modifiers = list(
 		STAT_ROB = -8,
@@ -45,14 +46,14 @@
 /datum/category_item/setup_option/background/ethnicity/chtmantra
 	name = "Ra Caste"
 	desc = "Ra are the warriors and sentries of the hives. Numbering in the hundreds they would tower over Ru’s and even \
-			most workers, the Ro. Their bodies were highly adapted to fight and they knew only loyalty unto death for the good of \
-			the hive’s. Due to this, and the existence of the Ru, they often heavily lacked any cognitive thinking skills and would \
+			most workers, the Ro. Their bodies were highly adapted for combat and they know only loyalty unto death for the good of \
+			the hive. Due to this, and the existence of the Ru, they often heavily lack any cognitive thinking skills and would \
 			rely on winning battles by sheer weight of numbers or pure attrition. The severe lack of intelligence they exhibit also bars them from most medical roles and all of science, engineering, and command roles."
 
 	restricted_to_species = list(FORM_CHTMANT)
 	allow_modifications = FALSE
 	restricted_depts = SCIENCE | ENGINEERING
-	restricted_jobs = list(/datum/job/cmo, /datum/job/rd, /datum/job/smc, /datum/job/swo, /datum/job/cmo, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/trauma_team, /datum/job/premier, /datum/job/pg, /datum/job/chief_engineer, /datum/job/chaplain, /datum/job/merchant)
+	restricted_jobs = list(/datum/job/cmo, /datum/job/rd, /datum/job/smc, /datum/job/swo, /datum/job/cmo, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/premier, /datum/job/pg, /datum/job/chief_engineer, /datum/job/chaplain, /datum/job/merchant)
 
 	perks = list(/datum/perk/chitinarmor)
 	racial_implants = (/obj/item/organ_module/active/simple/cht_mant_claws)

--- a/code/datums/setup_option/backgrounds/origin_folken.dm
+++ b/code/datums/setup_option/backgrounds/origin_folken.dm
@@ -21,7 +21,7 @@
 	name = "Sproutling"
 	desc = "Sproutlings are folken less than a century old who have yet to decide what they seek. These folken are common, often later in life choosing to become elders or shamans \
 	depending on which clique they fall into. Sproutlings have the advantage of refreshed bodies unaffected by age and thus are the most adept for dangerous or risky tasks. \
-	Unlike other folken, a sproutling’s healing organ has yet to wear down from use and thus can use it twice as often."
+	Unlike other folken, a sproutling’s healing organ has yet to wear down from use and thus works far more effectively."
 
 	restricted_to_species = list(FORM_FOLKEN)
 

--- a/code/datums/setup_option/backgrounds/origin_kriosan.dm
+++ b/code/datums/setup_option/backgrounds/origin_kriosan.dm
@@ -22,12 +22,9 @@
 	Vorhut battalions were originally formed and trained by the survivors of the rebellion with experience fighting the Terran military, and were seen as fanatical and violent extremists. \
 	Nowadays, Vorhut are far more focused on military superiority than racial, and have a reputation for following orders ruthlessly and without question. They often hold the belief that \
 	their deaths are predetermined, and that if their time has come, they must face it with courage and dignity. If it has not, then their Corpsmen will see to it they live to battle another \
-	day. As a result, they are fearless warriors with no patience for engineering or science, and their ultimately violent doctrines leave them barred from serving in \
-	command roles."
+	day."
 
 	restricted_to_species = list(FORM_KRIOSAN)
-
-	restricted_depts = COMMAND | ENGINEERING | SCIENCE
 
 	stat_modifiers = list(
 		STAT_ROB = 5,

--- a/code/datums/setup_option/backgrounds/origin_sablekyne.dm
+++ b/code/datums/setup_option/backgrounds/origin_sablekyne.dm
@@ -40,10 +40,7 @@
 			On their home-planet maunkyne are outcasts, executed in the north for the crime of existing and exiled in the south to the unforgiving desert wastes. \
 			As a maunkyne you might be able to pass as a normal sablekyne, even amongst your more aware kin, but the colony's strict regulation on demon powder has left you without your fix. \
 			Without it, your body is weak and prone to further addiction but your upbringing in the criminal underworld of Onkarth has left you with a feral cunning and tolerance to most drugs. \
-			Even the most 'noble' maunkyne knows much about medicine, in particular the creation of highly profitable and illegal drugs. \
-			Due to maunkyne's innate addictions they are barred from command and security roles."
-
-	restricted_depts = SECURITY | COMMAND
+			Even the most 'noble' maunkyne knows much about medicine, in particular the creation of highly profitable and illegal drugs."
 
 	restricted_to_species = list(FORM_SABLEKYNE)
 

--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -9,9 +9,6 @@
 		/datum/job/rd,
 		/datum/job/cmo,
 		/datum/job/chief_engineer,
-		/datum/job/supsec,
-		/datum/job/inspector,
-		/datum/job/officer,
 		/datum/job/smc,
 		/datum/job/outsider
 		)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -41,6 +41,7 @@
 	var/loyalties = ""
 
 	var/setup_restricted = FALSE
+	var/list/disallow_species = list()
 
 	//Character stats modifers
 	var/list/stat_modifiers = list()
@@ -191,6 +192,10 @@
 /datum/job/proc/is_restricted(datum/preferences/prefs, feedback)
 	if(is_setup_restricted(prefs.setup_options))
 		to_chat(feedback, "<span class='boldannounce'>[setup_restricted ? "The job requires you to pick a specific setup option." : "The job conflicts with one of your setup options."]</span>")
+		return TRUE
+
+	if(prefs.species_form in disallow_species)
+		to_chat(feedback, "<span class='boldannounce'>[setup_restricted ? "You are playing a species that cannot take this job." : "The job conflicts with one of your setup options."]</span>")
 		return TRUE
 
 	if(minimum_character_age && (prefs.age < minimum_character_age))

--- a/code/game/jobs/job/offcolony.dm
+++ b/code/game/jobs/job/offcolony.dm
@@ -135,6 +135,7 @@
 //	minimal_access = list(access_maint_tunnels)
 	outfit_type = /decl/hierarchy/outfit/job/outsider
 	difficulty = "Impossible!"
+	disallow_species = list(FORM_FBP, FORM_UNBRANDED, FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 
 	stat_modifiers = list(
 		STAT_BIO = 5,

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -133,6 +133,8 @@
 			bad_message = "\[IN [(available_in_days)] DAYS]"*/
 		else if(job.minimum_character_age && user.client && (user.client.prefs.age < job.minimum_character_age))
 			bad_message = "\[MINIMUM CHARACTER AGE: [job.minimum_character_age]]"
+		else if(user.client.prefs.species_form in job.disallow_species)
+			bad_message = "\[SPECIES DISALLOWED]"
 		/*else if(job.playtimerequired && user.client)
 			if(job.playtimerequired > user.client.prefs.playtime[job.department])
 				bad_message = "\[MINIMUM PLAYTIME: [job.playtimerequired] Minutes]"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -784,15 +784,15 @@
 		if(stats.getPerk(PERK_FOLKEN_HEALING) || stats.getPerk(PERK_FOLKEN_HEALING_YOUNG)) // Folken will have this perk
 			if(light_amount >= species.light_dam) // Enough light threshold
 				if(stats.getPerk(PERK_FOLKEN_HEALING_YOUNG)) // They are young Folken and will heal faster
-					heal_overall_damage(5,5)
+					heal_overall_damage(3,3)
 					adjustNutrition(2)
 				else
-					heal_overall_damage(2,2)
+					heal_overall_damage(1,1)
 					adjustNutrition(1)
 
 		else if(stats.getPerk(PERK_DARK_HEAL)) // Is the species a Mycus?
 			if(light_amount <= species.light_dam) // Enough light threshold
-				heal_overall_damage(5,5)
+				heal_overall_damage(2,2)
 
 		else if(light_amount > species.light_dam) //if there's enough light, start dying
 			take_overall_damage(1,1)

--- a/code/modules/psionics/psionic_items.dm
+++ b/code/modules/psionics/psionic_items.dm
@@ -417,8 +417,7 @@
 		if(PT) // Is the target a psion
 			if(PT.max_psi_points - PT.psi_points >= point_per_use) // Is there space to give the psion the points?
 				if(use) // Do we have uses left?
-					user.visible_message("You inject [point_per_use] dose into [T.name]'s body.",
-										"[user.name] injects [point_per_use] dose into [T.name]'s body.")
+					user.visible_message("[user] injects [target] with [T.name].", "You inject [target] with [T.name]!")
 					PT.psi_points += point_per_use
 					use--
 					update_icon()


### PR DESCRIPTION
-Some backgrounds no longer have as heavy restrictions, allowing for more character options. These backgrounds now note you should have certain records extensively listed instead of barring you entirely.
--Akula ganger background can now be security.
--Former pirate background can now be command. (Fitting for CEO/FM)
--Former criminal background can now be command. (Fitting for CEO/FM)
--Ru caste cht'mant can now play as salvager/foreman.
--Vorhut kriosans can now be in command, engineering, and science.
--Maunkyne can now be in security and command.
-Due to the events of the most recent arc, Boris has lifted the restriction for cruciform users towards officer, supply spec, and ranger in light of the supposed crimes against Soteria proven to be false.
-Mycus and folken passive healing slightly nerfed, as it proved far too powerful under testing scenarios. Sprout healing is now 3/3, down from 5/5 and standard healing is now 1/1, down from 2/2. Mycus darkness healing is now 2/2, down from 5/5.
-Fixed the issue with cerebrix inhalers displaying the wrong message when injecting someone.
-Outsiders can no longer be synthetic races. This was a long standing issue with occupation code that has now finally been corrected. Certain players were using an exploit by not taking any background options to circumvent the outsider lock in background code. This has now been rectified as outsiders were never intended to be playable as full synthetics. You can still be a human race with mostly synthetic parts.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
