### PR TITLE
Allows research borgs to unlock other borgs again

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -770,7 +770,7 @@
 		else
 			to_chat(user, SPAN_WARNING("Unable to locate a radio."))
 
-	else if(I.GetIdCard() || length(I.GetAccess()))			// trying to unlock the interface with an ID card
+	else if(I.GetIdCard() || length(I.GetAccess()) || istype(I, /obj/item/card/robot))			// trying to unlock the interface with an ID card
 		if(HasTrait(CYBORG_TRAIT_EMAGGED))//still allow them to open the cover
 			to_chat(user, SPAN_WARNING("The interface seems slightly damaged."))
 		if(opened)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Research borgs were unable to lock/unlock other borgs because their card/robot module was never being used.
This PR adds a simple additional check if said card was used on a borg. 


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->



## Changelog
:cl:
fix: Research borgs can lock/unlock borgs again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
