### PR TITLE
Ups rocket damage

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -21,10 +21,10 @@
 	explosion(target, 0, 1, 2)
 	return TRUE
 
-/obj/item/projectile/bullet/rocket
+/obj/item/projectile/bullet/rocket  
 	name = "high explosive rocket"
 	icon_state = "rocket"
-	damage_types = list(BRUTE = 70)
+	damage_types = list(BRUTE = 95) //please this is a rocket it shouldn't do less damage than an AMR like come on
 	armor_penetration = 100
 	check_armour = ARMOR_BULLET
 


### PR DESCRIPTION
The previous damage of the rocket was 75, this is less than an AMR, and less than a shunted reductor. One of the rarest and heaviest weapons in the game, not only that, but designed for anti-tank duties, did less damage than a weapon the guild can manufacture anywhere, and have a shitty cell and cheap soteria mod put in.
