### PR TITLE
[CONTROVERSIAL] Adds surgical training perk to Corpsman, ups starting Roboticist BIO, bruise pack organ repair adjustment

### DIFF
--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -436,8 +436,8 @@
 	desc = "You've become an excellent appraiser of goods over the years. Just by looking at the item, you can know how much it would sell for in today's market rates."
 
 /datum/perk/surgical_master
-	name = "Surgery Training"
-	desc = "While you may not know the more advanced medical procedures, your mandatory training on surgery for implantation purposes allows you to perform basic surgical procedures with ease."
+	name = "Surgical Training"
+	desc = "While you may not be the most proficient surgeon around, your modest medical knowledge allows you to perform basic surgical procedures with ease."
 
 /datum/perk/advanced_medical
 	name = "Advanced Surgical Techniques"

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -94,7 +94,7 @@
 	description = "The Doctor is a professional medic and surgeon dedicated to healing the sick and injured, at all costs.<br>\
 	A broad range of medical procedures fall under your purview - diagnostics, general treatment, surgery, and virology.<br>\
 	You are not expected to be an expert in all: specializing in an area is fine. Divide tasks amongst colleagues, with CBO guidance.<br>\
-	Remember that chemistry has a dedicated specialist. Avoid this department unless it is notably short-staffed.<br>\
+	Remember that chemistry has shared access. If the Trauma Team isn't mixing chemicals, you may use the lab to do so yourself.<br>\
 	Due to the nature of your work, you may find yourself confined to the department for the shift majority. Don't abandon patients."
 
 	duties = "Heal the sick and injured, whatever their complaint.<br>\
@@ -138,11 +138,11 @@
 	software_on_spawn = list(/datum/computer_file/program/chem_catalog,
 							/datum/computer_file/program/scanner)
 
-	description = "Members of the trauma team are not men of science nor medicine, they are strictly in charge of enforcing the chief biolabs orders and sometimes the chief research overseer's orders.<br>\
+	description = "Members of the trauma team are not men of science nor medicine, they are strictly in charge of enforcing the chief biolab's orders and sometimes the chief research overseer's orders.<br>\
 	Your primary role is that of an armed thug for medical. You make sure that medical remains safe by ensuring people don't trespass or steal items and remove those who shouldn't be there, by force if necessary.<br>\
-	Your secondary responsibility is that of an soteria enforcer. Actions that require in house enforcement such as aiding doctors and security with violent patients in medical, securing the virology lab during an outbreak, and aiding in the destruction of escape slimes or kudzu from science.<br>\
+	Your secondary responsibility is that of an soteria enforcer. Actions that require in house enforcement such as aiding doctors and security with violent patients in medical, securing the virology lab during an outbreak, and aiding in the destruction of escaped slimes or experiments from science.<br>\
 	Your third duty is to aid medical doctors and act as a paramedic in fixing patients and collecting patients, this can include retrieving chemicals, doing basic triage, and going out to recover injured patients.<br>\
-	You are fully licensed to enforce the will of the overseer and to protect the soteria, its staff, and your patients with your personal weapons and armor.<br>\
+	You are fully licensed to enforce the will of the overseer and to protect Soteria, its staff, and your patients with your personal weapons and armor.<br>\
 	It's worth noting that you function heavily as a nurse when not acting as muscle and treatment of patients should be priority, in particular when assisting doctors."
 
 	duties = "Act as a guard for medical, ensuring unneeded colonist leave and nothing is stolen.<br>\

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -131,13 +131,13 @@
 	stat_modifiers = list(
 		STAT_MEC = 30,
 		STAT_COG = 25,
-		STAT_BIO = 25,
+		STAT_BIO = 30, // Enough to not flunk surgical operations on the chest for the sake of prosthetic implantation/replacement on fleshy patients. - Seb
 	)
 
-	perks = list(/datum/perk/surgical_master, /datum/perk/robotics_expert, /datum/perk/si_sci)
+	perks = list(/*/datum/perk/surgical_master,*/ /datum/perk/robotics_expert, /datum/perk/si_sci) // Roboticists don't need knowledge on ATK use for sealing wounds and fixing FLESH organs, which are the only two things this perk granted them. They deal with metal more than flesh. - Seb
 
 	description = "The Roboticist is a specialized scientist with a busy workload - at the forefront of Soteria's service offerings.<br>\
-	You must maintain and upgrade the fleet of synthetics that keep the ship running, as well as constructing new ones on occasion.<br>\
+	You must maintain and upgrade the myriad of synthetics that keep the colony running, as well as constructing new ones on occasion.<br>\
 	In addition, you may be asked to manufacture prosthetic limbs and enhancements. Medical can perform the installation if you lack surgical skills.<br>\
 	Though not requested often you can also construct massive and powerful mechanized vehicles. These have powerful mining, rescue, and military applications.<br>\
 	Remember that you are ultimately running a commercial cybernetic clinic - charge for your valuable services to earn a living."

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -134,7 +134,7 @@
 		STAT_BIO = 30, // Enough to not flunk surgical operations on the chest for the sake of prosthetic implantation/replacement on fleshy patients. - Seb
 	)
 
-	perks = list(/*/datum/perk/surgical_master,*/ /datum/perk/robotics_expert, /datum/perk/si_sci) // Roboticists don't need knowledge on ATK use for sealing wounds and fixing FLESH organs, which are the only two things this perk granted them. They deal with metal more than flesh. - Seb
+	perks = list(/datum/perk/surgical_master, /datum/perk/robotics_expert, /datum/perk/si_sci) // Robotics gives implants and augmentation for flesh and metal alike, they require the extra perk to help them step in for medical as well as per their SoP
 
 	description = "The Roboticist is a specialized scientist with a busy workload - at the forefront of Soteria's service offerings.<br>\
 	You must maintain and upgrade the myriad of synthetics that keep the colony running, as well as constructing new ones on occasion.<br>\

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -312,7 +312,7 @@
 		STAT_ROB = 10,
 	)
 
-	perks = list(/datum/perk/medicalexpertise)
+	perks = list(/datum/perk/medicalexpertise, /datum/perk/surgical_master) // How the hell is a roboticist more trained at using an ATK to fix organs than a supposed combat surgeon?
 				// /datum/perk/chemist -Thanos Voice: "I'm sorry little one..."
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
@@ -324,7 +324,7 @@
 	Your first duty is that of a field medic. Serve on the back line of any combat situations, treating the wounded and evacuating the critical.<br>\
 	Your second duty is to treat any prisoners and suspects in custody. Wounds from escape and suicide attempts will test your surgical skills.<br>\
 	Your third duty, when faced with strange crimes, is to serve as a scientific analyst - scanning traces and conducting autopsies.<br>\
-	Remember that although you can be armed, the combat is better left to your colleagues. Focus on the tasks only you can do."
+	Remember that although you can be armed, combat is better left to your colleagues. Focus on the tasks only you can do."
 
 	duties = "Minimize casualties in combat situations and treat all related wounds.<br>\
 	Treat any prisoners and suspects, and thoroughly monitor their health.<br>\

--- a/code/modules/surgery/organic_damage.dm
+++ b/code/modules/surgery/organic_damage.dm
@@ -4,7 +4,7 @@
 	target_organ_type = /obj/item/organ/internal
 	allowed_tools = list(
 		/obj/item/stack/medical/advanced/bruise_pack = 100,
-		/obj/item/stack/medical/bruise_pack = 50, // It was unbelievably unfair and frustrating to have such a low chance, and an abysmal difference of success chance between the two. - Seb
+		/obj/item/stack/medical/bruise_pack = 35, // Still unbelievably unfair and frustrating to have such a low chance, but given that it's gauze it's justified to be abysmally lower than specialized biogel - Seb
 		/obj/item/stack/medical/advanced/bruise_pack/mending_ichor = 100,
 	)
 

--- a/code/modules/surgery/organic_damage.dm
+++ b/code/modules/surgery/organic_damage.dm
@@ -4,7 +4,7 @@
 	target_organ_type = /obj/item/organ/internal
 	allowed_tools = list(
 		/obj/item/stack/medical/advanced/bruise_pack = 100,
-		/obj/item/stack/medical/bruise_pack = 20,
+		/obj/item/stack/medical/bruise_pack = 50, // It was unbelievably unfair and frustrating to have such a low chance, and an abysmal difference of success chance between the two. - Seb
 		/obj/item/stack/medical/advanced/bruise_pack/mending_ichor = 100,
 	)
 


### PR DESCRIPTION
## Why, you may ask?

The only things the `surgical_master` perk modifies and grants, code wise, are two:
- [Being able to use Advanced Trauma Kits](https://github.com/sojourn-13/sojourn-station/blob/274dc008f18681f450e58f7bf5cb45676d875edc/code/game/objects/items/stacks/medical.dm#L364) [(and Advanced Burn Kits)](https://github.com/sojourn-13/sojourn-station/blob/274dc008f18681f450e58f7bf5cb45676d875edc/code/game/objects/items/stacks/medical.dm#L513) [for bandaging external wounds (as an alternate perk bypass)](https://github.com/sojourn-13/sojourn-station/blob/274dc008f18681f450e58f7bf5cb45676d875edc/code/game/objects/items/stacks/medical.dm#L39)
- [Using Advanced Trauma Kits on organic (fleshy) organs for Organ Repair Surgery.](https://github.com/sojourn-13/sojourn-station/blob/202fc1d8558b32815d53c10f570cc59ed12ad72e/code/modules/surgery/surgery.dm#L106)

Given the broad spectrum of things roboticists are able to do, and their overall duties, this perk serves no practical purpose for them to have, as the only time they'd interact with flesh is by virtue of opening an incision on the chest area to connect prosthetic arms  (or groin area for legs), and this perk **aids them in no way to do this**, only the BIO stat handles this interaction.

This perk has long been a straight up Roboticist buff **for no reason**, for them to perform procedures they're **not** supposed to perform (even the job description states to leave the incision opening to doctors _"if you lack the surgical skills"_), as cybernetic organs are fixed with screwdrivers and not trauma kits, and handled by MEC and not BIO (which they were more geared towards, and even then has a lower failchance than normal organic surgery)

Worthy of note, this is not a _"Corpsman buff"_, a _"salt pr"_, or favoritism. This is just adjusting an unfair and senseless advantage roboticists had over jobs supposed to deal with organic surgery. But the controversy will remain out of the well known argument of _"We had to nerf corpsmen because people preferd to play them over troopers."_ This changes nothing on what Corpsmen usually do or are expected to do, it just facilitates a mechanic they should've had all this time.

Hence, this PR serves the following purpose:

- Bump up their BIO stat to 30 by profession so that they have an easier time performing incisions on patients with a fleshy torso that want better prosthetics
- Give Corpsmen the Surgical Proficiency perk, so that they're able to perform _[combat surgery](https://github.com/sojourn-13/sojourn-station/blob/a1939dd0318830325ad7deee683f41445aa50457/code/game/jobs/job/security.dm#L293)_ on repairing damaged organs, considering they did not have a functional way to do so (they already could use ATK's to seal wounds as their primary perk, advanced_medical is what does this)
- Bump up the success chance of gauze on organ repair surgery from 20% to 50% as it was absolutely infuriating and an abysmal difference between tiers, necessitating either spam and luck or grinding 120 BIO
- Rewrites the surgical master perk's description to accommodate for Corpsmen

<hr>

## Changelog
:cl:
add: Corpsmen given the surgical training perk
tweak: Gauze success chance on organ repair increased from 20% to 35%
balance: Roboticists starting BIO stat increased from 20 to 30
spellcheck: Fixed jobs descriptions to adapt "ship" into "colony" and better, updated job descriptions.
/:cl: