### PR TITLE
RandPixel Hotfix for human mobs

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/human/human.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/human.dm
@@ -7,6 +7,7 @@
 	viewRange = 8
 	speak_chance = 5
 	turns_per_move = 5
+	randpixel = 0
 
 	attack_sound = 'sound/weapons/slice.ogg'
 


### PR DESCRIPTION
-Fixed a long running and minor visual bug where human mobs like excelsior slaves and void wolves would have randomized pixel off set.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
