### PR TITLE
Shield Halloss max tweaking

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -90,7 +90,7 @@
 	if(istype(attacker, /mob/living/simple_animal/hostile) || istype(attacker, /mob/living/carbon/superior_animal/))
 		var/mob/living/carbon/human/defender = user
 		if(check_shield_arc(defender, bad_arc, damage_source, attacker))
-			if(defender.halloss >= 40 || (defender.halloss + damage_recieved) >= 50) //THIS HAS PROVEN TO BE FAR TOO DANGEROUS AT 50, YOU /WILL/ PAINCRIT.
+			if(defender.halloss >= 40 || (defender.halloss + damage_received) >= 50) //THIS HAS PROVEN TO BE FAR TOO DANGEROUS AT 50, YOU /WILL/ PAINCRIT.
 				defender.visible_message(SPAN_DANGER("\The [defender] is too tired to block!"))
 				return 0
 			else

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -89,7 +89,7 @@
 	if(istype(attacker, /mob/living/simple_animal/hostile) || istype(attacker, /mob/living/carbon/superior_animal/))
 		var/mob/living/carbon/human/defender = user
 		if(check_shield_arc(defender, bad_arc, damage_source, attacker))
-			if(defender.halloss >= 50)
+			if(defender.halloss >= 30) //THIS HAS PROVEN TO BE FAR TOO DANGEROUS AT 50, YOU /WILL/ PAINCRIT.
 				defender.visible_message(SPAN_DANGER("\The [defender] is too tired to block!"))
 				return 0
 			else

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -85,15 +85,15 @@
 		return 0
 
 	//block as long as they are not directly behind us
+	var/damage_received = CLAMP(damage * (CLAMP(100-user.stats.getStat(STAT_TGH)/2,0,100) / 100) - user.stats.getStat(STAT_TGH)/5,1,100) //Move this here, because... Well. It was dumb.
 	var/bad_arc = reverse_direction(user.dir) //arc of directions from which we cannot block
 	if(istype(attacker, /mob/living/simple_animal/hostile) || istype(attacker, /mob/living/carbon/superior_animal/))
 		var/mob/living/carbon/human/defender = user
 		if(check_shield_arc(defender, bad_arc, damage_source, attacker))
-			if(defender.halloss >= 30) //THIS HAS PROVEN TO BE FAR TOO DANGEROUS AT 50, YOU /WILL/ PAINCRIT.
+			if(defender.halloss >= 40 || (defender.halloss + damage_recieved) >= 50) //THIS HAS PROVEN TO BE FAR TOO DANGEROUS AT 50, YOU /WILL/ PAINCRIT.
 				defender.visible_message(SPAN_DANGER("\The [defender] is too tired to block!"))
 				return 0
 			else
-				var/damage_received = CLAMP(damage * (CLAMP(100-user.stats.getStat(STAT_TGH)/2,0,100) / 100) - user.stats.getStat(STAT_TGH)/5,1,100)
 				src.durability = src.durability -  CLAMP(damage_received,10,100) // Shields still take some damage, can't have it go unscathed
 				defender.adjustHalLoss(damage_received)
 				defender.visible_message(SPAN_DANGER("\The [defender] blocks [attack_text] with \the [src]!"))

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -91,7 +91,7 @@
 		var/mob/living/carbon/human/defender = user
 		if(check_shield_arc(defender, bad_arc, damage_source, attacker))
 			if(defender.halloss >= 40 || (defender.halloss + damage_received) >= 50) //THIS HAS PROVEN TO BE FAR TOO DANGEROUS AT 50, YOU /WILL/ PAINCRIT.
-				defender.visible_message(SPAN_DANGER("\The [defender] is too tired to block!"))
+				defender.visible_message(SPAN_DANGER("\The [defender] is too weak to block!"))
 				return 0
 			else
 				src.durability = src.durability -  CLAMP(damage_received,10,100) // Shields still take some damage, can't have it go unscathed


### PR DESCRIPTION
Title. This makes shields no longer go up to 50 halloss before being unable to block, as this value was able to put you into INSTANT SHOCKCRIT due to how this was being handled.

Also prevents you from blocking if blocking would put you above 50 halloss, to help prevent players from dying from just using a shield.
## Changelog
:cl:
tweak: Testing lowering shield halloss check to 45 instead of 50. Hopefully should prevent renders from 2 hit shock critting shock users, as the check was not checking if your halloss would be /over/ 50 beforehand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
