### PR TITLE
Bat'ko Balance & Hotfix

### DIFF
--- a/code/modules/projectiles/guns/energy/railgun.dm
+++ b/code/modules/projectiles/guns/energy/railgun.dm
@@ -175,14 +175,14 @@
 	recoil_buildup = 30
 	one_hand_penalty = 80 //guh
 	zoom_factor = 1.8
-	extra_damage_mult_scoped = 0.2
+	extra_damage_mult_scoped = 0.4
 	damage_multiplier = 1.6
-	penetration_multiplier = 2.0
+	penetration_multiplier = 1.5
 	twohanded = TRUE
 	slowdown_hold = 1.5
 	brace_penalty = 30
 	init_firemodes = list(
-		list(mode_name="powered-rod", mode_desc="fires a metal rod at incredible speeds", projectile_type=/obj/item/projectile/plasma/gauss, icon="kill"),
+		list(mode_name="powered-rod", mode_desc="fires a metal rod at incredible speeds", projectile_type=/obj/item/projectile/bullet/gauss, icon="kill"),
 		list(mode_name="fragmented scrap", mode_desc="fires a brittle, sharp piece of scrap-metal", projectile_type=/obj/item/projectile/bullet/grenade/frag, charge_cost=30000, icon="grenade"),
 	)
 	consume_cell = FALSE
@@ -199,6 +199,9 @@
 	//Blacklisting upgrades currently dosnt work, - Trilby
 	blacklist_upgrades = list(/obj/item/gun_upgrade/mechanism/battery_shunt,
 							/obj/item/gun_upgrade/mechanism/greyson_master_catalyst)
+	
+	//Until blacklisting works, this will be the supliment. You get one attachment - use it wisely....... - Rebel0
+	max_upgrades = 1
 
 /obj/item/gun/energy/laser/railgun/gauss/Initialize()
 	..()
@@ -242,6 +245,7 @@
 /obj/item/gun/energy/laser/railgun/gauss/examine(user)
 	. = ..()
 	to_chat(user, "It holds [stored_matter]/[max_stored_matter] [matter_type].")
+	to_chat(user, SPAN_NOTICE("Control-Click to manually vent this weapon's heat."))
 
 /obj/item/gun/energy/laser/railgun/gauss/update_icon()
 	cut_overlays()

--- a/code/modules/projectiles/guns/energy/railgun.dm
+++ b/code/modules/projectiles/guns/energy/railgun.dm
@@ -187,7 +187,6 @@
 	)
 	consume_cell = FALSE
 	price_tag = 6000
-	max_upgrades = 2
 
 	var/max_stored_matter = 4
 	var/stored_matter = 0
@@ -201,7 +200,7 @@
 							/obj/item/gun_upgrade/mechanism/greyson_master_catalyst)
 	
 	//Until blacklisting works, this will be the supliment. You get one attachment - use it wisely....... - Rebel0
-	max_upgrades = 1
+	max_upgrades = 2
 
 /obj/item/gun/energy/laser/railgun/gauss/Initialize()
 	..()

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -633,6 +633,19 @@
 		M.adjust_fire_stacks(fire_stacks)
 		M.IgniteMob()
 
+//Gauss rifle
+/obj/item/projectile/bullet/gauss
+	name = "gauss"
+	icon_state = "gauss"
+	mob_hit_sound = list('sound/effects/gore/sear.ogg')
+	hitsound_wall = 'sound/weapons/guns/misc/ric4.ogg'
+	damage_types = list(BRUTE = 54)
+	armor_penetration = 40
+	check_armour = ARMOR_BULLET
+	affective_damage_range = 12
+	affective_ap_range = 12
+	hitscan = TRUE
+
 //Should do about 68 damage at 1 tile distance (adjacent), and 40 damage at 3 tiles distance.
 //Overall less damage than slugs in exchange for more damage at very close range and more embedding
 /obj/item/projectile/bullet/pellet/shotgun


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Some changes to the Bat'ko. Removed it as a plasma projectile, preventing limb-gibbing as easily, and instead made it akin to the rail rifle as a ballistic projectile. Reduced its AP from 100 to 60. This should limit making the gun too powerful. As a note: Previous PR fixed the heat-gain issue, and I've also added text when examining it to remind you to vent it. (Or else you take 50 burn.) Similarly Trilby's previous PR made the gun only able to take two attachments, limiting one's ability to mod it to high-shit. **I may need to re-buff this in some way in the future**, such as increased ammo capacity or less cell-cost usage, but this should service for now. I'll keep watch of the rifle in game and adjust it accordingly.
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
balance: Bat'ko rebalanced to specifics suggested.
/:cl: