### PR TITLE
Prevent testing Engines from announcing their startup and shutdown.

### DIFF
--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -230,7 +230,8 @@
 		for(var/obj/machinery/am_shielding/Core in linked_cores)
 			flick("core_desactivating", Core)
 			Core.icon_state = "core_inactive"
-	radio.autosay(alert_msg, "Antimatter Automated Announcement", "Engineering")
+	if(announce_stability)
+		radio.autosay(alert_msg, "Antimatter Automated Announcement", "Engineering")
 	update_icon()
 	return
 


### PR DESCRIPTION
## About The Pull Request
Prevent Antimatter Engines which can't announce their stability from announcing their startup and shutdown.