### PR TITLE
[Quickfix] Makes Helltaker waistcoat obtainable again

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -52,6 +52,7 @@
 	new /obj/item/clothing/under/helltaker_m(src)
 	new /obj/item/clothing/under/helltaker(src)
 	new /obj/item/clothing/suit/storage/helltaker_apron(src)
+	new /obj/item/clothing/suit/storage/wcoat/helltaker(src)
 
 /*
  * Janitor

--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -129,6 +129,10 @@
 	display_name = "winter coat"
 	path = /obj/item/clothing/suit/hooded/wintercoat
 
+/datum/gear/suit/htwaistcoat
+	display_name = "charming waistcoat"
+	path = /obj/item/clothing/suit/storage/wcoat/helltaker
+
 /datum/gear/suit/modular
 	display_name = "suit jacket selection"
 	path = /obj/item/clothing/suit/storage/suitjacket


### PR DESCRIPTION
## About The Pull Request

Adds the Charming Waistcoat to Loadout and the Chef's locker, as the waistcoat refactor of my earlier PR made them unobtainable in-game.


<hr>

## Changelog
:cl:
add: Added charming waistcoat to the chef's locker.
fix: Due to an oversight from waistcoat refactor, adds the Charming Waistcoat to loadout options (under suits) again.
/:cl: