### PR TITLE
Mild Buffs to 7.5 (Oversights??)

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -326,18 +326,17 @@
 	armor_penetration = 20
 	penetrating = 1
 	can_ricochet = TRUE
-	step_delay = 0.5
-	affective_damage_range = 5
-	affective_ap_range = 5
-
-/obj/item/projectile/bullet/rifle_75/hv
-	damage_types = list(BRUTE = 20)
-	armor_penetration = 35
-	penetrating = 2
-	can_ricochet = TRUE
 	step_delay = 0.3
 	affective_damage_range = 7
 	affective_ap_range = 7
+
+/obj/item/projectile/bullet/rifle_75/hv
+	damage_types = list(BRUTE = 22)
+	armor_penetration = 36
+	penetrating = 2
+	hitscan = TRUE
+	affective_damage_range = 8
+	affective_ap_range = 8
 	nocap_structures = TRUE //Helps against walls and doors
 
 /obj/item/projectile/bullet/rifle_75/practice
@@ -391,8 +390,8 @@
 /obj/item/projectile/bullet/rifle_75/scrap
 	damage_types = list(BRUTE = 22)
 	armor_penetration = 10
-	affective_damage_range = 2
-	affective_ap_range = 2
+	affective_damage_range = 3
+	affective_ap_range = 3
 
 /// .408 OMNI ///
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	So - basically, it feels as if 7.5 ammo was never balanced with the other calibers. 7.5 HV rounds were objectively weaker than their counter parts due to low pen-to-damage ratio (effectively doing less damage even if it pens) and not being hitscan. Also the step delay on the 7.5 bullets were 0.2 higher than .408 and .257. Why? No clue. Also - increased the affective range to 7, still lower than .408 but actually can be used as DMR caliber now instead of only 'best' at close range.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: Balances 7.5 affective range, HV fixes (hitscan, AP, etc) and bullet-speed changes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
