### PR TITLE
Allow borgs to interact with antimatter engine stuff

### DIFF
--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -23,6 +23,8 @@
 		/obj/item/device/assembly,//Primarily for making improved cameras, but opens many possibilities
 		/obj/item/computer_hardware,
 		/obj/item/tool_upgrade,
+		/obj/item/am_containment,
+		/obj/item/am_shielding_container,
 		/obj/item/stack/tile //Repair floors yay
 		)
 
@@ -201,6 +203,8 @@
 	can_hold = list(
 		/obj/item/cell,
 		/obj/item/stock_parts,
+		/obj/item/am_containment,
+		/obj/item/am_shielding_container,
 		/obj/item/circuitboard/miningdrill
 	)
 
@@ -247,6 +251,8 @@
 		/obj/item/seeds,
 		/obj/item/tank,
 		/obj/item/computer_hardware,
+		/obj/item/am_containment,
+		/obj/item/am_shielding_container,
 		/obj/item/device/integrated_electronics,
 		/obj/item/integrated_circuit
 		)
@@ -262,6 +268,8 @@
 		/obj/item/reagent_containers/spray,
 		/obj/item/storage/pill_bottle,
 		/obj/item/hand_labeler,
+		/obj/item/am_containment,
+		/obj/item/am_shielding_container,
 		/obj/item/stack/material/plasma
 		)
 
@@ -280,6 +288,8 @@
 		/obj/item/paper,
 		/obj/item/newspaper,
 		/obj/item/circuitboard/broken,
+		/obj/item/am_containment,
+		/obj/item/am_shielding_container,
 		/obj/item/clothing/mask/smokable/cigarette,
 		///obj/item/reagent_containers/cooking_container //PArt of cooking overhaul, not yet ported
 		)
@@ -293,6 +303,8 @@
 		/obj/item/ammo_casing,
 		/obj/item/ammo_kit,
 		/obj/item/ammo_magazine,
+		/obj/item/am_containment,
+		/obj/item/am_shielding_container,
 		/obj/item/mech_ammo_box
 		)
 

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -187,7 +187,15 @@
 /obj/machinery/power/am_control_unit/attack_hand(mob/user as mob)
 	if(anchored)
 		interact(user)
+	else
+		to_chat(user, SPAN_NOTICE("The console need to be anchored first."))
 	return
+
+/obj/machinery/power/am_control_unit/attack_ai(mob/user as mob)
+	if(anchored)
+		interact(user)
+	else
+		to_chat(user, SPAN_NOTICE("The console need to be anchored first."))
 
 /obj/machinery/power/am_control_unit/proc/add_shielding(obj/machinery/am_shielding/AMS, AMS_linking = FALSE)
 	if(!istype(AMS))

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -165,6 +165,11 @@
 				remove_shielding(AMS)
 			return
 
+	if(istype(I, /obj/item/gripper)) // Are we attacking with a borg gripper?
+		var/obj/item/gripper/G = I
+		if(istype(G.wrapped, /obj/item/am_containment))
+			attackby(G.wrapped, user, params)
+
 	else if(istype(I, /obj/item/am_containment))
 		if(fueljar)
 			to_chat(user, "\red There is already a [fueljar] inside!")


### PR DESCRIPTION
## About The Pull Request
Allow cyborgs to pick up and manipulate stuff related to the Antimatter Engine.

- Allow cyborgs to pick up antimatter fuel jars.
- Allow cyborgs to pick up antimatter shielding boxes.
- Allow cyborgs to remotely access the Antimatter Engine Console.
- Allow cyborgs to insert antimatter jars into the Antimatter Engine Console.