### PR TITLE
SMG balance stuff

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -52,12 +52,26 @@
 #define FULL_AUTO_600		list(mode_name = "full auto",    mode_desc = "600 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 2  , icon="auto", damage_mult_add = -0.2)
 #define FULL_AUTO_800		list(mode_name = "fuller auto",  mode_desc = "800 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1,   icon="auto", damage_mult_add = -0.2)
 
+#define FULL_AUTO_300_NOLOSS		list(mode_name = "full auto",    mode_desc = "300 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 3  , icon="auto")
+#define FULL_AUTO_400_NOLOSS		list(mode_name = "full auto",    mode_desc = "400 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 2.5, icon="auto")
+#define FULL_AUTO_600_NOLOSS		list(mode_name = "full auto",    mode_desc = "600 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 2  , icon="auto")
+#define FULL_AUTO_800_NOLOSS		list(mode_name = "fuller auto",  mode_desc = "800 rounds per minute",   mode_type = /datum/firemode/automatic, fire_delay = 1,   icon="auto")
+
+
+
 #define SEMI_AUTO_NODELAY	list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=0.2, move_delay=null, icon="semi") //Some delay
 
 #define BURST_2_ROUND		list(mode_name="2-round bursts", mode_desc = "Short, two shot bursts",     burst=2, fire_delay=null, move_delay=2, icon="burst", damage_mult_add = -0.2)
 #define BURST_3_ROUND		list(mode_name="3-round bursts", mode_desc = "Short, three shot bursts",   burst=3, fire_delay=null, move_delay=4, icon="burst", damage_mult_add = -0.2)
 #define BURST_5_ROUND		list(mode_name="5-round bursts", mode_desc = "Short, controlled bursts",   burst=5, fire_delay=null, move_delay=6, icon="burst", damage_mult_add = -0.2)
 #define BURST_8_ROUND		list(mode_name="8-round bursts", mode_desc = "Short, uncontrolled bursts", burst=8, fire_delay=null, move_delay=8, icon="burst", damage_mult_add = -0.2)
+
+#define BURST_2_ROUND_NOLOSS		list(mode_name="2-round bursts", mode_desc = "Short, two shot bursts",     burst=2, fire_delay=null, move_delay=2, icon="burst")
+#define BURST_3_ROUND_NOLOSS		list(mode_name="3-round bursts", mode_desc = "Short, three shot bursts",   burst=3, fire_delay=null, move_delay=4, icon="burst")
+#define BURST_5_ROUND_NOLOSS		list(mode_name="5-round bursts", mode_desc = "Short, controlled bursts",   burst=5, fire_delay=null, move_delay=6, icon="burst")
+#define BURST_8_ROUND_NOLOSS		list(mode_name="8-round bursts", mode_desc = "Short, uncontrolled bursts", burst=8, fire_delay=null, move_delay=8, icon="burst")
+
+
 
 #define WEAPON_NORMAL		list(mode_name="standard", burst =1, icon="semi")
 #define WEAPON_CHARGE		list(mode_name="charge mode", mode_desc="Hold down the trigger, and let loose a more powerful shot", mode_type = /datum/firemode/charge, icon="charge")

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -27,9 +27,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE, GUN_CALIBRE_35, GUN_SCOPE, GUN_MAGWELL)
 
 	init_firemodes = list(
-		FULL_AUTO_400,
+		FULL_AUTO_400_NOLOSS,
 		SEMI_AUTO_NODELAY,
-		BURST_3_ROUND
+		BURST_3_ROUND_NOLOSS
 		)
 
 /obj/item/gun/projectile/automatic/c20r/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/drozd.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/drozd.dm
@@ -20,7 +20,7 @@
 	one_hand_penalty = 5 //smg level
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_35, GUN_MAGWELL)
 	init_firemodes = list(
-		FULL_AUTO_600,
+		FULL_AUTO_600_NOLOSS,
 		SEMI_AUTO_NODELAY
 		)
 

--- a/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
@@ -20,7 +20,7 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_35, GUN_MAGWELL)
 	one_hand_penalty = 3
 	init_firemodes = list(
-		FULL_AUTO_400,
+		FULL_AUTO_400_NOLOSS,
 		SEMI_AUTO_NODELAY
 		)
 

--- a/code/modules/projectiles/guns/projectile/automatic/luger.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/luger.dm
@@ -16,7 +16,7 @@
 	one_hand_penalty = 20
 	load_method = SINGLE_CASING|MAGAZINE
 	init_firemodes = list(
-		FULL_AUTO_600,
+		FULL_AUTO_600_NOLOSS,
 		SEMI_AUTO_NODELAY,
 		)
 

--- a/code/modules/projectiles/guns/projectile/automatic/mac.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/mac.dm
@@ -19,8 +19,8 @@
 	one_hand_penalty = 5 //smg level
 
 	init_firemodes = list(
-		FULL_AUTO_600,
-		BURST_8_ROUND,
+		FULL_AUTO_600_NOLOSS,
+		BURST_8_ROUND_NOLOSS,
 		SEMI_AUTO_NODELAY
 		)
 

--- a/code/modules/projectiles/guns/projectile/automatic/ppsh.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ppsh.dm
@@ -24,9 +24,9 @@
 	auto_eject = 1
 	brace_penalty = 5 //Holding the line, not pushing
 	init_firemodes = list(
-		FULL_AUTO_800,
-		BURST_3_ROUND,
-		BURST_8_ROUND,
+		FULL_AUTO_800_NOLOSS,
+		BURST_3_ROUND_NOLOSS,
+		BURST_8_ROUND_NOLOSS,
 		)
 
 /obj/item/gun/projectile/automatic/ppsh/NM_colony

--- a/code/modules/projectiles/guns/projectile/automatic/texan.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/texan.dm
@@ -20,9 +20,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_35, GUN_MAGWELL)
 
 	init_firemodes = list(
-		FULL_AUTO_400,
+		FULL_AUTO_400_NOLOSS,
 		SEMI_AUTO_NODELAY,
-		BURST_3_ROUND
+		BURST_3_ROUND_NOLOSS
 		)
 
 /obj/item/gun/projectile/automatic/texan/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/tommygun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/tommygun.dm
@@ -21,9 +21,9 @@
 	fire_sound = 'sound/weapons/guns/fire/grease_fire.ogg'
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SILENCABLE, GUN_SCOPE)
 	init_firemodes = list(
-		FULL_AUTO_400,
-		BURST_3_ROUND,
-		BURST_5_ROUND
+		FULL_AUTO_400_NOLOSS,
+		BURST_3_ROUND_NOLOSS,
+		BURST_5_ROUND_NOLOSS
 		)
 
 /obj/item/gun/projectile/automatic/thompson/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/triage.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/triage.dm
@@ -23,9 +23,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SCOPE, GUN_SILENCABLE)
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
-		BURST_2_ROUND,
-		BURST_3_ROUND,
-		FULL_AUTO_400
+		BURST_2_ROUND_NOLOSS,
+		BURST_3_ROUND_NOLOSS,
+		FULL_AUTO_400_NOLOSS
 		)
 
 /obj/item/gun/projectile/automatic/triage/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/vector.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vector.dm
@@ -30,8 +30,8 @@
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
-		BURST_3_ROUND,
-		FULL_AUTO_400
+		BURST_3_ROUND_NOLOSS,
+		FULL_AUTO_400_NOLOSS
 		)
 
 /obj/item/gun/projectile/automatic/vector/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/wirbelwind.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wirbelwind.dm
@@ -22,8 +22,8 @@
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
-		BURST_3_ROUND,
-		FULL_AUTO_600
+		BURST_3_ROUND_NOLOSS,
+		FULL_AUTO_600_NOLOSS
 		)
 
 /obj/item/gun/projectile/automatic/wirbelwind/update_icon()


### PR DESCRIPTION
An simple change to SMG weapons(and only SMG weapons). Currently, they're in a very weird place where a generally low damage mod, plus pistol caliber(.35 almost exclusively) and further penalties for using full auto meant that they were highly unfavorable to use in almost all scenarios. Consequently, adds new fire modes without the -.2 damage mod ONLY for SMGs. This will hopefully help their lackluster performance in almost all fields when not being used essentially as large pistols, which you'll note retain their damage penalty for full auto.  

This change affects the c20r, Drozd, Greasegun, Vintovka Lyugera, Mac10, PPSH, Texan, Ekaterina, Semyonovich, Thompson

Looking at .35 and .40 in a vacuum, this will amount to a total damage bonus of 4.8 per shot on .40 SMGs(24->28.8) and a total damage bonus of 3.2(16->19.3) on .35. Obviously, these numbers may need some tweaking but overall should make SMGs less of a collection of depressing, trash guns.

Additionally, SMGs may no longer be braced by default(this is subject to change, we'll see.), without going and getting a proper bipod to use.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
