### PR TITLE
Massive greyson gauntlet and map improvements

### DIFF
--- a/code/game/objects/random/mob/greyson.dm
+++ b/code/game/objects/random/mob/greyson.dm
@@ -1,0 +1,110 @@
+//spawners
+/obj/random/mob/roomba
+	name = "random guntlet greyson bot (100% Spawns Any) stasis"
+	icon_state = "hostilemob-black"
+	has_postspawn = TRUE
+	alpha = 128
+
+/obj/random/mob/roomba/item_to_spawn()
+	return pickweight(list(
+				/mob/living/carbon/superior_animal/robot/greyson/roomba = 17,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/slayer = 15,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/trip = 10,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/trip/armored = 3,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/boomba = 7,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/armored = 5,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba = 10,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/plasma = 4,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical = 5,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical/med = 3,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical/med/healer = 3,
+				/mob/living/carbon/superior_animal/robot/greyson/custodian = 25,
+				/mob/living/carbon/superior_animal/robot/greyson/custodian/chef = 10,
+				/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer = 15,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic = 10,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol = 15,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg = 12,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle = 9,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy = 4,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = 3,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = 2
+				))
+
+/obj/random/mob/roomba/post_spawn(var/list/spawns)
+	for(var/mob/living/simple_animal/A in spawns)
+		A.stasis = TRUE
+
+/obj/random/mob/roomba/any
+	name = "random greyson bot (100% Spawns Any)"
+	has_postspawn = FALSE
+
+/obj/random/mob/roomba/job
+	name = "random greyson bot (100% Spawns Job based)"
+	has_postspawn = FALSE
+
+/obj/random/mob/roomba/job/item_to_spawn()
+	return pickweight(list(
+				/mob/living/carbon/superior_animal/robot/greyson/roomba = 15,
+				/mob/living/carbon/superior_animal/robot/greyson/custodian = 25,
+				/mob/living/carbon/superior_animal/robot/greyson/custodian/chef = 10,
+				/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer = 15,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic = 5,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = 1
+				))
+
+/obj/random/mob/roomba/melee
+	name = "random greyson bot (100% Spawns melee based)"
+	has_postspawn = FALSE
+
+/obj/random/mob/roomba/melee/item_to_spawn()
+	return pickweight(list(
+				/mob/living/carbon/superior_animal/robot/greyson/roomba = 25,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/slayer = 20,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/trip = 15,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/trip/armored = 10,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/boomba = 7,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical = 10,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical/med = 6,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical/med/healer = 6,
+				/mob/living/carbon/superior_animal/robot/greyson/custodian = 25,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic = 20,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = 2,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = 1
+				))
+
+/obj/random/mob/roomba/range
+	name = "random greyson bot (100% Spawns range based)"
+	has_postspawn = FALSE
+
+/obj/random/mob/roomba/range/low
+	name = "random greyson bot (10% Spawns range based)"
+	has_postspawn = FALSE
+	spawn_nothing_percentage = 90
+
+/obj/random/mob/roomba/range/item_to_spawn()
+	return pickweight(list(
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/armored = 7,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba = 12,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/plasma = 8,
+				/mob/living/carbon/superior_animal/robot/greyson/custodian/chef = 12,
+				/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer = 15,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol = 15,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg = 6,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle = 5,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy = 4
+				))
+
+/obj/random/mob/roomba/mecha
+	name = "random greyson bot (100% Spawns mecha based)"
+	has_postspawn = FALSE
+
+/obj/random/mob/roomba/mecha/low
+	name = "random greyson bot (10% Spawns mecha based)"
+	spawn_nothing_percentage = 90
+
+/obj/random/mob/roomba/mecha/item_to_spawn()
+	return pickweight(list(
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = 10,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = 1
+				))
+

--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/greyson/greyson.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/greyson/greyson.dm
@@ -6,38 +6,3 @@
 	faction = "greyson"
 	cant_be_pulled = TRUE
 
-//spawners
-/obj/random/mob/roomba
-	name = "random greyson bot"
-	icon_state = "hostilemob-black"
-	has_postspawn = TRUE
-	alpha = 128
-
-/obj/random/mob/roomba/item_to_spawn()
-	return pickweight(list(
-				/mob/living/carbon/superior_animal/robot/greyson/roomba = 17,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/slayer = 15,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/trip = 10,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/trip/armored = 3,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/boomba = 7,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/armored = 5,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba = 10,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/plasma = 4,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical = 5,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical/med = 3,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical/med/healer = 3,
-				/mob/living/carbon/superior_animal/robot/greyson/custodian = 25,
-				/mob/living/carbon/superior_animal/robot/greyson/custodian/chef = 10,
-				/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer = 15,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic = 10,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol = 15,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg = 12,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle = 9,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy = 4,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = 3,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = 2
-				))
-
-/obj/random/mob/roomba/post_spawn(var/list/spawns)
-	for(var/mob/living/simple_animal/A in spawns)
-		A.stasis = TRUE

--- a/maps/DeepForest/map/_Deep_Forest.dmm
+++ b/maps/DeepForest/map/_Deep_Forest.dmm
@@ -677,7 +677,6 @@
 /area/nadezhda/outside/one_star)
 "cC" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
 "cD" = (
@@ -1169,7 +1168,7 @@
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "eo" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "ep" = (
@@ -1638,7 +1637,7 @@
 /area/nadezhda/dungeon/outside/prepper)
 "fQ" = (
 /obj/machinery/light/floor,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "fR" = (
@@ -3314,6 +3313,10 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
+"lK" = (
+/obj/random/mob/roomba/mecha/low,
+/turf/simulated/floor/tiled/derelict/white_red_edges,
+/area/nadezhda/outside/one_star)
 "lL" = (
 /obj/machinery/disease2/incubator,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -4248,7 +4251,7 @@
 /obj/structure/bed/chair/custom/onestar/red{
 	dir = 4
 	},
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
 "pa" = (
@@ -4452,10 +4455,6 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"pR" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer,
-/turf/simulated/floor/tiled/derelict/red_white_edges,
-/area/nadezhda/outside/one_star)
 "pS" = (
 /obj/structure/bed/chair/custom/onestar{
 	dir = 1
@@ -4544,8 +4543,8 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "qf" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic,
-/turf/simulated/floor/tiled/derelict/white_big_edges,
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
 "qg" = (
 /obj/structure/window/reinforced{
@@ -4671,7 +4670,7 @@
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
 "qD" = (
-/mob/living/carbon/superior_animal/robot/greyson/roomba/boomba,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
 "qE" = (
@@ -4800,6 +4799,7 @@
 /obj/machinery/light/floor,
 /obj/structure/bed/chair/custom/onestar,
 /obj/item/remains,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
 "rb" = (
@@ -4833,13 +4833,14 @@
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
 "rh" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/asteroid/rogue)
 "ri" = (
-/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba,
-/turf/simulated/floor/tiled/derelict/red_white_edges,
-/area/asteroid/rogue)
+/obj/machinery/light/floor,
+/obj/random/mob/roomba/range,
+/turf/simulated/floor/tiled/derelict/white_big_edges,
+/area/nadezhda/outside/one_star)
 "rj" = (
 /obj/item/tank/onestar_regenerator,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -8139,6 +8140,10 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"DO" = (
+/obj/random/mob/roomba/range,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/nadezhda/outside/one_star)
 "DP" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/ausbushes/brflowers,
@@ -9104,6 +9109,10 @@
 /obj/structure/flora/small/bushb3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"HQ" = (
+/obj/random/mob/roomba/range,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star)
 "HR" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/big/bush2,
@@ -9700,7 +9709,7 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "Ki" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
 "Kj" = (
@@ -9805,10 +9814,6 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"KE" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
-/turf/simulated/floor/tiled/derelict/white_big_edges,
-/area/nadezhda/outside/one_star)
 "KF" = (
 /obj/item/folder/cyan,
 /obj/item/folder/cyan,
@@ -9823,7 +9828,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
 "KH" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg,
+/obj/random/mob/roomba/mecha/low,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
 "KI" = (
@@ -9831,7 +9836,7 @@
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/asteroid/rogue)
 "KJ" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg,
+/obj/random/mob/roomba/range/low,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/asteroid/rogue)
 "KK" = (
@@ -9893,11 +9898,6 @@
 /obj/item/clothing/suit/armor/heavy,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"KV" = (
-/obj/random/lathe_disk,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg,
-/turf/simulated/floor/tiled/derelict/red_white_edges,
-/area/nadezhda/outside/one_star)
 "KW" = (
 /mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -9928,10 +9928,6 @@
 "Lc" = (
 /mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
-/area/nadezhda/outside/one_star)
-"Ld" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy,
-/turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "Le" = (
 /mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg,
@@ -10821,7 +10817,7 @@
 "Pe" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/item/clothing/head/hairflower/yellow,
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
 "Pf" = (
@@ -10998,7 +10994,7 @@
 /obj/machinery/light/floor{
 	pixel_y = -7
 	},
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
 "PV" = (
@@ -11036,6 +11032,10 @@
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"Qf" = (
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star)
 "Qg" = (
 /turf/simulated/floor/asteroid/grass/colonialjungle4,
 /area/nadezhda/outside/forest)
@@ -11281,6 +11281,11 @@
 /obj/machinery/door/airlock/highsecurity,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
+"Rl" = (
+/obj/structure/catwalk,
+/obj/random/mob/roomba/range,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/one_star)
 "Rm" = (
 /obj/structure/bed/chair/custom/onestar{
 	dir = 1
@@ -11375,10 +11380,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
 "RH" = (
-/obj/machinery/light/floor,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic,
-/turf/simulated/floor/tiled/derelict,
-/area/nadezhda/outside/one_star)
+/obj/random/mob/roomba/range,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/asteroid/rogue)
 "RI" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/random/mob/vox,
@@ -11686,6 +11690,10 @@
 /obj/random/single,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"Td" = (
+/obj/random/mob/roomba/job,
+/turf/simulated/floor/tiled/derelict/white_red_edges,
+/area/nadezhda/outside/one_star)
 "Te" = (
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/mineral/planet,
@@ -11795,7 +11803,7 @@
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/forest)
 "TB" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
 "TC" = (
@@ -12461,6 +12469,11 @@
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"Wr" = (
+/obj/structure/catwalk,
+/obj/random/mob/roomba/mecha/low,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/one_star)
 "Ws" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/big/bush3,
@@ -12486,6 +12499,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"Wz" = (
+/obj/random/mob/roomba/job,
+/turf/simulated/floor/tiled/derelict/white_big_edges,
+/area/nadezhda/outside/one_star)
 "WB" = (
 /obj/structure/table/rack/shelf,
 /obj/random/tool/advanced/low_chance,
@@ -12571,7 +12588,7 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "WU" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "WV" = (
@@ -12584,6 +12601,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star)
+"WX" = (
+/obj/random/mob/roomba/range,
+/turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
 "WY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12705,7 +12726,7 @@
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
 "XF" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy,
+/obj/random/mob/roomba/range/low,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
 "XG" = (
@@ -12754,7 +12775,7 @@
 /area/nadezhda/outside/one_star)
 "XR" = (
 /obj/structure/window/reinforced,
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
 "XS" = (
@@ -13063,9 +13084,9 @@
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
 "Zf" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic,
+/obj/random/mob/roomba/mecha/low,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
-/area/nadezhda/outside/one_star)
+/area/asteroid/rogue)
 "Zg" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/derelict,
@@ -13215,6 +13236,10 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"ZM" = (
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star)
 "ZN" = (
 /obj/structure/flora/small/bushb3,
 /turf/simulated/mineral/planet,
@@ -28638,7 +28663,7 @@ aV
 af
 af
 pO
-yO
+ri
 pO
 af
 ai
@@ -29060,18 +29085,18 @@ qv
 KH
 af
 ai
-al
+qf
 al
 ak
 af
 av
-al
-qF
 qf
+qF
+ak
 af
 af
 ak
-aC
+KJ
 aC
 aC
 aC
@@ -29269,7 +29294,7 @@ ak
 ax
 af
 ai
-qf
+ak
 qI
 ak
 af
@@ -29699,7 +29724,7 @@ re
 af
 ak
 aC
-ri
+aC
 yf
 yf
 aC
@@ -29709,7 +29734,7 @@ aC
 aC
 aC
 aC
-rh
+aC
 aC
 aC
 ak
@@ -30119,7 +30144,7 @@ ak
 aC
 aC
 aC
-aC
+RH
 aC
 aC
 aC
@@ -30335,7 +30360,7 @@ JJ
 aC
 aC
 JO
-aC
+Zf
 pQ
 aC
 aC
@@ -30537,7 +30562,7 @@ ak
 aC
 aC
 aC
-aC
+RH
 aC
 aC
 aC
@@ -30749,7 +30774,7 @@ aC
 aC
 aC
 aC
-ri
+aC
 aC
 aC
 aC
@@ -30957,10 +30982,10 @@ aC
 yf
 yf
 aC
-aC
-aC
-aC
 rh
+aC
+aC
+aC
 aC
 aC
 aC
@@ -31370,7 +31395,7 @@ az
 af
 af
 ak
-rh
+aC
 aC
 yf
 yf
@@ -31569,8 +31594,8 @@ KH
 af
 aj
 qF
-al
-KE
+qf
+ak
 af
 aw
 qT
@@ -31579,7 +31604,7 @@ az
 af
 af
 ak
-aC
+KJ
 aC
 aC
 aC
@@ -31782,7 +31807,7 @@ pQ
 as
 af
 ak
-KV
+qU
 ra
 rd
 af
@@ -31982,7 +32007,7 @@ aV
 af
 af
 pO
-yO
+ri
 pO
 af
 aj
@@ -65430,11 +65455,11 @@ ao
 ao
 ao
 ao
-qJ
 ao
 ao
+Ki
 ao
-qJ
+ao
 ao
 ao
 ao
@@ -65608,16 +65633,16 @@ ao
 ao
 pl
 ao
-KZ
+ao
 ao
 pl
 ao
 ao
-KZ
+ao
 pl
 ao
 ao
-KZ
+ao
 ao
 pl
 ao
@@ -65637,7 +65662,7 @@ ao
 ao
 ao
 ao
-ao
+ZM
 ao
 ao
 ao
@@ -65645,7 +65670,7 @@ Sj
 ao
 ao
 ao
-ao
+ZM
 ao
 ao
 ao
@@ -65814,20 +65839,20 @@ pI
 ao
 ao
 ao
-KZ
+ZM
+ao
+ao
+ao
+ao
+ao
+ZM
 ao
 ao
 ao
 ao
 ao
 ao
-ao
-ao
-ao
-ao
-ao
-ao
-ao
+ZM
 ao
 ao
 ao
@@ -65850,7 +65875,7 @@ ao
 RU
 OT
 Zw
-Zf
+al
 Zm
 RP
 ao
@@ -66054,7 +66079,7 @@ Pp
 so
 ao
 ao
-RH
+pl
 ao
 SE
 ak
@@ -66267,7 +66292,7 @@ ao
 ao
 SE
 cC
-ak
+Wz
 YV
 YV
 SE
@@ -66481,9 +66506,9 @@ PL
 VE
 RU
 ao
-qJ
 ao
-KZ
+ao
+ao
 ao
 ao
 ao
@@ -66653,7 +66678,7 @@ af
 ao
 pT
 ao
-qa
+Ki
 ao
 Vz
 ao
@@ -66682,15 +66707,15 @@ ao
 ao
 ao
 ao
-ao
-ao
-qJ
-ao
+ZM
 ao
 ao
 ao
 ao
 ao
+ao
+ao
+ZM
 ao
 ao
 ao
@@ -66895,9 +66920,9 @@ ao
 ao
 ao
 pl
+Ki
 ao
 ao
-KZ
 ao
 pl
 ao
@@ -67115,7 +67140,7 @@ ao
 ao
 ao
 ao
-KZ
+ao
 Nr
 Nr
 pI
@@ -67316,12 +67341,12 @@ KZ
 ao
 ao
 ao
-KM
 ao
 ao
 ao
 ao
-KM
+ao
+ao
 ao
 ao
 ao
@@ -67735,10 +67760,10 @@ ao
 pI
 pI
 Oa
-pI
+WU
 ao
 ao
-pI
+WU
 Oa
 pI
 pI
@@ -68110,15 +68135,15 @@ yP
 pI
 pl
 ao
-ao
 Ki
+ao
 ao
 ao
 Ph
 Wx
 pl
 ao
-qa
+Ki
 pN
 ao
 ao
@@ -68142,7 +68167,7 @@ pN
 pN
 pN
 pN
-ru
+Td
 pN
 Wn
 Kh
@@ -68349,7 +68374,7 @@ ro
 af
 al
 al
-ru
+Td
 sf
 sf
 pN
@@ -68561,7 +68586,7 @@ al
 pN
 sf
 sf
-ru
+Td
 al
 Pi
 af
@@ -68737,7 +68762,7 @@ yP
 pI
 rN
 ao
-qa
+Ki
 pI
 af
 ao
@@ -69161,7 +69186,7 @@ af
 ao
 ao
 ao
-qa
+Ki
 ao
 ao
 ao
@@ -69192,15 +69217,15 @@ ZU
 pN
 pN
 pN
+lK
 pN
 pN
-pN
-pN
+Td
 af
 qA
 QU
 qA
-qA
+Wr
 rV
 sp
 af
@@ -69208,7 +69233,7 @@ pI
 ao
 ao
 ao
-WU
+pI
 yP
 hW
 Dl
@@ -69417,7 +69442,7 @@ pI
 ao
 ao
 ao
-pI
+WU
 yP
 hW
 hW
@@ -70204,7 +70229,7 @@ pk
 pk
 af
 pM
-pR
+TB
 al
 al
 al
@@ -70249,7 +70274,7 @@ qA
 Sf
 sw
 af
-pI
+Qf
 ao
 Rs
 Rs
@@ -70408,14 +70433,14 @@ au
 rk
 ao
 ao
-KL
+ao
 ao
 ao
 HX
 pN
 pN
 pN
-pV
+qD
 pV
 al
 pk
@@ -70437,7 +70462,7 @@ ru
 pN
 qh
 af
-al
+DO
 al
 al
 XQ
@@ -70617,7 +70642,7 @@ au
 rs
 ao
 ao
-ao
+HQ
 ao
 ao
 IC
@@ -70625,7 +70650,7 @@ pN
 pN
 pN
 pV
-pV
+qD
 al
 pk
 ao
@@ -70639,9 +70664,9 @@ KW
 pN
 pN
 pN
-rb
-rb
-rb
+qD
+qD
+qD
 pN
 pN
 pN
@@ -70831,7 +70856,7 @@ pk
 pk
 af
 pM
-pR
+al
 al
 qD
 pN
@@ -71064,7 +71089,7 @@ ZT
 pN
 pN
 af
-al
+DO
 al
 al
 XQ
@@ -71287,7 +71312,7 @@ rT
 af
 ZZ
 af
-qA
+Rl
 qA
 sl
 Qo
@@ -71492,7 +71517,7 @@ al
 al
 al
 al
-Ld
+WU
 af
 dR
 af
@@ -71676,7 +71701,7 @@ af
 pk
 pk
 pI
-qZ
+Td
 pN
 pN
 rq
@@ -71712,7 +71737,7 @@ qA
 rV
 sg
 af
-pI
+Qf
 ao
 Qi
 Qi
@@ -71886,7 +71911,7 @@ QE
 pk
 PY
 pN
-rK
+qD
 pN
 ao
 pN
@@ -71919,7 +71944,7 @@ qA
 Kg
 sl
 qA
-Tq
+Rl
 af
 pI
 ao
@@ -72094,7 +72119,7 @@ af
 qi
 pk
 pI
-qZ
+Td
 pN
 SD
 af
@@ -72112,7 +72137,7 @@ dm
 af
 XF
 al
-Ld
+WU
 af
 UM
 al
@@ -72126,7 +72151,7 @@ af
 TH
 rV
 qA
-qA
+Wr
 sh
 MI
 af
@@ -72304,7 +72329,7 @@ QE
 pk
 pI
 pN
-rK
+qD
 pN
 rq
 pN
@@ -72502,7 +72527,7 @@ PT
 Wm
 ao
 pN
-qZ
+Td
 qh
 pN
 pZ
@@ -72512,7 +72537,7 @@ af
 pk
 pk
 pI
-qZ
+Td
 pN
 pN
 ao
@@ -72546,7 +72571,7 @@ QU
 sl
 sl
 qA
-qA
+Rl
 af
 pI
 ao
@@ -72746,7 +72771,7 @@ al
 al
 al
 al
-Ld
+WU
 af
 dR
 af
@@ -72966,7 +72991,7 @@ qA
 si
 si
 af
-pI
+Qf
 ao
 Vv
 Vv
@@ -73154,7 +73179,7 @@ ZT
 pN
 Le
 af
-al
+DO
 al
 al
 XQ
@@ -73168,7 +73193,7 @@ af
 af
 af
 af
-qA
+Rl
 qA
 Kg
 sl
@@ -73339,7 +73364,7 @@ pk
 pk
 af
 pM
-pR
+TB
 al
 qD
 pN
@@ -73543,7 +73568,7 @@ au
 rk
 ao
 ao
-ao
+HQ
 ao
 ao
 HX
@@ -73551,7 +73576,7 @@ pN
 pN
 pN
 pV
-pV
+qD
 al
 af
 qe
@@ -73565,9 +73590,9 @@ KW
 pN
 pN
 pN
-rb
-rb
-rb
+qD
+qD
+qD
 pN
 pN
 pN
@@ -73752,14 +73777,14 @@ au
 rs
 ao
 ao
-KL
+ao
 ao
 ao
 IC
 pN
 pN
 pN
-pV
+qD
 pV
 al
 af
@@ -73781,7 +73806,7 @@ ru
 pN
 qh
 af
-al
+DO
 al
 al
 XQ
@@ -73966,7 +73991,7 @@ pk
 pk
 af
 pM
-pR
+TB
 al
 al
 al
@@ -74392,7 +74417,7 @@ Ui
 af
 SD
 pI
-qZ
+Td
 pN
 pI
 af
@@ -74602,7 +74627,7 @@ af
 af
 pN
 pN
-qZ
+Td
 pN
 pk
 pm
@@ -74810,7 +74835,7 @@ pI
 pI
 pk
 pN
-qZ
+Td
 pN
 pN
 pk
@@ -74836,7 +74861,7 @@ pN
 pN
 pN
 pN
-Le
+pN
 pN
 pN
 Zh
@@ -75047,12 +75072,12 @@ pN
 pN
 pN
 pN
-pN
+WX
 af
 qA
 QU
 qA
-qA
+Wr
 qA
 qA
 af
@@ -75640,7 +75665,7 @@ af
 pI
 sk
 pT
-KM
+Ki
 ao
 NO
 XB
@@ -75657,7 +75682,7 @@ af
 af
 af
 pN
-qZ
+qD
 pI
 pN
 My
@@ -76086,7 +76111,7 @@ pN
 pN
 pN
 pN
-pR
+TB
 pN
 af
 Sd
@@ -76293,7 +76318,7 @@ pN
 pN
 pN
 pN
-ru
+Td
 pN
 al
 pN
@@ -76478,11 +76503,11 @@ Ph
 Wx
 pl
 ao
-qa
+ZM
 pN
 pN
 qh
-pN
+qD
 pN
 pN
 pN
@@ -76708,7 +76733,7 @@ pN
 pN
 af
 pI
-KW
+WU
 pI
 pI
 pJ
@@ -76721,12 +76746,12 @@ ao
 pl
 ao
 ao
-KM
+HQ
 KZ
 ao
 Xx
 ao
-KM
+HQ
 ao
 ao
 ao
@@ -77097,7 +77122,7 @@ yP
 pI
 rC
 sv
-KZ
+ao
 pI
 af
 pI
@@ -77306,7 +77331,7 @@ yP
 pI
 rz
 LU
-KZ
+ao
 pI
 af
 pI
@@ -77933,7 +77958,7 @@ yP
 pI
 ao
 ao
-ao
+ZM
 pI
 af
 af
@@ -78144,7 +78169,7 @@ pI
 pI
 pl
 pI
-Sl
+pI
 pI
 pI
 pI
@@ -78360,7 +78385,7 @@ ao
 ao
 ao
 ao
-KZ
+ao
 ao
 ao
 ao
@@ -78566,7 +78591,7 @@ ao
 ao
 ao
 ao
-ao
+ZM
 ao
 ao
 ao

--- a/maps/DeepForest/map/_Greyson_Field_Office.dmm
+++ b/maps/DeepForest/map/_Greyson_Field_Office.dmm
@@ -102,7 +102,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "av" = (
-/mob/living/carbon/superior_animal/robot/greyson/roomba/boomba,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "aw" = (
@@ -183,7 +183,7 @@
 /obj/structure/bed/chair/custom/onestar{
 	dir = 1
 	},
-/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "aL" = (
@@ -194,7 +194,7 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "aM" = (
 /obj/machinery/light/floor,
-/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "aN" = (
@@ -483,8 +483,9 @@
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "bW" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer,
-/turf/simulated/floor/tiled/derelict/red_white_edges,
+/obj/machinery/light/floor,
+/obj/random/mob/roomba/mecha/low,
+/turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "bX" = (
 /obj/machinery/light/floor,
@@ -641,7 +642,7 @@
 /obj/structure/bed/chair/custom/onestar{
 	dir = 1
 	},
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle,
+/obj/random/mob/roomba/range/low,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "cD" = (
@@ -1022,9 +1023,9 @@
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/one_star/fo_outside)
 "eh" = (
-/obj/item/material/shard/shrapnel/scrap,
-/turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/outside/one_star/fo_outside)
+/obj/random/mob/roomba/job,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star/fo_internal)
 "ei" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/unsimulated/wall/jungle,
@@ -1044,9 +1045,9 @@
 /area/nadezhda/outside/one_star/fo_outside)
 "em" = (
 /obj/machinery/door/airlock/multi_tile/metal{
+	dir = 2;
 	locked = 1;
-	name = "Greyson Positronic Outpost";
-	dir = 2
+	name = "Greyson Positronic Outpost"
 	},
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
@@ -1103,7 +1104,7 @@
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "ey" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/outside/one_star/fo_outside)
 "ez" = (
@@ -1335,7 +1336,7 @@
 /area/nadezhda/outside/one_star/fo_outside)
 "fs" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/robot/greyson/custodian,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/outside/one_star/fo_outside)
 "ft" = (
@@ -1376,7 +1377,7 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/nadezhda/outside/one_star/fo_internal)
 "fB" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/nadezhda/outside/one_star/fo_internal)
 "fC" = (
@@ -1482,7 +1483,7 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/outside/one_star/fo_internal)
 "fT" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle,
+/obj/random/mob/roomba/range/low,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/nadezhda/outside/one_star/fo_internal)
 "fU" = (
@@ -2218,8 +2219,8 @@
 /area/nadezhda/outside/one_star/fo_outside)
 "it" = (
 /obj/structure/sink{
-	pixel_x = 1;
 	dir = 1;
+	pixel_x = 1;
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -2231,8 +2232,8 @@
 /area/nadezhda/outside/one_star/fo_outside)
 "iv" = (
 /obj/structure/sink{
-	pixel_x = 1;
 	dir = 1;
+	pixel_x = 1;
 	pixel_y = 28
 	},
 /obj/random/booze/low_chance,
@@ -2291,7 +2292,7 @@
 /obj/structure/bed/chair/custom/onestar/red{
 	dir = 4
 	},
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star/fo_outside)
 "iI" = (
@@ -2303,7 +2304,7 @@
 /obj/structure/bed/chair/custom/onestar/red{
 	dir = 1
 	},
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star/fo_outside)
 "iK" = (
@@ -2375,7 +2376,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_outside)
 "iW" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_outside)
 "iX" = (
@@ -2529,7 +2530,7 @@
 "jC" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/item/clothing/head/hairflower,
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star/fo_outside)
 "jD" = (
@@ -2559,7 +2560,7 @@
 "jI" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/item/clothing/head/hairflower/white,
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star/fo_outside)
 "jJ" = (
@@ -2621,7 +2622,7 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/one_star/fo_internal)
 "jU" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg,
+/obj/random/mob/roomba/melee,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "jV" = (
@@ -2688,8 +2689,8 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "kh" = (
 /obj/structure/sink{
-	pixel_x = 1;
 	dir = 1;
+	pixel_x = 1;
 	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/purcarpet,
@@ -2807,20 +2808,16 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "kB" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star/fo_outside)
 "kC" = (
-/mob/living/carbon/superior_animal/robot/greyson/roomba/slayer,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star/fo_outside)
 "kD" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict,
-/area/nadezhda/outside/one_star/fo_outside)
-"kE" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian,
-/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/one_star/fo_outside)
 "kF" = (
 /obj/structure/railing/grey{
@@ -2840,17 +2837,17 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "kI" = (
 /obj/machinery/door/airlock/multi_tile/metal{
+	dir = 2;
 	locked = 1;
-	name = "Greyson Positronic Outpost";
-	dir = 2
+	name = "Greyson Positronic Outpost"
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/one_star/fo_outside)
 "kJ" = (
 /obj/machinery/door/airlock/multi_tile/metal{
+	dir = 2;
 	locked = 1;
-	name = "Greyson Positronic Outpost";
-	dir = 2
+	name = "Greyson Positronic Outpost"
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star/fo_outside)
@@ -2900,14 +2897,14 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "kT" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star/fo_outside)
 "kU" = (
 /obj/machinery/door/airlock/multi_tile/metal{
+	dir = 2;
 	locked = 1;
-	name = "Greyson Positronic Outpost";
-	dir = 2
+	name = "Greyson Positronic Outpost"
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/one_star/fo_internal)
@@ -3001,7 +2998,7 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "lm" = (
 /obj/structure/flora/small/grassa2,
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star/fo_outside)
 "ln" = (
@@ -3133,7 +3130,7 @@
 /area/nadezhda/outside/one_star/fo_outside)
 "lK" = (
 /obj/structure/bed/chair/custom/onestar/red,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star/fo_outside)
 "lL" = (
@@ -3452,10 +3449,6 @@
 	},
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
-"mP" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
-/turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/outside/one_star/fo_outside)
 "mQ" = (
 /obj/structure/closet/secure_closet/freezer,
 /obj/machinery/light{
@@ -3465,8 +3458,8 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "mR" = (
 /obj/structure/sink{
-	pixel_x = 1;
 	dir = 1;
+	pixel_x = 1;
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/derelict,
@@ -3612,7 +3605,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "ns" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/one_star/fo_outside)
 "nt" = (
@@ -3625,9 +3618,9 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "nu" = (
 /obj/machinery/door/airlock/multi_tile/metal{
+	dir = 2;
 	locked = 1;
-	name = "Greyson Positronic Outpost";
-	dir = 2
+	name = "Greyson Positronic Outpost"
 	},
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
@@ -3701,8 +3694,8 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "nI" = (
 /obj/structure/sink{
-	pixel_x = 1;
 	dir = 1;
+	pixel_x = 1;
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -3759,8 +3752,8 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "nT" = (
 /obj/structure/sink{
-	pixel_x = 1;
-	dir = 1
+	dir = 1;
+	pixel_x = 1
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/outside/one_star/fo_internal)
@@ -3776,7 +3769,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
+/obj/random/mob/roomba/range/low,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "nX" = (
@@ -3971,7 +3964,7 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "oE" = (
 /obj/structure/bed/chair/office/dark,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
+/obj/random/mob/roomba/range/low,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "oF" = (
@@ -4118,8 +4111,8 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "pc" = (
 /obj/structure/sink{
-	pixel_x = -12;
-	dir = 8
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
@@ -4139,11 +4132,11 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "pg" = (
 /obj/structure/sink{
-	pixel_x = 1;
 	dir = 1;
+	pixel_x = 1;
 	pixel_y = 28
 	},
-/mob/living/carbon/superior_animal/robot/greyson/custodian,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "ph" = (
@@ -4379,7 +4372,7 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "pW" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star/fo_outside)
 "pX" = (
@@ -4490,7 +4483,7 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "qq" = (
 /obj/structure/bed/chair/custom/onestar,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "qr" = (
@@ -4612,12 +4605,12 @@
 /obj/structure/bed/chair/custom/onestar/red{
 	dir = 1
 	},
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "qL" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle,
-/turf/simulated/floor/tiled/derelict,
+/obj/random/mob/roomba/job,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "qM" = (
 /obj/structure/scrap/food/large,
@@ -4727,7 +4720,7 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/one_star/fo_outside)
 "rg" = (
-/mob/living/carbon/superior_animal/robot/greyson/custodian/chef,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/one_star/fo_outside)
 "rh" = (
@@ -5026,7 +5019,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy,
+/obj/random/mob/roomba/melee,
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/outside/one_star/fo_internal)
 "sg" = (
@@ -5145,7 +5138,7 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "sx" = (
 /obj/structure/bed/chair/custom/onestar/red,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "sy" = (
@@ -5191,7 +5184,7 @@
 /obj/structure/bed/chair/custom/onestar{
 	dir = 1
 	},
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "sG" = (
@@ -5436,7 +5429,7 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/one_star/fo_outside)
 "tw" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "tx" = (
@@ -5512,8 +5505,7 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/one_star/fo_outside)
 "tH" = (
-/obj/structure/table/onestar,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "tI" = (
@@ -5592,7 +5584,7 @@
 /obj/structure/bed/chair/custom/onestar/red{
 	dir = 4
 	},
-/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "tV" = (
@@ -5659,7 +5651,7 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "uf" = (
 /obj/machinery/light/floor,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "ug" = (
@@ -5742,7 +5734,7 @@
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "us" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "ut" = (
@@ -5816,8 +5808,8 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "uD" = (
 /obj/structure/sink{
-	pixel_x = 1;
 	dir = 1;
+	pixel_x = 1;
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -5940,6 +5932,17 @@
 /obj/item/reagent_containers/food/condiment/sugar,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
+"vl" = (
+/obj/structure/bed/chair/custom/onestar{
+	dir = 1
+	},
+/obj/random/mob/roomba/range/low,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
+"vv" = (
+/obj/random/mob/roomba/range,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "vA" = (
 /mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -5949,8 +5952,7 @@
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "wa" = (
-/obj/machinery/light/floor,
-/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/plasma,
+/obj/random/mob/roomba/range/low,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "wj" = (
@@ -5987,6 +5989,10 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/one_star/fo_internal)
+"zH" = (
+/obj/random/mob/roomba/mecha/low,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "zY" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/toy/plushie/spider{
@@ -6001,6 +6007,7 @@
 /obj/item/gun_upgrade/mechanism/glass_widow,
 /obj/random/lathe_disk/advanced/onestar,
 /obj/item/storage/box/data_disk,
+/obj/random/mob/roomba/mecha,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/one_star/fo_internal)
 "Af" = (
@@ -6010,6 +6017,17 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
+"AH" = (
+/obj/structure/bed/chair/custom/onestar/red{
+	dir = 1
+	},
+/obj/random/mob/roomba/range/low,
+/turf/simulated/floor/tiled/steel/brown_perforated,
+/area/nadezhda/outside/one_star/fo_outside)
+"AL" = (
+/obj/random/mob/roomba/range/low,
+/turf/simulated/floor/tiled/steel/brown_perforated,
+/area/nadezhda/outside/one_star/fo_outside)
 "Bh" = (
 /obj/structure/table/onestar,
 /obj/item/gun/energy/cog,
@@ -6030,7 +6048,7 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "Cg" = (
 /obj/machinery/light/floor,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "Cx" = (
@@ -6047,6 +6065,10 @@
 	},
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
+"Dh" = (
+/obj/random/mob/roomba/mecha/low,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "Do" = (
 /obj/structure/table/onestar,
 /obj/item/storage/firstaid/surgery,
@@ -6055,6 +6077,7 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "Dt" = (
 /obj/item/remains/robot,
+/obj/random/mob/roomba/melee,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "Dw" = (
@@ -6073,7 +6096,6 @@
 "DP" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/blood/oil,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "DR" = (
@@ -6097,6 +6119,10 @@
 /mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/plasma,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/one_star/fo_outside)
+"EH" = (
+/obj/random/mob/roomba/melee,
+/turf/simulated/floor/carpet/blucarpet,
+/area/nadezhda/outside/one_star/fo_internal)
 "EJ" = (
 /obj/structure/table/onestar,
 /obj/structure/scrap/medical/large,
@@ -6127,7 +6153,7 @@
 /area/nadezhda/outside/one_star/fo_internal)
 "FU" = (
 /obj/machinery/light/floor,
-/mob/living/carbon/superior_animal/robot/greyson/roomba/trip/armored,
+/obj/random/mob/roomba/melee,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "Gh" = (
@@ -6135,9 +6161,22 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_outside)
 "Gn" = (
-/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/armored,
+/obj/random/mob/roomba/melee,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
+"Gu" = (
+/obj/random/mob/roomba/job,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/outside/one_star/fo_internal)
+"GF" = (
+/obj/random/mob/roomba/job,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/one_star/fo_outside)
+"GR" = (
+/obj/structure/bed/chair/custom/onestar/red,
+/obj/random/mob/roomba/range/low,
+/turf/simulated/floor/tiled/steel/brown_perforated,
+/area/nadezhda/outside/one_star/fo_outside)
 "GT" = (
 /obj/structure/sink{
 	dir = 4;
@@ -6186,9 +6225,18 @@
 /obj/structure/salvageable/implant_container_os,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
+"Jz" = (
+/obj/structure/bed/chair/custom/onestar,
+/obj/random/mob/roomba/range/low,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "JG" = (
 /obj/structure/table/onestar,
 /turf/simulated/floor/reinforced,
+/area/nadezhda/outside/one_star/fo_outside)
+"JT" = (
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/one_star/fo_outside)
 "JZ" = (
 /mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/plasma,
@@ -6206,6 +6254,10 @@
 /mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/armored,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star/fo_outside)
+"LU" = (
+/obj/random/mob/roomba/mecha/low,
+/turf/simulated/floor/tiled/derelict,
+/area/nadezhda/outside/one_star/fo_internal)
 "Mc" = (
 /mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/plasma,
 /turf/simulated/floor/tiled/derelict,
@@ -6226,7 +6278,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star/fo_outside)
 "Nj" = (
-/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/armored,
+/obj/random/mob/roomba/range/low,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "Nm" = (
@@ -6240,12 +6292,25 @@
 /obj/item/tool/wirecutters/onestar_pliers,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
+"OF" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/random/mob/roomba/job,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/one_star/fo_outside)
 "OL" = (
 /mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/one_star/fo_outside)
 "OM" = (
 /mob/living/carbon/superior_animal/robot/greyson/roomba/trip/armored,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
+"OW" = (
+/obj/random/mob/roomba/mecha/low,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/nadezhda/outside/one_star/fo_internal)
+"OY" = (
+/obj/random/mob/roomba/melee,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "PA" = (
@@ -6278,7 +6343,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_outside)
 "RN" = (
-/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/plasma,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/steel/airless,
 /area/nadezhda/outside/one_star/fo_internal)
 "Se" = (
@@ -6329,6 +6394,10 @@
 /mob/living/carbon/superior_animal/robot/greyson/roomba/chemical,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
+"TE" = (
+/obj/random/mob/roomba/job,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/nadezhda/outside/one_star/fo_outside)
 "TP" = (
 /mob/living/carbon/superior_animal/robot/greyson/roomba/trip/armored,
 /turf/simulated/floor/tiled/derelict,
@@ -6396,7 +6465,7 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "WL" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
+/obj/random/mob/roomba/range/low,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/outside/one_star/fo_internal)
 "WV" = (
@@ -6446,6 +6515,10 @@
 "Yq" = (
 /mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle,
 /turf/simulated/floor/carpet,
+/area/nadezhda/outside/one_star/fo_internal)
+"Yx" = (
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "YC" = (
 /mob/living/carbon/superior_animal/robot/greyson/roomba/trip/armored,
@@ -15058,7 +15131,7 @@ am
 am
 am
 am
-aF
+av
 am
 am
 am
@@ -15515,7 +15588,7 @@ am
 am
 az
 am
-aI
+eh
 am
 aP
 aP
@@ -15666,10 +15739,10 @@ au
 as
 am
 aA
-aI
+eh
 am
 am
-aI
+eh
 am
 an
 am
@@ -15966,14 +16039,14 @@ ac
 ac
 am
 as
-an
+bW
 as
 am
 am
 aJ
 an
 am
-aI
+eh
 am
 an
 am
@@ -16277,7 +16350,7 @@ aB
 am
 am
 am
-aI
+eh
 am
 an
 am
@@ -16882,7 +16955,7 @@ am
 am
 am
 am
-aF
+av
 am
 am
 am
@@ -20905,7 +20978,7 @@ ab
 ab
 ab
 bg
-wa
+an
 am
 cf
 ca
@@ -21209,7 +21282,7 @@ ab
 ab
 ab
 bg
-bR
+eh
 aH
 cd
 ca
@@ -21362,7 +21435,7 @@ bg
 bg
 bg
 am
-Mc
+am
 cg
 ca
 ae
@@ -21493,8 +21566,8 @@ bB
 bB
 bN
 bS
-bW
 ae
+tH
 ae
 bM
 cd
@@ -21514,7 +21587,7 @@ am
 an
 ci
 am
-am
+wa
 am
 bZ
 ae
@@ -21662,16 +21735,16 @@ am
 am
 cl
 am
-bR
+eh
 am
 cb
 an
 am
-Mc
+LU
 ca
 ae
 cw
-bO
+vv
 cK
 bg
 ab
@@ -21802,7 +21875,7 @@ ae
 ae
 bZ
 am
-aI
+am
 am
 ch
 an
@@ -21954,7 +22027,7 @@ ae
 ae
 bM
 an
-am
+eh
 am
 cb
 am
@@ -21970,12 +22043,12 @@ bg
 bg
 bg
 am
-am
+wa
 cg
 ca
 ae
 bL
-cm
+tH
 ae
 bg
 ab
@@ -22062,8 +22135,8 @@ ab
 ab
 ac
 ae
-TP
-Xm
+Gn
+jU
 ac
 ab
 ab
@@ -22254,7 +22327,7 @@ bB
 bt
 ae
 bt
-bW
+ae
 ae
 bM
 am
@@ -22406,7 +22479,7 @@ bB
 ae
 ae
 ae
-ae
+tH
 ae
 bM
 cc
@@ -22425,7 +22498,7 @@ ab
 ab
 ab
 bg
-wa
+an
 am
 cf
 ca
@@ -24253,9 +24326,9 @@ an
 am
 cf
 ca
-jU
 ae
 ae
+Nj
 af
 bg
 ab
@@ -24553,7 +24626,7 @@ ab
 ab
 ab
 bg
-bR
+av
 aH
 cd
 ca
@@ -24807,7 +24880,7 @@ ae
 ae
 TC
 ae
-ae
+jU
 vS
 ae
 ae
@@ -25006,7 +25079,7 @@ an
 am
 cl
 am
-bR
+eh
 am
 cb
 an
@@ -25014,7 +25087,7 @@ am
 Mc
 ca
 ae
-ae
+tH
 cE
 af
 bg
@@ -25109,10 +25182,10 @@ ae
 ae
 ae
 ae
-ae
+jU
 TC
 Lw
-cm
+jU
 ae
 ae
 ae
@@ -25319,7 +25392,7 @@ cg
 ca
 ae
 ae
-cm
+ae
 ae
 bg
 ab
@@ -25465,7 +25538,7 @@ ab
 ab
 ab
 bg
-am
+av
 aH
 cc
 ca
@@ -25773,9 +25846,9 @@ an
 am
 cf
 ca
-jU
 ae
 ae
+Nj
 af
 bg
 ab
@@ -28029,7 +28102,7 @@ bu
 bg
 ae
 ae
-bW
+ae
 ae
 ae
 bM
@@ -28211,7 +28284,7 @@ ae
 cM
 ae
 ac
-bW
+ae
 ae
 bg
 ab
@@ -28332,13 +28405,13 @@ ae
 bu
 bM
 ae
-ae
+Nj
 ae
 ae
 ae
 bZ
 am
-aI
+am
 am
 ch
 an
@@ -28359,8 +28432,8 @@ am
 bZ
 ae
 ae
-bW
-bO
+ae
+tH
 ae
 ae
 ae
@@ -28490,7 +28563,7 @@ vS
 ae
 bM
 an
-am
+wa
 am
 cb
 am
@@ -28509,7 +28582,7 @@ an
 am
 Mc
 ca
-ae
+Dh
 cB
 af
 cN
@@ -28636,7 +28709,7 @@ bg
 bg
 bg
 ae
-ae
+Nj
 ae
 ae
 ae
@@ -28646,7 +28719,7 @@ am
 am
 ch
 an
-TP
+Gn
 ck
 bg
 ae
@@ -28662,11 +28735,11 @@ am
 am
 bZ
 ae
-bO
+tH
 ae
 ae
 ae
-bO
+tH
 ae
 ae
 bg
@@ -28790,7 +28863,7 @@ bg
 ae
 Eg
 ae
-bW
+ae
 ae
 bM
 am
@@ -28969,7 +29042,7 @@ ae
 cA
 ae
 cM
-bW
+ae
 ac
 ae
 ae
@@ -33047,7 +33120,7 @@ bP
 bP
 bX
 bP
-RN
+bP
 ca
 cd
 aH
@@ -33199,7 +33272,7 @@ bP
 bP
 bP
 bP
-bP
+RN
 ca
 an
 am
@@ -34102,7 +34175,7 @@ bg
 bj
 bn
 bn
-bo
+qL
 bl
 bg
 bL
@@ -34124,7 +34197,9 @@ ae
 ae
 am
 ae
-vS
+ae
+ae
+jU
 ae
 ae
 ae
@@ -34137,10 +34212,8 @@ ae
 ae
 ae
 ae
+Yx
 ae
-ae
-ae
-Xm
 bL
 bg
 am
@@ -34254,7 +34327,7 @@ bg
 bj
 bo
 br
-bo
+qL
 bl
 bG
 am
@@ -34293,7 +34366,7 @@ am
 am
 am
 an
-TP
+Gn
 cP
 am
 cR
@@ -34406,7 +34479,7 @@ bg
 bk
 bn
 bn
-bo
+qL
 bl
 bH
 bL
@@ -34433,7 +34506,7 @@ ae
 ae
 ae
 ae
-vS
+jU
 ae
 ae
 ae
@@ -34443,8 +34516,8 @@ ae
 ae
 ae
 ae
+Yx
 ae
-Xm
 bL
 bg
 am
@@ -37517,7 +37590,7 @@ ds
 ds
 dI
 ds
-ds
+OW
 ds
 ds
 dI
@@ -37678,7 +37751,7 @@ ds
 dN
 ga
 am
-ef
+wa
 am
 gD
 gE
@@ -38128,7 +38201,7 @@ am
 am
 am
 ep
-ef
+wa
 am
 am
 ep
@@ -38646,7 +38719,7 @@ kZ
 kZ
 Dx
 kZ
-qI
+EH
 sg
 sk
 sv
@@ -38721,7 +38794,7 @@ aa
 ac
 de
 ds
-ds
+OW
 ds
 de
 ac
@@ -39188,7 +39261,7 @@ dN
 eQ
 ds
 eQ
-dF
+ds
 ds
 ds
 eQ
@@ -39340,10 +39413,10 @@ eE
 ds
 ds
 ds
-ds
+fB
 ds
 fA
-ds
+fB
 ds
 ds
 fA
@@ -39492,12 +39565,12 @@ dN
 ds
 fg
 ds
-dt
+ds
 fC
 ds
 ds
-dF
 ds
+fB
 ds
 dN
 ew
@@ -39644,12 +39717,12 @@ dN
 ds
 ds
 ds
-dF
-ds
-dt
+fB
 ds
 ds
-dt
+fB
+ds
+ds
 ds
 dN
 am
@@ -39801,7 +39874,7 @@ fD
 fD
 ds
 fT
-fM
+ds
 fD
 fX
 ac
@@ -41258,7 +41331,7 @@ tX
 ae
 bn
 bn
-ud
+FU
 bn
 ae
 ae
@@ -41381,8 +41454,8 @@ qy
 qK
 am
 am
-am
-am
+wa
+wa
 am
 am
 sx
@@ -41473,7 +41546,7 @@ eN
 eN
 eN
 eN
-fu
+Gu
 eN
 eN
 ac
@@ -41533,8 +41606,8 @@ lo
 lo
 qT
 am
-Gn
-Gn
+am
+am
 am
 qT
 lo
@@ -41741,7 +41814,7 @@ tM
 cz
 ca
 am
-bm
+OY
 am
 ca
 ae
@@ -41836,10 +41909,10 @@ bg
 lo
 lo
 am
-am
+Gn
 mN
 mN
-am
+Gn
 am
 lo
 lo
@@ -42077,7 +42150,7 @@ eN
 eN
 eN
 eN
-eN
+Gu
 eN
 eN
 eS
@@ -43158,7 +43231,7 @@ dv
 hg
 dv
 et
-iB
+GF
 hC
 hC
 et
@@ -43320,7 +43393,7 @@ dv
 dv
 kX
 ee
-iB
+GF
 dv
 dv
 dv
@@ -43343,7 +43416,7 @@ eg
 fy
 eg
 dH
-iB
+GF
 dv
 dH
 eg
@@ -43386,7 +43459,7 @@ ca
 ca
 ci
 am
-bm
+OY
 am
 ca
 ca
@@ -43658,7 +43731,7 @@ eg
 eg
 eg
 eg
-mP
+ns
 eg
 eg
 eg
@@ -43786,7 +43859,7 @@ eg
 eg
 eg
 eg
-mP
+ns
 eg
 eg
 eg
@@ -45280,7 +45353,7 @@ dH
 eg
 eg
 eg
-fd
+JT
 eg
 eg
 eg
@@ -45732,7 +45805,7 @@ eg
 eg
 eg
 eg
-fd
+JT
 eg
 eg
 eg
@@ -45910,7 +45983,7 @@ eq
 eq
 md
 am
-aI
+eh
 am
 nm
 ac
@@ -46063,13 +46136,13 @@ eg
 cT
 am
 am
-bR
+eh
 am
 nF
 am
 am
 ac
-aI
+eh
 ar
 ar
 am
@@ -46223,7 +46296,7 @@ ac
 ac
 am
 am
-am
+LU
 am
 ac
 ac
@@ -46236,8 +46309,8 @@ dv
 ok
 dv
 dv
-iB
 dv
+GF
 dv
 dv
 cV
@@ -46521,16 +46594,16 @@ am
 nd
 am
 nq
-aI
+eh
 nq
 am
 ao
 am
 ar
 ar
-aI
+eh
 am
-aI
+eh
 am
 ac
 cV
@@ -46688,7 +46761,7 @@ ac
 cV
 dv
 dv
-dv
+GF
 dP
 dv
 dv
@@ -46840,7 +46913,7 @@ ac
 cV
 dv
 dv
-iB
+dv
 dv
 dv
 dv
@@ -47136,7 +47209,7 @@ bn
 bn
 ac
 oV
-bR
+eh
 pf
 am
 pl
@@ -47165,7 +47238,7 @@ bg
 oe
 cV
 dW
-jD
+OF
 dW
 dv
 dv
@@ -47308,10 +47381,10 @@ cV
 bg
 bg
 rz
-cD
+vv
 ae
 ae
-cD
+vv
 so
 bg
 oe
@@ -47706,7 +47779,7 @@ eg
 eg
 eg
 eg
-er
+JT
 eg
 eg
 eg
@@ -47746,7 +47819,7 @@ oT
 am
 am
 nH
-bR
+eh
 nm
 ac
 cV
@@ -48211,7 +48284,7 @@ cV
 bg
 bg
 am
-bm
+zH
 an
 qf
 qf
@@ -48232,7 +48305,7 @@ qe
 qf
 qe
 an
-bn
+zH
 am
 bg
 bg
@@ -48501,7 +48574,7 @@ mN
 ac
 am
 bn
-bR
+eh
 ac
 eb
 pc
@@ -49587,12 +49660,12 @@ ae
 ae
 am
 am
-am
+Gn
 am
 bn
 bn
 am
-am
+Gn
 am
 am
 ae
@@ -50654,7 +50727,7 @@ am
 am
 am
 bn
-bn
+zH
 am
 am
 tl
@@ -50780,7 +50853,7 @@ ep
 mN
 ac
 am
-bo
+qL
 am
 ac
 mN
@@ -51104,7 +51177,7 @@ nm
 bg
 qk
 qo
-tt
+Jz
 qD
 am
 am
@@ -51114,7 +51187,7 @@ zY
 Af
 am
 sy
-Wv
+vl
 bn
 an
 ts
@@ -51198,7 +51271,7 @@ eg
 eg
 eg
 eg
-er
+JT
 eg
 eg
 eg
@@ -51508,7 +51581,7 @@ eg
 eg
 eg
 eg
-er
+JT
 eg
 eg
 eg
@@ -51566,7 +51639,7 @@ am
 am
 am
 bn
-bn
+zH
 am
 am
 tl
@@ -51824,14 +51897,14 @@ dv
 dv
 iE
 dW
-jD
+OF
 dW
 dH
 dH
 dH
 dH
 dW
-jD
+OF
 dW
 iE
 dv
@@ -51983,7 +52056,7 @@ dH
 dH
 dH
 jh
-jD
+OF
 jX
 iE
 dv
@@ -52409,7 +52482,7 @@ eg
 eg
 eg
 eg
-er
+JT
 eg
 eg
 eg
@@ -52627,12 +52700,12 @@ ae
 ae
 am
 am
-am
+Gn
 am
 bn
 bn
 am
-am
+Gn
 am
 am
 ae
@@ -52756,7 +52829,7 @@ nr
 nG
 ac
 am
-bo
+qL
 am
 ac
 nG
@@ -53192,14 +53265,14 @@ dv
 dv
 iE
 dW
-jD
+OF
 dW
 dH
 dH
 dH
 dH
 dW
-jD
+OF
 dW
 iE
 dv
@@ -53351,7 +53424,7 @@ dH
 dH
 dH
 jh
-jD
+OF
 jX
 iE
 dv
@@ -53835,7 +53908,7 @@ cV
 bg
 bg
 am
-bm
+zH
 an
 qe
 qf
@@ -53843,20 +53916,20 @@ qf
 qf
 qe
 am
-am
-an
-bn
-bn
-an
-am
-am
-qe
-qe
-qf
-qf
-qe
+Gn
 an
 bn
+zH
+an
+am
+am
+qe
+qe
+qf
+qf
+qe
+an
+zH
 am
 bg
 bg
@@ -54087,7 +54160,7 @@ eg
 eg
 eg
 eg
-er
+JT
 eg
 eg
 eg
@@ -54150,7 +54223,7 @@ am
 am
 am
 bn
-bn
+OY
 am
 am
 am
@@ -54298,8 +54371,8 @@ am
 am
 am
 am
-qL
 am
+wa
 am
 bn
 bm
@@ -54560,14 +54633,14 @@ dv
 uT
 iE
 dW
-jD
+OF
 dW
 dH
 dH
 dH
 dH
 dW
-jD
+OF
 dW
 iE
 dv
@@ -54580,7 +54653,7 @@ ep
 mN
 ac
 am
-bo
+qL
 am
 ac
 mN
@@ -54702,7 +54775,7 @@ fy
 eg
 eg
 fy
-er
+JT
 fy
 eg
 eg
@@ -54747,7 +54820,7 @@ cV
 bg
 bg
 aw
-bO
+ae
 ae
 ae
 ae
@@ -54903,7 +54976,7 @@ ae
 cz
 cz
 cz
-ae
+tH
 qs
 bg
 bg
@@ -54916,10 +54989,10 @@ sp
 bg
 bg
 pU
-ae
-cz
-cz
 tH
+cz
+cz
+cz
 ae
 qs
 bg
@@ -54998,7 +55071,7 @@ eg
 fy
 fy
 fy
-er
+JT
 eg
 fy
 fy
@@ -55068,7 +55141,7 @@ qs
 bg
 bg
 pV
-bO
+ae
 cz
 qh
 cz
@@ -55207,7 +55280,7 @@ ae
 cz
 cz
 cz
-bO
+ae
 qs
 bg
 bg
@@ -55224,7 +55297,7 @@ ae
 cz
 cz
 cz
-ae
+tH
 qs
 bg
 bg
@@ -55356,7 +55429,7 @@ bg
 bg
 be
 ae
-ae
+tH
 ae
 ae
 ae
@@ -55488,7 +55561,7 @@ ac
 mV
 am
 am
-bR
+eh
 am
 am
 bn
@@ -55496,7 +55569,7 @@ bn
 bn
 am
 am
-bR
+eh
 am
 am
 pm
@@ -56296,7 +56369,7 @@ oW
 dv
 dv
 qX
-iB
+GF
 dv
 dv
 cV
@@ -56359,7 +56432,7 @@ dH
 eg
 eg
 eg
-er
+JT
 eg
 eg
 eg
@@ -56385,7 +56458,7 @@ ii
 iG
 iG
 jG
-jY
+GR
 kn
 kC
 iG
@@ -56577,7 +56650,7 @@ eT
 oM
 eT
 oX
-iB
+GF
 dv
 dv
 dH
@@ -56694,7 +56767,7 @@ kp
 iG
 iG
 ik
-iJ
+AH
 iG
 iG
 lK
@@ -56717,7 +56790,7 @@ dv
 dv
 dv
 dW
-jD
+OF
 dW
 nZ
 eT
@@ -56729,7 +56802,7 @@ eT
 eT
 eT
 oX
-iB
+GF
 dv
 dv
 dH
@@ -56737,7 +56810,7 @@ eg
 eg
 dH
 dv
-iB
+GF
 dv
 nZ
 eT
@@ -56903,7 +56976,7 @@ eT
 oX
 dv
 dv
-iB
+GF
 dv
 dv
 dv
@@ -57147,8 +57220,8 @@ jk
 en
 en
 en
-kD
 en
+kD
 en
 en
 en
@@ -57268,7 +57341,7 @@ dv
 dv
 dH
 dH
-eh
+eg
 eg
 eg
 eg
@@ -57457,7 +57530,7 @@ in
 jZ
 iG
 iG
-lK
+jY
 kp
 fn
 dH
@@ -57601,7 +57674,7 @@ in
 iJ
 iG
 iG
-iG
+AL
 kp
 iG
 kC
@@ -57609,7 +57682,7 @@ im
 iJ
 iG
 jG
-iG
+AL
 in
 fn
 dv
@@ -57672,7 +57745,7 @@ oe
 bn
 br
 bn
-vA
+us
 bn
 br
 bn
@@ -57739,7 +57812,7 @@ eg
 eg
 eg
 eg
-er
+JT
 eg
 eg
 eg
@@ -57753,7 +57826,7 @@ io
 iG
 iG
 iG
-ka
+iG
 ik
 iG
 iG
@@ -57824,7 +57897,7 @@ hJ
 bn
 bn
 bn
-OM
+OY
 bn
 bn
 am
@@ -58127,7 +58200,7 @@ eq
 oo
 bn
 bn
-vA
+qL
 bn
 bn
 bn
@@ -58182,7 +58255,7 @@ dv
 dH
 eg
 eg
-er
+JT
 eg
 eg
 eg
@@ -58371,7 +58444,7 @@ dv
 dv
 dv
 dv
-iB
+GF
 dv
 dv
 dH
@@ -58585,7 +58658,7 @@ bn
 vA
 bn
 bn
-OM
+OY
 bn
 am
 ca
@@ -58683,7 +58756,7 @@ eg
 eg
 dH
 dW
-jD
+OF
 dW
 dv
 dH
@@ -60187,7 +60260,7 @@ dL
 dL
 eC
 dH
-kE
+rg
 dH
 dH
 dH
@@ -60351,7 +60424,7 @@ ae
 ae
 mY
 ae
-cm
+tH
 ae
 ae
 ae
@@ -61114,7 +61187,7 @@ ae
 am
 nw
 am
-aI
+eh
 oz
 am
 iD
@@ -61380,7 +61453,7 @@ et
 eT
 eT
 et
-et
+kB
 et
 dv
 dv
@@ -62081,7 +62154,7 @@ fH
 ae
 ae
 ci
-ef
+eh
 bn
 am
 ca
@@ -62136,7 +62209,7 @@ dv
 dv
 LH
 dW
-dW
+kT
 dW
 dP
 dW
@@ -62774,7 +62847,7 @@ iE
 dH
 dH
 kR
-iB
+GF
 cV
 ac
 mi
@@ -63753,7 +63826,7 @@ tP
 tW
 ae
 bn
-bm
+qL
 br
 bn
 ae
@@ -63826,7 +63899,7 @@ en
 en
 en
 gJ
-gX
+TE
 en
 gh
 iw
@@ -63846,7 +63919,7 @@ am
 am
 am
 mJ
-cm
+tH
 am
 lZ
 nL
@@ -64211,7 +64284,7 @@ ae
 ci
 am
 bn
-au
+eh
 ca
 fH
 tO
@@ -64243,7 +64316,7 @@ bg
 ae
 ae
 ae
-Nj
+vv
 bg
 aa
 "}
@@ -64306,7 +64379,7 @@ ae
 mn
 nw
 am
-lD
+eh
 oD
 am
 iD
@@ -64694,7 +64767,7 @@ ca
 ca
 am
 bn
-am
+Gn
 uH
 vS
 ae
@@ -64978,7 +65051,7 @@ bn
 br
 bn
 bn
-ud
+uf
 bn
 bn
 bn
@@ -64992,7 +65065,7 @@ bn
 bn
 bn
 bn
-ud
+uf
 bn
 bn
 bn
@@ -65155,7 +65228,7 @@ bg
 ae
 ae
 ae
-Nj
+vv
 bg
 aa
 "}
@@ -65369,7 +65442,7 @@ ae
 ne
 ae
 ae
-cm
+tH
 ae
 ae
 ex

--- a/maps/DeepForest/map/_River_Forest.dmm
+++ b/maps/DeepForest/map/_River_Forest.dmm
@@ -385,6 +385,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest/river_forest_underground)
+"fW" = (
+/obj/item/stool,
+/obj/random/mob/roomba/range,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "fX" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
@@ -1039,7 +1044,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "pQ" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "pS" = (
@@ -1242,8 +1247,7 @@
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/forest/river_forest_light)
 "sj" = (
-/obj/machinery/shower,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "sl" = (
@@ -1557,6 +1561,10 @@
 /obj/random/material_resources,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest/river_forest_underground)
+"vr" = (
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "vt" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass/jungle,
@@ -2696,7 +2704,7 @@
 /area/nadezhda/outside/forest/river_forest_underground)
 "HJ" = (
 /obj/structure/bed/chair/custom/onestar/red,
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star/fo_internal)
 "HK" = (
@@ -2908,7 +2916,7 @@
 /turf/simulated/floor/asteroid/grass/colonialjungle2,
 /area/nadezhda/outside/forest/river_forest_light)
 "KC" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
+/obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star/fo_internal)
 "KF" = (
@@ -3541,6 +3549,11 @@
 "Su" = (
 /turf/simulated/floor/rock/alt,
 /area/nadezhda/outside/forest/river_forest_light)
+"Sx" = (
+/obj/machinery/light/floor,
+/obj/random/mob/roomba/mecha,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/nadezhda/outside/one_star/fo_internal)
 "SF" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/asteroid/grass,
@@ -3842,7 +3855,7 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/forest/river_forest_light)
 "VW" = (
-/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass/colonialjungle2,
 /area/nadezhda/outside/forest/river_forest_light)
 "VY" = (
@@ -29376,7 +29389,7 @@ bl
 Ij
 MD
 Ij
-pQ
+vr
 fN
 bz
 IP
@@ -29639,7 +29652,7 @@ bz
 IP
 Ij
 As
-sH
+vr
 As
 Ij
 AC
@@ -30917,7 +30930,7 @@ fN
 MD
 MD
 MD
-ee
+pQ
 Ij
 Ij
 Ij
@@ -31951,7 +31964,7 @@ ca
 Ij
 Ij
 Ij
-sH
+vr
 Ij
 Ij
 Ij
@@ -33488,7 +33501,7 @@ MD
 XA
 Du
 MD
-ee
+pQ
 MD
 Ak
 Vp
@@ -34007,7 +34020,7 @@ MD
 Ij
 Ij
 aS
-sH
+vr
 Ij
 Ij
 aS
@@ -36572,7 +36585,7 @@ MD
 MD
 Ak
 MD
-ee
+pQ
 MD
 Ak
 ZR
@@ -36835,7 +36848,7 @@ Ij
 Ij
 Ij
 Ij
-ee
+pQ
 Ij
 Ij
 Ij
@@ -37343,7 +37356,7 @@ MD
 MD
 oi
 Ij
-ee
+pQ
 Ij
 Ij
 Ij
@@ -37592,8 +37605,8 @@ fN
 fN
 MD
 Ij
-sj
-tQ
+XK
+fW
 Ij
 MD
 MD
@@ -39130,7 +39143,7 @@ Ij
 Ij
 Ij
 Ij
-ee
+pQ
 ca
 Ij
 Ij
@@ -41957,7 +41970,7 @@ oi
 oi
 cM
 Ij
-ee
+pQ
 Ij
 Ak
 Yr
@@ -42985,7 +42998,7 @@ Yr
 oi
 cM
 Ij
-ee
+pQ
 Ij
 Ak
 oi
@@ -44768,7 +44781,7 @@ fN
 RF
 Ij
 Ij
-TO
+sj
 ZT
 fN
 ca
@@ -45025,7 +45038,7 @@ fN
 RF
 TO
 aS
-TO
+sj
 ZT
 ZT
 ca
@@ -45282,7 +45295,7 @@ fN
 lG
 Ij
 Ij
-TO
+sj
 ZT
 fN
 ee
@@ -45310,7 +45323,7 @@ iC
 oi
 Ij
 Ij
-TI
+vr
 Ij
 oi
 oi
@@ -45543,7 +45556,7 @@ Ij
 ld
 fN
 ca
-pb
+vr
 Ij
 Ak
 fz
@@ -46326,7 +46339,7 @@ iC
 oi
 Ij
 Ij
-TI
+vr
 Ij
 oi
 oi
@@ -46594,7 +46607,7 @@ Yr
 Lm
 oi
 cM
-ee
+pQ
 Ij
 Ij
 Ak
@@ -48125,7 +48138,7 @@ oi
 oi
 cM
 Ij
-TI
+vr
 pb
 Ak
 fz
@@ -48394,7 +48407,7 @@ aC
 oi
 Ij
 ca
-ee
+pQ
 Ij
 oi
 oi
@@ -50695,7 +50708,7 @@ fN
 Oq
 Ij
 Ij
-aS
+Sx
 Ij
 Ij
 Oq

--- a/maps/submaps/dungeon_rooms/entrances/1.dmm
+++ b/maps/submaps/dungeon_rooms/entrances/1.dmm
@@ -9,16 +9,8 @@
 "c" = (
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
-"d" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "e" = (
 /turf/simulated/floor/bluegrid,
-/area/crawler)
-"f" = (
-/obj/machinery/light/floor/built,
-/turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "g" = (
 /obj/crawler/crawler_wallbreaker/vertical,
@@ -69,11 +61,11 @@ a
 (4,1,1) = {"
 a
 c
-d
 c
 c
 c
-d
+c
+c
 c
 a
 "}
@@ -135,11 +127,11 @@ a
 (10,1,1) = {"
 a
 c
-f
 c
 c
 c
-f
+c
+c
 c
 a
 "}

--- a/maps/submaps/dungeon_rooms/exits/1.dmm
+++ b/maps/submaps/dungeon_rooms/exits/1.dmm
@@ -1,10 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/simulated/wall,
+/turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "b" = (
 /obj/crawler/crawler_wallbreaker,
-/turf/simulated/wall,
+/turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "c" = (
 /turf/simulated/floor/tiled/derelict,
@@ -14,7 +14,7 @@
 /area/crawler)
 "e" = (
 /obj/crawler/crawler_wallbreaker/vertical,
-/turf/simulated/wall,
+/turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "f" = (
 /obj/rogue/telebeacon,
@@ -56,12 +56,6 @@
 /obj/item/tool_upgrade/augment/ai_tool,
 /obj/item/tool_upgrade/augment/ai_tool,
 /obj/item/tool_upgrade/augment/ai_tool,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
-"m" = (
-/obj/machinery/light,
-/obj/structure/closet/onestar/tier3/special,
-/obj/random/credits/c1000,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "n" = (
@@ -177,7 +171,7 @@ c
 f
 c
 d
-m
+h
 b
 "}
 (8,1,1) = {"

--- a/maps/submaps/dungeon_rooms/rooms/1.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/1.dmm
@@ -21,11 +21,6 @@
 /obj/structure/closet/onestar/tier1/mineral,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/crawler)
-"g" = (
-/obj/machinery/light/small,
-/obj/structure/table/onestar,
-/turf/simulated/floor/tiled/derelict/red_white_edges,
-/area/crawler)
 "h" = (
 /obj/random/mob/roomba,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -58,7 +53,7 @@ c
 c
 c
 c
-g
+T
 a
 "}
 (3,1,1) = {"

--- a/maps/submaps/dungeon_rooms/rooms/Escape_Pod_West-East.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/Escape_Pod_West-East.dmm
@@ -22,10 +22,6 @@
 "g" = (
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
-"h" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "i" = (
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall/untinted/onestar,
@@ -65,9 +61,9 @@ e
 e
 c
 i
-h
 g
-h
+g
+g
 d
 c
 e
@@ -153,9 +149,9 @@ e
 e
 c
 d
-h
 g
-h
+g
+g
 i
 c
 e

--- a/maps/submaps/dungeon_rooms/rooms/Hallway_4way.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/Hallway_4way.dmm
@@ -2,10 +2,6 @@
 "a" = (
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
-"b" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "c" = (
 /turf/simulated/floor/asteroid/grass,
 /area/crawler)
@@ -99,9 +95,9 @@ a
 a
 d
 a
-b
 e
-b
+e
+e
 a
 d
 p
@@ -109,11 +105,11 @@ p
 (6,1,1) = {"
 p
 e
-b
+e
 e
 h
 e
-b
+e
 e
 p
 "}
@@ -131,11 +127,11 @@ p
 (8,1,1) = {"
 p
 e
-b
 e
 e
 e
-b
+e
+e
 e
 p
 "}
@@ -143,9 +139,9 @@ p
 a
 f
 a
-b
 e
-b
+e
+e
 a
 f
 p

--- a/maps/submaps/dungeon_rooms/rooms/Hallway_Buried_West-East-South.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/Hallway_Buried_West-East-South.dmm
@@ -12,10 +12,6 @@
 "d" = (
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
-"e" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/crawler)
 "f" = (
 /obj/crawler/crawler_wallbreaker/vertical,
 /turf/simulated/wall/untinted/onestar_reinforced,
@@ -77,11 +73,11 @@ a
 (2,1,1) = {"
 a
 c
-e
+d
 h
 h
 h
-e
+d
 x
 a
 "}
@@ -191,7 +187,7 @@ c
 j
 h
 h
-e
+d
 n
 a
 "}

--- a/maps/submaps/dungeon_rooms/rooms/Hallway_North-South.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/Hallway_North-South.dmm
@@ -2,10 +2,6 @@
 "a" = (
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
-"b" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "c" = (
 /turf/simulated/floor/asteroid/grass,
 /area/crawler)
@@ -102,11 +98,11 @@ k
 (6,1,1) = {"
 k
 e
-b
 e
-b
 e
-b
+e
+e
+e
 e
 k
 "}
@@ -124,11 +120,11 @@ k
 (8,1,1) = {"
 k
 e
-b
 e
-b
 e
-b
+e
+e
+e
 e
 k
 "}

--- a/maps/submaps/dungeon_rooms/rooms/anomaly.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/anomaly.dmm
@@ -20,13 +20,6 @@
 /obj/structure/railing/grey,
 /turf/simulated/floor/plating/under,
 /area/crawler)
-"f" = (
-/obj/structure/catwalk,
-/obj/machinery/light/built{
-	dir = 1
-	},
-/turf/simulated/floor/plating/under,
-/area/crawler)
 "g" = (
 /turf/simulated/floor/tiled/dark/cargo,
 /area/crawler)
@@ -81,27 +74,9 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/crawler)
-"o" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/machinery/light/small/built{
-	dir = 8
-	},
-/turf/simulated/floor/plating/under,
-/area/crawler)
 "p" = (
 /obj/structure/inflatable/wall,
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/crawler)
-"r" = (
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/machinery/light/small/built{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
 /area/crawler)
 "s" = (
 /obj/structure/railing/grey,
@@ -161,7 +136,7 @@ a
 c
 i
 i
-o
+i
 i
 i
 c
@@ -191,7 +166,7 @@ a
 "}
 (5,1,1) = {"
 a
-f
+j
 j
 j
 p
@@ -235,7 +210,7 @@ b
 "}
 (9,1,1) = {"
 a
-f
+j
 j
 j
 p
@@ -271,7 +246,7 @@ a
 c
 k
 k
-r
+k
 k
 k
 c

--- a/maps/submaps/dungeon_rooms/rooms/armory.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/armory.dmm
@@ -10,14 +10,6 @@
 /obj/structure/closet/onestar/tier3,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
-"d" = (
-/obj/machinery/light/built{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline,
-/obj/structure/closet/onestar/tier3,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/crawler)
 "e" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -34,15 +26,6 @@
 "h" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
-	},
-/turf/simulated/floor/tiled/derelict/red_white_edges,
-/area/crawler)
-"i" = (
-/obj/machinery/light/built{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/crawler)
@@ -73,33 +56,12 @@
 "m" = (
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/crawler)
-"n" = (
-/obj/machinery/light/built{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/derelict/red_white_edges,
-/area/crawler)
 "o" = (
 /obj/random/mob/roomba,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/crawler)
-"p" = (
-/obj/machinery/light/small/built{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/crawler)
 "q" = (
 /obj/machinery/door/airlock/vault/bolted,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/crawler)
-"r" = (
-/obj/machinery/light/small/built{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/crawler)
 "s" = (
@@ -111,14 +73,6 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "u" = (
-/obj/effect/floor_decal/industrial/outline,
-/obj/structure/closet/onestar/tier2,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/crawler)
-"v" = (
-/obj/machinery/light/built{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/outline,
 /obj/structure/closet/onestar/tier2,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -424,13 +378,13 @@ f
 k
 a
 y
-p
+f
 E
 a
 "}
 (3,1,1) = {"
 a
-d
+c
 f
 l
 a
@@ -467,7 +421,7 @@ b
 o
 o
 b
-i
+e
 e
 H
 s
@@ -489,7 +443,7 @@ b
 o
 o
 b
-n
+h
 h
 I
 s
@@ -518,7 +472,7 @@ a
 "}
 (11,1,1) = {"
 a
-v
+u
 f
 z
 a
@@ -534,7 +488,7 @@ f
 A
 a
 D
-r
+f
 K
 a
 "}

--- a/maps/submaps/dungeon_rooms/rooms/armory_secure.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/armory_secure.dmm
@@ -41,9 +41,6 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/machinery/light/built{
-	dir = 4
-	},
 /obj/random/structures/os,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/crawler)

--- a/maps/submaps/dungeon_rooms/rooms/autolathe_South-East.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/autolathe_South-East.dmm
@@ -16,12 +16,6 @@
 "d" = (
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/crawler)
-"e" = (
-/obj/machinery/light/built{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/crawler)
 "f" = (
 /turf/simulated/floor/tiled/dark/cargo,
 /area/crawler)
@@ -112,22 +106,6 @@
 /obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/tiled/techmaint,
 /area/crawler)
-"B" = (
-/obj/machinery/light/built{
-	dir = 1
-	},
-/obj/random/structures/os,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/crawler)
-"C" = (
-/obj/machinery/light/built,
-/turf/simulated/floor/carpet/bcarpet,
-/area/crawler)
-"D" = (
-/obj/machinery/light/built,
-/obj/random/structures/os,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/crawler)
 "E" = (
 /obj/random/mob/roomba,
 /turf/simulated/floor/tiled/dark/cargo,
@@ -187,13 +165,13 @@ a
 "}
 (3,1,1) = {"
 a
-e
+d
 U
 i
 q
 k
 u
-C
+u
 a
 "}
 (4,1,1) = {"
@@ -275,13 +253,13 @@ a
 "}
 (11,1,1) = {"
 a
-B
+g
 f
 f
 E
 f
 f
-D
+g
 a
 "}
 (12,1,1) = {"

--- a/maps/submaps/dungeon_rooms/rooms/cargo_horizontal.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/cargo_horizontal.dmm
@@ -13,12 +13,6 @@
 "d" = (
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/crawler)
-"e" = (
-/obj/machinery/light/built{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/derelict/white_big_edges,
-/area/crawler)
 "f" = (
 /obj/structure/railing,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -69,10 +63,6 @@
 /obj/structure/catwalk,
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/crawler)
-"p" = (
-/obj/machinery/light/built,
-/turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/crawler)
 "q" = (
 /obj/structure/railing{
@@ -161,7 +151,7 @@ l
 s
 s
 s
-p
+d
 b
 b
 "}
@@ -190,11 +180,11 @@ m
 (7,1,1) = {"
 m
 b
-e
+d
 i
 k
 i
-p
+d
 b
 m
 "}
@@ -234,11 +224,11 @@ b
 (11,1,1) = {"
 b
 b
-e
+d
 j
 d
 j
-p
+d
 b
 b
 "}

--- a/maps/submaps/dungeon_rooms/rooms/cargo_vertical.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/cargo_vertical.dmm
@@ -2,21 +2,8 @@
 "a" = (
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
-"b" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light/small/built{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/derelict/white_red_edges,
-/area/crawler)
 "c" = (
 /turf/simulated/floor/tiled/derelict/white_big_edges,
-/area/crawler)
-"d" = (
-/obj/machinery/light/built{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/crawler)
 "e" = (
 /obj/structure/railing,
@@ -24,9 +11,6 @@
 /area/crawler)
 "f" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light/small/built{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/crawler)
 "g" = (
@@ -101,10 +85,6 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/crawler)
-"t" = (
-/obj/machinery/light/built,
-/turf/simulated/floor/tiled/derelict/white_big_edges,
-/area/crawler)
 "u" = (
 /obj/crawler/crawler_wallbreaker,
 /turf/simulated/wall/untinted/onestar_reinforced,
@@ -151,11 +131,11 @@ a
 "}
 (2,1,1) = {"
 a
-b
+f
 g
 g
 g
-b
+f
 a
 a
 a
@@ -184,13 +164,13 @@ a
 "}
 (5,1,1) = {"
 a
-d
+r
 j
 p
 j
 r
 v
-t
+c
 u
 "}
 (6,1,1) = {"
@@ -234,7 +214,7 @@ q
 m
 r
 c
-t
+c
 u
 "}
 (10,1,1) = {"

--- a/maps/submaps/dungeon_rooms/rooms/checkpoint_horizontal.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/checkpoint_horizontal.dmm
@@ -38,7 +38,6 @@
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "i" = (
-/obj/machinery/light/floor,
 /obj/structure/railing/grey{
 	dir = 4
 	},
@@ -58,7 +57,6 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
 "l" = (
-/obj/machinery/light/floor,
 /obj/structure/railing/grey{
 	dir = 8
 	},
@@ -78,7 +76,6 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "p" = (
-/obj/structure/low_wall/onestar,
 /obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
@@ -111,8 +108,8 @@
 /area/crawler)
 "w" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
@@ -121,7 +118,6 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/crawler)
 "y" = (
-/obj/machinery/light/floor,
 /obj/structure/railing/grey{
 	dir = 1
 	},
@@ -138,7 +134,6 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
 "A" = (
-/obj/machinery/light/floor,
 /obj/structure/railing/grey{
 	dir = 1
 	},

--- a/maps/submaps/dungeon_rooms/rooms/commanderoffice.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/commanderoffice.dmm
@@ -9,10 +9,6 @@
 "c" = (
 /turf/simulated/floor/wood,
 /area/crawler)
-"d" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/wood,
-/area/crawler)
 "e" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/wood,
@@ -56,10 +52,6 @@
 "n" = (
 /mob/living/carbon/superior_animal/robot/greyson/roomba/boomba,
 /turf/simulated/floor/wood,
-/area/crawler)
-"o" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/cafe,
 /area/crawler)
 "p" = (
 /turf/simulated/floor/tiled/cafe,
@@ -221,13 +213,13 @@ a
 "}
 (3,1,1) = {"
 a
-d
+c
 c
 B
 c
 a
 p
-o
+p
 a
 "}
 (4,1,1) = {"
@@ -255,11 +247,11 @@ b
 (6,1,1) = {"
 b
 c
-d
+c
 j
 j
 j
-d
+c
 q
 b
 "}
@@ -299,11 +291,11 @@ b
 (10,1,1) = {"
 a
 c
-d
 c
 c
 c
-d
+c
+c
 I
 a
 "}

--- a/maps/submaps/dungeon_rooms/rooms/corner_energy_NE.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/corner_energy_NE.dmm
@@ -20,9 +20,11 @@
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "f" = (
-/obj/structure/catwalk,
-/obj/machinery/light/floor,
-/turf/simulated/floor/plating/under,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "g" = (
 /obj/structure/window/reinforced{
@@ -74,11 +76,11 @@
 /turf/simulated/floor/bluegrid,
 /area/crawler)
 "p" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
+/obj/machinery/power/terminal,
+/obj/structure/catwalk,
+/obj/random/powercell,
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "q" = (
 /obj/crawler/crawler_wallbreaker/vertical,
@@ -97,10 +99,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "u" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "v" = (
@@ -111,17 +110,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/crawler)
-"w" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/crawler)
-"x" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "y" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -198,7 +186,7 @@ a
 "}
 (2,1,1) = {"
 a
-f
+e
 l
 n
 t
@@ -211,7 +199,7 @@ a
 a
 e
 l
-n
+f
 t
 t
 A
@@ -235,7 +223,7 @@ e
 l
 n
 t
-x
+t
 a
 A
 b
@@ -246,8 +234,8 @@ e
 l
 n
 t
+u
 t
-x
 t
 C
 "}
@@ -255,10 +243,10 @@ C
 b
 e
 l
-p
+n
 B
 t
-t
+u
 t
 C
 "}
@@ -267,7 +255,7 @@ b
 e
 k
 a
-u
+y
 y
 y
 R
@@ -288,7 +276,7 @@ b
 a
 d
 h
-N
+p
 s
 N
 s
@@ -311,7 +299,7 @@ a
 T
 j
 c
-w
+j
 c
 j
 T

--- a/maps/submaps/dungeon_rooms/rooms/corner_energy_NW.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/corner_energy_NW.dmm
@@ -20,9 +20,11 @@
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "f" = (
-/obj/structure/catwalk,
-/obj/machinery/light/floor,
-/turf/simulated/floor/plating/under,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "g" = (
 /obj/structure/window/reinforced{
@@ -69,11 +71,10 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "o" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
+/obj/machinery/power/terminal,
+/obj/structure/catwalk,
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "p" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -84,13 +85,6 @@
 "q" = (
 /obj/crawler/crawler_wallbreaker/vertical,
 /turf/simulated/floor/bluegrid,
-/area/crawler)
-"r" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "s" = (
 /obj/machinery/power/smes/buildable,
@@ -105,13 +99,6 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
-"u" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "v" = (
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
@@ -125,10 +112,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
-"y" = (
-/obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "A" = (
@@ -179,10 +162,12 @@
 /obj/machinery/power/terminal,
 /obj/structure/catwalk,
 /obj/random/powercell,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "U" = (
 /obj/item/tool_upgrade/augment/cell_mount,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "Z" = (
@@ -206,7 +191,7 @@ a
 c
 g
 c
-r
+g
 Z
 g
 c
@@ -229,7 +214,7 @@ d
 i
 R
 s
-n
+o
 s
 Z
 a
@@ -250,7 +235,7 @@ b
 e
 k
 a
-u
+x
 x
 x
 x
@@ -260,7 +245,7 @@ C
 b
 e
 l
-o
+p
 v
 U
 v
@@ -274,7 +259,7 @@ l
 G
 v
 v
-y
+v
 v
 C
 "}
@@ -293,7 +278,7 @@ b
 a
 e
 l
-p
+f
 P
 v
 A
@@ -313,7 +298,7 @@ a
 "}
 (12,1,1) = {"
 a
-f
+e
 l
 p
 v

--- a/maps/submaps/dungeon_rooms/rooms/corner_energy_SE.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/corner_energy_SE.dmm
@@ -3,8 +3,10 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "b" = (
-/obj/crawler/crawler_wallbreaker,
-/turf/simulated/floor/bluegrid,
+/obj/machinery/power/terminal,
+/obj/structure/catwalk,
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "c" = (
 /turf/simulated/floor/tiled/derelict,
@@ -42,7 +44,7 @@
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "j" = (
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "k" = (
@@ -73,14 +75,12 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "p" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
-"q" = (
-/turf/simulated/floor/bluegrid,
+/obj/structure/lattice,
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/plating/under,
 /area/crawler)
 "r" = (
 /obj/effect/floor_decal/industrial/loading{
@@ -88,10 +88,6 @@
 	},
 /obj/random/powercell,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/crawler)
-"s" = (
-/obj/crawler/crawler_wallbreaker/vertical,
-/turf/simulated/floor/bluegrid,
 /area/crawler)
 "t" = (
 /obj/machinery/power/terminal,
@@ -102,26 +98,9 @@
 /obj/machinery/power/smes/buildable,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/crawler)
-"v" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/crawler)
-"w" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "x" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/derelict,
-/area/crawler)
-"y" = (
-/obj/structure/catwalk,
-/obj/machinery/light/floor,
-/turf/simulated/floor/plating/under,
 /area/crawler)
 "z" = (
 /obj/structure/railing/grey{
@@ -176,9 +155,9 @@
 a
 a
 a
-q
-q
-s
+a
+a
+o
 a
 a
 a
@@ -191,7 +170,7 @@ c
 c
 x
 z
-y
+A
 a
 "}
 (3,1,1) = {"
@@ -199,7 +178,7 @@ a
 i
 h
 c
-c
+j
 x
 z
 A
@@ -220,17 +199,17 @@ a
 a
 h
 a
-j
 c
+j
 x
 z
 A
 C
 "}
 (6,1,1) = {"
-b
+C
 c
-j
+c
 c
 D
 x
@@ -239,24 +218,24 @@ A
 C
 "}
 (7,1,1) = {"
-b
+C
 c
 c
 c
 c
-w
+x
 z
 A
 C
 "}
 (8,1,1) = {"
-b
+C
 d
 d
 d
-p
+d
 a
-i
+p
 A
 C
 "}
@@ -275,7 +254,7 @@ C
 a
 f
 k
-t
+b
 G
 t
 u
@@ -298,7 +277,7 @@ a
 Q
 n
 g
-v
+n
 W
 n
 Q

--- a/maps/submaps/dungeon_rooms/rooms/corner_energy_SW.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/corner_energy_SW.dmm
@@ -65,7 +65,7 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "n" = (
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "o" = (
@@ -75,6 +75,7 @@
 "p" = (
 /obj/machinery/power/terminal,
 /obj/structure/catwalk,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "q" = (
@@ -84,36 +85,17 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "r" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict/white_small_edges,
+/obj/effect/floor_decal/industrial/warning,
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "s" = (
 /obj/crawler/crawler_wallbreaker/vertical,
 /turf/simulated/floor/bluegrid,
 /area/crawler)
-"t" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "u" = (
 /obj/machinery/power/smes/buildable,
 /turf/simulated/floor/tiled/techmaint_panels,
-/area/crawler)
-"v" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
-"w" = (
-/obj/structure/catwalk,
-/obj/machinery/light/floor,
-/turf/simulated/floor/plating/under,
 /area/crawler)
 "x" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -186,7 +168,7 @@ a
 c
 j
 Q
-r
+j
 c
 j
 c
@@ -230,7 +212,7 @@ b
 f
 f
 D
-t
+f
 a
 i
 A
@@ -240,9 +222,9 @@ C
 b
 g
 g
+n
 g
-g
-v
+x
 z
 A
 C
@@ -250,7 +232,7 @@ C
 (8,1,1) = {"
 b
 g
-n
+g
 g
 g
 x
@@ -262,7 +244,7 @@ C
 a
 h
 a
-n
+g
 M
 x
 z
@@ -275,7 +257,7 @@ i
 h
 g
 g
-x
+r
 z
 A
 a
@@ -299,7 +281,7 @@ g
 g
 x
 z
-w
+A
 a
 "}
 (13,1,1) = {"

--- a/maps/submaps/dungeon_rooms/rooms/corner_garden_NE.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/corner_garden_NE.dmm
@@ -20,10 +20,6 @@
 /obj/structure/railing/grey,
 /turf/simulated/floor/asteroid/grass,
 /area/crawler)
-"g" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/asteroid/grass,
-/area/crawler)
 "h" = (
 /obj/crawler/crawler_wallbreaker/vertical,
 /turf/simulated/wall/untinted/onestar_reinforced,
@@ -41,14 +37,14 @@
 /obj/effect/floor_decal/spline/grass_edge{
 	dir = 1
 	},
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "l" = (
 /obj/effect/floor_decal/spline/grass_edge{
 	dir = 4
 	},
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "m" = (
@@ -59,7 +55,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "o" = (
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "p" = (
@@ -216,7 +212,7 @@ D
 (8,1,1) = {"
 b
 c
-g
+c
 a
 l
 t
@@ -228,7 +224,7 @@ D
 a
 d
 d
-g
+c
 p
 p
 p

--- a/maps/submaps/dungeon_rooms/rooms/corner_garden_NW.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/corner_garden_NW.dmm
@@ -9,10 +9,6 @@
 "c" = (
 /turf/simulated/floor/asteroid/grass,
 /area/crawler)
-"d" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/asteroid/grass,
-/area/crawler)
 "e" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/asteroid/grass,
@@ -25,14 +21,14 @@
 /obj/effect/floor_decal/spline/grass_edge{
 	dir = 1
 	},
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "h" = (
 /obj/effect/floor_decal/spline/grass_edge{
 	dir = 8
 	},
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "i" = (
@@ -51,7 +47,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/crawler)
 "l" = (
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "m" = (
@@ -169,7 +165,7 @@ a
 a
 c
 c
-d
+c
 k
 k
 k
@@ -179,7 +175,7 @@ b
 (6,1,1) = {"
 b
 c
-d
+c
 a
 h
 o

--- a/maps/submaps/dungeon_rooms/rooms/corner_garden_SE.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/corner_garden_SE.dmm
@@ -79,7 +79,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/crawler)
 "q" = (
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "r" = (
@@ -106,12 +106,12 @@
 /obj/effect/floor_decal/spline/grass_edge{
 	dir = 4
 	},
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "x" = (
 /obj/effect/floor_decal/spline/grass_edge,
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "y" = (
@@ -123,8 +123,8 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "A" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/asteroid/grass,
+/obj/random/mob/roomba/job,
+/turf/simulated/floor/wood,
 /area/crawler)
 "C" = (
 /turf/simulated/floor/asteroid/grass,
@@ -224,7 +224,7 @@ i
 i
 w
 a
-A
+C
 C
 F
 "}
@@ -234,7 +234,7 @@ j
 r
 r
 r
-A
+C
 C
 C
 F
@@ -253,7 +253,7 @@ a
 (11,1,1) = {"
 a
 l
-r
+A
 s
 r
 C

--- a/maps/submaps/dungeon_rooms/rooms/corner_garden_SW.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/corner_garden_SW.dmm
@@ -66,7 +66,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/crawler)
 "n" = (
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "o" = (
@@ -107,7 +107,7 @@
 /obj/effect/floor_decal/spline/grass_edge{
 	dir = 8
 	},
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "u" = (
@@ -121,10 +121,8 @@
 /turf/simulated/floor/bluegrid,
 /area/crawler)
 "w" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/machinery/light/floor,
+/obj/structure/catwalk,
+/obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/crawler)
 "x" = (
@@ -135,12 +133,8 @@
 /area/crawler)
 "y" = (
 /obj/effect/floor_decal/spline/grass_edge,
-/obj/machinery/light/floor,
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/derelict,
-/area/crawler)
-"z" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/asteroid/grass,
 /area/crawler)
 "A" = (
 /obj/effect/floor_decal/spline/grass_edge,
@@ -177,7 +171,7 @@ a
 a
 d
 m
-m
+w
 m
 x
 c
@@ -201,7 +195,7 @@ e
 m
 s
 m
-w
+x
 c
 c
 C
@@ -213,7 +207,7 @@ f
 f
 t
 a
-z
+c
 c
 C
 "}

--- a/maps/submaps/dungeon_rooms/rooms/crematorium.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/crematorium.dmm
@@ -34,8 +34,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "j" = (
-/obj/structure/low_wall,
-/obj/effect/window_lwall_spawn,
+/obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "k" = (
@@ -45,10 +44,6 @@
 /obj/structure/closet/onestar/tier1,
 /obj/random/medical,
 /turf/simulated/floor/tiled/dark/golden,
-/area/crawler)
-"m" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/white,
 /area/crawler)
 "n" = (
 /obj/structure/morgue,
@@ -75,10 +70,6 @@
 "q" = (
 /obj/structure/morgue,
 /turf/simulated/floor/tiled/white,
-/area/crawler)
-"r" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "s" = (
 /obj/machinery/light/floor,
@@ -177,9 +168,9 @@ a
 a
 j
 a
-r
 k
-r
+k
+k
 a
 j
 b
@@ -221,9 +212,9 @@ b
 a
 j
 a
-r
 k
-r
+k
+k
 a
 j
 b
@@ -241,13 +232,13 @@ a
 "}
 (11,1,1) = {"
 a
-m
+c
 y
 k
 i
 k
 o
-m
+c
 a
 "}
 (12,1,1) = {"

--- a/maps/submaps/dungeon_rooms/rooms/droppod.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/droppod.dmm
@@ -7,6 +7,7 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "c" = (
+/obj/random/mob/roomba/any,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/crawler)
 "d" = (
@@ -80,9 +81,34 @@
 "r" = (
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
+"s" = (
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/crawler)
+"A" = (
+/obj/machinery/power/supply_beacon,
+/turf/simulated/floor/asteroid,
+/area/crawler)
+"G" = (
+/obj/random/mob/roomba/any,
+/turf/simulated/floor/tiled/derelict,
+/area/crawler)
 "P" = (
 /obj/random/structures/os,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/crawler)
+"R" = (
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor/asteroid,
+/area/crawler)
+"X" = (
+/obj/random/mob/roomba/mecha/low,
+/turf/simulated/floor/tiled/derelict,
+/area/crawler)
+"Y" = (
+/obj/structure/lattice,
+/obj/effect/window_lwall_spawn/smartspawn/onestar,
+/turf/simulated/floor/asteroid,
 /area/crawler)
 
 (1,1,1) = {"
@@ -111,9 +137,9 @@ a
 a
 d
 a
-f
-f
-f
+Y
+R
+Y
 a
 d
 a
@@ -121,33 +147,33 @@ a
 (4,1,1) = {"
 a
 d
-f
+Y
 h
 h
 h
-f
+Y
 d
 a
 "}
 (5,1,1) = {"
 a
 d
-f
+Y
 h
+A
 h
-h
-f
+Y
 d
 b
 "}
 (6,1,1) = {"
 b
 d
-f
+Y
 h
 h
 h
-f
+Y
 d
 b
 "}
@@ -178,7 +204,7 @@ a
 o
 p
 r
-r
+X
 r
 q
 o
@@ -198,11 +224,11 @@ a
 (11,1,1) = {"
 a
 j
-e
+s
 r
+G
 r
-r
-e
+s
 j
 a
 "}

--- a/maps/submaps/dungeon_rooms/rooms/garden.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/garden.dmm
@@ -3,8 +3,8 @@
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
 "b" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light/floor,
+/obj/random/mob/roomba,
+/obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/crawler)
 "c" = (
@@ -67,7 +67,6 @@
 "o" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/light/floor,
 /turf/simulated/floor/asteroid/grass,
 /area/crawler)
 "p" = (
@@ -229,11 +228,11 @@ a
 (4,1,1) = {"
 a
 a
-b
+j
 t
 A
 p
-r
+b
 a
 a
 "}
@@ -299,7 +298,7 @@ o
 p
 n
 F
-b
+j
 a
 a
 "}

--- a/maps/submaps/dungeon_rooms/rooms/hallway_West-East.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/hallway_West-East.dmm
@@ -20,10 +20,6 @@
 /obj/crawler/crawler_wallbreaker/vertical,
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
-"g" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "h" = (
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
@@ -75,9 +71,9 @@ a
 a
 c
 e
-g
 h
-g
+h
+h
 e
 c
 a
@@ -108,9 +104,9 @@ b
 b
 c
 e
-g
 h
-g
+h
+h
 e
 c
 b
@@ -141,9 +137,9 @@ b
 a
 c
 e
-g
 h
-g
+h
+h
 e
 c
 a

--- a/maps/submaps/dungeon_rooms/rooms/hallway_executive.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/hallway_executive.dmm
@@ -6,13 +6,6 @@
 /obj/structure/noticeboard,
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
-"c" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/wood,
-/area/crawler)
 "d" = (
 /turf/simulated/floor/wood,
 /area/crawler)
@@ -37,21 +30,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/crawler)
-"i" = (
-/obj/structure/bed/chair/office/dark,
-/obj/machinery/light/floor,
-/turf/simulated/floor/wood,
-/area/crawler)
 "j" = (
 /obj/structure/table/onestar,
 /turf/simulated/floor/tiled/techmaint,
 /area/crawler)
 "k" = (
 /obj/structure/table/onestar,
-/turf/simulated/floor/wood,
-/area/crawler)
-"l" = (
-/obj/machinery/light/floor,
 /turf/simulated/floor/wood,
 /area/crawler)
 "m" = (
@@ -208,11 +192,11 @@ a
 (2,1,1) = {"
 a
 d
-c
+s
 n
 e
 d
-l
+d
 x
 a
 "}
@@ -318,11 +302,11 @@ a
 (12,1,1) = {"
 a
 w
-i
+e
 d
 p
 d
-l
+d
 C
 a
 "}

--- a/maps/submaps/dungeon_rooms/rooms/hallway_storage.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/hallway_storage.dmm
@@ -6,10 +6,6 @@
 /obj/structure/extinguisher_cabinet,
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
-"c" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/crawler)
 "d" = (
 /obj/machinery/antigrav,
 /turf/simulated/floor/bluegrid,
@@ -94,14 +90,10 @@
 /area/crawler)
 "w" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
+	dir = 4;
+	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/derelict,
-/area/crawler)
-"y" = (
-/obj/random/toy/plushie,
-/turf/simulated/floor/bluegrid,
 /area/crawler)
 "z" = (
 /obj/structure/salvageable/data_os,
@@ -170,11 +162,11 @@ a
 (2,1,1) = {"
 a
 d
-c
+n
 z
 a
 B
-c
+n
 I
 a
 "}
@@ -270,7 +262,7 @@ a
 a
 l
 n
-y
+B
 a
 F
 n
@@ -280,11 +272,11 @@ a
 (12,1,1) = {"
 a
 T
-c
+n
 z
 a
 X
-c
+n
 I
 a
 "}

--- a/maps/submaps/dungeon_rooms/rooms/hallwayatmos_west-east.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/hallwayatmos_west-east.dmm
@@ -31,11 +31,6 @@
 /obj/crawler/crawler_wallbreaker/vertical,
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
-"s" = (
-/obj/structure/catwalk,
-/obj/machinery/light/floor,
-/turf/simulated/floor/plating/under,
-/area/crawler)
 "u" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -107,9 +102,9 @@ a
 a
 e
 a
-s
+u
 z
-s
+u
 a
 e
 b
@@ -151,9 +146,9 @@ b
 a
 e
 a
-s
+u
 z
-s
+u
 a
 e
 b

--- a/maps/submaps/dungeon_rooms/rooms/mechbay.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/mechbay.dmm
@@ -30,12 +30,6 @@
 /obj/structure/closet/onestar/tier3,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
-"h" = (
-/obj/effect/floor_decal/rust,
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/crawler)
 "i" = (
 /obj/structure/table/onestar,
 /turf/simulated/floor/tiled/derelict,
@@ -55,14 +49,8 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "m" = (
-/obj/structure/low_wall,
-/obj/effect/window_lwall_spawn,
+/obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/tiled/techmaint,
-/area/crawler)
-"n" = (
-/obj/structure/table/onestar,
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "o" = (
 /obj/structure/railing/grey{
@@ -122,17 +110,6 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/simulated/floor/tiled/dark/panels,
 /area/crawler)
-"x" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
-"y" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "z" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -172,11 +149,6 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
-"G" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "H" = (
 /obj/machinery/conveyor/north{
 	id = 4
@@ -193,10 +165,6 @@
 "J" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/derelict,
-/area/crawler)
-"K" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "M" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -302,9 +270,9 @@ b
 b
 i
 X
-n
+i
 C
-y
+C
 i
 i
 b
@@ -324,9 +292,9 @@ b
 b
 j
 j
-x
+z
 C
-G
+J
 M
 M
 b
@@ -344,13 +312,13 @@ b
 "}
 (10,1,1) = {"
 a
-h
+t
 r
 A
 C
 J
 q
-K
+q
 a
 "}
 (11,1,1) = {"

--- a/maps/submaps/dungeon_rooms/rooms/office.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/office.dmm
@@ -2,14 +2,6 @@
 "aa" = (
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
-"ab" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/obj/item/remains/human,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/crawler)
 "ac" = (
 /obj/structure/noticeboard,
 /turf/simulated/wall/untinted/onestar_reinforced,
@@ -19,6 +11,7 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/office/dark,
+/obj/random/mob/roomba,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/crawler)
 "ae" = (
@@ -89,7 +82,6 @@
 	dir = 4
 	},
 /obj/structure/table/onestar,
-/obj/item/stamp/chameleon,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
 "an" = (
@@ -136,7 +128,6 @@
 	dir = 6
 	},
 /obj/structure/table/onestar,
-/obj/item/clothing/accessory/medal/conduct,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
 "at" = (
@@ -211,12 +202,9 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "aB" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/bed/chair/office/dark,
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/dark/brown_platform,
+/obj/structure/table/onestar,
+/obj/item/device/toner,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
 "aC" = (
 /obj/structure/window/reinforced{
@@ -325,6 +313,7 @@
 	dir = 8
 	},
 /obj/item/remains/human,
+/obj/random/mob/roomba,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/crawler)
 "aO" = (
@@ -350,7 +339,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/light/floor,
 /obj/item/remains/human,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/dark/brown_platform,
@@ -445,6 +433,21 @@
 /obj/random/structures/os,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
+"vJ" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/crawler)
+"DW" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/crawler)
+"MQ" = (
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/crawler)
+"SY" = (
+/obj/random/mob/roomba,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/crawler)
 
 (1,1,1) = {"
 aa
@@ -481,7 +484,7 @@ aa
 "}
 (4,1,1) = {"
 ac
-ab
+aN
 aR
 aM
 ae
@@ -503,8 +506,8 @@ ar
 "}
 (6,1,1) = {"
 ar
-af
-af
+aB
+MQ
 af
 aW
 aZ
@@ -514,19 +517,19 @@ ar
 "}
 (7,1,1) = {"
 ar
-af
-aT
+vJ
+SY
 af
 af
 aZ
 ae
-aB
+aR
 ar
 "}
 (8,1,1) = {"
 ar
-af
-af
+DW
+MQ
 af
 aT
 af

--- a/maps/submaps/dungeon_rooms/rooms/penitentiary.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/penitentiary.dmm
@@ -25,10 +25,6 @@
 "g" = (
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/crawler)
-"h" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/dark/brown_platform,
-/area/crawler)
 "i" = (
 /obj/structure/table/onestar,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -61,10 +57,6 @@
 "o" = (
 /obj/crawler/crawler_wallbreaker/vertical,
 /turf/simulated/wall/untinted/onestar_reinforced,
-/area/crawler)
-"p" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "q" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -119,7 +111,6 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
 "C" = (
-/obj/structure/low_wall/onestar,
 /obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
@@ -172,7 +163,7 @@ e
 a
 s
 u
-p
+u
 a
 a
 a
@@ -201,11 +192,11 @@ b
 "}
 (7,1,1) = {"
 b
-h
+g
 m
 C
 u
-p
+u
 a
 a
 b
@@ -238,7 +229,7 @@ a
 a
 s
 u
-p
+u
 a
 a
 a

--- a/maps/submaps/dungeon_rooms/rooms/refinery.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/refinery.dmm
@@ -16,8 +16,10 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "e" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
+/obj/machinery/conveyor_switch/oneway{
+	id = 1
+	},
+/turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/crawler)
 "f" = (
 /turf/simulated/floor/tiled/derelict,
@@ -35,6 +37,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/random/structures/os,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "j" = (
@@ -73,9 +76,6 @@
 /obj/crawler/crawler_wallbreaker/vertical,
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
-"p" = (
-/turf/simulated/floor/bluegrid,
-/area/crawler)
 "q" = (
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/crawler)
@@ -104,7 +104,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/crawler)
 "v" = (
-/obj/machinery/light/floor,
 /turf/simulated/floor/plating,
 /area/crawler)
 "w" = (
@@ -115,28 +114,17 @@
 /area/crawler)
 "x" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/conveyor_switch/oneway{
-	id = 1
-	},
-/obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "y" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/structure/railing/grey{
-	dir = 8
-	},
 /obj/random/material,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
-"z" = (
-/obj/crawler/crawler_wallbreaker/vertical,
-/turf/simulated/floor/bluegrid,
-/area/crawler)
 "A" = (
-/obj/structure/salvageable/autolathe,
+/obj/structure/salvageable/autolathe_os,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/crawler)
 "B" = (
@@ -161,10 +149,6 @@
 "E" = (
 /obj/structure/plushie/beepsky,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
-/area/crawler)
-"F" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "G" = (
 /obj/machinery/conveyor/northwest{
@@ -199,11 +183,11 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/random/structures/os,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "L" = (
 /obj/structure/table/onestar,
-/obj/machinery/light/floor,
 /obj/random/material,
 /obj/random/material,
 /obj/random/material,
@@ -239,9 +223,9 @@
 a
 a
 a
-p
-p
-z
+o
+o
+o
 a
 a
 a
@@ -253,19 +237,19 @@ d
 q
 q
 q
-F
+T
 T
 a
 "}
 (3,1,1) = {"
 a
-e
+f
 f
 q
 M
 q
 f
-e
+f
 a
 "}
 (4,1,1) = {"
@@ -275,8 +259,8 @@ d
 M
 q
 Q
-F
-F
+T
+T
 a
 "}
 (5,1,1) = {"
@@ -306,7 +290,7 @@ c
 a
 j
 t
-a
+q
 C
 G
 a
@@ -317,8 +301,8 @@ c
 a
 k
 a
-a
-a
+q
+e
 H
 a
 c

--- a/maps/submaps/dungeon_rooms/rooms/room_templates.dm
+++ b/maps/submaps/dungeon_rooms/rooms/room_templates.dm
@@ -19,6 +19,20 @@
 	room_tag = "dead_end"
 	directional_flags = list("west")
 
+/datum/map_template/dungeon_template/room/shooting_range
+	name = "shooting_range"
+	desc = "Enjoy your stay."
+	mappath = 'maps/submaps/dungeon_rooms/rooms/shootingrange.dmm'
+	room_tag = "dead_end"
+	directional_flags = list("west")
+
+/datum/map_template/dungeon_template/room/refinery
+	name = "refinery"
+	desc = "Enjoy your stay."
+	mappath = 'maps/submaps/dungeon_rooms/rooms/refinery.dmm'
+	room_tag = "dead_end"
+	directional_flags = list("east")
+
 /datum/map_template/dungeon_template/room/autolathe_south_east
 	name = "autolathe_South-East"
 	desc = "Enjoy your stay."
@@ -32,6 +46,13 @@
 	mappath = 'maps/submaps/dungeon_rooms/rooms/cargo_horizontal.dmm'
 	room_tag = "dead_end"
 	directional_flags = list("west")
+
+/datum/map_template/dungeon_template/room/cargo_vertical
+	name = "cargo_vertical"
+	desc = "Enjoy your stay."
+	mappath = 'maps/submaps/dungeon_rooms/rooms/cargo_vertical.dmm'
+	room_tag = "dead_end"
+	directional_flags = list("south")
 
 /datum/map_template/dungeon_template/room/checkpoint_horizontal
 	name = "checkpoint_horizontal"
@@ -47,6 +68,12 @@
 	directional_flags = list("south", "north")
 	room_tag = "above_only"
 
+/datum/map_template/dungeon_template/room/corner_energy_SE
+	name = "corner_energy_SE"
+	desc = "Enjoy your stay."
+	mappath = 'maps/submaps/dungeon_rooms/rooms/corner_energy_SE.dmm'
+	directional_flags = list("east", "south")
+	room_tag = "above_only"
 
 /datum/map_template/dungeon_template/room/commanderoffice
 	name = "commanderoffice"
@@ -61,26 +88,22 @@
 	mappath = 'maps/submaps/dungeon_rooms/rooms/crematorium.dmm'
 	directional_flags = list("west", "east", "south")
 
+/* - looks nice but not all that good
 /datum/map_template/dungeon_template/room/Escape_Pod_West_East
 	name = "Escape_Pod_West-East"
 	desc = "Enjoy your stay."
 	mappath = 'maps/submaps/dungeon_rooms/rooms/Escape_Pod_West-East.dmm'
+*/
 
 /datum/map_template/dungeon_template/room/garden
 	name = "garden"
 	desc = "Enjoy your stay."
-	mappath = 'maps/submaps/dungeon_rooms/rooms/garden.dmm'
+	mappath = 'maps/submaps/dungeon_rooms/rooms/garden.dmm' //Allows getto bricord do to flowers and looks nice
 
 /datum/map_template/dungeon_template/room/Hallway_4way
 	name = "Hallway_4way"
 	desc = "Enjoy your stay."
 	mappath = 'maps/submaps/dungeon_rooms/rooms/Hallway_4way.dmm'
-
-/datum/map_template/dungeon_template/room/Hallway_4way
-	name = "Hallway_4way"
-	desc = "Enjoy your stay."
-	mappath = 'maps/submaps/dungeon_rooms/rooms/Hallway_4way.dmm'
-
 
 /datum/map_template/dungeon_template/room/hallway_executive
 	name = "hallway_executive"
@@ -88,30 +111,28 @@
 	mappath = 'maps/submaps/dungeon_rooms/rooms/hallway_executive.dmm'
 	directional_flags = list("south", "north")
 	room_tag = "above_only"
-
-
+/*
 /datum/map_template/dungeon_template/room/Hallway_North_South
 	name = "Hallway_North-South"
 	desc = "Enjoy your stay."
 	mappath = 'maps/submaps/dungeon_rooms/rooms/Hallway_North-South.dmm'
 	directional_flags = list("south", "north")
 	room_tag = "above_only"
-
+*/
 /datum/map_template/dungeon_template/room/hallway_storage
 	name = "hallway_storage"
 	desc = "Enjoy your stay."
 	mappath = 'maps/submaps/dungeon_rooms/rooms/hallway_storage.dmm'
 	directional_flags = list("south", "north")
 	room_tag = "above_only"
-
-
+/*
 /datum/map_template/dungeon_template/room/hallway_West_east
 	name = "hallway_West-East"
 	desc = "Enjoy your stay."
 	mappath = 'maps/submaps/dungeon_rooms/rooms/hallway_West-East.dmm'
 	directional_flags = list("west", "east")
 	room_tag = "horizontal_only"
-
+*/
 /datum/map_template/dungeon_template/room/hallwayatmos_west_east
 	name = "hallwayatmos_west-east"
 	desc = "Enjoy your stay."
@@ -119,21 +140,19 @@
 	directional_flags = list("west", "east")
 	room_tag = "horizontal_only"
 
-
 /datum/map_template/dungeon_template/room/mechbay
 	name = "mechbay"
 	desc = "Enjoy your stay."
 	mappath = 'maps/submaps/dungeon_rooms/rooms/mechbay.dmm'
 	room_tag = "dead_end"
 	directional_flags = list("east")
-/*
 
 /datum/map_template/dungeon_template/room/office
 	name = "office"
 	desc = "Enjoy your stay."
 	mappath = 'maps/submaps/dungeon_rooms/rooms/office.dmm'
-	room_tag = "under_only"
-	directional_flags = list("north", "east")*/
+	room_tag = "dead_end"
+	directional_flags = list("east")
 
 /datum/map_template/dungeon_template/room/penitentiary
 	name = "penitentiary"
@@ -156,14 +175,12 @@
 	directional_flags = list("west", "east")
 	room_tag = "horizontal_only"
 
-
 /datum/map_template/dungeon_template/room/surgery
 	name = "surgery"
 	desc = "Enjoy your stay."
 	mappath = 'maps/submaps/dungeon_rooms/rooms/surgery.dmm'
-	directional_flags = list("south", "north")
-	room_tag = "above_only"
-
+	room_tag = "dead_end"
+	directional_flags = list("south")
 
 /datum/map_template/dungeon_template/room/blocker
 	name = "blocker"

--- a/maps/submaps/dungeon_rooms/rooms/secure_storage_horizontal.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/secure_storage_horizontal.dmm
@@ -22,20 +22,11 @@
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "g" = (
-/obj/machinery/door/blast/shutters,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/crawler)
 "h" = (
 /obj/crawler/crawler_wallbreaker/vertical,
 /turf/simulated/wall/untinted/onestar_reinforced,
-/area/crawler)
-"i" = (
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/plating/under,
 /area/crawler)
 "j" = (
 /obj/structure/catwalk,
@@ -48,39 +39,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/crawler)
-"l" = (
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/plating/under,
-/area/crawler)
-"m" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/plating/under,
-/area/crawler)
 "n" = (
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/turf/simulated/floor/plating/under,
-/area/crawler)
-"o" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/machinery/light/floor,
 /turf/simulated/floor/plating/under,
 /area/crawler)
 "p" = (
@@ -150,9 +113,9 @@ a
 a
 a
 a
-i
+n
 j
-m
+t
 a
 a
 a
@@ -172,9 +135,9 @@ b
 b
 a
 a
-l
+k
 j
-o
+p
 a
 a
 b
@@ -194,9 +157,9 @@ b
 b
 a
 a
-i
+n
 q
-m
+t
 a
 a
 b
@@ -216,9 +179,9 @@ b
 a
 a
 a
-l
+k
 j
-o
+p
 a
 a
 a

--- a/maps/submaps/dungeon_rooms/rooms/shootingrange.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/shootingrange.dmm
@@ -25,19 +25,9 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "h" = (
-/obj/machinery/light/floor,
+/obj/structure/table/onestar,
+/obj/item/clothing/head/helmet/laserproof/iron_lock_security,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/crawler)
-"i" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict/white_big_edges,
-/area/crawler)
-"j" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "k" = (
 /obj/structure/railing/grey{
@@ -61,6 +51,7 @@
 /area/crawler)
 "p" = (
 /obj/structure/target_stake,
+/obj/item/target/syndicate,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/crawler)
 "q" = (
@@ -74,11 +65,6 @@
 /obj/item/tool/crowbar/onestar,
 /obj/item/gun/energy/captain,
 /obj/item/computer_hardware/hard_drive/portable/design/onestar/cog,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
-"s" = (
-/obj/structure/railing/grey,
-/obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "t" = (
@@ -142,11 +128,11 @@ a
 (2,1,1) = {"
 a
 c
-h
 g
 g
 g
-h
+g
+g
 u
 a
 "}
@@ -186,11 +172,11 @@ b
 (6,1,1) = {"
 b
 e
-i
 n
 n
 n
-i
+n
+n
 e
 b
 "}
@@ -199,7 +185,7 @@ b
 f
 a
 o
-o
+h
 o
 a
 f
@@ -208,11 +194,11 @@ b
 (8,1,1) = {"
 b
 g
-j
+k
 e
 e
 e
-s
+t
 g
 b
 "}

--- a/maps/submaps/dungeon_rooms/rooms/showers.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/showers.dmm
@@ -51,10 +51,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/crawler)
-"l" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "m" = (
 /obj/random/mob/roomba,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -98,9 +94,9 @@ a
 a
 c
 f
-l
 e
-l
+e
+e
 q
 n
 a
@@ -186,9 +182,9 @@ a
 a
 c
 f
-l
 e
-l
+e
+e
 q
 n
 a

--- a/maps/submaps/dungeon_rooms/rooms/surgery.dmm
+++ b/maps/submaps/dungeon_rooms/rooms/surgery.dmm
@@ -2,10 +2,6 @@
 "a" = (
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/crawler)
-"b" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/cafe,
-/area/crawler)
 "c" = (
 /turf/simulated/floor/tiled/cafe,
 /area/crawler)
@@ -22,13 +18,6 @@
 "f" = (
 /obj/crawler/crawler_wallbreaker/vertical,
 /turf/simulated/wall/untinted/onestar_reinforced,
-/area/crawler)
-"g" = (
-/obj/machinery/light/floor,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "h" = (
 /obj/structure/table/onestar,
@@ -78,20 +67,6 @@
 /obj/structure/medical_stand,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
-"q" = (
-/obj/machinery/light/floor,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
-"r" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/tiled/derelict,
-/area/crawler)
 "s" = (
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/derelict,
@@ -104,7 +79,6 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/effect/floor_decal/sign,
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "v" = (
@@ -123,8 +97,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/crawler)
 "y" = (
-/obj/structure/low_wall,
-/obj/effect/window_lwall_spawn,
+/obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/crawler)
 "z" = (
@@ -227,13 +200,13 @@ a
 "}
 (3,1,1) = {"
 a
-b
+c
 l
 j
 j
 j
 A
-b
+c
 a
 "}
 (4,1,1) = {"
@@ -259,18 +232,18 @@ y
 i
 "}
 (6,1,1) = {"
-i
+a
 j
 j
-g
 u
-g
+u
+u
 j
 j
 i
 "}
 (7,1,1) = {"
-i
+a
 j
 x
 x
@@ -281,12 +254,12 @@ x
 i
 "}
 (8,1,1) = {"
-i
+a
 j
 j
-q
 v
-r
+v
+v
 j
 j
 i
@@ -315,13 +288,13 @@ a
 "}
 (11,1,1) = {"
 a
-b
+c
 n
 j
 j
 j
 D
-b
+c
 a
 "}
 (12,1,1) = {"

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -1262,6 +1262,7 @@
 #include "code\game\objects\random\lathe_disks\lathe_disks.dm"
 #include "code\game\objects\random\lathe_disks\onestar.dm"
 #include "code\game\objects\random\lathe_disks\tools.dm"
+#include "code\game\objects\random\mob\greyson.dm"
 #include "code\game\objects\random\mob\misc.dm"
 #include "code\game\objects\random\mob\roach.dm"
 #include "code\game\objects\random\mob\slime.dm"


### PR DESCRIPTION
Improves on RnG spawners in grayson themed maps
Grayson gauntlet has been improved apond to have new once unused rooms with more loot and themes, well also removing more hallway based rooms to give more slower content then 80% hallways hoping for those armors
Removes annoying shutters form one of the gauntlets room