### PR TITLE
trade station fixes and balance

### DIFF
--- a/code/controllers/subsystems/trade.dm
+++ b/code/controllers/subsystems/trade.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(trade)
 /datum/controller/subsystem/trade/Initialize()
 	InitStations()
 	. = ..()
-	DiscoverAllTradeStations()
+	//DiscoverAllTradeStations() better balanced system
 
 /datum/controller/subsystem/trade/proc/ReInitStations()
 	DeInitStations()
@@ -152,36 +152,41 @@ SUBSYSTEM_DEF(trade)
 
 // Checks item stacks amd item containers to see if they match their base states (no more selling empty first-aid kits or split item stacks as if they were full)
 // Checks reagent containers to see if they match their base state or if they match the special offer from a station
-/datum/controller/subsystem/trade/proc/check_contents(item_path, offer_path, assessing_special_offer = FALSE)
+/datum/controller/subsystem/trade/proc/check_contents(item, offer_path, assessing_special_offer = FALSE)
 	if(!ispath(offer_path, /datum/reagent))
-		if(istype(item_path, /obj/item/stack))					// Check if item is an item stack
-			var/obj/item/stack/item_stack = item_path
+		if(istype(item, /obj/machinery/portable_atmospherics/canister))			// Air canisters can be constructed for 10 steel
+			var/obj/machinery/portable_atmospherics/canister/canister = item
+			if(canister.air_contents.total_moles >= 1871.71)
+				return TRUE
+			return FALSE
+
+		if(istype(item, /obj/item/stack))						// Check if item is an item stack
+			var/obj/item/stack/item_stack = item
 			if(item_stack.amount == item_stack.max_amount)
 				return TRUE										// You can only sell items when they are at max stacks
 			return FALSE
 
-		if(istype(item_path, /obj/item/storage))			// Storage items are too resource intensive to check (populate_contents() means we have to create new instances of every object within the initial object)
-			return FALSE									// Also, directly selling storage items after emptying them is abusable
+		if(istype(item, /obj/item/storage))						// Storage items are too resource intensive to check (populate_contents() means we have to create new instances of every object within the initial object)
+			return FALSE										// Also, directly selling storage items after emptying them is abusable
 
-	if(istype(item_path, /obj/item/reagent_containers/glass))						// Check if item is a reagent container - TEMP Soj edit to make food trades work, this is a banaid untill eris fixes it with a real correction
+		if(istype(item, /obj/item/reagent_containers/food))		// Food check (needed because contents are populated using something other than preloaded_reagents)
+			return TRUE
 
-		var/obj/item/reagent_containers/current_container = item_path
+	if(istype(item, /obj/item/reagent_containers))					// Check if item is a reagent container
+		var/obj/item/reagent_containers/current_container = item
 		var/datum/reagent/target_reagent = offer_path
 		var/target_volume = 0
 
 		if(!ispath(offer_path, /datum/reagent))
-			if(istype(item_path, /obj/item/reagent_containers/food))			// Food check (needed because contents are populated using something other than preloaded_reagents)
-				return TRUE
-
-			if(istype(item_path, /obj/item/reagent_containers/blood))			// Blood pack check (needed because contents are populated using something other than preloaded_reagents)
+			if(istype(item, /obj/item/reagent_containers/blood))	// Blood pack check (needed because contents are populated using something other than preloaded_reagents)
 				if(current_container.reagents?.reagent_list[1]?.id == "blood" && current_container.reagents?.reagent_list[1]?.volume >= 200)
 					return TRUE
 
 			if(current_container.preloaded_reagents?.len < 1)		// If a new instance of the container does not start with reagents and the offer is not a reagent, pass
 				return TRUE
 
