### PR TITLE
talking/controle spider fix and bomb spider fix

### DIFF
--- a/code/game/objects/items/weapons/implant/implants/carrion/control_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/control_spider.dm
@@ -2,6 +2,7 @@
 	name = "control spider"
 	icon_state = "spiderling_control"
 	spider_price = 25
+	ignore_activate_all = TRUE
 	var/active = FALSE
 	var/last_use = - 2 MINUTES
 	var/cooldown = 2 MINUTES

--- a/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/explosive_spider.dm
@@ -1,9 +1,11 @@
+
 /obj/item/implant/carrion_spider/explosive
 	name = "explosive spider"
+	desc = "A large, glowing spider, about the size of your fist. It's undulating and emitting a soft ticking noise."
 	icon_state = "spiderling_explosive"
 	spider_price = 40
-	var/devastation_range = -1
-	var/heavy_range = 0
+	var/devastation_range = 0
+	var/heavy_range = 1
 	var/weak_range = 2
 	var/flash_range = 6
 	var/det_time = 2 SECONDS
@@ -11,8 +13,10 @@
 /obj/item/implant/carrion_spider/explosive/activate()
 	..()
 	if(wearer)
+		wearer.apply_damage(10, BRUTE, part)
 		src.uninstall()
-		visible_message(SPAN_DANGER("[src] pops out of [wearer] and flashes brightly!"))
+		to_chat(wearer, SPAN_WARNING("You feel something moving within [part]!"))
+		visible_message(SPAN_DANGER("[src] crawls out of [wearer] and flashes brightly!"))
 	else
 		visible_message(SPAN_DANGER("[src] flashes brightly!"))
 	playsound(src, 'sound/voice/insect_battle_screeching.ogg', 80, 1, 5)

--- a/code/game/objects/items/weapons/implant/implants/carrion/talking_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/talking_spider.dm
@@ -2,6 +2,7 @@
 	name = "talking spider"
 	icon_state = "spiderling_talking"
 	spider_price = 30
+	ignore_activate_all = TRUE
 	var/on_cooldown = FALSE
 
 /obj/item/implant/carrion_spider/talking/activate()


### PR DESCRIPTION
Carrion talking and contole spider no longer can be toggled using `activate all` to prevent shunting by misstake to things when you dont mean to
Bomb spider now accully blows up into a bomb rather then gibs