### PR TITLE
Mobs are half as patient as they were before and will untarget mobs they can't see quicker.

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -25,10 +25,8 @@
 	var/retarget_rush_timer_increment = 10 SECONDS //arbitrary value for now
 	/// Will this mob continue to fire even if LOS has been broken?
 	var/fire_through_wall = FALSE
-	/// Initial value of patience, make sure to match it with patience.
-	var/patience_initial = 10
 	/// How many ticks are we willing to wait before untargetting a mob that we can't see?
-	var/patience = 10
+	var/patience = 5
 
 	/// Telegraph message base for mobs that are range
 	var/range_telegraph = "aims their weapon at"
@@ -435,11 +433,11 @@
 	if (!((can_see(src, targetted_mob, get_dist(src, targetted_mob))) && !fire_through_wall)) //why attack if we can't even see the enemy
 		if (patience <= 0)
 			loseTarget()
-			patience = patience_initial
+			patience = initial(patience)
 		else
 			patience--
 		return
-	patience = patience_initial
+	patience = initial(patience)
 	if(!ranged)
 		prepareAttackOnTarget()
 	else if(ranged)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Also removes patience_initial becuase I realized the initial() proc exists.

Making this change because I found 10 ticks is way too long, and people can easily just sneak up on ranged mobs to fuck them up.

Untested because there's no reason this shouldn't just work right out of the gate.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
balance: Mobs will now wait half as long to retarget if they can't see a target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
