### PR TITLE
Tetra Rebalance

### DIFF
--- a/code/modules/projectiles/guns/energy/tetra.dm
+++ b/code/modules/projectiles/guns/energy/tetra.dm
@@ -15,7 +15,7 @@
 	matter = list(MATERIAL_PLASTEEL = 18, MATERIAL_STEEL = 8, MATERIAL_PLASTIC = 8, MATERIAL_SILVER = 12, MATERIAL_GOLD = 2)
 	price_tag = 1500
 	silenced = FALSE
-	damage_multiplier = 0.8
+	damage_multiplier = 1.0
 	recoil_buildup = 1
 	one_hand_penalty = 5
 	zoom_factor = 0.2

--- a/code/modules/projectiles/guns/energy/tetra.dm
+++ b/code/modules/projectiles/guns/energy/tetra.dm
@@ -15,7 +15,7 @@
 	matter = list(MATERIAL_PLASTEEL = 18, MATERIAL_STEEL = 8, MATERIAL_PLASTIC = 8, MATERIAL_SILVER = 12, MATERIAL_GOLD = 2)
 	price_tag = 1500
 	silenced = FALSE
-	damage_multiplier = 0.6
+	damage_multiplier = 0.8
 	recoil_buildup = 1
 	one_hand_penalty = 5
 	zoom_factor = 0.2
@@ -24,12 +24,10 @@
 	charge_cost = 40
 	gun_tags = list(GUN_LASER, GUN_ENERGY)
 	init_firemodes = list(
-		list(mode_name = "focused",     mode_desc = "Fire a focused, higher damage beam", burst = 1, fire_delay = 5, damage_mult_add = 0.75, move_delay=null, icon="semi", projectile_type = /obj/item/projectile/beam, silenced = FALSE),
-		list(mode_name = "slow auto",    mode_desc = "A more controllable automatic firerate",   mode_type = /datum/firemode/automatic, fire_delay = 4, icon="burst", projectile_type = /obj/item/projectile/beam, silenced = FALSE),
-		list(mode_name = "full auto",    mode_desc = "Higher volume automatic fire",   mode_type = /datum/firemode/automatic, fire_delay = 1.5, icon="auto", projectile_type = /obj/item/projectile/beam, silenced = FALSE),
-		list(mode_name = "IR focused",     mode_desc = "Fire invisible, quieter focused IR beams", burst = 1, fire_delay = 5, damage_mult_add = 0.75, move_delay=null, icon="semi", projectile_type = /obj/item/projectile/beam/infrared, silenced = TRUE),
-		list(mode_name = "IR slow auto",    mode_desc = "Invisible, quieter IR beams at a more controllable automatic firerate",   mode_type = /datum/firemode/automatic, fire_delay = 4, icon="burst", projectile_type = /obj/item/projectile/beam/infrared, silenced = TRUE),
-		list(mode_name = "bake",    mode_desc = "Bake targets in infrared radiation",   mode_type = /datum/firemode/automatic, fire_delay = 1.5, icon="auto", projectile_type = /obj/item/projectile/beam/infrared, silenced = TRUE)
+		WEAPON_NORMAL,
+		BURST_3_ROUND,
+		FULL_AUTO_600,
+		list(mode_name = "Infared overclock",    mode_desc = "Invisible, quieter IR beams that bake the target from the inside.",   mode_type = /datum/firemode/automatic, charge_cost = 80, fire_delay = 4, icon="burst", projectile_type = /obj/item/projectile/beam/infrared, silenced = TRUE)
 		)
 	serial_type = "AG"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Tetra was a bit unbalanced before due to it effectively having no downside to using its IR setting over a default setting, its fire delays not appearing to work properly(?) and its ability to be a duel wieldable Cog with better damage and cell-usage cost. Now its more of a proper SMG with a similar niche-usage, but no major 'buff' in damage to its firemode. Should still function as an objectively better version of a Firestorm and likely /be/ better than a Cog - but as an SMG putting rounds down range rather than a rifle-SMG hybrid.
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
balance: Rebalances Tetra's damages and firemodes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
