### PR TITLE
Using the mining drill is no longer suicide

### DIFF
--- a/code/modules/mining/drilling/wurm_wave.dm
+++ b/code/modules/mining/drilling/wurm_wave.dm
@@ -17,48 +17,48 @@ GLOBAL_LIST_INIT(wurm_waves, list(/datum/wurm_wave/dormant,
 
 /datum/wurm_wave/dormant
 	burrow_count = 2
-	burrow_interval = 30 SECONDS
+	burrow_interval = 300 SECONDS
 	wurm_spawn = 2
-	spawn_interval = 24 SECONDS
+	spawn_interval = 120 SECONDS
 	special_probability = 0
 	mineral_multiplier = 1.0
 
 /datum/wurm_wave/negligible
 	burrow_count = 3
-	burrow_interval = 24 SECONDS
+	burrow_interval = 240 SECONDS
 	wurm_spawn = 2
-	spawn_interval = 24 SECONDS
+	spawn_interval = 120 SECONDS
 	special_probability = 4
 	mineral_multiplier = 1.4
 
 /datum/wurm_wave/typical
 	burrow_count = 3
-	burrow_interval = 20 SECONDS
+	burrow_interval = 200 SECONDS
 	wurm_spawn = 3
-	spawn_interval = 18 SECONDS
+	spawn_interval = 90 SECONDS
 	special_probability = 3
 	mineral_multiplier = 1.7
 
 /datum/wurm_wave/substantial
 	burrow_count = 4
-	burrow_interval = 24 SECONDS
+	burrow_interval = 240 SECONDS
 	wurm_spawn = 3
-	spawn_interval = 18 SECONDS
+	spawn_interval = 90 SECONDS
 	special_probability = 3
 	mineral_multiplier = 2
 
 /datum/wurm_wave/major
 	burrow_count = 5
-	burrow_interval = 20 SECONDS
+	burrow_interval = 200 SECONDS
 	wurm_spawn = 4
-	spawn_interval = 14 SECONDS
+	spawn_interval = 70 SECONDS
 	special_probability = 3
 	mineral_multiplier = 2.3
 
 /datum/wurm_wave/abnormal
 	burrow_count = 7
-	burrow_interval = 18 SECONDS
+	burrow_interval = 180 SECONDS
 	wurm_spawn = 4
-	spawn_interval = 12 SECONDS
+	spawn_interval = 60 SECONDS
 	special_probability = 2
 	mineral_multiplier = 3.0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Even small wurms are rather dangerous mobs, and the current spawn/burrow rates are overtuned, spawning 4 wurms every 12 seconds at the maximum. Rather than alter the stats of the wurms to make them less deadly, I have instead posed changes to make the wurm waves themselves more manageable. The only changes are to the duration between spawn intervals for the burrows themselves and the wurms that come out of them, in order to give miners enough time to potentially clear the wurms and burrows before they get overwhelmed.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: multiplied spawn rate from burrows by x5, with intervals shortening by 10 seconds for each level of wave severity, except for from dormant to negligible (20 seconds difference). Burrow interval is 2x spawn interval
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
