### PR TITLE
German color

### DIFF
--- a/code/modules/mob/language/german.dm
+++ b/code/modules/mob/language/german.dm
@@ -1,7 +1,7 @@
 /datum/language/german
 	name = LANGUAGE_GERMAN
 	desc = "Language used by the descendants of Europe."
-	colour = "german"
+	colour = "blue"
 	key = "q"
 	space_chance = 80
 	shorthand = "GE"


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

To my knowledge german actually isn't a colored language like the rest so giving it nice shade of blue should do the trick since no other language uses it. It shouldn't clash with command blue but since I have no actual way to test it just gonna hope.
![ger1](https://user-images.githubusercontent.com/67122131/169823858-02c20cf8-2f5f-491f-9b6e-85820d2858dc.png)

![ger2](https://user-images.githubusercontent.com/67122131/169823736-46448c4f-8753-43ef-bcd6-9533aa3502c8.png)



<hr>
</details>

## Changelog
:cl:
fix: German being colorless
/:cl: