### PR TITLE
Fix examine not showing as unknown when wearing mask

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -445,9 +445,9 @@
 
 	if(stat & NOPOWER)
 		return
-	else if(istype(I, /obj/item/clothing/suit/space))
+	else if(istype(I, /obj/item/clothing/suit))
 		load(I, user, LOAD_SLOT_SUIT)
-	else if(istype(I, /obj/item/clothing/head/helmet))
+	else if(istype(I, /obj/item/clothing/head))
 		load(I, user, LOAD_SLOT_HELMET)
 	else if(istype(I, /obj/item/clothing/mask))
 		load(I, user, LOAD_SLOT_MASK)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -46,7 +46,7 @@
 	var/has  = gender_word("has", T)
 	var/does = gender_word("does",T)
 
-	msg += "<EM>[src.name]</EM>, <b><font color='[species_color_key]'>a[species_aan] [species_name]</font></b>"
+	msg += "<EM>[src.get_visible_name()]</EM>, <b><font color='[species_color_key]'>a[species_aan] [species_name]</font></b>"
 	msg += "!\n"
 
 	//uniform

--- a/code/modules/mob/living/simple_animal/friendly/ameridian_tender.dm
+++ b/code/modules/mob/living/simple_animal/friendly/ameridian_tender.dm
@@ -33,12 +33,9 @@
 	mob_push_flags = SIMPLE_ANIMAL
 	mob_always_swap = TRUE
 	pass_flags = PASSTABLE
-	possession_candidate = TRUE
-
+	possession_candidate = FALSE
 	armor = list(melee = 5, bullet = 5, energy = 5, bomb = 0, bio = 100, rad = 100) // Fragile fren
-
 	attack_sound = 'sound/weapons/heavysmash.ogg' //So we dont make bite sounds
-
 	maxHealth = 125 //Lets not die to a single roach bit
 	health = 125 //Most things deal 40 at a time
 	melee_damage_lower = 5
@@ -46,6 +43,9 @@
 	var/obj/item/held_item = null //Storage for single item they can hold.
 	var/obj/structure/ameridian_crystal/target_crystal
 	var/spread_threshold = 3 // How many crystals need to be near a mature crystal for it to be available to harvest?
+
+/mob/living/simple_animal/ameridian_tender/ghost_control
+	possession_candidate = TRUE
 
 /mob/living/simple_animal/ameridian_tender/New()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/ameridian_tender.dm
+++ b/code/modules/mob/living/simple_animal/friendly/ameridian_tender.dm
@@ -3,8 +3,8 @@
 
 /mob/living/simple_animal/ameridian_tender
 	name = "ameridian tender"
-	desc = "An automaton powered by an ameridian core. It instinctively care for ameridian crystals, letting them grow and spread before harvesting them. \
-			Its unique nature mean that it doesn't get attacked by other ameridian-based lifeform or get damaged by anti-ameridian sonic weaponry."
+	desc = "An automaton powered by an ameridian core. It instinctively cares for ameridian crystals, letting them grow and spread before harvesting them. \
+			Its unique nature means that it doesn't get attacked by other ameridian-based lifeform or get damaged by anti-ameridian sonic weaponry."
 	icon = 'icons/obj/ameridian.dmi'
 	icon_state = "tender" // Sprites by Quill#6000
 	faction = "ameridian"


### PR DESCRIPTION
# About The Pull Request
\- Fix examine not showing as unknown when wearing mask
\- Fix some typo in the ameridian tender's description.
\- Make the Ameridian Tender not controllable by default, but add a subtype that is.