### PR TITLE
Little additions to cargo sec! (Now with AMR removed due to Trillby)

### DIFF
--- a/code/modules/cargo/packs_security.dm
+++ b/code/modules/cargo/packs_security.dm
@@ -256,6 +256,17 @@
 	group = "Enforcement"
 	
 	
+/datum/supply_pack/sts_75
+	name = "Arms of the Free World pack"
+	contains = list(/obj/item/gun/projectile/automatic/sts/rifle,
+					/obj/item/gun/projectile/automatic/sts/rifle,
+					/obj/item/gun/projectile/automatic/sts/rifle,
+					/obj/item/gun/projectile/automatic/sts/rifle)
+					
+	cost = 3000
+	crate_name = "STS Rifles Crate"
+	group = "Enforcement"
+	
 /datum/supply_pack/Heavyrifle_ammo
 	name = "Heavy Rifle Ammunition Pack"
 	contains = list(/obj/item/ammo_magazine/heavy_rifle_408,
@@ -408,7 +419,7 @@
 	
 	
 /datum/supply_pack/voidwolfmarksman
-	name = "Void Marksman Kit"
+	name = "Void Wolf Marksman Kit"
 	contains = list(/obj/item/gun/projectile/boltgun/scout,
 					/obj/item/ammo_magazine/ammobox/heavy_rifle_408_small/hv,
 					/obj/item/gun_upgrade/barrel/gauss)
@@ -416,6 +427,38 @@
 	cost = 1600
 	crate_name = "Void Wolf Marksman Kit"
 	group = "Xanorath Syndicate"
+	
+	
+/datum/supply_pack/voidwolfantimaterial
+	name = "Void Wolf Mecha Hunter Kit"
+	contains = list(/obj/item/gun/projectile/boltgun/heavysniper,
+					/obj/item/ammo_magazine/ammobox/antim,
+					/obj/item/ammo_magazine/ammobox/antim,
+					/obj/item/gun_upgrade/barrel/gauss)
+					
+	cost = 4000
+	crate_name = "Void Wolf Anti-material Kit"
+	group = "Xanorath Syndicate"
+	
+	
+/datum/supply_pack/voidwolfrocketman
+	name = "Void Wolf Rocket-Man Weapons Kit"
+	contains = list(/obj/item/gun/projectile/rpg,
+					/obj/item/ammo_casing/rocket,
+					/obj/item/ammo_casing/rocket,
+					/obj/item/ammo_casing/rocket,
+					/obj/item/ammo_casing/rocket,
+					/obj/item/ammo_casing/rocket,
+					/obj/item/ammo_casing/rocket,
+					/obj/item/ammo_casing/rocket,
+					/obj/item/ammo_casing/rocket)
+					
+	cost = 5500
+	crate_name = "Void Wolf Rocket-Man Kit"
+	group = "Xanorath Syndicate"
+	
+	
+	
 
 /datum/supply_pack/voidwolfflamer_ammo
 	name = "Void Wolf HellFire Canisters Crate"

--- a/code/modules/cargo/packs_security.dm
+++ b/code/modules/cargo/packs_security.dm
@@ -424,7 +424,7 @@
 					/obj/item/ammo_magazine/ammobox/heavy_rifle_408_small/hv,
 					/obj/item/gun_upgrade/barrel/gauss)
 					
-	cost = 1600
+	cost = 2500
 	crate_name = "Void Wolf Marksman Kit"
 	group = "Xanorath Syndicate"
 	

--- a/code/modules/cargo/packs_security.dm
+++ b/code/modules/cargo/packs_security.dm
@@ -436,7 +436,7 @@
 					/obj/item/ammo_magazine/ammobox/antim,
 					/obj/item/gun_upgrade/barrel/gauss)
 					
-	cost = 4000
+	cost = 5200
 	crate_name = "Void Wolf Anti-material Kit"
 	group = "Xanorath Syndicate"
 	

--- a/code/modules/cargo/packs_security.dm
+++ b/code/modules/cargo/packs_security.dm
@@ -428,19 +428,6 @@
 	crate_name = "Void Wolf Marksman Kit"
 	group = "Xanorath Syndicate"
 	
-	
-/datum/supply_pack/voidwolfantimaterial
-	name = "Void Wolf Mecha Hunter Kit"
-	contains = list(/obj/item/gun/projectile/boltgun/heavysniper,
-					/obj/item/ammo_magazine/ammobox/antim,
-					/obj/item/ammo_magazine/ammobox/antim,
-					/obj/item/gun_upgrade/barrel/gauss)
-					
-	cost = 5200
-	crate_name = "Void Wolf Anti-material Kit"
-	group = "Xanorath Syndicate"
-	
-	
 /datum/supply_pack/voidwolfrocketman
 	name = "Void Wolf Rocket-Man Weapons Kit"
 	contains = list(/obj/item/gun/projectile/rpg,


### PR DESCRIPTION
So, I have added options to buy one anti-material rifle, one RPG, and some STS 7.5 rifles at cargo, they're accurately priced as to not be overpowered, although those may be liable to change in case it's not enough.

