### PR TITLE
Finally Fixes Yassari Colors

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput_override.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_override.css
@@ -55,6 +55,8 @@
 .jive					{color: #666666}
 .jana					{color: #993399}
 .latin					{color: #deb63d}
+.esperanto				{color: #ed7961}
+.yassari				{color: #5fbf4e}
 
 .good                   {color: #4f8529; font-weight: bold;}
 .bad                    {color: #ee0000; font-weight: bold;}

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -145,6 +145,8 @@
 	add_language(LANGUAGE_JANA, 1)
 	add_language(LANGUAGE_CYRILLIC, 1)
 	add_language(LANGUAGE_LATIN, 1)
+	add_language(LANGUAGE_ESPERANTO, 1)
+	add_language(LANGUAGE_YASSARI, 1)
 
 	wires = new(src)
 

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -99,7 +99,7 @@ h1.alert, h2.alert		{color: #000000;}
 .jana					{color: #993399}
 .latin					{color: #deb63d}
 .esperanto				{color: #ed7961}
-.yassari				{color: #96d18c}
+.yassari				{color: #5fbf4e}
 
 .interface				{color: #330033;}
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Yassari should have the proper color now when spoken. Robots should also now be able to learn Esperanto and Yassari now instead of being unable to learn it.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fixes: Missing interface color for Yassari.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
