### PR TITLE
Make the Nanite rig give the verbs upon spawning the rig

### DIFF
--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -29,11 +29,11 @@
 
 /datum/perk/nanite_armor/assign(mob/living/carbon/human/H)
 	..()
-	holder.brute_mod_perk -= armor_mod
+	holder?.brute_mod_perk -= armor_mod
 
 /datum/perk/nanite_armor/remove()
 	..()
-	holder.brute_mod_perk += armor_mod
+	holder?.brute_mod_perk += armor_mod
 
 /datum/perk/nanite_chem
 	name = "Nanite Chemicals"
@@ -104,7 +104,7 @@
 	anti_cheat = TRUE
 
 	var/list/ammo_boxes = typesof(/obj/item/ammo_magazine/ammobox)
-	//We cant print everything under the sun sadly, so we limit are options a small bit! 
+	//We cant print everything under the sun sadly, so we limit are options a small bit!
 	//No SI laser ammo, explosives, some higher end boxes/ammo, and church biomatter boxes
 	ammo_boxes -= list(	/obj/item/ammo_magazine/ammobox,
 						/obj/item/ammo_magazine/ammobox/pistol_35/laser,
@@ -127,6 +127,6 @@
 	var/obj/item/choice = input(usr, "Which type of ammo do you want?", "Ammo Choice", null) as null|anything in ammo_boxes
 	usr.put_in_hands(new choice(usr.loc))
 	cooldown_time = world.time + cooldown
-	
+
 	anti_cheat = FALSE
 	return ..()

--- a/code/modules/nanogate/powers/rig.dm
+++ b/code/modules/nanogate/powers/rig.dm
@@ -26,6 +26,18 @@ List of powers in this page :
 			nanite_rig.seal_delay = initial(nanite_rig.seal_delay) // resetting the seal delay
 			verbs -= /obj/item/organ/internal/nanogate/proc/nanite_rig
 
+			// Add the nanite rig verbs at activation
+			verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_storage
+			verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_laser
+			verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_autodoc
+			verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_eva
+
+			//Add to owner_verbs so it can be removed properly should the need arise.
+			owner_verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_storage
+			owner_verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_laser
+			owner_verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_autodoc
+			owner_verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_eva
+
 // Create the *opifex* nanite rig
 /obj/item/organ/internal/nanogate/proc/nanite_rig_opifex()
 	set category = "Nanogate Powers"
@@ -44,6 +56,18 @@ List of powers in this page :
 			owner.replace_in_slot(nanite_rig, slot_back, skip_covering_check = TRUE)
 			nanite_rig.seal_delay = initial(nanite_rig.seal_delay) // resetting the seal delay
 			verbs -= /obj/item/organ/internal/nanogate/proc/nanite_rig_opifex
+
+			// Add the nanite rig verbs at activation
+			verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_storage
+			verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_laser
+			verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_autodoc
+			verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_eva
+
+			//Add to owner_verbs so it can be removed properly should the need arise.
+			owner_verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_storage
+			owner_verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_laser
+			owner_verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_autodoc
+			owner_verbs += /obj/item/organ/internal/nanogate/proc/nanite_rig_eva
 
 // Give the nanite rig a storage module
 /obj/item/organ/internal/nanogate/proc/nanite_rig_storage()

--- a/code/modules/organs/internal/nanogate.dm
+++ b/code/modules/organs/internal/nanogate.dm
@@ -36,11 +36,7 @@
 		/obj/item/organ/internal/nanogate/proc/nanite_chem,
 
 		// Rig Upgrades
-		/obj/item/organ/internal/nanogate/proc/nanite_rig,
-		/obj/item/organ/internal/nanogate/proc/nanite_rig_storage,
-		/obj/item/organ/internal/nanogate/proc/nanite_rig_laser,
-		/obj/item/organ/internal/nanogate/proc/nanite_rig_autodoc,
-		/obj/item/organ/internal/nanogate/proc/nanite_rig_eva
+		/obj/item/organ/internal/nanogate/proc/nanite_rig
 
 		)
 
@@ -80,9 +76,5 @@ obj/item/organ/internal/nanogate/artificer
 		/obj/item/organ/internal/nanogate/proc/nanite_ammo,
 
 		// Rig Upgrades
-		/obj/item/organ/internal/nanogate/proc/nanite_rig_opifex,
-		/obj/item/organ/internal/nanogate/proc/nanite_rig_storage,
-		/obj/item/organ/internal/nanogate/proc/nanite_rig_laser,
-		/obj/item/organ/internal/nanogate/proc/nanite_rig_autodoc,
-		/obj/item/organ/internal/nanogate/proc/nanite_rig_eva
+		/obj/item/organ/internal/nanogate/proc/nanite_rig_opifex
 		)


### PR DESCRIPTION
## About The Pull Request
The Nanogate's rig powers now follow the same concept as the Nanobot Powers, so that the upgrades appear once the player get a nanobot instead of always clogging the power tab.
Also fix a nanogate runtime.