### PR TITLE
SST balancing

### DIFF
--- a/code/modules/projectiles/guns/energy/sst.dm
+++ b/code/modules/projectiles/guns/energy/sst.dm
@@ -14,7 +14,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	force = WEAPON_FORCE_NORMAL
 	origin_tech = list(TECH_COMBAT = 10)
-	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 8, MATERIAL_SILVER = 8)
+	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 8, MATERIAL_SILVER = 8, MATERIAL_PLATINUM = 0.1)
 	charge_cost = 100
 	twohanded = FALSE
 	gun_tags = list(GUN_PROJECTILE, GUN_LASER, GUN_ENERGY, GUN_CALIBRE_35)
@@ -44,7 +44,7 @@
 	damage_multiplier = 1.3
 	w_class = ITEM_SIZE_NORMAL
 	projectile_type = /obj/item/projectile/bullet/magnum_40/rubber/soporific
-	matter = list(MATERIAL_PLASTEEL = 18, MATERIAL_STEEL = 10,  MATERIAL_SILVER = 12)
+	matter = list(MATERIAL_PLASTEEL = 18, MATERIAL_STEEL = 10,  MATERIAL_SILVER = 12, MATERIAL_PLATINUM = 0.2)
 	price_tag = 1600
 
 /obj/item/gun/energy/sst/formatbound/preloaded
@@ -72,7 +72,7 @@
 	twohanded = TRUE
 	suitable_cell = /obj/item/cell/large
 	slot_flags = SLOT_BACK
-	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_STEEL = 20, MATERIAL_SILVER = 15, MATERIAL_GOLD = 12)
+	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_STEEL = 20, MATERIAL_SILVER = 15, MATERIAL_GOLD = 12, MATERIAL_PLATINUM = 0.5)
 	price_tag = 2500
 	recoil_buildup = 15
 	projectile_type=/obj/item/projectile/bullet/shotgun/beanbag/soporific
@@ -113,7 +113,7 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_LASER, GUN_ENERGY)
 	w_class = ITEM_SIZE_HUGE
 	force = WEAPON_FORCE_PAINFUL
-	matter = list(MATERIAL_PLASTEEL = 35, MATERIAL_STEEL = 25, MATERIAL_SILVER = 15, MATERIAL_GOLD = 12)
+	matter = list(MATERIAL_PLASTEEL = 35, MATERIAL_STEEL = 25, MATERIAL_SILVER = 15, MATERIAL_GOLD = 12, MATERIAL_PLATINUM = 0.5)
 	damage_multiplier = 1.2
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,

--- a/code/modules/projectiles/guns/energy/sst.dm
+++ b/code/modules/projectiles/guns/energy/sst.dm
@@ -14,7 +14,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	force = WEAPON_FORCE_NORMAL
 	origin_tech = list(TECH_COMBAT = 10)
-	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 8, MATERIAL_SILVER = 8, MATERIAL_PLATINUM = 2)
+	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_STEEL = 8, MATERIAL_SILVER = 8)
 	charge_cost = 100
 	twohanded = FALSE
 	gun_tags = list(GUN_PROJECTILE, GUN_LASER, GUN_ENERGY, GUN_CALIBRE_35)
@@ -44,7 +44,7 @@
 	damage_multiplier = 1.3
 	w_class = ITEM_SIZE_NORMAL
 	projectile_type = /obj/item/projectile/bullet/magnum_40/rubber/soporific
-	matter = list(MATERIAL_PLASTEEL = 18, MATERIAL_STEEL = 10,  MATERIAL_SILVER = 12, MATERIAL_PLATINUM = 5)
+	matter = list(MATERIAL_PLASTEEL = 18, MATERIAL_STEEL = 10,  MATERIAL_SILVER = 12)
 	price_tag = 1600
 
 /obj/item/gun/energy/sst/formatbound/preloaded
@@ -72,7 +72,7 @@
 	twohanded = TRUE
 	suitable_cell = /obj/item/cell/large
 	slot_flags = SLOT_BACK
-	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_STEEL = 20, MATERIAL_SILVER = 15, MATERIAL_GOLD = 12, MATERIAL_PLATINUM = 10)
+	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_STEEL = 20, MATERIAL_SILVER = 15, MATERIAL_GOLD = 12)
 	price_tag = 2500
 	recoil_buildup = 15
 	projectile_type=/obj/item/projectile/bullet/shotgun/beanbag/soporific
@@ -113,7 +113,7 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_LASER, GUN_ENERGY)
 	w_class = ITEM_SIZE_HUGE
 	force = WEAPON_FORCE_PAINFUL
-	matter = list(MATERIAL_PLASTEEL = 35, MATERIAL_STEEL = 25, MATERIAL_SILVER = 15, MATERIAL_GOLD = 12, MATERIAL_PLATINUM = 12, MATERIAL_URANIUM = 8)
+	matter = list(MATERIAL_PLASTEEL = 35, MATERIAL_STEEL = 25, MATERIAL_SILVER = 15, MATERIAL_GOLD = 12)
 	damage_multiplier = 1.2
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -27,12 +27,18 @@
 
 /obj/item/projectile/bullet/pistol_35/rubber/soporific
 	name = "soporific coated rubber bullet"
+	var/spray = "stoxin"
+
+/obj/item/projectile/bullet/pistol_35/rubber/soporific/New()
+	..()
+	create_reagents(2)
+	reagents.add_reagent(spray, 2)
 
 /obj/item/projectile/bullet/pistol_35/rubber/soporific/on_hit(atom/target, def_zone = null)
 	if(isliving(target))
 		var/mob/living/L = target
 		if(istype(L) && L.reagents)
-			L.reagents.add_reagent("stoxin", 2)
+			reagents.trans_to_mob(L, 2, CHEM_TOUCH, copy = FALSE)
 
 /obj/item/projectile/bullet/pistol_35/rubber/soporific/cbo
 	name = "soporific condensed plastic bullet"
@@ -156,12 +162,18 @@
 
 /obj/item/projectile/bullet/magnum_40/rubber/soporific
 	name = "soporific coated rubber bullet"
+	var/spray = "stoxin"
+
+/obj/item/projectile/bullet/magnum_40/rubber/soporific/New()
+	..()
+	create_reagents(3)
+	reagents.add_reagent(spray, 3)
 
 /obj/item/projectile/bullet/magnum_40/rubber/soporific/on_hit(atom/target, def_zone = null)
 	if(isliving(target))
 		var/mob/living/L = target
 		if(istype(L) && L.reagents)
-			L.reagents.add_reagent("stoxin", 3)
+			reagents.trans_to_mob(L, 3, CHEM_TOUCH, copy = FALSE)
 
 /obj/item/projectile/bullet/magnum_40/lethal
 	name = "hollow-point bullet"
@@ -351,12 +363,19 @@
 
 /obj/item/projectile/bullet/rifle_75/rubber/soporific
 	name = "soporific coated rubber bullet"
+	var/spray = "stoxin"
+
+/obj/item/projectile/bullet/rifle_75/rubber/soporific/New()
+	..()
+	create_reagents(1)
+	reagents.add_reagent(spray, 1)
 
 /obj/item/projectile/bullet/rifle_75/rubber/soporific/on_hit(atom/target, def_zone = null)
 	if(isliving(target))
 		var/mob/living/L = target
 		if(istype(L) && L.reagents)
-			L.reagents.add_reagent("stoxin", 1)
+			reagents.trans_to_mob(L, 1, CHEM_TOUCH, copy = FALSE)
+
 
 /obj/item/projectile/bullet/rifle_75/lethal
 	name = "hollow-point bullet"
@@ -517,17 +536,24 @@
 	embed = FALSE
 	sharp = FALSE
 	step_delay = 1.65
-	affective_damage_range = 1
+	affective_damage_range = 5
 	affective_ap_range = 2
 
 /obj/item/projectile/bullet/shotgun/beanbag/soporific
 	name = "soporific coated beanbag"
+	var/spray = "stoxin"
+
+/obj/item/projectile/bullet/shotgun/beanbag/soporific/New()
+	..()
+	create_reagents(5)
+	reagents.add_reagent(spray, 5)
 
 /obj/item/projectile/bullet/shotgun/beanbag/soporific/on_hit(atom/target, def_zone = null)
 	if(isliving(target))
 		var/mob/living/L = target
 		if(istype(L) && L.reagents)
-			L.reagents.add_reagent("stoxin", 5)
+			reagents.trans_to_mob(L, 5, CHEM_TOUCH, copy = FALSE)
+
 
 /obj/item/projectile/bullet/shotgun/practice
 	name = "practice slug"

--- a/code/modules/trade/machinery/trade_beacon.dm
+++ b/code/modules/trade/machinery/trade_beacon.dm
@@ -3,7 +3,7 @@
 	icon_state = "beacon"
 	anchored = TRUE
 	density = TRUE
-	var/entropy_value = 1
+	var/entropy_value = 0.25
 
 /obj/machinery/trade_beacon/attackby(obj/item/I, mob/user)
 	if(default_deconstruction(I, user))


### PR DESCRIPTION
SST guns nerfed, but also not that badly.
SST weapon no longer work through all armor, they now instead work much akin to pepperball ammo(checks face covering, essentially. Must be something akin to a gas mask to be defended against). They retain their rubber rounds and still punch high above their weight.
Additionally they were given some slightly adjusted 'effective range', to give a distinct advantage over just using a /real/ gun using similar rubber ammo.
Abnegate : affective_damage_range = 2->5
Formatbound : affective_damage_range = 4->6
Humility: affective_damage_range = 1->5
Systemcost : unchanged.
Their price in the protolathe however has been reduced. They no longer require uranium, and at request instead of fully removing their platinum it has been SIGNIFICANTLY reduced(.1, .2, .5 for the abnegate, formatbound, humility/systemcost respectively). Their silver/gold costs have been left alone.

The idea of these changes is to make the SSTs a little more accessible and a little less of an 'i win' button with no real counter. They'll still OFTEN be a preferable option over cheaper, more readily available options, without being....so broken.

ALSO emergency nerfs the entropy for the beacon from 1 to .25, @KV-90 "Bear" ICBM#9021 was accurate in his initial guess about what was a valid number for the gain :V