### PR TITLE
Makes obligate name = false the default.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -15,7 +15,7 @@
 
 	var/default_form = FORM_HUMAN	//If nothing else sets it, what do we look like.
 	var/obligate_form = FALSE		//If true, character creation will force the use of either this form or its subforms.
-	var/obligate_name = TRUE		//If true, forces the character's species name and name color to conform.
+	var/obligate_name = FALSE		//If true, forces the character's species name and name color to conform.
 
 	var/list/permitted_ears  = null
 	var/list/permitted_tail  = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Only races with obligate name = true in their code actually have obligate names now.
I literally only did this because I want the spider upbringing on a character that is supposed to be a custom species and not a cht'mant.
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
tweak: most species can now be renamed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
