### PR TITLE
Gives scavenger armor and hand made gear more downsides

### DIFF
--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -27,6 +27,7 @@
 	siemens_coefficient = 0.9
 	species_restricted = list("exclude")
 	flash_protection = FLASH_PROTECTION_MAJOR
+	obscuration = LIGHT_OBSCURATION
 
 	var/obj/machinery/camera/camera
 	var/list/camera_networks

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -89,7 +89,7 @@
 
 	matter = list(MATERIAL_STEEL = 6, MATERIAL_GLASS = 4, MATERIAL_PLASTIC = 3)
 	armor_list = list(
-		melee = 40,
+		melee = 25,
 		bullet = 20,
 		energy = 20,
 		bomb = 25,
@@ -98,6 +98,7 @@
 	)
 	light_overlay = "helmet_light_dual"
 	siemens_coefficient = 0.8
+	obscuration = MEDIUM_OBSCURATION
 
 /obj/item/clothing/head/space/void/riggedvoidsuit/verb/toggle_style()
 	set name = "Adjust Style"
@@ -130,7 +131,7 @@
 	item_state = "makeshift_void"
 	siemens_coefficient = 0.4
 	armor_list = list(
-		melee = 40,
+		melee = 30,
 		bullet = 20,
 		energy = 20,
 		bomb = 25,

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -588,6 +588,7 @@
 	pockets.storage_slots = 2	//two slots
 	pockets.max_w_class = ITEM_SIZE_NORMAL		//fits two normal size items as its big pockets
 	pockets.max_storage_space = 8
+	pockets.cant_hold |= list(/obj/item/tool_upgrade/armor) //Prevents a bug
 
 //Blackshield armor
 /obj/item/clothing/suit/armor/platecarrier

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -317,9 +317,11 @@ obj/item/clothing/suit/fluff/kimono
 
 /obj/item/clothing/suit/storage/scavengerarmor
 	name = "scavenger armor"
-	desc = "A rigged yet sturdy scavenger armor. Strong and protective as most vests, it is made entirely from reclaimed materials. It even has pockets!"
+	desc = "A rigged yet sturdy scavenger armor. Strong and protective as most vests, it is made entirely from reclaimed materials. It even has pockets as well as room for additional plates of armor to be added."
 	icon_state = "scav_armor"
 	item_state = "scav_armor"
+	tool_qualities = list(QUALITY_ARMOR = 100)
+	max_upgrades = 2
 	stiffness = MEDIUM_STIFFNESS
 	equip_delay = 2 SECONDS
 	slowdown = 0.2

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -320,10 +320,13 @@ obj/item/clothing/suit/fluff/kimono
 	desc = "A rigged yet sturdy scavenger armor. Strong and protective as most vests, it is made entirely from reclaimed materials. It even has pockets!"
 	icon_state = "scav_armor"
 	item_state = "scav_armor"
+	stiffness = MEDIUM_STIFFNESS
+	equip_delay = 2 SECONDS
+	slowdown = 0.2
 	armor_list = list(
-		melee = 35, //Not the best armor, but easily crafted and adds some utility with decent protection all round.
-		bullet = 35,
-		energy = 35,
+		melee = 30, //Not the best armor, but easily crafted and adds some utility with decent protection all round.
+		bullet = 25,
+		energy = 15,
 		bomb = 25,
 		bio = 0,
 		rad = 0

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -1,7 +1,8 @@
 /obj/item/clothing/suit/storage
 	item_flags = DRAG_AND_DROP_UNEQUIP|EQUIP_SOUNDS
 	var/obj/item/storage/internal/pockets
-	var/cant_hold = list(/obj/item/clothing/accessory)
+	var/cant_hold = list(/obj/item/clothing/accessory,
+						 /obj/item/tool_upgrade/armor)
 
 /obj/item/clothing/suit/storage/New()
 	..()
@@ -130,6 +131,7 @@
 	pockets.storage_slots = 4
 	pockets.max_w_class = ITEM_SIZE_SMALL
 	pockets.max_storage_space = 8
+	pockets.cant_hold |= list(/obj/item/tool_upgrade/armor) //Prevents a bug
 
 /obj/item/clothing/suit/storage/vest/ironhammer/New()
 	..()
@@ -137,6 +139,7 @@
 	pockets.storage_slots = 4
 	pockets.max_w_class = ITEM_SIZE_SMALL
 	pockets.max_storage_space = 8
+	pockets.cant_hold |= list(/obj/item/tool_upgrade/armor) //Prevents a bug
 
 /*Puffer Vest*/
 
@@ -951,6 +954,7 @@ obj/item/clothing/suit/sweater/blue
 	pockets.storage_slots = 8
 	pockets.max_w_class = ITEM_SIZE_SMALL
 	pockets.max_storage_space = 16
+	pockets.cant_hold |= list(/obj/item/tool_upgrade/armor) //Prevents a bug
 
 /*Suit Jackets*/
 /obj/item/clothing/suit/storage/suitjacket/black


### PR DESCRIPTION
Wait they are a direct upgrade form even full plate armor?

Scavenger armor now has less stats and more downsides form longer time to take off and on to a small amount of slowdown
Scavenger welding helmet now observs vision along with all space helmets
Lowers melee armor on scavenger gear to not be better then plate armor
Fixes scavenger armor not getting its upgrades
Fixes pocketed suits storing upgrades inside the pockets and wasting slots