### PR TITLE
Buffs Tape Recorder!!!!!

### DIFF
--- a/code/modules/modular_computers/file_system/data.dm
+++ b/code/modules/modular_computers/file_system/data.dm
@@ -24,7 +24,7 @@
 /datum/computer_file/data/audio
 	filetype = "AUD"
 	var/transcribed = FALSE
-	var/max_capacity = 600
+	var/max_capacity = 10000
 	var/used_capacity = 0
 	var/list/storedinfo = list()
 	var/list/timestamp = list()


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Over doubles the data on the audio recording disk. Why? Because otherwise the software breaks if you use it to its limit, for some reason. (This is clearly a Marshal uber-buff...................)
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
tweak: Over doubles the size of the audio-recording disk.
/:cl:
