### PR TITLE
Viro no cure self fix

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -65,9 +65,11 @@
 
 	if(mob.stat == DEAD)
 		return
+	/*
 	if(stage <= 1 && clicks == 0) 	// with a certain chance, the mob may become immune to the disease before it starts properly
 		if(prob(5))
 			mob.antibodies |= antigen // 20% immunity is a good chance IMO, because it allows finding an immune person easily
+	*/
 
 	// Some species are flat out immune to organic viruses.
 	var/mob/living/carbon/human/H = mob
@@ -79,28 +81,36 @@
 		if(prob(1))
 			majormutate()
 
-	//Space antibiotics stop disease completely
+	/*Space antibiotics stop disease completely
 	if(mob.reagents.has_reagent("spaceacillin"))
 		if(stage == 1 && prob(20))
 			src.cure(mob)
 		return
+	*/
 
 	//Virus food speeds up disease progress
 	if(mob.reagents.has_reagent("virusfood"))
 		mob.reagents.remove_reagent("virusfood",0.1)
 		clicks += 10
 
+	/*
 	if(prob(1) && prob(stage)) // Increasing chance of curing as the virus progresses
 		src.cure(mob)
 		mob.antibodies |= src.antigen
+	*/
 
 	//Moving to the next stage
 	if(clicks > max(stage*100, 200) && prob(10))
-		if((stage <= max_stage) && prob(20)) // ~60% of viruses will be cured by the end of S4 with this
+		/*if((stage <= max_stage) && prob(20)) // ~60% of viruses will be cured by the end of S4 with this
 			src.cure(mob)
 			mob.antibodies |= src.antigen
-		stage++
-		clicks = 0
+		*/
+		if (mob.reagents.has_reagent("spaceacillin"))
+			mob.reagents.remove_reagent("spaceacillin",0.5)
+			return
+		else
+			stage++
+			clicks = 0
 
 	//Do nasty effects
 	for(var/datum/disease2/effectholder/e in effects)

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -128,12 +128,9 @@
 		SSnano.update_uis(src)
 
 	if(beaker)
-		if(foodsupply < 100 && (foodsupply + 5) <= 100)
-			if (beaker.reagents.has_reagent("virusfood", 1) < 0)
-				return
-			else
-				beaker.reagents.remove_reagent("virusfood", 1)
-				foodsupply += 5
+		if(foodsupply < 100 && (foodsupply + 5) <= 100 && (beaker.reagents.has_reagent("virusfood", 1)))
+			beaker.reagents.remove_reagent("virusfood", 1)
+			foodsupply += 5
 			SSnano.update_uis(src)
 
 		if (locate(/datum/reagent/toxin) in beaker.reagents.reagent_list && toxins < 100)

--- a/code/modules/virus2/dishincubator.dm
+++ b/code/modules/virus2/dishincubator.dm
@@ -128,12 +128,12 @@
 		SSnano.update_uis(src)
 
 	if(beaker)
-		if(foodsupply < 100 && beaker.reagents.remove_reagent("virusfood",5))
-			if(foodsupply + 10 <= 100)
-				foodsupply += 10
+		if(foodsupply < 100 && (foodsupply + 5) <= 100)
+			if (beaker.reagents.has_reagent("virusfood", 1) < 0)
+				return
 			else
-				beaker.reagents.add_reagent("virusfood",(100 - foodsupply)/2)
-				foodsupply = 100
+				beaker.reagents.remove_reagent("virusfood", 1)
+				foodsupply += 5
 			SSnano.update_uis(src)
 
 		if (locate(/datum/reagent/toxin) in beaker.reagents.reagent_list && toxins < 100)

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -29,12 +29,14 @@
 
 /obj/machinery/disease2/isolator/attackby(var/obj/O as obj, var/mob/user)
 	if(!istype(O,/obj/item/reagent_containers/syringe)) return
-	var/obj/item/reagent_containers/syringe/S = O
+	//var/obj/item/reagent_containers/syringe/S = O
 
 	if(sample)
 		to_chat(user, "\The [src] is already loaded.")
 		return
-
+	else
+		to_chat(user, "\The [src] has a slot for a syringe style you've never seen before.")
+/* Currently bugged. Unable to interact with machine after inserting syringe. Quick fix of not being able to insert anything for now. ~Aeger
 	sample = S
 	user.drop_item()
 	S.loc = src
@@ -44,6 +46,7 @@
 	update_icon()
 
 	src.attack_hand(user)
+*/
 
 /obj/machinery/disease2/isolator/attack_hand(mob/user as mob)
 	if(stat & (NOPOWER|BROKEN)) return


### PR DESCRIPTION
Alters viro to be more usable on server! I will add more viruses and light changes over time while me and Ayshe figure out how we want to restructure it. But for now the following changes are:
People will no longer cure themselves randomly. They will require virology equipment or radium injections to produce antibodies. (Antibodies can be shared afterwards tho and are easy to produce in large quantities.)
Viro's Isolator machine will no longer lock up when a syringe is put in.
Virus food is no longer able to be bugged to be infinite in the incubator.
Incubator has been adjusted to get far more food for every unit of virus food in exchange.
Spaceacillin no longer cures stage 1 diseases. It instead stops diseases from moving to the next stage. (Consumes some of the spaceacillin each time it stops the advancement.)