### PR TITLE
Fixes Marshal Negotiator Disk

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
@@ -48,7 +48,7 @@
 		/datum/design/autolathe/gun/judge = 2,
 		//SMGs
 		/datum/design/autolathe/gun/wirbelwind = 2,
-		/obj/item/gun/projectile/automatic/ppsh/ppv = 2,
+		/datum/design/autolathe/gun/ppv = 2,
 		//rifles
 		/datum/design/autolathe/gun/strelki,
 		/datum/design/autolathe/gun/ostwind = 3,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	I did a fucky-wucky in a PR last minute and forgot to merge a commit that fixed the PPV on the Marshal negotiator disk. This should fix the issue completely.
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
fixes: Marshal negotiator disk loading an improper icon due to bad pathing.
/:cl: