### PR TITLE
Allow multiple cloning mutations to be active in a single sample plate

### DIFF
--- a/code/modules/genetics/genetics.dm
+++ b/code/modules/genetics/genetics.dm
@@ -147,7 +147,7 @@
 	#ifdef JANEDEBUG
 	log_debug("findCloneMutation: getting a random active clone mutation for cloning")
 	#endif
-	var/list/clone_mutation_pool
+	var/list/clone_mutation_pool = list()
 	for (var/datum/genetics/mutation/selected_mutation in mutation_pool)
 		if(selected_mutation.clone_gene && selected_mutation.active)
 			clone_mutation_pool += selected_mutation


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
SHOULD fix a bug where multiple active on_clone mutations in a single genetic sample caused the cloning vat to runtime.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
