### PR TITLE
Adds the Marshal BDU to the Marshal outfit lockers.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -214,6 +214,9 @@
 	new /obj/item/clothing/suit/storage/armor/commander/marshal_coat(src)
 	new /obj/item/clothing/suit/storage/armor/commander/marshal_coat(src)
 	new /obj/item/clothing/suit/storage/armor/commander/marshal_coat(src)
+	new /obj/item/clothing/under/rank/bdu/marshal(src)
+	new /obj/item/clothing/under/rank/bdu/marshal(src)
+	new /obj/item/clothing/under/rank/bdu/marshal(src)
 
 /obj/structure/closet/wardrobe/militia
 	name = "blackshield wardrobe"


### PR DESCRIPTION
Does what the title says. These lockers contain every other Marshal loadout outfit besides the Marshal BDU, so I decided to add it.

Playtested, functional with no errors.