### PR TITLE
Removes the forced harddel on mobs

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -11,8 +11,7 @@
 		client.screen = list()
 
 	ghostize()
-	..()
-	return QDEL_HINT_HARDDEL
+	return ..()
 
 /mob/get_fall_damage(var/turf/from, var/turf/dest)
 	return 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A while ago, eris updated their mob file to force harddels on everything. THis was due to a very old TG PR. TG has moved on from that as it was a temporary, awful measure. See https://github.com/tgstation/tgstation/pull/51887.

WARNING. I just found out this causes most mobs to fail GC on deletion. This means they are stuck in the memory and can cause a memory leak. This isnt to say its our only memory leak, we have a fuckton of GC failures, this'll jsut make it worse.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
## Changelog
:cl:
code: Updated mob destroy() to not force harddels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
