### PR TITLE
Carp changes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -48,9 +48,8 @@
 	icon = 'icons/mob/spaceshark.dmi'
 	icon_state = "shark"
 	meat_amount = 6
-	turns_per_move = 2
-	move_to_delay = 2
-	speed = 0
+	turns_per_move = 3
+	move_to_delay = 3
 	mob_size = MOB_LARGE
 
 	//pixel_x = -16
@@ -70,15 +69,15 @@
 	icon = 'icons/mob/mobs-monster.dmi'
 	icon_state = "neocarp"
 	meat_amount = 8
-	turns_per_move = 1
-	move_to_delay = 1
+	turns_per_move = 3
+	move_to_delay = 3
 	mob_size = MOB_LARGE
 
-	health = 275
-	maxHealth = 275
+	health = 200
+	maxHealth = 200
 	special_parts = list(/obj/item/animal_part/wolf_tooth,/obj/item/animal_part/wolf_tooth)
-	melee_damage_lower = 40
-	melee_damage_upper = 65
+	melee_damage_lower = 25
+	melee_damage_upper = 30
 	inherent_mutations = list(MUTATION_GIGANTISM, MUTATION_EPILEPSY, MUTATION_DEAF, MUTATION_BAROTRAUMA)
 
 	break_stuff_probability = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Shark carps are insanely stupid right now. They have instant movement and can hit harder than some boss-level monsters. 
And this is all while they are in space where you are usually drifting around, where you have left your good armor behind for the one they give in the trash beacon. With all this considered, I made these changes after talking with a few people about it. 
Sure, I do not know if it's balanced, but I shot for the stars hoping that it's going to fix the problem of people never going into the trash beacon place.

https://youtu.be/T8r6eXTa8o4 Without changes.
https://youtu.be/jOSz7Eket-8 With changes.

Also, FIRST PR here. Woah.
## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
