### PR TITLE
Minor addition to cargo packs

### DIFF
--- a/code/modules/cargo/packs_security.dm
+++ b/code/modules/cargo/packs_security.dm
@@ -234,7 +234,7 @@
 	group = "Enforcement"
 	
 /datum/supply_pack/ammo_disks_1
-	name = "SA "Always prepared" Ammunition Disks Pack"
+	name = "SA Always prepared Ammunition Disks Pack"
 	contains = list(/obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo,
 					/obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_rifle)
 	cost = 2200

--- a/code/modules/cargo/packs_security.dm
+++ b/code/modules/cargo/packs_security.dm
@@ -232,6 +232,48 @@
 	cost = 750
 	crate_name = "HS .50 Kurtz Non-Lethal ammunition crate"
 	group = "Enforcement"
+	
+/datum/supply_pack/ammo_disks_1
+	name = "SA "Always prepared" Ammunition Disks Pack"
+	contains = list(/obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo,
+					/obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_rifle)
+	cost = 2200
+	crate_name = "Standard Ammunition Disks Crate"
+	group = "Enforcement"
+	
+	
+/datum/supply_pack/rifle_75and257
+	name = "Rifle and Carbine Ammunition Pack"
+	contains = list(/obj/item/ammo_magazine/rifle_75,
+					/obj/item/ammo_magazine/rifle_75,
+					/obj/item/ammo_magazine/ammobox/rifle_75,
+					/obj/item/ammo_magazine/ammobox/light_rifle_257,
+					/obj/item/ammo_magazine/light_rifle_257,
+					/obj/item/ammo_magazine/light_rifle_257)
+					
+	cost = 980
+	crate_name = "7.5 and .257 Ammunition Crate"
+	group = "Enforcement"
+	
+	
+/datum/supply_pack/Heavyrifle_ammo
+	name = "Heavy Rifle Ammunition Pack"
+	contains = list(/obj/item/ammo_magazine/heavy_rifle_408,
+					/obj/item/ammo_magazine/heavy_rifle_408,
+					/obj/item/ammo_magazine/ammobox/heavy_rifle_408,
+					/obj/item/ammo_magazine/ammobox/heavy_rifle_408)
+					
+	cost = 1200
+	crate_name = ".408 Ammunition Crate"
+	group = "Enforcement"
+	
+/datum/supply_pack/exotic_ammo_disk
+	name = "SA Exotic Ammunition Disk Pack"
+	contains = list(/obj/item/computer_hardware/hard_drive/portable/design/exotic_ammo)
+					
+	cost = 1500
+	crate_name = "Exotic Ammunition Disk Crate"
+	group = "Enforcement"
 
 /datum/supply_pack/ntweapons
 	name = "CA Energy Weapons Crate"
@@ -362,6 +404,17 @@
 	cost = 3500
 	containertype = /obj/structure/closet/crate/serbcrate_gray
 	crate_name = "Void Wolf HellFire Crate"
+	group = "Xanorath Syndicate"
+	
+	
+/datum/supply_pack/voidwolfmarksman
+	name = "Void Marksman Kit"
+	contains = list(/obj/item/gun/projectile/boltgun/scout,
+					/obj/item/ammo_magazine/ammobox/heavy_rifle_408_small/hv,
+					/obj/item/gun_upgrade/barrel/gauss)
+					
+	cost = 1600
+	crate_name = "Void Wolf Marksman Kit"
 	group = "Xanorath Syndicate"
 
 /datum/supply_pack/voidwolfflamer_ammo


### PR DESCRIPTION
This change adds new 7.5 and 257 ammo packs, aswell as orders for ammo disks and a last void wolf "Marksman" kit with a single bolt gun, a few rounds, and a mod. All of these were designed to be accurately priced so they're not overpowered, but to also make them relatively accessible for departments when cargo is /actually/ there.

I was tired that there was only handgun ammunition in the cargo console so I added more options. 
