### PR TITLE
ports removal of disarm spam

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -256,7 +256,6 @@
 
 			if(w_uniform)
 				w_uniform.add_fingerprint(M)
-			var/obj/item/organ/external/affecting = get_organ(ran_zone(M.targeted_organ))
 
 			var/list/holding = list(get_active_hand() = 40, get_inactive_hand = 20)
 
@@ -269,31 +268,34 @@
 					if(turfs.len)
 						var/turf/target = pick(turfs)
 						visible_message(SPAN_DANGER("[src]'s [W] goes off during the struggle!"))
-						return W.afterattack(target,src)
+						W.afterattack(target,src)
 
-			var/randn = rand(1, 100)
-			randn = max(1, randn - H.stats.getStat(STAT_ROB))
-			if(!(species.flags & NO_SLIP) && !(src.stats.getPerk(PERK_ASS_OF_CONCRETE) || src.stats.getPerk(PERK_BRAWN)) && randn <= 20)
-				apply_effect(3, WEAKEN, getarmor(affecting, ARMOR_MELEE))
-				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-				visible_message(SPAN_DANGER("[M] has pushed [src]!"))
-				return
-
-			if(randn <= 50)
-				//See about breaking grips or pulls
-				if(break_all_grabs(M))
-					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-					return
-
-				//Actually disarm them
-				for(var/obj/item/I in holding)
-					if(I && src.unEquip(I))
+			//Actually disarm them
+			var/rob_attacker = (50 / (1 + 150 / max(1, H.stats.getStat(STAT_ROB))) + 40) //soft capped amount of recoil that attacker deals
+			var/rob_target = max(0, min(400,stats.getStat(STAT_ROB))) //hard capped amount of recoil the target negates upon disarming
+			var/recoil_damage = (rob_attacker * (1 - (rob_target / 400))) //recoil itself
+			for(var/obj/item/I in holding)
+				external_recoil(recoil_damage)
+				if(recoil >= 60) //disarming
+					if(istype(I, /obj/item/grab)) //did M grab someone?
+						break_all_grabs(M) //See about breaking grips or pulls
+						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+						return
+					if(I.wielded) //is the held item wielded?
+						if(!recoil >= 80) //if yes, we need more recoil to disarm
+							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+							visible_message(SPAN_WARNING("[M] attempted to disarm [src]"))
+							return
+					if(istype(I, /obj/item/twohanded/offhand)) //did someone dare to switch to offhand to not get disarmed?
+						unEquip(src.get_inactive_hand())
 						visible_message(SPAN_DANGER("[M] has disarmed [src]!"))
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 						return
+					else
+						unEquip(I)
 
 			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-			visible_message("\red <B>[M] attempted to disarm [src]!</B>")
+			visible_message(SPAN_WARNING("[M] attempted to disarm [src]"))
 	return
 
 /mob/living/carbon/human/proc/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, inrange, params)

--- a/code/modules/mob/living/recoil.dm
+++ b/code/modules/mob/living/recoil.dm
@@ -7,6 +7,12 @@
 		recoil += G.recoil_buildup
 		update_recoil()
 
+/mob/living/proc/external_recoil(var/recoil_amount) //used in human_attackhand.dm
+	deltimer(recoil_reduction_timer)
+	if(recoil_amount)
+		recoil += recoil_amount
+		update_recoil()
+
 /mob/living/proc/calc_recoil()
 	recoil -= 300
 	recoil_reduction_timer = addtimer(CALLBACK(src, .proc/calc_recoil), 1 SECONDS, TIMER_STOPPABLE)


### PR DESCRIPTION
disarming adds recoil that scales off of ROB
your own ROB negates some of recoil damage
you need 60+ recoil to disarm
80 if item is wielded!

the CRAZY formulas, made up by Humon
rob_attacker = (50 / (1 + 150 / (min(1, attacker robustness))) + 40) - soft capped amount of recoil that attacker deals
rob_target = max(0, min(400, target robustness)) - hard capped amount of recoil the target negates upon disarming. 400 - no recoil
recoil_damage = (rob_attacker * (1 - (rob_target / 400))) - recoil itself

By Kegdo and Humonitarian
add: disarm deals recoil, scales off of ROB from both the attacker and target, wielding matters