### PR TITLE
Blackshield Adjustments

### DIFF
--- a/code/datums/contract.dm
+++ b/code/datums/contract.dm
@@ -585,7 +585,7 @@ GLOBAL_LIST_INIT(blackshield_item_targets,list(
 //TODO: Make let them send in other things/place items in areas to allow for addionation points
 /datum/antag_contract/blackshield/appropriate
 	name = "Appropriate"
-	reward = 100 //How many points we give for items
+	reward = 200 //How many points we give for items
 	var/target_desc
 	var/target_type
 

--- a/code/game/machinery/excelsior/blackshield_teleporter.dm
+++ b/code/game/machinery/excelsior/blackshield_teleporter.dm
@@ -28,7 +28,7 @@ var/global/blackshield_max_energy //Maximaum combined energy of all teleporters
 		MATERIAL_WOOD = list("amount" = 15, "price" = 15),
 		MATERIAL_PLASTIC = list("amount" = 15, "price" = 50),
 		MATERIAL_GLASS = list("amount" = 15, "price" = 50),
-		MATERIAL_PLASTEEL = list("amount" = 10, "price" = 150)
+		MATERIAL_PLASTEEL = list("amount" = 10, "price" = 250)
 		)
 
 	var/list/parts_list = list(

--- a/code/game/machinery/excelsior/blackshield_teleporter.dm
+++ b/code/game/machinery/excelsior/blackshield_teleporter.dm
@@ -14,7 +14,7 @@ var/global/blackshield_max_energy //Maximaum combined energy of all teleporters
 	idle_power_usage = 40
 	active_power_usage = 15000
 	circuit = /obj/item/circuitboard/blackshield_teleporter
-	var/energy_gain = 0.1
+	var/energy_gain = 0.2
 
 	var/max_energy = 7500
 	var/processing_order = FALSE
@@ -28,7 +28,7 @@ var/global/blackshield_max_energy //Maximaum combined energy of all teleporters
 		MATERIAL_WOOD = list("amount" = 15, "price" = 15),
 		MATERIAL_PLASTIC = list("amount" = 15, "price" = 50),
 		MATERIAL_GLASS = list("amount" = 15, "price" = 50),
-		MATERIAL_PLASTEEL = list("amount" = 10, "price" = 250)
+		MATERIAL_PLASTEEL = list("amount" = 10, "price" = 150)
 		)
 
 	var/list/parts_list = list(
@@ -45,6 +45,13 @@ var/global/blackshield_max_energy //Maximaum combined energy of all teleporters
 		/obj/item/ammo_magazine/light_rifle_257 = 30,
 		/obj/item/ammo_magazine/rifle_75 = 35,
 		/obj/item/ammo_magazine/heavy_rifle_408 = 50,
+		/obj/item/ammo_magazine/ammobox/pistol_35 = 75,
+		/obj/item/ammo_magazine/ammobox/kurtz_50 = 200,
+		/obj/item/ammo_magazine/ammobox/magnum_40 = 150,
+		/obj/item/ammo_magazine/ammobox/light_rifle_257 = 300,
+		/obj/item/ammo_magazine/ammobox/heavy_rifle_408 = 400,
+		/obj/item/ammo_magazine/ammobox/shotgun = 500,
+		/obj/item/ammo_magazine/ammobox/rifle_75 = 400,
 		//Guns
 		/obj/item/gun/projectile/automatic/slaught_o_matic = 15, //So blackshiled can trade with propis :P
 		/obj/item/gun/projectile/boltgun/flare_gun = 10, //DAZZLATION!
@@ -67,13 +74,18 @@ var/global/blackshield_max_energy //Maximaum combined energy of all teleporters
 		/obj/item/gun/projectile/automatic/ak47/saiga/NM_colony = 500,
 		/obj/item/gun/projectile/automatic/maxim/NM_colony = 600,
 		/obj/item/gun/projectile/automatic/bull_autoshotgun = 700,
+		/obj/item/shield/buckler = 250,
+		/obj/item/shield/riot = 350,
 		//Armor
 		/obj/item/clothing/suit/space/void/security/odst/mil = 300,
 		/obj/item/clothing/suit/space/void/odst/corps = 300,
+		/obj/item/storage/box/bs_kit/bullet_armor = 500,
+		/obj/item/storage/box/bs_kit/laser_armor = 750,
 		/obj/item/clothing/suit/space/void/SCAF/blackshield = 1250, //One of the best things we can get
 		//misc
 		/obj/item/tool/baton = 200,
-		/obj/item/storage/firstaid/surgery/traitor = 250 //Advanced tools inside
+		/obj/item/storage/firstaid/surgery/traitor = 250, //Advanced tools inside
+		/obj/item/computer_hardware/hard_drive/portable/design/blackshield = 500
 		)
 	var/entropy_value = 1 //It is still bluespace
 

--- a/code/game/objects/items/weapons/autolathe_disk/blackshield_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/blackshield_disks.dm
@@ -1,6 +1,7 @@
 //Blackshield
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield
-	disk_name = "Blackshield 'Shall-not-be-Infringed' Pack"
+	disk_name = ""
+	name = "Blackshield 'Shall-not-be-Infringed' Pack"
 	icon_state = "blackshield"
 	license = 20
 
@@ -12,7 +13,7 @@
 		//SMGs
 		/datum/design/autolathe/gun/greasegun = 2,
 		/datum/design/autolathe/gun/buckler = 3,
-		/datum/design/autolathe/gun/triage = 4,
+		/datum/design/autolathe/gun/triage = 3,
 		//rifles
 		/datum/design/autolathe/gun/boltgun_sa = 0,
 		/datum/design/autolathe/gun/zatvor,
@@ -24,7 +25,7 @@
 		/datum/design/autolathe/gun/strelki = 2,
 		/datum/design/autolathe/gun/watchtower = 3,
 		/datum/design/autolathe/gun/rushing_bull = 4,
-		/datum/design/autolathe/gun/duty = 6,
+		/datum/design/autolathe/gun/duty = 3,
 		//machinegun
 		/datum/design/autolathe/gun/saw = 4,
 		/datum/design/autolathe/gun/ppv = 5,

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -85,7 +85,7 @@
 	local forces so often put within it."
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EARS
-	armor_list = list(melee = 15, bullet = 15, energy = 60, bomb = 0, bio = 0, rad = 0)
+	armor_list = list(melee = 25, bullet = 25, energy = 60, bomb = 10, bio = 0, rad = 0)
 	action_button_name = "Toggle Headlamp"
 	brightness_on = 4
 	light_overlay = "bs_ablative"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -761,6 +761,7 @@
 	icon_state = "bulletproof_bs"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS
 
+
 /obj/item/clothing/suit/armor/vest/ablative/militia
 	name = "Blackshield ablative plate"
 	desc = "An outdated set of ablative armor, utilizing advanced materials to absorb rather than reflect energy projeciles and painted in Blackshield's colors.\
@@ -768,6 +769,8 @@
 	appearance than its capabilities. Despite its bad reputation as a tax-payer credit sink it serves as a fairly adequate piece of gear."
 	icon_state = "ablative_bs"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS
+	slowdown = 0.5
+	armor_list = list(melee = 25, bullet = 25, energy = 60, bomb = 10, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/platecarrier/green
 	name = "green plate carrier"

--- a/code/modules/psionics/conquest_powers.dm
+++ b/code/modules/psionics/conquest_powers.dm
@@ -197,7 +197,7 @@
 			if(L.ckey)
 				if(alert(L, "An alien presence touches your mind, offering you power and insight into the very fabric of reality. Do you accept its offer and become a Psion?",
 					"Become Psion", "No", "Yes") != "Yes")
-					to_chat(owner, "They refuses your gift!")
+					to_chat(owner, "They refused your gift!")
 					return
 				else
 					if(L && isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC && pay_power_cost(psi_point_cost))

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -20771,7 +20771,6 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "eMJ" = (
-/obj/structure/closet/bombcloset/security,
 /obj/machinery/blackshield_teleporter,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory_blackshield)
@@ -39761,6 +39760,11 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
+"jbb" = (
+/obj/structure/invislight,
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/mineral,
+/area/asteroid/cave)
 "jbi" = (
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/tiled/techmaint,
@@ -52255,6 +52259,7 @@
 /obj/item/storage/box/teargas,
 /obj/item/storage/box/flashbangs,
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield,
+/obj/item/computer_hardware/hard_drive/portable/design/blackshieldammo,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "lNf" = (
@@ -107830,14 +107835,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "ydE" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/computer_hardware/hard_drive/portable/design/security{
-	pixel_x = 7;
-	pixel_y = 0
-	},
-/obj/item/computer_hardware/hard_drive/portable/design/blackshieldammo{
-	pixel_x = -6;
-	pixel_y = 1
-	},
+/obj/item/computer_hardware/hard_drive/portable/design/security,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "ydG" = (
@@ -190134,7 +190132,7 @@ wLD
 veZ
 veZ
 veZ
-wLD
+nMu
 wLD
 veZ
 veZ
@@ -190344,7 +190342,7 @@ veZ
 veZ
 veZ
 veZ
-wLD
+nMu
 wLD
 wLD
 wLD
@@ -193181,7 +193179,7 @@ veZ
 veZ
 veZ
 scG
-scG
+qmH
 scG
 veZ
 veZ
@@ -193775,7 +193773,7 @@ veZ
 veZ
 veZ
 veZ
-wLD
+nMu
 veZ
 veZ
 veZ
@@ -194591,7 +194589,7 @@ veZ
 veZ
 veZ
 wLD
-scG
+qmH
 veZ
 veZ
 veZ
@@ -194775,7 +194773,7 @@ hLN
 sUr
 sUr
 veZ
-veZ
+rRe
 veZ
 veZ
 wLD
@@ -194979,7 +194977,7 @@ sUr
 veZ
 veZ
 veZ
-veZ
+rRe
 veZ
 veZ
 veZ
@@ -195383,7 +195381,7 @@ sUr
 veZ
 veZ
 veZ
-veZ
+rRe
 veZ
 veZ
 veZ
@@ -195583,7 +195581,7 @@ wkz
 sUr
 sUr
 veZ
-veZ
+rRe
 veZ
 veZ
 veZ
@@ -195794,7 +195792,7 @@ veZ
 veZ
 veZ
 veZ
-wLD
+nMu
 veZ
 veZ
 veZ
@@ -195988,7 +195986,7 @@ sUr
 sUr
 veZ
 veZ
-veZ
+rRe
 veZ
 veZ
 sUr
@@ -196402,7 +196400,7 @@ sUr
 sUr
 sUr
 veZ
-veZ
+rRe
 veZ
 veZ
 sUr
@@ -226151,7 +226149,7 @@ bIh
 scG
 kIT
 veZ
-mGX
+jbb
 xaW
 tfX
 cJV
@@ -226549,7 +226547,7 @@ bZN
 bZN
 tCl
 hxR
-scG
+etf
 bIh
 kIT
 sUr
@@ -226755,7 +226753,7 @@ bIh
 bIh
 veZ
 veZ
-veZ
+rRe
 veZ
 veZ
 oHS


### PR DESCRIPTION
Adjusts the Shield teleporter's energy gain slightly and its rewards for doing the acquirement quests, incentives shields to actually get said items. 
Adds in several new items that can be acquired from the teleporter, ranging from armor, ammo, to shield gun disk. Reduced point cost for plasteel, bringing it down from 250 to 150. 
Reduces license point cost of the Duty on the Blackshield disk. It was too much for it to be 6 license points for what it was worth.
Moved the ammo disk back into the secure armory. Was a mistake to have it outside.
Readjusts Blackshield ablative armor, giving it slowdown and raises some more general protections against other types, but better to wear other armor for said stuff.
Adds in more traps for those who tunnel in farther into the colony.
