### PR TITLE
Nanobot balance and fixes

### DIFF
--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -92,7 +92,25 @@
 		return FALSE
 
 	var/list/ammo_boxes = typesof(/obj/item/ammo_magazine/ammobox)
-	ammo_boxes -= /obj/item/ammo_magazine/ammobox
+	//We cant print everything under the sun sadly, so we limet are options a small bit! No SI laser ammo, explosives, some higher end boxes/ammo, and church biomatter boxes
+	ammo_boxes -= list(	/obj/item/ammo_magazine/ammobox,
+						/obj/item/ammo_magazine/ammobox/pistol_35/laser,
+						/obj/item/ammo_magazine/ammobox/pistol_35/biomatter,
+						/obj/item/ammo_magazine/ammobox/magnum_40/laser,
+						/obj/item/ammo_magazine/ammobox/magnum_40/biomatter,
+						/obj/item/ammo_magazine/ammobox/light_rifle_257_small/laser,
+						/obj/item/ammo_magazine/ammobox/rifle_75_small/laser,
+						/obj/item/ammo_magazine/ammobox/laser_223,
+						/obj/item/ammo_magazine/ammobox/laser_223/ap,
+						/obj/item/ammo_magazine/ammobox/laser_223/lethal,
+						/obj/item/ammo_magazine/ammobox/kurtz_50/laser,
+						/obj/item/ammo_magazine/ammobox/antim, //Unlike the small box holds 15
+						/obj/item/ammo_magazine/ammobox/ball,
+						/obj/item/ammo_magazine/ammobox/heavy_rifle_408_small/laser,
+						/obj/item/ammo_magazine/ammobox/shotgun/flashshells, //holds 70 shells, its a map item not meant to be common
+						/obj/item/ammo_magazine/ammobox/shotgun/payload,
+						/obj/item/ammo_magazine/ammobox/shotgun/incendiary
+						)
 	var/obj/item/choice = input(usr, "Which type of ammo do you want?", "Ammo Choice", null) as null|anything in ammo_boxes
 	usr.put_in_hands(new choice(usr.loc))
 	cooldown_time = world.time + cooldown

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -838,7 +838,7 @@
 	name = "ballistic plating"
 	desc = "A sturdy bit of plasteel that can be bolted onto any armor to enhance its ballistic resistance."
 	icon_state = "bullet"
-	matter = list(MATERIAL_PLASTEEL = 30)
+	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 10)
 	price_tag = 750
 
 /obj/item/tool_upgrade/armor/bullet/New()
@@ -854,7 +854,7 @@
 	name = "energy plating"
 	desc = "A sturdy bit of plasteel that can be bolted onto any armor to enhance its energy resistance."
 	icon_state = "energy"
-	matter = list(MATERIAL_PLATINUM = 30)
+	matter = list(MATERIAL_PLATINUM = 3, MATERIAL_PLASTIC = 12)
 	price_tag = 1000
 
 /obj/item/tool_upgrade/armor/energy/New()
@@ -870,7 +870,7 @@
 	name = "bomb proofing"
 	desc = "A sturdy bit of plasteel that can be bolted onto any armor to enhance its bomb resistance."
 	icon_state = "bomb"
-	matter = list(MATERIAL_PLASTEEL = 20)
+	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASTEEL = 20)
 	price_tag = 450
 
 /obj/item/tool_upgrade/armor/bomb/New()

--- a/code/modules/mob/living/carbon/superior_animal/nanobot/nanobot.dm
+++ b/code/modules/mob/living/carbon/superior_animal/nanobot/nanobot.dm
@@ -73,6 +73,12 @@
 	Console = new /obj/item/modular_computer/console/preset/nanobot(src)
 	update_icon()
 
+/mob/living/carbon/superior_animal/nanobot/rejuvenate()
+	..()
+	//We trgain are consol and radio if revived!
+	Radio = new/obj/item/device/radio(src)
+	Console = new /obj/item/modular_computer/console/preset/nanobot(src)
+
 /mob/living/carbon/superior_animal/nanobot/examine(mob/user)
 	..()
 	if(iscarbon(user) || issilicon(user))
@@ -93,6 +99,11 @@
 		to_chat(src, "You are suddenly shunted out of your nanobot as it dies.")
 		controller.adjustBrainLoss(rand(5, 10)) // Get some brain damage.
 		return_mind() // Send them back
+	//We lose are items as not to make them farmable by lonestar when people leave the round/get lost
+	Radio = null
+	Console = null
+	for(var/internals_items in contents)
+		qdel(internals_items)
 	. = ..()
 
 /mob/living/carbon/superior_animal/nanobot/update_icon()

--- a/code/modules/nanogate/powers/user.dm
+++ b/code/modules/nanogate/powers/user.dm
@@ -99,13 +99,25 @@ List of powers in this page :
 						/obj/item/gun_upgrade/scope
 						)
 
-	// Removing the mods that shouldn't be available : AKA Bluespace, Greyson and AI stuff
+	// Removing the mods that shouldn't be available : AKA Bluespace, Greyson, AI and guild handmade only stuff
 	choices_mods -= list(/obj/item/tool_upgrade/augment/holding_tank,
 						/obj/item/tool_upgrade/augment/ai_tool,
 						/obj/item/tool_upgrade/augment/ai_tool_excelsior,
 						/obj/item/tool_upgrade/augment/repair_nano,
 						/obj/item/tool_upgrade/augment/randomizer,
 						/obj/item/tool_upgrade/artwork_tool_mod,
+						/obj/item/tool_upgrade/augment/sanctifier,	//Has biomatter, sadly nanites are not able to use that
+						/obj/item/tool_upgrade/armor/melee,
+						/obj/item/tool_upgrade/armor/bullet,
+						/obj/item/tool_upgrade/armor/energy,
+						/obj/item/tool_upgrade/armor/bomb,
+						/obj/item/gun_upgrade/barrel/forged,
+						/obj/item/gun_upgrade/barrel/bore,
+						/obj/item/gun_upgrade/barrel/excruciator,	//Sadly has biomatter
+						/obj/item/gun_upgrade/mechanism/upgrade_kit,
+						/obj/item/gun_upgrade/mechanism/clock_block,//Brass and unknown tech
+						/obj/item/gun_upgrade/trigger/boom,			//Illegal
+						/obj/item/gun_upgrade/scope/watchman,
 						/obj/item/gun_upgrade/mechanism/glass_widow,
 						/obj/item/gun_upgrade/mechanism/greyson_master_catalyst,
 						/obj/item/gun_upgrade/mechanism/brass_kit,

--- a/code/modules/organs/internal/nanogate.dm
+++ b/code/modules/organs/internal/nanogate.dm
@@ -6,14 +6,15 @@
 	organ_efficiency = list(BP_NANOGATE = 100)
 	parent_organ_base = BP_HEAD // It's at the base of the skull in the spine.
 	icon_state = "nanogate" //TODO: Replace this with a proper sprite.
-	force = 1.0
+	force = 1.
 	w_class = ITEM_SIZE_SMALL
 	specific_organ_size = 0.5
-	throwforce = 1.0
+	throwforce = 1
 	throw_speed = 3
 	throw_range = 5
 	layer = ABOVE_MOB_LAYER
-	origin_tech = list(TECH_ENGINEERING = 20)
+	origin_tech = list(TECH_ENGINEERING = 15, TECH_BIO = 5, TECH_DATA = 10)
+	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_GOLD = 4, MATERIAL_SILVER = 4, MATERIAL_PLASTIC = 10, MATERIAL_GLASS = 15, MATERIAL_DIAMOND = 1)
 	attack_verb = list("attacked", "slapped", "whacked")
 	price_tag = 12000
 	var/nanite_points = 10
@@ -58,6 +59,9 @@ obj/item/organ/internal/nanogate/artificer
 	desc = "A custom built nanogate designed from the far superior opifex blueprints. It is implanted right where the spine meets the skull and provides a wide variety of nanite based uses. This \
 	particular design is made by the Artificer Guild, able to store more nanites for additional uses."
 	nanite_points = 15
+	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_GOLD = 8, MATERIAL_SILVER = 9, MATERIAL_PLASTIC = 20, MATERIAL_GLASS = 15, MATERIAL_DIAMOND = 2)
+	origin_tech = list(TECH_ENGINEERING = 20, TECH_BIO = 10, TECH_DATA = 20)
+
 
 // Opifexes are the creator of the tech, they get a better one.
 /obj/item/organ/internal/nanogate/opifex
@@ -67,6 +71,8 @@ obj/item/organ/internal/nanogate/artificer
 	icon_state = "nanogate_opi" //TODO: Replace this with a proper sprite. Opifex branded.
 	price_tag = 20000 // Better than the standard one.
 	nanite_points = 20
+	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_GOLD = 12, MATERIAL_SILVER = 12, MATERIAL_PLASTIC = 20, MATERIAL_GLASS = 15, MATERIAL_DIAMOND = 3)
+	origin_tech = list(TECH_ENGINEERING = 25, TECH_BIO = 15, TECH_DATA = 10)
 
 	owner_verbs = list(
 		/obj/item/organ/internal/nanogate/proc/nanite_message,

--- a/code/modules/organs/internal/nanogate.dm
+++ b/code/modules/organs/internal/nanogate.dm
@@ -6,7 +6,7 @@
 	organ_efficiency = list(BP_NANOGATE = 100)
 	parent_organ_base = BP_HEAD // It's at the base of the skull in the spine.
 	icon_state = "nanogate" //TODO: Replace this with a proper sprite.
-	force = 1.
+	force = 1
 	w_class = ITEM_SIZE_SMALL
 	specific_organ_size = 0.5
 	throwforce = 1


### PR DESCRIPTION
Nanogate no longer gives biomatter
Nanogate rnd and materal levels are way higher!
Nanogate fabrication has been tweaked, removing mods and ammo that contain explosives or biomatter
Nanogate ammo fabricator can no longer make ammo packets that are laser based
Nanogate ammo fabricator can no longer make fire shot shells or large shotgun crate mapping box flare box
Nanobot can no longer be harvested in to get the best console gear in the game. SAD (prevents soft locks and balance issues to get a console bigger then the bot popping out of a small drone)

Guild armor plates now have the materials it takes to make them inside them (no more getting 30 platium when making an item that costs 3)