### PR TITLE
Guild Belts: The Unshittening

### DIFF
--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -325,9 +325,9 @@
 	)
 
 /datum/craft_recipe/guild/webbing
-	name = "Webbing"
+	name = "Artificer Guild Web Harness"
 	icon_state = "clothing"
-	result = /obj/item/storage/belt/webbing
+	result = /obj/item/storage/belt/webbing/artificer
 	steps = list(
 		list(/obj/item/storage/belt, 1, "time" = 30),
 		list(/obj/item/storage/belt, 1, "time" = 30),

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -440,6 +440,12 @@
 	max_w_class = ITEM_SIZE_SMALL //Holds 14 small items like a real harness, and hats
 	max_storage_space = DEFAULT_NORMAL_STORAGE
 
+/obj/item/storage/belt/webbing/artificer
+	name = "artificer guild web harness"
+	desc = "Everything you need at hand, at belt. This one is hand crafted by the artificer guild, allowing it to better store larger items by sacrificing a small bit of space. Better than most tool belts."
+	max_w_class = ITEM_SIZE_NORMAL // This is specifically crafted by the guild as webbings are useless for tools without being able to fit normal sized items.
+	storage_slots = 12 // Holds slightly less items than a regular webbing but still 5 more than a toolbelt given how many tools an adept needs. -Kaz
+
 /obj/item/storage/belt/webbing/green
 	name = "green web harness"
 	desc = "Everything you need at hand, at belt."


### PR DESCRIPTION
-The artificer guild now crafts a unique webbing instead of the generic webbing, it holds 12 items (down from 14) but can take normal sized items.
**Editor's Note**: The changes to webbing made this crafting recipe completely worthless and given most guild need to carry the basic 7 + hammers, drills, saws, and spare cells this webbing is actually viable for them. It can also be crafted for other purposes, if somene wants da good stuff in terms of belt storage with size.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
