### PR TITLE
spiders now apply less venom to things that can't be injected

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
@@ -6,5 +6,5 @@
 	if(isliving(A))
 		var/mob/living/L = A
 		if(istype(L) && L.reagents)
-			var/poison_injected = poison_per_bite * ((-100 * L.getarmor(targeted_organ, ARMOR_MELEE) + 100) - 40)
+			var/poison_injected = poison_per_bite * (-100 * L.getarmor(targeted_organ, ARMOR_MELEE) + 100)
 			L.reagents.add_reagent(poison_type, poison_per_bite)

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
@@ -6,5 +6,5 @@
 	if(isliving(A))
 		var/mob/living/L = A
 		if(istype(L) && L.reagents)
-			var/poison_injected = L.can_inject(src) ? poison_per_bite * 0.3 : poison_per_bite
+			var/poison_injected = L.can_inject(src) ? poison_per_bite * 0.6 : poison_per_bite
 			L.reagents.add_reagent(poison_type, poison_per_bite)

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
@@ -6,5 +6,5 @@
 	if(isliving(A))
 		var/mob/living/L = A
 		if(istype(L) && L.reagents)
-			var/poison_injected = L.can_inject(src) ? poison_per_bite * 0.6 : poison_per_bite
+			var/poison_injected = poison_per_bite * ((-100 * L.getarmor(targeted_organ, ARMOR_MELEE) + 100) - 40)
 			L.reagents.add_reagent(poison_type, poison_per_bite)

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
@@ -5,5 +5,6 @@
 
 	if(isliving(A))
 		var/mob/living/L = A
-		if(istype(L) && L.reagents && L.can_inject(src))
+		if(istype(L) && L.reagents)
+			var/poison_injected = L.can_inject(src) ? poison_per_bite * 0.3 : poison_per_bite
 			L.reagents.add_reagent(poison_type, poison_per_bite)

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
@@ -5,5 +5,5 @@
 
 	if(isliving(A))
 		var/mob/living/L = A
-		if(istype(L) && L.reagents)
+		if(istype(L) && L.reagents && L.can_inject(src))
 			L.reagents.add_reagent(poison_type, poison_per_bite)


### PR DESCRIPTION
tin

psi monsters/xenomorphs/greyson hypo drones are unaffected because 1. they should be stronger and 2. they'd feasibly be strong enough to pierce suits (xeno/psi)  or have a injector that ignores suits (greyson)