### PR TITLE
Economic Recession (Price Balance)

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -20,7 +20,7 @@
 	var/inject_amount = 10
 	required_type = /obj/mecha/medical
 	salvageable = 0
-	price_tag = 200
+	price_tag = 120
 
 	New()
 		..()

--- a/code/game/mecha/equipment/tools/shields.dm
+++ b/code/game/mecha/equipment/tools/shields.dm
@@ -7,7 +7,7 @@
 	equip_cooldown = 5
 	energy_drain = 20
 	range = 0
-	price_tag = 2000
+	price_tag = 520
 
 	var/obj/item/shield_projector/line/exosuit/my_shield = null
 	var/my_shield_type = /obj/item/shield_projector/line/exosuit

--- a/code/game/mecha/equipment/tools/thruster.dm
+++ b/code/game/mecha/equipment/tools/thruster.dm
@@ -9,7 +9,7 @@
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_GLASS = 5)
 	equip_cooldown = 5
 	energy_drain = 50
-	price_tag = 300
+	price_tag = 100
 	var/wait = 0
 	var/obj/item/tank/jetpack/mecha/thrust
 	equip_ready = FALSE

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -22,6 +22,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/tool
 	matter = list(MATERIAL_STEEL = 15)
+	price_tag = 60
 
 /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp
 	name = "hydraulic clamp"
@@ -31,6 +32,8 @@
 	var/dam_force = 20
 	var/obj/mecha/working/ripley/cargo_holder
 	required_type = list(/obj/mecha/working, /obj/mecha/combat, /obj/mecha/medical)
+	matter = list(MATERIAL_STEEL = 15)
+	price_tag = 60
 
 	attach(obj/mecha/M as obj)
 		..()
@@ -108,7 +111,8 @@
 	icon_state = "mecha_drill"
 	equip_cooldown = 30
 	energy_drain = 10
-	price_tag = 150
+	matter = list(MATERIAL_STEEL = 15)
+	price_tag = 60
 	force = WEAPON_FORCE_DANGEROUS
 	required_type = list(/obj/mecha/working, /obj/mecha/combat, /obj/mecha/medical)
 
@@ -166,6 +170,7 @@
 	icon_state = "mecha_diamond_drill"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_STEEL = 15, MATERIAL_DIAMOND = 3)
+	price_tag = 210
 	equip_cooldown = 10 // 3 diamonds for 3x the speed!
 	force = 25 //Lets not be out classed by a wrench...
 
@@ -221,7 +226,8 @@
 	energy_drain = 0
 	range = MECHA_MELEE|MECHA_RANGED
 	required_type = /obj/mecha/working
-	price_tag = 100
+	matter = list(MATERIAL_STEEL = 15)
+	price_tag = 60
 	var/spray_particles = 5
 	var/spray_amount = 5	//units of liquid per particle. 5 is enough to wet the floor - it's a big fire extinguisher, so should be fine
 	var/max_water = 1000
@@ -295,7 +301,7 @@
 	energy_drain = 250
 	range = MECHA_MELEE|MECHA_RANGED
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASMA = 15, MATERIAL_URANIUM = 15)
-	price_tag = 1500
+	price_tag = 860
 	var/mode = 0 //0 - deconstruct, 1 - wall or floor, 2 - airlock.
 	var/disabled = 0 //malf
 
@@ -580,7 +586,7 @@
 	deflect_coeff = 1.15
 	damage_coeff = 0.8
 	melee = 1
-	price_tag = 600
+	price_tag = 130
 
 	activate_boost()
 		if(..())
@@ -605,7 +611,7 @@
 	deflect_coeff = 1.15
 	damage_coeff = 0.8
 	melee = 0
-	price_tag = 600
+	price_tag = 180
 
 	activate_boost()
 		if(..())
@@ -629,7 +635,7 @@
 	energy_drain = 100
 	range = 0
 	matter = list(MATERIAL_STEEL = 10, MATERIAL_GOLD = 10, MATERIAL_SILVER = 2, MATERIAL_GLASS = 5)
-	price_tag = 1200
+	price_tag = 180
 	var/health_boost = 2
 	var/datum/global_iterator/pr_repair_droid
 	var/icon/droid_overlay
@@ -725,7 +731,7 @@
 	equip_cooldown = 10
 	energy_drain = 0
 	range = 0
-	price_tag = 900
+	price_tag = 118
 	var/datum/global_iterator/pr_energy_relay
 	var/coeff = 100
 	var/list/use_channels = list(STATIC_EQUIP,STATIC_ENVIRON,STATIC_LIGHT)
@@ -812,6 +818,7 @@
 	energy_drain = 0
 	range = MECHA_MELEE
 	matter = list(MATERIAL_STEEL = 10, MATERIAL_SILVER = 5, MATERIAL_GLASS = 1)
+	price_tag = 94
 	var/datum/global_iterator/pr_mech_generator
 	var/coeff = 100
 	var/obj/item/stack/material/fuel

--- a/code/game/mecha/equipment/weapons/ranged.dm
+++ b/code/game/mecha/equipment/weapons/ranged.dm
@@ -7,6 +7,7 @@
 	range = MECHA_RANGED
 	origin_tech = list(TECH_MATERIAL = 3, TECH_COMBAT = 3)
 	matter = list(MATERIAL_STEEL = 15)
+	price_tag = 60
 	var/projectile //Type of projectile fired.
 	var/projectiles = 1 //Amount of projectiles loaded.
 	var/projectiles_per_shot = 1 //Amount of projectiles fired per single shot.

--- a/code/game/mecha/equipment/weapons/ranged/bullet_weapons.dm
+++ b/code/game/mecha/equipment/weapons/ranged/bullet_weapons.dm
@@ -21,6 +21,7 @@
 	var/amount_per_click = 1 //how many we load per click. Used to
 	var/ammo_type = "mew" //What kinda ammo do we load?
 	matter = list(MATERIAL_STEEL = 35)
+	price_tag = 140
 
 /obj/item/mech_ammo_box/examine(mob/user)
 	..()
@@ -99,7 +100,8 @@
 	ammo_amount_left = 40
 	ammo_max_amout = 40
 	ammo_type = "12g"
-	price_tag = 30
+	matter = list(MATERIAL_STEEL = 35)
+	price_tag = 140
 
 /obj/item/mecha_parts/mecha_equipment/ranged_weapon/ballistic/scattershot
 	name = "\improper LBX AC 10 \"Scattershot\""
@@ -131,7 +133,8 @@
 	projectiles_per_shot = 6
 	deviation = 0.9
 	required_type = list(/obj/mecha/combat, /obj/mecha/working, /obj/mecha/working)
-	price_tag = 700
+	matter = list(MATERIAL_STEEL = 15)
+	price_tag = 60
 
 /obj/item/mecha_parts/mecha_equipment/ranged_weapon/ballistic/scattershot/flak/loaded
 	loaded = TRUE
@@ -145,7 +148,8 @@
 	ammo_max_amout = 300
 	amount_per_click = 3 //Hack to make them impossable to go into negitives
 	ammo_type = "5.56"
-	price_tag = 30
+	matter = list(MATERIAL_STEEL = 35)
+	price_tag = 140
 
 /obj/item/mecha_parts/mecha_equipment/ranged_weapon/ballistic/lmg
 	name = "\improper Ultra AC 2"

--- a/code/game/mecha/equipment/weapons/ranged/laser_weapons.dm
+++ b/code/game/mecha/equipment/weapons/ranged/laser_weapons.dm
@@ -15,6 +15,8 @@
 	name = "general energy weapon"
 	auto_rearm = 1
 	range = MECHA_MELEE | MECHA_RANGED
+	matter = list(MATERIAL_STEEL = 15)
+	price_tag = 60
 
 /obj/item/mecha_parts/mecha_equipment/ranged_weapon/energy/laser
 	equip_cooldown = 8
@@ -23,7 +25,6 @@
 	energy_drain = 30
 	projectile = /obj/item/projectile/beam
 	fire_sound = 'sound/weapons/Laser.ogg'
-	price_tag = 400
 
 /obj/item/mecha_parts/mecha_equipment/ranged_weapon/energy/riggedlaser
 	equip_cooldown = 15
@@ -34,7 +35,6 @@
 	projectile = /obj/item/projectile/beam
 	fire_sound = 'sound/weapons/Laser.ogg'
 	required_type = list(/obj/mecha/combat, /obj/mecha/working, /obj/mecha/working)
-	price_tag = 200
 
 /obj/item/mecha_parts/mecha_equipment/ranged_weapon/energy/laser/heavy
 	equip_cooldown = 15
@@ -43,7 +43,6 @@
 	energy_drain = 60
 	projectile = /obj/item/projectile/beam/heavylaser
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
-	price_tag = 500
 
 /obj/item/mecha_parts/mecha_equipment/ranged_weapon/energy/laser/heavy/auto
 	equip_cooldown = 5
@@ -64,7 +63,6 @@
 	energy_drain = 120
 	projectile = /obj/item/projectile/ion
 	fire_sound = 'sound/weapons/Laser.ogg'
-	price_tag = 300
 
 /obj/item/mecha_parts/mecha_equipment/ranged_weapon/energy/pulse
 	equip_cooldown = 30
@@ -92,7 +90,7 @@
 	origin_tech = list(TECH_COMBAT = 9, TECH_MATERIAL = 7, TECH_PLASMA = 10)
 	projectile = /obj/item/projectile/hydrogen/cannon/max
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
-	price_tag = 1300 //state of the art
+	price_tag = 320 //state of the art
 
 /* Commenting this out rather than removing it because it may be useful for reference.
 /obj/item/mecha_parts/mecha_equipment/ranged_weapon/honker

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -43,7 +43,7 @@
 	desc = "A chassis or case for a Ripley mech, needs Ripley torso, arms and legs."
 	construct_type = /datum/construction/mecha/ripley_chassis
 	matter = list(MATERIAL_STEEL = 30)
-	price_tag = 700
+	price_tag = 120
 
 /obj/item/mecha_parts/chassis/ripley/firefighter
 	name = "Firefighter Chassis"
@@ -56,7 +56,7 @@
 	icon_state = "ripley_harness"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_BIO = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 40, MATERIAL_GLASS = 25)
-	price_tag = 700
+	price_tag = 260
 
 /obj/item/mecha_parts/part/ripley_left_arm
 	name = "Ripley Left Arm"
@@ -64,7 +64,7 @@
 	icon_state = "ripley_l_arm"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 18)
-	price_tag = 700
+	price_tag = 72
 
 /obj/item/mecha_parts/part/ripley_right_arm
 	name = "Ripley Right Arm"
@@ -72,7 +72,7 @@
 	icon_state = "ripley_r_arm"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 18)
-	price_tag = 700
+	price_tag = 72
 
 /obj/item/mecha_parts/part/ripley_left_leg
 	name = "Ripley Left Leg"
@@ -80,7 +80,7 @@
 	icon_state = "ripley_l_leg"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 18)
-	price_tag = 700
+	price_tag = 72
 
 /obj/item/mecha_parts/part/ripley_right_leg
 	name = "Ripley Right Leg"
@@ -88,7 +88,7 @@
 	icon_state = "ripley_r_leg"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 18)
-	price_tag = 700
+	price_tag = 72
 
 ///////// Ivan
 
@@ -97,7 +97,7 @@
 	desc = "A chassis or case for a Ivan mech, needs Ivan torso, arms and legs."
 	construct_type = /datum/construction/mecha/ivan_chassis
 	matter = list(MATERIAL_STEEL = 20)
-	price_tag = 350
+	price_tag = 80
 
 /obj/item/mecha_parts/part/ivan_torso
 	name = "Ivan Torso"
@@ -105,7 +105,7 @@
 	icon_state = "ripley_harness"
 	origin_tech = list(TECH_DATA = 1, TECH_MATERIAL = 1, TECH_BIO = 1, TECH_ENGINEERING = 1)
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_GLASS = 20)
-	price_tag = 350
+	price_tag = 160
 
 /obj/item/mecha_parts/part/ivan_left_arm
 	name = "Ivan Left Arm"
@@ -113,7 +113,7 @@
 	icon_state = "ripley_l_arm"
 	origin_tech = list(TECH_DATA = 1, TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	matter = list(MATERIAL_STEEL = 10)
-	price_tag = 350
+	price_tag = 40
 
 /obj/item/mecha_parts/part/ivan_right_arm
 	name = "Ivan Right Arm"
@@ -121,7 +121,7 @@
 	icon_state = "ripley_r_arm"
 	origin_tech = list(TECH_DATA = 1, TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	matter = list(MATERIAL_STEEL = 10)
-	price_tag = 350
+	price_tag = 40
 
 /obj/item/mecha_parts/part/ivan_left_leg
 	name = "Ivan Left Leg"
@@ -129,7 +129,7 @@
 	icon_state = "ripley_l_leg"
 	origin_tech = list(TECH_DATA = 1, TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	matter = list(MATERIAL_STEEL = 10)
-	price_tag = 350
+	price_tag = 40
 
 /obj/item/mecha_parts/part/ivan_right_leg
 	name = "Ivan Right Leg"
@@ -137,7 +137,7 @@
 	icon_state = "ripley_r_leg"
 	origin_tech = list(TECH_DATA = 1, TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 	matter = list(MATERIAL_STEEL = 10)
-	price_tag = 350
+	price_tag = 40
 
 ///////// Gygax
 
@@ -146,6 +146,7 @@
 	desc = "The chassis for a Gygax mech. Needs a Gygax head, torso, arms and legs, as well as anti-staining paint and a SMES coil."
 	construct_type = /datum/construction/mecha/gygax_chassis
 	matter = list(MATERIAL_PLASTEEL = 30)
+	price_tag = 480
 
 /obj/item/mecha_parts/part/gygax_torso
 	name = "Gygax Torso"
@@ -153,6 +154,7 @@
 	icon_state = "gygax_harness"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_BIO = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 25)
+	price_tag = 400
 
 /obj/item/mecha_parts/part/gygax_head
 	name = "Gygax Head"
@@ -160,6 +162,7 @@
 	icon_state = "gygax_head"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_MAGNET = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_GLASS = 10)
+	price_tag = 440
 
 /obj/item/mecha_parts/part/gygax_left_arm
 	name = "Gygax Left Arm"
@@ -167,6 +170,7 @@
 	icon_state = "gygax_l_arm"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 20)
+	price_tag = 320
 
 /obj/item/mecha_parts/part/gygax_right_arm
 	name = "Gygax Right Arm"
@@ -174,24 +178,28 @@
 	icon_state = "gygax_r_arm"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 20)
+	price_tag = 320
 
 /obj/item/mecha_parts/part/gygax_left_leg
 	name = "Gygax Left Leg"
 	icon_state = "gygax_l_leg"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 20)
+	price_tag = 320
 
 /obj/item/mecha_parts/part/gygax_right_leg
 	name = "Gygax Right Leg"
 	icon_state = "gygax_r_leg"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 20)
+	price_tag = 320
 
 /obj/item/mecha_parts/part/gygax_armour
 	name = "Gygax Armour Plates"
 	icon_state = "gygax_armour"
 	origin_tech = list(TECH_MATERIAL = 6, TECH_COMBAT = 4, TECH_ENGINEERING = 5)
 	matter = list(MATERIAL_STEEL = 30, MATERIAL_PLASMA = 10)
+	price_tag = 280
 
 
 //////////// Durand
@@ -201,48 +209,56 @@
 	desc = "The chassis for a Durand mech. Needs a Durand head, torso, arms and legs, as well as magboots and four brace bars."
 	construct_type = /datum/construction/mecha/durand_chassis
 	matter = list(MATERIAL_PLASTEEL = 30)
+	price_tag = 480
 
 /obj/item/mecha_parts/part/durand_torso
 	name = "Durand Torso"
 	icon_state = "durand_harness"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 3, TECH_BIO = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 50, MATERIAL_GLASS = 10, MATERIAL_SILVER = 10)
+	price_tag = 940
 
 /obj/item/mecha_parts/part/durand_head
 	name = "Durand Head"
 	icon_state = "durand_head"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 3, TECH_MAGNET = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_GLASS = 10, MATERIAL_SILVER = 3)
+	price_tag = 390
 
 /obj/item/mecha_parts/part/durand_left_arm
 	name = "Durand Left Arm"
 	icon_state = "durand_l_arm"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_SILVER = 3)
+	price_tag = 510
 
 /obj/item/mecha_parts/part/durand_right_arm
 	name = "Durand Right Arm"
 	icon_state = "durand_r_arm"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_SILVER = 3)
+	price_tag = 510
 
 /obj/item/mecha_parts/part/durand_left_leg
 	name = "Durand Left Leg"
 	icon_state = "durand_l_leg"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_SILVER = 3)
+	price_tag = 510
 
 /obj/item/mecha_parts/part/durand_right_leg
 	name = "Durand Right Leg"
 	icon_state = "durand_r_leg"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_SILVER = 3)
+	price_tag = 510
 
 /obj/item/mecha_parts/part/durand_armour
 	name = "Durand Armour Plates"
 	icon_state = "durand_armour"
 	origin_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 4, TECH_ENGINEERING = 5)
 	matter = list(MATERIAL_PLASTEEL = 50, MATERIAL_URANIUM = 10)
+	price_tag = 1000
 
 
 
@@ -256,48 +272,56 @@
 	origin_tech = list(TECH_MATERIAL =7)
 	construct_type = /datum/construction/mecha/phazon_chassis
 	matter = list(MATERIAL_PLASTEEL = 25)
+	price_tag = 400
 
 /obj/item/mecha_parts/part/phazon_torso
 	name = "Phazon Torso"
 	icon_state = "phazon_harness"
 	origin_tech = list(TECH_MATERIAL = 7, TECH_BLUESPACE = 7, TECH_DATA = 7, TECH_POWER = 7)
 	matter = list(MATERIAL_PLASTEEL = 35, MATERIAL_GLASS = 10, MATERIAL_PLASMA = 20)
+	price_tag = 920
 
 /obj/item/mecha_parts/part/phazon_head
 	name = "Phazon Head"
 	icon_state = "phazon_head"
 	origin_tech = list(TECH_MATERIAL = 5, TECH_BLUESPACE = 2, TECH_MAGNET = 6, TECH_DATA = 6)
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_GLASS = 5, MATERIAL_PLASMA = 10, MATERIAL_SILVER = 30)
+	price_tag = 720
 
 /obj/item/mecha_parts/part/phazon_left_arm
 	name = "Phazon Left Arm"
 	icon_state = "phazon_l_arm"
 	origin_tech = list(TECH_MATERIAL = 5, TECH_BLUESPACE = 2, TECH_MAGNET = 3)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASMA = 10, MATERIAL_SILVER = 3)
+	price_tag = 510
 
 /obj/item/mecha_parts/part/phazon_right_arm
 	name = "Phazon Right Arm"
 	icon_state = "phazon_r_arm"
 	origin_tech = list(TECH_MATERIAL = 5, TECH_BLUESPACE = 2, TECH_MAGNET = 3)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASMA = 10, MATERIAL_SILVER = 3)
+	price_tag = 510
 
 /obj/item/mecha_parts/part/phazon_left_leg
 	name = "Phazon Left Leg"
 	icon_state = "phazon_l_leg"
 	origin_tech = list(TECH_MATERIAL = 5, TECH_BLUESPACE = 2, TECH_MAGNET = 3)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASMA = 10, MATERIAL_SILVER = 3)
+	price_tag = 510
 
 /obj/item/mecha_parts/part/phazon_right_leg
 	name = "Phazon Right Leg"
 	icon_state = "phazon_r_leg"
 	origin_tech = list(TECH_MATERIAL = 5, TECH_BLUESPACE = 2, TECH_MAGNET = 3)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASMA = 10, MATERIAL_SILVER = 3)
+	price_tag = 510
 
 /obj/item/mecha_parts/part/phazon_armor
 	name = "Phazon Armor Plates"
 	icon_state = "phazon_armor"
 	origin_tech = list(TECH_MATERIAL = 5, TECH_BLUESPACE = 3, TECH_MAGNET = 3)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASMA = 10, MATERIAL_URANIUM = 10, MATERIAL_SILVER = 10, MATERIAL_DIAMOND = 5)
+	price_tag = 1030
 
 ///////// Odysseus
 
@@ -307,14 +331,14 @@
 	desc = "The chassis for an Odysseus mech. Needs an Odysseus head, arms and legs."
 	construct_type = /datum/construction/mecha/odysseus_chassis
 	matter = list(MATERIAL_STEEL = 25)
-	price_tag = 800
+	price_tag = 100
 
 /obj/item/mecha_parts/part/odysseus_head
 	name = "Odysseus Head"
 	icon_state = "odysseus_head"
 	origin_tech = list(TECH_DATA = 3, TECH_MATERIAL = 2)
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_GLASS = 15)
-	price_tag = 800
+	price_tag = 140
 
 /obj/item/mecha_parts/part/odysseus_torso
 	name = "Odysseus Torso"
@@ -322,7 +346,7 @@
 	icon_state = "odysseus_torso"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_BIO = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 20)
-	price_tag = 800
+	price_tag = 80
 
 /obj/item/mecha_parts/part/odysseus_left_arm
 	name = "Odysseus Left Arm"
@@ -330,7 +354,7 @@
 	icon_state = "odysseus_l_arm"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 12)
-	price_tag = 800
+	price_tag = 48
 
 /obj/item/mecha_parts/part/odysseus_right_arm
 	name = "Odysseus Right Arm"
@@ -338,7 +362,7 @@
 	icon_state = "odysseus_r_arm"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 12)
-	price_tag = 800
+	price_tag = 48
 
 /obj/item/mecha_parts/part/odysseus_left_leg
 	name = "Odysseus Left Leg"
@@ -346,7 +370,7 @@
 	icon_state = "odysseus_l_leg"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 12)
-	price_tag = 800
+	price_tag = 48
 
 /obj/item/mecha_parts/part/odysseus_right_leg
 	name = "Odysseus Right Leg"
@@ -354,4 +378,4 @@
 	icon_state = "odysseus_r_leg"
 	origin_tech = list(TECH_DATA = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_STEEL = 12)
-	price_tag = 800
+	price_tag = 48

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -7,7 +7,7 @@
 	icon_state = "bodybag_folded"
 	w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_PLASTIC = 2)
-	price_tag = 10
+	price_tag = 4
 
 	attack_self(mob/user)
 		var/obj/structure/closet/body_bag/R = new /obj/structure/closet/body_bag(user.loc)
@@ -90,7 +90,7 @@
 	icon_state = "bodybag_folded"
 	origin_tech = list(TECH_BIO = 4)
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 1)
-	price_tag = 50
+	price_tag = 9
 
 /obj/item/bodybag/cryobag/attack_self(mob/user)
 	var/obj/structure/closet/body_bag/cryobag/R = new /obj/structure/closet/body_bag/cryobag(user.loc)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -10,7 +10,7 @@
 	flags = CONDUCT
 	origin_tech = list(TECH_MAGNET = 2, TECH_COMBAT = 1)
 	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
-	price_tag = 5
+	price_tag = 8
 	var/times_used = 0 //Number of times it's been used.
 	var/broken = 0     //Is the flash burnt out?
 	var/last_used = 0 //last world.time it was used.

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -6,7 +6,7 @@
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
 	w_class = ITEM_SIZE_SMALL
 	flags = CONDUCT
-	price_tag = 10
+	price_tag = 12
 
 	cell = null
 	suitable_cell = /obj/item/cell/small

--- a/code/game/objects/items/devices/mental_imprinter.dm
+++ b/code/game/objects/items/devices/mental_imprinter.dm
@@ -8,7 +8,7 @@
 	var/stat_increase = 5
 	var/apply_sanity_damage = 30
 	var/spent = FALSE
-	price_tag = 1200
+	price_tag = 24
 
 /obj/item/device/mental_imprinter/proc/imprint(mob/living/carbon/human/user)
 	var/stat = input(user, "Select stat to boost", "Mental imprinter") as null|anything in ALL_STATS
@@ -28,7 +28,7 @@
 
 	to_chat(user, SPAN_DANGER("[src] plunges into your eye, imprinting your mind with new information!"))
 	spent = TRUE
-	price_tag = 30
+	price_tag = 24
 
 /obj/item/device/mental_imprinter/attack(mob/M, mob/living/carbon/human/user, target_zone)
 	if(!istype(user) || M != user || target_zone != BP_EYES || user.incapacitated() || spent)

--- a/code/game/objects/items/devices/organ_module/active/armblades.dm
+++ b/code/game/objects/items/devices/organ_module/active/armblades.dm
@@ -20,7 +20,7 @@
 	matter = list(MATERIAL_STEEL = 16)
 	allowed_organs = list(BP_R_ARM, BP_L_ARM)
 	holding_type = /obj/item/tool/armblade
-	price_tag = 200 //Just some metal
+	price_tag = 64 //Just some metal
 
 
 /obj/item/tool/armblade/claws

--- a/code/game/objects/items/devices/organ_module/active/armguns.dm
+++ b/code/game/objects/items/devices/organ_module/active/armguns.dm
@@ -6,7 +6,7 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 5, MATERIAL_STEEL = 5)
 	allowed_organs = list(BP_R_ARM, BP_L_ARM)
 	holding_type = /obj/item/gun/projectile/automatic/armsmg
-	price_tag = 780 //Quite costly
+	price_tag = 360 //Quite costly
 
 /obj/item/organ_module/active/simple/armsmg/blackshield
 	holding_type = /obj/item/gun/projectile/automatic/armsmg/blackshield
@@ -20,4 +20,4 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 5, MATERIAL_STEEL = 5)
 	allowed_organs = list(BP_R_ARM, BP_L_ARM)
 	holding_type = /obj/item/gun/projectile/shotgun/pump/hunter_crossbow_implanted
-	price_tag = 800
+	price_tag = 360

--- a/code/game/objects/items/devices/organ_module/active/armshields.dm
+++ b/code/game/objects/items/devices/organ_module/active/armshields.dm
@@ -15,4 +15,4 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 5, MATERIAL_STEEL = 5)
 	allowed_organs = list(BP_R_ARM, BP_L_ARM)
 	holding_type = /obj/item/shield/riot/arm
-	price_tag = 850
+	price_tag = 360

--- a/code/game/objects/items/devices/organ_module/active/custom.dm
+++ b/code/game/objects/items/devices/organ_module/active/custom.dm
@@ -7,7 +7,7 @@
 	matter = list(MATERIAL_STEEL = 20)
 	allowed_organs = list(BP_R_ARM, BP_L_ARM)
 	holding_type = null
-	price_tag = 200 //Just some metal
+	price_tag = 80 //Just some metal
 
 /obj/item/organ_module/active/simple/custom/attackby(var/obj/item/O, var/mob/user)
 	if(!holding) // Do we have an item inserted?

--- a/code/game/objects/items/devices/organ_module/active/engineer.dm
+++ b/code/game/objects/items/devices/organ_module/active/engineer.dm
@@ -5,7 +5,8 @@
 	icon_state = "multitool"
 	allowed_organs = list(BP_R_ARM, BP_L_ARM)
 	holding_type = /obj/item/tool/engimplant
-	price_tag = 575
+	matter = list(MATERIAL_STEEL = 12)
+	price_tag = 48
 
 /obj/item/organ_module/active/simple/engineer/organic
 	name = "embedded organic engineering multitool"
@@ -15,6 +16,7 @@
 	allowed_organs = list(BP_R_ARM, BP_L_ARM)
 	holding_type = /obj/item/tool/engimplant/organic
 	matter = list(MATERIAL_BIOMATTER = 10)
+	price_tag = 20
 	is_organic_module = TRUE
 
 /obj/item/biogoop/engineer

--- a/code/game/objects/items/devices/organ_module/active/hud_types.dm
+++ b/code/game/objects/items/devices/organ_module/active/hud_types.dm
@@ -4,7 +4,8 @@
 	verb_name = "Activate Med Hud"
 	icon_state = "medshades"
 	holding_type = /obj/item/clothing/glasses/hud/health/shades
-	price_tag = 575
+	matter = list(MATERIAL_STEEL = 12)
+	price_tag = 48
 
 /obj/item/organ_module/active/hud/sec
 	name = "embedded security hud shades"
@@ -12,7 +13,8 @@
 	verb_name = "Activate Security Hud"
 	icon_state = "secshades"
 	holding_type = /obj/item/clothing/glasses/hud/security/shades
-	price_tag = 875
+	matter = list(MATERIAL_STEEL = 12)
+	price_tag = 48
 
 /obj/item/organ_module/active/hud/night
 	name = "embedded night vision shades"
@@ -20,7 +22,8 @@
 	verb_name = "Activate Night Vision Goggles"
 	icon_state = "nightshades"
 	holding_type = /obj/item/clothing/glasses/shades/night
-	price_tag = 1275
+	matter = list(MATERIAL_STEEL = 12)
+	price_tag = 48
 
 /obj/item/organ_module/active/hud/thermal
 	name = "embedded thermal shades"
@@ -28,7 +31,8 @@
 	verb_name = "Activate Thermal Goggles"
 	icon_state = "thermalshades"
 	holding_type = /obj/item/clothing/glasses/shades/thermal
-	price_tag = 2550
+	matter = list(MATERIAL_STEEL = 12)
+	price_tag = 48
 
 /obj/item/organ_module/active/hud/welder
 	name = "embedded welder shades"
@@ -36,7 +40,8 @@
 	verb_name = "Activate Welder Goggles"
 	icon_state = "weldershades"
 	holding_type = /obj/item/clothing/glasses/welding/superior/shades
-	price_tag = 675
+	matter = list(MATERIAL_STEEL = 12)
+	price_tag = 48
 
 /obj/item/organ_module/active/hud/thermal_bio
 	name = "embedded bio-thermal overlays"

--- a/code/game/objects/items/devices/organ_module/active/multitool.dm
+++ b/code/game/objects/items/devices/organ_module/active/multitool.dm
@@ -5,7 +5,7 @@
 	icon_state = "multitool"
 	allowed_organs = list(BP_R_ARM, BP_L_ARM)
 	matter = list(MATERIAL_STEEL = 5)
-	price_tag = 535
+	price_tag = 20
 	var/list/items = list()
 
 /obj/item/organ_module/active/multitool/New()

--- a/code/game/objects/items/devices/organ_module/active/surgical.dm
+++ b/code/game/objects/items/devices/organ_module/active/surgical.dm
@@ -5,7 +5,8 @@
 	icon_state = "medimplant"
 	allowed_organs = list(BP_R_ARM, BP_L_ARM)
 	holding_type = /obj/item/tool/medmultitool/medimplant
-	price_tag = 685
+	matter = list(MATERIAL_STEEL = 12)
+	price_tag = 48
 
 /obj/item/organ_module/active/simple/surgical/cht_mant
 	name = "surgical omni-gland"

--- a/code/game/objects/items/devices/organ_module/active/taser.dm
+++ b/code/game/objects/items/devices/organ_module/active/taser.dm
@@ -6,7 +6,7 @@
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6, MATERIAL_SILVER = 3)
 	allowed_organs = list(BP_R_ARM, BP_L_ARM)
 	holding_type = /obj/item/gun/energy/taser
-	price_tag = 1385
+	price_tag = 246
 
 /obj/item/organ_module/active/simple/taser/blackshield
 	holding_type = /obj/item/gun/energy/taser/blackshield

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -789,7 +789,8 @@ var/global/list/default_medbay_channels = list(
 	canhear_range = 4
 	var/random_hear = 20
 	channels = list("Command" = 1, "Blackshield" = 1, "Marshal" = 1, "Engineering" = 1, "Church" = 1, "Science" = 1, "Medical" = 1, "Supply" = 1, "Service" = 1, "AI Private" = 1, "Prospector" = 1)
-	price_tag = 20000
+	matter = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1)
+	price_tag = 16
 	origin_tech = list(TECH_DATA = 7, TECH_ENGINEERING = 7, TECH_ILLEGAL = 7)
 	var/list/obj/item/oddity/used_oddity = list()
 	var/last_produce = 0

--- a/code/game/objects/items/oddities_faction.dm
+++ b/code/game/objects/items/oddities_faction.dm
@@ -10,7 +10,7 @@
 	throwforce = WEAPON_FORCE_PAINFUL
 	throw_speed = 1
 	throw_range = 2
-	price_tag = 20000
+	price_tag = 52
 	origin_tech = list(TECH_MATERIAL = 4, TECH_BIO = 13, TECH_POWER = 7) //high bio as it works on making donuts!
 	matter = list(MATERIAL_PLASTIC = 6, MATERIAL_GLASS = 7)
 	var/last_produce = 0
@@ -136,7 +136,7 @@
 	volume = 200
 	w_class = ITEM_SIZE_HUGE
 	reagent_flags = OPENCONTAINER
-	price_tag = 20000
+	price_tag = 190
 	origin_tech = list(TECH_BIO = 9, TECH_MATERIAL = 9, TECH_PLASMA = 3)
 	unacidable = TRUE //glass doesn't dissolve in acid
 	matter = list(MATERIAL_GLASS = 3, MATERIAL_STEEL = 2, MATERIAL_PLASMA = 5, MATERIAL_BIOMATTER = 50)
@@ -401,7 +401,7 @@ No more of that.
 	throwforce = WEAPON_FORCE_WEAK
 	throw_speed = 3
 	throw_range = 15
-	price_tag = 20000
+	price_tag = 260
 	origin_tech = list(TECH_MATERIAL = 10)
 	var/affect_radius = 7
 	matter = list(MATERIAL_GLASS = 5, MATERIAL_GOLD = 7, MATERIAL_SILVER = 5, MATERIAL_DIAMOND = 1)
@@ -693,7 +693,7 @@ No more of that.
 	volume = 100 //Average bottle volume
 	reagent_flags = OPENCONTAINER
 
-	price_tag = 4000
+	price_tag = 100
 
 	matter = list(MATERIAL_BIOMATTER = 50)
 	var/ticks

--- a/code/game/objects/items/stacks/ichor.dm
+++ b/code/game/objects/items/stacks/ichor.dm
@@ -8,4 +8,4 @@
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	amount = 5
 	w_class = ITEM_SIZE_SMALL //just so you can place same places that a brute pack would be
-	price_tag = 0
+	price_tag = 4

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -254,7 +254,7 @@
 	amount = 8
 	max_amount = 8
 	heal_brute = 5
-	price_tag = 25
+	price_tag = 10
 
 /obj/item/stack/medical/ointment
 	name = "ointment"

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -8,7 +8,7 @@
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
 	amount = 5
 	w_class = ITEM_SIZE_SMALL //just so you can place same places that a brute pack would be
-	price_tag = 80
+	price_tag = 12 // Technically 11.2, but BYOND is bad with decimals, so I just rounded up. -R4d6
 
 
 /obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -14,7 +14,7 @@
 	matter = list(MATERIAL_STEEL = 1)
 	max_amount = 120
 	attack_verb = list("hit", "bludgeoned", "whacked")
-	price_tag = 1
+	price_tag = 4
 	novariants = FALSE
 	stacktype_alt = /obj/item/stack/rods/random
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -24,7 +24,7 @@
 	throw_range = 20
 	matter = list(MATERIAL_PLASTIC = 3)
 	force = NONE
-	price_tag = 10
+	price_tag = 12
 
 
 /*

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -9,7 +9,7 @@
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_WEAK
 	armor_penetration = ARMOR_PEN_DEEP
-	price_tag = 300
+	price_tag = 70
 	matter = list(MATERIAL_BIOMATTER = 25, MATERIAL_STEEL = 5)
 
 /obj/item/tool/sword/nt/equipped(mob/living/M)
@@ -29,7 +29,7 @@
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_WEAK
 	armor_penetration = ARMOR_PEN_DEEP
-	price_tag = 300
+	price_tag = 70
 	matter = list(MATERIAL_BIOMATTER = 25, MATERIAL_STEEL = 5)
 
 /obj/item/tool/sword/nt/longsword
@@ -41,7 +41,7 @@
 	force = WEAPON_FORCE_ROBUST
 	armor_penetration = ARMOR_PEN_EXTREME
 	w_class = ITEM_SIZE_BULKY
-	price_tag = 500
+	price_tag = 270
 	matter = list(MATERIAL_BIOMATTER = 75, MATERIAL_STEEL = 10, MATERIAL_PLASTEEL = 5)
 
 /obj/item/tool/knife/dagger/nt
@@ -53,7 +53,7 @@
 	item_state = "nt_dagger"
 	force = WEAPON_FORCE_PAINFUL
 	armor_penetration = ARMOR_PEN_MASSIVE
-	price_tag = 120
+	price_tag = 24
 	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_STEEL = 1)
 
 /obj/item/tool/spear/halberd
@@ -67,7 +67,7 @@
 	wielded_icon = "nt_halberd_wielded"
 	force = WEAPON_FORCE_BRUTAL
 	armor_penetration = ARMOR_PEN_MASSIVE
-	price_tag = 600
+	price_tag = 244
 	matter = list(MATERIAL_BIOMATTER = 80, MATERIAL_STEEL = 8, MATERIAL_WOOD = 10, MATERIAL_PLASTEEL = 2)
 
 /obj/item/tool/sword/nt/scourge
@@ -85,7 +85,7 @@
 	var/agony_extended = 45 //Church harmbaton! This is legit better then a normal baton as it can be upgraded AND has base 15 damage
 	var/stun = 0
 	w_class = ITEM_SIZE_BULKY
-	price_tag = 800
+	price_tag = 152
 	matter = list(MATERIAL_BIOMATTER = 50, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 2)
 
 /obj/item/tool/sword/nt/scourge/attack_self(mob/user)
@@ -144,7 +144,7 @@
 	throwforce = WEAPON_FORCE_LETHAL * 1.5
 	armor_penetration = ARMOR_PEN_HALF
 	throw_speed = 3
-	price_tag = 150
+	price_tag = 200
 	matter = list(MATERIAL_BIOMATTER = 20, MATERIAL_PLASTEEL = 10) // More expensive, high-end spear
 
 /obj/item/tool/sword/nt/spear/equipped(mob/living/W)
@@ -186,7 +186,7 @@
 	force = WEAPON_FORCE_ROBUST
 	armor_penetration = ARMOR_PEN_MASSIVE
 	w_class = ITEM_SIZE_BULKY
-	price_tag = 800
+	price_tag = 230
 	matter = list(MATERIAL_BIOMATTER = 50, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 5, MATERIAL_SILVER = 3)
 	tool_qualities = list(QUALITY_HAMMERING = 10) //Not designed for that fine nailing
 	var/glowing = FALSE
@@ -239,7 +239,7 @@
 	force = WEAPON_FORCE_DANGEROUS //Naturally weaker do to knockbacking are targets (can stun lock)
 	armor_penetration = ARMOR_PEN_EXTREME
 	w_class = ITEM_SIZE_BULKY
-	price_tag = 800
+	price_tag = 312
 	matter = list(MATERIAL_BIOMATTER = 50, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 12)
 	tool_qualities = list(QUALITY_HAMMERING = 30) //Not designed for that fine nailing
 	var/glowing = FALSE
@@ -266,7 +266,7 @@
 	force = WEAPON_FORCE_DANGEROUS
 	armor_list = list(melee = 20, bullet = 30, energy = 30, bomb = 0, bio = 0, rad = 0)
 	matter = list(MATERIAL_BIOMATTER = 50, MATERIAL_STEEL = 10, MATERIAL_PLASTEEL = 10, MATERIAL_GOLD = 5)
-	price_tag = 1000
+	price_tag = 400
 	base_block_chance = 60
 	item_flags = DRAG_AND_DROP_UNEQUIP
 
@@ -334,7 +334,7 @@
 	item_state = "nt_buckler"
 	matter = list(MATERIAL_BIOMATTER = 15, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 2, MATERIAL_GOLD = 1)
 	//aspects = list(SANCTIFIED) todo:port this
-	price_tag = 300
+	price_tag = 122
 	base_block_chance = 45
 	item_flags = DRAG_AND_DROP_UNEQUIP
 	max_durability = 110 //So we can brake and need healing time to time
@@ -396,7 +396,7 @@
 	force = WEAPON_FORCE_LETHAL
 	armor_penetration = ARMOR_PEN_HALF
 	matter = list(MATERIAL_DURASTEEL = 25, MATERIAL_GOLD = 3)
-	price_tag = 10000
+	price_tag = 50060 // Durasteel is worth 1000$ a piece
 
 //Throwables
 
@@ -409,7 +409,7 @@
 	throwforce = WEAPON_FORCE_WEAK
 	armor_penetration = ARMOR_PEN_DEEP
 	//aspects = list(SANCTIFIED) todo:port this
-	price_tag = 300
+	price_tag = 70
 	matter = list(MATERIAL_BIOMATTER = 25, MATERIAL_STEEL = 5)
 
 /obj/item/stack/thrown/nt/equipped(mob/living/M)
@@ -434,7 +434,7 @@
 	throwforce = WEAPON_FORCE_LETHAL
 	armor_penetration = ARMOR_PEN_DEEP
 	throw_speed = 3
-	price_tag = 150
+	price_tag = 40
 	allow_spin = FALSE
 	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_STEEL = 5) // Easy to mass-produce and arm the faithful
 	//style_damage = 30 - todo port this maybe?

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -6,7 +6,7 @@
 	icon_state = "b_st"
 	maxcharge = 2000
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3)
-	price_tag = 200
+	price_tag = 42
 
 /obj/item/cell/large/high
 	name = "Lonestar \"Robustcell 6000L\""
@@ -64,6 +64,7 @@
 	origin_tech = list(TECH_POWER = 7)
 	maxcharge = 20000
 	max_chargerate = 0.24
+	price_tag = 162
 
 /obj/item/cell/large/moebius/nuclear
 	name = "Soteria \"Atomcell 14000L\""
@@ -73,7 +74,7 @@
 	origin_tech = list(TECH_POWER = 6)
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 6)
 	maxcharge = 14000
-	price_tag = 400
+	price_tag = 162
 
 /obj/item/cell/large/greyson
 	name = "GP-SI \"Posi-cell 16000L\""
@@ -83,7 +84,7 @@
 	autorecharging = TRUE
 	autorecharge_rate = 0.06
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_PLATINUM = 3, MATERIAL_URANIUM = 6)
-	price_tag = 600
+	price_tag = 252
 
 /obj/item/cell/large/excelsior
 	name = "Excelsior \"Zarya 18000L\""
@@ -101,6 +102,7 @@
 	maxcharge = 13000
 	max_chargerate = 0
 	created_max_charge = TRUE
+	price_tag = 42
 
 /obj/item/cell/large/neotheology/plasma
 	name = "Absolute \"Radiance 20000L\""
@@ -108,6 +110,7 @@
 	icon_state = "b_nt_pl"
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_BIOMATTER = 7.5)
 	maxcharge = 20000
+	price_tag = 27
 
 //Meme cells - for fun
 
@@ -135,7 +138,7 @@
 	throw_range = 7
 	maxcharge = 600
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2)
-	price_tag = 100
+	price_tag = 36
 
 /obj/item/cell/medium/depleted
 	charge = 0
@@ -201,6 +204,7 @@
 	origin_tech = list(TECH_POWER = 7)
 	maxcharge = 1600
 	max_chargerate = 0.24
+	price_tag = 116
 
 /obj/item/cell/medium/moebius/nuclear
 	name = "Soteria \"Atomcell 1000M\""
@@ -210,7 +214,7 @@
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_URANIUM = 4)
 	origin_tech = list(TECH_POWER = 6)
 	maxcharge = 1000
-	price_tag = 200
+	price_tag = 116
 
 /obj/item/cell/medium/greyson
 	name = "GP-SI \"Posi-cell 1600M\""
@@ -220,7 +224,7 @@
 	autorecharging = TRUE
 	autorecharge_rate = 0.06
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_PLATINUM = 2, MATERIAL_URANIUM = 4)
-	price_tag = 300
+	price_tag = 176
 
 /obj/item/cell/medium/excelsior
 	name = "Excelsior \"Zarya 1100M\""
@@ -258,7 +262,7 @@
 	throw_range = 7
 	maxcharge = 100
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1)
-	price_tag = 50
+	price_tag = 18
 
 /obj/item/cell/small/depleted
 	charge = 0
@@ -324,6 +328,7 @@
 	origin_tech = list(TECH_POWER = 7)
 	maxcharge = 500
 	max_chargerate = 0.24
+	price_tag = 58
 
 /obj/item/cell/small/moebius/nuclear
 	name = "Soteria \"Atomcell 300S\""
@@ -332,7 +337,7 @@
 	autorecharging = TRUE
 	origin_tech = list(TECH_POWER = 6)
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1, MATERIAL_URANIUM = 2)
-	maxcharge = 300
+	maxcharge = 58
 	price_tag = 100
 
 /obj/item/cell/small/moebius/pda
@@ -346,7 +351,7 @@
 	autorecharging = TRUE
 	autorecharge_rate = 0.007
 	recharge_time = 1
-	price_tag = 65
+	price_tag = 28
 
 /obj/item/cell/small/greyson
 	name = "GP-SI \"Posi-cell 400S\""
@@ -356,7 +361,7 @@
 	autorecharging = TRUE
 	autorecharge_rate = 0.06
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_PLATINUM = 1, MATERIAL_URANIUM = 2)
-	price_tag = 150
+	price_tag = 88
 
 /obj/item/cell/small/excelsior
 	name = "Excelsior \"Zarya 400S\""
@@ -463,6 +468,7 @@
 	icon = 'icons/obj/machines/chemistry.dmi'
 	icon_state = "centrifuge_makeshift"
 	matter = list(MATERIAL_STEEL = 30)
+	price_tag = 120
 	cell = null
 	suitable_cell = /obj/item/cell
 


### PR DESCRIPTION
## About The Pull Request
Change most of the prices tags for most items in the game according to the following formula : `(Combined price of materials) * 2`
I am using [this page](https://github.com/sojourn-13/sojourn-station/blob/master/code/modules/materials/material_sheets.dm) as a reference for the prices of the materials.

It is that way so that if you sell something, you should get enough money to buy enough mats for 2 of that something.
I am not balancings items that : A) Don't have a list of materials **AND** B) Who's parent is too far for me to easily find.
If I do find the parent, I'm copying the list of material the item is made out of down to the item in question.

If you disagree with a specific price for a specific item, either comment here or ping me on Discord.