### PR TITLE
Add radio message to AME instability.

### DIFF
--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -28,10 +28,13 @@
 
 	var/stored_power = 0//Power to deploy per tick
 
+	var/obj/item/device/radio/radio
+
 /obj/machinery/power/am_control_unit/New()
 	..()
 	linked_shielding = list()
 	linked_cores = list()
+	radio = new /obj/item/device/radio{channels=list("Engineering", "Command")}(src)
 
 /obj/machinery/power/am_control_unit/Destroy() //Perhaps damage and run stability checks rather than just qdel on the others
 	for(var/obj/machinery/am_shielding/AMS in linked_shielding)
@@ -88,6 +91,7 @@
 			AMS.stability -= core_damage
 			AMS.check_stability(1)
 		playsound(src.loc, 'sound/effects/bang.ogg', 50, 1)
+	check_stability()
 	return
 
 
@@ -248,6 +252,14 @@
 	stored_core_stability/=linked_cores.len
 	spawn(40)
 		stored_core_stability_delay = 0
+
+	var/alert_msg = "WARNING, Antimatter Engine Stability at [stored_core_stability]%!"
+	if(stored_core_stability <= 75)
+		radio.autosay(alert_msg, "Antimatter Automated Announcement", "Engineering")
+	if(stored_core_stability <= 50)
+		radio.autosay(alert_msg, "Antimatter Automated Announcement", "Command")
+	if(stored_core_stability <= 25)
+		radio.autosay(alert_msg, "Antimatter Automated Announcement")
 
 /obj/machinery/power/am_control_unit/proc/reset_stored_core_stability_delay()
 	stored_core_stability_delay = 0

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -213,7 +213,7 @@
 	matter = list(MATERIAL_STEEL = 3)
 
 /obj/item/am_shielding_container/attackby(obj/item/I as obj, mob/user as mob)
-	if((QUALITY_BOLT_TURNING) && isturf(src.loc))
+	if((QUALITY_PULSING in I.tool_qualities) && isturf(src.loc))
 		new /obj/machinery/am_shielding(src.loc)
 		qdel(src)
 		return


### PR DESCRIPTION
## About The Pull Request
The Antimatter Engine will notify Engineering when the stability is less than 75%, Command when less than 50%, and will announce it on general when the stability is less than 25%.