### PR TITLE
Fixes nanite regen to work on synths (as wiki intended)

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -774,6 +774,10 @@
 		var/datum/perk/nanite_regen/P = stats.getPerk(PERK_NANITE_REGEN) // Add a reference to the perk for us to use.
 		if(P && P.regen_rate) // Check if the perk is actually there and got regeneration enabled.
 			heal_overall_damage(P.regen_rate, P.regen_rate, P.regen_rate)
+		if(species?.reagent_tag == IS_SYNTHETIC)
+			for(var/obj/item/organ/augmentic in src) // Run this loop for every organ the user has
+				if(augmentic.nature == MODIFICATION_SILICON) // Are the organ made of metal?
+					augmentic.heal_damage(1, 1, TRUE) // Repair the organ
 
 	if(species.light_dam)//TODO: Use this proc for flora and mycus races. Search proc mycus. -Note for Kaz.
 		var/light_amount = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -771,13 +771,16 @@
 	if(status_flags & GODMODE)	return 0	//godmode
 
 	if(stats.getPerk(PERK_NANITE_REGEN)) // Do they have the nanite regen perk?
+		var/cooldown_time //Initialise the var per person instead of per perk.
 		var/datum/perk/nanite_regen/P = stats.getPerk(PERK_NANITE_REGEN) // Add a reference to the perk for us to use.
 		if(P && P.regen_rate) // Check if the perk is actually there and got regeneration enabled.
 			heal_overall_damage(P.regen_rate, P.regen_rate, P.regen_rate)
 		if(species?.reagent_tag == IS_SYNTHETIC)
-			for(var/obj/item/organ/augmentic in src) // Run this loop for every organ the user has
-				if(augmentic.nature == MODIFICATION_SILICON) // Are the organ made of metal?
-					augmentic.heal_damage(P.regen_rate, P.regen_rate, TRUE) // Repair the organ
+			if(world.time > cooldown_time)
+				cooldown_time = world.time + 5 //5 ingame tick delay for synths
+				for(var/obj/item/organ/augmentic in src) // Run this loop for every organ the user has
+					if(augmentic.nature == MODIFICATION_SILICON) // Are the organ made of metal?
+						augmentic.heal_damage(P.regen_rate, P.regen_rate, TRUE) // Repair the organ
 
 	if(species.light_dam)//TODO: Use this proc for flora and mycus races. Search proc mycus. -Note for Kaz.
 		var/light_amount = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -777,7 +777,7 @@
 		if(species?.reagent_tag == IS_SYNTHETIC)
 			for(var/obj/item/organ/augmentic in src) // Run this loop for every organ the user has
 				if(augmentic.nature == MODIFICATION_SILICON) // Are the organ made of metal?
-					augmentic.heal_damage(1, 1, TRUE) // Repair the organ
+					augmentic.heal_damage(P.regen_rate, P.regen_rate, TRUE) // Repair the organ
 
 	if(species.light_dam)//TODO: Use this proc for flora and mycus races. Search proc mycus. -Note for Kaz.
 		var/light_amount = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Title

## Changelog
:cl:
fix: Nanogate regen now applies to synthetics, as implied by the wiki.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
