### PR TITLE
more CQC

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -8,8 +8,6 @@
 /datum/unarmed_attack/claws
 	attack_verb = list("scratched", "clawed", "slashed")
 	attack_noun = list("claws")
-	eye_attack_text = "claws"
-	eye_attack_text_victim = "sharp claws"
 	attack_sound = 'sound/weapons/slice.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	sharp = 1

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -15,9 +15,6 @@ var/global/list/sparring_attack_cache = list()
 	var/deal_halloss
 	var/sparring_variant_type = /datum/unarmed_attack/light_strike
 
-	var/eye_attack_text
-	var/eye_attack_text_victim
-
 /datum/unarmed_attack/proc/get_sparring_variant()
 	if(sparring_variant_type)
 		if(!sparring_attack_cache[sparring_variant_type])
@@ -112,8 +109,8 @@ var/global/list/sparring_attack_cache = list()
 	var/obj/item/organ/internal/eyes/eyes = target.random_organ_by_process(OP_EYES)
 	eyes.take_damage(rand(3,4), 1)
 
-	user.visible_message(SPAN_DANGER("[user] presses \his [eye_attack_text] into [target]'s [eyes.name]!"))
-	to_chat(target, SPAN_DANGER("You experience[(target.species.flags & NO_PAIN)? "" : " immense pain as you feel" ] [eye_attack_text_victim] being pressed into your [eyes.name][(target.species.flags & NO_PAIN)? "." : "!"]"))
+	user.visible_message(SPAN_DANGER("[user] presses \his fingers into [target]'s [eyes.name]!")) //no need to check for claws because only humans(monkeys?) can grab(no, humans and monkeys don't have claws)
+	to_chat(target, SPAN_DANGER("You experience[(target.species.flags & NO_PAIN)? "" : " immense pain as you feel" ] digits being pressed into your [eyes.name][(target.species.flags & NO_PAIN)? "." : "!"]"))
 
 /datum/unarmed_attack/bite
 	attack_verb = list("bit")
@@ -134,8 +131,6 @@ var/global/list/sparring_attack_cache = list()
 /datum/unarmed_attack/punch
 	attack_verb = list("punched")
 	attack_noun = list("fist")
-	eye_attack_text = "fingers"
-	eye_attack_text_victim = "digits"
 	damage = 0
 
 /datum/unarmed_attack/punch/hammer_fist

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -278,7 +278,7 @@
 			to_chat(assailant, SPAN_NOTICE("You squeeze [affecting], but nothing interesting happens."))
 			return
 
-		assailant.visible_message(SPAN_WARNING("[assailant] grabs [affecting] neck!"))
+		assailant.visible_message(SPAN_WARNING("[assailant] grabs [affecting] by the neck!"))
 		state = GRAB_NECK
 		icon_state = "grabbed+1"
 		assailant.set_dir(get_dir(assailant, affecting))
@@ -385,6 +385,10 @@
 						attack_eye(affecting, assailant)
 					else if(hit_zone == BP_HEAD)
 						headbut(affecting, assailant)
+					else if(hit_zone == BP_CHEST)
+						suplex(affecting, assailant)
+					else if(hit_zone == BP_GROIN)
+						dropkick(affecting, assailant)
 					else
 						dislocate(affecting, assailant, hit_zone)
 

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -100,7 +100,7 @@
 		kick_dir = turn(kick_dir, 180)
 	target.throw_at(get_edge_target_turf(target, kick_dir), 3, 1)
 	//deal damage AFTER the kick
-	var/damage = attacker.stats.getStat(STAT_ROB) / 3
+	var/damage = CLAMP(10, attacker.stats.getStat(STAT_ROB), 40) //SoJ edit to not be better then then an amr well also not dealing negitive damage
 	target.damage_through_armor(damage, BRUTE, BP_GROIN, ARMOR_MELEE)
 	//admin messaging
 	attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Dropkicked [target.name] ([target.ckey])</font>")

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -86,6 +86,54 @@
 
 	attack.handle_eye_attack(attacker, target)
 
