### PR TITLE
7.5 & LMG Rebalance

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -19,7 +19,7 @@
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/ltrifle_cock.ogg'
-	damage_multiplier = 1 //the uncheap
+	damage_multiplier = 1.2 //the uncheap
 	recoil_buildup = 1.25
 	one_hand_penalty = 10 //automatic rifle level
 	gun_tags = list(GUN_PROJECTILE, GUN_SCOPE, GUN_MAGWELL)
@@ -114,9 +114,7 @@
 	item_state = "AK"
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
 	price_tag = 1200
-	damage_multiplier = 0.9 //7.5 cal
-	penetration_multiplier = 1.1
-	recoil_buildup = 2
+	recoil_buildup = 2.25
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	saw_off = TRUE
 	sawn = /obj/item/gun/projectile/automatic/ak47/sawn
@@ -136,7 +134,7 @@
 	price_tag = 850
 	recoil_buildup = 4
 	one_hand_penalty = 20
-	damage_multiplier = 0.8
+	damage_multiplier = 1
 	saw_off = FALSE
 
 /obj/item/gun/projectile/automatic/ak47/sa/tac
@@ -148,7 +146,7 @@
 	icon_state = "AK"
 	item_state = "AK"
 	price_tag = 1250
-	recoil_buildup = 2.25
+	recoil_buildup = 3
 	saw_off = FALSE
 
 	var/obj/item/gun/projectile/automatic/underslung/shotgun_3/shotgun

--- a/code/modules/projectiles/guns/projectile/automatic/dp.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dp.dm
@@ -7,8 +7,9 @@
 	w_class = ITEM_SIZE_HUGE
 	force = WEAPON_FORCE_PAINFUL
 	slot_flags = 0
-	max_shells = 63
-	damage_multiplier = 0.9 //7.5 is really good
+	max_shells = 96
+	damage_multiplier = 1.0
+	penetration_multiplier = 0.9
 	caliber = CAL_RIFLE
 	origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BACK
@@ -21,11 +22,11 @@
 	reload_sound 	= 'sound/weapons/guns/interact/lmg_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/lmg_cock.ogg'
 	fire_sound = 'sound/weapons/guns/fire/dp_fire.ogg'
-	recoil_buildup = 0.25
+	recoil_buildup = 0.5
 	twohanded = TRUE
 	one_hand_penalty = 30 //not like it's used anyway, but LMG level
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG)
-	slowdown_hold = 1
+	slowdown_hold = 0.5
 	brace_penalty = 10 //wellmade
 	init_firemodes = list(
 		FULL_AUTO_400,

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -104,7 +104,7 @@
 	icon_base = "pk"
 	icon_state = "pk_closed"
 	item_state = "pk_closed"
-	damage_multiplier = 0.8
+	damage_multiplier = 0.9
 	init_firemodes = list(
 		FULL_AUTO_400,
 		BURST_5_ROUND,
@@ -123,7 +123,7 @@
 	mag_well = MAG_WELL_BOX|MAG_WELL_STANMAG
 	caliber = CAL_LRIFLE
 	penetration_multiplier = 0.85
-	damage_multiplier = 0.6
+	damage_multiplier = 1.0
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_PLASTIC = 10)
 	price_tag = 1500
 	fire_sound = 'sound/weapons/guns/fire/sfrifle_fire.ogg'
@@ -144,9 +144,9 @@
 	item_state = "tk"
 	mag_well = MAG_WELL_BOX|MAG_WELL_STANMAG
 	caliber = CAL_LRIFLE
-	damage_multiplier = 1
-	penetration_multiplier = 1
-	recoil_buildup = 1.7 //Why is this so good?
+	damage_multiplier = 1.2
+	penetration_multiplier = 1.2
+	recoil_buildup = 0.75
 	serial_type = "SD GmbH"
 
 /obj/item/gun/projectile/automatic/lmg/tk/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/nordwind.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/nordwind.dm
@@ -73,7 +73,7 @@
 	zoom_factor = 0.6
 	recoil_buildup = 14
 	damage_multiplier = 0.9
-	extra_damage_mult_scoped = 0.1
+	extra_damage_mult_scoped = 0.3
 	one_hand_penalty = 25
 	see_invisible_gun = -1
 	auto_eject = FALSE
@@ -116,7 +116,7 @@
 	price_tag = 450
 	zoom_factor = 0.0
 	recoil_buildup = 15
-	damage_multiplier = 0.7
+	damage_multiplier = 0.8
 	one_hand_penalty = 25
 	saw_off = FALSE
 	serial_type = "NM"

--- a/code/modules/projectiles/guns/projectile/automatic/sts.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts.dm
@@ -56,6 +56,7 @@
 	icon = 'icons/obj/guns/projectile/sts25.dmi'
 	icon_state = "sts"
 	item_state = "sts"
+	price_tag = 1250
 	gun_tags = list(GUN_PROJECTILE,GUN_SILENCABLE, GUN_MAGWELL)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 12)
 	saw_off = TRUE
@@ -105,10 +106,12 @@
 	icon = 'icons/obj/guns/projectile/sts30.dmi'
 	icon_state = "sts"
 	item_state = "sts"
+	price_tag = 1500
 	w_class = ITEM_SIZE_HUGE
 	caliber = CAL_RIFLE
 	mag_well = MAG_WELL_RIFLE
 	damage_multiplier = 1
+	penetration_multiplier = 1.2
 	recoil_buildup = 2
 	one_hand_penalty = 20
 	fire_sound = 'sound/weapons/guns/fire/lmg_fire.ogg'
@@ -130,8 +133,8 @@
 	w_class = ITEM_SIZE_BULKY
 	caliber = CAL_RIFLE
 	mag_well = MAG_WELL_RIFLE
-	damage_multiplier = 0.8
-	recoil_buildup = 2.5
+	penetration_multiplier = 1.0
+	recoil_buildup = 3
 	one_hand_penalty = 20 //automatic rifle level
 	saw_off = FALSE
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 6)
@@ -151,8 +154,8 @@
 	w_class = ITEM_SIZE_HUGE
 	caliber = CAL_RIFLE
 	mag_well = MAG_WELL_RIFLE
-	damage_multiplier = 1.1 //Well oiled
-	recoil_buildup = 1.25
+	damage_multiplier = 1.2 //Well oiled
+	recoil_buildup = 1.75
 	one_hand_penalty = 18
 	fire_sound = 'sound/weapons/guns/fire/lmg_fire.ogg'
 	saw_off = TRUE
@@ -174,7 +177,7 @@
 	w_class = ITEM_SIZE_BULKY
 	caliber = CAL_RIFLE
 	mag_well = MAG_WELL_RIFLE
-	damage_multiplier = 0.9 //Rifle was fine
+	damage_multiplier = 1.0 //Rifle was fine
 	recoil_buildup = 2.5
 	one_hand_penalty = 22 //automatic rifle level
 	saw_off = FALSE
@@ -196,9 +199,10 @@
 	w_class = ITEM_SIZE_HUGE
 	caliber = CAL_HRIFLE
 	mag_well = MAG_WELL_HRIFLE|MAG_WELL_DRUM
+	price_tag = 1750
 	penetration_multiplier = 1.1
 	damage_multiplier = 1.1
-	recoil_buildup = 15
+	recoil_buildup = 12
 	one_hand_penalty = 25
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/batrifle_cock.ogg'

--- a/code/modules/projectiles/guns/projectile/boltgun/zatvor_ak.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/zatvor_ak.dm
@@ -8,7 +8,7 @@
 	force = WEAPON_FORCE_NORMAL
 	caliber = CAL_RIFLE
 	max_shells = 20
-	damage_multiplier = 0.8
+	damage_multiplier = 1.2
 	penetration_multiplier  = 1.0
 	slot_flags = SLOT_BELT|SLOT_BACK
 	recoil_buildup = 10


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Mostly small changes to 7.5 guns across the board and various LMGs. The Takeshi, for example, was called 'so good' as well as the DP-27 - which was a clear indication of their time not being upkept. These guns had worse stats than even their counterparts. Now all **should** have some resemblance of a usable, balanced gun. And an incentive to actually use various rifles instead of sawn off AKs being worse than .35 pistols or LMGs being objectively worse than all rifles. Minor changes to STS guns, mostly prices and recoil changes. This is intended to go hand-in-hand with the 7.5 rebalance, they are kept separate for input purposes. With the changes this should make 7.5s balanced akin to the .257 platform, some having bonus pen, others bonus damage. Giving trade-offs between guns instead of straight upgrades or downgrades.
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
balance: Balances all rifle-caliber guns across the board (excluding Bluecross).
balance: Rebalanced LMGs since ones like the Takeshi and DP-27 were relatively unkept compared to new recoil and automatic damage reduction changes.
balance: STS-25, 30 and 40 no longer all cost the same price. They now have different prices. An STS-25 should not be valued the same as an STS-40
balance: STS platforms have seen a mild rebalance to their recoil, including the STS-40 series. The 40 should not have more than double that of an Omni rifle; it is intended to be 'shittier' but it makes the weapon pointless compared to any omni-platform.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
