### PR TITLE
The Revenge of the Trilogy: Risikio's Own ATK Ideas

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -327,6 +327,8 @@ SUBSYSTEM_DEF(job)
 			for(var/datum/gear/G in spawn_in_storage)
 				G.spawn_in_storage_or_drop(H, H.client.prefs.Gear()[G.display_name])
 
+		job.alt_TitleTweaks(H)
+
 		job.add_stats(H)
 
 		job.add_knownCraftRecipes(H)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -81,8 +81,13 @@
 		target.stats.changeStat(name, stat_modifiers[name])
 	for(var/perk in perks)
 		target.stats.addPerk(perk)
-
 	return TRUE
+
+/datum/job/proc/alt_TitleTweaks(var/mob/living/carbon/human/target)
+	if (!ishuman(target))
+		return FALSE
+	if (target.mind.role_alt_title == "Sawbones")
+		perks = list(/datum/perk/medicalexpertise, /datum/perk/stalker)
 
 /datum/job/proc/add_additiional_language(var/mob/living/carbon/human/target)
 	if(!ishuman(target))

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -358,6 +358,10 @@
 		to_chat(user, SPAN_WARNING("What [user.targeted_organ]?"))
 		return TRUE
 
+	if (icon_state == "traumakit" && (!(user.stats.getPerk(PERK_MEDICAL_EXPERT) || user.stats.getPerk(PERK_SURGICAL_MASTER))))
+		to_chat(user, SPAN_WARNING("You do not have the training to use an Advanced Trauma Kit in this way."))
+		return 1
+
 	if(affecting.open == 0)
 		if(affecting.is_bandaged() && affecting.is_disinfected())
 			to_chat(user, SPAN_WARNING("The wounds on [M]'s [affecting.name] have already been treated."))
@@ -490,6 +494,10 @@
 		if(!affecting)
 			to_chat(user, SPAN_WARNING("What [user.targeted_organ]?"))
 			return TRUE
+
+		if (icon_state == "burnkit" && (!(user.stats.getPerk(PERK_MEDICAL_EXPERT) || user.stats.getPerk(PERK_SURGICAL_MASTER))))
+		to_chat(user, SPAN_WARNING("You do not have the training to use an Advanced Burn Kit in this way."))
+		return 1
 
 		if(affecting.open == 0)
 			if(affecting.is_salved())

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -99,6 +99,11 @@
 			S.require_tool_message(user)
 		return FALSE
 
+	if (istype(tool,/obj/item/stack/medical/advanced/bruise_pack))
+		if (tool.icon_state == "traumakit" && (!(user.stats.getPerk(PERK_ADVANCED_MEDICAL) || user.stats.getPerk(PERK_SURGICAL_MASTER))))
+			to_chat(user, SPAN_WARNING("You do not have the training to use an Advanced Trauma Kit in this way."))
+			return FALSE
+
 	if(!S.can_use(user, src, tool, target) || !S.prepare_step(user, src, tool, target))
 		SSnano.update_uis(src)
 		return FALSE


### PR DESCRIPTION
**Locks the Advanced Trauma Kit in the following ways**

>Using an ATK in actual surgery to heal organs is locked to: Doctors, Roboticists, and Soteria Heads

>Using an ATKs and ABKs in the field to heal Brute/Burn damage like bandages/ointment is locked to: Sawbones, Corpsman, Trauma Team, Doctors, Roboticists, Soteria Heads

> Choosing the Salvager Alternate Title "Sawbones" now removes the _Expert Scavenger_ perk and replaces it with the _Medical Expertise_ perk, allowing for the use of ATKs and BTKs in the field.

**Pros:** 
Not having to rip out hundreds of items and recode everything.

Makes surgery and big boy injuries really only possible to be repaired by those who have proper Soteria Medical training.

Allows Corpsman, Trauma Team, and Sawbones to still be big healers in the field long enough to get them to a proper medical professional.

Sets up an area in code for future "Tweaks" to specific alternate titles.