### PR TITLE
Remove the Antag Tax program 

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -22,8 +22,8 @@
 	hard_drive.store_file(new /datum/computer_file/program/wordprocessor())
 	hard_drive.store_file(new /datum/computer_file/program/records())
 	hard_drive.store_file(new /datum/computer_file/program/bounty_board_app())
-	if(prob(30)) //harmless tax software
-		hard_drive.store_file(new /datum/computer_file/program/uplink())
+	//if(prob(30)) //harmless tax software // We don't have antags that can use it and it can get confused with the other one. -R4d6
+	//	hard_drive.store_file(new /datum/computer_file/program/uplink())
 	if(prob(60))
 		hard_drive.store_file(new /datum/computer_file/program/tax())
 

--- a/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/uplink.dm
@@ -5,12 +5,13 @@
 	extended_desc = "An online tax filing software. It is a few years out of date."
 	size = 0 // it is cloud based
 	requires_ntnet = 0
+	available_on_ntnet = FALSE // We don't have any antag that use it and we have a working tax program, we don't need to use it. -R4d6
 	usage_flags = PROGRAM_PDA
 	nanomodule_path = /datum/nano_module/program/uplink
 	var/authenticated = FALSE
 
 /datum/nano_module/program/uplink
-	name = "TaxQuickly 2559"
+	name = "TaxQuickly 2545"
 	var/error = FALSE
 	var/stored_login = ""
 

--- a/code/modules/modular_computers/file_system/programs/generic/taxes.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/taxes.dm
@@ -11,7 +11,7 @@
 
 
 /datum/nano_module/program/tax
-	name = "TaxQuickly 2565"
+	name = "TaxQuickly 2561"
 	var/popup_message = ""
 	var/popup = FALSE
 	var/logined = FALSE


### PR DESCRIPTION
Remove the Antag Tax program and also fix the typos in the names of the tax programs.


We do not have any antags which (to my knowledge) use the antag uplink disguised as a tax program. And since we now have an actual, working tax program, it will probably just cause some confusion if someone doesn't know which one is which.

Also since all the antags we do get are powered by admins, they don't really need the uplink anyway. And if they do, I am sure that the admins will be able to give them a disk or something with the program for them to use.