### PR TITLE
fixes cog on back sprites

### DIFF
--- a/code/modules/projectiles/guns/energy/cog.dm
+++ b/code/modules/projectiles/guns/energy/cog.dm
@@ -25,3 +25,7 @@
 	if(prob(50))
 		icon = 'icons/obj/guns/energy/cog_alt.dmi'
 	return
+
+/obj/item/gun/energy/cog/update_icon()
+	..()
+	set_item_state(null, back = TRUE)


### PR DESCRIPTION
When the cog is on back, it now will have its proper icons