### PR TITLE
Lonestar Organ Market

### DIFF
--- a/code/game/machinery/computer/supply.dm
+++ b/code/game/machinery/computer/supply.dm
@@ -12,10 +12,10 @@
 	var/temp
 	var/reqtime = 0 //Cooldown for requisitions - Quarxink
 	var/last_viewed_group = "categories"
-	var/can_order_contraband = FALSE
+	var/can_order_contraband = TRUE
 	var/requestonly = FALSE
-	var/contraband = FALSE
-	var/hacked = FALSE
+	var/contraband = TRUE
+	var/hacked = TRUE
 
 /obj/machinery/computer/supplycomp/attack_hand(mob/user)
 	if(!allowed(user))


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Simply allows Supply consoles to buy contraband, but more importantly sell contraband without the need of a EMAG. In this case, allowing the exporting of organs and other questionable items.

Considering we don't have any contraband that we can buy, and getting hold of a EMAG is near impossible. I believe this PR simply allows Lonestar to export more...questionable things. 
</summary>
<hr>	
<hr>
</details>

## Changelog
:cl:
Edit Supply console.
/:cl:


