### PR TITLE
crank charger buffs + fixes crank charger

### DIFF
--- a/code/datums/autolathe/tools.dm
+++ b/code/datums/autolathe/tools.dm
@@ -253,3 +253,7 @@
 /datum/design/autolathe/tool/isprayer
 	name = "industrial chemical sprayer"
 	build_path = /obj/item/reagent_containers/spray/chemsprayer/industrial
+
+/datum/design/autolathe/tool/manual_charger
+	name = "hand crank charger"
+	build_path = /obj/item/device/manual_charger

--- a/code/game/objects/items/weapons/autolathe_disk/lonestar_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/lonestar_disks.dm
@@ -214,6 +214,7 @@
 		/datum/design/autolathe/clothing/scav_armor,
 		/datum/design/autolathe/clothing/scav_armor_void,
 		/datum/design/autolathe/clothing/scav_helm_void = 0,
+		/datum/design/autolathe/tool/manual_charger,
 		)
 
 /obj/item/computer_hardware/hard_drive/portable/design/scav/forman

--- a/code/game/objects/items/weapons/autolathe_disk/lonestar_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/lonestar_disks.dm
@@ -214,7 +214,7 @@
 		/datum/design/autolathe/clothing/scav_armor,
 		/datum/design/autolathe/clothing/scav_armor_void,
 		/datum/design/autolathe/clothing/scav_helm_void = 0,
-		/datum/design/autolathe/tool/manual_charger,
+		/datum/design/autolathe/tool/manual_charger
 		)
 
 /obj/item/computer_hardware/hard_drive/portable/design/scav/forman

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -470,11 +470,11 @@
 	if(!cell)
 		return
 	user.visible_message(SPAN_NOTICE("[user] starts turning the handle on [src]."), SPAN_NOTICE("You start to turn the handle on [src]."))
-	if(do_after(user, 5 + (20 * user.stats.getMult(STAT_TGH, STAT_LEVEL_ADEPT))))
+	if(do_after(user, 7.5 + (17.5 * user.stats.getMult(STAT_TGH, STAT_LEVEL_ADEPT))))
 		if(!cell)
 			return
 		if(cell.charge >= cell.maxcharge)
 			user.visible_message(SPAN_NOTICE("The cell can not be charged any more!"))
 			return
 		else
-			cell.charge += 25
+			cell.charge += min(25, cell.maxcharge - cell.charge)

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -467,14 +467,14 @@
 	suitable_cell = /obj/item/cell
 
 /obj/item/device/manual_charger/attack_self(mob/user)
-	var/obj/item/cell/cell
-	if(do_after(user, 60 - (1 * user.stats.getMult(STAT_TGH, STAT_LEVEL_ADEPT))))
+	if(!cell)
+		return
+	user.visible_message(SPAN_NOTICE("[user] starts turning the handle on [src]."), SPAN_NOTICE("You start to turn the handle on [src]."))
+	if(do_after(user, 5 + (20 * user.stats.getMult(STAT_TGH, STAT_LEVEL_ADEPT))))
 		if(!cell)
 			return
 		if(cell.charge >= cell.maxcharge)
 			user.visible_message(SPAN_NOTICE("The cell can not be charged any more!"))
 			return
 		else
-			user.visible_message(SPAN_NOTICE("[user] have started to turn handle on \the [src]."), SPAN_NOTICE("You started to turn handle on \the [src]."))
-			cell.charge += 10
-			return //Stafy Return
+			cell.charge += 25

--- a/code/modules/research/designs/cell.dm
+++ b/code/modules/research/designs/cell.dm
@@ -88,3 +88,9 @@
 /datum/design/research/item/powercell/small/nuclear/pda
 	name = "Soteria \"Atomcell 50S\""
 	build_path = /obj/item/cell/small/moebius/pda
+
+//Hand crank for cells
+/datum/design/research/item/hand_charger
+	name = "Soteria \"Hand Crank\""
+	build_path = /obj/item/device/manual_charger
+	category = CAT_POWER

--- a/code/modules/research/designs/cell.dm
+++ b/code/modules/research/designs/cell.dm
@@ -88,9 +88,3 @@
 /datum/design/research/item/powercell/small/nuclear/pda
 	name = "Soteria \"Atomcell 50S\""
 	build_path = /obj/item/cell/small/moebius/pda
-
-//Hand crank for cells
-/datum/design/research/item/hand_charger
-	name = "Soteria \"Hand Crank\""
-	build_path = /obj/item/device/manual_charger
-	category = CAT_POWER

--- a/code/modules/research/nodes/power.dm
+++ b/code/modules/research/nodes/power.dm
@@ -113,7 +113,7 @@
 
 /datum/technology/improved_power_generation
 	name = "Improved Power Generation"
-	desc = "PACMAN MK2, uranium based power."
+	desc = "PACMAN MK2, uranium based power, hand crank generator for cells."
 	tech_type = RESEARCH_POWERSTORAGE
 
 	x = 0.25
@@ -125,6 +125,7 @@
 	cost = 450
 
 	unlocks_designs = list(/datum/design/research/circuit/superpacman,
+							/datum/design/research/item/hand_charger,
 							/datum/design/research/circuit/diesel)
 
 /datum/technology/advanced_power_generation


### PR DESCRIPTION
buffs crank charger so it no longer takes an entire minute to charge S cells- it now takes 16 seconds to charge a 800M cell at 25 toughness, and 80 seconds to charge it at 0 toughness and below. large cells still need an obscene amount of time (2 minutes at max TGH), to stop handcrank charger from being the be-all end-all cell charger

it's been moved from soteria to prospectors' disk,  since they're concievably the ones who need it the most (being away from chargers and all)


## Changelog
:cl:
balance: crank charger no longer sucks
fix: crank charger
/:cl:

