### PR TITLE
spooder wall fix

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -276,7 +276,7 @@ mob/living/carbon/superior_animal/adjustToxLoss(var/amount)
 		layer = LYING_MOB_LAYER
 
 	AI_inactive = TRUE //Optimation, were dead
-
+	density = 0 //In death were no longer blocking. 
 	. = ..()
 
 /mob/living/carbon/superior_animal/rejuvenate()

--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -286,6 +286,8 @@
 			lying = buckled.buckle_lying
 	if(lying)
 		set_density(FALSE)
+	if(stat == DEAD)
+		set_density(FALSE)
 	else
 		canmove = TRUE
 		set_density(initial(density))


### PR DESCRIPTION
When a dense mob dies it now will properly be density = 0