### PR TITLE
rebalances ecom a bit + a score fix

### DIFF
--- a/code/game/gamemodes/scores.dm
+++ b/code/game/gamemodes/scores.dm
@@ -154,6 +154,11 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 	var/obj/item/cell/large/high/HC = /obj/item/cell/large/high
 	var/min_charge = initial(HC.maxcharge) * 0.6
 
+	//calculate guild profits in a sane way
+	var/ending_balance = get_account_credits(department_accounts[DEPARTMENT_LSS])
+	var/datum/department/guild/guild_var = new/datum/department/guild
+	GLOB.supply_profit = ending_balance - guild_var.account_initial_balance
+
 	//Check station's power levels
 	for(var/area/A in ship_areas)
 		if(A.fire || A.atmosalm)
@@ -210,7 +215,7 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 	GLOB.score_neotheology_faction_item_loss -= GLOB.neotheology_faction_item_loss * 150 //300
 	GLOB.neotheology_objectives_score = GLOB.neotheology_objectives_completed * 25 // ~100
 	GLOB.score_mess -= GLOB.dirt_areas * 25 //~250
-	GLOB.biomatter_score = round(GLOB.biomatter_neothecnology_amt/50) //350?  //target_max~350//
+	GLOB.biomatter_score = round(GLOB.biomatter_neothecnology_amt/10) //350?  //target_max~1750//
 	GLOB.grup_ritual_score += GLOB.grup_ritual_performed * 5
 	GLOB.new_neothecnology_convert_score = GLOB.new_neothecnology_convert * 50 // ~150-300
 
@@ -239,9 +244,7 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 	//Guild score
 	GLOB.score_guild_faction_item_loss -= 150 * GLOB.guild_faction_item_loss // ~-300
 	GLOB.guild_objectives_score = GLOB.guild_objectives_completed * 25 // ~100
-	//calculate guild profits in a sane way
-	var/ending_balance = get_account_credits(department_accounts[DEPARTMENT_LSS])
-	GLOB.supply_profit = ending_balance - 15000
+	GLOB.guild_profit_score	= round(GLOB.supply_profit/50) // ? review it //target_max~500//
 	GLOB.guild_shared_gears_score = GLOB.guild_shared_gears * 30 // ~150-300
 
 	GLOB.guild_score = GLOB.initial_guild_score + GLOB.guild_objectives_score + GLOB.guild_profit_score

--- a/code/game/jobs/department.dm
+++ b/code/game/jobs/department.dm
@@ -72,7 +72,7 @@
 	id = DEPARTMENT_SECURITY
 	funding_type = FUNDING_EXTERNAL
 	account_initial_balance = 20000 //20k do to being state funded
-	account_budget = 1000 //Pays for a few people, likely the most played department, we dont require them to really do trades
+	account_budget = 3500 //Really is the most played department has most slots and isnt exspected to trade much at all
 
 /datum/department/technomancers
 	name = "Artificer's Guild"

--- a/code/game/jobs/department.dm
+++ b/code/game/jobs/department.dm
@@ -71,8 +71,8 @@
 	name = "Marshal and Blackshield Division"
 	id = DEPARTMENT_SECURITY
 	funding_type = FUNDING_EXTERNAL
-	account_initial_balance = 20000 //20k do to being state funded
-	account_budget = 3500 //Really is the most played department has most slots and isnt exspected to trade much at all
+	account_initial_balance = 25000 //25k do to being state funded
+	account_budget = 1500 //Really is the most played department has most slots and isnt exspected to trade much at all
 
 /datum/department/technomancers
 	name = "Artificer's Guild"

--- a/code/game/jobs/department.dm
+++ b/code/game/jobs/department.dm
@@ -59,7 +59,7 @@
 	In future, we will implement largescale missions and research contracts to earn money, and then set it
 	to a much lower starting value
 	*/
-	account_initial_balance = 20000
+	account_initial_balance = 50000
 	funding_type = FUNDING_EXTERNAL
 
 
@@ -71,12 +71,16 @@
 	name = "Marshal and Blackshield Division"
 	id = DEPARTMENT_SECURITY
 	funding_type = FUNDING_EXTERNAL
-	account_initial_balance = 5000
+	account_initial_balance = 20000 //20k do to being state funded
+	account_budget = 1000 //Pays for a few people, likely the most played department, we dont require them to really do trades
 
 /datum/department/technomancers
 	name = "Artificer's Guild"
 	id = DEPARTMENT_ENGINEERING
-	funding_type = FUNDING_EXTERNAL
+	funding_type = FUNDING_NONE
+	account_initial_balance = 17500 //15k do to being state funded
+	//A full crew GM + 4 adpets is 1700 an hour, takes 10~ hours to drain the department funds
+
 
 /datum/department/civilian
 	name = "Nadezhda Contractors"
@@ -94,20 +98,22 @@
 /datum/department/moebius_medical
 	name = "Soteria Institution: Medical Division"
 	id = DEPARTMENT_MEDICAL
-	funding_type = FUNDING_EXTERNAL
+	account_budget = 15000 //For buying medical and items and payments
+	funding_type = FUNDING_NONE
 	funding_source = "Soteria Institution."
 
 /datum/department/moebius_research
 	name = "Soteria Institution: Research Division"
 	id = DEPARTMENT_SCIENCE
-	account_budget = 5000 //For buying materials and components and things of scientific value
-	funding_type = FUNDING_EXTERNAL
+	account_budget = 10000 //For buying materials and components and things of scientific value as well as pay the demanding staff
+	funding_type = FUNDING_NONE
 	funding_source = "Soteria Institution."
 
 /datum/department/church
 	name = "Church of Absolute"
 	id = DEPARTMENT_CHURCH
-	funding_type = FUNDING_EXTERNAL
+	account_budget = 25000 //Materals, and they are the faith, they donate and get a lot to the colony thus they have a lot to spend
+	funding_type = FUNDING_NONE
 	funding_source = "Church of Absolute"
 
 
@@ -126,14 +132,14 @@
 	/* if you want to change this remember to do so in code\game\gamemodes\score.dm as well,
 	if you manage to get this variable refferenced there you're a better man than me. godspeed
 	*/
-	account_initial_balance = 15000
+	account_initial_balance = 25000 //has a lot of workers thus needs a higher starting to off-set its paychecks if no one actively runs the cargo shuttle
 	funding_type = FUNDING_NONE //So we want to trade and make money not magiclly get it every hour
 
 /datum/department/prospector
 	name = "Prospectors"
 	id = DEPARTMENT_PROSPECTOR
-	account_initial_balance = 7500
-	funding_type = FUNDING_EXTERNAL
+	account_initial_balance = 10000 //Has a lot of workers and people
+	funding_type = FUNDING_NONE
 
 /datum/department/independent
 	name = "Independent Allied Factions"

--- a/maps/CEVEris/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/CEVEris/_Nadezhda_Colony_Omni_STU.dmm
@@ -7371,6 +7371,12 @@
 /area/nadezhda/crew_quarters/dorm1{
 	name = "Dormitory 1"
 	})
+"bNK" = (
+/obj/machinery/account_database{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/command/captain/quarters)
 "bNO" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
@@ -47180,16 +47186,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "kSi" = (
-/obj/structure/table/rack,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/head/helmet/space/capspace,
-/obj/item/clothing/suit/space/captain,
+/obj/structure/bed/chair/comfy/black,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-s"
 	},
-/turf/simulated/floor/carpet/turcarpet,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/captain/quarters)
 "kSj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -88407,6 +88409,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "ulw" = (
+/obj/structure/table/rack,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/head/helmet/space/capspace,
+/obj/item/clothing/suit/space/captain,
 /obj/machinery/light,
 /obj/machinery/newscaster{
 	pixel_y = -34
@@ -122138,8 +122145,8 @@ jwy
 epL
 ulw
 bBv
-cwW
-cwW
+eOx
+eOx
 cwW
 xqi
 soy
@@ -122340,8 +122347,8 @@ wUu
 epL
 tbg
 kSi
-cwW
-cwW
+bNK
+eOx
 cwW
 eqg
 piz

--- a/maps/CEVEris/centcomm.dmm
+++ b/maps/CEVEris/centcomm.dmm
@@ -762,7 +762,7 @@
 "oH" = (/obj/structure/largecrate/animal/goat,/turf/simulated/shuttle/floor/mining{icon_state = "9,23"},/area/centcom/evac)
 "oI" = (/obj/structure/largecrate/animal/pig,/turf/simulated/shuttle/floor/mining{icon_state = "9,23"},/area/centcom/evac)
 "oJ" = (/obj/effect/window_lwall_spawn/smartspawnplasma,/obj/structure/disposalpipe/segment{dir = 8},/turf/simulated/floor/tiled/dark/gray_platform,/area/centcom/evac)
-"oK" = (/turf/space,/obj/machinery/door/blast/regular/open{id = "shipjackshutters"},/obj/effect/window_lwall_spawn/plasma/reinforced,/turf/simulated/floor/plating/under,/area/shuttle/skipjack_area)
+"oK" = (/obj/machinery/door/blast/regular/open{id = "shipjackshutters"},/obj/effect/window_lwall_spawn/plasma/reinforced,/turf/space,/turf/simulated/floor/plating/under,/area/shuttle/skipjack_area)
 "oY" = (/obj/machinery/optable/altar,/turf/simulated/floor/carpet/oracarpet,/area/centcom/evac)
 "oZ" = (/obj/structure/table/woodentable,/obj/item/device/binoculars,/turf/simulated/floor/tiled/dark/golden,/area/centcom/evac)
 "pc" = (/obj/structure/table/woodentable,/obj/item/paper_bin{pixel_y = 4},/obj/item/pen{pixel_y = 4},/turf/simulated/floor/tiled/dark/gray_perforated,/area/centcom/evac)
@@ -798,7 +798,7 @@
 "sU" = (/obj/machinery/vending/fitness,/turf/simulated/floor/tiled/dark/golden,/area/centcom/evac)
 "sW" = (/obj/structure/flora/small/grassb2,/turf/simulated/floor/fixed/fgrass,/area/centcom/evac)
 "ti" = (/obj/machinery/light{dir = 1},/obj/machinery/body_scanconsole,/turf/simulated/floor/tiled/dark/gray_platform,/area/centcom/evac)
-"tl" = (/obj/structure/filingcabinet/filingcabinet,/turf/simulated/floor/tiled/dark/golden,/area/centcom/evac)
+"tl" = (/obj/machinery/account_database{dir = 4},/turf/simulated/floor/tiled/dark/golden,/area/centcom/evac)
 "tt" = (/obj/structure/table/standard,/obj/random/material_resources,/obj/random/material_resources,/obj/random/material_rare,/obj/random/material_rare,/obj/random/lathe_disk/advanced,/obj/random/material_rare,/obj/random/material_resources,/obj/random/material,/obj/random/material,/turf/simulated/floor/tiled/techmaint,/area/centcom/raider_base)
 "tu" = (/obj/structure/railing,/obj/structure/railing{dir = 8},/turf/simulated/floor/beach/sand,/area/centcom/evac)
 "tz" = (/turf/simulated/floor/carpet/turcarpet,/area/centcom/evac)
@@ -931,7 +931,7 @@
 "KL" = (/obj/random/closet,/turf/simulated/floor/tiled/dark,/area/centcom/raider_base)
 "KR" = (/turf/unsimulated/wall,/area/centcom/evac)
 "Lb" = (/obj/structure/railing{dir = 1},/turf/simulated/floor/beach/sand,/area/centcom/evac)
-"Lk" = (/obj/machinery/door/airlock/glass_command,/obj/machinery/door/firedoor,/turf/simulated/floor/tiled/dark/techfloor_grid,/area/centcom/evac)
+"Lk" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/vault,/turf/simulated/floor/tiled/dark/techfloor_grid,/area/centcom/evac)
 "LD" = (/obj/structure/closet/secure_closet/freezer/fridge,/turf/simulated/floor/tiled/cafe,/area/centcom/raider_base)
 "LE" = (/obj/structure/table/woodentable,/obj/item/organ/internal/bone/head,/turf/simulated/floor/tiled/dark/golden,/area/centcom/evac)
 "Mc" = (/obj/random/closet_wardrobe,/obj/effect/floor_decal/industrial/warningwhite/full,/turf/simulated/floor/carpet/turcarpet,/area/centcom/raider_base)
@@ -955,6 +955,7 @@
 "Ok" = (/obj/structure/table/rack/shelf,/turf/simulated/floor/tiled/dark/gray_perforated,/area/centcom/evac)
 "Om" = (/obj/structure/closet/crate,/obj/random/common_oddities,/obj/random/common_oddities,/obj/random/common_oddities,/obj/effect/floor_decal/industrial/outline,/obj/machinery/light{dir = 4},/turf/simulated/floor/tiled/white/cargo,/area/centcom/raider_base)
 "OA" = (/obj/structure/table/rack/shelf,/obj/item/toy/figure/character/bobblehead/excelsior,/turf/simulated/floor/tiled/dark/gray_platform,/area/centcom/evac)
+"OH" = (/obj/structure/filingcabinet/employment,/turf/simulated/floor/tiled/dark/golden,/area/centcom/evac)
 "OK" = (/obj/machinery/light/floor{dir = 8; pixel_x = 5},/turf/simulated/floor/tiled/white/gray_platform,/area/centcom/merc_base)
 "OU" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/floor/tiled/white/gray_perforated,/area/centcom/merc_base)
 "OZ" = (/obj/structure/table/rack/shelf,/obj/random/gun_fancy,/obj/random/gun_fancy,/obj/effect/floor_decal/industrial/outline,/turf/simulated/floor/tiled/white/cargo,/area/centcom/raider_base)
@@ -1151,7 +1152,7 @@ qHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHKRhohohohohocNQwrwEPEPEPEPEPEP
 qHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHKRhoxxrTQXhocNQwrwEPEPEPEPEPEPEPEPEPEPEPEPxOIScNLkcNtzupWKpmcNhoKRqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHhkqHqHqHqHqHqHhlhlhlhlhlhlqHqHqHqHqHqHqHqHqHqHqHbObPbQbPbOqHqHqHhfhfhfhfbJbJhFbJbJbJbJbJbJbJhlhlhlhlhlhlhlhlhlhlhlhlhlhleYitqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHfpeYqHqHqHqHqHqHqHqHqHqHqH
 qHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHKRhoBpcNcNFkcNQwrwEPEPEPEPEPEPEPEPEPEPEPEPxOIScNhoNKtztzMvtzsBhoKRqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHhkqHqHqHqHqHqHhlhlhlhlhlhlqHqHqHqHqHqHqHqHqHqHbPbPbRdhegbPbPqHqHhfiNiNiNchiNiNhTbJhUinisiybJhlhlhlhlhlhlhlhlhlhlhlhlhlhleYfpqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHfpeYqHqHqHqHqHqHqHqHqHqHqH
 qHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHKRhoznBKEBhocNQwtuUFUFUFUFUFUFUFUFUFUFUFUFwdIScNhotlHSHSHSHSZUhoKRqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHhkqHqHqHqHqHqHqHhlhlhlhlhlqHqHqHqHqHqHqHqHqHbPbPezfEgffEhpbPbPqHhfiNiNckckiNiNiNiAiOiOiOiCbJbJbJbJbJhlhlhlhlhlhlhlhlhlhleYfpqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHfpeYqHqHqHqHqHqHqHqHqHqHqH
-qHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHKRhohohohohocNaDXZXZXZXZXZXZXZXZXZXZXZXZXZXZaDcNhoQNcNJbcLcLLEhoKRKRKRKRKRqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHhkqHqHqHqHqHqHqHqHhlhlhlhlqHqHqHqHqHqHqHqHqHbPhqfEkqkqkqfEhsbPqHhfiNiEiFiDcniNiNbJiOiOiOiPbJkNiXiYbJhlhlhlhlhlhlhlhlhlhleYfpqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHfpeYqHqHqHqHqHqHqHqHqHqHqH
+qHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHKRhohohohohocNaDXZXZXZXZXZXZXZXZXZXZXZXZXZXZaDcNhoQNcNJbOHcLLEhoKRKRKRKRKRqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHhkqHqHqHqHqHqHqHqHhlhlhlhlqHqHqHqHqHqHqHqHqHbPhqfEkqkqkqfEhsbPqHhfiNiEiFiDcniNiNbJiOiOiOiPbJkNiXiYbJhlhlhlhlhlhlhlhlhlhleYfpqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHfpeYqHqHqHqHqHqHqHqHqHqHqH
 qHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHKRKRKRKRKRhoBmXISyreSNcNcNcNcNcNcNcNcNcNaDcNcNcNhohoBUzkzkzkhohohoxDhohoKRqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHhkqHqHqHqHqHqHqHqHqHhlhlqHqHqHqHqHqHqHqHqHqHbPhHfEkqkqkqhLkrbPqHhfiNiNgZgZiNiNjabJjbkijciZbJlSkwjmbJhlhlhlhlhlhlhlhlhlhleYfpqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHfpeYqHqHqHqHqHqHqHqHqHqHqH
 qHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHKRhohohohohohohohohohohohohohoTLVfnVhohohoXccNcNcNcNXcyREXsdEXhoKRqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHhkqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHbPhSfEkqhrkqfEijbPqHhfiNiNiNkGiNiNjnbJbJbJbJbJbJjokOjpbJhlhlhlhlhlhlhlhlhlhleYfpqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHfpeYqHqHqHqHqHqHqHqHqHqHqH
 qHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHKRKRKRKRhoCtcNdjcNcNcNcNcNdjcNcNZqcNXCcNdjcNdndnaDFMFMFMFMFMFMhoKRqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHhkqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHiririvivirivivirirqHhfhfhfhfbJjqjqjqbJjujujCjDbJjEkwjFbJhlhlhlhlhlhlhlhlhlhleYfpqHqHqHqHqHqHqHqHqHqHqHqHqHfWfWfWfWfWqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHqHfpeYqHqHqHqHqHqHqHqHqHqHqH


### PR DESCRIPTION
Fixes LSS score, if this dosnt get merged ill just make a new pr with the singular fix
Drastically increases starter funds of every department
Removes most drip feed free money to help incentives departments paying one a other and using the credit
Marshals/Blackshield still get 1.5k an hour to try and not drain the most played department 
Adds account balance terminal to Preimer room, this allows them to monitor against fraud, see payments and termitate dead accounts and deal with det better