### PR TITLE
Opifex gas mask fix

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -213,6 +213,7 @@
 	var/gas_filter_strength = 1			//For gas mask filters
 	item_flags = AIRTIGHT
 	w_class = ITEM_SIZE_SMALL
+	body_parts_covered = EYES //We only care about the eyes.
 	cold_protection = 0.5 //Instead of giving gas protection, it gives you other types of protection
 	heat_protection = 0.5
 	gas_transfer_coefficient = 0.001


### PR DESCRIPTION
The alt opifex gas mask that legit states you can eat with it on, now allows you to eat with it on.