### PR TITLE
Rebalances klutz

### DIFF
--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -90,7 +90,7 @@
 
 /datum/perk/klutz
 	name = "Klutz"
-	desc = "You find a lot of tasks a little beyond your ability to perform, but being accident prone has at least made you used to getting hurt."
+	desc = "You find a lot of tasks a little beyond your ability to perform such is using any type of weaponry, but being accident prone has at least made you used to getting hurt."
 	//icon_state = "selfmedicated" // https://game-icons.net/1x1/lorc/overdose.html
 
 /datum/perk/klutz/assign(mob/living/carbon/human/H)

--- a/code/datums/setup_option/backgrounds/origin_upbringing.dm
+++ b/code/datums/setup_option/backgrounds/origin_upbringing.dm
@@ -90,7 +90,7 @@
 /datum/category_item/setup_option/background/bckgrnd/klutz
 	name = "Klutz"
 	desc = "Your entire life has been a series of unlucky and often self-inflicted accidents, you spent enough time hurting yourself due to your own clumsiness that you've built up a more \
-	pain tolerance than most of common folks, meaning that due to this clumsiness problem, you were always a good fighter due to your natural resistance. A shame, this doesn't stop you from time to time failing even the most basic tasks at times. In fact, you find some tasks that require precision damn near impossible, and even handling or using guns are literally impossible to use. And due to this problem, you have a serious problem of perception around, and you are not the most smart guy around here."
+	pain tolerance than most of common folks, meaning that due to this clumsiness problem, you've become quite tough and a little stronger too. A shame, this doesn't stop you from time to time failing even the most basic tasks at times. In fact, you find some tasks that require precision damn near impossible, and even handling or using guns is a dangerous prospect. Due to this problem, you have a terrible perception around the area around you."
 
 	perks = list(/datum/perk/klutz)
 	

--- a/code/datums/setup_option/backgrounds/origin_upbringing.dm
+++ b/code/datums/setup_option/backgrounds/origin_upbringing.dm
@@ -96,11 +96,11 @@
 
 	stat_modifiers = list(
 		STAT_ROB = 15,
-		STAT_TGH = 30,
-		STAT_VIG = -40,
-		STAT_BIO = -2,
-		STAT_MEC = -2,
-		STAT_COG = -15
+		STAT_TGH = 20,
+		STAT_VIG = -30,
+		STAT_BIO = -1,
+		STAT_MEC = -1,
+		STAT_COG = -10
 	)
 
 /datum/category_item/setup_option/background/bckgrnd/no_light

--- a/code/datums/setup_option/backgrounds/origin_upbringing.dm
+++ b/code/datums/setup_option/backgrounds/origin_upbringing.dm
@@ -89,18 +89,18 @@
 
 /datum/category_item/setup_option/background/bckgrnd/klutz
 	name = "Klutz"
-	desc = "Your entire life has been a series of unlucky and often self inflicted accidents, you spent enough time hurting yourself due to your own clumsiness that you've built up a bit more \
-	pain tolerance than most. A shame this doesn't stop you from failing even the most basic tasks at times. In fact, you find some tasks that require precision damn near impossible."
+	desc = "Your entire life has been a series of unlucky and often self-inflicted accidents, you spent enough time hurting yourself due to your own clumsiness that you've built up a more \
+	pain tolerance than most of common folks, meaning that due to this clumsiness problem, you were always a good fighter due to your natural resistance. A shame, this doesn't stop you from time to time failing even the most basic tasks at times. In fact, you find some tasks that require precision damn near impossible, and even handling or using guns are literally impossible to use. And due to this problem, you have a serious problem of perception around, and you are not the most smart guy around here."
 
-	perks = list(/datum/perk/klutz)
+	perks = list(/datum/perk/klutz,/datum/perk/oddity/harden)
 
 	stat_modifiers = list(
-		STAT_ROB = 0,
-		STAT_TGH = 20,
-		STAT_VIG = -5,
-		STAT_BIO = 0,
-		STAT_MEC = 0,
-		STAT_COG = 0
+		STAT_ROB = 15,
+		STAT_TGH = 30,
+		STAT_VIG = -40,
+		STAT_BIO = -2,
+		STAT_MEC = -2,
+		STAT_COG = -15
 	)
 
 /datum/category_item/setup_option/background/bckgrnd/no_light

--- a/code/datums/setup_option/backgrounds/origin_upbringing.dm
+++ b/code/datums/setup_option/backgrounds/origin_upbringing.dm
@@ -93,14 +93,14 @@
 	pain tolerance than most of common folks, meaning that due to this clumsiness problem, you were always a good fighter due to your natural resistance. A shame, this doesn't stop you from time to time failing even the most basic tasks at times. In fact, you find some tasks that require precision damn near impossible, and even handling or using guns are literally impossible to use. And due to this problem, you have a serious problem of perception around, and you are not the most smart guy around here."
 
 	perks = list(/datum/perk/klutz)
-
+	
 	stat_modifiers = list(
-		STAT_ROB = 15,
+		STAT_ROB = 10,
 		STAT_TGH = 20,
-		STAT_VIG = -30,
-		STAT_BIO = -1,
-		STAT_MEC = -1,
-		STAT_COG = -10
+		STAT_VIG = -20,
+		STAT_BIO = 0,
+		STAT_MEC = 0,
+		STAT_COG = 0
 	)
 
 /datum/category_item/setup_option/background/bckgrnd/no_light

--- a/code/datums/setup_option/backgrounds/origin_upbringing.dm
+++ b/code/datums/setup_option/backgrounds/origin_upbringing.dm
@@ -92,7 +92,7 @@
 	desc = "Your entire life has been a series of unlucky and often self-inflicted accidents, you spent enough time hurting yourself due to your own clumsiness that you've built up a more \
 	pain tolerance than most of common folks, meaning that due to this clumsiness problem, you were always a good fighter due to your natural resistance. A shame, this doesn't stop you from time to time failing even the most basic tasks at times. In fact, you find some tasks that require precision damn near impossible, and even handling or using guns are literally impossible to use. And due to this problem, you have a serious problem of perception around, and you are not the most smart guy around here."
 
-	perks = list(/datum/perk/klutz,/datum/perk/oddity/harden)
+	perks = list(/datum/perk/klutz)
 
 	stat_modifiers = list(
 		STAT_ROB = 15,

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -16,8 +16,8 @@
 	var/last_used = 0 //last world.time it was used.
 
 /obj/item/device/flash/proc/clown_check(var/mob/user)
-	if(user && (CLUMSY in user.mutations) && prob(50))
-		to_chat(user, SPAN_WARNING("\The [src] slips out of your hand."))
+	if(user && (CLUMSY in user.mutations) && prob(15))
+		to_chat(user, SPAN_WARNING("\The [src] clumsily slips out from your hand."))
 		user.drop_item()
 		return 0
 	return 1

--- a/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
@@ -261,7 +261,7 @@
 	add_fingerprint(user)
 	if(on && user.targeted_organ == BP_EYES)
 
-		if((CLUMSY in user.mutations) && prob(50))	//too dumb to use flashlight properly
+		if((CLUMSY in user.mutations) && prob(15))	//too dumb to use flashlight properly
 			return ..()	//just hit them in the head
 
 		var/mob/living/carbon/human/H = M	//mob has protective eyewear

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -54,12 +54,12 @@
 		to_chat(usr, SPAN_WARNING("Your biological understanding isn't enough to use this."))
 		return
 
-	if ((CLUMSY in user.mutations) && prob(50))
+	if ((CLUMSY in user.mutations) && prob(15))
 		. = list()
 
-		user.visible_message(SPAN_NOTICE("\The [user] runs \the [scanner] over the floor."))
-		. += span("highlight", "<b>Scan results for the floor:</b>")
-		. += span("highlight", "Overall Status: Healthy")
+		user.visible_message(SPAN_NOTICE("\The [user] runs \the [scanner] clumsily over the air, trying to scan something else!"))
+		. += span("highlight", "<b>Unknown Scan results:</b>")
+		. += span("highlight", "Overall Status: Unknown")
 		return jointext(., "<br>")
 
 	var/mob/living/carbon/human/scan_subject = null

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -16,7 +16,7 @@
 
 /obj/item/grenade/proc/clown_check(var/mob/living/user)
 	if((CLUMSY in user.mutations) && prob(10))
-		to_chat(user, SPAN_WARNING("Huh?... HELL, I PRIMED THE GRENADE-"))
+		to_chat(user, SPAN_WARNING("Huh? ... HELL, I PRIMED THE GRENADE!"))
 
 		activate(user)
 		add_fingerprint(user)

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -15,8 +15,8 @@
 	var/variance = 0 //How much the fuse time varies up or down. Punishes cooking with makeshift nades, proper ones should have 0
 
 /obj/item/grenade/proc/clown_check(var/mob/living/user)
-	if((CLUMSY in user.mutations) && prob(50))
-		to_chat(user, SPAN_WARNING("Huh? How does this thing work?"))
+	if((CLUMSY in user.mutations) && prob(10))
+		to_chat(user, SPAN_WARNING("Huh?... HELL, I PRIMED THE GRENADE-"))
 
 		activate(user)
 		add_fingerprint(user)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -24,7 +24,7 @@
 		return
 
 	if ((CLUMSY in user.mutations) && prob(15))
-		to_chat(user, SPAN_WARNING("Uh ... why handcuffs are so hard to use?!"))
+		to_chat(user, SPAN_WARNING("Uh ... why are handcuffs so hard to use?!"))
 		place_handcuffs(user, user)
 		return
 

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -23,8 +23,8 @@
 	if(!user.IsAdvancedToolUser())
 		return
 
-	if ((CLUMSY in user.mutations) && prob(50))
-		to_chat(user, SPAN_WARNING("Uh ... how do those things work?!"))
+	if ((CLUMSY in user.mutations) && prob(15))
+		to_chat(user, SPAN_WARNING("Uh ... why handcuffs are so hard to use?!"))
 		place_handcuffs(user, user)
 		return
 

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -29,7 +29,7 @@
 
 	if(user.a_intent != I_HELP)
 		if(user.targeted_organ in list(BP_HEAD, BP_EYES))
-			if((CLUMSY in user.mutations) && prob(50))
+			if((CLUMSY in user.mutations) && prob(15))
 				M = user
 			return eyestab(M,user)
 		else
@@ -94,10 +94,10 @@
 	thrown_force_divisor = 1 // as above
 
 /obj/item/material/kitchen/rollingpin/attack(mob/living/M as mob, mob/living/user as mob)
-	if ((CLUMSY in user.mutations) && prob(50))
-		to_chat(user, SPAN_WARNING("\The [src] slips out of your hand and hits your head."))
+	if ((CLUMSY in user.mutations) && prob(15))
+		to_chat(user, SPAN_WARNING("\The [src] accidentally slips out of your hand."))
 		user.drop_from_inventory(src)
-		user.take_organ_damage(10)
+		user.take_organ_damage(2)
 		user.Paralyse(2)
 		return
 	return ..()

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -44,7 +44,7 @@
 
 /obj/item/melee/energy/attack_self(mob/living/user as mob)
 	if (active)
-		if ((CLUMSY in user.mutations) && prob(50))
+		if ((CLUMSY in user.mutations) && prob(15))
 			user.visible_message(SPAN_DANGER("\The [user] accidentally cuts \himself with \the [src]."),\
 			SPAN_DANGER("You accidentally cut yourself with \the [src]."))
 			user.take_organ_damage(5,5)

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -549,9 +549,10 @@
 	return base_block_chance
 
 /obj/item/shield/buckler/energy/attack_self(mob/living/user as mob)
-	if ((CLUMSY in user.mutations) && prob(50))
-		to_chat(user, SPAN_WARNING("You beat yourself in the head with [src]."))
-		user.take_organ_damage(5)
+	if ((CLUMSY in user.mutations) && prob(15))
+		to_chat(user, SPAN_WARNING("You accidentally bash yourself with the [src]."))
+		user.damage_through_armor(10, BURN, user.hand)
+		user.Weaken(3 * force)
 	active = !active
 	if (active)
 		force = WEAPON_FORCE_PAINFUL

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -552,7 +552,7 @@
 	if ((CLUMSY in user.mutations) && prob(15))
 		to_chat(user, SPAN_WARNING("You accidentally bash yourself with the [src]."))
 		user.damage_through_armor(10, BURN, user.hand)
-		user.Weaken(3 * force)
+		user.Weaken(1 * force)
 	active = !active
 	if (active)
 		force = WEAPON_FORCE_PAINFUL

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -34,7 +34,7 @@
 		damtype = BRUTE
 		force = WEAPON_FORCE_ROBUST
 
-	if ((CLUMSY in user.mutations) && prob(50))
+	if ((CLUMSY in user.mutations) && prob(10))
 		to_chat(user, SPAN_WARNING("You club yourself over the head."))
 		playsound(src.loc, 'sound/effects/woodhit.ogg', 50, 1, -1)
 		user.Weaken(3 * force)
@@ -121,7 +121,7 @@
 			damtype = BRUTE
 			force = WEAPON_FORCE_DANGEROUS
 
-		if ((CLUMSY in user.mutations) && prob(50))
+		if ((CLUMSY in user.mutations) && prob(10))
 			to_chat(user, SPAN_WARNING("You club yourself over the head."))
 			user.Weaken(3 * force)
 			if(ishuman(user))

--- a/code/game/objects/items/weapons/tools/screwdrivers.dm
+++ b/code/game/objects/items/weapons/tools/screwdrivers.dm
@@ -58,7 +58,7 @@
 		return ..()
 	if(user.targeted_organ != BP_EYES && user.targeted_organ != BP_HEAD)
 		return ..()
-	if((CLUMSY in user.mutations) && prob(50))
+	if((CLUMSY in user.mutations) && prob(15))
 		M = user
 	return eyestab(M,user)
 

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -59,7 +59,7 @@
 	if(!armed)
 		to_chat(user, "<span class='notice'>You arm [src].</span>")
 	else
-		if((CLUMSY in user.mutations)&& prob(50))
+		if((CLUMSY in user.mutations)&& prob(15))
 			var/which_hand = "l_hand"
 			if(!user.hand)
 				which_hand = "r_hand"
@@ -75,7 +75,7 @@
 
 /obj/item/device/assembly/mousetrap/attack_hand(mob/living/user as mob)
 	if(armed)
-		if((CLUMSY in user.mutations) && prob(50))
+		if((CLUMSY in user.mutations) && prob(15))
 			var/which_hand = "l_hand"
 			if(!user.hand)
 				which_hand = "r_hand"

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -30,7 +30,7 @@
 	if(!usr.stat_check(STAT_MEC, STAT_LEVEL_ADEPT))
 		to_chat(usr, SPAN_WARNING("Your mechanical understanding isn't high enough to use this!"))
 		return
-	if((CLUMSY in user.mutations) && prob(50))
+	if((CLUMSY in user.mutations) && prob(15))
 		to_chat(user, text("\red You try to analyze the floor's vitals!"))
 		for(var/mob/O in viewers(M, null))
 			O.show_message(text("\red [user] has analyzed the floor's vitals!"), 1)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -132,7 +132,7 @@
 	set src in usr
 	playsound(src,'sound/effects/PEN_Ball_Point_Pen_Circling_01_mono.ogg',40,1)
 
-	if((CLUMSY in usr.mutations) && prob(50))
+	if((CLUMSY in usr.mutations) && prob(15))
 		to_chat(usr, SPAN_WARNING("You cut yourself on the paper."))
 		papercut()
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -218,19 +218,14 @@
 		handle_click_empty(user)
 		return FALSE
 
-	if((CLUMSY in M.mutations) && prob(40)) //Clumsy handling
-		var/obj/P = consume_next_projectile()
-		if(P)
-			if(process_projectile(P, user, user, pick(BP_L_LEG, BP_R_LEG)))
-				handle_post_fire(user, user)
-				user.visible_message(
-					SPAN_DANGER("\The [user] shoots \himself in the foot with \the [src]!"),
-					SPAN_DANGER("You shoot yourself in the foot with \the [src]!")
-					)
-				M.drop_item()
-		else
-			handle_click_empty(user)
-		return FALSE
+		if(CLUMSY in M.mutations)
+			user.drop_item()
+			user.visible_message(
+				SPAN_DANGER("\the [user] fumbles with \the [src], dropping it on the floor!"),
+				SPAN_DANGER("You fumble with \the [src] not knowing how to fire it or how to use it!")
+				)
+			return FALSE
+
 	if(rigged)
 		var/obj/P = consume_next_projectile()
 		if(P)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -218,13 +218,19 @@
 		handle_click_empty(user)
 		return FALSE
 
-		if(CLUMSY in M.mutations)
-			user.drop_item()
-			user.visible_message(
-				SPAN_DANGER("\the [user] fumbles with \the [src], dropping it on the floor!"),
-				SPAN_DANGER("You fumble with \the [src] not knowing how to fire it or how to use it!")
-				)
-			return FALSE
+	if((CLUMSY in M.mutations) && prob(15))
+		var/obj/P = consume_next_projectile()
+		if(P)
+			if(process_projectile(P, user, user, pick(BP_L_LEG, BP_R_LEG)))
+				handle_post_fire(user, user)
+				user.visible_message(
+					SPAN_DANGER("\The [user] fumbles with \the [src] and shoot themselves in the foot with \the [src]!"),
+					SPAN_DANGER("You fumble with the gun and accidentally shoot yourself in the foot with \the [src]!")
+					)
+				M.drop_item()
+		else
+			handle_click_empty(user)
+		return FALSE
 
 	if(rigged)
 		var/obj/P = consume_next_projectile()
@@ -359,7 +365,31 @@
 	user.set_move_cooldown(move_delay)
 	if(!twohanded && user.stats.getPerk(PERK_GUNSLINGER))
 		next_fire_time = world.time + fire_delay - fire_delay * 0.33
-	else
+	else	if((CLUMSY in M.mutations) && prob(40)) //Clumsy handling
+		var/obj/P = consume_next_projectile()
+		if(P)
+			if(process_projectile(P, user, user, pick(BP_L_LEG, BP_R_LEG)))
+				handle_post_fire(user, user)
+				user.visible_message(
+					SPAN_DANGER("\The [user] shoots \himself in the foot with \the [src]!"),
+					SPAN_DANGER("You shoot yourself in the foot with \the [src]!")
+					)
+				M.drop_item()
+		else
+			handle_click_empty(user)
+		return FALSE	if((CLUMSY in M.mutations) && prob(40)) //Clumsy handling
+		var/obj/P = consume_next_projectile()
+		if(P)
+			if(process_projectile(P, user, user, pick(BP_L_LEG, BP_R_LEG)))
+				handle_post_fire(user, user)
+				user.visible_message(
+					SPAN_DANGER("\The [user] shoots \himself in the foot with \the [src]!"),
+					SPAN_DANGER("You shoot yourself in the foot with \the [src]!")
+					)
+				M.drop_item()
+		else
+			handle_click_empty(user)
+		return FALSE
 		next_fire_time = world.time + fire_delay
 
 	if(muzzle_flash)

--- a/code/modules/projectiles/guns/breacher.dm
+++ b/code/modules/projectiles/guns/breacher.dm
@@ -108,7 +108,7 @@
 
 	if(isliving(user))
 		var/mob/living/M = user
-		if ((CLUMSY in M.mutations) && prob(50))
+		if ((CLUMSY in M.mutations) && prob(8))
 			to_chat(user, SPAN_DANGER("[src] blows up in your face."))
 			M.drop_item()
 			Fire(get_turf(M))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -67,7 +67,7 @@
 		return
 
 	if(user.a_intent == I_HURT && ismob(target))
-		if((CLUMSY in user.mutations) && prob(50))
+		if((CLUMSY in user.mutations) && prob(10))
 			target = user
 		syringestab(target, user)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Klutz is a horrible perk based on pure RNG and being utterly awful to have.
So I toned it down meaning that people will not have much of trouble of having it but still a decent chance of failing of doing certain actions.
Also, re-balances the klutz Upbringing.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
add: Klutz upbringing has their stats balanced, and they can perform way more task without having a ridiculous chancing of fail.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
