### PR TITLE
ID cards get a title toggle verb.

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -102,6 +102,7 @@ var/const/NO_EMAG_ACT = -50
 	var/registered_name = "Unknown" // The name registered_name on the card
 	var/list/associated_email_login = list("login" = "", "password" = "")
 	var/associated_account_number = 0
+	var/show_title = 0
 
 	var/age = "\[UNSET\]"
 	var/blood_type = "\[UNSET\]"
@@ -194,6 +195,11 @@ var/const/NO_EMAG_ACT = -50
 
 /obj/item/card/id/GetIdCard()
 	return src
+
+/obj/item/card/id/verb/Toggle_Title(mob/user as mob)
+	set src in view(1)
+	show_title = !show_title
+	user.visible_message("[user] alters the title on the ID card.")
 
 /obj/item/card/id/syndicate_command
 	name = "syndicate ID card"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -334,6 +334,8 @@ var/list/rank_prefix = list(\
 		id = wear_id.GetIdCard()
 	if(!id)
 		id = get_idcard()
+	if(id.show_title == 0)
+		return ""
 	if(id)
 		rank = id.rank
 		if(rank_prefix[rank])


### PR DESCRIPTION
Adds ability to toggle the title on ID cards.
No longer are well known people stuck having their first names removed with a worthless snowflake title.
Marshals and Blackshield can now go on break! (Then get yelled at by commander and warrent officer!)

Right clicking the ID card allows you to alter if it shows the title or not. Or you can use the "Toggle-Title" command for those who like to type. Tested with proof picture in development-general.