### PR TITLE
Removes the hand-holder rail mod. 

### DIFF
--- a/code/datums/contract.dm
+++ b/code/datums/contract.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_INIT(blackshield_item_targets,list(
 		"Magnetic overheat barrel" = /obj/item/gun_upgrade/barrel/overheat,
 		"Danger Zone Trigger" = /obj/item/gun_upgrade/trigger/dangerzone,
 		"Gauss Coil barrel" = /obj/item/gun_upgrade/barrel/gauss,
-		"HandHolder Barrel Rail" = /obj/item/gun_upgrade/mechanism/gun_rail,
+		//"HandHolder Barrel Rail" = /obj/item/gun_upgrade/mechanism/gun_rail,
 		"Watchman scope" = /obj/item/gun_upgrade/scope/watchman,
 		"Contract Killer scope" = /obj/item/gun_upgrade/scope/killer,
 		"Melee armor plating" = /obj/item/tool_upgrade/armor/melee,

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -301,7 +301,7 @@
 				/obj/item/gun_upgrade/trigger/honker = 0.1,
 				/obj/item/gun_upgrade/barrel/toxin_coater = 1,
 				/obj/item/gun_upgrade/barrel/gauss = 1,
-				/obj/item/gun_upgrade/mechanism/gun_rail = 1,
+				///obj/item/gun_upgrade/mechanism/gun_rail = 1,
 				/obj/item/gun_upgrade/trigger/boom = 0.5,
 				/obj/item/gun_upgrade/scope/watchman = 0.7,
 				/obj/item/gun_upgrade/scope/killer = 0.7,

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -491,7 +491,7 @@
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_PLASTEEL = 3, MATERIAL_GLASS = 2)
 	can_remove = FALSE
 	price_tag = 60
-*/
+
 /obj/item/gun_upgrade/mechanism/gun_rail/New()
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
@@ -505,7 +505,7 @@
 	I.breakable = FALSE
 	I.unique_removal = TRUE
 	I.unique_removal_type = GUN_SCOPE
-
+*/
 /obj/item/gun_upgrade/mechanism/greyson_master_catalyst
 	name = "Greyson \"Master Unmaker\" infuser"
 	desc = "One of the rarest and most powerful weapon modification ever made by Greyson Positronics and one of the numerous reasons they remain a threat even after the company collapsed into malfunctioning artificial intelligences. It can infuse any weapon with immense power that causes utter ruin to machine and organic matter alike."

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -483,6 +483,7 @@
 	I.req_gun_tags = list(GUN_PROJECTILE)
 	I.gun_loc_tag = GUN_MECHANISM
 */
+/* //The handholder rail and its consequences have been a disaster for Sojournkind.
 /obj/item/gun_upgrade/mechanism/gun_rail
 	name = "H&S \"HandHolder\" Barrel Rail"
 	desc = "A simple magnetic barrel rail, designed to fit onto a variety of weapons. Easy to attach, impossible to remove."
@@ -490,7 +491,7 @@
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_PLASTEEL = 3, MATERIAL_GLASS = 2)
 	can_remove = FALSE
 	price_tag = 60
-
+*/
 /obj/item/gun_upgrade/mechanism/gun_rail/New()
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Comments out the handholder rail from the modlist. 
This is for several reasons;

1. The rail breaks typical balance by allowing *more* exchanges of gunfire past viewing range, this alone is a massive issue as it removes the niche of proper 'sniper' type weapons and encourages an incredibly bland strategy where its use is never not beneficial
2.  The rail further breaks balance by allowing scope attachments to _all_ weapons, even if they already have a scope - this results in very silly things such as scout-rifles with several screens of view range
3. The rail is insanely easy to obtain - it has been included in the basic leveled list for weapon mods which means a handful of random weapon-mod-crates grants an extraordinarily powerful item.

</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