+/obj/item/grab/proc/dropkick(mob/living/carbon/target, mob/living/carbon/human/attacker)
+	if(state < GRAB_AGGRESSIVE) //blue grab check
+		to_chat(attacker, SPAN_WARNING("You require a better grab to do this."))
+		return
+	if(target.lying)
+		return
+	visible_message(SPAN_DANGER("[attacker] dropkicks [target], pushing \him onwards!"))
+	attacker.Weaken(2)
+	target.Weaken(6) //the target will fly over tables, railings, etc.
+	var/kick_dir = get_dir(attacker, target)
+	if(attacker.loc == target.loc) // if we are on the same tile(e.g. neck grab), turn the direction to still push them away
+		kick_dir = turn(kick_dir, 180)
+	target.throw_at(get_edge_target_turf(target, kick_dir), 3, 1)
+	//deal damage AFTER the kick
+	var/damage = attacker.stats.getStat(STAT_ROB) / 3
+	target.damage_through_armor(damage, BRUTE, BP_GROIN, ARMOR_MELEE)
+	//admin messaging
+	attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Dropkicked [target.name] ([target.ckey])</font>")
+	target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Dropkicked by [attacker.name] ([attacker.ckey])</font>")
+	msg_admin_attack("[key_name(attacker)] has dropkicked [key_name(target)]")
+	//kill the grab
+	attacker.drop_from_inventory(src)
+	loc = null
+	qdel(src)
+
+/obj/item/grab/proc/suplex(mob/living/carbon/human/target, mob/living/carbon/human/attacker)
+	if(state < GRAB_NECK) //red grab check
+		to_chat(attacker, SPAN_WARNING("You require a better grab to do this."))
+		return
+	visible_message(SPAN_WARNING("[attacker] lifts [target] off the ground..." ))
+	attacker.next_move = world.time + 20 //2 seconds, also should prevent user from triggering this repeatedly
+	if(do_after(attacker, 20, progress=0) && target)
+		visible_message(SPAN_DANGER("...And falls backwards, slamming the opponent back onto the floor!"))
+		var/damage = CLAMP(15, attacker.stats.getStat(STAT_ROB) - 15, 50) //SoJ edit to not be better then then an amr well also not dealing negitive damage
+		target.damage_through_armor(damage, BRUTE, BP_CHEST, ARMOR_MELEE) //crunch
+		attacker.Weaken(2)
+		target.Stun(6)
+		playsound(loc, 'sound/machines/Table_Fall.ogg', 50, 1, -1)
+		//admin messaging
+		attacker.attack_log += text("\[[time_stamp()]\] <font color='red'>Suplexed [target.name] ([target.ckey])</font>")
+		target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Suplexed by [attacker.name] ([attacker.ckey])</font>")
+		msg_admin_attack("[key_name(attacker)] has suplexed [key_name(target)]")
+		//kill the grab
+		attacker.drop_from_inventory(src)
+		loc = null
+		qdel(src)
+
+
 /obj/item/grab/proc/headbut(mob/living/carbon/human/target, mob/living/carbon/human/attacker)
 	if(!istype(attacker))
 		return


### PR DESCRIPTION
By Kegdo 
add: suplex. Aim chest, neck grab, harm intent. Damage - (ROB/2)+15
add: dropkick. Aim groin, aggro grab, harm intent. Damage - (ROB/3)
spellcheck: fixed a few typos in eye attack and neck grabbing texts.
By Trilby
Rebalance the math of suplexing and drop kicking
Suplexing is now - CLAMP(15, attacker.stats.getStat(STAT_ROB) - 15, 50) aka min 15 max 50 
Drop kicking is now - CLAMP(10, attacker.stats.getStat(STAT_ROB), 40) aka min 10 max 40