### PR TITLE
Stunslug Affective Range

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -60,6 +60,7 @@
 	damage_types = list(BURN = 5)
 	taser_effect = 1
 	agony = 80
+	affective_damage_range = 1
 
 /obj/item/projectile/energy/declone
 	name = "declone"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -60,7 +60,7 @@
 	damage_types = list(BURN = 5)
 	taser_effect = 1
 	agony = 80
-	affective_damage_range = 1
+	affective_damage_range = 2
 
 /obj/item/projectile/energy/declone
 	name = "declone"


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Stunslugs do 80 agony damage, equivalency of a 40mm baton round - yet have an infinite affective range. This will make it slowly drop agony damage for each tile traveled. Akin to how the beanbag loses effectiveness after a few tiles traveled.
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
balance: Stunslugs now have an affective range.
/:cl:
