### PR TITLE
Lowers sheet snatcher screwdriver costs

### DIFF
--- a/code/datums/craft/recipes/storage.dm
+++ b/code/datums/craft/recipes/storage.dm
@@ -31,7 +31,7 @@
 	result = /obj/item/storage/bag/sheetsnatcher
 	steps = list(
 		list(CRAFT_MATERIAL, 10, MATERIAL_WOOD, "time" = 30),
-		list(QUALITY_SCREW_DRIVING, 40, "time" = 20),
+		list(QUALITY_SCREW_DRIVING, 10, "time" = 20), //So knifes and other misc tools work on it.
 		list(CRAFT_MATERIAL, 3, MATERIAL_STEEL, "time" = 60),
 		list(QUALITY_ADHESIVE, 10, "time" = 60)
 	)


### PR DESCRIPTION
Unlike the guilds fancy better verson the normal sheet snatcher should be availed to most roles that get scrap tools or can crate them for easier storage in line with other storage means