### PR TITLE
Adds plastic to cargo buying

### DIFF
--- a/code/modules/cargo/packs_engineering.dm
+++ b/code/modules/cargo/packs_engineering.dm
@@ -111,6 +111,26 @@
 	crate_name = "Bulk metal crate"
 	group = "Engineering"
 
+/datum/supply_pack/plastic120
+	name = "Plastic Sheets Crate (120)"
+	contains = list(/obj/item/stack/material/plastic)
+	amount = 120
+	cost = 400
+	containertype = /obj/structure/closet/crate/secure
+	crate_name = "plastic sheets crate"
+	group = "Engineering"
+
+/datum/supply_pack/plastic480
+	name = "Bulk Plastic Sheets Crate"
+	contains = list(/obj/item/stack/material/plastic/full,
+	/obj/item/stack/material/plastic/full,
+	/obj/item/stack/material/plastic/full,
+	/obj/item/stack/material/plastic/full)
+	cost = 1160
+	containertype = /obj/structure/largecrate
+	crate_name = "Bulk plastic crate"
+	group = "Engineering"
+
 /datum/supply_pack/glass120
 	name = "Glass Sheets Crate (120)"
 	contains = list(/obj/item/stack/material/glass)


### PR DESCRIPTION
Simular to steel, glass, and plasteel, adds in both bulk and normal 120 sheet buying of the basic plastic, this is more exspensive then buying steel do to steel needing 2 ores rather then 1 to make and plastic needing just smelted carbon.
Or doing chems to make endless plastic. qol on cargo/colony and miners