### PR TITLE
Tesla_Links & Reinforced Glass Hotfix

### DIFF
--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -521,7 +521,7 @@ var/list/name_to_material
 	hardness = 40
 	weight = 30
 	stack_origin_tech = "materials=2"
-	composite_material = list(MATERIAL_STEEL = 2,MATERIAL_GLASS = 3)
+	composite_material = list(MATERIAL_STEEL = 1,MATERIAL_GLASS = 1)
 	window_options = list("One Direction" = 1, "Full Window" = 6, "Windoor" = 5)
 	created_window = /obj/structure/window/reinforced
 	created_window_full = /obj/structure/window/reinforced/full

--- a/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_tablet.dm
@@ -102,6 +102,7 @@
 	cell = new /obj/item/cell/small/moebius/high(src)
 	scanner = new /obj/item/computer_hardware/scanner/medical(src)
 	gps_sensor = new /obj/item/computer_hardware/gps_sensor(src)
+	tesla_link = new/obj/item/computer_hardware/tesla_link(src)
 
 /obj/item/modular_computer/tablet/moebius/preset/install_default_programs()
 	..()


### PR DESCRIPTION
This adds a Tesla Link to all Soteria Tablets on round start akin to normal Tablets already in Soteria Medical

Fixes reinforced glass to give the proper 1 Steel 1 Glass rather than the bugged amounts

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
