### PR TITLE
Energy Weapons: Twohand and can_duel

### DIFF
--- a/code/game/machinery/vendor/weapon_vendors.dm
+++ b/code/game/machinery/vendor/weapon_vendors.dm
@@ -456,6 +456,8 @@
 					/obj/item/storage/box/bs_kit/stallion = "Stallion",
 					/obj/item/storage/box/bs_kit/lamia = "Lamia",
 					/obj/item/storage/box/bs_kit/colt = "Colt",
+					/obj/item/storage/box/bs_kit/rex10 = "Cowboy",
+					/obj/item/storage/box/bs_kit/pilgrim = "Pilgrim",
 					/obj/item/storage/box/bs_kit/sawn_shotgun = "Sawn-Off Shotgun",
 					/obj/item/storage/box/bs_kit/martin = "Martin"
 					)

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -199,7 +199,7 @@
 		fail("You feel stupid.",user,C,targets)
 		return FALSE
 
-	var/text = input(user, "What message will you send to the target? The message will be recieved telepathically and they will not know who it is from unless you reveal yourself.", "Sending a message") as text|null
+	var/text = input(user, "What message will you send to the target? The message will be recieved telepathically.", "Sending a message") as text|null
 	if (!text)
 		return
 	to_chat(H, "<span class='notice'><b><font size='3px'><font color='#ffaa00'>[user.real_name]'s voice speaks in your mind: \"[text]\"</font><b></span>")

--- a/code/modules/projectiles/guns/energy/cassad.dm
+++ b/code/modules/projectiles/guns/energy/cassad.dm
@@ -20,6 +20,8 @@
 		list(mode_name="armor penetrating", mode_desc="Harder hitting plasma bolts to reduce armor", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/Laser.ogg', fire_delay=12, icon="kill", projectile_color = "#00AAFF"),
 	)
 	gun_tags = list(GUN_ENERGY, GUN_SCOPE)
+	twohanded = TRUE
+	can_dual = FALSE
 
 /obj/item/gun/energy/pulse/cassad/update_icon()
 	..()

--- a/code/modules/projectiles/guns/energy/mindflayer.dm
+++ b/code/modules/projectiles/guns/energy/mindflayer.dm
@@ -7,3 +7,5 @@
 	fire_sound = 'sound/weapons/Laser.ogg'
 	price_tag = 1500
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
+	twohanded = TRUE
+	can_dual = FALSE

--- a/code/modules/projectiles/guns/energy/mindflayer.dm
+++ b/code/modules/projectiles/guns/energy/mindflayer.dm
@@ -7,5 +7,4 @@
 	fire_sound = 'sound/weapons/Laser.ogg'
 	price_tag = 1500
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
-	twohanded = TRUE
 	can_dual = FALSE

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -13,6 +13,7 @@
 	price_tag = 2000
 	charge_cost = 50
 	can_dual = FALSE
+	twohanded = TRUE
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE) //Were all three and can have a scope if someone wants
 	init_firemodes = list(
 		STUNBOLT,

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -19,6 +19,7 @@
 	recoil_buildup = 0.9 //pulse weapons have a bit more recoil
 	one_hand_penalty = 5
 	twohanded = TRUE
+	can_dual = FALSE
 	damage_multiplier = 0.9
 	init_firemodes = list(
 		list(mode_name="destroy", mode_desc="An armor-stripping plasma round", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/pulse.ogg', fire_delay=14, icon="destroy", projectile_color = "#FFFFFF"),
@@ -80,6 +81,7 @@
 	recoil_buildup = 1
 	one_hand_penalty = 0
 	twohanded = FALSE
+	can_dual = TRUE
 	gun_tags = list(GUN_ENERGY)
 
 	init_firemodes = list(
@@ -98,6 +100,9 @@
 	charge_cost = 100
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 20, MATERIAL_SILVER = 5, MATERIAL_PLASMA = 10)
 	damage_multiplier = 1
+	twohanded = FALSE
+	can_dual = TRUE
+	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_HOLSTER
 
 	var/explode_chance // the % of chance the gun has to explode each time it is fired without coolant. It is random between each gun.
 	var/explode_chance_min = 5 // The mininum of explode_chance

--- a/code/modules/projectiles/guns/energy/railgun.dm
+++ b/code/modules/projectiles/guns/energy/railgun.dm
@@ -95,6 +95,7 @@
 	force = WEAPON_FORCE_PAINFUL
 	gun_tags = list(GUN_PROJECTILE, GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 	twohanded = TRUE
+	can_dual = FALSE
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)

--- a/code/modules/projectiles/guns/energy/tesla_gun.dm
+++ b/code/modules/projectiles/guns/energy/tesla_gun.dm
@@ -11,7 +11,7 @@
 	suitable_cell = /obj/item/cell/medium
 	cell_type = /obj/item/cell/medium/moebius
 	slot_flags = SLOT_BELT|SLOT_HOLSTER|SLOT_BACK
-	twohanded = FALSE
+	twohanded = TRUE
 	w_class = ITEM_SIZE_BULKY
 	can_dual = FALSE
 	projectile_type = /obj/item/projectile/beam/tesla

--- a/code/modules/projectiles/guns/energy/tesla_shotgun.dm
+++ b/code/modules/projectiles/guns/energy/tesla_shotgun.dm
@@ -11,7 +11,7 @@
 	suitable_cell = /obj/item/cell/medium
 	cell_type = /obj/item/cell/medium/moebius
 	slot_flags = SLOT_BELT|SLOT_BACK
-	twohanded = FALSE // It is a shotgun, but beams don't have recoil
+	twohanded = TRUE
 	w_class = ITEM_SIZE_BULKY // It's a shotgun
 	can_dual = FALSE
 	projectile_type = /obj/item/projectile/beam/tesla/shotgun

--- a/code/modules/projectiles/guns/plasma/hydrogen.dm
+++ b/code/modules/projectiles/guns/plasma/hydrogen.dm
@@ -21,7 +21,8 @@ Securing and unsecuring the flask is a long and hard task, and a failure when un
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 5, TECH_PLASMA = 8)
 	w_class = ITEM_SIZE_BULKY
 	recoil_buildup = 1
-	twohanded = TRUE
+	twohanded = FALSE
+	can_dual = TRUE
 	max_upgrades = 3
 	fire_delay = 10
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'

--- a/code/modules/projectiles/guns/plasma/variant.dm
+++ b/code/modules/projectiles/guns/plasma/variant.dm
@@ -35,6 +35,8 @@
 		list(mode_name = "standard", mode_desc="A large ball of hydrogen to blow up bulwarks or weak targets", projectile_type = /obj/item/projectile/hydrogen/cannon, fire_sound = 'sound/weapons/lasercannonfire.ogg', fire_delay = 30, icon = "destroy", use_plasma_cost = 20),
 		list(mode_name = "overclock", mode_desc="A large ball of volatile hydrogen to blow up cover or targets", projectile_type = /obj/item/projectile/hydrogen/cannon/max, fire_sound = 'sound/effects/supermatter.ogg', fire_delay = 50, icon = "kill", use_plasma_cost = 40)
 	)
+	twohanded = TRUE
+	can_dual = FALSE
 
 // Blue cross weapon, no overheat.
 /obj/item/gun/hydrogen/incinerator


### PR DESCRIPTION
-The cassad now requires 2 hands and cannot be duel wielded.
-The mindflayer now requires 2 hands and cannot be duel wielded.
-The AEG now requires 2 hands and cannot be duel wielded.
-All plasma based church weapons can no longer be duel wielded and require two hands.
-All pistol sprite hydrogen weapons can now be duel wielded and used with one hand.
-The tesla shotguns and all subtypes now require you to 2 hand them.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
