### PR TITLE
Boost the custom drone's health and damage

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/robots/build_a_drone/build_a_drone.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/build_a_drone/build_a_drone.dm
@@ -4,6 +4,10 @@
 	desc = "A custom-built drone. They come in a variety of color and equipment."
 	icon = 'icons/mob/build_a_drone.dmi'
 	icon_state = "drone_st"
+	health = 100 // 10 more than Greyson's armored roomba
+	maxHealth = 100
+	melee_damage_lower = 10
+	melee_damage_upper = 15
 	faction = "neutral"
 	cleaning = FALSE
 	drop1 = null


### PR DESCRIPTION
## About The Pull Request
Boost the custom drone's health, 25 -> 100, and damage (5-10 -> 10-15) so that they survive a bit longer.