### PR TITLE
Makes shock stage not stack infinitely

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1001,7 +1001,7 @@
 	else if(shock_resist)
 		shock_stage = min(shock_stage, 58)
 
-	if(traumatic_shock >= 80)
+	if(traumatic_shock >= 80 && shock_stage <= 160)
 		shock_stage += 1
 	else if(health < health_threshold_softcrit)
 		shock_stage = max(shock_stage, 61)


### PR DESCRIPTION
Shock shouldn't stack infinitely and is why being set on fire was made such a death sentence, you can easily accrue 2000+ shock which makes anything other than oxycodone completely worthless.
