### PR TITLE
Scav rng improvements

### DIFF
--- a/code/game/objects/items/weapons/tools/mods/_defines.dm
+++ b/code/game/objects/items/weapons/tools/mods/_defines.dm
@@ -40,25 +40,6 @@
 
 #define UPGRADE_CELLMINUS "cell_down_size"
 
-
-//Salvager perk define, got stuck here because fuck making a new file for something so small. -Kaz
-#define RANDOM_RARE_ITEM list(\
-					/obj/random/common_oddities = 8,\
-					/obj/random/material_rare = 3,\
-					/obj/random/tool/advanced = 5,\
-					/obj/random/gun_normal = 3,\
-					/obj/random/lathe_disk/advanced = 2,\
-					/obj/item/cell/small/moebius/nuclear = 1,\
-					/obj/item/cell/medium/moebius/hyper = 1,\
-					/obj/random/rig = 1.5,\
-					/obj/random/rig/damaged = 1.5,\
-					/obj/random/voidsuit = 4,\
-					/obj/random/pouch = 2,\
-					/obj/random/tool_upgrade/rare = 4,\
-					/obj/random/rig_module/rare = 4,\
-					/obj/random/credits/c1000 = 3,\
-					/obj/item/stash_spawner = 1)
-
 //Weapon upgrade defines
 
 //Int multiplier
@@ -128,6 +109,31 @@
 #define GUN_CALIBRE_35 "caliber .35"
 #define GUN_CALIBRE_50 "caliber .50"
 #define GUN_AMR "caliber 60-06"
+
+//Salvager perk define
+#define RANDOM_RARE_ITEM list(\
+					/obj/random/common_oddities/always_spawn = 6,\
+					/obj/random/material_rare/always_spawn = 3,\
+					/obj/random/tool/advanced/always_spawn = 5,\
+					/obj/item/storage/firstaid/adv = 2,\
+					/obj/random/medical/always_spawn = 5,\
+					/obj/random/gun_normal/always_spawn = 3,\
+					/obj/random/gun_fancy/alawys_spawn = 2,\
+					/obj/random/lathe_disk/advanced = 2,\
+					/obj/item/cell/small/moebius/nuclear = 1,\
+					/obj/item/cell/medium/moebius/hyper = 1,\
+					/obj/random/rig/always_spawn = 1.5,\
+					/obj/item/material/butterfly/frenchman = 0.1,/*insainly rare do to being a bad item*/\
+					/obj/random/rig/damaged/always_spawn = 1.5,\
+					/obj/random/pouch/hardcase = 4,\
+					/obj/random/voidsuit = 4,\
+					/obj/random/pouch = 2,\
+					/obj/random/tool_upgrade/rare/always_spawn = 4,\
+					/obj/random/rig_module/rare/always_spawn = 4,\
+					/obj/random/credits/c1000 = 3,\
+					/obj/item/stash_spawner = 1)
+
+
 GLOBAL_LIST_INIT(tool_aspects_blacklist, list(UPGRADE_COLOR, UPGRADE_ITEMFLAGPLUS, UPGRADE_CELLPLUS, UPGRADE_SHARP, UPGRADE_BULK))
 GLOBAL_LIST_INIT(weapon_aspects_blacklist, list(GUN_UPGRADE_SILENCER, GUN_UPGRADE_FORCESAFETY, GUN_UPGRADE_HONK, GUN_UPGRADE_FULLAUTO,
 											GUN_UPGRADE_EXPLODE, GUN_UPGRADE_RIGGED, UPGRADE_SANCTIFY, GUN_UPGRADE_AUTOEJECT))

--- a/code/game/objects/random/contraband.dm
+++ b/code/game/objects/random/contraband.dm
@@ -25,7 +25,7 @@
 				/obj/item/gun/energy/chameleon = 2,
 				/obj/item/reagent_containers/syringe/drugs = 1,
 				/obj/item/reagent_containers/syringe/drugs_recreational = 1,
-				/obj/item/material/butterfly/frenchman = 0.1))
+				/obj/item/material/butterfly/frenchman = 1))
 
 /obj/random/contraband/low_chance
 	name = "low chance random illegal item"

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -50,6 +50,7 @@
 	spawn_nothing_percentage = 10
 
 /obj/random/gun_normal/always_spawn
+	name = "random always spawn normal gun"
 	spawn_nothing_percentage = 0
 
 /obj/random/gun_normal/item_to_spawn()
@@ -139,6 +140,9 @@
 	name = "random fancy gun"
 	icon_state = "gun-blue"
 	spawn_nothing_percentage = 30
+
+/obj/random/gun_fancy/alawys_spawn
+	name = "random always spawn fancy gun"
 
 /obj/random/gun_fancy/item_to_spawn()
 	return pickweight(list(/obj/item/gun/projectile/automatic/wirbelwind = 3,\

--- a/code/game/objects/random/materials.dm
+++ b/code/game/objects/random/materials.dm
@@ -51,6 +51,11 @@
 				/obj/item/stack/material/silver/random = 2,\
 				/obj/item/stack/material/glass/plasmaglass/random = 2))
 
+/obj/random/material_rare/always_spawn
+	name = "random always spawn rare material"
+	icon_state = "material-orange"
+	spawn_nothing_percentage = 0
+
 /obj/random/material_rare/low_chance
 	name = "low chance random rare material"
 	icon_state = "material-orange-low"

--- a/code/game/objects/random/medicine.dm
+++ b/code/game/objects/random/medicine.dm
@@ -3,6 +3,10 @@
 	icon_state = "meds-green"
 	spawn_nothing_percentage = 60
 
+/obj/random/medical/always_spawn
+	name = "random always spawn medicine"
+	spawn_nothing_percentage = 0
+
 /obj/random/medical/item_to_spawn()
 	return pickweight(list(/obj/item/stack/medical/bruise_pack = 4,\
 				/obj/item/stack/medical/ointment = 4,\

--- a/code/game/objects/random/oddities.dm
+++ b/code/game/objects/random/oddities.dm
@@ -1,6 +1,7 @@
 /obj/random/common_oddities
 	name = "random common odities"
 	icon_state = "techloot-grey"
+	spawn_nothing_percentage = 20
 
 /obj/random/common_oddities/item_to_spawn()
 	return pickweight(list(
@@ -36,6 +37,10 @@
 				/obj/item/oddity/common/disk = 2,
 				/obj/item/oddity/rare/eldritch_tie = 0.01 //SO RARE
 				))
+
+/obj/random/common_oddities/always_spawn
+	name = "random always spawn common odities"
+	icon_state = "techloot-black"
 
 /obj/random/common_oddities/low_chance
 	name = "low chance random common odities"

--- a/code/game/objects/random/rig.dm
+++ b/code/game/objects/random/rig.dm
@@ -31,6 +31,10 @@
 	/obj/item/rig/hazard/equipped = 2,
 	))
 
+/obj/random/rig/always_spawn
+	name = "random always spawn rig suit"
+	spawn_nothing_percentage = 0
+
 /obj/random/rig/low_chance
 	name = "low chance random rig suit"
 	icon_state = "armor-blue-low"
@@ -54,6 +58,10 @@
 	name = "random damaged rig suit"
 	icon_state = "armor-red"
 	has_postspawn = TRUE
+
+/obj/random/rig/damaged/always_spawn
+	name = "random always spawn damaged rig suit"
+	spawn_nothing_percentage = 0
 
 /obj/random/rig/damaged/post_spawn(var/list/spawns)
 	for (var/obj/item/rig/module in spawns)
@@ -140,6 +148,10 @@
 	name = "random rare hardsuit module"
 	icon_state = "box-red"
 	spawn_nothing_percentage = 60
+
+/obj/random/rig_module/rare/always_spawn
+	name = "random always spawn rare hardsuit module"
+	spawn_nothing_percentage = 0
 
 /obj/random/rig_module/rare/item_to_spawn()
 	return pickweight(list(

--- a/code/game/objects/random/tool_mods.dm
+++ b/code/game/objects/random/tool_mods.dm
@@ -41,6 +41,10 @@
 	name = "random rare tool upgrade"
 	icon_state = "tech-red"
 
+/obj/random/tool_upgrade/rare/always_spawn
+	name = "random always spawn rare tool upgrade"
+	spawn_nothing_percentage = 0
+
 //A fancier subset of the most desireable upgrades
 /obj/random/tool_upgrade/rare/item_to_spawn()
 	return pickweight(list(

--- a/code/game/objects/random/tools.dm
+++ b/code/game/objects/random/tools.dm
@@ -105,6 +105,10 @@
 	name = "random advanced tool"
 	icon_state = "tool-orange"
 
+/obj/random/tool/advanced/always_spawn
+	name = "random always spawn advanced tool"
+	icon_state = "material-blue"
+
 /obj/random/tool/advanced/item_to_spawn()
 	return pickweight(list(
 				/obj/item/tool/screwdriver/combi_driver = 3,


### PR DESCRIPTION
the scav perk that lets them get a fancy item in the trash pile now, always should spawn an item if they get the coin flip
adds more to the fancy item list to add more randomness