### PR TITLE
Fix the suit's armor value

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/hydrogen_knight.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/hydrogen_knight.dm
@@ -4,7 +4,7 @@
 	suit_type = "hydrogen knight"
 	desc = "An armored, knight-like suit designed by Soteria's best roboticists and powered by hydrogen."
 	icon_state = "hydrogen_knight_rig"
-	armor_list = list(melee = 30, bullet = 30, energy = 35, bomb = 10, bio = 100, rad = 100)
+	armor_list = list(melee = 80, bullet = 80, energy = 80, bomb = 70, bio = 100, rad = 100)
 	slowdown = 0 // Lot of stuff used in its construction that justify not having any slowdown while active
 	offline_slowdown = 5 // Very heavy and the suit isn't helping while offline
 	offline_vision_restriction = 2
@@ -27,12 +27,10 @@
 
 /obj/item/clothing/suit/space/rig/hydrogen_knight
 	name = "suit"
-	armor_list = list(melee = 80, bullet = 80, energy = 80, bomb = 70, bio = 100, rad = 100)
 	retract_while_active = FALSE
 
 /obj/item/clothing/head/helmet/space/rig/hydrogen_knight
 	name = "helmet"
-	armor_list = list(melee = 80, bullet = 80, energy = 80, bomb = 70, bio = 100, rad = 100)
 	retract_while_active = TRUE
 	flash_protection = FLASH_PROTECTION_MAJOR
 

--- a/code/modules/clothing/spacesuits/rig/suits/hydrogen_knight.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/hydrogen_knight.dm
@@ -17,7 +17,11 @@
 	cell_type =  /obj/item/cell/large/hydrogen/loaded // With how it is made, it start ready to be used
 	air_type =   /obj/item/tank/oxygen
 	suitable_cell = /obj/item/cell/large
-	initial_modules = list(/obj/item/rig_module/storage/expanded)
+	initial_modules = list(	/obj/item/rig_module/storage/expanded,
+							/obj/item/rig_module/mounted,
+							/obj/item/rig_module/held/shield,
+							/obj/item/rig_module/vision/nvg,
+							/obj/item/rig_module/maneuvering_jets)
 	extra_allowed = list(
 		/obj/item/hydrogen_fuel_cell
 	)


### PR DESCRIPTION
Apparently the rig *completely* overwrite any armor values that the armor would otherwise have.

- Make the Hydrogen Knight Rig's armor values actually work.
- Also give the suit a bit more starting stuff since it is admin-only.