### PR TITLE
Fixes and rebalances

### DIFF
--- a/code/controllers/subsystems/trade.dm
+++ b/code/controllers/subsystems/trade.dm
@@ -243,8 +243,10 @@ SUBSYSTEM_DEF(trade)
 		beacon.activate()
 
 		var/datum/money_account/A = account
-		var/datum/transaction/T = new(offer_price, account.get_name(), "Special deal", station.name)
+		var/datum/transaction/T = new(round(offer_price * 0.8), account.get_name(), "Special deal", station.name)
+		var/datum/transaction/TL = new(round(offer_price * 0.2), department_accounts[DEPARTMENT_LSS].get_name(), "Special deal", station.name)
 		T.apply_to(A)
+		TL.apply_to(A)
 		station.add_to_wealth(offer_price, TRUE)
 		// clear offer, wait until next tick to generate a new one
 		offer_content["amount"] = 0
@@ -304,6 +306,8 @@ SUBSYSTEM_DEF(trade)
 		qdel(thing)
 		senderBeacon.activate()
 		var/datum/money_account/A = account
-		var/datum/transaction/T = new(cost, account.get_name(), "Sold item", station.name)
+		var/datum/transaction/T = new(round(cost * 0.8), account.get_name(), "Sold item", station.name)
+		var/datum/transaction/TL = new(round(cost * 0.2), department_accounts[DEPARTMENT_LSS].get_name(), "Sold item", station.name)
 		T.apply_to(A)
+		TL.apply_to(department_accounts[DEPARTMENT_LSS])
 		station.add_to_wealth(cost)

--- a/code/datums/setup_option/backgrounds/origin_homeworld.dm
+++ b/code/datums/setup_option/backgrounds/origin_homeworld.dm
@@ -49,7 +49,7 @@
 	described as having a green thumb. Decades of living on a garden world have also made many of Neapolis obligate herbivores, preferring organic diets, but the lack of protein makes them \
 	weaker on average."
 
-	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_CHTMANT)
+	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_KRIOSAN, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_CHTMANT)
 	perks = list(/datum/perk/greenthumb, /datum/perk/herbivore)
 
 	stat_modifiers = list(

--- a/code/game/objects/items/weapons/tools/screwdrivers.dm
+++ b/code/game/objects/items/weapons/tools/screwdrivers.dm
@@ -31,12 +31,12 @@
 	icon_state = "e-screwdriver"
 	worksound = WORKSOUND_DRIVER_TOOL
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 1)
-	tool_qualities = list(QUALITY_SCREW_DRIVING = 40, QUALITY_DRILLING = 10, QUALITY_BONE_SETTING = 10)
+	tool_qualities = list(QUALITY_SCREW_DRIVING = 50, QUALITY_DRILLING = 10, QUALITY_BONE_SETTING = 10)
 	degradation = 0.7
 	max_upgrades = 4
 	use_power_cost = 0.18
 	suitable_cell = /obj/item/cell/small
-	price_tag = 240
+	price_tag = 300
 
 /obj/item/tool/screwdriver/combi_driver
 	name = "combination drill"
@@ -46,12 +46,12 @@
 	worksound = WORKSOUND_DRIVER_TOOL
 	slot_flags = SLOT_BELT
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTEEL = 1, MATERIAL_PLASTIC = 2)
-	tool_qualities = list(QUALITY_SCREW_DRIVING = 50, QUALITY_BOLT_TURNING = 50, QUALITY_DRILLING = 20)
+	tool_qualities = list(QUALITY_SCREW_DRIVING = 40, QUALITY_BOLT_TURNING = 40, QUALITY_DRILLING = 20)
 	degradation = 0.7
 	use_power_cost = 0.54
 	suitable_cell = /obj/item/cell/small
 	max_upgrades = 4
-	price_tag = 800 // Highly prized
+	price_tag = 600 // Highly prized
 
 /obj/item/tool/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M) || user.a_intent == "help")

--- a/code/game/objects/items/weapons/tools/wrenches.dm
+++ b/code/game/objects/items/weapons/tools/wrenches.dm
@@ -33,11 +33,11 @@
 	desc = "If everything else failed - bring a bigger wrench."
 	icon_state = "big-wrench"
 	w_class = ITEM_SIZE_NORMAL
-	tool_qualities = list(QUALITY_BOLT_TURNING = 45, QUALITY_HAMMERING = 30)
+	tool_qualities = list(QUALITY_BOLT_TURNING = 50, QUALITY_HAMMERING = 30)
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASTEEL = 1)
 	force = WEAPON_FORCE_DANGEROUS
 	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
 	throwforce = WEAPON_FORCE_PAINFUL
 	degradation = 0.7
 	max_upgrades = 4
-	price_tag = 175
+	price_tag = 225

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -1,3 +1,7 @@
+//////////////////////////////////////////////////
+/////////         TESSELLATE             /////////
+//////////////////////////////////////////////////
+
 /datum/ritual/cruciform/tessellate
 	name = "cruciform"
 	phrase = null
@@ -17,9 +21,9 @@
 	cooldown = TRUE
 	cooldown_time = 15 MINUTES
 	cooldown_category = "grepose"
-	power = 60 //stronger healing higher cost
-	nutri_cost = 50//high cost
-	blood_cost = 50//high cost
+	power = 60
+	nutri_cost = 50
+	blood_cost = 50
 
 /datum/ritual/cruciform/tessellate/heal_heathen_special/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C)
 	var/list/people_around = list()
@@ -98,12 +102,95 @@
 		participant.adjustOxyLoss(-40)
 		participant.adjustBrainLoss(-5)
 		participant.updatehealth()
+/*
+/datum/ritual/cruciform/tessellate/canticle_of_absolution
+	name = "Canticle of Absolution"
+	phrase = "PLACE HOLDER TEXT."
+	desc = "Cures the person in front of you of all genetic instability and cone damage while removing all forms of genetic mutation. This litany requires a great deal of power and thus may \
+	only be used once per hour."
+	cooldown = TRUE
+	cooldown_time = 60 MINUTES
+	power = 50
+	nutri_cost = 100
+	blood_cost = 50
+
+/datum/ritual/cruciform/tessellate/canticle_of_absolution/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C)
+	var/mob/living/carbon/human/T = get_front_human_in_range(user, 1)
+	if(!T)
+		fail("No target in front of you.", user, C)
+		return FALSE
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
+	to_chat(T, SPAN_NOTICE("You feel your body returning to its natural state."))
+	to_chat(user, SPAN_NOTICE("You bring [T.name] back to their natural state."))
+
+	T.adjustCloneLoss(-200)
+	T.unnatural_mutations.removeAllMutations()
+
+	return TRUE
+
+/datum/ritual/cruciform/tessellate/desperate_calculation
+	name = "Martyr's Calculation"
+	phrase = "PLACE HOLDER TEXT."
+	desc = "An immensely powerful healing litany that restores any who hear it around the speaker, however the strength of the litany requires so much that the body of the speaker is temporarily stunned. \
+	Due to the strength of this hymn, it can only be used once every half hour."
+	cooldown = TRUE
+	power = 50
+	cooldown_time = 30 MINUTES
+	cooldown_category = "dcalculation" //Seperate cooldown since it stuns the user.
+	nutri_cost = 100
+	blood_cost = 50
+
+/datum/ritual/cruciform/tessellate/desperate_calculation/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C)
+	var/list/people_around = list()
+	if(user.species?.reagent_tag != IS_SYNTHETIC)
+		if(user.nutrition >= nutri_cost)
+			user.nutrition -= nutri_cost
+		else
+			to_chat(user, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
+			user.vessel.remove_reagent("blood",blood_cost)
+	for(var/mob/living/carbon/human/H in view(user))
+		if(H != user && !isdeaf(H))
+			people_around.Add(H)
+
+	if(people_around.len > 0)
+		to_chat(user, SPAN_NOTICE("Your feel the air thrum with an inaudible vibration, your cruciform withdrawing everything you have to empower your litany."))
+		playsound(user.loc, 'sound/machines/signal.ogg', 50, 1)
+		for(var/mob/living/carbon/human/participant in people_around)
+			to_chat(participant, SPAN_NOTICE("You hear a silent signal..."))
+			heal_other(participant)
+			add_effect(participant, FILTER_HOLY_GLOW, 25)
+		set_personal_cooldown(user)
+		user.Weaken(10)
+		return TRUE
+	else
+		fail("Your cruciform sings, alone, unto the void.", user, C)
+		return FALSE
+
+/datum/ritual/cruciform/tessellate/desperate_calculation/proc/heal_other(mob/living/carbon/human/participant)
+		to_chat(participant, "<span class='info'>A sensation of relief bathes you, washing away most of your pain</span>")
+		participant.reagents.add_reagent("laudanum", 10)
+		participant.adjustBruteLoss(-40)
+		participant.adjustFireLoss(-40)
+		participant.adjustToxLoss(-40)
+		participant.adjustOxyLoss(-80)
+		participant.adjustBrainLoss(-10)
+		participant.updatehealth()
+*/
+//////////////////////////////////////////////////
+/////////         LEMNISCATE             /////////
+//////////////////////////////////////////////////
 
 /datum/ritual/cruciform/lemniscate
 	name = "cruciform"
 	phrase = null
 	implant_type = /obj/item/implant/core_implant/cruciform/lemniscate
 	category = "Lemniscate"
+
 /datum/ritual/targeted/cruciform/lemniscate
 	name = "cruciform targeted"
 	phrase = null
@@ -190,6 +277,10 @@
 	phrase = "Confortare et esto robustus. Nolite timere nec paveatis a conspectu eorum quia Dominus Deus tuus ipse est ductor tuus. Et non dimittet nec derelinquet te."
 	stats_to_boost = list(STAT_ROB = 15, STAT_TGH = 15, STAT_VIG = 15)
 
+//////////////////////////////////////////////////
+/////////         MONOMIAL               /////////
+//////////////////////////////////////////////////
+
 /datum/ritual/cruciform/monomial
 	name = "cruciform"
 	phrase = null
@@ -272,6 +363,10 @@
 	user.stats.changeStat(STAT_BIO, -10)
 	user.stats.changeStat(STAT_MEC, -10)
 
+//////////////////////////////////////////////////
+/////////         DIVISOR                /////////
+//////////////////////////////////////////////////
+
 /datum/ritual/cruciform/divisor
 	name = "cruciform"
 	phrase = null
@@ -338,6 +433,10 @@
 				to_chat(victim, SPAN_NOTICE("Your legs feel numb, but you managed to stay on your feet!"))
 	set_personal_cooldown(user)
 	return TRUE
+
+//////////////////////////////////////////////////
+/////////         FACTORIAL              /////////
+//////////////////////////////////////////////////
 
 /datum/ritual/cruciform/factorial
 	name = "cruciform"

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -304,7 +304,7 @@
 	permitted_tail  = list("Akula Tail")
 	permitted_wings = list()
 
-	perks = list(/datum/perk/recklessfrenzy, /datum/perk/iron_flesh)
+	perks = list(/datum/perk/recklessfrenzy, /datum/perk/iron_flesh, /datum/perk/carnivore)
 
 /datum/species/akula/get_bodytype()
 	return "Akula"

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -45,9 +45,9 @@
 /datum/reagent/organic/nutriment/affect_ingest(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(ishuman(M))
 		if(M.stats.getPerk(PERK_HERBIVORE))
-			nutriment_factor = nutriment_factor += 2
+			nutriment_factor = 7
 		else if(M.stats.getPerk(PERK_CARNIVORE))
-			nutriment_factor = nutriment_factor -= 4
+			nutriment_factor = 1
 
 	// Small bodymass, more effect from lower volume.
 	M.adjustNutrition(nutriment_factor * (issmall(M) ? effect_multiplier * 2 : effect_multiplier)) // For hunger and fatness
@@ -73,9 +73,9 @@
 /datum/reagent/organic/nutriment/protein/affect_ingest(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(ishuman(M))
 		if(M.stats.getPerk(PERK_CARNIVORE))
-			nutriment_factor = nutriment_factor += 6
+			nutriment_factor = 7
 		else if(M.stats.getPerk(PERK_HERBIVORE))
-			nutriment_factor = nutriment_factor -= 6
+			nutriment_factor = 1
 
 	return ..()
 


### PR DESCRIPTION
-Fixed carnivores losing nutrition when eating nutriment due to a factoring error.
-Akulas are now carnivores and have the aforementioned perk. Akulas can no longer take the Neapolis homeworld.
-Added some currently commented out church code that I will likely expand on tomorrow once I finish todays upkeeping.
-Rebalanced combi drivers. Combi drives now have tool qualities 40 in screw driving and bolt turning. Electric screw drivers and big wrenches now have their qualities set to 50.
-The trade beacon now takes a 20% commission from any and all transaction using any account that is not the main lonestar account. This comes in response to a simple code solution to an otherwise annoying problem with crediting accounts and values for commissions.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
