### PR TITLE
buffs SI

### DIFF
--- a/code/modules/research/nodes/greyson.dm
+++ b/code/modules/research/nodes/greyson.dm
@@ -199,7 +199,7 @@
 	y = 0.6
 	icon = "greysonfuel"
 
-	required_technologies = list(/datum/technology/GP_fuel_tools
+	required_technologies = list(/datum/technology/GP_fuel_tools,
 								 /datum/technology/bluespace_extended
 								 )
 	required_tech_levels = list()

--- a/code/modules/research/nodes/greyson.dm
+++ b/code/modules/research/nodes/greyson.dm
@@ -49,7 +49,7 @@
 						   /datum/design/research/item/greyson/iron_lock_security_helmet,
 						   /datum/design/research/item/greyson/iron_lock_security_gloves,
 						   /datum/design/research/item/greyson/iron_lock_security_boots)
-
+/*
 /datum/technology/GP_window
 	name = "Greyson Positronic Glass-Widow Infuser"
 	desc = "The GP Glass Widow Infuser design and manufacturing."
@@ -80,7 +80,7 @@
 
 	unlocks_designs = list(/datum/design/research/item/greyson/unmaker,
 			       /datum/design/research/item/greyson/combat_shield)
-
+*/
 /datum/technology/GP_cells
 	name = "Greyson Positronic Cells"
 	desc = "A mix of old cell manufacturing with a GP characteristics."
@@ -173,7 +173,7 @@
 						   /datum/design/research/item/tool/hammer_onestar,
 						   /datum/design/research/item/tool/omni_surgery_onestar,
 						   /datum/design/research/item/tool/jackhammer_onestar)
-
+/*
 /datum/technology/GP_nano_toolmods
 	name = "Greyson Positronic Nano Reapir & NanoAI"
 	desc = "GP pre-programed self replicating nanites to fit onto any ."
@@ -189,7 +189,7 @@
 	unlocks_designs = list(/datum/design/research/item/greyson/repair_nano,
 						   /datum/design/research/item/greyson/ai_tool)
 	cost = 5000
-
+*/
 /datum/technology/GP_fuel_toolmods
 	name = "Greyson Positronic Bluespace Holding Tank & Randomizer"
 	desc = "GP pre-programed Randomizer blue paint and Bluespace Fuel Tank ."
@@ -199,12 +199,14 @@
 	y = 0.6
 	icon = "greysonfuel"
 
-	required_technologies = list(/datum/technology/GP_fuel_tools,
-								 /datum/technology/bluespace_extended)
+	required_technologies = list(/datum/technology/GP_fuel_tools
+								 //datum/technology/bluespace_extended //people can endlessly rerole and spam this to get the best tool mod possable
+								 )
 	required_tech_levels = list()
 
 	unlocks_designs = list(/datum/design/research/item/greyson/holding_tank,
-						   /datum/design/research/item/greyson/randomizer)
+						   //datum/design/research/item/greyson/randomizer
+						   )
 	cost = 2500 //Not THAT high-tech, but still...
 
 /datum/technology/GP_robotics

--- a/code/modules/research/nodes/greyson.dm
+++ b/code/modules/research/nodes/greyson.dm
@@ -64,23 +64,23 @@
 	required_tech_levels = list(RESEARCH_COMBAT = 10)
 	cost = 7500
 	unlocks_designs = list(/datum/design/research/item/greyson/glass_widow)
-
+*/
 /datum/technology/GP_unmaker
-	name = "Greyson Positronic Tyrant Destroyers"
-	desc = "The rare and highly vauleable GP Master Unmaker Infuser gun mod and portable self charging combat shields."
+	name = "Greyson Positronic combat shield"
+	desc = "The rare and portable self charging combat shields."
 	tech_type = RESEARCH_GREYSON
 
 	x = 0.5 //Bottom middle
 	y = 0.1
 	icon = "mastermind"
 
-	required_technologies = list(/datum/technology/GP_window)
+	required_technologies = list()
 	required_tech_levels = list(RESEARCH_COMBAT = 13)
 	cost = 25000
 
-	unlocks_designs = list(/datum/design/research/item/greyson/unmaker,
+	unlocks_designs = list(//datum/design/research/item/greyson/unmaker,
 			       /datum/design/research/item/greyson/combat_shield)
-*/
+
 /datum/technology/GP_cells
 	name = "Greyson Positronic Cells"
 	desc = "A mix of old cell manufacturing with a GP characteristics."
@@ -191,8 +191,8 @@
 	cost = 5000
 */
 /datum/technology/GP_fuel_toolmods
-	name = "Greyson Positronic Bluespace Holding Tank & Randomizer"
-	desc = "GP pre-programed Randomizer blue paint and Bluespace Fuel Tank ."
+	name = "Greyson Positronic Bluespace Holding Tank"
+	desc = "Bluespace Fuel Tank."
 	tech_type = RESEARCH_GREYSON
 
 	x = 0.6
@@ -200,12 +200,12 @@
 	icon = "greysonfuel"
 
 	required_technologies = list(/datum/technology/GP_fuel_tools
-								 //datum/technology/bluespace_extended //people can endlessly rerole and spam this to get the best tool mod possable
+								 /datum/technology/bluespace_extended
 								 )
 	required_tech_levels = list()
 
 	unlocks_designs = list(/datum/design/research/item/greyson/holding_tank,
-						   //datum/design/research/item/greyson/randomizer
+						   //datum/design/research/item/greyson/randomizer //people can endlessly rerole and spam this to get the best tool mod possable
 						   )
 	cost = 2500 //Not THAT high-tech, but still...
 

--- a/maps/submaps/dungeon_rooms/exits/1.dmm
+++ b/maps/submaps/dungeon_rooms/exits/1.dmm
@@ -1,10 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/simulated/wall,
+/turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "b" = (
 /obj/crawler/crawler_wallbreaker,
-/turf/simulated/wall,
+/turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "c" = (
 /turf/simulated/floor/tiled/derelict,
@@ -14,7 +14,7 @@
 /area/crawler)
 "e" = (
 /obj/crawler/crawler_wallbreaker/vertical,
-/turf/simulated/wall,
+/turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "f" = (
 /obj/rogue/telebeacon,
@@ -53,9 +53,6 @@
 /obj/random/dungeon_ammo,
 /obj/random/dungeon_ammo,
 /obj/random/dungeon_gun_energy,
-/obj/item/tool_upgrade/augment/ai_tool,
-/obj/item/tool_upgrade/augment/ai_tool,
-/obj/item/tool_upgrade/augment/ai_tool,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "m" = (
@@ -68,8 +65,6 @@
 /obj/structure/table/onestar,
 /obj/random/dungeon_gun_energy,
 /obj/random/material_rare,
-/obj/item/tool_upgrade/augment/holding_tank,
-/obj/item/tool_upgrade/augment/holding_tank,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "o" = (
@@ -87,8 +82,6 @@
 /obj/random/dungeon_gun_ballistic,
 /obj/random/dungeon_gun_energy,
 /obj/random/material_rare,
-/obj/item/tool_upgrade/augment/repair_nano,
-/obj/item/tool_upgrade/augment/repair_nano,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "q" = (
@@ -101,6 +94,68 @@
 /obj/random/material_resources,
 /obj/random/material_resources,
 /turf/simulated/floor/tiled/derelict,
+/area/crawler)
+"v" = (
+/obj/structure/table/onestar,
+/obj/item/gun_upgrade/mechanism/glass_widow,
+/obj/item/gun_upgrade/mechanism/glass_widow,
+/turf/simulated/floor/tiled/derelict,
+/area/crawler)
+"w" = (
+/obj/structure/table/onestar,
+/obj/item/tool_upgrade/augment/ai_tool,
+/obj/item/tool_upgrade/augment/ai_tool,
+/obj/item/tool_upgrade/augment/ai_tool,
+/turf/simulated/floor/tiled/derelict,
+/area/crawler)
+"A" = (
+/obj/structure/table/onestar,
+/obj/item/tool_upgrade/augment/repair_nano,
+/obj/item/tool_upgrade/augment/repair_nano,
+/turf/simulated/floor/tiled/derelict,
+/area/crawler)
+"B" = (
+/obj/structure/table/onestar,
+/obj/item/clothing/suit/greatcoat/os,
+/obj/item/clothing/suit/greatcoat/os,
+/turf/simulated/floor/tiled/derelict,
+/area/crawler)
+"F" = (
+/obj/structure/table/onestar,
+/obj/item/gun/energy/captain,
+/turf/simulated/floor/tiled/derelict,
+/area/crawler)
+"I" = (
+/obj/structure/table/onestar,
+/obj/item/clothing/head/os_cap,
+/obj/item/clothing/head/os_cap,
+/turf/simulated/floor/tiled/derelict,
+/area/crawler)
+"T" = (
+/obj/structure/table/onestar,
+/obj/random/lathe_disk/advanced/onestar,
+/obj/random/lathe_disk/advanced/onestar,
+/obj/random/lathe_disk/advanced/onestar,
+/turf/simulated/floor/carpet,
+/area/crawler)
+"U" = (
+/obj/structure/table/onestar,
+/obj/item/tool_upgrade/augment/holding_tank,
+/obj/item/tool_upgrade/augment/holding_tank,
+/turf/simulated/floor/tiled/derelict,
+/area/crawler)
+"W" = (
+/obj/structure/table/onestar,
+/obj/item/clothing/head/helmet/space/os,
+/obj/item/clothing/head/helmet/space/os,
+/obj/item/clothing/suit/space/os,
+/obj/item/clothing/suit/space/os,
+/turf/simulated/floor/tiled/derelict,
+/area/crawler)
+"X" = (
+/obj/structure/table/onestar,
+/obj/item/gun_upgrade/mechanism/greyson_master_catalyst,
+/turf/simulated/floor/carpet,
 /area/crawler)
 
 (1,1,1) = {"
@@ -141,7 +196,7 @@ a
 j
 c
 c
-c
+w
 c
 c
 l
@@ -151,9 +206,9 @@ a
 a
 j
 c
-c
-c
-c
+I
+A
+B
 c
 k
 a
@@ -163,7 +218,7 @@ a
 c
 d
 d
-d
+T
 d
 d
 n
@@ -185,7 +240,7 @@ a
 c
 d
 c
-d
+X
 c
 d
 p
@@ -195,9 +250,9 @@ a
 a
 j
 c
-c
-c
-c
+v
+F
+W
 c
 o
 a
@@ -207,7 +262,7 @@ a
 j
 c
 c
-c
+U
 c
 c
 q


### PR DESCRIPTION
Retires, Nano AI and nanites node making it grayson found only
Retires, the bluespace randomizer making it grayson found only
Retires the grayson unmaker making it grayson found only
Retires making the glass window mod in rnd making it grayson found only

Massively improves the exit room in the grayson teleporter
![image](https://user-images.githubusercontent.com/30435998/140970933-349bf63b-09b9-40e7-a677-419f1d308a59.png)

