### PR TITLE
Adds New blood chems, Fixes Sanguinum OD

### DIFF
--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -147,6 +147,18 @@
 	icon_state = "bottle"
 	preloaded_reagents = list("tahcacillin" = 60)
 
+/obj/item/reagent_containers/glass/bottle/nosfernium
+	name = "nosfernium bottle"
+	desc = "A small bottle. Contains the blood based chemical nosfernium. Handle with care."
+	icon_state = "bottle"
+	preloaded_reagents = list("nosfernium" = 60)
+
+/obj/item/reagent_containers/glass/bottle/viroputine
+	name = "viroputine bottle"
+	desc = "A horrific replicating chemical. Fruit of questionable virology research."
+	icon_state = "bottle"
+	preloaded_reagents = list("viroputine" = 60)
+
 /obj/item/reagent_containers/glass/bottle/organic
 	name = "resin bottle"
 	desc = "A small bottle made of organic resin with a small bark-like lid."
@@ -195,6 +207,7 @@
 
 /obj/item/reagent_containers/glass/bottle/organic/dermatane
 	preloaded_reagents = list("dermaline" = 30, "kelotane" = 30)
+
 
 // === Used by trade stations
 /obj/item/reagent_containers/glass/bottle/carpotoxin

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -405,7 +405,7 @@
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "sanguinum_w")
 	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, STIM_TIME, "sanguinum_w")
 	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, STIM_TIME, "sanguinum_w")
-
+/*
 /datum/reagent/drug/sanguinum/overdose(var/mob/living/carbon/M, var/alien)
 	var/mob/living/carbon/human/H = M
 	if(istype(H))
@@ -419,3 +419,33 @@
 			//var/list/obj/item/organ/external/unluckyPart = pick(bodyParts)
 			//var/datum/wound/internal_bleeding/I = new (15)
 			//unluckyPart.wounds += I
+*/
+/datum/reagent/drug/nosfernium
+	name = "Nosfernium"
+	id = "nosfernium"
+	description = "A chemical for when the body is bleed dry, and if its not will ensure you are left a skeleton."
+	taste_description = "teeth"
+	reagent_state = LIQUID
+	color = "#e06270"
+	metabolism = REM
+	overdose = REAGENTS_OVERDOSE/6
+	nerve_system_accumulations = 80
+	addiction_chance = 30
+
+/datum/reagent/drug/nosfernium/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.add_chemical_effect(CE_BLOODRESTORE, 3 * effect_multiplier)
+	M.adjustToxLoss(1.5)
+	M.adjustNutrition(-10)
+	if(prob(10 * effect_multiplier))
+		M.vomit()
+	if(prob(5))
+		spawn
+			M.emote("me", 1, "pukes up blood!")
+		M.drip_blood(20)
+
+/datum/reagent/drug/nosfernium/withdrawal_act(mob/living/carbon/M)
+	M.add_chemical_effect(CE_SLOWDOWN, 1)
+	M.adjustNutrition(-25)
+
+datum/reagent/drug/sanguinum/overdose(var/mob/living/carbon/M, var/alien)
+	M.adjustBrainLoss(5) // This is meant to be lethal. If you survive this give your doctor a pat on the back.

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -270,6 +270,18 @@
 /datum/reagent/adrenaline/withdrawal_act(mob/living/carbon/M)
 	M.adjustOxyLoss(15)
 
+/datum/reagent/other/viroputine
+	name = "Viroputine"
+	id = "viroputine"
+	description = "A horrid by product of nosfernium that creates more of it. vary bad withdrawels."
+	taste_description = "chalky backwash"
+	reagent_state = LIQUID
+	color = "#A5F0EE"
+	addiction_chance = 5
+
+/datum/reagent/other/viroputine/withdrawal_act(mob/living/carbon/M)
+	M.drowsyness = max(M.drowsyness, 20)
+
 /datum/reagent/other/diethylamine
 	name = "Diethylamine"
 	id = "diethylamine"

--- a/code/modules/reagents/recipes/recipes.dm
+++ b/code/modules/reagents/recipes/recipes.dm
@@ -720,6 +720,23 @@
 	required_reagents = list("bicaridine" = 1, "spaceacillin" = 1, "mercury" = 1)
 	result_amount = 3
 
+/datum/chemical_reaction/nosfernium // yes I'm aware of the cancer that the mix is. Its meant to be annoying for reasons.
+	result = "nosfernium" // reagent/drug
+	required_reagents = list("sanguinum" = 27, "bicaridine" = 34, "milk" = 1, "iron" = 29, "lithium" = 16, "sugar" = 8)
+	catalysts = list("plasma" = 21)
+	result_amount = 1
+	byproducts= list("viroputine" = 1) // reagent/other
+	minimum_temperature = 358
+	maximum_temperature = 373
+
+/datum/chemical_reaction/nosfernium2
+	result = "nosfernium" // reagent/drug
+	required_reagents = list("viroputine" = 1, "nosfernium" = 1, "milk" = 5, "blood" = 5)
+	result_amount = 2
+	byproducts= list("viroputine" = 1) // reagent/other
+	minimum_temperature = 358
+	maximum_temperature = 373
+
 /datum/chemical_reaction/kyphotorin
 	result = "kyphotorin"
 	required_reagents = list("peridaxon" = 1, "mutagen" = 1, "clonexadone" = 1)


### PR DESCRIPTION
Fixes sanguinum overdose. Its now the same as any other overdose. No more putting hundreds of units into you without consiquence.
Adds two chems, nosfernium and viroputine. I have more plans for viroputine down the road.
Nosfernium is a much stronger blood restore with toxin damage and bad withdrawels.
Viroputine is a unique chem in that you feed it blood and chems with nosfernium to make more. (This is why the innitial making of nosfernium is so low)
