### PR TITLE
Buffs artest

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -132,7 +132,7 @@
 		STAT_TGH = 30, //basically a punching bag, he can't robust anyone or shoot guns anyway
 	)
 
-	perks = list(/datum/perk/market_prof, PERK_ARTIST)
+	perks = list(/datum/perk/market_prof, PERK_ARTIST, /datum/perk/stalker)
 	software_on_spawn = list(///datum/computer_file/program/supply,
 							 ///datum/computer_file/program/deck_management,
 							 /datum/computer_file/program/scanner,


### PR DESCRIPTION
Allows the artest to be able to see perks on oddites, given that they work with them so often and barely can even use them for personal gain