### PR TITLE
Church Knight rigsuit cost nerf

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -193,7 +193,7 @@
 
 /datum/design/bioprinter/nt_clothes/knight_rig
 	name = "Knight Hardsuit Module"
-	materials = list(MATERIAL_BIOMATTER = 50, MATERIAL_GOLD = 5, MATERIAL_SILVER = 5, MATERIAL_PLASTEEL = 10)
+	materials = list(MATERIAL_BIOMATTER = 100, MATERIAL_GOLD = 10, MATERIAL_SILVER = 10, MATERIAL_PLASTEEL = 100)
 	build_path = /obj/item/rig/combat/knight
 
 //[MELEE]


### PR DESCRIPTION
Material costs of the knight rigsuit doubled for biomatter, gold, silver. Material cost of plasteel raised to 100. While these numbers may seem high it's worth noting that printed from a bioprinter the final value will only be 60% of these numbers. This means that the new, total cost for the suit is lower than initially seems.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
