### PR TITLE
Removes sliding from C, makes it so users have to macro it instead.

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -167,12 +167,6 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+Y"
 		command = "Activate-Held-Object"
-	elem
-		name = "C"
-		command = "rest"
-	elem
-		name = "C+UP"
-		command = "stopSliding"
 	elem 
 		name = "Z"
 		command = "Activate-Held-Object"


### PR DESCRIPTION
This was a stupid change.

Placing a key that STUNS YOU AND FORCES YOU TO DROP YOUR WEAPONS right next to the KEY TO SWITCH BETWEEN YOUR HANDS is a FUCKING AWFUL IDEA

Eris designers should be shot in the head.