### PR TITLE
Bullet balance changes.

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -425,6 +425,7 @@
 		base += options[choice]
 		icon_state = base
 		item_state = base
+		item_state_slots = null
 		to_chat(M, "You roll your [choice].")
 		update_icon()
 		update_wear_icon()

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -46,8 +46,8 @@
 			L.reagents.add_reagent("stoxin", 5)
 
 /obj/item/projectile/bullet/pistol_35/hv
-	damage_types = list(BRUTE = 20)
-	armor_penetration = 10
+	damage_types = list(BRUTE = 10)
+	armor_penetration = 20
 	step_delay = 0.5
 	affective_damage_range = 4
 	affective_ap_range = 4
@@ -65,8 +65,8 @@
 
 /obj/item/projectile/bullet/pistol_35/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 18)
-	agony = 20
+	damage_types = list(BRUTE = 22)
+	agony = 18
 	armor_penetration = 0
 	penetrating = 0
 	can_ricochet = FALSE
@@ -117,8 +117,8 @@
 	step_delay = 0.4
 
 /obj/item/projectile/bullet/magnum_40/hv
-	damage_types = list(BRUTE = 28)
-	armor_penetration = 25
+	damage_types = list(BRUTE = 20)
+	armor_penetration = 33
 	penetrating = 1
 	step_delay = 0.25
 	nocap_structures = TRUE //Door breaching
@@ -146,9 +146,9 @@
 
 /obj/item/projectile/bullet/magnum_40/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 26)
+	damage_types = list(BRUTE = 29)
 	agony = 32
-	armor_penetration = 5
+	armor_penetration = 0
 	penetrating = 0
 	can_ricochet = FALSE
 	embed = TRUE
@@ -175,8 +175,8 @@
 
 /// .50 Kurtz ///
 /obj/item/projectile/bullet/kurtz_50
-	damage_types = list(BRUTE = 30)
-	armor_penetration = 20
+	damage_types = list(BRUTE = 35)
+	armor_penetration = 15
 	can_ricochet = TRUE
 	embed = TRUE
 	step_delay = 0.65
@@ -204,17 +204,17 @@
 
 /obj/item/projectile/bullet/kurtz_50/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 35)
-	agony = 35
-	armor_penetration = 5
+	damage_types = list(BRUTE = 40)
+	agony = 40
+	armor_penetration = 0
 	penetrating = 0
 	can_ricochet = FALSE
 	step_delay = 0.8
 
 /obj/item/projectile/bullet/kurtz_50/hv
 	name = "AV bullet"
-	damage_types = list(BRUTE = 40)
-	armor_penetration = 25
+	damage_types = list(BRUTE = 30)
+	armor_penetration = 35
 	penetrating = 2
 	can_ricochet = FALSE
 	step_delay = 0.45
@@ -248,8 +248,8 @@
 	step_delay = 0.5
 
 /obj/item/projectile/bullet/light_rifle_257/hv
-	damage_types = list(BRUTE = 26)
-	armor_penetration = 24
+	damage_types = list(BRUTE = 20)
+	armor_penetration = 30
 	penetrating = 2
 	hitscan = TRUE
 	affective_damage_range = 8 //Can snipe
@@ -270,9 +270,9 @@
 
 /obj/item/projectile/bullet/light_rifle_257/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 24)
-	agony = 20
-	armor_penetration = 5
+	damage_types = list(BRUTE = 26)
+	agony = 22
+	armor_penetration = 0
 	penetrating = 0
 	can_ricochet = FALSE
 	embed = TRUE
@@ -291,7 +291,7 @@
 ///7.5 Rifle///
 
 /obj/item/projectile/bullet/rifle_75
-	damage_types = list(BRUTE = 26)
+	damage_types = list(BRUTE = 25)
 	armor_penetration = 20
 	penetrating = 1
 	can_ricochet = TRUE
@@ -300,8 +300,8 @@
 	affective_ap_range = 5
 
 /obj/item/projectile/bullet/rifle_75/hv
-	damage_types = list(BRUTE = 25)
-	armor_penetration = 30
+	damage_types = list(BRUTE = 20)
+	armor_penetration = 35
 	penetrating = 2
 	can_ricochet = TRUE
 	step_delay = 0.3
@@ -341,7 +341,7 @@
 
 /obj/item/projectile/bullet/rifle_75/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 25)
+	damage_types = list(BRUTE = 30)
 	agony = 28
 	armor_penetration = 5
 	penetrating = 0
@@ -420,7 +420,7 @@
 
 /obj/item/projectile/bullet/c10x24
 	damage_types = list(BRUTE = 18)
-	armor_penetration = 15
+	armor_penetration = 18
 	penetrating = 2
 	can_ricochet = TRUE
 	sharp = TRUE
@@ -682,8 +682,8 @@
 /obj/item/projectile/bullet/crossbow_bolt
 	name = "bolt"
 	icon_state = "bolt"
-	damage_types = list(BRUTE = 54)
-	armor_penetration = 10
+	damage_types = list(BRUTE = 45)
+	armor_penetration = 15
 	knockback = 0 //Bug doups hits
 	step_delay = 0.9
 	affective_damage_range = 7
@@ -693,16 +693,16 @@
 /obj/item/projectile/bullet/crossbow_bolt/lethal
 	name = "bolt"
 	icon_state = "bolt"
-	damage_types = list(BRUTE = 56)
-	agony = 22
+	damage_types = list(BRUTE = 47)
+	agony = 29
 	armor_penetration = 5
 	step_delay = 0.9
 
 /obj/item/projectile/bullet/crossbow_bolt/hv
 	name = "bolt"
 	icon_state = "bolt"
-	damage_types = list(BRUTE = 58)
-	armor_penetration = 40
+	damage_types = list(BRUTE = 45)
+	armor_penetration = 55
 	penetrating = 3
 	hitscan = TRUE
 	affective_damage_range = 9


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>

General outline; The idea of these changes are to maintain roughly the same PVE experience while making HV/HP more niche(and subsequently more effective when used properly). As it currently stands, HV is the hottest kid on the block. This change won't make HV less useful, but it will force consideration. .408 SLAP will tear through someone in bulletproof armor, but if you bring it out against the scav in hand-made plate? You'll see better performance from ball with its more balanced performance. 
(also includes a small fix for a bug related to change_appearance for BDUs)
<hr>

.35 standard
Dam: 16
AP: 5

.35HP(the small numbers here made it hard to make meaningful change.)
Damage:18->22
Agony:20->18
AP: 0

,35HV
damage and AP reversed, against mobs this means the same damage but when it ocmes to players 
Damage: 20->10
AP 10->20

<hr>

.40 standard
Dam: 24
AP:10

.40 HV
Dam:28->20
AP: 25->33

.40HP
Damage: 26->29
Agony: 32
AP: 5->0

<hr>

.50 standard - First actual change to a standard. Damage raised a bit to put it between HV/HP in terms of AP/Damage
Dam: 30 ->35
AP:20->15

.50 HV
Damage: 40->30
AP: 25->35

.50 HP
dam: 35->40
Agony:35
AP:5->0

<hr>

.257 standard
Damage: 22
AP: 15

.257 HV
Damage:26->20
AP:24 -> 30

.257 HP
Damage: 24->26
Agony:22
AP: 5 ->0 

<hr>

7.5 standard
dam:26->25
AP:20

7.5 HV
Dam:25->20
AP:30->35

7.5 HP
dam:25->30
agony:28
AP:5->0

<hr>

.408 standard
dam:28
AP:30

.408 HV
Dam:32 - > 24
AP: 40 - > 48

.408 HP
Dam:30 -> 40 //not a 1/1 swap of Dam to AP but 40 is nuts good.
Agony:32
AP:15 -> 0 //No AP on HPs!!!!

<hr>

10x24 snowflake cartridge
dam: 18
AP: 15->18 //Trilbys suggestion. 

<hr>

Hunter bolt
dam:54-> 45
AP: 10->15

Hunter bolt HV
dam: 58 -> 40
AP:40 ->55

Hunter bolt HP
dam:56->47
Agony:22->29
AP:5 -> 0
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
