### PR TITLE
Fixes RIG suit drill

### DIFF
--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -160,8 +160,7 @@
 	price_tag = 900
 
 /obj/item/tool/pickaxe/diamonddrill/rig
-	switched_off_qualities = list(QUALITY_DIGGING = 50, QUALITY_DRILLING = 50)
-	switched_on_qualities = list(QUALITY_EXCAVATION = 10, QUALITY_DRILLING = 20)
+	tool_qualities = list(QUALITY_DIGGING = 50, QUALITY_DRILLING = 50)
 	use_fuel_cost = 0
 	passive_fuel_cost = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	This just fixes the RIG suit drill so it actually functions as a digging tool now instead of an excavation tool.
	The reason the previous fix didn't work was the toggle function is never called so it never updates the starting tool qualities that are inherited from the diamond drill it's parented off from. 
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fix: RIG drill module digs instead of excavates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
