### PR TITLE
Recettear: An Item Shop's Tale

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -2126,7 +2126,15 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "axL" = (
-/obj/structure/table/steel,
+/obj/item/stack/material/steel{
+	amount = 8
+	},
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/manipulator,
+/obj/item/stack/cable_coil/random,
+/obj/structure/table/steel_reinforced,
+/obj/item/tool/screwdriver,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/pros/prep)
 "axS" = (
@@ -9069,9 +9077,6 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
 "ccU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10254,6 +10259,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/rbreakroom)
+"crr" = (
+/obj/structure/table/standard,
+/obj/item/stack/material/steel{
+	amount = 8
+	},
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/manipulator,
+/obj/item/stack/cable_coil/random,
+/obj/item/tool/screwdriver,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "crv" = (
 /obj/effect/decal/weldable/cracks,
 /obj/item/material/shard/shrapnel/scrap,
@@ -11536,10 +11553,16 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "cFG" = (
 /obj/structure/table/standard,
-/obj/item/storage/fancy/vials,
 /obj/machinery/alarm{
 	pixel_y = 26
 	},
+/obj/item/stack/material/steel{
+	amount = 8
+	},
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/manipulator,
+/obj/item/stack/cable_coil/random,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
 "cFL" = (
@@ -15479,9 +15502,6 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/crew_quarters/fitness)
 "dAM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -58156,7 +58176,8 @@
 /obj/structure/table/standard,
 /obj/machinery/button/remote/blast_door{
 	id = "Chem";
-	name = "Chemistry shutter control"
+	name = "Chemistry shutter control";
+	pixel_x = -16
 	},
 /obj/machinery/light{
 	dir = 4
@@ -58165,6 +58186,7 @@
 	dir = 4;
 	pixel_x = 30
 	},
+/obj/item/storage/fancy/vials,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
 "nbU" = (
@@ -60997,7 +61019,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "nIZ" = (
-/obj/structure/closet/l3closet,
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
@@ -63775,8 +63796,16 @@
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/pond)
 "oqO" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/dark/danger,
+/obj/structure/table/standard,
+/obj/item/stack/material/steel{
+	amount = 8
+	},
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/manipulator,
+/obj/item/stack/cable_coil/random,
+/obj/item/tool/screwdriver,
+/turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "oqV" = (
 /obj/structure/multiz/stairs/active,
@@ -69520,6 +69549,16 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
+/obj/structure/table/steel_reinforced,
+/obj/item/circuitboard/vending,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/console_screen,
+/obj/item/stack/cable_coil/random,
+/obj/item/tool/screwdriver,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stack/material/steel{
+	amount = 8
+	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
 "pHC" = (
@@ -74853,8 +74892,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/section4)
 "qQe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
+/obj/structure/table/standard,
+/obj/item/stack/material/steel{
+	amount = 8
+	},
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/manipulator,
+/obj/item/stack/cable_coil/random,
 /obj/machinery/camera/network/engineering{
 	dir = 1
 	},
@@ -217836,7 +217881,7 @@ uUU
 pes
 mZy
 pes
-jXd
+crr
 uVK
 uVK
 tzn


### PR DESCRIPTION
Sick and tired of needing to be at the desk 24/7 to sell your products?
Sick and tired of going around getting the parts needed to get yourself a custom vender to pay off the considerable debt that your father had accumulated before his mysterious disappearance?
Well no longer will you have to suffer as much!
Like cargo has 3 custom vendors every department (Other then blackshield) has a easy to set up vendor with metal, wire and parts to go with the board! Everything you need to set up so you can accully do your job for 4 seconds before needing to refill the darn thing...