### PR TITLE
Old Data (10% reduction)

### DIFF
--- a/code/datums/autolathe/autolathe_datums.dm
+++ b/code/datums/autolathe/autolathe_datums.dm
@@ -172,6 +172,18 @@
 
 	if(mat_efficiency != 1 && adjust_materials)
 		for(var/obj/O in A.GetAllContents(includeSelf = TRUE))
+/*
+Z:/FloppyDisk/TRILBYMOD: //It had to be done.
+Z:/FloppyDisk/TRILBYMOD: O.surplus_tag = TRUE
+Z:/FloppyDisk/TRILBYMOD: DEPLOY FANRICATE NERF
+*/
+			O.surplus_tag = TRUE
+/*
+Trilby... Did you?
+You tampered with my fabrication
+You thought it too powerful no doubt. But Please...
+No more of that.
+*/
 			if(length(O.matter))
 				for(var/i in O.matter)
 					O.matter[i] = round(O.matter[i] * mat_efficiency, 0.01)

--- a/code/datums/autolathe/autolathe_datums.dm
+++ b/code/datums/autolathe/autolathe_datums.dm
@@ -174,10 +174,10 @@
 		for(var/obj/O in A.GetAllContents(includeSelf = TRUE))
 /*
 Z:/FloppyDisk/TRILBYMOD: //It had to be done.
-Z:/FloppyDisk/TRILBYMOD: O.surplus_tag = TRUE
+Z:/FloppyDisk/TRILBYMOD: O.autolathen_printed = TRUE
 Z:/FloppyDisk/TRILBYMOD: DEPLOY FANRICATE NERF
 */
-			O.surplus_tag = TRUE
+			O.autolathen_printed = TRUE
 /*
 Trilby... Did you?
 You tampered with my fabrication

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -21,6 +21,7 @@
 	//spawn_values
 	var/price_tag = 0 // The item price in credits. atom/movable so we can also assign a price to animals and other thing.
 	var/surplus_tag = FALSE //If true, attempting to export this will net you a greatly reduced amount of credits, but we don't want to affect the actual price tag for selling to others.
+	var/autolathen_printed = FALSE //If true, attempting to export this will net reduced amount of credits, but not the same surplus
 
 /atom/movable/Del()
 	if(isnull(gc_destroyed) && loc)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -186,6 +186,8 @@
 			message += SPAN_NOTICE("\nThis item cost: [get_item_cost()][CREDITS]")
 		if(H.stats.getPerk(PERK_MARKET_PROF) && surplus_tag == TRUE)
 			message += SPAN_NOTICE("\nThis item has a surplus tag and is only worth ten percent its usual value on exports.")
+		if(H.stats.getPerk(PERK_MARKET_PROF) && autolathen_printed == TRUE)
+			message += SPAN_NOTICE("\nThis item is work ten percent less on the shuttle exported. But not for trade beacons!")
 
 	return ..(user, distance, "", message)
 

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -55,7 +55,9 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 		if(!found_export)
 			var/item_value = thing.get_item_cost(TRUE)
 			if(thing.surplus_tag)
-				item_value = round(item_value * 0.1)
+				item_value = round(item_value * 0.1) //90% less for buyed form the cargo shuttle, not beacons tho
+			if(thing.autolathen_printed)
+				item_value = round(item_value * 0.9) //10% less for autolathen printed items
 			if(item_value)
 				cost += item_value
 				sold_str += " [thing.name]"


### PR DESCRIPTION
Printing items on an autolathen is worth 10% less on cargo shuttle, dosnt affect beacons 
