### PR TITLE
Corrects long-standing bug with crafting the nanoforge

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -131,7 +131,7 @@
 		/obj/item/stock_parts/matter_bin = 2,
 		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/stock_parts/console_screen = 1,
-		/obj/item/oddity/blackbox_nanoforge = 1,
+	 //	/obj/item/oddity/blackbox_nanoforge = 1,
 		/obj/item/stock_parts/micro_laser = 1
 	)
 


### PR DESCRIPTION
Legacy code caused this machine to need two boxes when being built, but only returned one.

Was because we made it able to take new artifacts on the fly, without having to rebuild it.