### PR TITLE
some bolt gun banaid permient fix

### DIFF
--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -141,10 +141,18 @@
 
 /obj/item/gun/projectile/boltgun/load_ammo(var/obj/item/A, mob/user)
 	if(!bolt_open)
+		to_chat(user, SPAN_WARNING("You add in ammo [src] while the bolt is closed!"))
 		return
+	//Prevents a bug, banaid-fix
+	if(istype(A, /obj/item/ammo_casing))
+		var/obj/item/ammo_casing/C = A
+		if(C.is_caseless)
+			to_chat(user, SPAN_WARNING("Adding in caseless ammo into [src] would trigger a chain reaction in the chamber!"))
+			return
 	..()
 
 /obj/item/gun/projectile/boltgun/unload_ammo(mob/user, var/allow_dump=1)
 	if(!bolt_open)
+		to_chat(user, SPAN_WARNING("You can't take out ammo [src] while the bolt is closed!"))
 		return
 	..()


### PR DESCRIPTION
Bolt guns now give more feedback when failing to load it
Bolt guns no longer can take caseless ammo do to it bugging the gun