### PR TITLE
The service lounge is now service only 

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -10257,7 +10257,7 @@
 "cmR" = (
 /obj/machinery/door/airlock{
 	name = "Chef's room";
-	req_access = list(25)
+	req_access = list(28)
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -66601,7 +66601,8 @@
 /area/nadezhda/rnd/rbreakroom)
 "omb" = (
 /obj/machinery/door/airlock/glass{
-	name = "Employee Lounge"
+	name = "Employee Lounge";
+	req_access = list(22,28,26,25,35,43)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -75292,7 +75293,8 @@
 /area/nadezhda/outside/meadow)
 "qfe" = (
 /obj/machinery/door/airlock/glass{
-	name = "Employee Lounge"
+	name = "Employee Lounge";
+	req_access = list(22,28,26,25,35,43)
 	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
@@ -75642,7 +75644,9 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/swo/quarters)
 "qip" = (
-/obj/machinery/door/airlock/multi_tile/metal,
+/obj/machinery/door/airlock/multi_tile/metal{
+	req_access = list(22,28,26,25,35,43)
+	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -87542,7 +87546,7 @@
 	},
 /obj/machinery/door/airlock{
 	name = "Chef's Bedroom";
-	req_access = list(25)
+	req_access = list(28)
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what it says on the tin. The service lounge now takes access from: 22,28,26,25,35,43
bar, hydro, chaplain, the cook, the janitor, and theater enjoyers fall under this.
This PR also 'fixes' the access on the cook's downstairs room, which required bar access- not kitchen access.
![image](https://user-images.githubusercontent.com/61367602/163724787-405b3660-5ddf-4d47-9089-b24e194e96a6.png)


## Changelog
🆑 
tweak: Airlock restrictions in service
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
