### PR TITLE
Allow the Pilgrim to directly reload from boxes

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver/lemant.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/lemant.dm
@@ -113,7 +113,7 @@
 			loading_gun:
 				while(do_after(user, reload_delay, user))
 					for(var/obj/item/ammo_casing/C in AM.stored_ammo)
-						if(loaded.len >= max_shells || AM.stored_ammo.len <= 0) // The gun is full or the box is empty
+						if(loaded.len >= max_shells) // The gun is full or the box is empty
 							break loading_gun // Stop loading at all
 						if(C.caliber == caliber)
 							C.forceMove(src)
@@ -121,7 +121,10 @@
 							AM.stored_ammo -= C //should probably go inside an ammo_magazine proc, but I guess less proc calls this way...
 							count++
 							AM.update_icon()
-							continue loading_gun
+							break
+
+					if(AM.stored_ammo.len <= 0) // The packet is out of bullets
+						break loading_gun // Stop loading at all
 
 		if(count)
 			user.visible_message("[user] reloads [src].", SPAN_NOTICE("You load [count] round\s into [src]."))

--- a/code/modules/projectiles/guns/projectile/revolver/lemant.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/lemant.dm
@@ -23,6 +23,7 @@
 		)
 
 	var/obj/item/gun/projectile/underslung_shotgun/shotgun
+	var/reload_delay = 5 // Delay between bullets when reloading from a box.
 
 /obj/item/gun/projectile/revolver/lemant/claw
 	name = "\"Pilgrim Claw\" magnum revolver"
@@ -98,6 +99,35 @@
 
 	if(user.get_inactive_hand() == src && cur_mode.settings["use_launcher"])
 		shotgun.unload_ammo(user)
+	else
+		..()
+
+/obj/item/gun/projectile/revolver/lemant/load_ammo(var/obj/item/A, mob/user)
+	if(istype(A, /obj/item/ammo_magazine))
+		var/obj/item/ammo_magazine/AM = A
+		var/count = 0
+		if(AM.reload_delay)
+			to_chat(user, SPAN_NOTICE("It takes some time to reload [src] with [AM]..."))
+
+		if(do_after(user, AM.reload_delay, user)) // Initial delay before the loading start
+			loading_gun:
+				while(do_after(user, reload_delay, user))
+					for(var/obj/item/ammo_casing/C in AM.stored_ammo)
+						if(loaded.len >= max_shells || AM.stored_ammo.len <= 0) // The gun is full or the box is empty
+							break loading_gun // Stop loading at all
+						if(C.caliber == caliber)
+							C.forceMove(src)
+							loaded += C
+							AM.stored_ammo -= C //should probably go inside an ammo_magazine proc, but I guess less proc calls this way...
+							count++
+							AM.update_icon()
+							continue loading_gun
+
+		if(count)
+			user.visible_message("[user] reloads [src].", SPAN_NOTICE("You load [count] round\s into [src]."))
+			if(reload_sound) playsound(src.loc, reload_sound, 75, 1)
+			cock_gun(user)
+			update_firemode()
 	else
 		..()
 


### PR DESCRIPTION
## About The Pull Request
Make it so that when hitting a Pilgrim with an ammo box, after a small delay, to start individually loading the ammo into the gun.
This way players don't have to take the ammo out of the box, then load the Pilgrim manually using those bullets.
It apply to all type of pilgrims, however, it doesn't automatically remove the old ammo for you.