### PR TITLE
Fix the ameridian plant pot

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/ameridian.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/ameridian.dm
@@ -37,7 +37,7 @@
 /obj/item/circuitboard/ameridian_analyzer
 	name = "liquid ameridian analyzer"
 	board_type = "machine"
-	build_path = /obj/machinery/liquid_ameridian_analyzer
+	build_path = /obj/machinery/ameridian_analyzer
 	origin_tech = list(TECH_DATA = 4, TECH_MATERIAL = 9, TECH_ENGINEERING = 5)
 	req_components = list(
 		/obj/item/stock_parts/matter_bin = 1,

--- a/code/game/objects/items/weapons/circuitboards/machinery/ameridian.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/ameridian.dm
@@ -37,7 +37,7 @@
 /obj/item/circuitboard/ameridian_analyzer
 	name = "liquid ameridian analyzer"
 	board_type = "machine"
-	build_path = /obj/machinery/liquid_ameridian_processor
+	build_path = /obj/machinery/liquid_ameridian_analyzer
 	origin_tech = list(TECH_DATA = 4, TECH_MATERIAL = 9, TECH_ENGINEERING = 5)
 	req_components = list(
 		/obj/item/stock_parts/matter_bin = 1,

--- a/code/game/objects/structures/flora/flora_potted.dm
+++ b/code/game/objects/structures/flora/flora_potted.dm
@@ -300,8 +300,8 @@
 
 //Shard
 /obj/structure/flora/pottedplant/green_rock
-	name = "contained ameridian shard"
-	desc = "A contained shiny shard of ameridian, uses a positronic cell for its power and has some osium for emp shielding making it super safe."
+	name = "potted ameridian shard"
+	desc = "An ameridian shard in a plant pot, contained using a small sonic fence powered by a duo of Atomcells. It has a small knob to set the fence's opacity level."
 	icon = 'icons/obj/plants.dmi'
 	icon_state = "ameridian_pot_shield_powered"
 	layer = PROJECTILE_HIT_THRESHHOLD_LAYER
@@ -312,20 +312,16 @@
 	var/shield_level = 3
 
 /obj/structure/flora/pottedplant/green_rock/attack_hand(mob/living/user as mob)
-	if(shield_level >= 3)
-		shield_level -= 1
-	if(shield_level <= -1)
-		shield_level += 1
-	if(shield_level == 3)
-		icon_state = "ameridian_pot_shield_powered"
-		desc = "A contained shiney shard of ameridian, uses a posi sound for its power and has some osium for emp shielding making it super safe.."
-		return
-	if(shield_level == 2)
+	switch(shield_level)
+		if(3)
+			shield_level = 2
+			icon_state = "ameridian_pot_shield_powered"
+			to_chat(user, "You turn the knob and make the fence translucent."
+		if(2)
+			shield_level = 1
 		icon_state = "ameridian_pot_shield_unpowered"
-		desc = "A contained shiney shard of ameridian, uses a posi sound for its power and has some osium for emp shielding making it super safe.."
-		return
-	if(shield_level == 1)
-		icon_state = "ameridian_pot_shieldless"
-		desc = "A contained shiney shard of ameridian, uses a posi sound for its power and has some osium for emp shielding making it super safe. Its shield light level is set to its lowest level making it still contained but look nice."
-		return
-	shield_level = 3 //Reset out of bound list
+			to_chat(user, "You turn the knob and make the fence opaque."
+		if(1)
+			shield_level = 3
+			icon_state = "ameridian_pot_shieldless"
+			to_chat(user, "You turn the knob and make the fence almost invisible."

--- a/code/game/objects/structures/flora/flora_potted.dm
+++ b/code/game/objects/structures/flora/flora_potted.dm
@@ -316,12 +316,12 @@
 		if(3)
 			shield_level = 2
 			icon_state = "ameridian_pot_shield_powered"
-			to_chat(user, "You turn the knob and make the fence translucent."
+			to_chat(user, "You turn the knob and make the fence translucent.")
 		if(2)
 			shield_level = 1
 			icon_state = "ameridian_pot_shield_unpowered"
-			to_chat(user, "You turn the knob and make the fence opaque."
+			to_chat(user, "You turn the knob and make the fence opaque.")
 		if(1)
 			shield_level = 3
 			icon_state = "ameridian_pot_shieldless"
-			to_chat(user, "You turn the knob and make the fence almost invisible."
+			to_chat(user, "You turn the knob and make the fence almost invisible.")

--- a/code/game/objects/structures/flora/flora_potted.dm
+++ b/code/game/objects/structures/flora/flora_potted.dm
@@ -319,7 +319,7 @@
 			to_chat(user, "You turn the knob and make the fence translucent."
 		if(2)
 			shield_level = 1
-		icon_state = "ameridian_pot_shield_unpowered"
+			icon_state = "ameridian_pot_shield_unpowered"
 			to_chat(user, "You turn the knob and make the fence opaque."
 		if(1)
 			shield_level = 3


### PR DESCRIPTION
## About The Pull Request
Rename the 'contained ameridian shard' to 'potted ameridian shard'
Change the description to hint at the ability to change the field's opacity.
Make the opacity change not bugged.