### PR TITLE
Raise the maximum chicken limit by 10, to 20

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -207,7 +207,7 @@
 			new /mob/living/simple_animal/chicken(src.loc)
 			qdel(src)
 
-var/const/MAX_CHICKENS = 10
+var/const/MAX_CHICKENS = 20
 var/global/chicken_count = 0
 
 /mob/living/simple_animal/chicken


### PR DESCRIPTION
Raise the universal maximum chicken limit by 10, to a limit 20
5 chicken, or half the current limit, were in the Admin Genetic Testing area, thus just about blocking more chicken from spawning from the eggs.
It was either raising the limit, or doing map work to remove the chicken crate.