### PR TITLE
Minor fixes and temp additions

### DIFF
--- a/code/game/objects/random/mob/misc.dm
+++ b/code/game/objects/random/mob/misc.dm
@@ -105,8 +105,8 @@
 				/mob/living/carbon/superior_animal/psi_monster/mind_gazer = 4,
 				/mob/living/carbon/superior_animal/psi_monster/pus_maggot/ash_wendigo = 4,
 				/mob/living/carbon/superior_animal/psi_monster/cerebral_crusher = 4,
-				/mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly = 3,
-				/mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly/pitch_horror = 2,
+				//mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly = 3,
+				//mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly/pitch_horror = 2,
 				))
 
 /obj/random/mob/psi_monster_mega_fauna

--- a/code/modules/genetics/creatures/wasonce.dm
+++ b/code/modules/genetics/creatures/wasonce.dm
@@ -25,6 +25,7 @@ Has ability of every roach.
 	chameleon_skill = 255 // Psionics not developed, can't turn invisible.
 	healing_factor = 25
 	size_pixel_offset_x = -16
+	momento_mori = /obj/effect/gibspawner
 
 	faction= "psi_monster"
 	friendly_to_colony = FALSE

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/ai.dm
@@ -4,13 +4,13 @@
 		if(last_noise <= (world.time) && aggro_noise)
 			playsound(src.loc, list(aggro_noise), 120, 1)
 			last_noise = world.time + 30 SECONDS
-		animate(src, alpha = chameleon_skill, time = 2)
+/*		animate(src, alpha = chameleon_skill, time = 2)
 		sleep(2)
 		animate(src, alpha = 55, time = 2)
 		sleep(2)
 		animate(src, alpha = 155, time = 2)
 		sleep(2)
-		animate(src, alpha = 255, time = 2)
+		animate(src, alpha = 255, time = 2)*/
 
 /mob/living/carbon/superior_animal/psi_monster/death(var/gibbed,var/message = deathmessage)
 	if (stat != DEAD)

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/life.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/life.dm
@@ -4,14 +4,14 @@
 	if(L.get_lumcount() < 0.8)
 		heal_overall_damage(healing_factor,healing_factor)
 		updatehealth()
-	if(health >= (maxHealth * 0.9) && (L.get_lumcount() <= 0.8) && stance == HOSTILE_STANCE_IDLE)
+/*	if(health >= (maxHealth * 0.9) && (L.get_lumcount() <= 0.8) && stance == HOSTILE_STANCE_IDLE)
 		animate(src, alpha = 255, time = 2)
 		sleep(2)
 		animate(src, alpha = 155, time = 2)
 		sleep(2)
 		animate(src, alpha = 55, time = 2)
 		sleep(2)
-		animate(src, alpha = chameleon_skill, time = 2)
+		animate(src, alpha = chameleon_skill, time = 2)*/
 
 /mob/living/carbon/superior_animal/psi_monster/dreaming_king/Life()
 	. = ..()

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
@@ -18,7 +18,7 @@
 	maxHealth = 120
 	health = 120
 	randpixel = 0
-	attack_sound = 'sound/voice/insect_battle_bite.ogg'
+	attack_sound = list('sound/xenomorph/alien_claw_flesh1.ogg', 'sound/xenomorph/alien_claw_flesh2.ogg', 'sound/xenomorph/alien_claw_flesh3.ogg', 'sound/xenomorph/alien_tail_attack.ogg')
 	var/aggro_noise = 'sound/hallucinations/hell_screech.ogg'
 	attack_sound_chance = 100
 	speak_emote = list("murmurs", "howls", "whispers")
@@ -41,8 +41,12 @@
 	acceptableTargetDistance = 5
 	flash_resistances = 50 //No eyes.
 
+	breath_required_type = 0 // Doesn't need to breath, in a space suit
+	breath_poison_type = 0 // Can't be poisoned
+	min_air_pressure = 0 // Doesn't need pressure
+	breath_required_type = NONE
+	breath_poison_type = NONE
 	min_breath_required_type = 0
-	min_air_pressure = 0 //below this, brute damage is dealt
 	min_breath_poison_type = 0
 
 	var/poison_per_bite = 0

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
@@ -9,7 +9,7 @@
 	health = 200
 	melee_damage_lower = 14
 	melee_damage_upper = 19
-	emote_see = list("chitters in greetings.", "whispers, \"Let me caress your flesh...\"", "twitches its antenni.")
+	emote_see = list("chitters in greeting.", "whispers, \"Let me caress your flesh...\"", "twitches its antenni.")
 	poison_per_bite = 2
 	turns_per_move = 4 // Slow
 	attacktext = "punched"


### PR DESCRIPTION
-Temporarily disabled shoggoth class enemies from spawning and the fade/appear functions for psi-mobs as both were determined to be bugged. Will develop a work around tomorrow, just really tired after coding all day and running the event.
-Fixed a sound issue with psi mobs attacking.
-Fixed a air pressure issue with psi-mobs that made them progressive take toxin damage.
-Fixed a typo in the ponderous.

TODO:
-Fix and then re-enabled the shoggoth class psi mobs.
-Find a more server resource viable fade/appear method.
-Add the custom ambiance for deep maints (has some odd musical choices, which will require me to test it carefully.
-Add more voice lines to the various deep maint mobs.
-Remove kebab.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
