### PR TITLE
Makes mobs check for hardcrit on humans instead of just 0 health on most AI checks.

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/attack.dm
@@ -76,7 +76,7 @@
 		loseTarget()
 		return
 
-	if (!firing_target.check_if_alive())
+	if (!firing_target.check_if_alive(TRUE))
 		loseTarget()
 		return
 

--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -356,7 +356,7 @@
 		targetted_mob = (target_mob?.resolve())
 	if (!targetted_mob) //will be false if there is no target_mob or if the resolved value is null
 		loseTarget()
-	else if (!targetted_mob.check_if_alive()) //else if because we dont want a runtime
+	else if (!targetted_mob.check_if_alive(TRUE)) //else if because we dont want a runtime
 		loseTarget()
 
 	switch(stance)
@@ -441,7 +441,7 @@
 	if(!ranged)
 		prepareAttackOnTarget()
 	else if(ranged)
-		if (!check_if_alive(targetted_mob))
+		if (!(targetted_mob.check_if_alive(TRUE)))
 			loseTarget()
 			return
 		if (!check_if_alive())
@@ -457,8 +457,10 @@
 /atom/proc/check_if_alive(var/critcheck = FALSE) //A simple yes no if were alive
 	if (critcheck)
 		if (istype(src, /mob/living/carbon/human))
-			if(health < HEALTH_THRESHOLD_CRIT) //only matters for humans
+			if(health > HEALTH_THRESHOLD_CRIT) //only matters for humans
 				return TRUE
+			else
+				return FALSE
 	if(health > 0)
 		return TRUE
 	return FALSE

--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -453,7 +453,12 @@
 			walk_to(src, targetted_mob, 4, move_to_delay)
 			prepareAttackPrecursor(targetted_mob, .proc/OpenFire, RANGED_TYPE)
 
-/atom/proc/check_if_alive() //A simple yes no if were alive
+/// If critcheck = FALSE, will check if health is more than 0. Otherwise, if is a human, will check if theyre in hardcrit.
+/atom/proc/check_if_alive(var/critcheck = FALSE) //A simple yes no if were alive
+	if (critcheck)
+		if (istype(src, /mob/living/carbon/human))
+			if(health < HEALTH_THRESHOLD_CRIT) //only matters for humans
+				return TRUE
 	if(health > 0)
 		return TRUE
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. THis is how it is because otherwise crit can be cheesed for most humans to not aggro any mobs and just kill everything. Also, this is the threshold eris originally uses for targetting, so it's only fair we use it here.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
tweak: Mobs will now stop attacking at -50 HP instead of just 0.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
