### PR TITLE
Make absolutist garments unrestricted by role again :)

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/factionabsolute.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionabsolute.dm
@@ -23,17 +23,14 @@
 /datum/gear/factionabsolute/mono_belt
 	display_name = "monomial belt"
 	path = /obj/item/clothing/under/monomial_belt
-	allowed_roles = list("Prime","Vector")
 
 /datum/gear/factionabsolute/lemniscate
 	display_name = "lemniscate skirt"
 	path = /obj/item/clothing/under/rank/lemniscate
-	allowed_roles = list("Prime","Vector")
 
 /datum/gear/factionabsolute/monashka
 	display_name = "monashka garments"
 	path = /obj/item/clothing/under/rank/monashka
-	allowed_roles = list("Prime","Vector")
 
 /datum/gear/factionabsolute/laurel
 	display_name = "laurel selection"
@@ -44,13 +41,11 @@
 	display_name = "numerical hat"
 	path = /obj/item/clothing/head/numerical_hat
 	slot = slot_head
-	allowed_roles = list("Prime","Vector")
 
 /datum/gear/factionabsolute/numerical_grab
 	display_name = "numerical garb"
 	path = /obj/item/clothing/suit/storage/numericalgarb
 	slot = slot_wear_suit
-	allowed_roles = list("Prime","Vector")
 
 /datum/gear/factionabsolute/tabard
 	display_name = "tabard selection"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>
	
<hr>
</details>
Removed role restriction for Absolutist path-based clothing, because they're simply the clothing for the path- not a uniform for being on-duty as church, but day-to-day clothes (to my knowledge).

<!-- I just want my skirts and robes back, man -->

## Changelog
:cl:
Removed role restriction for Absolutist path-based clothing.
/:cl:


