### PR TITLE
map things that are approved

### DIFF
--- a/code/modules/reagents/reagent_containers/glass/bottled_chemicals.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottled_chemicals.dm
@@ -1,0 +1,102 @@
+
+/obj/item/reagent_containers/glass/bottle/sulfur
+	name = "sulfur bottle"
+	desc = "A small bottle. Contains sulfur."
+	icon_state = "bottle"
+	preloaded_reagents = list("sulfur" = 60)
+
+/obj/item/reagent_containers/glass/bottle/tungsten
+	name = "tungsten bottle"
+	desc = "A small bottle. Contains tungsten."
+	icon_state = "bottle"
+	preloaded_reagents = list("tungsten" = 60)
+
+/obj/item/reagent_containers/glass/bottle/radium
+	name = "radium bottle"
+	desc = "A small bottle. Contains radium."
+	icon_state = "bottle"
+	preloaded_reagents = list("radium" = 60)
+
+/obj/item/reagent_containers/glass/bottle/sacid
+	name = "sulphuric acid bottle"
+	desc = "A small bottle. Contains sulphuric acid."
+	icon_state = "bottle"
+	preloaded_reagents = list("sacid" = 60)
+
+/obj/item/reagent_containers/glass/bottle/silicon
+	name = "silicon bottle"
+	desc = "A small bottle. Contains silicon."
+	icon_state = "bottle"
+	preloaded_reagents = list("silicon" = 60)
+
+/obj/item/reagent_containers/glass/bottle/sodium
+	name = "sodium bottle"
+	desc = "A small bottle. Contains sodium."
+	icon_state = "bottle"
+	preloaded_reagents = list("sodium" = 60)
+
+/obj/item/reagent_containers/glass/bottle/potassium
+	name = "potassium bottle"
+	desc = "A small bottle. Contains potassium."
+	icon_state = "bottle"
+	preloaded_reagents = list("potassium" = 60)
+
+/obj/item/reagent_containers/glass/bottle/phosphorus
+	name = "phosphorus bottle"
+	desc = "A small bottle. Contains phosphorus."
+	icon_state = "bottle"
+	preloaded_reagents = list("phosphorus" = 60)
+
+/obj/item/reagent_containers/glass/bottle/hclacid
+	name = "hydrochloric acid bottle"
+	desc = "A small bottle. Contains hydrochloric acid."
+	icon_state = "bottle"
+	preloaded_reagents = list("hclacid" = 60)
+
+/obj/item/reagent_containers/glass/bottle/hydrazine
+	name = "hydrazine bottle"
+	desc = "A small bottle. Contains hydrazine."
+	icon_state = "bottle"
+	preloaded_reagents = list("hydrazine" = 60)
+
+/obj/item/reagent_containers/glass/bottle/mercury
+	name = "mercury bottle"
+	desc = "A small bottle. Contains mercury."
+	icon_state = "bottle"
+	preloaded_reagents = list("mercury" = 60)
+
+/obj/item/reagent_containers/glass/bottle/acetone
+	name = "acetone bottle"
+	desc = "A small bottle. Contains acetone."
+	icon_state = "bottle"
+	preloaded_reagents = list("acetone" = 60)
+
+/obj/item/reagent_containers/glass/bottle/aluminum
+	name = "aluminum bottle"
+	desc = "A small bottle. Contains aluminum."
+	icon_state = "bottle"
+	preloaded_reagents = list("aluminum" = 60)
+
+/obj/item/reagent_containers/glass/bottle/ammonia
+	name = "ammonia bottle"
+	desc = "A small bottle. Contains ammonia."
+	icon_state = "bottle"
+	preloaded_reagents = list("ammonia" = 60)
+
+/obj/item/reagent_containers/glass/bottle/carbon
+	name = "carbon bottle"
+	desc = "A small bottle. Contains carbon."
+	icon_state = "bottle"
+	preloaded_reagents = list("carbon" = 60)
+
+/obj/item/reagent_containers/glass/bottle/copper
+	name = "copper bottle"
+	desc = "A small bottle. Contains copper."
+	icon_state = "bottle"
+	preloaded_reagents = list("copper" = 60)
+
+/obj/item/reagent_containers/glass/bottle/ethanol
+	name = "ethanol bottle"
+	desc = "A small bottle. Contains ethanol."
+	icon_state = "bottle"
+	preloaded_reagents = list("ethanol" = 60)

--- a/maps/DeepForest/map/_Deep_Forest.dmm
+++ b/maps/DeepForest/map/_Deep_Forest.dmm
@@ -286,9 +286,7 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "bj" = (
-/obj/machinery/drone_fabricator/derelict{
-	fabricator_tag = "Prepper Base"
-	},
+/obj/structure/salvageable/implant_container,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
 "bk" = (
@@ -11588,6 +11586,10 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"SK" = (
+/obj/structure/salvageable/personal,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/dungeon/outside/prepper)
 "SL" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
@@ -57821,7 +57823,7 @@ ym
 OM
 bj
 OM
-bj
+SK
 fC
 fC
 fD
@@ -58028,9 +58030,9 @@ kB
 fC
 ln
 OM
-fO
+bj
 OM
-fO
+SK
 fC
 fC
 fD

--- a/maps/DeepForest/map/_Deep_Forest.dmm
+++ b/maps/DeepForest/map/_Deep_Forest.dmm
@@ -403,6 +403,11 @@
 /obj/random/firstaid,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"bE" = (
+/obj/structure/window/reinforced,
+/obj/item/storage/hcases/med/has_items_spawn,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/dungeon/outside/smuggler_zone_u)
 "bF" = (
 /obj/item/mine_old{
 	layer = 2.6
@@ -428,6 +433,15 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"bK" = (
+/obj/structure/table/standard,
+/obj/item/stack/nanopaste,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/dungeon/outside/smuggler_zone_u)
 "bL" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
@@ -563,10 +577,29 @@
 /obj/random/cloth/armor/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"cl" = (
+/obj/structure/table/standard,
+/obj/item/storage/deferred/rations,
+/obj/item/storage/firstaid/ifak,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/dungeon/outside/smuggler_zone_u)
 "cm" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/syndie_kit/imp_compress,
 /turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/dungeon/outside/smuggler_zone_u)
+"cn" = (
+/obj/structure/table/standard,
+/obj/item/storage/deferred/crate/alcohol,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "co" = (
 /obj/structure/flora/small/bushc1,
@@ -583,6 +616,18 @@
 /obj/item/storage/deferred/meds,
 /obj/item/stack/nanopaste,
 /turf/simulated/floor/tiled/white/brown_platform,
+/area/nadezhda/dungeon/outside/smuggler_zone_u)
+"cr" = (
+/obj/item/storage/hcases/med/has_items_spawn,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/dungeon/outside/smuggler_zone_u)
+"cs" = (
+/obj/structure/table/standard,
+/obj/item/storage/box/bodybags,
+/obj/item/roller,
+/obj/random/medical,
+/obj/random/medical_lowcost,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "ct" = (
 /mob/living/simple_animal/hostile/hivebot,
@@ -607,6 +652,26 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"cy" = (
+/obj/structure/table/standard,
+/obj/item/device/scanner/mass_spectrometer/adv,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/dungeon/outside/smuggler_zone_u)
+"cz" = (
+/obj/structure/table/standard,
+/obj/item/roller,
+/obj/random/medical,
+/obj/random/medical_lowcost,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/dungeon/outside/smuggler_zone_u)
+"cA" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/dungeon/outside/smuggler_zone_u)
 "cB" = (
 /obj/machinery/light/floor,
 /mob/living/carbon/superior_animal/robot/greyson/custodian/engineer,
@@ -625,8 +690,10 @@
 /turf/simulated/wall/wood_old,
 /area/asteroid/rogue)
 "cF" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/white/brown_perforated,
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/random/medical_lowcost_handmade,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "cG" = (
 /obj/machinery/door/unpowered/simple/wood,
@@ -745,12 +812,45 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/meadow)
+"de" = (
+/obj/structure/table/standard,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment,
+/obj/item/stack/medical/splint,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost_handmade,
+/obj/random/medical_lowcost,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/dungeon/outside/smuggler_zone_u)
 "df" = (
 /obj/random/furniture/bedsheet,
 /obj/landmark/join/late/dormitory_outsider,
 /obj/structure/bed/padded,
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
+"dg" = (
+/obj/structure/table/standard,
+/obj/item/reagent_containers/glass/bottle/aluminum,
+/obj/item/reagent_containers/glass/bottle/ammonia,
+/obj/item/reagent_containers/glass/bottle/carbon,
+/obj/item/reagent_containers/glass/bottle/copper,
+/obj/item/reagent_containers/glass/bottle/ethanol,
+/obj/item/reagent_containers/glass/bottle/hclacid,
+/obj/item/reagent_containers/glass/bottle/hydrazine,
+/obj/item/reagent_containers/glass/bottle/mercury,
+/obj/item/reagent_containers/glass/bottle/phosphorus,
+/obj/item/reagent_containers/glass/bottle/pacid,
+/obj/item/reagent_containers/glass/bottle/potassium,
+/obj/item/reagent_containers/glass/bottle/phosphorus,
+/obj/item/reagent_containers/glass/bottle/radium,
+/obj/item/reagent_containers/glass/bottle/sacid,
+/obj/item/reagent_containers/glass/bottle/silicon,
+/obj/item/reagent_containers/glass/bottle/sodium,
+/obj/item/reagent_containers/glass/bottle/sulfur,
+/obj/item/reagent_containers/glass/bottle/tungsten,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/dungeon/outside/smuggler_zone_u)
 "dh" = (
 /obj/structure/table/rack,
 /obj/random/junkfood,
@@ -792,21 +892,18 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "do" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/closet/random_medsupply,
+/obj/random/medical_lowcost,
+/turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "dp" = (
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "dq" = (
-/obj/machinery/sleeper{
-	dir = 4;
-	icon_state = "sleeper_0"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/smuggler_zone_u)
+/obj/effect/decal/cleanable/dirt,
+/obj/random/traps/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/dungeon/outside/zoo)
 "dr" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/uplink,
@@ -878,6 +975,10 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
+"dC" = (
+/obj/random/traps/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/dungeon/outside/zoo)
 "dD" = (
 /obj/random/cluster/spiders/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -888,12 +989,15 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/forest)
+"dF" = (
+/obj/random/traps/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/zoo)
 "dG" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/bodybags,
-/obj/item/roller,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/smuggler_zone_u)
+/obj/item/stack/rods,
+/obj/random/traps/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/zoo)
 "dH" = (
 /obj/structure/sign/medsci/firstaidstation{
 	pixel_x = -30
@@ -901,10 +1005,9 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "dI" = (
-/obj/structure/table/standard,
-/obj/item/roller,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/smuggler_zone_u)
+/obj/random/traps/low_chance,
+/turf/simulated/floor/beach/sand/desert,
+/area/nadezhda/dungeon/outside/zoo)
 "dJ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -943,6 +1046,14 @@
 /obj/random/lathe_disk/advanced,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/dungeon/outside/prepper)
+"dR" = (
+/obj/structure/table/onestar,
+/obj/structure/flora/pottedplant/dead{
+	oldified = 1;
+	pixel_y = 8
+	},
+/turf/simulated/floor/beach/sand,
+/area/nadezhda/outside/one_star)
 "dS" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/small/bushb1,
@@ -1532,6 +1643,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
+"fQ" = (
+/obj/machinery/light/floor,
+/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star)
 "fR" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 4;
@@ -2096,9 +2212,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"ia" = (
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/zoo)
 "ib" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
@@ -4164,10 +4277,6 @@
 /obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/nadezhda/dungeon/outside/zoo)
-"pe" = (
-/obj/item/stack/rods,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/zoo)
 "pf" = (
 /obj/item/stack/rods,
 /obj/item/material/shard,
@@ -6050,19 +6159,8 @@
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"vZ" = (
-/obj/map_data/nadezda_s,
-/turf/unsimulated/mineral,
-/area/colony/exposedsun/pastgate)
 "wa" = (
 /obj/machinery/body_scanconsole,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/dungeon/outside/smuggler_zone_u)
-"wb" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "wc" = (
@@ -6086,13 +6184,6 @@
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"wg" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/tablet/lease/preset/chemistry,
-/obj/item/device/scanner/mass_spectrometer/adv,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/dungeon/outside/smuggler_zone_u)
 "wh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -6108,10 +6199,6 @@
 /obj/random/medical_lowcost/low_chance,
 /obj/random/medical_lowcost/low_chance,
 /turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/smuggler_zone_u)
-"wj" = (
-/obj/machinery/chemical_dispenser,
-/turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "wk" = (
 /obj/structure/table/standard,
@@ -6143,10 +6230,6 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/dungeon/outside/smuggler_zone_u)
-"wn" = (
-/obj/structure/closet/random_medsupply,
-/turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "wo" = (
 /obj/random/pack/junk_machine,
@@ -11722,10 +11805,6 @@
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"TD" = (
-/obj/structure/flora/pottedplant/dead,
-/turf/simulated/floor/beach/sand,
-/area/nadezhda/outside/one_star)
 "TG" = (
 /mob/living/simple_animal/hostile/hivebot{
 	health = 400
@@ -15037,13 +15116,13 @@ bm
 bn
 cc
 cf
-do
+bK
 dp
 dJ
 dp
 wd
 we
-wj
+dg
 bm
 sS
 aV
@@ -15246,7 +15325,7 @@ bm
 bo
 dN
 cg
-dp
+cl
 dp
 dK
 dp
@@ -15455,12 +15534,12 @@ bm
 bp
 cc
 cq
-dq
+cn
 ez
 wa
 dp
-cd
-wg
+de
+cy
 wl
 bm
 sS
@@ -15663,8 +15742,8 @@ sS
 bm
 bq
 cd
-cF
-dp
+bE
+cr
 dp
 dp
 dp
@@ -15879,7 +15958,7 @@ dp
 dp
 we
 wd
-wj
+dg
 bm
 sS
 aV
@@ -16088,7 +16167,7 @@ dp
 dp
 cc
 cc
-wn
+do
 bm
 sS
 aV
@@ -16291,13 +16370,13 @@ bm
 bD
 cd
 cd
-dG
-dI
-wb
-dp
+cs
+cz
+cA
+cF
 cc
 wh
-wn
+do
 bm
 sS
 aV
@@ -55193,7 +55272,7 @@ fF
 fF
 fF
 fF
-vZ
+fF
 "}
 (2,1,2) = {"
 ab
@@ -71398,14 +71477,14 @@ al
 pQ
 af
 af
-pJ
+fQ
 al
 al
 al
 al
-pI
+Ld
 af
-TD
+dR
 af
 Ov
 Oy
@@ -72652,14 +72731,14 @@ al
 pQ
 af
 af
-pJ
+fQ
 al
 al
 al
 al
-pI
+Ld
 af
-TD
+dR
 af
 sh
 sh
@@ -92050,7 +92129,7 @@ nE
 KA
 nZ
 pa
-ia
+dF
 pt
 pt
 pt
@@ -92257,7 +92336,7 @@ lx
 lx
 nE
 nT
-nZ
+dq
 oW
 ib
 pt
@@ -92663,8 +92742,8 @@ lx
 lx
 lx
 lx
-nj
-kn
+WL
+WL
 nW
 kn
 lx
@@ -92672,7 +92751,7 @@ WL
 kn
 lx
 lx
-kn
+WL
 wV
 nZ
 oX
@@ -92876,7 +92955,7 @@ kn
 kn
 ke
 kn
-lx
+WL
 lx
 lx
 YA
@@ -92885,7 +92964,7 @@ kn
 oF
 nT
 nZ
-nT
+dC
 ib
 pt
 pt
@@ -93084,7 +93163,7 @@ kn
 kn
 nS
 gt
-kn
+WL
 kn
 lx
 lx
@@ -93095,7 +93174,7 @@ nE
 nT
 nZ
 pb
-pe
+dG
 pt
 pt
 pq
@@ -93306,7 +93385,7 @@ nZ
 nZ
 pf
 pt
-pt
+dI
 pt
 py
 pD

--- a/maps/Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -1,4 +1,32 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aaa" = (
+/obj/structure/table/woodentable,
+/obj/item/oddity/ls/puzzlebox,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/maintenance/undergroundfloor1north)
+"aab" = (
+/obj/structure/table/woodentable,
+/obj/item/cardholder,
+/obj/item/cardholder/squirl,
+/obj/item/cardholder,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/maintenance/undergroundfloor1north)
+"aac" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/burrow{
+	deepmaint_entry_point = 1;
+	desc = "Cracks on the floor, yet you can see shifting lights and hear the tick of crawling clawed beasts below...";
+	isSealed = 1;
+	name = "strange cracks"
+	},
+/obj/random/mob/nightmare/low_chance,
+/turf/simulated/floor/asteroid/dirt/burned,
+/area/colony)
+"aad" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral,
+/area/colony)
 "aae" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/cobweb2{
@@ -8,10 +36,97 @@
 /obj/random/scrap,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"aaf" = (
+/obj/machinery/door/airlock/maintenance_engineering{
+	name = "Engineering Maintenance";
+	req_access = list(10)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/substation/section5)
+"aag" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/crew_quarters/sleep/cryo2)
+"aah" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/cyancorner,
+/area/nadezhda/crew_quarters/sleep/cryo2)
+"aai" = (
+/obj/machinery/holoposter{
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central6{
+	pixel_y = -10
+	},
+/obj/landmark/join/late/cryo/elevator,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/crew_quarters/sleep/cryo2)
+"aaj" = (
+/obj/machinery/camera/network/cev_eris,
+/turf/simulated/floor/tiled/dark/cyancorner,
+/area/nadezhda/crew_quarters/sleep/cryo2)
+"aak" = (
+/obj/machinery/computer/cryopod/elevator{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark/cyancorner,
+/area/nadezhda/crew_quarters/sleep/cryo2)
 "aam" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,10"
 	},
+/area/nadezhda/hallway/main/stairwell)
+"aan" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/crew_quarters/sleep/cryo2)
+"aap" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/unsimulated/mineral,
+/area/nadezhda/security/armory_blackshield)
+"aaq" = (
+/turf/unsimulated/mineral,
+/area/nadezhda/security/armory_blackshield)
+"aar" = (
+/turf/unsimulated/mineral,
+/area/nadezhda/command/gmaster)
+"aas" = (
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
+"aat" = (
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/multi_tile,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/hallway/main/stairwell)
+"aau" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "aav" = (
 /obj/machinery/power/apc{
@@ -25,6 +140,22 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
+"aaw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/hallway/main/stairwell)
+"aax" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/obj/machinery/camera/network/cev_eris{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
+"aay" = (
+/turf/simulated/mineral,
+/area/nadezhda/engineering/workshop)
 "aaz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -46,6 +177,10 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
+"aaB" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "aaC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -3244,18 +3379,6 @@
 /area/nadezhda/security{
 	name = "Security Training"
 	})
-"aMh" = (
-/obj/machinery/door/airlock/maintenance_engineering{
-	name = "Engineering Maintenance";
-	req_access = list(10)
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/substation/section5)
 "aMj" = (
 /obj/random/structures,
 /obj/effect/spider/stickyweb,
@@ -6249,16 +6372,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"bxB" = (
-/obj/machinery/computer/cryopod/elevator{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/crew_quarters/sleep/cryo2)
 "bxC" = (
 /obj/structure/closet/random_milsupply,
 /obj/machinery/light/small{
@@ -7307,17 +7420,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"bKc" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/burrow{
-	deepmaint_entry_point = 1;
-	desc = "Cracks on the floor, yet you can see shifting lights and hear the tick of crawling clawed beasts below...";
-	name = "strange cracks"
-	},
-/obj/random/mob/nightmare/low_chance,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/colony)
 "bKj" = (
 /turf/simulated/wall,
 /area/nadezhda/quartermaster/office)
@@ -9808,11 +9910,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
-"cnd" = (
-/obj/structure/table/woodentable,
-/obj/item/oddity/nt/openedpuzzlebox,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/maintenance/undergroundfloor1north)
 "cnh" = (
 /obj/machinery/camera/network/cev_eris{
 	dir = 4
@@ -11149,14 +11246,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
-"cCi" = (
-/obj/machinery/holoposter{
-	pixel_y = 32
-	},
-/obj/landmark/join/late/cryo/elevator,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/crew_quarters/sleep/cryo2)
 "cCu" = (
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -33476,12 +33565,6 @@
 /obj/structure/closet/lasertag/blue,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/security/tactical_blackshield)
-"hCB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
 "hCV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warningred{
@@ -55099,15 +55182,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"mtc" = (
-/obj/structure/table/standard,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/crew_quarters/sleep/cryo2)
 "mtm" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -64500,9 +64574,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
-"oyY" = (
-/turf/simulated/mineral,
-/area/nadezhda/command/gmaster)
 "ozb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
@@ -69655,11 +69726,6 @@
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
-"pJQ" = (
-/obj/machinery/camera/network/cev_eris,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/crew_quarters/sleep/cryo2)
 "pJR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -86129,14 +86195,6 @@
 /obj/machinery/computer/rdconsole/core,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/bridge)
-"trY" = (
-/obj/structure/table/woodentable,
-/obj/item/cardholder,
-/obj/item/cardholder/shell,
-/obj/item/cardholder/squirl,
-/obj/item/cardholder,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/maintenance/undergroundfloor1north)
 "tse" = (
 /obj/machinery/atm{
 	dir = 1;
@@ -86199,14 +86257,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"tsQ" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
 "tsS" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/surgery,
@@ -88430,14 +88480,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/medical/sleeper)
-"tUh" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
 "tUD" = (
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/industrial/hatch,
@@ -88758,14 +88800,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
-"tZr" = (
-/obj/structure/disposalpipe/segment,
-/obj/random/furniture/pottedplant,
-/obj/machinery/holoposter{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white/cargo,
-/area/nadezhda/hallway/main/stairwell)
 "tZt" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -98936,15 +98970,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"wfx" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/hallway/main/stairwell)
 "wfJ" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "WO"
@@ -116024,10 +116049,10 @@ nNr
 rVH
 kWE
 gEI
-hfy
-bxB
-rNn
 bmT
+aah
+aak
+hfy
 hfy
 ehF
 rNn
@@ -116226,10 +116251,10 @@ dAi
 gEI
 rtf
 gEI
-xno
+aag
 ydY
 emM
-mtc
+xno
 hfy
 gIY
 lOY
@@ -116428,10 +116453,10 @@ lKM
 gEI
 gEI
 gEI
-hfy
-cCi
-buw
 jnM
+lOY
+aai
+hfy
 hfy
 rPm
 wYZ
@@ -116630,10 +116655,10 @@ nNr
 xxw
 cak
 gEI
-xno
+jnt
 lOY
 emM
-jnt
+xno
 hfy
 buw
 buw
@@ -116832,10 +116857,10 @@ kiZ
 gEI
 gEI
 gEI
-hfy
-pJQ
-emM
 mGe
+lOY
+aan
+hfy
 hfy
 laf
 nHR
@@ -117035,7 +117060,7 @@ gEI
 gEI
 gEI
 hfy
-rNn
+aaj
 hfy
 hfy
 hfy
@@ -136975,7 +137000,7 @@ wjj
 sPD
 iYe
 lhL
-cnd
+aaa
 vDd
 iYe
 iYe
@@ -137994,8 +138019,8 @@ wjj
 wjj
 oJG
 dJd
-bKc
-dJd
+aac
+aad
 hSx
 sFI
 sFI
@@ -139400,7 +139425,7 @@ iYe
 iYe
 fJz
 wjj
-trY
+aab
 uwD
 wjj
 rSP
@@ -142253,7 +142278,7 @@ pqo
 pqo
 kZI
 hKB
-aMh
+aaf
 aPK
 aXC
 bbE
@@ -166495,7 +166520,7 @@ giH
 wDK
 tnX
 bZM
-uoL
+aaB
 tnX
 fbv
 hVN
@@ -167480,14 +167505,14 @@ eEn
 vLg
 eEn
 eEn
-eEn
-eEn
+aaq
+aaq
 hSx
 ncI
 xCT
-xCT
-xCT
-xCT
+tnX
+tnX
+tnX
 xCT
 xCT
 tnX
@@ -167679,16 +167704,16 @@ hSx
 eEn
 eEn
 eEn
-vLg
-eEn
+aap
+aaq
 hSx
 hSx
-hSx
-hSx
-ncI
+xGi
+xGi
 tnX
 tnX
 tnX
+dVP
 tnX
 tnX
 tnX
@@ -167882,15 +167907,15 @@ hSx
 hSx
 hSx
 coc
-ncI
-ncI
 tnX
 tnX
 tnX
 tnX
-tnX
-tnX
-dVP
+aas
+iBP
+uog
+uog
+aau
 uog
 iBP
 uoL
@@ -168085,11 +168110,11 @@ tYb
 tYb
 dfa
 toD
-toD
-toD
-toD
-tZr
-tUh
+azK
+azK
+azK
+azK
+azK
 azK
 lFr
 nAF
@@ -168288,15 +168313,15 @@ hSx
 hSx
 tnX
 tRD
-tsQ
+uog
 uog
 uog
 uoL
 uoL
 qDv
 uoL
-hCB
-uoL
+aax
+uog
 uog
 uoL
 uog
@@ -168493,12 +168518,12 @@ ldN
 uoL
 vFY
 uog
-uog
-uog
-uog
-uoL
-vbu
-oci
+tnX
+tnX
+tnX
+aaw
+tnX
+tnX
 tRD
 tnX
 tnX
@@ -168697,26 +168722,26 @@ uog
 tnX
 tnX
 tnX
+xCT
+xCT
+xCT
+tnX
+tnX
+tnX
+xCT
+xCT
 tnX
 tnX
 tnX
 tnX
-tnX
-tnX
-tnX
-tnX
-tnX
-tnX
-tnX
-tnX
-tnX
-tnX
-tnX
-tnX
-tnX
-tnX
-tnX
-tnX
+xCT
+xCT
+xCT
+xCT
+xCT
+xCT
+xCT
+xCT
 toD
 tqO
 fgf
@@ -168896,10 +168921,10 @@ tnX
 tNN
 uog
 uoL
-wfx
+aat
 wVp
 tnX
-tnX
+xCT
 sFI
 sFI
 sFI
@@ -168916,9 +168941,9 @@ sFI
 sFI
 sFI
 sFI
-tnX
-tnX
-tnX
+xCT
+xCT
+xCT
 tnX
 cUR
 fgf
@@ -169101,26 +169126,26 @@ uog
 wii
 wWc
 tnX
-tnX
+xCT
+sFI
+sFI
+hSx
+sFI
+hSx
+hSx
+hSx
+sFI
+sFI
+hSx
+hSx
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-tnX
-tnX
-tnX
+hSx
+hSx
+xCT
+xCT
+xCT
 tnX
 tRD
 fgf
@@ -169303,26 +169328,26 @@ eeI
 tnX
 tnX
 tnX
-tnX
+xCT
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-tnX
-tnX
-tnX
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
+ncI
+xCT
+xCT
 tnX
 tnX
 tnX
@@ -169508,8 +169533,8 @@ xCT
 xCT
 sFI
 sFI
-sFI
-sFI
+hSx
+hSx
 jXV
 jXV
 jXV
@@ -169522,9 +169547,9 @@ jXV
 jXV
 jXV
 rgK
-rgK
-rgK
-rgK
+aay
+aay
+aay
 rgK
 wiT
 wXe
@@ -169707,11 +169732,11 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+hSx
+hSx
+hSx
+hSx
+hSx
 jXV
 mTr
 mZG
@@ -169903,13 +169928,13 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
 jXV
 jXV
 jXV
@@ -170104,8 +170129,8 @@ sFI
 sFI
 sFI
 sFI
-sFI
-oyY
+hSx
+aar
 jXV
 jXV
 jXV
@@ -170306,7 +170331,7 @@ sFI
 sFI
 sFI
 sFI
-sFI
+hSx
 jXV
 jXV
 nEk
@@ -170508,7 +170533,7 @@ sFI
 sFI
 sFI
 sFI
-sFI
+hSx
 jXV
 lOw
 nEk
@@ -170710,7 +170735,7 @@ sFI
 sFI
 sFI
 sFI
-sFI
+hSx
 jXV
 dna
 uVy
@@ -170912,7 +170937,7 @@ sFI
 eaA
 eaA
 eaA
-eaA
+etI
 eyR
 eyR
 eyR

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -2765,6 +2765,7 @@
 #include "code\modules\reagents\reagent_containers\food\snacks\meat.dm"
 #include "code\modules\reagents\reagent_containers\glass\beaker.dm"
 #include "code\modules\reagents\reagent_containers\glass\bottle.dm"
+#include "code\modules\reagents\reagent_containers\glass\bottled_chemicals.dm"
 #include "code\modules\reagents\reagent_containers\glass\bottle\robot.dm"
 #include "code\modules\reagents\reagents\core.dm"
 #include "code\modules\reagents\reagents\dispenser.dm"


### PR DESCRIPTION
Removes and replaces the sleepers, and chem dispenders in void wolfs. Replacing them with more medical gear and bottled chems rather then the boards needed to produce endless chems

Fixes a deepmaints spawn
Flips the lifts and improves the stairwell hallway to look better
Makes tunneling harder into GM room silently