### PR TITLE
Bugfix for clucker eggs

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/lodge/types/clucker.dm
+++ b/code/modules/mob/living/carbon/superior_animal/lodge/types/clucker.dm
@@ -56,19 +56,6 @@
 		if(prob(34)) //A little over one in three, so as not to cuck the Lodge, but not make them OP either
 			START_PROCESSING(SSobj, E)
 
-
-/obj/item/reagent_containers/food/snacks/egg/clucker/amount_grown = 0
-/obj/item/reagent_containers/food/snacks/egg/clucker/Process()
-	if(isturf(loc))
-		amount_grown += rand(1,2)
-		if(amount_grown >= 100)
-			visible_message("[src] hatches with a quiet cracking sound.")
-			new /mob/living/carbon/superior_animal/lodge/chick_clucker(get_turf(src))
-			STOP_PROCESSING(SSobj, src)
-			qdel(src)
-	else
-		STOP_PROCESSING(SSobj, src)
-
 //Baby Clucker
 //Looks nearly the same as a regular chick. Credit to scar#1579 for the sprite.
 /mob/living/carbon/superior_animal/lodge/chick_clucker


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Fixes a bug with clucker eggs in which having their own Process() proc stacked with the existing one they get from being a subtype of eggs laid by chickens. The duplicate proc has been removed, preventing further double-processing that may have an impact on performance.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fix: clucker eggs no longer double-process
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
