### PR TITLE
nerfs some op healing

### DIFF
--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -12,7 +12,7 @@
 	name = "Nanite Regeneration"
 	desc = "You configure your nanite matrix to begin aiding in your natural healing."
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
-	var/regen_rate = 1
+	var/regen_rate = 0.5 //This seems low but this is per human handle_chemicals_in_body meaning this is rather robust
 
 /datum/perk/nanite_muscle
 	name = "Nanofiber Muscle Therapy"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -784,7 +784,7 @@
 		if(stats.getPerk(PERK_FOLKEN_HEALING) || stats.getPerk(PERK_FOLKEN_HEALING_YOUNG)) // Folken will have this perk
 			if(light_amount >= species.light_dam) // Enough light threshold
 				if(stats.getPerk(PERK_FOLKEN_HEALING_YOUNG)) // They are young Folken and will heal faster
-					heal_overall_damage(3,3)
+					heal_overall_damage(2,2)
 					adjustNutrition(2)
 				else
 					heal_overall_damage(1,1)
@@ -792,7 +792,7 @@
 
 		else if(stats.getPerk(PERK_DARK_HEAL)) // Is the species a Mycus?
 			if(light_amount <= species.light_dam) // Enough light threshold
-				heal_overall_damage(2,2)
+				heal_overall_damage(1,1)
 
 		else if(light_amount > species.light_dam) //if there's enough light, start dying
 			take_overall_damage(1,1)

--- a/code/modules/projectiles/guns/matter/launcher/books.dm
+++ b/code/modules/projectiles/guns/matter/launcher/books.dm
@@ -45,6 +45,7 @@
 	armor_penetration = ARMOR_PEN_EXTREME
 	structure_damage_factor = STRUCTURE_DAMAGE_HEAVY
 	max_stored_matter = 20
+	fire_delay = 5
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_BIOMATTER = 20, MATERIAL_GOLD = 10)
 	price_tag = 3000 //So its worth stealing >:D
 	w_class = ITEM_SIZE_HUGE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -198,10 +198,10 @@ In pvp they also have more lasting damages, such as infections, and pain form bu
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
-		L.adjustOxyLoss(-10)
-		L.adjustToxLoss(-5)
-		L.adjustBruteLoss(-5)
-		L.adjustFireLoss(-5)
+		L.adjustOxyLoss(-5)
+		L.adjustToxLoss(-3)
+		L.adjustBruteLoss(-3)
+		L.adjustFireLoss(-3)
 
 /obj/item/projectile/beam/sniper/healing/staff
 	name = "harmony"
@@ -210,10 +210,10 @@ In pvp they also have more lasting damages, such as infections, and pain form bu
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
-		L.adjustOxyLoss(-20)
-		L.adjustToxLoss(-7)
-		L.adjustBruteLoss(-7)
-		L.adjustFireLoss(-7)
+		L.adjustOxyLoss(-7)
+		L.adjustToxLoss(-4)
+		L.adjustBruteLoss(-4)
+		L.adjustFireLoss(-4)
 
 /obj/item/projectile/beam/tesla
 	name = "lightning"

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -166,17 +166,17 @@
 		if(ishuman(mob))
 			var/mob/living/carbon/human/H = mob
 			for (var/obj/item/organ/external/E in H.organs)
-				if (E.status & ORGAN_BROKEN && prob(30))
+				if (E.status & ORGAN_BROKEN && prob(1))
 					E.mend_fracture()
-		var/heal_amt = 5*multiplier
+		var/heal_amt = 1*multiplier
 		mob.heal_overall_damage(heal_amt,heal_amt,heal_amt,heal_amt)
 
 	deactivate(var/mob/living/carbon/mob,var/multiplier)
 		if(ishuman(mob))
 			var/mob/living/carbon/human/H = mob
 			to_chat(H, SPAN_NOTICE("You suddenly feel hurt and old..."))
-			H.age += 8
-		var/backlash_amt = 5*multiplier
+			//H.age += 8 we dont use that kinda system of age here
+		var/backlash_amt = 1*multiplier
 		mob.apply_damages(backlash_amt,backlash_amt,backlash_amt,backlash_amt)
 
 /datum/disease2/effect/bones


### PR DESCRIPTION
yikes
Nanogate regen healing has been halfed
young Folken now heal 33% less, this is still more then normal folken
mycus healing also halfed
heavilly reduces harmoney staffs healing and greatly increases fire delay, this was not meant to out heal mid-combat
Longevity Syndrome no longer ages you up rapidly
Longevity Syndrome now is much weaker at healing

## Note that they all still can heal by standing still and doing nothing completely removing the need for medical aid in 80% of fights in many roles, this just helps against steam rolling in a combat