### PR TITLE
Scope standardization

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -53,6 +53,25 @@
 	var/dual_wielding
 	var/can_dual = FALSE // Controls whether guns can be dual-wielded (firing two at once).
 	var/zoom_factor = 0 //How much to scope in when using weapon
+	
+/*
+
+NOTE: For the sake of standardizing guns and extra vision range, here's a general guideline for zooming factor.
+		  Do keep in mind that a normal player's view is seven tiles of vision in each direction.
+
+						Minimum value is 0.2 which gives 1 extra tile of vision.
+				From there, increases are mostly linear, with the following shared exceptions:
+									0.3 and 0.4 = 2 extra tiles
+									0.6 and 0.7 = 4 extra tiles
+			0.9 gives 6 extra tiles, from there jumps straight to 8 extra tiles at both 1 and 1.1
+						1.3 and 1.4 = 10 extra tiles (Character no longer seen on screen)
+									1.6 and 1.7 = 12 extra tiles
+					Largest zooming factor being 2, increases tile vision by 16 extra tiles.
+
+
+For the sake of consistency, I suggest always rounding up on even values when applicable. - Seb (ThePainkiller)
+
+*/
 
 	var/suppress_delay_warning = FALSE
 

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -600,7 +600,7 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_OFFSET = 0.9,
-		GUN_UPGRADE_ZOOM = 1.2
+		GUN_UPGRADE_ZOOM = 1.2 // 9 extra tiles
 		)
 	I.gun_loc_tag = GUN_SCOPE
 	I.req_gun_tags = list(GUN_SCOPE)
@@ -618,7 +618,7 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_OFFSET = 0.9,
-		GUN_UPGRADE_ZOOM = 1.1
+		GUN_UPGRADE_ZOOM = 1 // 8 extra tiles of vision
 		)
 	I.gun_loc_tag = GUN_SCOPE
 	I.req_gun_tags = list(GUN_SCOPE)

--- a/code/modules/projectiles/guns/projectile/automatic/battlerifle.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/battlerifle.dm
@@ -67,7 +67,7 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 10, MATERIAL_GLASS = 5)
 	mag_well = MAG_WELL_HRIFLE
 	price_tag = 1500
-	zoom_factor = 0.3
+	zoom_factor = 0.4
 	recoil_buildup = 2.5
 	one_hand_penalty = 10
 	penetration_multiplier = 1
@@ -84,7 +84,7 @@
 	desc = "A heavy front line designated marksman rifle manufactured by H&S, also known as the M13A2 Special Purpose Rifle in its generic military form. \
 		 Either a copy or 'liberated' example, it fires a variety of utility and specialized munitions. \
 		 Chambered in .408, its gaping bore allows virtually any imaginable payload, however the recoil and magazine suffer for it. \
-		 This example is fitted with an advanced combat sight and limited to semiautomatic and two-round burst."
+		 This example is fitted with an advanced combat sight and limited to semiautomatic and burst modes."
 	icon = 'icons/obj/guns/projectile/DMR.dmi'
 	icon_state = "DMR"
 	item_state = "DMR"
@@ -166,7 +166,7 @@
 	damage_multiplier = 1.1
 	recoil_buildup = 3.25
 	one_hand_penalty = 23
-	zoom_factor = 0.3
+	zoom_factor = 0.4
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
 		BURST_3_ROUND

--- a/code/modules/projectiles/guns/projectile/automatic/blackguard.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/blackguard.dm
@@ -1,7 +1,7 @@
 /obj/item/gun/projectile/automatic/blackguard
 	name = "\"Blackguard\" heavy marksman rifle"
 	desc = "A heavily modded and  \"improved\" omnirifle platform design made by the Marshals but used by Blackshield, chambered in .408, \
-	With an extended barrel, standard bayonet, and integrated ACOG scope this rifle has less customization than other weapons, but lends itself to a good all \
+	With an extended barrel, standard bayonet, and a reflex scope this rifle has less customization than other weapons, but lends itself to a good all \
 	round design and function. Unlike other omni rifles, this one can take standard mags or drum mags of .408 ammo."
 	icon = 'icons/obj/guns/projectile/blackguard.dmi'
 	icon_state = "sts_blackguard"
@@ -14,7 +14,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_HRIFLE|MAG_WELL_DRUM
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 5, MATERIAL_STEEL = 25, MATERIAL_GLASS = 5)
-	zoom_factor = 1 // In line with the Longarm omnirifle, less than the Osprey, and half of specialized sniper rifles like the Scout. - Seb
+	zoom_factor = 0.8 // Now it does have 5 more tiles as originally intended.
 	price_tag = 2500
 	penetration_multiplier = 1.2
 	damage_multiplier = 1.35 //Really hard to upgrade
@@ -22,7 +22,7 @@
 	one_hand_penalty = 15
 	brace_penalty = 15 //So this isn't literally better long arm in every way also it has a damn bayonet
 
-	max_upgrades = 3 // Trigger ang a guard; 2 less slots than usual due to its scope, pen and damage.
+	max_upgrades = 3 // Trigger and a guard; 2 less slots than usual due to its scope, pen and damage.
 
 	fire_sound = 'sound/weapons/guns/fire/lmg_fire.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/sfrifle_magout.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/blackguard.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/blackguard.dm
@@ -1,7 +1,7 @@
 /obj/item/gun/projectile/automatic/blackguard
 	name = "\"Blackguard\" heavy marksman rifle"
 	desc = "A heavily modded and  \"improved\" omnirifle platform design made by the Marshals but used by Blackshield, chambered in .408, \
-	With an extended barrel, standard bayonet, and a reflex scope this rifle has less customization than other weapons, but lends itself to a good all \
+	With an extended barrel, standard bayonet, and integrated ACOG scope this rifle has less customization than other weapons, but lends itself to a good all \
 	round design and function. Unlike other omni rifles, this one can take standard mags or drum mags of .408 ammo."
 	icon = 'icons/obj/guns/projectile/blackguard.dmi'
 	icon_state = "sts_blackguard"
@@ -14,7 +14,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_HRIFLE|MAG_WELL_DRUM
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 5, MATERIAL_STEEL = 25, MATERIAL_GLASS = 5)
-	zoom_factor = 0.5 //5 more tiles
+	zoom_factor = 1 // In line with the Longarm omnirifle, less than the Osprey, and half of specialized sniper rifles like the Scout. - Seb
 	price_tag = 2500
 	penetration_multiplier = 1.2
 	damage_multiplier = 1.35 //Really hard to upgrade

--- a/code/modules/projectiles/guns/projectile/automatic/bulldog.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/bulldog.dm
@@ -51,4 +51,4 @@
 	icon_state = "bulldog_rds"
 	item_state = "bulldog_rds"
 	price_tag = 1225
-	zoom_factor = 0.3
+	zoom_factor = 0.4

--- a/code/modules/projectiles/guns/projectile/boltgun/baroque.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/baroque.dm
@@ -13,7 +13,7 @@ Own a musket for department defense, since that's what the founding hunters inte
 /obj/item/gun/projectile/boltgun/baroque
 	name = "\"Baroque\" bone rifle"
 	desc = "A heavy smoothbore lever-action rifle made from dense bones fitted with a plasteel barrel. One of the few rifles produced and widely distributed by Kriosan Jaegers, this \
-	particular design imparted by kriosan's favoring the hunting lodge. Fires a single devistating shot which can fell most animals in a single blow, though it struggles to do the same \
+	particular design imparted by kriosan's favoring the hunting lodge. Fires a single devastating shot which can fell most animals in a single blow, though it struggles to do the same \
 	to people as it was designed primarily for game hunting. Still packs a hell of a punch. Uses 30mm rolled shot."
 	icon = 'icons/obj/guns/projectile/baroque.dmi'
 	icon_state = "baroque"
@@ -34,7 +34,7 @@ Own a musket for department defense, since that's what the founding hunters inte
 	price_tag = 750
 	extra_damage_mult_scoped = 0.4
 	one_hand_penalty = 80
-	zoom_factor = 1.3
+	zoom_factor = 1.4
 	twohanded = TRUE
 	sharp = FALSE
 	saw_off = FALSE //Todo. Pistole verson

--- a/code/modules/projectiles/guns/projectile/revolver/tacticool_revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/tacticool_revolver.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/projectile/revolver/tacticool_revolver
 	name = "\"Tacticool\" heavy revolver"
-	desc = "When people complained that the mataba was impractical due to its wrist snapping recoil Scarborough Arms decided what it really needed was a tactical scope for sniping. Uses .50 kurtz."
+	desc = "When people complained that the Mateba was impractical due to its wrist snapping recoil, Scarborough Arms decided what it really needed was a tactical scope for sniping. Uses .50 kurtz."
 	icon = 'icons/obj/guns/projectile/tacticool_revolver.dmi'
 	icon_state = "tacticool_revolver"
 	item_state = "tacticool_revolver"
@@ -12,7 +12,7 @@
 	price_tag = 1500 //more op and rare than miller, hits harder, but have fun with hittin anything
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.25
-	zoom_factor = 1.3
+	zoom_factor = 1.4
 	recoil_buildup = 4 //Less recoil due to the weight of the scope.
 	one_hand_penalty = 15
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_REVOLVER, GUN_CALIBRE_50)

--- a/code/modules/projectiles/guns/projectile/shotgun/sbaw.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/sbaw.dm
@@ -16,7 +16,7 @@
 	price_tag = 2000
 	penetration_multiplier = 1.5 //50% more ap
 	damage_multiplier = 1.1 //Payload "rifle" has a scope so fair enough
-	zoom_factor = 0.3
+	zoom_factor = 0.4
 	fire_delay = 12
 	recoil_buildup = 15
 	one_hand_penalty = 20


### PR DESCRIPTION
## About The Pull Request

- Added annotation guidelines for how zoom_factor var affects scoping in game, through extensive testing. This fixes the incorrect assumption that a 0.5 value means "five more tiles" when it's just 3.
- Standardizes most scopes and mods by rounding their values up to even values (amount of zoom unchanged)
- Ups the Blackguard zoom factor to 1 (8 extra tiles) as the scope was overwhelming for its (teleporter) power value, price and rarity.
- Minor typo fixes.

### In game testing of zoom_factor var has thrown the following results:

```
x0.2 = 1 extra tile
x0.3 / x0.4 = 2 extra tiles
x0.5 = 3 extra tiles
x0.6 / x0.7 = 4 extra tiles
x0.8 = 5 extra tiles
x0.9 = 6 extra tiles
x1 / x1.1 = 8 extra tiles (standard for anything to be considered a sniper rifle)
x1.2 = 9 extra tiles
x1.3 / x1.4 = 10 extra tiles (character no longer seen on screen)
x1.5 = 11 extra tiles
x1.6 / x1.7 = 12 extra tiles
x1.8 = 13 extra tiles
x2 = 16 extra tiles
```

## Changelog
:cl:
tweak: Rounded up values for scopes and scope attachments to be even numbers (total zoom values unchanged)
balance: Blackguard scope to x1 value (8 extra tiles of vision)
spellcheck: fixed a few typos
code: Adds annotation on gun.dm for guidelines on how zoom_factor works in game
/:cl: