### PR TITLE
powered crossbow/rxd rework

### DIFF
--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -197,7 +197,7 @@
 
 /datum/craft_recipe/gun/rxd
 	name = "RXD - rapid crossbow device"
-	result = /obj/item/gun/launcher/crossbow/RCD
+	result = /obj/item/gun/projectile/crossbow/RCD
 	steps = list(
 		list(/obj/item/rcd, 1, "time" = 30),
 		list(QUALITY_SCREW_DRIVING, 10, 30),
@@ -206,6 +206,8 @@
 		list(QUALITY_WELDING, 10, "time" = 30),
 		list(/obj/item/stack/cable_coil, 2, "time" = 10)
 	)
+
+
 
 /datum/craft_recipe/gun/multi_laser
 	name = "Multi-Laser Cannon"

--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -44,7 +44,7 @@
 
 /datum/craft_recipe/weapon/crossbow
 	name = "crossbow"
-	result = /obj/item/gun/launcher/crossbow
+	result = /obj/item/gun/projectile/crossbow
 	steps = list(
 		list(CRAFT_MATERIAL, 5, MATERIAL_WOOD), //old frame recipe
 		list(/obj/item/stack/rods, 3, "time" = 20),

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -745,7 +745,7 @@
 
 //Cross Bolt ammo
 /obj/item/ammo_casing/crossbow_bolts
-	name = "crossbaow bolt"
+	name = "crossbow bolt"
 	desc = "A finely made bolt designed for a crossbow."
 	icon_state = "bolt"
 	caliber = CAL_CROSSBOW

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -745,7 +745,7 @@
 
 //Cross Bolt ammo
 /obj/item/ammo_casing/crossbow_bolts
-	name = "crossbow bolt"
+	name = "crossbaow bolt"
 	desc = "A finely made bolt designed for a crossbow."
 	icon_state = "bolt"
 	caliber = CAL_CROSSBOW
@@ -780,3 +780,18 @@
 	amount = 10
 
 
+/obj/item/ammo_casing/rod_bolt
+	name = "metal rod"
+	desc = "Wait a second, this is a bullet!"
+	icon = 'icons/obj/stack/items.dmi'
+	icon_state = "rods"
+	caliber = "rod" //not a define
+	projectile_type = /obj/item/projectile/bullet/rod_bolt
+	matter = list(MATERIAL_STEEL = 1)
+	maxamount = 1
+	is_caseless = TRUE
+
+/obj/item/ammo_casing/rod_bolt/rcd
+	name = "flashforged rod"
+	desc = "Wait a second, this is a flashforged bullet!"
+	projectile_type = /obj/item/projectile/bullet/rod_bolt/rcd

--- a/code/modules/projectiles/guns/energy/charge.dm
+++ b/code/modules/projectiles/guns/energy/charge.dm
@@ -107,6 +107,7 @@
 	deltimer(overcharge_timer)
 	if(get_holding_mob() == user && get_cell() && cell.checked_use(1))
 		overcharge_level = min(overcharge_max, overcharge_level + get_overcharge_add(user))
+		to_chat(user, SPAN_NOTICE("[src] is now at [overcharge_level]/[overcharge_max] beam charge."))
 		set_light(2, overcharge_level/2, "#ff0d00")
 		if(overcharge_level < overcharge_max)
 			overcharge_timer = addtimer(CALLBACK(src, .proc/add_charge, user), 1 SECONDS, TIMER_STOPPABLE)

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -11,9 +11,6 @@
 	sharp = 1
 	edge = 0
 
-/obj/item/arrow/proc/removed() //Helper for metal rods falling apart.
-	return
-
 /obj/item/spike
 	name = "alloy spike"
 	desc = "A foot-long pointed stick made of a strange, silvery metal."
@@ -38,14 +35,12 @@
 	desc = "A projectile for a crossbow. Don't cry for me, Orithena."
 	icon_state = "metal-rod"
 
-/obj/item/arrow/rod/removed(mob/user)
-	if(throwforce == 15) // The rod has been superheated - we don't want it to be useable when removed from the bow.
-		to_chat(user, "[src] shatters into dozens of superheated metal shards as soon as it is launched from the crossbow!")
-		var/obj/item/material/shard/shrapnel/S = new()
-		S.loc = get_turf(src)
-		qdel(src)
+/obj/item/arrow/rcd
+	name = "flashforged bolt"
+	desc = "The ultimate ghetto 'deconstruction' implement."
+	throwforce = 6
 
-/obj/item/gun/launcher/crossbow
+/obj/item/gun/projectile/crossbow
 	name = "powered crossbow"
 	desc = "A 2557AD twist on an old classic. Pick up that can."
 	icon = 'icons/obj/guns/launcher/crossbow-solid.dmi'
@@ -57,49 +52,45 @@
 	slot_flags = SLOT_BACK
 	safety = FALSE
 	twohanded = TRUE
-
-	var/obj/item/bolt
+	load_method = SINGLE_CASING
+	max_shells = 1
+	ammo_type = /obj/item/ammo_casing/rod_bolt
+	var/obj/item/projectile/superheat_type = /obj/item/projectile/bullet/rod_bolt/superheated
 	var/tension = 0                         // Current draw on the bow.
 	var/max_tension = 5                     // Highest possible tension.
-	var/release_speed = 5                   // Speed per unit of tension.
 	cell = null    // Used for firing superheated rods.
 	var/current_user                        // Used to check if the crossbow has changed hands since being drawn.
 	var/draw_time = 20							// How long it takes to increase the draw on the bow by one "tension"
-	serial_type = "INDEX"
+	serial_type = null //it's a handmade crossbow who's putting serials on it
+	var/superheat_cost = 250
 
-/obj/item/gun/launcher/crossbow/update_release_force()
-	release_force = tension*release_speed
-
-/obj/item/gun/launcher/crossbow/consume_next_projectile(mob/user=null)
+/obj/item/gun/projectile/crossbow/consume_next_projectile(mob/user)
 	if(tension <= 0)
 		to_chat(user, SPAN_WARNING("\The [src] is not drawn back!"))
 		return null
-	return bolt
+	if(chambered)
+		var/obj/item/projectile/bullet/theBB = chambered.BB
+		for(var/damage in theBB.damage_types)
+			theBB.damage_types[damage] = initial(theBB.damage_types[damage]) * tension
+		return chambered.BB
 
-/obj/item/gun/launcher/crossbow/handle_post_fire(mob/user, atom/target)
-	bolt = null
+
+/obj/item/gun/projectile/crossbow/handle_post_fire(mob/user, atom/target)
 	tension = 0
 	update_icon()
 	..()
 
-/obj/item/gun/launcher/crossbow/attack_self(mob/living/user as mob)
+/obj/item/gun/projectile/crossbow/attack_self(mob/living/user as mob)
 	if(tension)
-		if(bolt)
-			user.visible_message("[user] relaxes the tension on [src]'s string and removes [bolt].","You relax the tension on [src]'s string and remove [bolt].")
-			bolt.loc = get_turf(src)
-			var/obj/item/arrow/A = bolt
-			bolt = null
-			A.removed(user)
-		else
-			user.visible_message("[user] relaxes the tension on [src]'s string.","You relax the tension on [src]'s string.")
+		user.visible_message("[user] relaxes the tension on [src]'s string and unloads it.","You relax the tension on [src]'s string and unload it.")
 		tension = 0
 		update_icon()
 	else
 		draw(user)
 
-/obj/item/gun/launcher/crossbow/proc/draw(var/mob/user as mob)
+/obj/item/gun/projectile/crossbow/proc/draw(var/mob/user as mob)
 
-	if(!bolt)
+	if(!chambered)
 		to_chat(user, "You don't have anything nocked to [src].")
 		return
 
@@ -110,15 +101,15 @@
 	user.visible_message("[user] begins to draw back the string of [src].",SPAN_NOTICE("You begin to draw back the string of [src]."))
 	tension = 1
 
-	while(bolt && tension && loc == current_user)
-		if(!do_after(user, draw_time, src)) //crossbow strings don't just magically pull back on their own.
+	while(chambered && tension && loc == current_user)
+		if(!do_after(user, draw_time, src, immobile = FALSE)) //crossbow strings don't just magically pull back on their own.
 			user.visible_message("[usr] stops drawing and relaxes the string of [src].",SPAN_WARNING("You stop drawing back and relax the string of [src]."))
 			tension = 0
 			update_icon()
 			return
 
 		//double check that the user hasn't removed the bolt in the meantime
-		if(!(bolt && tension && loc == current_user))
+		if(!(chambered && tension && loc == current_user))
 			return
 
 		tension++
@@ -131,68 +122,58 @@
 
 		user.visible_message("[usr] draws back the string of [src]!",SPAN_NOTICE("You continue drawing back the string of [src]!"))
 
-/obj/item/gun/launcher/crossbow/proc/increase_tension(var/mob/user as mob)
-
-	if(!bolt || !tension || current_user != user) //Arrow has been fired, bow has been relaxed or user has changed.
-		return
-
-
-/obj/item/gun/launcher/crossbow/attackby(obj/item/I, mob/user)
-	if(!bolt)
-		if (istype(I,/obj/item/arrow))
-			user.drop_from_inventory(I, src)
-			bolt = I
-			user.visible_message("[user] slides [bolt] into [src].","You slide [bolt] into [src].")
+/obj/item/gun/projectile/crossbow/attackby(obj/item/I, mob/user)
+	if(istype(I,/obj/item/stack/rods) && !chambered)
+		var/obj/item/stack/rods/R = I
+		if(R.use(1))
+			chambered = new /obj/item/ammo_casing/rod_bolt(src)
+			chambered.fingerprintslast = src.fingerprintslast
 			update_icon()
-			return
-		else if(istype(I,/obj/item/stack/rods))
-			var/obj/item/stack/rods/R = I
-			if (R.use(1))
-				bolt = new /obj/item/arrow/rod(src)
-				bolt.fingerprintslast = src.fingerprintslast
-				bolt.loc = src
-				update_icon()
-				user.visible_message("[user] jams [bolt] into [src].","You jam [bolt] into [src].")
-				superheat_rod(user)
-			return
+			user.visible_message("[user] jams [R] into [src].","You jam [R] into [src].")
+			superheat_rod(user)
+
 
 	if(istype(I, /obj/item/cell/large))
 		if(!cell)
-			user.drop_item()
+			insert_item(I, user)
 			cell = I
-			cell.loc = src
-			to_chat(user, SPAN_NOTICE("You jam [cell] into [src] and wire it to the firing coil."))
 			superheat_rod(user)
 		else
 			to_chat(user, SPAN_NOTICE("[src] already has a cell installed."))
 
-	else if(I.get_tool_type(usr, list(QUALITY_SCREW_DRIVING), src))
+	else if(I.get_tool_type(user, list(QUALITY_SCREW_DRIVING), src))
 		if(cell)
-			var/obj/item/C = cell
-			C.loc = get_turf(user)
-			to_chat(user, SPAN_NOTICE("You jimmy [cell] out of [src] with [I]."))
+			eject_item(cell, user)
 			cell = null
 		else
 			to_chat(user, SPAN_NOTICE("[src] doesn't have a cell installed."))
+	else if(chambered)
+		user.visible_message("[user] relaxes the tension on [src]'s string and removes [chambered].","You relax the tension on [src]'s string and remove [chambered].")
+		new /obj/item/stack/rods(get_turf(src))
+		QDEL_NULL(chambered)
+		tension = 0
+		update_icon()
 
 	else
 		..()
 
-/obj/item/gun/launcher/crossbow/proc/superheat_rod(var/mob/user)
-	if(!user || !cell || !bolt) return
-	if(cell.charge < 500) return
-	if(bolt.throwforce >= 15) return
-	if(!istype(bolt,/obj/item/arrow/rod)) return
+/obj/item/gun/projectile/crossbow/proc/superheat_rod(var/mob/user)
+	if(!user || !cell || !chambered)
+		return
+	if(cell.charge < superheat_cost)
+		return
+	if(istype(chambered.BB, superheat_type))
+		return
 
-	to_chat(user, SPAN_NOTICE("[bolt] sparks and crackles as it gives off a red-hot glow."))
-	bolt.throwforce = 15
-	bolt.icon_state = "metal-rod-superheated"
-	cell.use(500)
+	to_chat(user, SPAN_NOTICE("[chambered] sparks and crackles as it gives off a red-hot glow."))
+	QDEL_NULL(chambered.BB)
+	chambered.BB = new superheat_type(chambered)
+	cell.use(superheat_cost)
 
-/obj/item/gun/launcher/crossbow/update_icon()
+/obj/item/gun/projectile/crossbow/update_icon()
 	if(tension > 1)
 		icon_state = "crossbow-drawn"
-	else if(bolt)
+	else if(chambered)
 		icon_state = "crossbow-nocked"
 	else
 		icon_state = "crossbow"
@@ -200,25 +181,24 @@
 /*////////////////////////////
 //	Rapid Crossbow Device	//
 */////////////////////////////
-/obj/item/arrow/RCD
-	name = "flashforged bolt"
-	desc = "The ultimate ghetto 'deconstruction' implement."
-	throwforce = 6
 
-/obj/item/gun/launcher/crossbow/RCD
+/obj/item/gun/projectile/crossbow/RCD
 	name = "rapid crossbow device"
 	desc = "A hacked together RCD turns an innocent construction tool into the penultimate 'deconstruction' tool. Flashforges projectiles using matter units when the string is drawn back."
 	icon = 'icons/obj/guns/launcher/rxb.dmi'
 	icon_state = "rxb"
 	slot_flags = null
 	draw_time = 5
+	superheat_cost = 150 //guild design, more efficient or something
 	var/stored_matter = 0
 	var/max_stored_matter = 60
 	var/boltcost = 5
+	var/obj/item/ammo_casing/flashforge_type = /obj/item/ammo_casing/rod_bolt/rcd
+	superheat_type = /obj/item/projectile/bullet/rod_bolt/rcd/superhot
 
-/obj/item/gun/launcher/crossbow/RCD/proc/genBolt(var/mob/user)
-	if(stored_matter >= boltcost && !bolt)
-		bolt = new/obj/item/arrow/RCD(src)
+/obj/item/gun/projectile/crossbow/RCD/proc/genBolt(var/mob/user)
+	if(stored_matter >= boltcost && !chambered)
+		chambered = new flashforge_type(src)
 		stored_matter -= boltcost
 		to_chat(user, "<span class='notice'>The RXD flashforges a new bolt!</span>")
 		update_icon()
@@ -226,7 +206,7 @@
 		to_chat(user, "<span class='warning'>The \'Low Ammo\' light on the device blinks yellow.</span>")
 		flick("[icon_state]-empty", src)
 
-/obj/item/gun/launcher/crossbow/RCD/attack_self(mob/living/user as mob)
+/obj/item/gun/projectile/crossbow/RCD/attack_self(mob/living/user as mob)
 	if(tension)
 		user.visible_message("[user] relaxes the tension on [src]'s string.","You relax the tension on [src]'s string.")
 		tension = 0
@@ -235,21 +215,21 @@
 		genBolt(user)
 		draw(user)
 
-/obj/item/gun/launcher/crossbow/RCD/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/gun/projectile/crossbow/RCD/attackby(obj/item/W as obj, mob/user as mob)
 	var/obj/item/stack/material/M = W
 	if(istype(M) && M.material.name == MATERIAL_COMPRESSED_MATTER)
 		var/amount = min(M.get_amount(), round(max_stored_matter - stored_matter))
 		if(M.use(amount) && stored_matter < max_stored_matter)
 			stored_matter += amount
 			playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-			to_chat(user, "<span class='notice'>You load [amount] Compressed Matter into \the [src].</span>. The RXD now holds [stored_matter]/60 matter-units.")
+			to_chat(user, "<span class='notice'>You load [amount] Compressed Matter into \the [src].</span>. The RXD now holds [stored_matter]/[max_stored_matter] matter-units.")
 			update_icon()	//Updates the ammo counter
 		if (M.use(amount) && stored_matter >= max_stored_matter)
 			to_chat(user, "<span class='notice'>The RXD is full.")
 	else
 		..()
-	if(istype(W, /obj/item/arrow/RCD))
-		var/obj/item/arrow/RCD/A = W
+	if(istype(W, /obj/item/arrow/rcd))
+		var/obj/item/arrow/rcd/A = W
 		if((stored_matter + 5) > max_stored_matter)
 			to_chat(user, "<span class='notice'>Unable to reclaim flashforged bolt. The RXD can't hold that many additional matter-units.</span>")
 			return
@@ -260,9 +240,9 @@
 		update_icon()
 		return
 
-/obj/item/gun/launcher/crossbow/RCD/update_icon()
+/obj/item/gun/projectile/crossbow/RCD/update_icon()
 	cut_overlays()
-	if(bolt)
+	if(chambered)
 		add_overlay("rxb-bolt")
 	var/ratio = 0
 	if(stored_matter < boltcost)
@@ -276,7 +256,19 @@
 	else
 		icon_state = "rxb"
 
-/obj/item/gun/launcher/crossbow/RCD/examine(var/user)
+/obj/item/gun/projectile/crossbow/RCD/examine(var/user)
 	. = ..()
 	if(.)
 		to_chat(user, "It currently holds [stored_matter]/[max_stored_matter] matter-units.")
+
+
+/obj/item/gun/projectile/crossbow/RCD/industrial
+	name = "industrial rapid crossbow device"
+	desc = "A hacked together RCD turns an innocent construction tool into the penultimate 'deconstruction' tool. Flashforges projectiles using matter units when the string is drawn back."
+	icon = 'icons/obj/guns/launcher/rxb.dmi' //todo
+	icon_state = "rxb"
+	slot_flags = null
+	draw_time = 4
+	superheat_cost = 100 //guild design, more efficient or something
+	max_stored_matter = 120
+	boltcost = 2

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -75,6 +75,9 @@
 		return chambered.BB
 
 
+/obj/item/gun/projectile/crossbow/loadAmmoBestGuess()
+	return
+
 /obj/item/gun/projectile/crossbow/handle_post_fire(mob/user, atom/target)
 	tension = 0
 	update_icon()
@@ -133,7 +136,7 @@
 			superheat_rod(user)
 
 
-	if(istype(I, /obj/item/cell/large))
+	else if(istype(I, /obj/item/cell/large))
 		if(!cell)
 			insert_item(I, user)
 			cell = I
@@ -256,10 +259,9 @@
 	else
 		icon_state = "rxb"
 
-/obj/item/gun/projectile/crossbow/RCD/examine(var/user)
-	. = ..()
-	if(.)
-		to_chat(user, "It currently holds [stored_matter]/[max_stored_matter] matter-units.")
+/obj/item/gun/projectile/crossbow/RCD/examine(mob/user)
+	..()
+	to_chat(user, "It currently holds [stored_matter]/[max_stored_matter] matter-units.")
 
 
 /obj/item/gun/projectile/crossbow/RCD/industrial

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -55,6 +55,7 @@
 	load_method = SINGLE_CASING
 	max_shells = 1
 	ammo_type = /obj/item/ammo_casing/rod_bolt
+	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE)
 	var/obj/item/projectile/superheat_type = /obj/item/projectile/bullet/rod_bolt/superheated
 	var/tension = 0                         // Current draw on the bow.
 	var/max_tension = 5                     // Highest possible tension.

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -68,10 +68,12 @@
 	if(tension <= 0)
 		to_chat(user, SPAN_WARNING("\The [src] is not drawn back!"))
 		return null
+	new_damtypes = list()
 	if(chambered)
 		var/obj/item/projectile/bullet/theBB = chambered.BB
 		for(var/damage in theBB.damage_types)
-			theBB.damage_types[damage] = initial(theBB.damage_types[damage]) * tension
+			new_damtypes[damage] = theBB.damage_types[damage] * tension
+		chambered.bb.damage_types = new_damtypes
 		return chambered.BB
 
 

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -72,9 +72,7 @@
 	var/list/new_damtypes = list()
 	if(chambered)
 		var/obj/item/projectile/bullet/theBB = chambered.BB
-		for(var/damage in theBB.damage_types)
-			new_damtypes[damage] = theBB.damage_types[damage] * tension
-		theBB.damage_types = new_damtypes
+		theBB.multiply_projectile_damage(tension)
 		return chambered.BB
 
 

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -60,7 +60,7 @@
 	var/max_tension = 5                     // Highest possible tension.
 	cell = null    // Used for firing superheated rods.
 	var/current_user                        // Used to check if the crossbow has changed hands since being drawn.
-	var/draw_time = 20							// How long it takes to increase the draw on the bow by one "tension"
+	var/draw_time = 10							// How long it takes to increase the draw on the bow by one "tension"
 	serial_type = null //it's a handmade crossbow who's putting serials on it
 	var/superheat_cost = 250
 
@@ -68,12 +68,12 @@
 	if(tension <= 0)
 		to_chat(user, SPAN_WARNING("\The [src] is not drawn back!"))
 		return null
-	new_damtypes = list()
+	var/list/new_damtypes = list()
 	if(chambered)
 		var/obj/item/projectile/bullet/theBB = chambered.BB
 		for(var/damage in theBB.damage_types)
 			new_damtypes[damage] = theBB.damage_types[damage] * tension
-		chambered.bb.damage_types = new_damtypes
+		theBB.damage_types = new_damtypes
 		return chambered.BB
 
 
@@ -193,7 +193,7 @@
 	icon = 'icons/obj/guns/launcher/rxb.dmi'
 	icon_state = "rxb"
 	slot_flags = null
-	draw_time = 5
+	draw_time = 7.5
 	superheat_cost = 150 //guild design, more efficient or something
 	var/stored_matter = 0
 	var/max_stored_matter = 60
@@ -214,6 +214,14 @@
 /obj/item/gun/projectile/crossbow/RCD/attack_self(mob/living/user as mob)
 	if(tension)
 		user.visible_message("[user] relaxes the tension on [src]'s string.","You relax the tension on [src]'s string.")
+		if(chambered)
+			if((stored_matter + 5) > max_stored_matter)
+				to_chat(user, "<span class='notice'>Unable to reclaim flashforged bolt. The RXD can't hold that many additional matter-units.</span>")
+				new /obj/item/arrow/rcd(get_turf(src))
+				return
+			to_chat(user, "<span class='notice'>Reclaimed flashforged bolt.</span>")
+			QDEL_NULL(chambered)
+			stored_matter += 5
 		tension = 0
 		update_icon()
 	else
@@ -264,15 +272,3 @@
 /obj/item/gun/projectile/crossbow/RCD/examine(mob/user)
 	..()
 	to_chat(user, "It currently holds [stored_matter]/[max_stored_matter] matter-units.")
-
-
-/obj/item/gun/projectile/crossbow/RCD/industrial
-	name = "industrial rapid crossbow device"
-	desc = "A hacked together RCD turns an innocent construction tool into the penultimate 'deconstruction' tool. Flashforges projectiles using matter units when the string is drawn back."
-	icon = 'icons/obj/guns/launcher/rxb.dmi' //todo
-	icon_state = "rxb"
-	slot_flags = null
-	draw_time = 4
-	superheat_cost = 100 //guild design, more efficient or something
-	max_stored_matter = 120
-	boltcost = 2

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -746,3 +746,56 @@
 	affective_ap_range = 9
 	nocap_structures = TRUE //Can do well againt walls and doors
 
+
+/obj/item/projectile/bullet/rod_bolt
+	name = "metal rod"
+	icon_state = "bolt"
+	damage_types = list(BRUTE = 10) //This is multiplied by tension when fired, so it's actually 50 damage.
+	armor_penetration = 15
+	step_delay = 0.9
+	embed = FALSE
+	penetrating = 1
+	affective_damage_range = 7
+	affective_ap_range = 7
+	var/obj/item/create_type = /obj/item/stack/rods
+
+/obj/item/projectile/bullet/rod_bolt/on_impact(atom/A)
+	if(create_type)
+		new create_type(get_turf(src))
+	..()
+
+/obj/item/projectile/bullet/rod_bolt/superheated
+	name = "superheated metal rod"
+	damage_types = list(BRUTE = 10, BURN = 2.5) //This is multiplied by tension when fired, so it's actually 62.5 damage.
+	armor_penetration = 20
+	step_delay = 0.6
+	embed = TRUE
+	penetrating = 0
+	affective_damage_range = 7
+	affective_ap_range = 7
+	create_type = null
+
+
+/obj/item/projectile/bullet/rod_bolt/rcd
+	name = "flashforged rod"
+	icon_state = "bolt"
+	damage_types = list(BRUTE = 9) //This is multiplied by tension when fired, so it's actually 45 damage. Slightly worse, but it's faster and has higher AP.
+	armor_penetration = 30
+	step_delay = 0.6
+	embed = FALSE
+	penetrating = 1
+	affective_damage_range = 7
+	affective_ap_range = 7
+	create_type = /obj/item/arrow/rcd
+
+/obj/item/projectile/bullet/rod_bolt/rcd/superhot
+	name = "flashforged superheated rod"
+	icon_state = "bolt"
+	damage_types = list(BRUTE = 9, BURN = 2.5) //This is multiplied by tension when fired, so it's actually 57.5 damage. Slightly worse, but it's faster and has higher AP.
+	armor_penetration = 30
+	step_delay = 0.2
+	embed = TRUE
+	penetrating = 0
+	affective_damage_range = 7
+	affective_ap_range = 7
+	create_type = null

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -764,7 +764,6 @@
 	if(create_type)
 		new create_type(get_turf(src))
 
-
 /obj/item/projectile/bullet/rod_bolt/superheated
 	name = "superheated metal rod"
 	damage_types = list(BRUTE = 10, BURN = 2.5) //This is multiplied by tension when fired, so it's actually 62.5 damage.

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -760,9 +760,10 @@
 	var/obj/item/create_type = /obj/item/stack/rods
 
 /obj/item/projectile/bullet/rod_bolt/on_impact(atom/A)
+	..()
 	if(create_type)
 		new create_type(get_turf(src))
-	..()
+
 
 /obj/item/projectile/bullet/rod_bolt/superheated
 	name = "superheated metal rod"

--- a/maps/Centcom/map/centcom.dmm
+++ b/maps/Centcom/map/centcom.dmm
@@ -3109,7 +3109,7 @@
 /area/shuttle/skipjack_area)
 "iS" = (
 /obj/structure/table/rack,
-/obj/item/gun/launcher/crossbow,
+/obj/item/gun/projectile/crossbow,
 /obj/item/stack/rods{
 	amount = 10
 	},

--- a/maps/_DeepForest/map/_River_Forest.dmm
+++ b/maps/_DeepForest/map/_River_Forest.dmm
@@ -945,7 +945,7 @@
 /turf/simulated/floor/rock/grey,
 /area/nadezhda/outside/forest/river_forest_dark)
 "oO" = (
-/obj/item/gun/launcher/crossbow,
+/obj/item/gun/projectile/crossbow,
 /obj/structure/table/bench/padded,
 /turf/simulated/floor/asteroid/grass/jungle,
 /area/nadezhda/outside/forest/river_forest_light)
@@ -4250,7 +4250,7 @@
 /area/nadezhda/outside/forest/river_forest_light)
 "ZW" = (
 /obj/item/remains,
-/obj/item/gun/launcher/crossbow,
+/obj/item/gun/projectile/crossbow,
 /obj/item/clothing/under/gorka/camo,
 /obj/random/cloth/shoes,
 /obj/item/oddity/common/old_knife,

--- a/maps/__Nadezhda/map/Surface_Old.dmm
+++ b/maps/__Nadezhda/map/Surface_Old.dmm
@@ -25033,7 +25033,7 @@
 "bmj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/gun/launcher/crossbow,
+/obj/item/gun/projectile/crossbow,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest)
 "bmk" = (

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -84496,7 +84496,7 @@
 "rZf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/gun/launcher/crossbow,
+/obj/item/gun/projectile/crossbow,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest)
 "rZl" = (

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Surface.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Surface.dmm
@@ -13781,7 +13781,7 @@
 "iBW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/gun/launcher/crossbow,
+/obj/item/gun/projectile/crossbow,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest)
 "iCe" = (


### PR DESCRIPTION
powered crossbows are no longer only useful for pvp in closed areas (with pinning)


Crossbow projectile damage now scales with tension. Every second of charging gets you 100% more damage, with 10 damage base for metal rods.

crossbows now do 50 damage at full charge (achieved after 5 seconds of charging). Rods are still reusable as ammo. Basic rods can't embed.

RXDs have been nerfed slightly- now they have less damage, but higher AP. This is due to their ease of ammo handling compared to regular crossbows- you don't have to unwield to shoot, and to set them apart somewhat due to their significantly higher material cost.

Heated crossbow bolts do a mix of brute and burn: 12.5 extra burn on both regular bolts and RXD bolts, embedding, but at the cost of not being able to recover your ammunition and -1 wall penetration.

<hr>
</details>

## Changelog
:cl:
balance: crossbows have been buffed into usability
/:cl:
