### PR TITLE
Increases mob reaction time by approximately 300%.

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -119,7 +119,10 @@
 	M.Weaken(3)
 	var/mob/living/carbon/superior_animal/temp_ref
 	temp_ref = new /mob/living/carbon/superior_animal/giant_spider/tarantula/emperor(src.loc)
+	temp_ref.Paralyse(20)
 	temp_ref.target_mob = WEAKREF(M)
+	temp_ref.stance = HOSTILE_STANCE_ATTACKING
+	temp_ref = null
 	qdel(src)
 
 /obj/item/spider_shadow_trap/burrowing
@@ -146,7 +149,10 @@
 	M.Weaken(3)
 	var/mob/living/carbon/superior_animal/temp_ref
 	temp_ref = new /mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing(src.loc)
+	temp_ref.Paralyse(20)
 	temp_ref.target_mob = M
+	temp_ref.stance = HOSTILE_STANCE_ATTACKING
+	temp_ref = null
 	qdel(src)
 
 /obj/item/spider_shadow_trap/burrowing/New()

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -117,12 +117,7 @@
 	triggered = 1
 	playsound(src.loc, 'sound/sanity/screech.ogg', 300, 1)
 	M.Weaken(3)
-	var/mob/living/carbon/superior_animal/temp_ref
-	temp_ref = new /mob/living/carbon/superior_animal/giant_spider/tarantula/emperor(src.loc)
-	temp_ref.Paralyse(20)
-	temp_ref.target_mob = WEAKREF(M)
-	temp_ref.stance = HOSTILE_STANCE_ATTACKING
-	temp_ref = null
+	new /mob/living/carbon/superior_animal/giant_spider/tarantula/emperor(src.loc)
 	qdel(src)
 
 /obj/item/spider_shadow_trap/burrowing
@@ -147,12 +142,7 @@
 	triggered = 1
 	playsound(src.loc, 'sound/effects/impacts/rumble2.ogg', 300, 1)
 	M.Weaken(3)
-	var/mob/living/carbon/superior_animal/temp_ref
-	temp_ref = new /mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing(src.loc)
-	temp_ref.Paralyse(20)
-	temp_ref.target_mob = M
-	temp_ref.stance = HOSTILE_STANCE_ATTACKING
-	temp_ref = null
+	new /mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing(src.loc)
 	qdel(src)
 
 /obj/item/spider_shadow_trap/burrowing/New()

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -117,7 +117,9 @@
 	triggered = 1
 	playsound(src.loc, 'sound/sanity/screech.ogg', 300, 1)
 	M.Weaken(3)
-	new /mob/living/carbon/superior_animal/giant_spider/tarantula/emperor(src.loc)
+	var/mob/living/carbon/superior_animal/temp_ref
+	temp_ref = new /mob/living/carbon/superior_animal/giant_spider/tarantula/emperor(src.loc)
+	temp_ref.target_mob = WEAKREF(M)
 	qdel(src)
 
 /obj/item/spider_shadow_trap/burrowing
@@ -142,7 +144,9 @@
 	triggered = 1
 	playsound(src.loc, 'sound/effects/impacts/rumble2.ogg', 300, 1)
 	M.Weaken(3)
-	new /mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing(src.loc)
+	var/mob/living/carbon/superior_animal/temp_ref
+	temp_ref = new /mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing(src.loc)
+	temp_ref.target_mob = M
 	qdel(src)
 
 /obj/item/spider_shadow_trap/burrowing/New()

--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -327,38 +327,13 @@
 			targetted_mob = (target_mob?.resolve())
 			if (targetted_mob)
 				stance = HOSTILE_STANCE_ATTACK
+				handle_hostile_stance(targetted_mob)
 
 		if(HOSTILE_STANCE_ATTACK)
-			if(destroy_surroundings)
-				destroySurroundings()
-			if(!ranged)
-				stop_automated_movement = TRUE
-				stance = HOSTILE_STANCE_ATTACKING
-				set_glide_size(DELAY2GLIDESIZE(move_to_delay))
-				walk_to(src, targetted_mob, 1, move_to_delay)
-				moved = 1
-			if(ranged)
-				stop_automated_movement = 1
-				if(get_dist(src, targetted_mob) <= comfy_range)
-					stance = HOSTILE_STANCE_ATTACKING
-					return //We do a safty return
-				else
-					set_glide_size(DELAY2GLIDESIZE(move_to_delay))
-					walk_to(src, targetted_mob, 4, move_to_delay)
-				stance = HOSTILE_STANCE_ATTACKING
+			handle_hostile_stance(targetted_mob)
 
 		if(HOSTILE_STANCE_ATTACKING)
-			if(destroy_surroundings)
-				destroySurroundings()
-			if(!ranged)
-				prepareAttackOnTarget()
-			if(ranged)
-				if(get_dist(src, targetted_mob) <= 6)
-					OpenFire(targetted_mob)
-				else
-					set_glide_size(DELAY2GLIDESIZE(move_to_delay))
-					walk_to(src, targetted_mob, 4, move_to_delay)
-					OpenFire(targetted_mob)
+			handle_attacking_stance(targetted_mob)
 
 	//random movement
 	if(wander && !stop_automated_movement && !anchored)
@@ -374,6 +349,39 @@
 	//Speaking
 	if(speak_chance && prob(speak_chance))
 		visible_emote(emote_see)
+
+/mob/living/carbon/superior_animal/proc/handle_hostile_stance(var/atom/targetted_mob) //here so we can jump instantly to it if hostile stance is established
+	var/already_destroying_surroundings = FALSE
+	if(destroy_surroundings)
+		destroySurroundings()
+		already_destroying_surroundings = TRUE
+	if(ranged)
+		stop_automated_movement = 1
+		if(!(get_dist(src, targetted_mob) <= comfy_range)) //out of range? move closer
+			set_glide_size(DELAY2GLIDESIZE(move_to_delay))
+			walk_to(src, targetted_mob, 4, move_to_delay)
+		stance = HOSTILE_STANCE_ATTACKING
+		handle_attacking_stance(targetted_mob, already_destroying_surroundings)
+	else if (!ranged)
+		stop_automated_movement = TRUE
+		stance = HOSTILE_STANCE_ATTACKING
+		set_glide_size(DELAY2GLIDESIZE(move_to_delay))
+		walk_to(src, targetted_mob, 1, move_to_delay)
+		moved = 1
+		handle_attacking_stance(targetted_mob, already_destroying_surroundings)
+
+/mob/living/carbon/superior_animal/proc/handle_attacking_stance(var/atom/targetted_mob, var/already_destroying_surroundings = FALSE)
+	if(destroy_surroundings)
+		destroySurroundings()
+	if(!ranged)
+		prepareAttackOnTarget()
+	if(ranged)
+		if(get_dist(src, targetted_mob) <= 6)
+			OpenFire(targetted_mob)
+		else
+			set_glide_size(DELAY2GLIDESIZE(move_to_delay))
+			walk_to(src, targetted_mob, 4, move_to_delay)
+			OpenFire(targetted_mob)
 
 // Same as overridden proc but -3 instead of -1 since its 3 times less frequently envoked, if checks removed
 /mob/living/carbon/superior_animal/handle_status_effects()

--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -307,7 +307,6 @@
 
 /mob/living/carbon/superior_animal/proc/handle_ai()
 
-
 	if(ckey)
 		return
 
@@ -324,10 +323,11 @@
 			if (!busy) // if not busy with a special task
 				stop_automated_movement = FALSE
 			target_mob = WEAKREF(findTarget())
-			targetted_mob = (target_mob?.resolve())
-			if (targetted_mob)
-				stance = HOSTILE_STANCE_ATTACK
-				handle_hostile_stance(targetted_mob)
+			if (target_mob)
+				targetted_mob = (target_mob?.resolve())
+				if (targetted_mob)
+					stance = HOSTILE_STANCE_ATTACK
+					handle_hostile_stance(targetted_mob)
 
 		if(HOSTILE_STANCE_ATTACK)
 			handle_hostile_stance(targetted_mob)
@@ -356,26 +356,22 @@
 		destroySurroundings()
 		already_destroying_surroundings = TRUE
 	if(ranged)
-		stop_automated_movement = 1
-		if(!(get_dist(src, targetted_mob) <= comfy_range)) //out of range? move closer
-			set_glide_size(DELAY2GLIDESIZE(move_to_delay))
-			walk_to(src, targetted_mob, 4, move_to_delay)
+		stop_automated_movement = TRUE
 		stance = HOSTILE_STANCE_ATTACKING
-		handle_attacking_stance(targetted_mob, already_destroying_surroundings)
 	else if (!ranged)
 		stop_automated_movement = TRUE
 		stance = HOSTILE_STANCE_ATTACKING
 		set_glide_size(DELAY2GLIDESIZE(move_to_delay))
 		walk_to(src, targetted_mob, 1, move_to_delay)
 		moved = 1
-		handle_attacking_stance(targetted_mob, already_destroying_surroundings)
+	handle_attacking_stance(targetted_mob, already_destroying_surroundings)
 
 /mob/living/carbon/superior_animal/proc/handle_attacking_stance(var/atom/targetted_mob, var/already_destroying_surroundings = FALSE)
-	if(destroy_surroundings)
+	if(destroy_surroundings && !already_destroying_surroundings)
 		destroySurroundings()
 	if(!ranged)
 		prepareAttackOnTarget()
-	if(ranged)
+	else if(ranged)
 		if(get_dist(src, targetted_mob) <= 6)
 			OpenFire(targetted_mob)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so that when a mob finds a new target it aggros instantly and tries to attack it.

BE WARNED. THIS HAS BALANCE IMPLICATIONS. This increases aggro rate by 3x, I think, which will make the strategy of ganking a lot harder. Also, makes trap spiders attack before you can get up in some circumstances. 

I started this as a bugfux but realized it is just a buff to most mobs. 

NOTE. I tested this. Mobs seem to aggro very well now, targetting works, no runtimes, but I can't profile it. For some reason I don't have access to the native profiller. I don't know why.

I personally support this PR, because I think ganking is a shit strategy, and if we are basing our balance off of it, that kinda sucks. If this causes issues, I feel the best course of action would be to instead change other things, not this PR. Although, I will revert it if it causes too many problems.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
balance: Mobs should now react 3x as fast.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
