### PR TITLE
pile ripper fix(?)/rework

### DIFF
--- a/code/modules/scrap/scrap_pileripper.dm
+++ b/code/modules/scrap/scrap_pileripper.dm
@@ -53,9 +53,11 @@
 		if(istype(ripped_item, /obj/structure/scrap))
 			var/obj/structure/scrap/pile = ripped_item
 			while(!pile.clear_if_empty())
+				pile.dig_out_lump()
 				pile.shuffle_loot()
 				for(var/obj/item/looted_things in pile.loot)
 					pile.loot.remove_from_storage(looted_things, src.loc)
+				clear_if_empty()
 				if(prob(20))
 					break
 			count++

--- a/code/modules/scrap/scrap_pileripper.dm
+++ b/code/modules/scrap/scrap_pileripper.dm
@@ -55,7 +55,7 @@
 			while(!pile.clear_if_empty())
 				pile.shuffle_loot()
 				for(var/obj/item/looted_things in pile.loot)
-					loot.remove_from_storage(looted_things, src.loc)
+					pile.loot.remove_from_storage(looted_things, src.loc)
 				if(prob(20))
 					break
 			count++

--- a/code/modules/scrap/scrap_pileripper.dm
+++ b/code/modules/scrap/scrap_pileripper.dm
@@ -52,13 +52,16 @@
 			break
 		if(istype(ripped_item, /obj/structure/scrap))
 			var/obj/structure/scrap/pile = ripped_item
-			while(pile.dig_out_lump(loc, 1))
+			while(!pile.clear_if_empty())
+				pile.shuffle_loot()
+				for(var/obj/item/looted_things in pile.loot)
+					loot.remove_from_storage(looted_things, src.loc)
 				if(prob(20))
 					break
 			count++
 		else if(istype(ripped_item, /obj/item))
 			ripped_item.forceMove(src.loc)
-			if(prob(20))
+			if(emagged)
 				qdel(ripped_item)
 		else if(istype(ripped_item, /obj/structure/scrap_cube))
 			var/obj/structure/scrap_cube/cube = ripped_item

--- a/code/modules/scrap/scrap_pileripper.dm
+++ b/code/modules/scrap/scrap_pileripper.dm
@@ -57,7 +57,6 @@
 				pile.shuffle_loot()
 				for(var/obj/item/looted_things in pile.loot)
 					pile.loot.remove_from_storage(looted_things, src.loc)
-				clear_if_empty()
 				if(prob(20))
 					break
 			count++
@@ -93,6 +92,10 @@
 		emag_act(user)
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 
+	if(panel_open && I.use_tool(user, src, WORKTIME_EXTREMELY_LONG, QUALITY_PULSING, FAILCHANCE_IMPOSSIBLE, required_stat = STAT_MEC))
+		emag_act(user)
+		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+
 	if(default_deconstruction(I, user))
 		return
 
@@ -108,7 +111,7 @@
 			safety_mode = FALSE
 			update_icon()
 		playsound(loc, "sparks", 75, 1, -1)
-		to_chat(user, SPAN_NOTICE("You use the cryptographic sequencer on the [name]."))
+		to_chat(user, SPAN_NOTICE("You use disable the safeties on the [name]."))
 
 /obj/machinery/pile_ripper/update_icon()
 	..()


### PR DESCRIPTION
pile ripper can now dig out loot from trash piles. Hooray, it's now no longer just a murder machine. Pile ripper also now only deletes items when emagged (use the recycler or smelter instead). 

i sincerely doubt this will severely impact the trashpile economy, since you either 1. drag it around in maint after powering the area apc, wrench it down for every trashpile and unwrech it to move it, potentially gibbing yourself if you're not careful or
2. you get a ripley and start walking around compressing cubes into scrap, loading up the scrap cubes and moving it to a fixed pileripper, which is about as fast as manually going through the piles with a good shovel
3. it's more excuse for it to be used = more likely people will fall in = funny



## Changelog
:cl:
balance: pile ripper can now loot trashpiles, as Code intended
balance: pile ripper can now be emagged after a max difficulty check with multitool
/:cl:


