### PR TITLE
Psionic Powers : Heck Around And Find Out Edition.

### DIFF
--- a/code/modules/organs/internal/psionic.dm
+++ b/code/modules/organs/internal/psionic.dm
@@ -44,7 +44,8 @@
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_call,
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_banish,
 		/obj/item/organ/internal/psionic_tumor/proc/journey_to_nowhere,
-		/obj/item/organ/internal/psionic_tumor/proc/psionic_armor
+		/obj/item/organ/internal/psionic_tumor/proc/psionic_armor,
+		/obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster,
 	)
 
 /obj/item/organ/internal/psionic_tumor/psychiatrist
@@ -66,6 +67,7 @@
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_banish,
 		/obj/item/organ/internal/psionic_tumor/proc/journey_to_nowhere,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_armor,
+		/obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster,
 		// Psych unique powers just for them. Do not add these to other lists. -Kaz
 		/obj/item/organ/internal/psionic_tumor/proc/peace_of_mind,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_heal_other,

--- a/code/modules/organs/internal/psionic.dm
+++ b/code/modules/organs/internal/psionic.dm
@@ -45,14 +45,7 @@
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_banish,
 		/obj/item/organ/internal/psionic_tumor/proc/journey_to_nowhere,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_armor,
-		/obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster,
-		/obj/item/organ/internal/psionic_tumor/proc/cryo_kinetic_blaster,
-		/obj/item/organ/internal/psionic_tumor/proc/pyro_kinetic_blaster,
-		/obj/item/organ/internal/psionic_tumor/proc/electro_kinetic_blaster,
-		/obj/item/organ/internal/psionic_tumor/proc/kinetic_barrier,
-		/obj/item/organ/internal/psionic_tumor/proc/chosen_control,
-		/obj/item/organ/internal/psionic_tumor/proc/detect_thoughts,
-		/obj/item/organ/internal/psionic_tumor/proc/psychoactive_manipulation
+		/obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster
 	)
 
 /obj/item/organ/internal/psionic_tumor/psychiatrist

--- a/code/modules/organs/internal/psionic.dm
+++ b/code/modules/organs/internal/psionic.dm
@@ -46,6 +46,13 @@
 		/obj/item/organ/internal/psionic_tumor/proc/journey_to_nowhere,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_armor,
 		/obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster,
+		/obj/item/organ/internal/psionic_tumor/proc/cryo_kinetic_blaster,
+		/obj/item/organ/internal/psionic_tumor/proc/pyro_kinetic_blaster,
+		/obj/item/organ/internal/psionic_tumor/proc/electro_kinetic_blaster,
+		/obj/item/organ/internal/psionic_tumor/proc/kinetic_barrier,
+		/obj/item/organ/internal/psionic_tumor/proc/chosen_control,
+		/obj/item/organ/internal/psionic_tumor/proc/detect_thoughts,
+		/obj/item/organ/internal/psionic_tumor/proc/psychoactive_manipulation
 	)
 
 /obj/item/organ/internal/psionic_tumor/psychiatrist

--- a/code/modules/psionics/psionic_items/psi_catalysts.dm
+++ b/code/modules/psionics/psionic_items/psi_catalysts.dm
@@ -86,6 +86,46 @@
 	Kneel."
 	stored_power = /obj/item/organ/internal/psionic_tumor/proc/mind_jack
 
+/obj/item/device/psionic_catalyst/kinetic_blaster
+	name = "Kinetic Blaster"
+	desc = ""
+	stored_power = /obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster
+
+/obj/item/device/psionic_catalyst/cryo_kinetic_blaster
+	name = "Cryo-Kinetic Blaster"
+	desc = ""
+	stored_power = /obj/item/organ/internal/psionic_tumor/proc/cryo_kinetic_blaster
+
+/obj/item/device/psionic_catalyst/pyro_kinetic_blaster
+	name = "Pyro-Kinetic Blaster"
+	desc = ""
+	stored_power = /obj/item/organ/internal/psionic_tumor/proc/pyro_kinetic_blaster
+
+/obj/item/device/psionic_catalyst/electro_kinetic_blaster
+	name = "Electro-Kinetic Blaster"
+	desc = ""
+	stored_power = /obj/item/organ/internal/psionic_tumor/proc/electro_kinetic_blaster
+
+/obj/item/device/psionic_catalyst/kinetic_barrier
+	name = "Kinetic Barrier"
+	desc = ""
+	stored_power = /obj/item/organ/internal/psionic_tumor/proc/kinetic_barrier
+
+/obj/item/device/psionic_catalyst/chosen_control
+	name = "Chosen Control"
+	desc = ""
+	stored_power = /obj/item/organ/internal/psionic_tumor/proc/chosen_control
+
+/obj/item/device/psionic_catalyst/detect_thoughts
+	name = "Detect Thoughts"
+	desc = ""
+	stored_power = /obj/item/organ/internal/psionic_tumor/proc/detect_thoughts
+
+/obj/item/device/psionic_catalyst/psychoactive_manipulation
+	name = "Psychoactive Manipulation"
+	desc = ""
+	stored_power = /obj/item/organ/internal/psionic_tumor/proc/psychoactive_manipulation
+
 /obj/item/device/psionic_catalyst/Initialize()
 	. = ..()
 	src.transform *= 0.5

--- a/code/modules/psionics/psionic_items/psi_misc.dm
+++ b/code/modules/psionics/psionic_items/psi_misc.dm
@@ -79,13 +79,10 @@
 
 /obj/item/shield_projector/line/psionic/New(loc, var/cog)
 	..()
-	switch(cog)
-		if(40 to 49)
-			line_length = 5
-		if(50 to INFINITY)
-			line_length = 7
-		else
-			line_length = 3 // Mininum size I think we can make without errors
+	if(cog >= 40)
+		line_length = 5
+	else
+		line_length = 3 // Mininum size I think we can make without errors
 
 /obj/item/shield_projector/line/psionic/create_shield(newloc, new_dir)
 	var/obj/effect/directional_shield/psionic/S = new(newloc, src)

--- a/code/modules/psionics/psionic_items/psi_misc.dm
+++ b/code/modules/psionics/psionic_items/psi_misc.dm
@@ -68,3 +68,32 @@
 	psi_blocking = 10
 	price_tag = 150
 
+// The object that make the shield
+/obj/item/shield_projector/line/psionic
+	name = "psionic shield projector"
+	desc = ""
+	line_length = 3
+	always_on = TRUE
+	high_color = "#8000ff"
+	low_color = "#FF0000"
+
+/obj/item/shield_projector/line/psionic/New(loc, var/cog)
+	..()
+	switch(cog)
+		if(40 to 49)
+			line_length = 5
+		if(50 to INFINITY)
+			line_length = 7
+		else
+			line_length = 3 // Mininum size I think we can make without errors
+
+/obj/item/shield_projector/line/psionic/create_shield(newloc, new_dir)
+	var/obj/effect/directional_shield/psionic/S = new(newloc, src)
+	S.dir = new_dir
+	active_shields += S
+
+// The shield itself
+/obj/effect/directional_shield/psionic
+	name = "directional combat shield"
+	desc = "A wide shield, which has the property to block incoming projectiles but allow outgoing projectiles to pass it."
+	density = TRUE // People can't move pass these shields.

--- a/code/modules/psionics/psionic_items/psi_misc.dm
+++ b/code/modules/psionics/psionic_items/psi_misc.dm
@@ -77,12 +77,13 @@
 	high_color = "#8000ff"
 	low_color = "#FF0000"
 
-/obj/item/shield_projector/line/psionic/New(loc, var/cog)
-	..()
+/obj/item/shield_projector/line/psionic/New(loc, var/cog, var/_dir)
+	dir = _dir
 	if(cog >= 40)
 		line_length = 5
 	else
 		line_length = 3 // Mininum size I think we can make without errors
+	..()
 
 /obj/item/shield_projector/line/psionic/create_shield(newloc, new_dir)
 	var/obj/effect/directional_shield/psionic/S = new(newloc, src)
@@ -94,3 +95,18 @@
 	name = "directional combat shield"
 	desc = "A wide shield, which has the property to block incoming projectiles but allow outgoing projectiles to pass it."
 	density = TRUE // People can't move pass these shields.
+
+/obj/effect/directional_shield/psionic/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+    if(air_group || (height==0))
+        return TRUE
+    else if(istype(mover, /obj/item/projectile))
+        var/obj/item/projectile/P = mover
+        if(istype(P, /obj/item/projectile/test)) // Turrets need to try to kill the shield and so their test bullet needs to penetrate.
+            return TRUE
+
+        var/bad_arc = reverse_direction(dir) // Arc of directions from which we cannot block.
+        if(check_parry_arc(src, bad_arc, P)) // This is actually for mobs but it will work for our purposes as well.
+            return FALSE
+        else
+            return TRUE
+    return FALSE

--- a/code/modules/psionics/psionic_items/psi_temp_items.dm
+++ b/code/modules/psionics/psionic_items/psi_temp_items.dm
@@ -63,21 +63,22 @@
 /obj/item/tool/hammer/telekinetic_fist/attack(atom/movable/target, mob/user)
 	var/whack_speed = 0
 
-	if(user.stats.getStat(STAT_ROB) <= 0)
-		force = WEAPON_FORCE_HARMLESS
-		whack_speed = 2
-	else if(user.stats.getStat(STAT_ROB) <= 15)
-		force = WEAPON_FORCE_NORMAL // As strong as a kitchen knife
-		whack_speed = 4
-	else if(user.stats.getStat(STAT_ROB) <= 25)
-		force = WEAPON_FORCE_DANGEROUS // As strong as a butcher cleaver
-		whack_speed = 6
-	else if(user.stats.getStat(STAT_ROB) <= 35)
-		force = WEAPON_FORCE_ROBUST // As strong as a machete
-		whack_speed = 6
-	else if(user.stats.getStat(STAT_ROB) > 35)
-		force = WEAPON_FORCE_BRUTAL
-		whack_speed = 6
+	switch(user.stats.getStat(STAT_ROB))
+		if(1 to 14)
+			force = WEAPON_FORCE_NORMAL // As strong as a kitchen knife
+			whack_speed = 4
+		if(15 to 24)
+			force = WEAPON_FORCE_DANGEROUS // As strong as a butcher cleaver
+			whack_speed = 6
+		if(25 to 34)
+			force = WEAPON_FORCE_ROBUST // As strong as a machete
+			whack_speed = 6
+		if(35 to INFINITY)
+			force = WEAPON_FORCE_BRUTAL
+			whack_speed = 6
+		else
+			force = WEAPON_FORCE_HARMLESS
+			whack_speed = 2
 
 	if(user.stats.getPerk(PERK_PSI_MANIA))
 		force = WEAPON_FORCE_BRUTAL
@@ -123,18 +124,21 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/item/tool/knife/psionic_blade/attack(atom/target, mob/user)
-	if(user.stats.getStat(STAT_ROB) <= 0)
-		force = WEAPON_FORCE_HARMLESS
-	else if(user.stats.getStat(STAT_ROB) <= 15)
-		force = WEAPON_FORCE_NORMAL // As strong as a kitchen knife
-	else if(user.stats.getStat(STAT_ROB) <= 25)
-		force = WEAPON_FORCE_DANGEROUS // As strong as a butcher cleaver
-	else if(user.stats.getStat(STAT_ROB) <= 35)
-		force = WEAPON_FORCE_ROBUST // As strong as a machete
-	else if(user.stats.getStat(STAT_ROB) > 35)
-		force = WEAPON_FORCE_BRUTAL
+	switch(user.stats.getStat(STAT_ROB))
+		if(1 to 14)
+			force = WEAPON_FORCE_NORMAL // As strong as a kitchen knife
+		if(15 to 24)
+			force = WEAPON_FORCE_DANGEROUS // As strong as a butcher cleaver
+		if(25 to 34)
+			force = WEAPON_FORCE_ROBUST // As strong as a machete
+		if(35 to INFINITY)
+			force = WEAPON_FORCE_BRUTAL
+		else
+			force = WEAPON_FORCE_HARMLESS
+
 	if(user.stats.getPerk(PERK_PSI_MANIA))
 		force = WEAPON_FORCE_BRUTAL
+
 	..()
 	force = initial(force) // Reset the damage just in case
 

--- a/code/modules/psionics/psionic_items/psi_weptools.dm
+++ b/code/modules/psionics/psionic_items/psi_weptools.dm
@@ -221,9 +221,8 @@
 /obj/item/gun/kinetic_blaster
 	name = "psionic kinetic blaster"
 	desc = "A psionic-powered kinetic blaster. It has a small sticker addressed to a 'Possum', which says : \"Give this weapon a better description.\""
-	icon = 'icons/obj/guns/projectile.dmi'
-	icon_state = "carbine-20"
-	item_state = "gun"
+	icon = 'icons/obj/guns/energy/zapper.dmi'
+	icon_state = "zap"
 	fire_sound = 'sound/weapons/Taser.ogg'
 	fire_sound_text = "laser blast"
 	max_upgrades = 0
@@ -231,6 +230,10 @@
 	var/use_amount = 1 // How many psi-points is used per shot
 	var/mob/living/carbon/holder // The one that prevent the fist from fading
 	var/obj/item/organ/internal/psionic_tumor/PT // The psionic organ of the holder.
+
+/obj/item/gun/kinetic_blaster/New()
+	..()
+	START_PROCESSING(SSobj, src)
 
 /obj/item/gun/kinetic_blaster/consume_next_projectile()
 	if(!ispath(projectile_type)) // Do we actually shoot something?
@@ -295,7 +298,7 @@
 	nodamage = TRUE //Determines if the projectile will skip any damage inflictions
 	taser_effect = TRUE //If set then the projectile will apply it's agony damage using stun_effect_act() to mobs it hits, and other damage will be ignored
 
-/obj/item/projectile/kinetic_blast/cryo/New(cog = 0)
+/obj/item/projectile/kinetic_blast/cryo/New(cog)
 	..()
 	agony = round(clamp(cog/10, 0, 40))
 

--- a/code/modules/psionics/psionic_items/psi_weptools.dm
+++ b/code/modules/psionics/psionic_items/psi_weptools.dm
@@ -216,3 +216,110 @@
 	matter = list()
 	origin_tech = list()
 	price_tag = 0
+
+// Psionic gun.
+/obj/item/gun/kinetic_blaster
+	name = "psionic kinetic blaster"
+	desc = "A psionic-powered kinetic blaster. It has a small sticker addressed to a 'Possum', which says : \"Give this weapon a better description.\""
+	icon = 'icons/obj/guns/projectile.dmi'
+	icon_state = "carbine-20"
+	item_state = "gun"
+	fire_sound = 'sound/weapons/Taser.ogg'
+	fire_sound_text = "laser blast"
+	max_upgrades = 0
+	var/projectile_type = /obj/item/projectile/kinetic_blast // What does it shoot
+	var/use_amount = 1 // How many psi-points is used per shot
+	var/mob/living/carbon/holder // The one that prevent the fist from fading
+	var/obj/item/organ/internal/psionic_tumor/PT // The psionic organ of the holder.
+
+/obj/item/gun/kinetic_blaster/consume_next_projectile()
+	if(!ispath(projectile_type)) // Do we actually shoot something?
+		return null
+	if(!PT.pay_power_cost(use_amount)) // Do we have enough psi-points?
+		return null
+	return new projectile_type(src, holder.stats.getPerk(PERK_PSI_MANIA) ? 40 : holder.stats.getStat(STAT_COG))
+
+/obj/item/gun/kinetic_blaster/Process()
+	..()
+	if(loc != holder) // We're no longer in the psionic's hand.
+		visible_message("[src] fades into nothingness.")
+		STOP_PROCESSING(SSobj, src)
+		qdel(src)
+		return
+
+/obj/item/gun/kinetic_blaster/cryo
+	name = "psionic cryo-kinetic blaster"
+	desc = "A psionic-powered kinetic blaster. It has a small sticker addressed to a 'Possum', which says : \"Give this weapon a better description.\""
+	projectile_type = /obj/item/projectile/kinetic_blast/cryo
+	use_amount = 4
+
+/obj/item/gun/kinetic_blaster/pyro
+	name = "psionic pyro-kinetic blaster"
+	desc = "A psionic-powered kinetic blaster. It has a small sticker addressed to a 'Possum', which says : \"Give this weapon a better description.\""
+	projectile_type = /obj/item/projectile/kinetic_blast/pyro
+	use_amount = 2
+
+/obj/item/gun/kinetic_blaster/electro
+	name = "psionic electro-kinetic blaster"
+	desc = "A psionic-powered kinetic blaster. It has a small sticker addressed to a 'Possum', which says : \"Give this weapon a better description.\""
+	projectile_type = /obj/item/projectile/kinetic_blast/electro
+	use_amount = 3
+
+// Psionic Projectiles
+/obj/item/projectile/kinetic_blast
+	name = "kinetic blast"
+	icon_state = "magicm"
+	damage_types = list(BRUTE = 0)
+
+/obj/item/projectile/kinetic_blast/New(var/cog = 0)
+	..()
+	var/force
+	switch(cog)
+		if(1 to 14)
+			force = WEAPON_FORCE_NORMAL // As strong as a kitchen knife
+		if(15 to 24)
+			force = WEAPON_FORCE_DANGEROUS // As strong as a butcher cleaver
+		if(25 to 34)
+			force = WEAPON_FORCE_ROBUST // As strong as a machete
+		if(35 to INFINITY)
+			force = WEAPON_FORCE_BRUTAL
+		else
+			force = WEAPON_FORCE_HARMLESS
+
+	damage_types[BRUTE] = force
+
+/obj/item/projectile/kinetic_blast/cryo
+	name = "cryo-kinetic blast"
+	icon_state = "spell"
+	damage_types = list(BRUTE = 0)
+	nodamage = TRUE //Determines if the projectile will skip any damage inflictions
+	taser_effect = TRUE //If set then the projectile will apply it's agony damage using stun_effect_act() to mobs it hits, and other damage will be ignored
+
+/obj/item/projectile/kinetic_blast/cryo/New(cog = 0)
+	..()
+	agony = round(clamp(cog/10, 0, 40))
+
+/obj/item/projectile/kinetic_blast/pyro
+	name = "pyro-kinetic blast"
+	icon_state = "fireball"
+	damage_types = list(BRUTE = 0)
+	var/list/explosion_values = list(0, 1, 2, 4) // Explosions strengths, same value as a regular missile.
+
+/obj/item/projectile/kinetic_blast/pyro/on_impact(atom/target)
+	explosion(loc, explosion_values[0], explosion_values[1], explosion_values[2], explosion_values[3])
+	return TRUE
+
+/obj/item/projectile/kinetic_blast/electro
+	name = "electro-kinetic blast"
+	icon_state = "invisible"
+	damage_types = list(BRUTE = 0)
+	hitscan = TRUE
+	invisibility = 101	//beam projectiles are invisible as they are rendered by the effect engine
+
+	muzzle_type = /obj/effect/projectile/tesla/muzzle
+	tracer_type = /obj/effect/projectile/tesla/tracer
+	impact_type = /obj/effect/projectile/tesla/impact
+
+/obj/item/projectile/kinetic_blast/electro/New(var/cog = 0)
+	..()
+	damage_types[BRUTE] *= 1.5 // Deal 50% more damage

--- a/code/modules/psionics/psionic_items/psi_weptools.dm
+++ b/code/modules/psionics/psionic_items/psi_weptools.dm
@@ -310,7 +310,7 @@
 	var/list/explosion_values = list(0, 1, 2, 4) // Explosions strengths, same value as a regular missile.
 
 /obj/item/projectile/kinetic_blast/pyro/on_impact(atom/target)
-	explosion(loc, explosion_values[0], explosion_values[1], explosion_values[2], explosion_values[3])
+	explosion(loc, explosion_values[1], explosion_values[2], explosion_values[3], explosion_values[4])
 	return TRUE
 
 /obj/item/projectile/kinetic_blast/electro

--- a/code/modules/psionics/psionic_items/psi_weptools.dm
+++ b/code/modules/psionics/psionic_items/psi_weptools.dm
@@ -231,8 +231,10 @@
 	var/mob/living/carbon/holder // The one that prevent the fist from fading
 	var/obj/item/organ/internal/psionic_tumor/PT // The psionic organ of the holder.
 
-/obj/item/gun/kinetic_blaster/New()
+/obj/item/gun/kinetic_blaster/New(var/loc, var/mob/living/carbon/maker, var/obj/item/organ/internal/psionic_tumor/tumor)
 	..()
+	holder = maker
+	PT = tumor
 	START_PROCESSING(SSobj, src)
 
 /obj/item/gun/kinetic_blaster/consume_next_projectile()
@@ -243,7 +245,6 @@
 	return new projectile_type(src, holder.stats.getPerk(PERK_PSI_MANIA) ? 40 : holder.stats.getStat(STAT_COG))
 
 /obj/item/gun/kinetic_blaster/Process()
-	..()
 	if(loc != holder) // We're no longer in the psionic's hand.
 		visible_message("[src] fades into nothingness.")
 		STOP_PROCESSING(SSobj, src)

--- a/code/modules/psionics/researched_powers.dm
+++ b/code/modules/psionics/researched_powers.dm
@@ -7,9 +7,7 @@
 	psi_point_cost = 0
 
 	if(pay_power_cost(psi_point_cost))
