### PR TITLE
Removed atrophied loadout menus.

### DIFF
--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -34,12 +34,12 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	name = "Roles"
 	sort_order = 5
 	category_item_type = /datum/category_item/player_setup_item/antagonism
-
+/*
 /datum/category_group/player_setup_category/relations_preferences
 	name = "Matchmaking"
 	sort_order = 6
 	category_item_type = /datum/category_item/player_setup_item/relations
-
+*/
 /datum/category_group/player_setup_category/loadout_preferences
 	name = "Loadout"
 	update_preview_icon = TRUE
@@ -50,12 +50,12 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	name = "Global"
 	sort_order = 8
 	category_item_type = /datum/category_item/player_setup_item/player_global
-
+/*
 /datum/category_group/player_setup_category/law_pref
 	name = "Laws"
 	sort_order = 9
 	category_item_type = /datum/category_item/player_setup_item/law_pref
-
+*/
 
 /****************************
 * Category Collection Setup *


### PR DESCRIPTION
-The matchmaking menu from eris is commented out as its lrp, not used, and confused alot of players who are new to the server.
-Law prefs have been removed from the load out menu since it served no purpose.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
