### PR TITLE
Hopefully reduce some lag

### DIFF
--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -47,7 +47,7 @@
 	var/step_count = 0
 
 	var/tod = null // Time of death
-	var/update_slimes = 1
+	var/update_slimes = 0
 	var/is_busy = FALSE // Prevents stacking of certain actions, like resting and diving
 	var/silent = 0 		// Can't talk. Value goes down every life proc.
 	var/on_fire = 0 //The "Are we on fire?" var


### PR DESCRIPTION
Hopefully reduce some lag by changing a single variable. Might break slimes trying to eat you, but who do slimes anyway?

-- Trilby don't include the part below --
The variable 'update_slimes' is used in one place, here : https://github.com/sojourn-13/sojourn-station/blob/master/code/modules/mob/living/living.dm#L582
So every time any mob moved, it would check for nearby slimes.
So with this change, we reduce the number of checks from however shit the mob had near it to just 1, which, considering the minimum is at least 10 (9 turf + src mob), should reduce some lag.