### PR TITLE
Synthetics and Defibs

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -630,7 +630,7 @@
 			if(60 to INFINITY)
 				M.stats.addPerk(/datum/perk/rezsickness)
 				log_and_message_admins("Added mild rez sickness to [M].")
-	else
+	else if(!M.isSynthetic())
 		M.stats.addPerk(/datum/perk/rezsickness)
 		log_and_message_admins("Added mild rez sickness to [M].")
 

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -550,7 +550,7 @@
 	M.updatehealth()
 	apply_brain_damage(M, deadtime)
 
-	if(!M.stats.getPerk(/datum/perk/rezsickness))
+	if(!M.stats.getPerk(/datum/perk/rezsickness) && !M.isSynthetic())
 		var/rngStatRemoved
 		switch(M.stats.getStat(STAT_MEC))
 			if(0 to 40)
@@ -619,7 +619,7 @@
 				M.stats.changeStat(STAT_VIG, -rngStatRemoved)
 		log_and_message_admins("Removed [-rngStatRemoved] to the VIG stat of [M]")
 
-	if(!advanced_pads)
+	if(!advanced_pads && !M.isSynthetic())
 		switch(M.stats.getStat(STAT_TGH))
 			if(-200 to 40)
 				M.stats.addPerk(/datum/perk/rezsickness/severe/fatal)

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -311,7 +311,7 @@
 /obj/item/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
 	if((H.species.flags & NO_SCAN && H.species.reagent_tag != IS_SYNTHETIC)) //Synths and FBPs should now bypass the NO_SCAN requirement
 		return "buzzes: \"Unrecogized physiology. Operation aborted.\""
-	else if(H.isSynthetic() && !use_on_synthetic && !si_only) // The Advanced defibs will now work on both flesh and synth
+	else if(H.isSynthetic() && !use_on_synthetic && !advanced_pads) // All Advanced defibs will now work on both flesh and synth
 		return "buzzes: \"Synthetic Body. Operation aborted.\""
 	else if(!H.isSynthetic() && use_on_synthetic)
 		return "buzzes: \"Organic Body. Operation aborted.\""

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -291,7 +291,7 @@
 
 /obj/item/shockpaddles/proc/can_use(mob/user, mob/M)
 	if(si_only)
-		if(!user.stats?.getPerk(PERK_ADVANCED_MEDICAL) && !user.stats?.getPerk(PERK_ADVANCED_MEDICAL) && !user.stats?.getPerk(PERK_MEDICAL_EXPERT))
+		if(!user.stats?.getPerk(PERK_ADVANCED_MEDICAL) && !user.stats?.getPerk(PERK_ROBOTICS_EXPERT) && !user.stats?.getPerk(PERK_MEDICAL_EXPERT)) // PERK_ADVANCED_MEDICAL was listed twice. Changed one to PERK_ROBOTICS_EXPERT since synth repair is Robotics territory
 			to_chat(user, "<span class='warning'>\The [src] is so complex your need training to use this.</span>")
 			return 0
 	if(busy)
@@ -309,9 +309,9 @@
 
 //Checks for various conditions to see if the mob is revivable
 /obj/item/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
-	if((H.species.flags & NO_SCAN))
+	if((H.species.flags & NO_SCAN && H.species.reagent_tag != IS_SYNTHETIC)) //Synths and FBPs should now bypass the NO_SCAN requirement
 		return "buzzes: \"Unrecogized physiology. Operation aborted.\""
-	else if(H.isSynthetic() && !use_on_synthetic)
+	else if(H.isSynthetic() && !use_on_synthetic && !si_only) // The Advanced defibs will now work on both flesh and synth
 		return "buzzes: \"Synthetic Body. Operation aborted.\""
 	else if(!H.isSynthetic() && use_on_synthetic)
 		return "buzzes: \"Organic Body. Operation aborted.\""
@@ -368,9 +368,8 @@
 			var/working_organ = FALSE
 			for(var/obj/item/organ/org in organs)
 				if(org.damage <= org.max_damage)
-					working_organ = TRUE
 					break
-			if(!working_organ)
+			if(!working_organ && H.species.reagent_tag != IS_SYNTHETIC) // Synthetic bodies can survive in stasis with non-functional vital organs. Also the proc reports FBP vitals as too damaged even in full health so...
 				return "buzzes: \"Resuscitation failed - Excessive damage to vital organ ([name]). Further attempts futile.\""
 	return null
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -28,7 +28,7 @@
 	var/datum/species/species			//TODO: Fix this
 	var/datum/species_form/form
 
-	var/inserted_and_processing = TRUE //Organs are removed from the object subsystem when inserted inside of a person. 
+	var/inserted_and_processing = TRUE //Organs are removed from the object subsystem when inserted inside of a person.
 									   //This makes sure they can turn off processing while implanted in someone.
 
 	// Damage vars.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>

Robotics Expert now allows use of Adv. Defibs.

Adv. Defib can revive both Organics and FBPs/Synths

Jumper cables can now revive FBPs/Synths, as intended. Ghetto method of removing/inserting microbattery still works.

Due to their inability to permanently improve their stats, FBPs/Synths will not suffer permanent stat loss or revival sickness from being defibbed.

</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
tweak: Advanced Defibs can revive both Organics and Synthetics; can also now be used by Roboticists.
code: Added a condition to the NO_SCAN check to allow synthetic species to bypass it. Added the same bypass to the working organ check, due to an issue encountered where FBP vitals were at full HP and still were seen as non-functioning.
fix: Jumper cables can now revive synthetics. Normal defibs now reject synths for being synths, instead of unknown biology.
balance: FBPs won't suffer rez sickness or stat loss for being defibbed
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
