### PR TITLE
Dog and Shark

### DIFF
--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -200,7 +200,7 @@
 		return FALSE
 	cooldown_time = world.time + 15 MINUTES
 	user.visible_message("<b><font color='red'>[user] lets out deep guttural growl as their eyes glaze over!</font><b>", "<b><font size='3px'><font color='red'>You abandon all reason as your sink into a blood thirsty frenzy!</font><b>", "<b><font color='red'>You hear a terrifying roar!</font><b>")
-	playsound(usr.loc, 'sound/voice/akularoar.ogg', 50, 1)
+	playsound(usr.loc, 'sound/voice/akularoar.ogg', 70, 1)
 	log_and_message_admins("used their [src] perk.")
 	user.reagents.add_reagent("robustitol", 5)
 	return ..()
@@ -208,7 +208,6 @@
 /datum/perk/iron_flesh
 	name = "Iron Flesh"
 	desc = "Akula scales are not only tough and resistant to damage but exceptionally skilled at naturally forcing out embedded objects that somehow punch through. You'll never get a bullet nor object stuck inside when hit."
-
 
 ////////////////////////////////////////Naramad perks
 /datum/perk/adrenalineburst

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -221,7 +221,7 @@
 	hunger_factor = DEFAULT_HUNGER_FACTOR * 1.25
 	radiation_mod = 0.5
 	toxins_mod = 0.75
-	brute_mod = 0.75
+	brute_mod = 0.90 //A war dog, metallic prickles help but doesn't mean you get to facetank a rocket.
 	siemens_coefficient = 2
 
 	dark_color = "#ff0000"
@@ -272,6 +272,7 @@
 	name_plural = "Akulas"
 	default_form = FORM_AKULA
 	obligate_form = TRUE
+	aan = "n"
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/tail, /datum/unarmed_attack/bite/strong)
 	darksight = 4
 	num_alternate_languages = 2
@@ -281,6 +282,8 @@
 	blurb = "How did you find this? Report this to Kazkin if you're reading it."
 	taste_sensitivity = TASTE_DULL
 	hunger_factor = DEFAULT_HUNGER_FACTOR * 1.25
+	brute_mod = 0.85 //Thick skin perk kind of points at this being a thing
+	oxy_mod = 0.85 //They can stay under water for longer than humans
 
 	cold_level_1 = 240 //Default 270
 	cold_level_2 = 200 //Default 230

--- a/code/modules/reagents/reagents/race.dm
+++ b/code/modules/reagents/reagents/race.dm
@@ -126,6 +126,10 @@
 	M.stats.addTempStat(STAT_BIO, -100, STIM_TIME, "robustitol")
 	M.stats.addTempStat(STAT_VIG, -100, STIM_TIME, "robustitol")
 	M.stats.addTempStat(STAT_MEC, -100, STIM_TIME, "robustitol")
+	M.add_chemical_effect(CE_BLOODCLOT, 0.2)
+	M.add_chemical_effect(CE_PAINKILLER, 100, TRUE) //Weaker Tramadol
+	M.add_chemical_effect(CE_PULSE, 2)
+	M.add_chemical_effect(CE_SPEECH_VOLUME, rand(3,4)) //Angery
 
 /datum/reagent/drug/robustitol/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "robustitol_w")


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Increases brute modifier from 0.75 (this used to be 0.8 at some point) to 0.9 for Kriosans, simple reasoning being nowhere does it in their lore does it say they can survive direct AMR shot to the face and with rest of their perks overall creating something overwhelming (before I get hit with this is salt again, I play a kriosan myself and hate the fact you survive getting your arm getting gibbed and pretending nothing happened)

Gives Akula 0.85 modifier for brute and oxygen, first due to their perk literally saying this "Akula scales are not only tough and resistant to damage" which isn't really the case right now, oxygen is due to their lore mentioning while they cannot be under water indefinetly they can survive long time without going to to the surface.

Their rage perk now gives painkillers again but not to a degree it used to, only slightly worse tramadol and helps clot blood slightly. Rest of the changes are just flavor since pulse and yelling hardly does anthing.

Finally fixes the annoying typo in their name from A to AN Akula and makes the scream bit louder.
	
<hr>
</details>

## Changelog
:cl:
balance: Reduced kriosan brute modifier
fix: Typo in Akula name
balance: Akula perk and base stats (brute and oxy mod)
/:cl:
