### PR TITLE
Bat'ko Projectile

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -642,6 +642,9 @@
 	damage_types = list(BRUTE = 54)
 	armor_penetration = 40
 	check_armour = ARMOR_BULLET
+	embed = FALSE
+	can_ricochet = FALSE
+	sharp = FALSE
 	affective_damage_range = 12
 	affective_ap_range = 12
 	hitscan = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Adjusts Bat'ko to no longer be a sharp projectile. Because now, unlike before, it can one shot gib limbs with the change being ballistic.
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
fixes: Unintended side effect to remove the mythical 'one hit gib' Bat'ko - turning it into the real one-hit delimb bat'ko. Fixed.
/:cl:
