### PR TITLE
Propis and Scavs slots 1+

### DIFF
--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -57,8 +57,8 @@
 	department = DEPARTMENT_PROSPECTOR
 	department_flag = PROSPECTORS
 	faction = MAP_FACTION
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = "the Foreman"
 	difficulty = "Medium."
 	alt_titles = list("Scrapper","Sapper","Junk Technician","Sawbones")
@@ -102,8 +102,8 @@
 	department = DEPARTMENT_PROSPECTOR
 	department_flag = PROSPECTORS
 	faction = MAP_FACTION
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = "the Foreman"
 	difficulty = "Medium."
 	alt_titles = list("Enforcer","Frontiersmen","Triggerman")


### PR DESCRIPTION
Ups the amount of scavs and propis slots to 3 rather then 2.
They already have the spawn locations and lockers sence the start of the role I have no idea why we never upped it to 3 before