### PR TITLE
Adds the ACOG to the sec disk

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
@@ -16,6 +16,7 @@
 		/datum/design/autolathe/tool/combat_shovel,
 		/datum/design/autolathe/sec/beartrap,
 		/datum/design/autolathe/sec/silencer,
+		/datum/design/autolathe/sec/acog,
 		/datum/design/autolathe/sec/gun_case,
 		/datum/design/research/item/light_replacer,
 		/datum/design/autolathe/sec/hailer,


### PR DESCRIPTION
## About The Pull Request

Due to an oversight, I added the autolathe datum, but never assigned it to the Security disk as originally intended. This PR fixes that.

## Changelog
:cl:
fix: ACOG design now properly added to security disk
/:cl: