### PR TITLE
Mask Voice Transmitters

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -21,8 +21,13 @@
 		rad = 0
 	)
 	price_tag = 20
-	muffle_voice = TRUE
+	muffle_voice = FALSE
 	var/is_alts = TRUE
+
+/obj/item/clothing/mask/gas/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/tool/screwdriver))
+		to_chat(user, SPAN_NOTICE("[user] alters the voice transmitter in [src]."))
+		src.muffle_voice = !src.muffle_voice
 
 /obj/item/clothing/mask/gas/filter_air(datum/gas_mixture/air)
 	var/datum/gas_mixture/filtered = new

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -6,7 +6,7 @@
 	body_parts_covered = FACE
 	w_class = ITEM_SIZE_SMALL
 	gas_transfer_coefficient = 0.90
-	muffle_voice = TRUE
+	muffle_voice = FALSE
 
 /obj/item/clothing/mask/muzzle/tape
 	name = "length of tape"
@@ -26,6 +26,15 @@
 	if(user.wear_mask == src && !user.IsAdvancedToolUser())
 		return 0
 	..()
+
+/obj/item/clothing/mask/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/device/assembly/voice))
+		if(src.muffle_voice == TRUE)
+			to_chat(user, SPAN_NOTICE("[src] already has a voice transmitter in it!"))
+			return
+		to_chat(user, SPAN_NOTICE("[user] installs a voice transmitter in [src]."))
+		src.muffle_voice = TRUE
+		qdel(W)
 
 /obj/item/clothing/mask/surgical
 	name = "sterile mask"
@@ -108,7 +117,7 @@
 	item_flags = FLEXIBLEMATERIAL
 	w_class = ITEM_SIZE_SMALL
 	price_tag = 20
-	muffle_voice = TRUE
+	muffle_voice = FALSE
 
 /obj/item/clothing/mask/bandana/equipped(var/mob/user, var/slot)
 	switch(slot)


### PR DESCRIPTION
There is a difference between muffled and having a different voice now.
Added the ability to alter the transmitters in gas masks to turn you unknown. This is done with a screwdriver on ANY gas mask.
Adds in the ability to put voice recognizer from the assembly system onto any mask to give it the same effect as the gas masks.
This won't hide your face if the mask won't. BUT IT DOES WORK ON SNORKELS! Be warned it won't come back off once installed.