-		if(!current_container.reagents)		// If the previous check fails, we are looking for a container with reagents or a specific reagent
-			return FALSE					// If the container is empty, fail
+		if(!current_container.reagents)								// If the previous check fails, we are looking for a container with reagents or a specific reagent
+			return FALSE											// If the container is empty, fail
 
 		var/reagent_found = 0
 		for(var/datum/reagent/current_reagent in current_container.reagents?.reagent_list)

--- a/code/modules/trade/datums/_trade_station.dm
+++ b/code/modules/trade/datums/_trade_station.dm
@@ -7,9 +7,9 @@
 #define category_data(nam, listOfTags) list("name" = nam, "tags" = listOfTags)
 
 #define COMMON_GOODS 1.2
-#define UNCOMMON_GOODS 2.4
-#define RARE_GOODS 3.6
-#define UNIQUE_GOODS 4.8
+#define UNCOMMON_GOODS 2
+#define RARE_GOODS 3
+#define UNIQUE_GOODS 4
 
 /datum/trade_station
 	var/name

--- a/code/modules/trade/datums/trade_stations_presets/1-common/asterstradecapital.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/asterstradecapital.dm
@@ -22,6 +22,7 @@
 			/obj/item/computer_hardware/hard_drive/portable/design/janitor = good_data("Lonestar Janitor Pack", list(1, 10)),
 			/obj/item/computer_hardware/hard_drive/portable/design/nonlethal_ammo = good_data("H&S Nonlethal Magazines Pack", list(1, 10)),
 			/obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo = good_data("H&S Lethal Magazines Pack", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable/design/security = good_data("Security Miscellaneous Pack", list(1, 10)),
 			/obj/item/computer_hardware/hard_drive/portable = good_data("Blank Disk", list(1, 10))
 		),
 		"Tools and Equipment" = list(
@@ -194,7 +195,7 @@
 	)*/
 
 	offer_types = list(
-		/obj/item/tool/knife = offer_data("spare knifes", 50, 30),
+		/obj/item/tool/knife = offer_data("spare knifes", 150, 30),
 		/obj/item/reagent_containers/food/snacks/grown = offer_data("spare grown food", 10, 120), //10 credits a grown item basicl
 		/datum/reagent/organic/nutriment/honey = offer_data("Honey bottle (60u)", 800, 1),
 		/obj/item/organ/external/robotic/one_star = offer_data("grayson external prosthetic", 1800, 4)

--- a/code/modules/trade/datums/trade_stations_presets/1-common/boozefood.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/boozefood.dm
@@ -73,7 +73,7 @@
 	)
 
 	offer_types = list(
-		/obj/item/tool/knife = offer_data("spare knifes", 50, 0),
+		/obj/item/tool/knife = offer_data("spare knifes", 80, 0),
 		/obj/item/reagent_containers/food/snacks/grown = offer_data("spare grown food", 10, 120), //10 credits a grown item basicl
 		/obj/item/reagent_containers/food/snacks/kampferburger = offer_data("kampfer burger", 400, 3),
 		/obj/item/reagent_containers/food/snacks/panzerburger = offer_data("panzer burger", 500, 2),

--- a/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
@@ -58,7 +58,7 @@
 			/obj/item/reagent_containers/hypospray/autoinjector,
 			/obj/item/bodybag,
 			/obj/machinery/suspension_gen,
-			/obj/item/computer_hardware/hard_drive/portable/design
+			/obj/item/computer_hardware/hard_drive/portable/design/medicald = custom_good_amount_range(list(3, 6))
 		)
 	)
 	secret_inventory = list(

--- a/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
@@ -58,7 +58,7 @@
 			/obj/item/reagent_containers/hypospray/autoinjector,
 			/obj/item/bodybag,
 			/obj/machinery/suspension_gen,
-			/obj/item/computer_hardware/hard_drive/portable/design/medicald = custom_good_amount_range(list(3, 6))
+			/obj/item/computer_hardware/hard_drive/portable/design/medical = custom_good_amount_range(list(3, 6))
 		)
 	)
 	secret_inventory = list(

--- a/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
@@ -74,8 +74,8 @@
 		)
 	)
 	offer_types = list(
-		/obj/item/gun/energy/laser/railgun/pistol = offer_data("\"Myrmidon\" rail pistol", 1500, 2),
-		/obj/item/gun/energy/laser/railgun = offer_data("\"Reductor\" rail rifle", 3500, 1),
+		/obj/item/gun/energy/laser/railgun/pistol = offer_data("\"Myrmidon\" rail pistol", 3500, 2),
+		/obj/item/gun/energy/laser/railgun = offer_data("\"Reductor\" rail rifle", 5500, 1),
 		/obj/item/tool/shovel/combat = offer_data("combat crovel", 500, 13),
 		/obj/item/tool_upgrade/armor/melee = offer_data("melee armor plate", 500, 5),
 		/obj/item/tool_upgrade/armor/bullet = offer_data("ballistic armor plate", 1200, 3),

--- a/code/modules/trade/datums/trade_stations_presets/1-common/material_refine.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/material_refine.dm
@@ -22,10 +22,10 @@
 			/obj/item/ammo_casing/flare/prespawn
 			),
 		"Refined Materials" = list(
-			/obj/item/stack/material/plastic/full = good_data("plastic sheets (x120)", list(2, 5)),
+			/obj/item/stack/material/plastic/full = good_data("plastic sheets (x120)", list(4, 5)),
 			/obj/item/stack/material/cardboard/full = good_data("cardboard sheets (x120)", list(2, 5)),
-			/obj/item/stack/material/steel/full = good_data("steel sheets (x120)", list(2, 5)),
-			/obj/item/stack/material/plasteel/full = good_data("plasteel sheets (x120)", list(1, 2)),
+			/obj/item/stack/material/steel/full = good_data("steel sheets (x120)", list(3, 5)),
+			/obj/item/stack/material/plasteel/full = good_data("plasteel sheets (x120)", list(2, 3)),
 			/obj/item/stack/material/wood/full = good_data("wood planks (x120)", list(2, 5)),
 			/obj/item/stack/material/glass/full = good_data("glass sheets (x120)", list(2, 5)),
 			/obj/item/stack/material/plasma/full = good_data("plasma sheets (x120)", list(1, 2))

--- a/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
@@ -33,7 +33,6 @@
 			/obj/item/tracker_electronics,
 			/obj/machinery/power/emitter,
 			/obj/machinery/power/rad_collector,
-			/obj/machinery/power/supermatter,
 			/obj/machinery/power/generator,
 			/obj/machinery/atmospherics/binary/circulator,
 			/obj/item/clothing/gloves/insulated
@@ -43,7 +42,7 @@
 			/obj/item/storage/briefcase/inflatable/empty,
 			/obj/item/inflatable/door,
 			/obj/item/inflatable/wall,
-			/obj/item/stack/material/steel/full,
+			/obj/item/stack/material/steel/full = good_data("steel sheets (x120)", list(3, 5)),
 			/obj/item/storage/belt/utility/full,
 			/obj/item/clothing/head/welding,
 			/obj/item/tool/omnitool,

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/KriosanConfederacy.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/KriosanConfederacy.dm
@@ -3,7 +3,6 @@
 		"Kriosan 'Quill' Sporting" = "A common Federacy trade ship looking for the latest game to hunt. They're sending a message. \"Greeting. Please amuse yourself on our stock.\""
 	)
 	uid = "kriosanconfederacy"
-	recommendations_needed = 1
 	stations_recommended = list("mcronalds")
 	offer_limit = 20
 	base_income = 1600
@@ -17,17 +16,23 @@
 			/obj/item/gun/projectile/boltgun/light,
 			/obj/item/gun/projectile/boltgun/light_wood,
 			/obj/item/gun/projectile/boltgun/sa,
-			/obj/item/gun/projectile/automatic/survivalrifle
+			/datum/design/autolathe/gun/strelki,
+			/obj/item/gun/projectile/automatic/survivalrifle,
+			/obj/item/gun/projectile/shotgun/doublebarrel,
+			/obj/item/gun/projectile/shotgun/pump,
+			/obj/item/tool/knife/dagger
 		),
 		"Ammo" = list(
 			/obj/item/ammo_magazine/ammobox/rifle_75_small,
 			/obj/item/ammo_magazine/ammobox/light_rifle_257_small,
-			/obj/item/ammo_magazine/rifle_10x24
+			/obj/item/ammo_magazine/rifle_10x24,
+			/obj/item/ammo_magazine/ammobox/shotgun/buckshot,
+			/obj/item/ammo_magazine/ammobox/shotgun
 		),
 		"Pets" = list(
 			/mob/living/simple_animal/corgi = good_data("Noble Corgi", list(4, 5)),
 			/mob/living/simple_animal/corgi/puppy = good_data("Young Corgi", list(3, 5)),
-			/mob/living/simple_animal/lizard = good_data("Crate Pusher", list(2, 5)), //Donst have a price, intented
+			/mob/living/simple_animal/lizard = good_data("Crate Pusher", list(2, 5)),
 			/mob/living/simple_animal/cat = good_data("Rat Slayer", list(4, 5))
 		)
 	)
@@ -36,6 +41,12 @@
 			/obj/item/gun_upgrade/barrel/forged,
 			/obj/item/tool_upgrade/productivity/ergonomic_grip,
 			/obj/item/tool_upgrade/refinement/laserguide
+		)
+		"Big Game Hunting Gear" = list(
+			/obj/item/gun/projectile/boltgun/scout = custom_good_amount_range(list(-5, 1)),
+			/obj/item/tool/sword/saber = custom_good_amount_range(list(-1, 3)),
+			/obj/item/tool/sword/machete,
+			/obj/item/tool/spear //Useless other then to hand craft and sell it back to them
 		)
 	)
 	offer_types = list(

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/KriosanConfederacy.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/KriosanConfederacy.dm
@@ -41,9 +41,9 @@
 			/obj/item/gun_upgrade/barrel/forged,
 			/obj/item/tool_upgrade/productivity/ergonomic_grip,
 			/obj/item/tool_upgrade/refinement/laserguide
-		)
+		),
 		"Big Game Hunting Gear" = list(
-			/obj/item/gun/projectile/boltgun/scout = custom_good_amount_range(list(-5, 1)),
+			/obj/item/gun/projectile/boltgun/scout = custom_good_amount_range(list(-3, 1)),
 			/obj/item/tool/sword/saber = custom_good_amount_range(list(-1, 3)),
 			/obj/item/tool/sword/machete,
 			/obj/item/tool/spear //Useless other then to hand craft and sell it back to them

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/casino.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/casino.dm
@@ -3,7 +3,7 @@
 		"FTB 'Solntsey'" = "Free Trade Beacon 'Solntsey': \"Try your luck with our grab bag specials!\"",
 	)
 	uid = "casino"
-	markup = 10				// High markup, low base price to prevent export abuse
+	markup = 5				// High markup, low base price to prevent export abuse
 	base_income = 0
 	wealth = 0
 	secret_inv_threshold = 2000

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
@@ -38,7 +38,7 @@
 		),
 		"Syndicate Gun Mods" = list(
 			/obj/item/gun_upgrade/barrel/gauss,
-			/obj/item/gun_upgrade/mechanism/glass_widow,
+			//obj/item/gun_upgrade/mechanism/glass_widow,
 			/obj/item/gun_upgrade/scope/killer
 		)
 	)


### PR DESCRIPTION
By Pink
Fixes some older code and betters the trade code
Fixes trading air tanks as full
Balances having every trade station to needing use the favour system rather then having them all unlocked shift start - as intented by eris
More balanced trades and items and lowers some prices on things