### PR TITLE
Makes the trade beacon a lot more balanced

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/trade.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/trade.dm
@@ -11,7 +11,8 @@
 	size = 21
 	available_on_ntnet = FALSE
 	requires_ntnet = TRUE
-
+	clone_able = FALSE
+	copy_cat = TRUE
 	var/trade_screen = GOODS_SCREEN
 
 	var/list/shoppinglist = list()
@@ -23,6 +24,12 @@
 	var/datum/trade_station/station
 
 	var/datum/money_account/account
+
+/datum/computer_file/program/trade/cargo_download
+	available_on_ntnet = TRUE
+	clone_able = TRUE
+	required_access = access_cargo
+	requires_access_to_run = FALSE
 
 /datum/computer_file/program/trade/proc/set_choosed_category(value)
 	choosed_category = value


### PR DESCRIPTION
The basic trade beacon found in consoles can no longer be stolen, only used
An alt version is now only aviable on the NT.net access to cargo to download it and transfer the data to others.

This is both a fix for a rather gamey and jerk move form people to steal the program and allow cargo techs to freely hand out said program to whom they deal with or keep on their own to watch/do bounties remotely