### PR TITLE
Hides Crafting Menus of Unknown Categories

### DIFF
--- a/code/datums/craft/menu.dm
+++ b/code/datums/craft/menu.dm
@@ -46,8 +46,18 @@
 	var/list/data = list()
 	var/curr_category = get_category(usr)
 
+	var/list/unlocked_names
+
+	unlocked_names = SScraft.cat_names.Copy(1,0)
+
+	for(var/path in subtypesof(/datum/craft_recipe))
+		var/datum/craft_recipe/CX = path
+		CX = new CX
+		if (!CX.avaliableToEveryone && !user.stats.getPerk(CX.requiredPerk))
+			unlocked_names.Remove(CX.category)
+
 	data["is_admin"] = check_rights(show_msg = FALSE)
-	data["categories"] = SScraft.cat_names
+	data["categories"] = unlocked_names
 	data["cur_category"] = curr_category
 	var/datum/craft_recipe/CR = get_item(usr)
 	data["cur_item"] = null

--- a/code/datums/craft/recipe.dm
+++ b/code/datums/craft/recipe.dm
@@ -9,6 +9,7 @@
 	var/time = 30 //Used when no specific time is set
 	var/related_stats = list(STAT_COG)	// used to decrease crafting time for non tool steps
 	var/avaliableToEveryone = TRUE
+	var/datum/perk/requiredPerk = null
 	var/dir_type = CRAFT_WITH_USER_DIR  // spawn the result in the user's direction by default
 	// set it to CRAFT_TOWARD_USER to spawn the result towards the user
 	// set it to CRAFT_DEFAULT_DIR to spawn the result in its default direction (stored in dir_default)

--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -3,6 +3,7 @@
 	time = 100
 	related_stats = list(STAT_COG)
 	avaliableToEveryone = FALSE
+	requiredPerk = PERK_HANDYMAN
 
 //Materal Craft ------------------
 

--- a/code/datums/craft/recipes/lodge.dm
+++ b/code/datums/craft/recipes/lodge.dm
@@ -3,6 +3,7 @@
 	time = 100
 	related_stats = list(STAT_BIO)
 	avaliableToEveryone = FALSE
+	requiredPerk = PERK_BUTCHER
 
 // Weaponry -----------------
 /datum/craft_recipe/lodge/crossbow_bolts

--- a/code/datums/craft/recipes/robot.dm
+++ b/code/datums/craft/recipes/robot.dm
@@ -3,6 +3,7 @@
 	time = 100
 	related_stats = list(STAT_MEC)
 	avaliableToEveryone = FALSE // Only Roboticists know how to make robots. When adding new recipe, also add them to code/game/jobs/job/science.dm
+	requiredPerk = PERK_ROBOTICS_EXPERT
 
 // Control Module used in all the custom bots.
 /datum/craft_recipe/robotic/custom_board


### PR DESCRIPTION
Different hand crafting categories that are specific only to certain jobs can only been seen and clicked on by those specific jobs.