### PR TITLE
Adds vector armour to the vector lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -133,3 +133,5 @@
 	new /obj/item/gun/energy/ntpistol(src)
 	new /obj/item/cell/small(src)
 	new /obj/item/tool/knife/dagger/nt(src)
+	new /obj/item/clothing/head/helmet/acolyte(src)
+	new /obj/item/clothing/suit/armor/vest/acolyte(src)


### PR DESCRIPTION
With the removal of the Church armour bundles, re-adds the Vector armour to the Vector lockers, which has alternate sprites for the different Vector paths.