-		var/obj/item/gun/kinetic_blaster/cryo/KB = new(src)
-		KB.holder = owner
-		KB.PT = src
+		var/obj/item/gun/kinetic_blaster/cryo/KB = new(src, owner, src)
 		owner.visible_message(
 			"[owner] clenches their hand into a fist, electric energy crackling around it before a kinetic blaster forms over it!",
 			"You clench your hand into a fist, electric energy crackling around your fingers before a kinetic blaster forms over it!"
@@ -24,9 +22,7 @@
 	psi_point_cost = 0
 
 	if(pay_power_cost(psi_point_cost))
-		var/obj/item/gun/kinetic_blaster/pyro/KB = new(src)
-		KB.holder = owner
-		KB.PT = src
+		var/obj/item/gun/kinetic_blaster/pyro/KB = new(src, owner, src)
 		owner.visible_message(
 			"[owner] clenches their hand into a fist, electric energy crackling around it before a kinetic blaster forms over it!",
 			"You clench your hand into a fist, electric energy crackling around your fingers before a kinetic blaster forms over it!"
@@ -41,9 +37,7 @@
 	psi_point_cost = 0
 
 	if(pay_power_cost(psi_point_cost))
-		var/obj/item/gun/kinetic_blaster/electro/KB = new(src)
-		KB.holder = owner
-		KB.PT = src
+		var/obj/item/gun/kinetic_blaster/electro/KB = new(src, owner, src)
 		owner.visible_message(
 			"[owner] clenches their hand into a fist, electric energy crackling around it before a kinetic blaster forms over it!",
 			"You clench your hand into a fist, electric energy crackling around your fingers before a kinetic blaster forms over it!"
@@ -59,8 +53,7 @@
 	var/timer = 10 SECONDS
 
 	if(pay_power_cost(psi_point_cost))
-		var/obj/item/shield_projector/line/psionic/shield = new(src, owner.stats.getStat(STAT_COG))
-		shield.dir = owner.dir
+		var/obj/item/shield_projector/line/psionic/shield = new(src, owner.stats.getStat(STAT_COG), owner.dir)
 		owner.visible_message(
 			"[owner] do something weird!",
 			"You do something weird!"

--- a/code/modules/psionics/researched_powers.dm
+++ b/code/modules/psionics/researched_powers.dm
@@ -59,7 +59,8 @@
 	var/timer = 10 SECONDS
 
 	if(pay_power_cost(psi_point_cost))
-		var/obj/item/shield_projector/line/psionic/shield = new(src)
+		var/obj/item/shield_projector/line/psionic/shield = new(src, owner.stats.getStat(STAT_COG))
+		shield.dir = owner.dir
 		owner.visible_message(
 			"[owner] do something weird!",
 			"You do something weird!"

--- a/code/modules/psionics/researched_powers.dm
+++ b/code/modules/psionics/researched_powers.dm
@@ -1,1 +1,144 @@
 // These powers are obtained through the Soteria via researching into new powers. They may be granted to the researcher and others.
+
+/obj/item/organ/internal/psionic_tumor/proc/cryo_kinetic_blaster()
+	set category = "Psionic powers"
+	set name = "Cryo-Kinetic Blaster (0)"
+	set desc = "Gain a psionic-powered kinetic blaster"
+	psi_point_cost = 0
+
+	if(pay_power_cost(psi_point_cost))
+		var/obj/item/gun/kinetic_blaster/cryo/KB = new(src)
+		KB.holder = owner
+		KB.PT = src
+		owner.visible_message(
+			"[owner] clenches their hand into a fist, electric energy crackling around it before a kinetic blaster forms over it!",
+			"You clench your hand into a fist, electric energy crackling around your fingers before a kinetic blaster forms over it!"
+			)
+		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
+		usr.put_in_active_hand(KB)
+
+/obj/item/organ/internal/psionic_tumor/proc/pyro_kinetic_blaster()
+	set category = "Psionic powers"
+	set name = "Pyro-Kinetic Blaster (0)"
+	set desc = "Gain a psionic-powered kinetic blaster"
+	psi_point_cost = 0
+
+	if(pay_power_cost(psi_point_cost))
+		var/obj/item/gun/kinetic_blaster/pyro/KB = new(src)
+		KB.holder = owner
+		KB.PT = src
+		owner.visible_message(
+			"[owner] clenches their hand into a fist, electric energy crackling around it before a kinetic blaster forms over it!",
+			"You clench your hand into a fist, electric energy crackling around your fingers before a kinetic blaster forms over it!"
+			)
+		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
+		usr.put_in_active_hand(KB)
+
+/obj/item/organ/internal/psionic_tumor/proc/electro_kinetic_blaster()
+	set category = "Psionic powers"
+	set name = "Electro-Kinetic Blaster (0)"
+	set desc = "Gain a psionic-powered kinetic blaster"
+	psi_point_cost = 0
+
+	if(pay_power_cost(psi_point_cost))
+		var/obj/item/gun/kinetic_blaster/electro/KB = new(src)
+		KB.holder = owner
+		KB.PT = src
+		owner.visible_message(
+			"[owner] clenches their hand into a fist, electric energy crackling around it before a kinetic blaster forms over it!",
+			"You clench your hand into a fist, electric energy crackling around your fingers before a kinetic blaster forms over it!"
+			)
+		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
+		usr.put_in_active_hand(KB)
+
+/obj/item/organ/internal/psionic_tumor/proc/kinetic_barrier()
+	set category = "Psionic powers"
+	set name = "Kinetic Barrier (2)"
+	set desc = "Creates a semi-visible purple-ish barrier in front of the user that last 10 seconds. The barrier blocks all projectiles and movement but not vision."
+	psi_point_cost = 2
+	var/timer = 10 SECONDS
+
+	if(pay_power_cost(psi_point_cost))
+		var/obj/item/shield_projector/line/psionic/shield = new(src)
+		owner.visible_message(
+			"[owner] do something weird!",
+			"You do something weird!"
+			)
+		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
+		spawn(timer) shield.Destroy() // Delete the shield after 10 seconds
+
+/obj/item/organ/internal/psionic_tumor/proc/chosen_control()
+	set category = "Psionic powers"
+	set name = "Chosen Control (4)"
+	set desc = "Clears all pain, hallos, stuns, sleep effects, addictions, and removes handcuffs, buckling, and grapples. Clears the blood of all drugs, stims, and medicines, effectively giving you a full clean."
+	psi_point_cost = 4
+
+	if(pay_power_cost(psi_point_cost))
+		owner.visible_message(
+			"[owner] do something weird!",
+			"You do something weird!"
+			)
+		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
+		if(owner.buckled)
+			owner.buckled.unbuckle_mob()
+
+		if (owner.handcuffed && !initial(owner.handcuffed))
+			owner.drop_from_inventory(owner.handcuffed)
+		owner.handcuffed = initial(owner.handcuffed)
+
+		if (owner.legcuffed && !initial(owner.legcuffed))
+			owner.drop_from_inventory(owner.legcuffed)
+		owner.legcuffed = initial(owner.legcuffed)
+
+		owner.SetParalysis(0)
+		owner.SetStunned(0)
+		owner.SetWeakened(0)
+		owner.setHalLoss(0)
+		owner.reagents.clear_reagents()
+		for(var/datum/reagent/R in owner.metabolism_effects.addiction_list)
+			to_chat(owner, SPAN_NOTICE("You don't crave for [R.name] anymore."))
+			owner.metabolism_effects.addiction_list.Remove(R)
+			qdel(R)
+
+/obj/item/organ/internal/psionic_tumor/proc/detect_thoughts()
+	set category = "Psionic powers"
+	set name = "Detect Thoughts (5)"
+	set desc = "Gives you the exact coordinates of a current person. They must be alive, organic, and cannot have a cruciform or be wearing a tinfoil hat."
+	psi_point_cost = 5
+
+	var/list/creatures = list() // Who we can talk to
+	for(var/mob/living/carbon/human/h in world) // Check every players in the game
+		if(!h.species?.reagent_tag != IS_SYNTHETIC && !h.get_core_implant(/obj/item/implant/core_implant/cruciform) && !h.is_mannequin) // Can't talk to robots or people with cruciforms or mannequins
+			creatures += h // Add the player to the list we can talk to
+	var/mob/living/carbon/human/target = input("Who do you want to locate ?") as null|anything in creatures
+	if (isnull(target))
+		return
+
+	if(pay_power_cost(psi_point_cost))
+		if(target.psi_blocking >= 10)
+			owner.stun_effect_act(0, target.psi_blocking * 5, BP_HEAD)
+			owner.weakened = target.psi_blocking
+			usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
+		else
+			usr.show_message("\blue You psionically locate [target.real_name], they are at : [target.x], [target.y], [target.z]")
+
+/obj/item/organ/internal/psionic_tumor/proc/psychoactive_manipulation()
+	set category = "Psionic powers"
+	set name = "Psychoactive Manipulation (5)"
+	set desc = "Allows you to reroll an odditys stats and perk, effectively making a new() oddity in the hopes of getting a better outcome."
+	psi_point_cost = 2
+
+	var/obj/item/oddity/O = owner.get_active_hand()
+	if(!istype(O, /obj/item/oddity))
+		to_chat(owner, SPAN_NOTICE("This isn't the correct kind of oddity!"))
+		return FALSE
+	owner.visible_message("<b><font color='purple'>[owner] concentrates on the anomaly in their hand, something about it changing in a subtle way.</font><b>", "<b><font color='purple'>You focus on the energies around the object, swaying them to your will and enhancing it!</font><b>")
+
+	if(O.oddity_stats)
+		for(var/stat in O.oddity_stats)
+			O.oddity_stats[stat] = rand(1, O.oddity_stats[stat])
+
+	if(O.perk)
+		O.perk = null
+	if(prob(O.prob_perk))
+		O.perk = get_oddity_perk()

--- a/code/modules/psionics/standard_powers.dm
+++ b/code/modules/psionics/standard_powers.dm
@@ -160,9 +160,7 @@
 	psi_point_cost = 0
 
 	if(pay_power_cost(psi_point_cost))
-		var/obj/item/gun/kinetic_blaster/KB = new(src)
-		KB.holder = owner
-		KB.PT = src
+		var/obj/item/gun/kinetic_blaster/KB = new(src, owner, src)
 		owner.visible_message(
 			"[owner] clenches their hand into a fist, electric energy crackling around it before a kinetic blaster forms over it!",
 			"You clench your hand into a fist, electric energy crackling around your fingers before a kinetic blaster forms over it!"

--- a/code/modules/psionics/standard_powers.dm
+++ b/code/modules/psionics/standard_powers.dm
@@ -152,3 +152,20 @@
 			)
 		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
 		usr.put_in_active_hand(fist)
+
+/obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster()
+	set category = "Psionic powers"
+	set name = "Kinetic Blaster (0)"
+	set desc = "Gain a psionic-powered kinetic blaster"
+	psi_point_cost = 0
+
+	if(pay_power_cost(psi_point_cost))
+		var/obj/item/gun/kinetic_blaster/KB = new(src)
+		KB.holder = owner
+		KB.PT = src
+		owner.visible_message(
+			"[owner] clenches their hand into a fist, electric energy crackling around it before a kinetic blaster forms over it!",
+			"You clench your hand into a fist, electric energy crackling around your fingers before a kinetic blaster forms over it!"
+			)
+		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
+		usr.put_in_active_hand(KB)


### PR DESCRIPTION
This PR add multiple powers that @Kazkin asked me to code, with only one currently available to the public.
The rest will be added in a future update by Possum.

**Kinetic blast**: Standard power (all psions get it)
Creates a psi based item in your hand that fires a kinetic blast. The blast costs 1 psi point per shot. The item disappears if dropped. The damage scales off of cognition, dealing max damage if you have the psionic psychosis perk.

**Researched variants**
- **Cryo-Kinetic Blast**: 4 points per shot, deals no damage but stuns for 1 second per 10 points of cog, capping at 4.
- **Pyro-Kinetic Blast**: 2 points per shot, impacts like an explosive grenade, damaging objects, knocking people down, and setting flammable objects on fire.
- **Electro-Kinetic Blast**: Hit scan, costs 3 points per shot, acts like an upgraded kinetic blast that does more damage and hits harder while being instant.

Other Researched Powers
**Detect Thoughts** - Gives you the exact coordinates of a current person. They must be alive, organic, and cannot have a cruciform or be wearing a tinfoil hat. Costs 5 points.
**Psychoactive Manipulation** - Allows you to reroll an oddity's stats and perk, effectively making a new oddity in the hopes of getting a better outcome. 2 points.
**Kinetic Barrier** - Creates a semi-visible purple-ish barrier in front of the user that last 10 seconds. The barrier blocks all projectiles and movement but not vision. Cost 2 points. By default it spawn a 3x1 barrier. At 40+ cog, 5x1. The barrier is horizonal to the users current direction.
**Chosen Control** - Clears all pain, hallos, stuns, sleep effects, addictions, and removes handcuffs, buckling, and grapples. Clears the blood of all drugs, stims, and medicines, effectively giving you a full clean. Cost 4.

The Final Results may be different from the explications.