### PR TITLE
ports some micro opimation

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -32,13 +32,6 @@ would spawn and follow the beaker, even if it is carried or thrown.
 		pixel_x += rand(-random_offset,random_offset)
 		pixel_y += rand(-random_offset,random_offset)
 
-
-
-/obj/effect/Destroy()
-	if(reagents)
-		reagents.delete()
-	return ..()
-
 /datum/effect/effect/system
 	var/number = 3
 	var/cardinals = 0

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -60,6 +60,7 @@
 		SSchemistry.active_holders -= src
 
 	for(var/datum/reagent/R in reagent_list)
+		R.holder = null
 		qdel(R)
 	reagent_list.Cut()
 	reagent_list = null
@@ -110,12 +111,6 @@
 		else
 			total_volume += R.volume
 	return
-
-/datum/reagents/proc/delete()
-	for(var/datum/reagent/R in reagent_list)
-		R.holder = null
-	if(my_atom)
-		my_atom.reagents = null
 
 /datum/reagents/proc/handle_reactions()
 	if(SSchemistry)


### PR DESCRIPTION
By Kegdo

/datum/reagents/Destroy() does everything /datum/reagents/delete() does and more, and delete() is called only from /obj/effect/Destroy() which ITSELF is redundant with its parent /atom/movable/Destroy()
