### PR TITLE
Makes nurses unable to use magic

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -117,7 +117,7 @@
 	pixel_x = -16
 	pixel_y = null
 
-/mob/living/carbon/superior_animal/giant_spider/nurse/attemptAttackOnTarget()
+/mob/living/carbon/superior_animal/giant_spider/nurse/UnarmedAttack()
 	..()
 	if(ishuman(target_mob))
 		var/mob/living/carbon/human/H = target_mob


### PR DESCRIPTION
Spiders now will properly check if they have hit you when injecting spiderlings, rather then it assuming it is