### PR TITLE
(mostly) energy mod balancing

### DIFF
--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -150,7 +150,7 @@
 	UPGRADE_WORKSPEED = 0.15
 	)
 	I.weapon_upgrades = list(
-		GUN_UPGRADE_FIRE_DELAY_MULT = 0.8,
+		GUN_UPGRADE_FIRE_DELAY_MULT = 0.85,
 		UPGRADE_BULK = 1
 	)
 	I.gun_loc_tag = GUN_UNDERBARREL
@@ -338,7 +338,7 @@
 	)
 	I.weapon_upgrades = list(
 	GUN_UPGRADE_DAMAGE_MULT = 1.25,
-	GUN_UPGRADE_CHARGECOST = 1.35
+	GUN_UPGRADE_CHARGECOST = 1.3
 	)
 	I.prefix = "boosted"
 	I.req_fuel_cell = REQ_FUEL_OR_CELL

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -10,7 +10,7 @@
 //Silences the weapon, reduces damage multiplier slightly, Legacy port.
 /obj/item/gun_upgrade/muzzle/silencer
 	name = "Silencer"
-	desc = "A threaded silencer that can be attached to the muzzle of certain guns. Vastly reduces noise, but impedes muzzle velocity."
+	desc = "A threaded silencer that can be attached to the muzzle of certain guns. Vastly reduces noise, but increases bulk."
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 1)
 	icon_state = "silencer"
 	price_tag = 100
@@ -145,7 +145,7 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_DAMAGE_MULT = 1.3,
-		GUN_UPGRADE_CHARGECOST = 1.15,
+		GUN_UPGRADE_CHARGECOST = 1.3,
 		UPGRADE_BULK = 0.5,
 		)
 	I.gun_loc_tag = GUN_BARREL
@@ -164,7 +164,7 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_DAMAGE_MULT = 1.45,
-		GUN_UPGRADE_CHARGECOST = 1.25,
+		GUN_UPGRADE_CHARGECOST = 1.45,
 		UPGRADE_BULK = 0.75,
 		)
 	I.gun_loc_tag = GUN_BARREL
@@ -390,7 +390,8 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 	GUN_UPGRADE_RECOIL = 2,
-	GUN_UPGRADE_FIRE_DELAY_MULT = 1.5,
+	GUN_UPGRADE_PEN_MULT = 0.5,
+	GUN_UPGRADE_FIRE_DELAY_MULT = 2.5,
 	GUN_UPGRADE_DAMAGE_MULT = 2,
 	GUN_UPGRADE_CHARGECOST = 2)
 	I.req_fuel_cell = REQ_CELL
@@ -559,7 +560,7 @@
 		GUN_UPGRADE_DAMAGE_BRUTE = 5,
 		GUN_UPGRADE_PEN_MULT = 1.2,
 		GUN_UPGRADE_PIERC_MULT = 1,
-		GUN_UPGRADE_FIRE_DELAY_MULT = 1.2,
+		GUN_UPGRADE_FIRE_DELAY_MULT = 1.4,
 		GUN_UPGRADE_RECOIL = 1.2,
 		)
 	I.removal_time *= 10


### PR DESCRIPTION
### gun exclusive mods

shunt firedelay mult 1.5 >> 2.5, pen 1.0 >> 0.5. shunt is dominant energy weapon mod since it functionally has 0 downsides. increased alpha damage is generally always better than increased dps, because of how our systems work (breaking bones, armor, etc), so it fires significantly slower (unable to be returned to normal with other mods like dangerzone/ergonomicgrip). 

excruciator and factorial excruciator are now 1:1 chargecost:damage. again, alpha damage > dps, and these actually grant increased damage:charge ratios which is bad on a damage mod.

voidwolf barrel firedelay 1.2 >> 1.4. it was a little too good being commonly obtaianble from cargo trade program, this should put it in line especially with the ergonomicgrip nerf

### tool/gunmods

booster 1.35 >> 1.3 chargecost increase. it was a little meh imo, but now it should be a viable alternative to shunt/plasmablock/heatsink

ergonomicgrip 0.8 >> 0.85 firedelay mult. It's a really common mod, and this was fine when it slot conflicted with vibrocomp- but now that it doesn't anymore, it's got a 'free' slot- makes it a little too good. 


## Changelog
:cl:
balance: shunt firedelay mult 1.5 >> 2.5, pen 1.0 >> 0.5
balance: excruciator and factorial excruciator are now 1:1 chargecost:damage
balance: voidwolf barrel firedelay 1.2 >> 1.4
balance: booster 1.35 >> 1.3 chargecost
balance: ergonomicgrip 0.8 >> 0.85 firedelay mult
/:cl:


