### PR TITLE
hollowpoint rework, post-penetration damage

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -77,6 +77,8 @@
 	var/force = 0	//How much damage the weapon deals
 	var/embed_mult = 0.5 //Multiplier for the chance of embedding in mobs. Set to zero to completely disable embedding
 	var/structure_damage_factor = STRUCTURE_DAMAGE_NORMAL	//Multiplier applied to the damage when attacking structures and machinery
+
+	var/post_penetration_dammult = 1 //how much damage do we do post-armor-penetation
 	//Does not affect damage dealt to mobs
 	//var/attack_distance = 1
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -25,7 +25,7 @@
 		weapon_edge = 0
 
 	hit_impact(effective_force, get_step(user, src))
-	damage_through_armor(effective_force, I.damtype, hit_zone, ARMOR_MELEE, armour_pen = I.armor_penetration + (user.stats.getStat(STAT_ROB) * 0.25), used_weapon = I, sharp = weapon_sharp, edge = weapon_edge)
+	damage_through_armor(effective_force, I.damtype, hit_zone, ARMOR_MELEE, armour_pen = I.armor_penetration + (user.stats.getStat(STAT_ROB) * 0.25), used_weapon = I, sharp = weapon_sharp, edge = weapon_edge, post_pen_mult = I.post_penetration_dammult)
 
 /*Its entirely possible that we were gibbed or dusted by the above. Check if we still exist before
 continuing. Being gibbed or dusted has a 1.5 second delay, during which it sets the transforming var to

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -221,7 +221,7 @@
 		if(isitem(O))
 			var/obj/item/thingytocheck = O
 			ppd = thingytocheck.post_penetration_dammult
-		damage_through_armor(throw_damage, dtype, null, ARMOR_MELEE, null, used_weapon = O, sharp = is_sharp(O), edge = has_edge(O), ppd)
+		damage_through_armor(throw_damage, dtype, null, ARMOR_MELEE, null, used_weapon = O, sharp = is_sharp(O), edge = has_edge(O), post_pen_mult = ppd)
 
 		O.throwing = 0		//it hit, so stop moving
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -5,7 +5,7 @@
 //If you need to do something else with armor - just use getarmor() proc and do with those numbers all you want
 //Random absorb system was a cancer, and was removed from all across the codebase. Don't recreate it. Clockrigger 2019
 
-/mob/living/proc/damage_through_armor(var/damage = 0, var/damagetype = BRUTE, var/def_zone = null, var/attack_flag = ARMOR_MELEE, var/armour_pen = 0, var/used_weapon = null, var/sharp = 0, var/edge = 0)
+/mob/living/proc/damage_through_armor(var/damage = 0, var/damagetype = BRUTE, var/def_zone = null, var/attack_flag = ARMOR_MELEE, var/armour_pen = 0, var/used_weapon = null, var/sharp = 0, var/edge = 0, var/post_pen_mult = 1)
 
 	if(damage == 0)
 		return FALSE
@@ -63,7 +63,7 @@
 
 	//No armor? Damage as usual
 	if(armor_effectiveness == 0)
-		apply_damage(effective_damage, damagetype, def_zone, used_weapon, sharp, edge)
+		apply_damage(effective_damage * post_pen_mult, damagetype, def_zone, used_weapon, sharp, edge)
 
 	//Here we split damage in two parts, where armor value will determine how much damage will get through
 	else
@@ -75,7 +75,7 @@
 
 		//Actual part of the damage that passed through armor
 		var/actual_damage = round ( ( effective_damage * ( 100 - armor_effectiveness ) ) / 100 )
-		apply_damage(actual_damage, damagetype, def_zone, used_weapon, sharp, edge)
+		apply_damage(actual_damage * post_pen_mult, damagetype, def_zone, used_weapon, sharp, edge)
 		return actual_damage
 	return effective_damage
 
@@ -125,7 +125,7 @@
 		hit_impact(P.get_structure_damage(), hit_dir)
 		for(var/damage_type in P.damage_types)
 			var/damage = P.damage_types[damage_type]
-			damage_through_armor(damage, damage_type, def_zone, P.check_armour, armour_pen = P.armor_penetration, used_weapon = P, sharp=is_sharp(P), edge=has_edge(P))
+			damage_through_armor(damage, damage_type, def_zone, P.check_armour, armour_pen = P.armor_penetration, used_weapon = P, sharp=is_sharp(P), edge=has_edge(P), post_pen_mult = P.post_penetration_dammult)
 
 
 	if(P.agony > 0 && istype(P,/obj/item/projectile/bullet))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -217,8 +217,11 @@
 			IgniteMob()
 
 		src.visible_message(SPAN_WARNING("[src] has been hit by [O]."))
-
-		damage_through_armor(throw_damage, dtype, null, ARMOR_MELEE, null, used_weapon = O, sharp = is_sharp(O), edge = has_edge(O), O.post_penetration_dammult)
+		var/ppd = 1
+		if(isitem(O))
+			var/obj/item/thingytocheck = O
+			ppd = thingytocheck.post_penetration_dammult
+		damage_through_armor(throw_damage, dtype, null, ARMOR_MELEE, null, used_weapon = O, sharp = is_sharp(O), edge = has_edge(O), ppd)
 
 		O.throwing = 0		//it hit, so stop moving
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -191,7 +191,7 @@
 		effective_force *= 2
 
 	//Apply weapon damage
-	if (damage_through_armor(effective_force, I.damtype, hit_zone, ARMOR_MELEE, I.armor_penetration, used_weapon = I, sharp = is_sharp(I), edge = has_edge(I)))
+	if (damage_through_armor(effective_force, I.damtype, hit_zone, ARMOR_MELEE, I.armor_penetration, used_weapon = I, sharp = is_sharp(I), edge = has_edge(I), post_pen_mult = I.post_penetration_dammult))
 		return TRUE
 	else
 		return FALSE
@@ -218,7 +218,7 @@
 
 		src.visible_message(SPAN_WARNING("[src] has been hit by [O]."))
 
-		damage_through_armor(throw_damage, dtype, null, ARMOR_MELEE, null, used_weapon = O, sharp = is_sharp(O), edge = has_edge(O))
+		damage_through_armor(throw_damage, dtype, null, ARMOR_MELEE, null, used_weapon = O, sharp = is_sharp(O), edge = has_edge(O), O.post_penetration_dammult)
 
 		O.throwing = 0		//it hit, so stop moving
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -397,7 +397,7 @@
 
 	for(var/damage_type in Proj.damage_types)
 		var/damage = Proj.damage_types[damage_type]
-		damage_through_armor(damage, damage_type, def_zone, Proj.check_armour, armour_pen = Proj.armor_penetration, used_weapon = Proj, sharp=is_sharp(Proj), edge=has_edge(Proj))
+		damage_through_armor(damage, damage_type, def_zone, Proj.check_armour, armour_pen = Proj.armor_penetration, used_weapon = Proj, sharp=is_sharp(Proj), edge=has_edge(Proj), post_pen_mult = Proj.post_penetration_dammult)
 	return 0
 
 /mob/living/simple_animal/rejuvenate()

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -72,7 +72,7 @@
 
 /obj/item/projectile/bullet/pistol_35/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 22)
+	damage_types = list(BRUTE = 17)
 	agony = 6
 	post_penetration_dammult = 2
 	armor_penetration = 0
@@ -178,7 +178,7 @@
 
 /obj/item/projectile/bullet/magnum_40/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 29)
+	damage_types = list(BRUTE = 24)
 	agony = 11
 	armor_penetration = 0
 	post_penetration_dammult = 2
@@ -237,7 +237,7 @@
 
 /obj/item/projectile/bullet/kurtz_50/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 40)
+	damage_types = list(BRUTE = 30)
 	agony = 12
 	post_penetration_dammult = 2
 	armor_penetration = 0
@@ -304,7 +304,7 @@
 
 /obj/item/projectile/bullet/light_rifle_257/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 26)
+	damage_types = list(BRUTE = 18)
 	agony = 6
 	post_penetration_dammult = 2
 	armor_penetration = 0
@@ -382,7 +382,7 @@
 
 /obj/item/projectile/bullet/rifle_75/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 30)
+	damage_types = list(BRUTE = 24)
 	agony = 9
 	post_penetration_dammult = 2
 	armor_penetration = 0
@@ -443,7 +443,7 @@
 
 /obj/item/projectile/bullet/heavy_rifle_408/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 40)
+	damage_types = list(BRUTE = 29)
 	agony = 12
 	post_penetration_dammult = 2
 	armor_penetration = 0 //Half of normal

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -73,7 +73,8 @@
 /obj/item/projectile/bullet/pistol_35/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 22)
-	agony = 18
+	agony = 6
+	post_penetration_dammult = 2
 	armor_penetration = 0
 	penetrating = 0
 	can_ricochet = FALSE
@@ -178,8 +179,9 @@
 /obj/item/projectile/bullet/magnum_40/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 29)
-	agony = 32
+	agony = 11
 	armor_penetration = 0
+	post_penetration_dammult = 2
 	penetrating = 0
 	can_ricochet = FALSE
 	embed = TRUE
@@ -236,7 +238,8 @@
 /obj/item/projectile/bullet/kurtz_50/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 40)
-	agony = 40
+	agony = 12
+	post_penetration_dammult = 2
 	armor_penetration = 0
 	penetrating = 0
 	can_ricochet = FALSE
@@ -302,7 +305,8 @@
 /obj/item/projectile/bullet/light_rifle_257/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 26)
-	agony = 22
+	agony = 6
+	post_penetration_dammult = 2
 	armor_penetration = 0
 	penetrating = 0
 	can_ricochet = FALSE
@@ -379,7 +383,8 @@
 /obj/item/projectile/bullet/rifle_75/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 30)
-	agony = 28
+	agony = 9
+	post_penetration_dammult = 2
 	armor_penetration = 0
 	penetrating = 0
 	can_ricochet = FALSE
@@ -439,7 +444,8 @@
 /obj/item/projectile/bullet/heavy_rifle_408/lethal
 	name = "hollow-point bullet"
 	damage_types = list(BRUTE = 40)
-	agony = 32
+	agony = 12
+	post_penetration_dammult = 2
 	armor_penetration = 0 //Half of normal
 	penetrating = 0
 	can_ricochet = FALSE

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -239,8 +239,8 @@
 	icon_state = "fireball"
 	damage_types = list(BURN = 16)
 	check_armour = ARMOR_MELEE
-	var/life = 3
-	var/fire_stacks = 1 //10 pain a fire proc through ALL armor!
+	kill_count = 3
+	var/fire_stacks = 3
 
 /obj/item/projectile/flamer_lob/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -249,21 +249,15 @@
 		M.adjust_fire_stacks(fire_stacks)
 		M.IgniteMob()
 
-/obj/item/projectile/flamer_lob/New()
-	.=..()
-
 /obj/item/projectile/flamer_lob/Move(atom/A)
-	.=..()
-	life--
+	..()
 	var/turf/T = get_turf(src)
 	if(T)
 		new/obj/effect/decal/cleanable/liquid_fuel(T, 1 , 1)
 		T.hotspot_expose((T20C*2) + 380,500)
-	if(!life)
-		qdel(src)
 
 /obj/item/projectile/flamer_lob/flamethrower
-	life = 5
+	kill_count = 5
 
 /obj/item/projectile/bullet/flare
 	name = "flare"


### PR DESCRIPTION
adds post-pen damage to hollowpoints. nerfs hollowpoint agony by ~66% across the board.

## Changelog
:cl:
balance: hollowpoints deal greater post-penetration damage
/:cl:

