### PR TITLE
Standardizes gas mask parent icon_state option

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -47,7 +47,7 @@
 
 	var/mob/M = usr
 	var/list/options = list()
-	options["Base"] = "gas_mask"
+	options["Base"] = initial(icon_state) // This should make it work for every child of the original mask without needing to create verbs for every single one. - Seb
 	options["Alternative"] = "gas_alt"
 	options["Kriosan"] = "kriosan_gasmask"
 


### PR DESCRIPTION
## About The Pull Request

Makes it so that the toggle style function on gas mask parent returns the item's initial `icon_state`, this way any children of it can revert back to their original appearance without being forced back into the default gas mask sprite when choosing "default"

This PR fixes #3193 .

<hr>

## Changelog
:cl:
fix: Enviro gas mask (and every gas mask children with toggleable styles) now return to their own individual style when choosing "base" rather than being forced into the standard gas mask icon.
/:cl: