### PR TITLE
beacon balance pass part 1

### DIFF
--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -350,6 +350,35 @@
 	desc = "A small collection of circuit boards"
 	initial_contents = list(/obj/random/circuitboard = 7)
 
+/obj/item/storage/deferred/science
+	name = "scientific things box"
+	desc = "A small collection of scientific items."
+	initial_contents = list(/obj/random/science = 7)
+
+/obj/item/storage/deferred/rig
+	name = "hardsuit box"
+	desc = "They put a RIG in a box."
+	price_tag = 200 //*5 at casino beacon
+	initial_contents = list(/obj/random/rig = 1)
+
+/obj/item/storage/deferred/toolmods
+	name = "toolmod box"
+	desc = "An assortment of some toolmods."
+	price_tag = 150
+	initial_contents = list(/obj/random/tool_upgrade = 5)
+
+/obj/item/storage/deferred/medical
+	name = "medical supply box"
+	desc = "An assortment of some bandages, medicines."
+	initial_contents = list(/obj/random/medical/always_spawn = 7)
+
+/obj/item/storage/deferred/tools
+	name = "tools box"
+	desc = "A small collection of tools."
+	price_tag = 120
+	initial_contents = list(/obj/random/tool = 7)
+
+
 // Kitchen supply
 /obj/item/storage/deferred/kitchen
 	name = "galley supply box"

--- a/code/modules/trade/datums/_trade_station.dm
+++ b/code/modules/trade/datums/_trade_station.dm
@@ -1,7 +1,7 @@
 #define good_data(nam, randList, price) list("name" = nam, "amount_range" = randList, "price" = price)
 #define custom_good_name(nam) good_data(nam, null, null)
-#define custom_good_nameprice(nam, randList) good_data(nam, randList, null)
 #define custom_good_amount_range(randList) good_data(null, randList, null)
+#define custom_good_nameprice(nam, randList) good_data(nam, randList, null)
 #define custom_good_price(price) good_data(null, null, price)
 
 #define offer_data(name, price, amount) list("name" = name, "price" = price, "amount" = amount)

--- a/code/modules/trade/datums/_trade_station.dm
+++ b/code/modules/trade/datums/_trade_station.dm
@@ -1,5 +1,6 @@
 #define good_data(nam, randList, price) list("name" = nam, "amount_range" = randList, "price" = price)
 #define custom_good_name(nam) good_data(nam, null, null)
+#define custom_good_nameprice(nam, randList) good_data(nam, randList, null)
 #define custom_good_amount_range(randList) good_data(null, randList, null)
 #define custom_good_price(price) good_data(null, null, price)
 

--- a/code/modules/trade/datums/_trade_station.dm
+++ b/code/modules/trade/datums/_trade_station.dm
@@ -35,6 +35,8 @@
 
 	var/markup = WHOLESALE_GOODS
 	var/markdown = 0.8				// Default markdown is 20% - SoJ edit they get less markdown
+	var/favour_purchase_ratio = 0.25
+
 
 	var/list/inventory = list()
 	var/list/offer_types = list()	// Defines special offers
@@ -275,7 +277,7 @@
 	if(!isnum(income))
 		return
 	wealth += income
-	favor += income * (is_offer ? 1 : 0.125)
+	favor += income * (is_offer ? 1 : favour_purchase_ratio)
 
 	// Unlocks without needing to wait for update tick
 	if(!hidden_inv_unlocked)

--- a/code/modules/trade/datums/trade_stations_presets/1-common/factio.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/factio.dm
@@ -14,13 +14,13 @@
 	stations_recommended = list("greyson")
 	inventory = list(
 		"Disk Designs" = list(
-			/obj/item/computer_hardware/hard_drive/portable/design/misc = good_data("Lonestar Miscellaneous Pack", list(1, 10)),
-			/obj/item/computer_hardware/hard_drive/portable/design/robustcells = good_data("Lonestar Robustcells", list(1, 10)),
-			/obj/item/computer_hardware/hard_drive/portable/design/janitor = good_data("Lonestar Janitor Pack", list(1, 10)),
-			/obj/item/computer_hardware/hard_drive/portable/design/nonlethal_ammo = good_data("H&S Nonlethal Magazines Pack", list(1, 10)),
-			/obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo = good_data("H&S Lethal Magazines Pack", list(1, 10)),
-			/obj/item/computer_hardware/hard_drive/portable/design/security = good_data("Security Miscellaneous Pack", list(1, 10)),
-			/obj/item/computer_hardware/hard_drive/portable = good_data("Blank Disk", list(1, 10))
+			/obj/item/computer_hardware/hard_drive/portable/design/misc = custom_good_nameprice("Lonestar Miscellaneous Pack", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable/design/robustcells = custom_good_nameprice("Lonestar Robustcells", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable/design/janitor = custom_good_nameprice("Lonestar Janitor Pack", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable/design/nonlethal_ammo = custom_good_nameprice("H&S Nonlethal Magazines Pack", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo = custom_good_nameprice("H&S Lethal Magazines Pack", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable/design/security = custom_good_nameprice("Security Miscellaneous Pack", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable = custom_good_nameprice("Blank Disk", list(1, 10))
 		),
 		"Printed Goods" = list(
 			/obj/item/cell/large = good_data("Large Power Cell", list(-9900, -9850), 60),

--- a/code/modules/trade/datums/trade_stations_presets/1-common/factio.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/factio.dm
@@ -14,13 +14,13 @@
 	stations_recommended = list("greyson")
 	inventory = list(
 		"Disk Designs" = list(
-			/obj/item/computer_hardware/hard_drive/portable/design/misc = good_data("Lonestar Miscellaneous Pack", list(1, 10), 150),
-			/obj/item/computer_hardware/hard_drive/portable/design/robustcells = good_data("Lonestar Robustcells", list(1, 10), 130),
-			/obj/item/computer_hardware/hard_drive/portable/design/janitor = good_data("Lonestar Janitor Pack", list(1, 10), 60),
-			/obj/item/computer_hardware/hard_drive/portable/design/nonlethal_ammo = good_data("H&S Nonlethal Magazines Pack", list(1, 10), 750),
-			/obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo = good_data("H&S Lethal Magazines Pack", list(1, 10), 950),
-			/obj/item/computer_hardware/hard_drive/portable/design/security = good_data("Security Miscellaneous Pack", list(1, 10), 450),
-			/obj/item/computer_hardware/hard_drive/portable = good_data("Blank Disk", list(1, 10), 15)
+			/obj/item/computer_hardware/hard_drive/portable/design/misc = good_data("Lonestar Miscellaneous Pack", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable/design/robustcells = good_data("Lonestar Robustcells", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable/design/janitor = good_data("Lonestar Janitor Pack", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable/design/nonlethal_ammo = good_data("H&S Nonlethal Magazines Pack", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo = good_data("H&S Lethal Magazines Pack", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable/design/security = good_data("Security Miscellaneous Pack", list(1, 10)),
+			/obj/item/computer_hardware/hard_drive/portable = good_data("Blank Disk", list(1, 10))
 		),
 		"Printed Goods" = list(
 			/obj/item/cell/large = good_data("Large Power Cell", list(-9900, -9850), 60),
@@ -44,7 +44,6 @@
 			/obj/item/shield = good_data("Shield", list(-9900, -850), 250),
 			/obj/item/gun_upgrade = good_data("Gun Upgrade", list(-9900, -9850), 350),
 			/obj/item/tool/baton = good_data("Stun Baton", list(-9900, -9850), 250),
-			/obj/item/gun_upgrade = good_data("Gun Upgrade", list(-9900, -9850), 350),
 			/obj/item/extinguisher = good_data("Extinguisher", list(-9900, -9850), 30)
 		)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/1-common/material_refine.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/material_refine.dm
@@ -32,28 +32,28 @@
 			/obj/machinery/floodlight
 			),
 		"Refined Materials" = list(
-			/obj/item/stack/material/plastic/full = good_data("plastic sheets (x120)", list(4, 5), 1500),
-			/obj/item/stack/material/cardboard/full = good_data("cardboard sheets (x120)", list(2, 5), 2000),
-			/obj/item/stack/material/steel/full = good_data("steel sheets (x120)", list(3, 5), 1500),
-			/obj/item/stack/material/plasteel/full = good_data("plasteel sheets (x120)", list(2, 3), 4500),
-			/obj/item/stack/material/wood/full = good_data("wood planks (x120)", list(2, 5), 1500),
-			/obj/item/stack/material/glass/full = good_data("glass sheets (x120)", list(2, 5), 1500),
-			/obj/item/stack/material/plasma/full = good_data("plasma sheets (x120)", list(1, 2), 6000),
-			/obj/item/stack/material/glass/plasmaglass = good_data("borosilicate glass sheets (x120)", list(3, 5), 2500)
+			/obj/item/stack/material/plastic/full = good_data("plastic sheets (x120)", list(4, 5), 720),
+			/obj/item/stack/material/cardboard/full = good_data("cardboard sheets (x120)", list(2, 5), 720),
+			/obj/item/stack/material/steel/full = good_data("steel sheets (x120)", list(3, 5), 720),
+			/obj/item/stack/material/plasteel/full = good_data("plasteel sheets (x120)", list(2, 3), 2880),
+			/obj/item/stack/material/wood/full = good_data("wood planks (x120)", list(2, 5), 360),
+			/obj/item/stack/material/glass/full = good_data("glass sheets (x120)", list(2, 5), 720),
+			/obj/item/stack/material/plasma/full = good_data("plasma sheets (x120)", list(1, 2), 3600),
+			/obj/item/stack/material/glass/plasmaglass = good_data("borosilicate glass sheets (x120)", list(3, 5), 3600)
 		)
 	)
 
 	hidden_inventory = list(
 		"Refined Material Stacks" = list(
-			/obj/item/stack/material/iron/full = good_data("iron ingots (x120)", list(1, 2), 1000),
-			/obj/item/stack/material/silver/full = good_data("silver ingots (x120)", list(1, 2), 2000),
-			/obj/item/stack/material/gold/full = good_data("gold ingots (x120)", list(1, 2), 2500),
-			/obj/item/stack/material/diamond/full = good_data("diamond sheets (x120)", list(1, 2), 10000),
-			/obj/item/stack/material/platinum/full = good_data("platinum sheets (x120)", list(1, 2), 8750),
-			/obj/item/stack/material/osmium/full = good_data("osmium ingots (x120)", list(1, 21), 7500),
-			/obj/item/stack/material/mhydrogen/full = good_data("metallic hydrogen sheets (x120)", list(1, 2), 12500),
-			/obj/item/stack/material/tritium/full = good_data("tritium ingots (x120)", list(1, 2), 12500),
-			/obj/item/stack/material/uranium/full = good_data("uranium sheets (x120)", list(1, 2), 4500)
+			/obj/item/stack/material/iron/full = good_data("iron ingots (x120)", list(1, 2), 360),
+			/obj/item/stack/material/silver/full = good_data("silver ingots (x120)", list(1, 2), 1800),
+			/obj/item/stack/material/gold/full = good_data("gold ingots (x120)", list(1, 2), 3600),
+			/obj/item/stack/material/diamond/full = good_data("diamond sheets (x120)", list(1, 2), 9000),
+			/obj/item/stack/material/platinum/full = good_data("platinum sheets (x120)", list(1, 2), 7200),
+			/obj/item/stack/material/osmium/full = good_data("osmium ingots (x120)", list(1, 21), 4320),
+			/obj/item/stack/material/mhydrogen/full = good_data("metallic hydrogen sheets (x120)", list(1, 2), 10800),
+			/obj/item/stack/material/tritium/full = good_data("tritium ingots (x120)", list(1, 2), 7200),
+			/obj/item/stack/material/uranium/full = good_data("uranium sheets (x120)", list(1, 2), 3600)
 		)
 	)
 
@@ -62,14 +62,14 @@
 		/obj/item/trash/material/metal = offer_data("scrap metal", 120, 20),
 		/obj/item/trash/material/circuit = offer_data("burnt circuit", 90, 20),
 		/obj/item/trash/material/device = offer_data("broken device", 205, 20),
-		/obj/item/stack/ore/iron = offer_data("hematite", 2400, 2),
-		/obj/item/stack/ore/coal = offer_data("raw carbon", 2400, 2),
-		/obj/item/stack/ore/glass = offer_data("sand", 1200, 4),
-		/obj/item/stack/ore/silver = offer_data("native silver ore", 15000, 1),
-		/obj/item/stack/ore/gold = offer_data("native gold ore", 19200, 1),
-		/obj/item/stack/ore/diamond = offer_data("diamonds", 27000, 1),
-		/obj/item/stack/ore/osmium = offer_data("raw platinum", 19200, 1),
-		/obj/item/stack/ore/hydrogen = offer_data("raw hydrogen", 15000, 1),
-		/obj/item/stack/ore/uranium = offer_data("pitchblende", 27000, 1),
-		/obj/item/stack/ore/plasma = offer_data("plasma crystals", 9600, 1)
+		/obj/item/stack/ore/iron = offer_data("full stack of hematite", 2400, 2),
+		/obj/item/stack/ore/coal = offer_data("full stack of raw carbon", 2400, 2),
+		/obj/item/stack/ore/glass = offer_data("full stack of sand", 1200, 4),
+		/obj/item/stack/ore/silver = offer_data("full stack of native silver ore", 15000, 1),
+		/obj/item/stack/ore/gold = offer_data("full stack of native gold ore", 19200, 1),
+		/obj/item/stack/ore/diamond = offer_data("full stack of diamonds", 27000, 1),
+		/obj/item/stack/ore/osmium = offer_data("full stack of raw platinum", 19200, 1),
+		/obj/item/stack/ore/hydrogen = offer_data("full stack of raw hydrogen", 15000, 1),
+		/obj/item/stack/ore/uranium = offer_data("full stack of pitchblende", 27000, 1),
+		/obj/item/stack/ore/plasma = offer_data("full stack of plasma crystals", 9600, 1)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
@@ -42,8 +42,8 @@
 			/obj/item/storage/briefcase/inflatable/empty,
 			/obj/item/inflatable/door,
 			/obj/item/inflatable/wall,
-			/obj/item/stack/material/steel/full = good_data("steel sheets (x120)", list(3, 5), 2700), //Better deal here
-			/obj/item/stack/material/glass/plasmaglass = good_data("borosilicate glass sheets (x120)", list(3, 5), 3500),
+			/obj/item/stack/material/steel/full = good_data("steel sheets (x120)", list(3, 5), 660), //Better deal here
+			/obj/item/stack/material/glass/plasmaglass = good_data("borosilicate glass sheets (x120)", list(3, 5), 3200),
 			/obj/item/storage/belt/utility/full,
 			/obj/item/clothing/head/welding,
 			/obj/item/tool/omnitool,

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/advmoe.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/advmoe.dm
@@ -43,12 +43,12 @@
 		),
 		"Autoinjectors II" = list(
 			// Autoinjectors defined in hypospray.dm
-			/obj/item/reagent_containers/hypospray/autoinjector/polystem = custom_good_amount_range(list(10, 20)),
-			/obj/item/reagent_containers/hypospray/autoinjector/meralyne = custom_good_amount_range(list(10, 20)),
-			/obj/item/reagent_containers/hypospray/autoinjector/dermaline = custom_good_amount_range(list(10, 20)),
-			/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus = custom_good_amount_range(list(10, 20)),
-			/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = custom_good_amount_range(list(10, 20)),
-			/obj/item/reagent_containers/hypospray/autoinjector/ryetalyn = custom_good_amount_range(list(10, 20))
+			/obj/item/reagent_containers/hypospray/autoinjector/polystem = good_data("polystem autoinjector", list(10, 20), 40),
+			/obj/item/reagent_containers/hypospray/autoinjector/meralyne = good_data("meralyne autoinjector", list(10, 20), 65),
+			/obj/item/reagent_containers/hypospray/autoinjector/dermaline = good_data("dermaline autoinjector", list(10, 20), 60),
+			/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus = good_data("dexalin plus autoinjector", list(10, 20), 65),
+			/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = good_data("oxycodone autoinjector", list(10, 20), 40),
+			/obj/item/reagent_containers/hypospray/autoinjector/ryetalyn = good_data("ryetalyn autoinjector", list(10, 20), 40)
 		)
 	)
 	offer_types = list(

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/casino.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/casino.dm
@@ -6,19 +6,23 @@
 	markup = 5				// High markup, low base price to prevent export abuse
 	base_income = 0
 	wealth = 0
-	hidden_inv_threshold = 2000
+	hidden_inv_threshold = 1000
 	recommendation_threshold = 4000
 	stations_recommended = list("illegal1", "serbian", "greyson")
 	recommendations_needed = 1
 	inventory = list(
 		"Assorted Goods" = list(
-			//obj/item/storage/deferred/gun_parts = custom_good_amount_range(list(2, 4)),
 			/obj/item/storage/deferred/powercells = custom_good_amount_range(list(2, 4)),
-			/obj/item/storage/deferred/electronics = custom_good_amount_range(list(2, 4))
+			/obj/item/storage/deferred/electronics = custom_good_amount_range(list(2, 4)),
+			/obj/item/storage/deferred/science = custom_good_amount_range(list(2, 4)),
+			/obj/item/storage/deferred/toolmod = custom_good_amount_range(list(2, 4)),
+			/obj/item/storage/deferred/medical = custom_good_amount_range(list(2, 4))
 		)
 	)
 	hidden_inventory = list(
-			/obj/item/storage/deferred/disks = custom_good_amount_range(list(2, 4))
+			/obj/item/storage/deferred/disks = custom_good_amount_range(list(2, 4)),
+			/obj/item/storage/deferred/rig = custom_good_amount_range(list(2, 4)),
+			/obj/item/storage/deferred/tools = custom_good_amount_range(list(2, 4))
 	)
 	offer_types = list(
 		/obj/item/oddity/common/coin = offer_data("strange coin", 800, 1),

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/fs_weapon_factory.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/fs_weapon_factory.dm
@@ -60,7 +60,7 @@
 			/obj/item/grenade/frag,
 			/obj/item/grenade/explosive,
 			/obj/item/grenade/anti_photon,
-			/obj/item/plastique
+			/obj/item/plastique = good_data("plastic explosive", (list(2, 4)), 1500)
 		),
 		"Top Class Firearms" = list(
 			/obj/item/gun/projectile/boltgun/scout,

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/suit_up.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/suit_up.dm
@@ -9,7 +9,7 @@
 	offer_limit = 20
 	base_income = 3200
 	wealth = 0
-	hidden_inv_threshold = 24000
+	hidden_inv_threshold = 6000//was previously 24,000 which is absurd for bomb and radiation suits
 	recommendations_needed = 1
 	stations_recommended = list("rigs", "mecha")
 	inventory = list(
@@ -74,7 +74,7 @@
 	)
 
 	hidden_inventory = list(
-		"Unitity Suits" = list(
+		"Utility Suits" = list(
 			/obj/item/clothing/suit/space/bomb,
 			/obj/item/clothing/head/helmet/space/bomb,
 			/obj/item/clothing/suit/fire,

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/suit_up.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/suit_up.dm
@@ -9,7 +9,7 @@
 	offer_limit = 20
 	base_income = 3200
 	wealth = 0
-	hidden_inv_threshold = 6000//was previously 24,000 which is absurd for bomb and radiation suits
+	hidden_inv_threshold = 2000
 	recommendations_needed = 1
 	stations_recommended = list("rigs", "mecha")
 	inventory = list(

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
@@ -16,31 +16,31 @@
 			/obj/item/computer_hardware/hard_drive/portable/design/onestar = good_data("GP Tool Disk", list(-2, 1), 1200)
 		),
 		"Gongju" = list(
-			/obj/item/tool/crowbar/onestar = good_data("GP Crowbar", list(-100, -50)),
-			/obj/item/tool/onestar_multitool = good_data("GP Multitool", list(-100, -50)),
-			/obj/item/tool/weldingtool/onestar = good_data("GP Welding Tool", list(-100, -50)),
-			/obj/item/tool/screwdriver/combi_driver/onestar = good_data("GP Combination Drill", list(-100, -50)),
-			/obj/item/tool/hammer/powered_hammer/onestar_hammer = good_data("GP Sledgehammer", list(-100, -50)),
-			/obj/item/tool/pickaxe/jackhammer/onestar = good_data("GP Jackhammer", list(-100, -50)),
-			/obj/item/tool/pickaxe/drill/onestar = good_data("GP Mining Drill", list(-100, -50)),
-			/obj/item/tool/pickaxe/onestar = good_data("GP Pickaxe", list(-100, -500),
-			/obj/item/tool/shovel/onestar_shovel = good_data("GP Shovel", list(-100, -50)),
-			/obj/item/tool/saw/onestar_saw = good_data("GP Handsaw", list(-100, -50)),
-			/obj/item/tool/medmultitool = good_data("GP Medical Multitool", list(-100, -50)),
-			/obj/item/tool/wirecutters/onestar_pliers = good_data("GP Pliers", list(-100, -50))
+			/obj/item/tool/crowbar/onestar = custom_good_nameprice("GP Crowbar", list(-100, -50)),
+			/obj/item/tool/onestar_multitool = custom_good_nameprice("GP Multitool", list(-100, -50)),
+			/obj/item/tool/weldingtool/onestar = custom_good_nameprice("GP Welding Tool", list(-100, -50)),
+			/obj/item/tool/screwdriver/combi_driver/onestar = custom_good_nameprice("GP Combination Drill", list(-100, -50)),
+			/obj/item/tool/hammer/powered_hammer/onestar_hammer = custom_good_nameprice("GP Sledgehammer", list(-100, -50)),
+			/obj/item/tool/pickaxe/jackhammer/onestar = custom_good_nameprice("GP Jackhammer", list(-100, -50)),
+			/obj/item/tool/pickaxe/drill/onestar = custom_good_nameprice("GP Mining Drill", list(-100, -50)),
+			/obj/item/tool/pickaxe/onestar = custom_good_nameprice("GP Pickaxe", list(-100, -500),
+			/obj/item/tool/shovel/onestar_shovel = custom_good_nameprice("GP Shovel", list(-100, -50)),
+			/obj/item/tool/saw/onestar_saw = custom_good_nameprice("GP Handsaw", list(-100, -50)),
+			/obj/item/tool/medmultitool = custom_good_nameprice("GP Medical Multitool", list(-100, -50)),
+			/obj/item/tool/wirecutters/onestar_pliers = custom_good_nameprice("GP Pliers", list(-100, -50))
 		),
 		"Beijian" = list(
-			/obj/item/stock_parts/micro_laser/one_star = good_data("GP Micro Laser", list(-100, -50)),
-			/obj/item/stock_parts/matter_bin/one_star = good_data("GP Matter Bin", list(-100, -50)),
-			/obj/item/stock_parts/scanning_module/one_star = good_data("GP Scanning Module", list(-100, -50)),
-			/obj/item/stock_parts/capacitor/one_star = good_data("GP Capacitor", list(-100, -50)),
+			/obj/item/stock_parts/micro_laser/one_star = custom_good_nameprice("GP Micro Laser", list(-100, -50)),
+			/obj/item/stock_parts/matter_bin/one_star = custom_good_nameprice("GP Matter Bin", list(-100, -50)),
+			/obj/item/stock_parts/scanning_module/one_star = custom_good_nameprice("GP Scanning Module", list(-100, -50)),
+			/obj/item/stock_parts/capacitor/one_star = custom_good_nameprice("GP Capacitor", list(-100, -50)),
 			/obj/item/stock_parts/manipulator/one_star = good_data("GP Manipulator", list(-100, -50))
 		)
 	)
 	hidden_inventory = list(
 		"Wuqi pan" = list(
-			/obj/item/computer_hardware/hard_drive/portable/design/onestar/cog = good_data("GP Cog Disk", list(1, 1), 875),
-			/obj/item/computer_hardware/hard_drive/portable/design/onestar/armor = good_data("GP Ablative Disk", list(1, 2), 775)
+			/obj/item/computer_hardware/hard_drive/portable/design/onestar/cog = custom_good_nameprice("GP Cog Disk", list(1, 2)),
+			/obj/item/computer_hardware/hard_drive/portable/design/onestar/armor = custom_good_nameprice("GP Ablative Disk", list(1, 2))
 		),
 		"Wuqi yinshua" = list(
 			/obj/item/gun/energy/cog = good_data("GP Cog", list(-1, 0), 475)
@@ -54,12 +54,12 @@
 			/obj/item/clothing/suit/armor/vest/iron_lock_security = good_data("ILS Ablasive Vest", list(-100, -50), 475)
 		),
 		"Gongju mo zu" = list(
-			/obj/item/tool_upgrade/augment/holding_tank = good_data("GP Welder Fule Holding Tank", list(-100, -50)),
-			/obj/item/tool_upgrade/augment/repair_nano = good_data("GP Nano Repair", list(-100, -50)),
-			/obj/item/tool_upgrade/augment/ai_tool = good_data("GP Nano AI", list(-100, -50)),
+			/obj/item/tool_upgrade/augment/holding_tank = custom_good_nameprice("GP Welder Fule Holding Tank", list(-100, -50)),
+			/obj/item/tool_upgrade/augment/repair_nano = custom_good_nameprice("GP Nano Repair", list(-100, -50)),
+			/obj/item/tool_upgrade/augment/ai_tool = custom_good_nameprice("GP Nano AI", list(-100, -50)),
 			//Guns are tools too
-			/obj/item/gun_upgrade/mechanism/glass_widow = good_data("GP Glass Widow", list(-100, -50)),
-			/obj/item/gun_upgrade/mechanism/greyson_master_catalyst = good_data("GP \"Master Unmaker\" infuser", list(-100, -50))
+			/obj/item/gun_upgrade/mechanism/glass_widow = custom_good_nameprice("GP Glass Widow", list(-100, -50)),
+			/obj/item/gun_upgrade/mechanism/greyson_master_catalyst = custom_good_nameprice("GP \"Master Unmaker\" infuser", list(-100, -50))
 		)
 	)
 

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
@@ -23,7 +23,7 @@
 			/obj/item/tool/hammer/powered_hammer/onestar_hammer = custom_good_nameprice("GP Sledgehammer", list(-100, -50)),
 			/obj/item/tool/pickaxe/jackhammer/onestar = custom_good_nameprice("GP Jackhammer", list(-100, -50)),
 			/obj/item/tool/pickaxe/drill/onestar = custom_good_nameprice("GP Mining Drill", list(-100, -50)),
-			/obj/item/tool/pickaxe/onestar = custom_good_nameprice("GP Pickaxe", list(-100, -500),
+			/obj/item/tool/pickaxe/onestar = custom_good_nameprice("GP Pickaxe", list(-100, -500)),
 			/obj/item/tool/shovel/onestar_shovel = custom_good_nameprice("GP Shovel", list(-100, -50)),
 			/obj/item/tool/saw/onestar_saw = custom_good_nameprice("GP Handsaw", list(-100, -50)),
 			/obj/item/tool/medmultitool = custom_good_nameprice("GP Medical Multitool", list(-100, -50)),
@@ -34,7 +34,7 @@
 			/obj/item/stock_parts/matter_bin/one_star = custom_good_nameprice("GP Matter Bin", list(-100, -50)),
 			/obj/item/stock_parts/scanning_module/one_star = custom_good_nameprice("GP Scanning Module", list(-100, -50)),
 			/obj/item/stock_parts/capacitor/one_star = custom_good_nameprice("GP Capacitor", list(-100, -50)),
-			/obj/item/stock_parts/manipulator/one_star = good_data("GP Manipulator", list(-100, -50))
+			/obj/item/stock_parts/manipulator/one_star = custom_good_nameprice("GP Manipulator", list(-100, -50))
 		)
 	)
 	hidden_inventory = list(

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
@@ -16,25 +16,25 @@
 			/obj/item/computer_hardware/hard_drive/portable/design/onestar = good_data("GP Tool Disk", list(-2, 1), 1200)
 		),
 		"Gongju" = list(
-			/obj/item/tool/crowbar/onestar = good_data("GP Crowbar", list(-100, -50), 500),
-			/obj/item/tool/onestar_multitool = good_data("GP Multitool", list(-100, -50), 600),
-			/obj/item/tool/weldingtool/onestar = good_data("GP Welding Tool", list(-100, -50), 500),
-			/obj/item/tool/screwdriver/combi_driver/onestar = good_data("GP Combination Drill", list(-100, -50), 700),
-			/obj/item/tool/hammer/powered_hammer/onestar_hammer = good_data("GP Sledgehammer", list(-100, -50), 800),
-			/obj/item/tool/pickaxe/jackhammer/onestar = good_data("GP Jackhammer", list(-100, -50), 600),
-			/obj/item/tool/pickaxe/drill/onestar = good_data("GP Mining Drill", list(-100, -50), 600),
-			/obj/item/tool/pickaxe/onestar = good_data("GP Pickaxe", list(-100, -50), 500),
-			/obj/item/tool/shovel/onestar_shovel = good_data("GP Shovel", list(-100, -50), 450),
-			/obj/item/tool/saw/onestar_saw = good_data("GP Handsaw", list(-100, -50), 700),
-			/obj/item/tool/medmultitool = good_data("GP Medical Multitool", list(-100, -50), 800),
-			/obj/item/tool/wirecutters/onestar_pliers = good_data("GP Pliers", list(-100, -50), 700)
+			/obj/item/tool/crowbar/onestar = good_data("GP Crowbar", list(-100, -50)),
+			/obj/item/tool/onestar_multitool = good_data("GP Multitool", list(-100, -50)),
+			/obj/item/tool/weldingtool/onestar = good_data("GP Welding Tool", list(-100, -50)),
+			/obj/item/tool/screwdriver/combi_driver/onestar = good_data("GP Combination Drill", list(-100, -50)),
+			/obj/item/tool/hammer/powered_hammer/onestar_hammer = good_data("GP Sledgehammer", list(-100, -50)),
+			/obj/item/tool/pickaxe/jackhammer/onestar = good_data("GP Jackhammer", list(-100, -50)),
+			/obj/item/tool/pickaxe/drill/onestar = good_data("GP Mining Drill", list(-100, -50)),
+			/obj/item/tool/pickaxe/onestar = good_data("GP Pickaxe", list(-100, -500),
+			/obj/item/tool/shovel/onestar_shovel = good_data("GP Shovel", list(-100, -50)),
+			/obj/item/tool/saw/onestar_saw = good_data("GP Handsaw", list(-100, -50)),
+			/obj/item/tool/medmultitool = good_data("GP Medical Multitool", list(-100, -50)),
+			/obj/item/tool/wirecutters/onestar_pliers = good_data("GP Pliers", list(-100, -50))
 		),
 		"Beijian" = list(
-			/obj/item/stock_parts/micro_laser/one_star = good_data("GP Micro Laser", list(-100, -50), 575),
-			/obj/item/stock_parts/matter_bin/one_star = good_data("GP Matter Bin", list(-100, -50), 575),
-			/obj/item/stock_parts/scanning_module/one_star = good_data("GP Scanning Module", list(-100, -50), 575),
-			/obj/item/stock_parts/capacitor/one_star = good_data("GP Capacitor", list(-100, -50), 575),
-			/obj/item/stock_parts/manipulator/one_star = good_data("GP Manipulator", list(-100, -50), 575)
+			/obj/item/stock_parts/micro_laser/one_star = good_data("GP Micro Laser", list(-100, -50)),
+			/obj/item/stock_parts/matter_bin/one_star = good_data("GP Matter Bin", list(-100, -50)),
+			/obj/item/stock_parts/scanning_module/one_star = good_data("GP Scanning Module", list(-100, -50)),
+			/obj/item/stock_parts/capacitor/one_star = good_data("GP Capacitor", list(-100, -50)),
+			/obj/item/stock_parts/manipulator/one_star = good_data("GP Manipulator", list(-100, -50))
 		)
 	)
 	hidden_inventory = list(
@@ -54,12 +54,12 @@
 			/obj/item/clothing/suit/armor/vest/iron_lock_security = good_data("ILS Ablasive Vest", list(-100, -50), 475)
 		),
 		"Gongju mo zu" = list(
-			/obj/item/tool_upgrade/augment/holding_tank = good_data("GP Welder Fule Holding Tank", list(-100, -50), 1000),
-			/obj/item/tool_upgrade/augment/repair_nano = good_data("GP Nano Repair", list(-100, -50), 1275),
-			/obj/item/tool_upgrade/augment/ai_tool = good_data("GP Nano AI", list(-100, -50), 1375),
+			/obj/item/tool_upgrade/augment/holding_tank = good_data("GP Welder Fule Holding Tank", list(-100, -50)),
+			/obj/item/tool_upgrade/augment/repair_nano = good_data("GP Nano Repair", list(-100, -50)),
+			/obj/item/tool_upgrade/augment/ai_tool = good_data("GP Nano AI", list(-100, -50)),
 			//Guns are tools too
-			/obj/item/gun_upgrade/mechanism/glass_widow = good_data("GP Glass Widow", list(-100, -50), 1200),
-			/obj/item/gun_upgrade/mechanism/greyson_master_catalyst = good_data("GP \"Master Unmaker\" infuser", list(-100, -50), 15000)
+			/obj/item/gun_upgrade/mechanism/glass_widow = good_data("GP Glass Widow", list(-100, -50)),
+			/obj/item/gun_upgrade/mechanism/greyson_master_catalyst = good_data("GP \"Master Unmaker\" infuser", list(-100, -50))
 		)
 	)
 


### PR DESCRIPTION


## Changelog
:cl:
balance: purchasing now gives 25% of the money as favour, up from 12.5%
balance: recoll prices back to material sheet price * 3 (generally)
balance: casino sells more random things now, and has a lower secret inv threshold
balance: it's now cheaper to get disks from Factor instead of disk vendor
balance: C4 price is now 1500 again from Kaida
balance: suitup's secret inv threshold is now 6000, down from 24,000
balance: Greyson Printer station no longer sells greyson significantly cheaper
/:cl:

