### PR TITLE
Give a place for admin faxes to end up

### DIFF
--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -203,7 +203,7 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 		return
 
-	rcvdcopy.loc = null //hopefully this shouldn't cause trouble
+	rcvdcopy.loc = locate("Admin Fax").loc //hopefully this shouldn't cause trouble // We use tags so that admins can move the destination around -R4d6
 	adminfaxes += rcvdcopy
 
 	//message badmins that a fax has arrived

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -203,7 +203,7 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 		return
 
-	rcvdcopy.loc = locate("Admin Fax").loc //hopefully this shouldn't cause trouble // We use tags so that admins can move the destination around -R4d6
+	rcvdcopy.loc = locate("Admin Fax"):loc //hopefully this shouldn't cause trouble // We use tags so that admins can move the destination around -R4d6
 	adminfaxes += rcvdcopy
 
 	//message badmins that a fax has arrived

--- a/maps/Centcom/map/centcom.dmm
+++ b/maps/Centcom/map/centcom.dmm
@@ -6578,7 +6578,8 @@
 /area/centcom/evac)
 "PJ" = (
 /obj/machinery/photocopier/faxmachine{
-	pixel_y = 6
+	pixel_y = 6;
+	tag = "Admin Fax"
 	},
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/dark/golden,


### PR DESCRIPTION
## About The Pull Request
Make all of the faxes sent to admins end up in Central Command instead of nullspace, so that admins can see the faxes that were sent in the rounds without needing to be online when the fax was sent.