### PR TITLE
stack autostacking, haul on controlclicking tiles

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -272,6 +272,7 @@
 	if (!get_amount())
 		return 0
 	if(!istype(S))
+		return FALSE
 	if ((stacktype != S.stacktype) && !type_verified)
 		if((stacktype != S.stacktype_alt) && !type_verified)
 			return 0

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -77,7 +77,7 @@
 		if(!istype(crossing, /obj/item/stack))
 			return
 		var/obj/item/stack/crostack = crossing
-		crostack.transfer_to(src)
+		src.transfer_to(crostack)
 	. = ..()
 
 /obj/item/stack/examine(mob/user)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -72,6 +72,14 @@
 
 	return ..()
 
+/obj/item/stack/Crossed(atom/movable/crossing)
+	if(!crossing.throwing)
+		if(!istype(crossing, /obj/item/stack))
+			return
+		var/obj/item/stack/crostack = crossing
+		crostack.transfer_to(src)
+	. = ..()
+
 /obj/item/stack/examine(mob/user)
 	if(..(user, 1))
 		if(!uses_charge)
@@ -263,6 +271,7 @@
 /obj/item/stack/proc/transfer_to(obj/item/stack/S, var/tamount=null, var/type_verified)
 	if (!get_amount())
 		return 0
+	if(!istype(S))
 	if ((stacktype != S.stacktype) && !type_verified)
 		if((stacktype != S.stacktype_alt) && !type_verified)
 			return 0
@@ -441,6 +450,3 @@
 	New(title, recipes)
 		src.title = title
 		src.recipes = recipes
-
-
-

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -303,3 +303,7 @@ var/const/enterloopsanity = 100
 			if(!obj.anchored && obj.loc == src)// prevents the object from being affected if it's not currently here.
 				step_glide(obj, where, speed)
 			CHECK_TICK
+
+/turf/CtrlClick(mob/user)
+	user.haul_all_objs_proc(src)
+	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -13,7 +13,7 @@
 	ghostize()
 
 	LAssailant_weakref = null
-  
+
 	return ..()
 
 /mob/get_fall_damage(var/turf/from, var/turf/dest)
@@ -278,6 +278,18 @@
 		return
 
 	T.UnloadSlide(get_dir(T, src), src, 1)
+
+/mob/proc/haul_all_objs_proc(turf/T)
+	if(!src || !isturf(src.loc) || !(T in oview(1, src.loc)))
+		return 0
+	if(ismouse(src))
+		return
+	if(!src || !isturf(src.loc))
+		return
+	if(src.stat || src.restrained())
+		return
+	T.UnloadSlide(get_dir(T, src), src, 1)
+
 
 /mob/proc/ret_grab(obj/effect/list_container/mobl/L as obj, flag)
 	if(!istype(l_hand, /obj/item/grab) && !istype(r_hand, /obj/item/grab))


### PR DESCRIPTION
Tin. Stacks autostack when crossing a stack that they can stack with.
Controlclicking a tile calls Haul on that tile.
## Changelog
:cl:
add: Stacks autostack when crossing a stack that they can stack with. Controlclicking a tile calls Haul on that tile.
/:cl:
