### PR TITLE
Rework blue crystals

### DIFF
--- a/code/modules/ameridian/_defines.dm
+++ b/code/modules/ameridian/_defines.dm
@@ -1,6 +1,0 @@
-// Growth Stages defines, from 1 to 5
-#define GROWTH_SEED 1
-#define GROWTH_SMALL 2
-#define GROWTH_MEDIUM 3
-#define GROWTH_BIG 4
-#define GROWTH_HUGE 5

--- a/code/modules/ameridian/ameridian_crystal.dm
+++ b/code/modules/ameridian/ameridian_crystal.dm
@@ -9,7 +9,7 @@
 	light_color = COLOR_LIGHTING_GREEN_BRIGHT
 
 	var/growth // the growth level of the crystal. The higher it is, the older the crystal is.
-	var/max_growth = GROWTH_HUGE // Maximum growth level, in case we want to do stuff relative to size
+	var/max_growth = 5 // Maximum growth level, in case we want to do stuff relative to size
 	var/growth_prob = 1 // The % of chance for the crystal to grow every tickv
 	var/blue_crystal_prob = 5 // % chance of spawning a blue crystal instead of a green one when spreading
 	var/spread_range = 1 // Radius that the crystal can spawn new crystals.
@@ -31,13 +31,13 @@
 		if(mapload)
 			growth = max_growth
 		else
-			growth = GROWTH_SEED
+			growth = 1
 	golem_timer = 0 // Reset the timer
 	update_icon()
 
 /obj/structure/ameridian_crystal/Destroy()
 	..()
-	STOP_PROCESSING(SSturf, src)
+	STOP_PROCESSING(SSobj, src)
 
 /obj/structure/ameridian_crystal/Process()
 	irradiate()
@@ -148,7 +148,7 @@
 			var/sound/S = sound('sound/synthesized_instruments/chromatic/vibraphone1/c5.ogg')
 			for(var/mob/living/carbon/human/H in view(src))
 				if(H.stats.getPerk(PERK_PSION))
-					to_chat(H, "<b><font color='purple'>[src] chimes.</b></font>")
+					to_chat(H, SPAN_PSION("[src] chimes."))
 					H.playsound_local(get_turf(src), S, 50) // Only psionics can hear that
 
 			sleep((S.len + 1) SECONDS) // Wait until the sound is done, we're using S.len in case the sound change for another with a different duration. We add a second to give a slightly longer warning time.

--- a/code/modules/ameridian/ameridian_crystal_blue.dm
+++ b/code/modules/ameridian/ameridian_crystal_blue.dm
@@ -21,6 +21,9 @@
 
 // Spawn golems in groups.
 /obj/structure/ameridian_crystal/blue/handle_golems()
+	if(golem)
+		return FALSE
+
 	if(++golem_timer >= initial(golem_timer))
 		golem_timer = 0
 
@@ -80,4 +83,7 @@
 	sleep((S.len + 4) SECONDS) // 5 Seconds before the golems spawn
 
 	for(var/I = 0, I < runtling_amt, I++)
-		new /mob/living/carbon/superior_animal/ameridian_golem/runtling(pick(turf_list))
+		if(!golem) // Only one goelm out of the pack get to be our main golem
+			golem = new /mob/living/carbon/superior_animal/ameridian_golem/runtling(pick(turf_list))
+		else
+			new /mob/living/carbon/superior_animal/ameridian_golem/runtling(pick(turf_list))

--- a/code/modules/ameridian/ameridian_crystal_blue.dm
+++ b/code/modules/ameridian/ameridian_crystal_blue.dm
@@ -1,4 +1,6 @@
-// A blue crystal that spawn 3 runtling golems when fell
+// A blue crystal that spawn 3 runtling golems when fell.
+// It also boost the growth of nearby crystals.
+// It spawn more golems, but spend longer between spawns.
 /obj/structure/ameridian_crystal/blue
 	name = "blue ameridian crystal"
 	desc = "A strange crystal formation that seems to grow on its own..."
@@ -6,17 +8,37 @@
 	anchored = TRUE
 	density = FALSE
 	light_range = 5 // Glow in the dark
-	growth = 5 // Bigger than other crystals
+	growth = 5 // Start at max growth
 	max_growth = 5 // Doesn't grow
 	growth_prob = 2.5 // Spread crystals faster
-	spread_range = 2
+	blue_crystal_prob = 0 // Cannot spawn more blue crystal
 	rad_damage = 0.75
 	rad_range = 2
-	var/amount_runtling = 3 // Amount of runtlings spawned on destruction
+	golem_timer = 150
+	var/boost_range = 2
+	var/amount_runtlings_spawn = 5
+	var/amount_runtling_destruction = 3 // Amount of runtlings spawned on destruction
 
-// The tree doesn't spawn golems on its own.
+// Spawn golems in groups.
 /obj/structure/ameridian_crystal/blue/handle_golems()
-	return
+	if(++golem_timer >= initial(golem_timer))
+		golem_timer = 0
+
+		var/valid_crystal = 0
+		for(var/obj/structure/ameridian_crystal/AC in range(golem_range, src))
+			if(istype(AC, /obj/structure/ameridian_crystal/spire))
+				continue // Ignore the ameridian spire if there's one
+			if(AC.golem)
+				return FALSE // Don't spawn a golem if any nearby growth spawned one, to prevent a fuckton of golems from spawning
+			if(AC.growth >= max_growth)
+				valid_crystal++
+			if(valid_crystal >= golem_threshold)
+				break // We have enough crystals, leave early
+
+		if(valid_crystal >= golem_threshold)
+			spawn_runtling(amount_runtlings_spawn)
+			return TRUE
+		return FALSE
 
 /obj/structure/ameridian_crystal/blue/attackby(obj/item/I, mob/user)
 	if(user.a_intent == I_HELP && user.Adjacent(src) && (I.has_quality(QUALITY_EXCAVATION) || I.has_quality(QUALITY_DIGGING) || I.has_quality(QUALITY_SHOVELING)))
@@ -24,13 +46,22 @@
 		if(do_after(user, WORKTIME_SLOW, src))
 			visible_message("[src] crumbles into a pile of crystals...")
 			icon_state = ""
-			spawn_runtling(amount_runtling)
+			spawn_runtling(amount_runtling_destruction)
+			visible_message(SPAN_DANGER("[src] reforms into multiple golems!"))
 			activate_mobs_in_range(src, 15) // Wake up the nearby golems
 			qdel(src)
 		else
 			to_chat(user, SPAN_WARNING("You must stay still to finish excavation."))
 	else
 		..()
+
+/obj/structure/ameridian_crystal/blue/spread()
+	..()
+	for(var/obj/structure/ameridian_crystal/AC in range(boost_range))
+		if(istype(AC, /obj/structure/ameridian_crystal/blue) || istype(AC, /obj/structure/ameridian_crystal/spire))
+			continue // To prevent infinite loops
+		else
+			AC.handle_growth() // The crystal grow & spread faster
 
 /obj/structure/ameridian_crystal/blue/proc/spawn_runtling(var/runtling_amt = 1)
 	var/list/turf_list = list()
@@ -43,11 +74,10 @@
 	var/sound/S = sound('sound/effects/screech.ogg')
 	for(var/mob/living/carbon/human/H in viewers(src))
 		if(H.stats.getPerk(PERK_PSION))
-			to_chat(H, "<b><font color='purple'>[src] whistles...</b></font>")
+			to_chat(H, SPAN_PSION("[src] whistles..."))
 			H.playsound_local(get_turf(src), S, 50) // Only psionics can hear that
 
 	sleep((S.len + 4) SECONDS) // 5 Seconds before the golems spawn
 
-	visible_message(SPAN_DANGER("[src] reforms into multiple golems!"))
 	for(var/I = 0, I < runtling_amt, I++)
 		new /mob/living/carbon/superior_animal/ameridian_golem/runtling(pick(turf_list))

--- a/code/modules/ameridian/ameridian_spire.dm
+++ b/code/modules/ameridian/ameridian_spire.dm
@@ -13,6 +13,7 @@
 	spread_range = 3
 	rad_damage = 1
 	rad_range = 3
+	blue_crystal_prob = 10 // More chances of spawning a blue crystal
 	var/respawn_distance = 10 // How many tiles do we let the golem get before spawning another
 
 /obj/structure/ameridian_crystal/spire/update_icon()
@@ -47,7 +48,7 @@
 		var/sound/S = sound('sound/synthesized_instruments/chromatic/vibraphone1/c5.ogg')
 		for(var/mob/living/carbon/human/H in viewers(src))
 			if(H.stats.getPerk(PERK_PSION))
-				to_chat(H, "<b><font color='purple'>[src] chimes.")
+				to_chat(H, SPAN_PSION("[src] chimes."))
 				H.playsound_local(get_turf(src), S, 50) // Only psionics can hear that
 
 		sleep((S.len + 6) SECONDS) // 10 Seconds before the beefy golem spawn

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -1513,7 +1513,6 @@
 #include "code\modules\alarm\fire_alarm.dm"
 #include "code\modules\alarm\motion_alarm.dm"
 #include "code\modules\alarm\power_alarm.dm"
-#include "code\modules\ameridian\_defines.dm"
 #include "code\modules\ameridian\ameridian_core.dm"
 #include "code\modules\ameridian\ameridian_crystal.dm"
 #include "code\modules\ameridian\ameridian_crystal_blue.dm"


### PR DESCRIPTION
Rework the blue ameridian crystals : 
\- Spire has a 10% chance of spawning a blue crystal instead of a green crystal
\- Blue crystals now boost the growth & spread of every green crystals in a 2 tile range and spread normally instead of spreading 1 tile further and slightly faster.
\- Blue crystals now regularly spawn runtlings, albeit with 50% more time between spawns. Those runtlings spawn in packs of 5. The crystal will still spawn 3 runtlings upon being excavated.