### PR TITLE
Adds "Bulk Glass Crate"

### DIFF
--- a/code/modules/cargo/packs_engineering.dm
+++ b/code/modules/cargo/packs_engineering.dm
@@ -149,6 +149,17 @@
 	containertype = /obj/structure/closet/crate/secure
 	crate_name = "glass sheet crate"
 	group = "Engineering"
+	
+/datum/supply_pack/glass480
+	name = "Bulk Glass Sheets Crate"
+	contains = list(/obj/item/stack/material/glass/full,
+	/obj/item/stack/material/glass/full,
+	/obj/item/stack/material/glass/full,
+	/obj/item/stack/material/glass/full)
+	cost = 1740
+	containertype = /obj/structure/largecrate
+	crate_name = "Bulk glass crate"
+	group = "Engineering"
 
 /datum/supply_pack/borosilicate_glass120
 	name = "Borosilicate Glass Sheets Crate (120)"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Adds Bulk Glass Crate to Lonestar cargo. Priced proportionally as the rest of the bulk crates vs their single stack variants. We have this for plastic and steel so why not glass? Also QOL so I don't have to keep clicking around in our awful cargo UI if I'm trying to order the same amount of sheets
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
Adds Bulk Glass Sheets Crate
/:cl: