### PR TITLE
Gets extra info on the reader runtimes

### DIFF
--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -91,7 +91,8 @@ var/global/use_preloader = FALSE
 		// (1,1,1) = {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
 		else if(dmmRegex.group[3]) // Coords
 			if(!key_len)
-				throw EXCEPTION("Coords before model definition in DMM")
+				testing("[dmmRegex.group[3]]")
+				throw EXCEPTION("Coords before model definition in DMM - [dmm_file]")
 
 			var/xcrdStart = text2num(dmmRegex.group[3]) + x_offset - 1
 			//position of the currently processed square


### PR DESCRIPTION
By Shadow-Quill
Adds extra debugging info for the reader.dm runtimes.