### PR TITLE
Prospector Shuttle Buff

### DIFF
--- a/maps/__Nadezhda/data/shuttles-nadezhda.dm
+++ b/maps/__Nadezhda/data/shuttles-nadezhda.dm
@@ -182,7 +182,7 @@
 //Scav shuttle
 /datum/shuttle/autodock/multi/rocinante
 	name = "The Rocinante"
-	move_time = (15 MINUTES) / (1 SECOND)
+	move_time = (7 MINUTES) / (1 SECOND)
 	shuttle_area = /area/shuttle/rocinante_shuttle_area
 	current_location = "nav_rocinante_homebase"
 	landmark_transition = "nav_rocinante_transit"


### PR DESCRIPTION

## About The Pull Request
<summary>
	This PR simply alters the travel time of the Prospector shuttle from a whopping 15 minutes (not including time dilatation) down to 7 minutes instead. Reason for doing this is because by time the Prospector shuttle reaches somewhere, someone could of ran from the colony to the location within half the time which makes no sense.
</summary>

	
<hr>
</details>
