### PR TITLE
Port - Unrecognizable voice when wearing Gas Masks

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -457,7 +457,8 @@ BLIND     // can't see anything
 	slot_flags = SLOT_MASK
 	body_parts_covered = FACE|EYES
 
-	var/voicechange = 0
+	var/muffle_voice = FALSE
+	var/voicechange = FALSE
 	var/list/say_messages
 	var/list/say_verbs
 

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -21,6 +21,7 @@
 		rad = 0
 	)
 	price_tag = 20
+	muffle_voice = TRUE
 
 /obj/item/clothing/mask/gas/filter_air(datum/gas_mixture/air)
 	var/datum/gas_mixture/filtered = new
@@ -71,6 +72,7 @@
 	var/list/states = list("True Form" = "artist", "The clown" = "clown",
 	"The mime" = "mime", "The Feminist" = "sexyclown", "The Madman" = "joker",
 	"The Rainbow Color" = "rainbow", "The Monkey" = "monkeymask", "The Owl" = "owl")
+	muffle_voice = FALSE
 
 /obj/item/clothing/mask/gas/artist_hat/attack_self(mob/user)
 	var/choice = input(user, "To what form do you wish to morph this mask?","Morph Mask") as null|anything in states
@@ -85,6 +87,7 @@
 	desc = "A true prankster's facial attire. A clown is incomplete without their wig and mask. This one contains hologram tech that allows it to change its appearence."
 	icon_state = "clown"
 	item_state = "clown_hat"
+	muffle_voice = FALSE
 
 /obj/item/clothing/mask/gas/clown_hat/attack_self(mob/user)
 	var/list/options = list()

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -6,7 +6,7 @@
 	body_parts_covered = FACE
 	w_class = ITEM_SIZE_SMALL
 	gas_transfer_coefficient = 0.90
-	voicechange = 1
+	muffle_voice = TRUE
 
 /obj/item/clothing/mask/muzzle/tape
 	name = "length of tape"
@@ -108,6 +108,7 @@
 	item_flags = FLEXIBLEMATERIAL
 	w_class = ITEM_SIZE_SMALL
 	price_tag = 20
+	muffle_voice = TRUE
 
 /obj/item/clothing/mask/bandana/equipped(var/mob/user, var/slot)
 	switch(slot)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -7,7 +7,11 @@
 	var/speaker_name = speaker.name
 	if(ishuman(speaker))
 		var/mob/living/carbon/human/H = speaker
-		speaker_name = H.rank_prefix_name(H.GetVoice())
+		// GetVoice(TRUE) checks if mask hiding the voice
+		speaker_name = H.rank_prefix_name(H.GetVoice(TRUE))
+		// If we have the right perk or standing close - GetVoice() again, but skip mask check
+		if((get_dist(src, H) < 2) || stats.getPerk(PERK_EAR_OF_QUICKSILVER))
+			speaker_name = H.rank_prefix_name(H.GetVoice(FALSE))
 
 	if(speech_volume)
 		message = "<FONT size='[speech_volume]'>[message]</FONT>"

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -124,7 +124,7 @@
 
 	return ..()
 
-/mob/living/carbon/human/GetVoice()
+/mob/living/carbon/human/GetVoice(mask_check)
 
 	var/voice_sub
 	if(istype(back, /obj/item/rig))
@@ -133,6 +133,10 @@
 		if(rig.speech && rig.speech.voice_holder && rig.speech.voice_holder.active && rig.speech.voice_holder.voice)
 			voice_sub = rig.speech.voice_holder.voice
 	else
+		if(mask_check && wear_mask)
+			var/obj/item/clothing/mask/mask = wear_mask
+			if(istype(mask) && mask.muffle_voice)
+				voice_sub = "Unknown"
 		for(var/obj/item/gear in list(wear_mask, wear_suit, head))
 			if(!gear)
 				continue


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Ports over Eris' PR ( https://github.com/discordia-space/CEV-Eris/pull/6960 ) which makes voices muffled behind gas masks or other specific face coverings show as an unknown voice. Basically a one-to-one port.
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
add: Adds in muffled voices to mask identity of the wearer.
/:cl: