### PR TITLE
Reductor Rebalance & Misc change to Bat'Ko + Adjudicator 

### DIFF
--- a/code/modules/projectiles/guns/energy/abdicator.dm
+++ b/code/modules/projectiles/guns/energy/abdicator.dm
@@ -27,7 +27,7 @@ It also has more matterals then it takes to craft as a way to have a sunk cost.
 	charge_cost = 150
 	recoil_buildup = 12 //Big blast of heated shot, got some recoil to it.
 	damage_multiplier = 1 //already quite a bit lethal and dangerous with the burn damage and 'close range spray'.
-	gun_tags = list(GUN_PROJECTILE, GUN_LASER, GUN_ENERGY, GUN_SCOPE) //essentially a scattershot reductor.
+	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE) //essentially a scattershot reductor.
 
 	proj_step_multiplier = 0.5 //2x bullet speed, mostly for flares so they dont crawl
 

--- a/code/modules/projectiles/guns/energy/railgun.dm
+++ b/code/modules/projectiles/guns/energy/railgun.dm
@@ -202,8 +202,8 @@
 	blacklist_upgrades = list(/obj/item/gun_upgrade/mechanism/battery_shunt,
 							/obj/item/gun_upgrade/mechanism/greyson_master_catalyst)
 
-	//Until blacklisting works, this will be the supliment. You get one attachment - use it wisely. - Rebel0
-	max_upgrades = 2
+	//Until blacklisting works, this will be the supliment. You get three attachments - them it wisely. - Rebel0
+	max_upgrades = 3
 
 /obj/item/gun/energy/laser/railgun/gauss/Initialize()
 	..()

--- a/code/modules/projectiles/guns/energy/railgun.dm
+++ b/code/modules/projectiles/guns/energy/railgun.dm
@@ -15,8 +15,8 @@
 	slot_flags = SLOT_BACK
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 6, TECH_ENGINEERING = 6)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_STEEL = 8, MATERIAL_SILVER = 10)
-	charge_cost = 500
-	gun_tags = list(GUN_PROJECTILE, GUN_LASER, GUN_ENERGY, GUN_SCOPE)
+	charge_cost = 1000
+	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE)
 	suitable_cell = /obj/item/cell/large
 	one_hand_penalty = 10
 	fire_delay = 14 //Slow, on par with a shotgun pump then fire
@@ -202,7 +202,7 @@
 	blacklist_upgrades = list(/obj/item/gun_upgrade/mechanism/battery_shunt,
 							/obj/item/gun_upgrade/mechanism/greyson_master_catalyst)
 
-	//Until blacklisting works, this will be the supliment. You get one attachment - use it wisely....... - Rebel0
+	//Until blacklisting works, this will be the supliment. You get one attachment - use it wisely. - Rebel0
 	max_upgrades = 2
 
 /obj/item/gun/energy/laser/railgun/gauss/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Long-awaited Reductor rebalance. Simply increased the charge cost on the Reductor (making the norm large capacity cell shoot 10 rounds instead of 20) and made it unable to take energy attachments - I would have blacklisted the attachments instead but the blacklist system refuses to work. Similarly the Abdicator is no longer able to take ballistic mods to stop gauss barrel from stacking with it, and the Bat'ko has received 1 attachment slot back since it can also now only take ballistic mods.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: Reductor is no longer able to take laser/energy modifications & has received a increase in charge cost (1000<500)
balance: Abdicator can no longer take ballistic modifications.
balance: Bat'ko has received back one of its attachment slots as it can no longer take energy attachments.
/:cl:
