### PR TITLE
Tacticoool

### DIFF
--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -224,7 +224,7 @@
 
 /datum/perk/parkour
 	name = "Raiders Leap"
-	desc = "You can climb some objects faster than normal thanks to a life of raiding ships, settlements, and anywhere plunder was."
+	desc = "You cling to railings and low walls, climb faster, and get up after diving or sliding sooner hanks to a life of raiding ships, settlements, and anywhere plunder was"
 	//icon_state = "parkour" //https://game-icons.net/1x1/delapouite/jump-across.html
 
 /datum/perk/parkour/assign(mob/living/carbon/human/H)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -193,7 +193,13 @@
 		//cap projectile damage so that there's still a minimum number of hits required to break the door
 			take_damage(min(damage, 100))
 
-
+/obj/machinery/door/proc/hit_by_living(var/mob/living/M)
+	var/body_part = pick(BP_HEAD, BP_CHEST, BP_GROIN)
+	visible_message(SPAN_DANGER("[M] slams against \the [src]!"))
+	if(prob(30))
+		M.Weaken(1)
+	M.damage_through_armor(8, BRUTE, body_part, ARMOR_MELEE)
+	take_damage(M.mob_size)
 
 /obj/machinery/door/hitby(AM as mob|obj, var/speed=5)
 
@@ -203,8 +209,8 @@
 		var/obj/item/O = AM
 		damage = O.throwforce
 	else if (istype(AM, /mob/living))
-		var/mob/living/M = AM
-		damage = M.mob_size
+		hit_by_living(AM)
+		return
 	take_damage(damage)
 	return
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -193,6 +193,11 @@
 
 /obj/structure/window/hitby(AM as mob|obj)
 	..()
+
+	if(isliving(AM))
+		hit_by_living(AM)
+		return
+
 	visible_message(SPAN_DANGER("[src] was hit by [AM]."))
 	var/tforce = 0
 	if(ismob(AM))
@@ -278,6 +283,20 @@
 	sleep(5) //Allow a littleanimating time
 	return TRUE
 
+/obj/structure/window/proc/hit_by_living(var/mob/living/M)
+	var/body_part = pick(BP_HEAD, BP_CHEST, BP_GROIN)
+	visible_message(SPAN_DANGER("[M] slams against \the [src]!"))
+	if(prob(30))
+		M.Weaken(1)
+	M.damage_through_armor(8, BRUTE, body_part, ARMOR_MELEE)
+
+	var/tforce = 15
+	if(reinf) tforce *= 0.25
+	if(health - tforce <= 7 && !reinf)
+		set_anchored(FALSE)
+		step(src, get_dir(M, src))
+	hit(tforce)
+	mount_check()
 
 /obj/structure/window/attackby(obj/item/I, mob/user)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -622,7 +622,6 @@ default behaviour is:
 			while(livmomentum > 0 && C.true_dir)
 				H.Move(get_step(H.loc, dir),dir)
 				livmomentum = (livmomentum - speed)
-				H.regen_slickness(0.25) // The longer you slide, the more stylish it is
 				sleep(world.tick_lag + 1)
 			C.mloop = 0
 		else
@@ -637,7 +636,7 @@ default behaviour is:
 mob/living/carbon/human/verb/stopSliding()
 	set hidden = 1
 	set instant = 1
-	src.livmomentum = 0
+	livmomentum = 0
 
 /mob/living/proc/cannot_use_vents()
 	return "You can't fit into that vent."

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -590,51 +590,54 @@ default behaviour is:
 	set name = "Rest"
 	set category = "IC"
 
-	var/state_changed = FALSE
-	if(resting && can_stand_up())
-		resting = FALSE
-		state_changed = TRUE
-
-
-	else if (!resting)
-		if(ishuman(src))
-			var/obj/item/bedsheet/BS = locate(/obj/item/bedsheet) in get_turf(src)
-			// If there is unrolled bedsheet roll and unroll it to get in bed like a proper adult does
-			if(BS && !BS.rolled && !BS.folded)
-				resting = TRUE
-				BS.toggle_roll(src, no_message = TRUE)
-				BS.toggle_roll(src)
-			else
-				resting = TRUE
-			state_changed = TRUE
+	if(resting && unstack)
+		unstack = FALSE
+		if((livmomentum <= 0) && do_after(src, (src.stats.getPerk(PERK_PARKOUR) ? 0.3 SECONDS : 0.7 SECONDS), null, 0, 1, INCAPACITATION_DEFAULT, immobile = 0))
+			resting = FALSE
+			unstack = TRUE
+			to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")
+			update_lying_buckled_and_verb_status()
 		else
-			resting = TRUE
-			state_changed = TRUE
-	if(state_changed)
-		to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"]</span>")
-		update_lying_buckled_and_verb_status()
-
-/mob/living/proc/can_stand_up()
-	var/no_blankets = FALSE
-	no_blankets = unblanket()
-
-	if(no_blankets)
-		return TRUE
-	else
-		to_chat(src, SPAN_WARNING("You can't stand up, bedsheets are in the way and you struggle to get rid of them."))
-		return FALSE
-
-//used to push away bedsheets in order to stand up, only humans will roll them (see overriden human proc)
-/mob/living/proc/unblanket()
-	var/obj/item/bedsheet/blankets = (locate(/obj/item/bedsheet) in loc)
-	if (blankets && !blankets.rolled && !blankets.folded)
-		return blankets.toggle_roll(src)
-	return TRUE
+			unstack = TRUE
+	else if (!resting)
+		var/client/C = src.client
+		var/speed = movement_delay()
+		resting = TRUE
+		var/dir = C.true_dir
+		if(ishuman(src) && (dir))// If true_dir = 0(src isn't moving), doesn't proc
+			var/mob/living/carbon/human/H = src
+			livmomentum = 5 // Set momentum value as soon as possible for stopSliding to work better
+			to_chat(H, SPAN_NOTICE("You dive onwards!"))
+			pass_flags += PASSTABLE // Jump over them!
+			H.allow_spin = FALSE
+			var/is_jump = FALSE
+			if(istype(get_step(H, dir), /turf/simulated/open))
+				is_jump = TRUE
+			H.throw_at(get_edge_target_turf(H, dir), 2 + is_jump, 1)// "Diving"; if you dive over a table, your momentum is set to 0. If you dive over space, you are thrown a tile further.
+			update_lying_buckled_and_verb_status()
+			pass_flags -= PASSTABLE // Jumpn't over them anymore!
+			H.allow_spin = TRUE
+			sleep(2)
+			C.mloop = 1
+			while(livmomentum > 0 && C.true_dir)
+				H.Move(get_step(H.loc, dir),dir)
+				livmomentum = (livmomentum - speed)
+				H.regen_slickness(0.25) // The longer you slide, the more stylish it is
+				sleep(world.tick_lag + 1)
+			C.mloop = 0
+		else
+			to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"].</span>")
+			update_lying_buckled_and_verb_status()
 
 /mob/living/simple_animal/spiderbot/is_allowed_vent_crawl_item(var/obj/item/carried_item)
 	if(carried_item == held_item)
 		return FALSE
 	return ..()
+
+mob/living/carbon/human/verb/stopSliding()
+	set hidden = 1
+	set instant = 1
+	src.livmomentum = 0
 
 /mob/living/proc/cannot_use_vents()
 	return "You can't fit into that vent."
@@ -650,6 +653,7 @@ default behaviour is:
 
 /mob/living/proc/trip(tripped_on, stun_duration)
 	return FALSE
+
 
 //damage/heal the mob ears and adjust the deaf amount
 /mob/living/adjustEarDamage(var/damage, var/deaf)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -38,6 +38,7 @@
 	var/mob_push_flags = 0
 	var/mob_always_swap = 0
 	var/move_to_delay = 4 //delay for the automated movement.
+	var/livmomentum = 0 //Used for advanced movement options.
 	var/can_burrow = FALSE //If true, this mob can travel around using the burrow network.
 	//When this mob spawns at roundstart, a burrow will be created near it if it can't find one
 
@@ -47,6 +48,7 @@
 
 	var/tod = null // Time of death
 	var/update_slimes = 1
+	var/unstack = 1 //prevent stacking of certain actions, like resting/diving
 	var/silent = 0 		// Can't talk. Value goes down every life proc.
 	var/on_fire = 0 //The "Are we on fire?" var
 	var/fire_stacks
@@ -73,7 +75,7 @@
 
 	//Mutations populated through horrendous genetic tampering.
 	var/datum/genetics/genetics_holder/unnatural_mutations
-	
+
 	//How much material is used by the cloning process
 	var/clone_difficulty = CLONE_MEDIUM
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -328,7 +328,7 @@
 		if(istype(rig))
 			rig.force_rest(src)
 	else
-		if(resting && can_stand_up())
+		if(resting)
 			resting = FALSE
 		else if (!resting)
 			resting = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/huntersprey.dm
+++ b/code/modules/mob/living/simple_animal/hostile/huntersprey.dm
@@ -199,7 +199,7 @@
 /mob/living/simple_animal/hostile/renderpatriarch/lay_down()
 	set category = "IC"
 	var/state_changed = FALSE
-	if(resting && can_stand_up())
+	if(resting)
 		resting = FALSE
 		state_changed = TRUE
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -737,7 +737,7 @@
 /mob/living/simple_animal/lay_down()
 	set name = "Rest"
 	set category = "Abilities"
-	if(resting && can_stand_up())
+	if(resting)
 		wake_up()
 	else if (!resting)
 		fall_asleep()

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -1,5 +1,10 @@
 /obj/item/var/list/center_of_mass = list("x"=16, "y"=16) //can be null for no exact placement behaviour
 /obj/structure/table/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if(isliving(mover))
+		var/mob/living/L = mover
+		L.livmomentum = 0
+		if(L.weakened)
+			return 1
 	if(air_group || (height==0)) return 1
 	if(istype(mover,/obj/item/projectile))
 		return (check_cover(mover,target))

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -167,6 +167,12 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+Y"
 		command = "Activate-Held-Object"
+	elem
+		name = "C"
+		command = "rest"
+	elem
+		name = "C+UP"
+		command = "stopSliding"
 	elem 
 		name = "Z"
 		command = "Activate-Held-Object"


### PR DESCRIPTION
By Kegdo
add: diving, sliding, rest while moving, hold rest to move
add: resting hotkey - C
tweak: parkour perk reduces the time it takes to stand up
tweak: can't stack resting action anymore

Tactical Combat design doc PR stage 1
Rest hotkey - C
Can't stack resting action anymore
You can dive and dodge now, based on rest(more info in the video in discord, too big to post here)
Removed bay leftover SHEET ROLLING PROC
Parkour perk reduces the time it takes to stand up
Diving is a 1-tile JUMP(you can bridge gaps!) which lets you pass over tables, so you can vault over a table and cover. Press C(rest) while moving. You may continue to hold down C after a dive to preserve your momentum and slide. This will allow you to close a few extra tiles at an increased speed until you run out of momentum, and dodge unaimed projectiles. Being faster increases the maximum range of sliding.

By Humonitarian
balance: diving range decreased
balance: Titanfall removed
balance: diving into windows and doors takes longer to break them, damages the jumpe