### PR TITLE
Fixes some typos and grammar

### DIFF
--- a/code/game/objects/structures/flora/flora_potted.dm
+++ b/code/game/objects/structures/flora/flora_potted.dm
@@ -301,7 +301,7 @@
 //Shard
 /obj/structure/flora/pottedplant/green_rock
 	name = "contained ameridian shard"
-	desc = "A contained shiny shard of ameridian, uses a positronic cell for its power and has some osium for emp shielding making it super safe."
+	desc = "A contained shiny ameridian shard. Uses a positronic cell for power supply and an osmium coating for emp shielding making it super safe."
 	icon = 'icons/obj/plants.dmi'
 	icon_state = "ameridian_pot_shield_powered"
 	layer = PROJECTILE_HIT_THRESHHOLD_LAYER
@@ -318,14 +318,14 @@
 		shield_level += 1
 	if(shield_level == 3)
 		icon_state = "ameridian_pot_shield_powered"
-		desc = "A contained shiney shard of ameridian, uses a posi sound for its power and has some osium for emp shielding making it super safe.."
+		desc = "A contained shiny ameridian shard. Uses a positronic cell for power supply and an osmium coating for emp shielding making it super safe."
 		return
 	if(shield_level == 2)
 		icon_state = "ameridian_pot_shield_unpowered"
-		desc = "A contained shiney shard of ameridian, uses a posi sound for its power and has some osium for emp shielding making it super safe.."
+		desc = "A contained shiny ameridian shard. Uses a positronic cell for power supply and an osmium coating for emp shielding making it super safe."
 		return
 	if(shield_level == 1)
 		icon_state = "ameridian_pot_shieldless"
-		desc = "A contained shiney shard of ameridian, uses a posi sound for its power and has some osium for emp shielding making it super safe. Its shield light level is set to its lowest level making it still contained but look nice."
+		desc = "A contained shiny ameridian shard. Uses a positronic cell for power supply and an osmium coating for emp shielding making it super safe. Its shield light level is set to its lowest level making it still contained but look nice."
 		return
 	shield_level = 3 //Reset out of bound list


### PR DESCRIPTION
Love the new shard plants. Description had a few typos and grammar errors. Should fix these.



## About The Pull Request
<details>
<summary>
	Fixes amerdian shard plant description. It had some typos and odd grammar in it.
</summary>
<hr>


## Changelog
:cl:
fix: Grammar on ameridian shard plant fixed as well as typos.
/:cl:

