### PR TITLE
LITERALLY 1984: 2, cyberpunk boogaloo

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -3144,7 +3144,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "aIn" = (
 /obj/structure/flora/small/trailrocka5,
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
@@ -3324,6 +3324,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
 "aJQ" = (
@@ -6652,7 +6653,7 @@
 	},
 /obj/machinery/surveillance_pod,
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "bwP" = (
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/flashlight,
@@ -8369,7 +8370,7 @@
 	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "bQx" = (
 /obj/structure/closet/secure_closet/personal/salvager,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -10891,7 +10892,7 @@
 	req_access = list(1)
 	},
 /turf/simulated/wall/r_wall,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/evidencestorage)
 "ctt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -15584,7 +15585,7 @@
 /area/nadezhda/engineering/atmos)
 "dsi" = (
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "dsj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
@@ -19689,13 +19690,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "enp" = (
@@ -26947,11 +26948,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fML" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
-	name = "Evidence Storage";
-	req_access = list(1)
+	name = "E.Y.E Pod storage";
+	req_access = list(4)
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/detectives_office)
 "fMX" = (
 /obj/structure/table/steel,
@@ -35036,11 +35038,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "hAS" = (
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/detectives_office)
 "hBd" = (
 /obj/structure/sign/departmentold/botany,
 /turf/simulated/wall/r_wall,
@@ -36679,7 +36681,7 @@
 "hVt" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "hVu" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -39528,7 +39530,7 @@
 	id = "EYE"
 	},
 /turf/simulated/floor/plating,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "iBc" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -47632,9 +47634,9 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kmr" = (
 /obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monofloor,
+/turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/evidencestorage)
 "kms" = (
 /obj/structure/cable/green{
@@ -64708,7 +64710,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/evidencestorage)
 "nOb" = (
 /obj/structure/flora/small/trailrocka1,
 /obj/structure/flora/small/trailrockb1,
@@ -65683,7 +65685,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/evidencestorage)
 "oaa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -73766,6 +73768,10 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "pLO" = (
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
+/obj/random/contraband,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -77795,10 +77801,11 @@
 	},
 /obj/machinery/button/windowtint{
 	id = "BARA";
-	pixel_y = 21
+	pixel_y = 21;
+	range = 5
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "qDS" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/cobweb2,
@@ -82344,7 +82351,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/evidencestorage)
 "ryn" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -83624,9 +83631,11 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/surface/section1)
 "rMv" = (
-/obj/effect/floor_decal/industrial/arrows/white,
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "rMH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
@@ -86804,8 +86813,19 @@
 	name = "E.Y.E Pod storage";
 	req_access = list(4)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "svx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -88450,7 +88470,7 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "sPG" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/wood,
@@ -88653,7 +88673,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/evidencestorage)
 "sRM" = (
 /turf/simulated/floor/beach/water/coastwater{
 	dir = 10
@@ -89123,7 +89143,7 @@
 	pixel_x = -1
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "sWF" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -91434,7 +91454,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "tvG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -92281,7 +92301,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/evidencestorage)
 "tFg" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "15,6";
@@ -94658,7 +94678,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/evidencestorage)
 "uhI" = (
 /obj/structure/flora/small/trailrockb3,
 /turf/simulated/floor/rock,
@@ -97463,6 +97483,12 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
+"uKB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/bluecorner,
+/area/nadezhda/security/sechall)
 "uKG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/cev_eris{
@@ -98745,6 +98771,10 @@
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
+"uXp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/security/detectives_office)
 "uXx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -100503,7 +100533,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/evidencestorage)
 "vqd" = (
 /obj/structure/scrap_cube,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -101362,7 +101392,7 @@
 /obj/random/contraband,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/evidencestorage)
 "vxX" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/small/busha3,
@@ -102857,7 +102887,7 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "vPo" = (
 /obj/effect/floor_decal/industrial/box/white/corners{
 	dir = 8;
@@ -105380,7 +105410,8 @@
 /obj/machinery/button/windowtint{
 	id = "WO";
 	pixel_x = -6;
-	pixel_y = 4
+	pixel_y = 4;
+	range = 5
 	},
 /obj/item/folder/red,
 /obj/item/folder/red,
@@ -105447,7 +105478,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/evidencestorage)
 "wpN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
@@ -107152,7 +107183,7 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "wHT" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/random/lowkeyrandom,
@@ -109478,9 +109509,9 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "xjp" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows/white,
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/detectives_office)
 "xjr" = (
 /obj/structure/table/reinforced,
 /obj/structure/table/reinforced,
@@ -112032,15 +112063,12 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/disposaldrop)
 "xLI" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/random/contraband,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_access = list(1)
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/detectives_office)
 "xLS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -113924,7 +113952,7 @@
 "ygO" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/security/sechall)
+/area/nadezhda/security/evidencestorage)
 "ygV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -123338,13 +123366,13 @@ puh
 puh
 puh
 puh
-uHe
-uHe
-uHe
-uHe
-uHe
-uHe
-uHe
+puh
+puh
+puh
+puh
+puh
+puh
+puh
 ivh
 lvO
 bgD
@@ -123540,13 +123568,13 @@ aen
 nvy
 aFJ
 vQu
-uHe
+puh
 qDO
 hVt
 bwL
 tvC
-pLO
-uHe
+hAS
+puh
 pUX
 kgC
 bgD
@@ -123743,12 +123771,12 @@ xqR
 xds
 xqR
 khY
-rMv
+xjp
 dsi
 bQt
-rnp
-kmr
-svu
+uXp
+rMv
+fML
 xYV
 xea
 bgD
@@ -123944,7 +123972,7 @@ lUT
 kaC
 ctt
 dZf
-uHe
+puh
 sPE
 vPk
 aIm
@@ -124146,13 +124174,13 @@ puh
 puh
 ofA
 puh
-uHe
+puh
 iAW
 iAW
 svu
 iAW
 iAW
-uHe
+puh
 yiX
 nTQ
 bgD
@@ -125556,7 +125584,7 @@ vJt
 pwk
 puh
 puh
-fML
+xLI
 puh
 puh
 puh
@@ -125758,7 +125786,7 @@ gwa
 hrU
 nNZ
 uhF
-hAS
+kmr
 faZ
 oZj
 iOv
@@ -125960,7 +125988,7 @@ pGK
 rAb
 nZZ
 sRL
-xLI
+pLO
 faZ
 fau
 wPn
@@ -126361,10 +126389,10 @@ ilM
 qEU
 rzv
 eng
-rAb
+uKB
 tFf
 ryl
-xLI
+pLO
 faZ
 hfQ
 xCH
@@ -126565,8 +126593,8 @@ rzv
 jmM
 rAb
 ygO
-xjp
-hAS
+rnp
+kmr
 faZ
 xlw
 xCH
@@ -126766,8 +126794,8 @@ jBZ
 rzv
 vJt
 oXb
-bgD
-bgD
+uHe
+uHe
 cts
 faZ
 fyp

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -3129,11 +3129,6 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "aIm" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -6637,19 +6632,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/bridge)
 "bwL" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/camera/network/security{
 	dir = 4
-	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
 	},
 /obj/machinery/surveillance_pod,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -8355,11 +8339,6 @@
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
 "bQt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 8
@@ -10892,7 +10871,7 @@
 	req_access = list(1)
 	},
 /turf/simulated/wall/r_wall,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "ctt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -13705,11 +13684,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "cXu" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -19186,11 +19160,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -30885,6 +30854,10 @@
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"gFg" = (
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/security/detectives_office)
 "gFl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -35038,11 +35011,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "hAS" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/detectives_office)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/bluecorner,
+/area/nadezhda/security/sechall)
 "hBd" = (
 /obj/structure/sign/departmentold/botany,
 /turf/simulated/wall/r_wall,
@@ -47637,7 +47610,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "kms" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -64710,7 +64683,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "nOb" = (
 /obj/structure/flora/small/trailrocka1,
 /obj/structure/flora/small/trailrockb1,
@@ -65685,7 +65658,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "oaa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -73768,15 +73741,11 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "pLO" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/random/contraband,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "pLP" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,15"
@@ -81294,7 +81263,7 @@
 "rnp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/detectives_office)
 "rnr" = (
 /obj/machinery/light_switch{
 	dir = 1;
@@ -82351,7 +82320,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "ryn" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -86819,11 +86788,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/detectives_office)
 "svx" = (
@@ -88673,7 +88637,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "sRM" = (
 /turf/simulated/floor/beach/water/coastwater{
 	dir = 10
@@ -92301,7 +92265,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "tFg" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "15,6";
@@ -94678,7 +94642,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "uhI" = (
 /obj/structure/flora/small/trailrockb3,
 /turf/simulated/floor/rock,
@@ -97175,8 +97139,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "uHe" = (
-/turf/simulated/wall/r_wall,
-/area/nadezhda/security/evidencestorage)
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/security/detectives_office)
 "uHf" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -97483,12 +97451,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
-"uKB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/sechall)
 "uKG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/cev_eris{
@@ -98771,10 +98733,6 @@
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
-"uXp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/detectives_office)
 "uXx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -100533,7 +100491,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "vqd" = (
 /obj/structure/scrap_cube,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -101392,7 +101350,7 @@
 /obj/random/contraband,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "vxX" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/small/busha3,
@@ -105478,7 +105436,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "wpN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
@@ -109509,9 +109467,9 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "xjp" = (
-/obj/effect/floor_decal/industrial/arrows/white,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/security/detectives_office)
+/area/nadezhda/security/sechall)
 "xjr" = (
 /obj/structure/table/reinforced,
 /obj/structure/table/reinforced,
@@ -112063,12 +112021,15 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/disposaldrop)
 "xLI" = (
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage";
-	req_access = list(1)
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
+/obj/random/contraband,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/detectives_office)
+/area/nadezhda/security/sechall)
 "xLS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -113952,7 +113913,7 @@
 "ygO" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/security/evidencestorage)
+/area/nadezhda/security/sechall)
 "ygV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -123573,7 +123534,7 @@ qDO
 hVt
 bwL
 tvC
-hAS
+pLO
 puh
 pUX
 kgC
@@ -123771,10 +123732,10 @@ xqR
 xds
 xqR
 khY
-xjp
+gFg
 dsi
 bQt
-uXp
+rnp
 rMv
 fML
 xYV
@@ -125584,7 +125545,7 @@ vJt
 pwk
 puh
 puh
-xLI
+uHe
 puh
 puh
 puh
@@ -125988,7 +125949,7 @@ pGK
 rAb
 nZZ
 sRL
-pLO
+xLI
 faZ
 fau
 wPn
@@ -126389,10 +126350,10 @@ ilM
 qEU
 rzv
 eng
-uKB
+hAS
 tFf
 ryl
-pLO
+xLI
 faZ
 hfQ
 xCH
@@ -126593,7 +126554,7 @@ rzv
 jmM
 rAb
 ygO
-rnp
+xjp
 kmr
 faZ
 xlw
@@ -126794,8 +126755,8 @@ jBZ
 rzv
 vJt
 oXb
-uHe
-uHe
+bgD
+bgD
 cts
 faZ
 fyp

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -3140,6 +3140,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/evidencestorage)
 "aIn" = (
@@ -6633,11 +6636,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/bridge)
 "bwL" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/random/contraband/low_chance,
-/obj/item/contraband/poster,
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
@@ -6652,6 +6650,7 @@
 	pixel_x = -28;
 	pixel_y = 0
 	},
+/obj/machinery/surveillance_pod,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/evidencestorage)
 "bwP" = (
@@ -8361,6 +8360,14 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/box/white/corners,
+/obj/effect/floor_decal/industrial/box/white/corners{
+	dir = 8;
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/evidencestorage)
 "bQx" = (
@@ -10879,8 +10886,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
 "cts" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_access = list(1)
+	},
+/turf/simulated/wall/r_wall,
 /area/nadezhda/security/sechall)
 "ctt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -26941,9 +26951,8 @@
 	name = "Evidence Storage";
 	req_access = list(1)
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/security/evidencestorage)
+/turf/simulated/wall/r_wall,
+/area/nadezhda/security/detectives_office)
 "fMX" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/snacks/tomatomeat,
@@ -35027,11 +35036,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "hAS" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
 "hBd" = (
@@ -36670,10 +36677,7 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "hVt" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/random/contraband,
+/obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/evidencestorage)
 "hVu" = (
@@ -39519,8 +39523,10 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/cafeteria)
 "iAW" = (
-/obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced/polarized{
+	id = "EYE"
+	},
 /turf/simulated/floor/plating,
 /area/nadezhda/security/evidencestorage)
 "iBc" = (
@@ -47625,15 +47631,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kmr" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/security/sechall)
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/security/evidencestorage)
 "kms" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -64704,9 +64706,7 @@
 /area/nadezhda/command/captain)
 "nNZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/sechall)
 "nOb" = (
@@ -65679,12 +65679,9 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
 "nZZ" = (
-/obj/structure/table/standard,
-/obj/item/folder/red,
-/obj/item/folder/red,
-/obj/item/device/taperecorder,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/sechall)
 "oaa" = (
@@ -73769,10 +73766,6 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "pLO" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/random/contraband,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -77797,16 +77790,13 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "qDO" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/random/contraband/low_chance,
-/obj/random/contraband/low_chance,
-/obj/random/contraband/low_chance,
-/obj/item/contraband/poster,
+/obj/machinery/button/windowtint{
+	id = "BARA";
+	pixel_y = 21
+	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/evidencestorage)
 "qDS" = (
@@ -82350,7 +82340,10 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ryl" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/sechall)
 "ryn" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -86806,22 +86799,11 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/medical/cryo)
 "svu" = (
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage";
-	req_access = list(1)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "E.Y.E Pod storage";
+	req_access = list(4)
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/evidencestorage)
 "svx" = (
@@ -88456,6 +88438,17 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_pump,
+/obj/structure/table/standard,
+/obj/item/clothing/mask/breath{
+	pixel_x = 4
+	},
+/obj/item/clothing/mask/breath{
+	pixel_y = 4;
+	pixel_x = -4
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/evidencestorage)
 "sPG" = (
@@ -88655,11 +88648,11 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
 "sRL" = (
-/obj/structure/bed/chair/office/dark{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
+/turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/sechall)
 "sRM" = (
 /turf/simulated/floor/beach/water/coastwater{
@@ -89124,6 +89117,11 @@
 "sWE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/item/clothing/head/helmet/visor/cyberpunkgoggle{
+	pixel_y = 5;
+	pixel_x = -1
+	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/evidencestorage)
 "sWF" = (
@@ -91428,13 +91426,13 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "tvC" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 1
 	},
-/obj/random/contraband/low_chance,
-/obj/random/contraband/low_chance,
-/obj/random/contraband/low_chance,
-/obj/item/contraband/poster,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/evidencestorage)
 "tvG" = (
@@ -92274,6 +92272,14 @@
 /area/nadezhda/command/bridgebar)
 "tFf" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/sechall)
 "tFg" = (
@@ -94651,7 +94657,7 @@
 /obj/structure/noticeboard/marshal{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
+/turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/sechall)
 "uhI" = (
 /obj/structure/flora/small/trailrockb3,
@@ -100486,8 +100492,16 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
 "vpX" = (
-/obj/structure/table/standard,
-/obj/item/device/lighting/toggleable/lamp,
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_access = list(1)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/sechall)
 "vqd" = (
@@ -101342,11 +101356,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
 "vxW" = (
-/obj/structure/table/standard,
-/obj/item/device/eftpos{
-	eftpos_name = "Marshal EFTPOS scanner"
+/obj/structure/closet{
+	name = "Evidence Closet"
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/random/contraband,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
 "vxX" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -102833,6 +102848,14 @@
 "vPk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/item/tank/oxygen{
+	pixel_y = 4
+	},
+/obj/item/tank/oxygen{
+	pixel_x = 3;
+	pixel_y = -2
+	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/evidencestorage)
 "vPo" = (
@@ -105415,9 +105438,15 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
 "wpM" = (
-/obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/sechall)
 "wpN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -107118,6 +107147,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/item/clothing/under/cyber{
+	pixel_y = -3
+	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/evidencestorage)
 "wHT" = (
@@ -109445,11 +109478,8 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "xjp" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
+/turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/sechall)
 "xjr" = (
 /obj/structure/table/reinforced,
@@ -112002,8 +112032,13 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/disposaldrop)
 "xLI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
+/obj/random/contraband,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
 "xLS" = (
@@ -113887,11 +113922,7 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ygO" = (
-/obj/structure/table/standard,
-/obj/machinery/atm{
-	dir = 4;
-	pixel_x = 30
-	},
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/sechall)
 "ygV" = (
@@ -123716,8 +123747,8 @@ rMv
 dsi
 bQt
 rnp
-rMv
-fML
+kmr
+svu
 xYV
 xea
 bgD
@@ -125525,7 +125556,7 @@ vJt
 pwk
 puh
 puh
-puh
+fML
 puh
 puh
 puh
@@ -125727,7 +125758,7 @@ gwa
 hrU
 nNZ
 uhF
-kmr
+hAS
 faZ
 oZj
 iOv
@@ -125929,7 +125960,7 @@ pGK
 rAb
 nZZ
 sRL
-atB
+xLI
 faZ
 fau
 wPn
@@ -126736,7 +126767,7 @@ rzv
 vJt
 oXb
 bgD
-cts
+bgD
 cts
 faZ
 fyp


### PR DESCRIPTION
Slight map adjustment! Evidence storage has been moved to the top right corner of the 'investigation block' in the central Marshals, in its place is the E.Y.E Pods storage room, locked to Ranger access(All Marshals will have access thusly.)
To use it, simply put on the provided equipment in the room, turn on the provided internals and climb in before clicking the pod.
It functions similarly to the AIs eye, allowing you to pan through the camera network in a highly efficient fashion. Credit goes to @Kirov#6255 for the actual code of the thing!
![image](https://user-images.githubusercontent.com/87905328/167120929-282ba0a9-4a3d-45af-8915-af656e17800f.png)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
