### PR TITLE
Minor QoL

### DIFF
--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -652,9 +652,9 @@
 			else
 				to_chat(user, SPAN_WARNING("Decreases scope zoom by x[amount]"))
 
-		to_chat(user, SPAN_WARNING("Requires a weapon with the following properties"))
+		to_chat(user, SPAN_WARNING("Requires a weapon with the following properties:"))
 		to_chat(user, english_list(req_gun_tags))
-		to_chat(user, SPAN_WARNING("When applied to a weapon, this takes the following slot"))
+		to_chat(user, SPAN_WARNING("When applied to a weapon, this takes the following slot:"))
 		to_chat(user, "[gun_loc_tag]")
 
 /datum/component/item_upgrade/UnregisterFromParent()

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -21,7 +21,7 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.tool_upgrades = list(
 		UPGRADE_DEGRADATION_MULT = 0.65,
-		UPGRADE_FORCE_MOD = 1,
+		UPGRADE_FORCE_MOD = 1
 		)
 
 	I.required_qualities = list(QUALITY_BOLT_TURNING,QUALITY_PRYING, QUALITY_SAWING,QUALITY_SHOVELING,QUALITY_DIGGING,QUALITY_EXCAVATION)
@@ -377,7 +377,7 @@
 // 	 REFINEMENT: INCREASES PRECISION
 //------------------------------------------------
 /obj/item/tool_upgrade/refinement/laserguide
-	name = "Lonestars \"Guiding Light\" laser guide"
+	name = "\improper Lonestars \"Guiding Light\" laser guide"
 	desc = "A small visible laser which can be strapped onto any tool, giving an accurate representation of its target. Helps improve precision."
 	icon_state = "laser_guide"
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_URANIUM = 1)
@@ -389,7 +389,7 @@
 	I.tool_upgrades = list(
 	UPGRADE_PRECISION = 10)
 	I.weapon_upgrades = list(
-	GUN_UPGRADE_RECOIL = 0.9,
+	GUN_UPGRADE_RECOIL = 0.8,
 	UPGRADE_BULK = 1
 	)
 	I.gun_loc_tag = GUN_SIGHT

--- a/nano/templates/weapon_stats.tmpl
+++ b/nano/templates/weapon_stats.tmpl
@@ -200,6 +200,8 @@
 
 <div class="item">
 	<h3>Attachments:</h3>
+	Supports up to {{:data.upgrades_max}} attachments.
+
 	{{if data.attachments}}
 		<div class="statusDisplay" style="overflow: auto;">
 			<table style="width:100%;  overflow-wrap: break-all;">


### PR DESCRIPTION
-Guns now properly display how many attachments they support, standard is 5, but some guns can take more, less, or none at all. It also makes adding expansion ports to guns more clear.
-Fixed some minor typos.
-The lonestar  guiding light now gives -20% recoil instead of -10% given it takes uranium to make and is still inherently more useful on tools.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
