### PR TITLE
Fix detective kit

### DIFF
--- a/code/modules/detectivework/tools/crimekit.dm
+++ b/code/modules/detectivework/tools/crimekit.dm
@@ -5,13 +5,30 @@
 	icon = 'icons/obj/forensics.dmi'
 	icon_state = "case"
 	item_state = "case"
-	storage_slots = 12 //Techinnally better then a harness but, much bigger so no stacking them in bags
+	storage_slots = 21 //Should be used for detecive work only, 3 rows of storage
 	slot_flags = SLOT_BELT //This one is techinnally meant to be on a detective at all times
 	price_tag = 50
+	can_hold = list(/obj/item/forensics,
+					/obj/item/storage/box/swabs,
+					/obj/item/storage/box/fingerprints,
+					/obj/item/storage/box/evidence,
+					/obj/item/reagent_containers,
+					/obj/item/device,
+					/obj/item/evidencebag,
+					/obj/item/taperoll,
+					/obj/item/pen,
+					/obj/item/storage/fancy/crayons,
+					/obj/item/clothing/gloves,
+					/obj/item/clothing/glasses,
+					/obj/item/photo,
+					/obj/item/storage/photo_album,
+					/obj/item/flame/lighter,
+					/obj/item/sample)
 
 /obj/item/storage/briefcase/crimekit/populate_contents()
 	new /obj/item/storage/box/swabs(src)
 	new /obj/item/storage/box/fingerprints(src)
+	new /obj/item/storage/box/evidence(src)
 	new /obj/item/reagent_containers/spray/luminol(src)
 	new /obj/item/device/uv_light(src)
 	new /obj/item/forensics/sample_kit(src)


### PR DESCRIPTION
Detective kit has been rebalanced to better suit detective work then general storage

Detective kit wasnt meant to stick 12 first aid kits, or 12 guns or any sort of thing like that. So now it holds 21 (3 rows) of detective gear and some other basic things