### PR TITLE
Buffs Soteria medical gauze 

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -253,7 +253,8 @@
 	disinfectant  = TRUE
 	amount = 8
 	max_amount = 8
-	heal_brute = 5
+	heal_brute = 10
+	heal_toxin = 5
 	price_tag = 25
 
 /obj/item/stack/medical/ointment


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	This buffs the soteria medical gauze that doctors can make to match normal gauze in brute healing and adds the missing toxin healing that the description states.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: Buffs Soteria Medical Gauze from up from 5 to 10 brute heal to match normal gauze and adds 5 toxin heal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
