### PR TITLE
Buffs Goldilocks

### DIFF
--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -203,9 +203,9 @@
 		slot_r_hand_str = "goldilocks_helm",
 		)
 	armor_list = list(
-		melee = 20,
-		bullet = 20,
-		energy = 10,
+		melee = 50,
+		bullet = 25,
+		energy = 25,
 		bomb = 25,
 		bio = 100,
 		rad = 75
@@ -220,9 +220,9 @@
 	icon_state = "goldilocks_suit"
 	slowdown = 0.35
 	armor_list = list(
-		melee = 20,
-		bullet = 20,
-		energy = 10,
+		melee = 50,
+		bullet = 25,
+		energy = 25,
 		bomb = 25,
 		bio = 100,
 		rad = 75


### PR DESCRIPTION
I was too mean to the goldilocks. It's now similar in power to a regular mining voidsuit. Still not top tier, since it is a joke item, but on par with the basics available in Lonestar's department.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
- Buffed the goldilocks voidsuit to be similar in power to a regular mining voidsuit. Still not top tier, since it is a joke item, but now on par with the basics available in Lonestar.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
