### PR TITLE
Make cryo'ing remove the crew record.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -368,7 +368,7 @@
 /datum/mind/proc/manifest_status(var/datum/computer_file/report/crew_record/CR)
 	var/inactive_time = world.time - last_activity
 	if (inactive_time >= 60 MINUTES)
-		return null //The server hasn't seen us alive in an hour.
+		return "SSD" //The server hasn't seen us alive in an hour.
 		//We will not show on the manifest at all
 
 	//Ok we're definitely going to show on the manifest, lets see if any status is set for us in the records

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -446,8 +446,7 @@
 	// Remove the mob's record.
 	var/datum/computer_file/report/crew_record/record
 	for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records) // loop through the records
-		var/CR_name = CR.get_name()
-		if(occupant.mind.name == CR_name)
+		if(occupant.mind.name == CR.get_name()) // Check the mind's name to the record's name
 			record = CR
 			break
 		if(record) // Leave early if we get a match

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -443,10 +443,20 @@
 	//This should guarantee that ghosts don't spawn.
 	occupant.ckey = null
 
+	// Remove the mob's record.
+	var/datum/computer_file/report/crew_record/record
+	for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records) // loop through the records
+		var/name = CR.get_name()
+		//Minds should never be deleted, so our crew record must be in here somewhere
+		for(var/datum/mind/M in SSticker.minds) // loop through the minds
+			if(M.name == name)
+				record = CR
+				break
+	record?.Destroy() // Delete the crew record
+
 	// Delete the mob.
 	qdel(occupant)
 	set_occupant(null)
-
 
 /obj/machinery/cryopod/affect_grab(var/mob/user, var/mob/target)
 	try_put_inside(target, user)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -449,8 +449,8 @@
 		if(occupant.mind.name == CR.get_name()) // Check the mind's name to the record's name
 			record = CR
 			break
-	if(record)
-		record.Destroy() // Delete the crew record
+
+	record?.Destroy() // Delete the crew record
 
 	// Delete the mob.
 	qdel(occupant)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -449,10 +449,8 @@
 		if(occupant.mind.name == CR.get_name()) // Check the mind's name to the record's name
 			record = CR
 			break
-		if(record) // Leave early if we get a match
-			break
-
-	record?.Destroy() // Delete the crew record
+	if(record)
+		record.Destroy() // Delete the crew record
 
 	// Delete the mob.
 	qdel(occupant)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -446,12 +446,10 @@
 	// Remove the mob's record.
 	var/datum/computer_file/report/crew_record/record
 	for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records) // loop through the records
-		var/name = CR.get_name()
-		//Minds should never be deleted, so our crew record must be in here somewhere
-		for(var/datum/mind/M in SSticker.minds) // loop through the minds
-			if(M.name == name)
-				record = CR
-				break
+		var/CR_name = CR.get_name()
+		if(occupant.mind.name == CR_name)
+			record = CR
+			break
 		if(record) // Leave early if we get a match
 			break
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -452,6 +452,9 @@
 			if(M.name == name)
 				record = CR
 				break
+		if(record) // Leave early if we get a match
+			break
+
 	record?.Destroy() // Delete the crew record
 
 	// Delete the mob.


### PR DESCRIPTION
## About The Pull Request
- Players that are inactive for more than an hour are now shown as 'SSD' on the manifest instead of a blank status.
- Players that cryo now get their records deleted when their character is, removing them from the manifest.

Some staff members didn't know why the crew manifest didn't remove people when they left for the lower colony, and would have liked that it did.

So I looked at the code and managed to make it remove people from the crew manifest when they cryo.