### PR TITLE
Risikio "Breaks" Corn Bombs

### DIFF
--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -295,6 +295,8 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 
 			missed = abs(power-targetBoom) * 8000 // each step away from the target will result in 8,000 points less
 			calculated_research_points = 40000 - missed
+			if calculated_research_points < 0
+				calculated_research_points = 0
 
 
 			RD.files.adjust_research_points(calculated_research_points)

--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -294,9 +294,8 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 			var missed
 
 			missed = abs(power-targetBoom) * 8000 // each step away from the target will result in 8,000 points less
-			calculated_research_points = 40000 - missed
-			if (calculated_research_points < 0)
-				calculated_research_points = 0
+			calculated_research_points = max(0,40000 - missed)
+
 
 
 			RD.files.adjust_research_points(calculated_research_points)

--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -295,7 +295,7 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 
 			missed = abs(power-targetBoom) * 8000 // each step away from the target will result in 8,000 points less
 			calculated_research_points = 40000 - missed
-			if calculated_research_points < 0
+			if (calculated_research_points < 0)
 				calculated_research_points = 0
 
 

--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -267,6 +267,12 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 	desc = "Scans the level of kinetic energy from explosions. This beacon, is in fact bomb proof and to use it properly you must use the bomb within 10 tiles of this scanner."
 
 	channels = list("Science" = 1)
+	var targetBoom
+
+/obj/item/device/radio/beacon/explosion_watcher/examine()
+	..()
+	to_chat(usr, "EXPECTED EXPLOSION - [targetBoom]")
+	return
 
 /obj/item/device/radio/beacon/explosion_watcher/ex_act(severity)
 	return
@@ -274,6 +280,7 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 /obj/item/device/radio/beacon/explosion_watcher/Initialize()
 	. = ..()
 	GLOB.explosion_watcher_list += src
+	targetBoom = rand(1,20)
 
 /obj/item/device/radio/beacon/explosion_watcher/Destroy()
 	GLOB.explosion_watcher_list -= src
@@ -284,22 +291,19 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 	var/calculated_research_points = -1
 	for(var/obj/machinery/computer/rdconsole/RD in GLOB.computer_list)
 		if(RD.id == 1) // only core gets the science
-			var/saved_power_level = RD.files.experiments.saved_best_explosion
+			var missed
 
-			var/added_power = max(0, power - saved_power_level)
-			var/already_earned_power = min(saved_power_level, power)
+			missed = abs(power-targetBoom) * 8000 // each step away from the target will result in 8,000 points less
+			calculated_research_points = 40000 - missed
 
-			calculated_research_points = added_power * 500 + already_earned_power * 200
-
-			if(power > saved_power_level)
-				RD.files.experiments.saved_best_explosion = power
 
 			RD.files.adjust_research_points(calculated_research_points)
 
 	if(calculated_research_points > 0)
-		autosay("Detected explosion with power level [power], received [calculated_research_points] research points", name ,"Science")
+		autosay("Detected explosion with power level [power]. Expected explosion was [targetBoom]. Received [calculated_research_points] research points", name ,"Science")
 	else
-		autosay("Detected explosion with power level [power], R&D console is missing or broken", name ,"Science")
+		autosay("Detected explosion with power level [power], Expected explosion was [targetBoom]. Test Results Outside Expected Range", name ,"Science")
+	targetBoom = rand(1,20)
 
 // Universal tool to get research points from autopsy reports, virus info reports, archeology reports, slime cores
 /obj/item/device/science_tool


### PR DESCRIPTION
Doesn't actually affect the Nitroglycerin explosion in any way. However changes the kinetic explosion scanner.

Scanner now looks for a randomized number between 1 and 20 (found by just looking at it), and your job is to provide an explosion as close to that number as you can.

FUN FACT: There is a inverse correlation between the temperature of the 02 used in a TTV bomb and the power of the explosion.

Coders Note: So, when I first discovered that Nitroglycerin bombs not only were counted by the explosion meter, but was also stackable, I thought it was awesome because SCIENCE! Unfortunately, this quickly resulted in three problems.

1.) It broke Toxins. Corn bombs were (and still are) a source of large Research Points. Far more than traditional Toxin bomb making could ever dream of keeping up with. Now with this change, it brings the TTV testing back to something useful again.

2.) It took over Xenobotany. All that corn oil needed to come from somewhere, and it always means that Xenobotany would be dedicated to it. With the focus being back on Plasma gasses and booms down below, Xenobotany is free to get back to doing whatever it is they do besides drugs.

3.) It broke the server. During recent staff meetings, it was brought up that recently due to the recent lag issues, detonating 10+ gigantic bombs put huge strains on the server, almost to the point of crashing it each time. Changing how the meter worked was one of the most elegant solutions.

So as much fun as the corn bombs were, their mass production needs to be retired... for now. Don't worry, I have plans for more explosives in the future with the possibility of selling high explosives on the open market.