### PR TITLE
Small Radio tweak

### DIFF
--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -289,7 +289,7 @@ var/const/RADIO_MAGNETS = "radio_magnet"
 	if (!devices_line)
 		devices_line = new
 		devices[filter] = devices_line
-	devices_line+=device
+	devices_line|=device
 //			var/list/obj/devices_line___ = devices[filter_str]
 //			var/l = devices_line___.len
 	//log_admin("DEBUG: devices_line.len=[devices_line.len]")

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -544,8 +544,9 @@ var/global/list/default_medbay_channels = list(
 					accept = 1
 					break
 				else if(!RF)
-					log_debug("radio.recieve_range(): Channel name found in channels no secure_radio_connection analog set.")
-					log_debug("radio.recieve_range(): ch_name: [ch_name]")
+					log_debug("radio.receive_range(): Channel name found in channels no secure_radio_connection analog set.")
+					log_debug("radio.receive_range(): ch_name: [ch_name]")
+					log_debug("radio.receive_range(): Is ch_name listening?: [channels[ch_name]&FREQ_LISTENING]")
 		if (!accept)
 			return -1
 	return canhear_range

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -546,6 +546,8 @@ var/global/list/default_medbay_channels = list(
 				else if(!RF)
 					log_debug("radio.receive_range(): Channel name found in channels no secure_radio_connection analog set.")
 					log_debug("radio.receive_range(): ch_name: [ch_name]")
+					log_debug("radio.receive_range(): freq: [freq]")
+					log_debug("radio.receive_range(): level: [level]")
 					log_debug("radio.receive_range(): Is ch_name listening?: [channels[ch_name]&FREQ_LISTENING]")
 		if (!accept)
 			return -1


### PR DESCRIPTION
SHOULD Prevent radios from getting runaway situations where multiple of the same device are added to a listening list.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
SHOULD Prevent radios from getting runaway situations where multiple of the same device are added to a listening list.
Improves debugging for situation where frequency is dropped for whatever reason.

Improved logging for core error in case we see it again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
