### PR TITLE
Bar drink dispenser changes 

### DIFF
--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -262,14 +262,14 @@
 	simple_machinery = TRUE
 	level0 = list(
 		"water","ice","icetea","icegreentea","cola","spacemountainwind","dr_gibb","space_up",
-		"tonic","sodawater","lemon_lime","sugar","orangejuice","limejuice","lemonjuice", "pineapplejuice")
+		"tonic","sodawater","lemon_lime","sugar","orangejuice","limejuice","lemonjuice", "pineapplejuice", "berryjuice","grapesoda","watermelonjuice")
 
 	level1 = list("capsaicin", "carbon")
-	level2 = list("banana", "berryjuice")
+	level2 = list("banana")
 	level3 = list("soymilk") //Commie stock part gives this
 	level4 = list("enzyme")
 
-	hacked_reagents = list("thirteenloko","grapesoda")
+	hacked_reagents = list("thirteenloko")
 	circuit = /obj/item/circuitboard/chemical_dispenser/soda
 
 /obj/machinery/chemical_dispenser/soda/hacked(mob/user)
@@ -307,12 +307,12 @@
 	density = FALSE
 	simple_machinery = TRUE
 	level0 = list(
-		"coffee","cream","tea","greentea","sugar","hot_coco","espresso")
+		"coffee","cream","tea","greentea","sugar","hot_coco","espresso","milk")
 	hacked_reagents = list("ice")
 	level1 = list("cappuccino","coco")
 	level2 = list("macchiato")
 	level3 = list("soymilk") //Commie stock part gives this
-	level4 = list("milk","kahlua")
+	level4 = list("kahlua")
 	circuit = /obj/item/circuitboard/chemical_dispenser/coffee_master
 
 /obj/machinery/chemical_dispenser/beer
@@ -336,7 +336,7 @@
 	level3 = list("alliescocktail") //Commie stock part gives this
 	level4 = list("enzyme")
 
-	hacked_reagents = list("goldschlager","patron","watermelonjuice","berryjuice")
+	hacked_reagents = list("goldschlager","patron","berryjuice")
 	circuit = /obj/item/circuitboard/chemical_dispenser/beer
 
 /obj/machinery/chemical_dispenser/beer/hacked(mob/user)

--- a/nano/templates/chem_dispenser.tmpl
+++ b/nano/templates/chem_dispenser.tmpl
@@ -21,6 +21,7 @@ Used In File(s): \code\modules\reagents\machinery\chem_dispenser.dm
 		{{:helper.link('20', 'gear', {'amount' : 20}, (data.amount == 20) ? 'selected' : null)}}
 		{{:helper.link('30', 'gear', {'amount' : 30}, (data.amount == 30) ? 'selected' : null)}}
 		{{:helper.link('40', 'gear', {'amount' : 40}, (data.amount == 40) ? 'selected' : null)}}
+		{{:helper.link('60', 'gear', {'amount' : 60}, (data.amount == 60) ? 'selected' : null)}}
 	</div>
 </div>
 <div class="item">&nbsp;</div>


### PR DESCRIPTION
Moved milk , grape soda, watermelon juice and berry juice to there respective dispensers round start instead of behind upgraded parts. Milk to the coffee dispenser and the rest to the soda dispenser.