### PR TITLE
Loot rotation and missing disks

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disk/blackshield_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/blackshield_disks.dm
@@ -131,8 +131,8 @@
 		)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/luger
-	name = ""
-	disk_name = "NM .35 \"Vintovka Lyugera\" carbine"
+	name = "NM .35 \"Vintovka Lyugera\" carbine"
+	disk_name = ""
 	icon_state = "blackshield"
 	license = 15
 
@@ -150,8 +150,8 @@
 		)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/NM_colt
-	name = ""
-	disk_name = "NM HG .35 \"Bronco\""
+	name = "NM HG .35 \"Bronco\""
+	disk_name = ""
 	icon_state = "blackshield"
 	license = 8
 
@@ -168,8 +168,8 @@
 		)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/semyonovich
-	name = ""
-	disk_name = "Blackshield .35 Auto \"Semyonovich\""
+	name = "Blackshield .35 Auto \"Semyonovich\""
+	disk_name = ""
 	icon_state = "blackshield"
 	license = 8
 
@@ -183,8 +183,8 @@
 
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/greasegun
-	name = ""
-	disk_name = "Blackshield - .35 Auto \"Grease Gun\""
+	name = "Blackshield - .35 Auto \"Grease Gun\""
+	disk_name = ""
 	icon_state = "blackshield"
 
 	license = 8
@@ -197,8 +197,8 @@
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/buckler
-	name = ""
-	disk_name = "Blackshield - .35 Buckler SMG"
+	name = "Blackshield - .35 Buckler SMG"
+	disk_name = ""
 	icon_state = "blackshield"
 
 	license = 12
@@ -211,8 +211,8 @@
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/triage
-	name = ""
-	disk_name = "Blackshield - .40 Triage SMG"
+	name = "Blackshield - .40 Triage SMG"
+	disk_name = ""
 	icon_state = "blackshield"
 
 	license = 12
@@ -225,8 +225,8 @@
 		)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/strelki
-	name = ""
-	disk_name = "NM - 7.5mm \"Strelki\""
+	name = "NM - 7.5mm \"Strelki\""
+	disk_name = ""
 	icon_state = "blackshield"
 	license = 8
 
@@ -239,8 +239,8 @@
 		)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/watchtower
-	name = ""
-	disk_name = "NM - 7.5mm \"Watchtower\""
+	name = "NM - 7.5mm \"Watchtower\""
+	disk_name = ""
 	icon_state = "blackshield"
 	license = 8
 
@@ -253,8 +253,8 @@
 		)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/zatvor
-	name = ""
-	disk_name = "NM 7.5 bolt \"Zatvor\" rifle"
+	name = "NM 7.5 bolt \"Zatvor\" rifle"
+	disk_name = ""
 	icon_state = "blackshield"
 	license = 8
 
@@ -268,8 +268,8 @@
 		)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/dp
-	name = ""
-	disk_name = "NM - \"Pulemyot Degtyaryova\" LMG"
+	name = "NM - \"Pulemyot Degtyaryova\" LMG"
+	disk_name = ""
 	icon_state = "blackshield"
 	license = 8
 
@@ -279,8 +279,8 @@
 		)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/duty
-	name = ""
-	disk_name = "NM - .257 Duty Rifle"
+	name = "NM - .257 Duty Rifle"
+	disk_name = ""
 	icon_state = "blackshield"
 
 	license = 16
@@ -295,12 +295,11 @@
 		/datum/design/autolathe/ammo/lrifle = 2,
 		/datum/design/autolathe/ammo/lrifle_lethal = 4,
 		/datum/design/autolathe/ammo/lrifle_speed_loader
-
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/blackguard
-	name = ""
-	disk_name = "NM - .408 Blackguard Omni Rifle"
+	name = "NM - .408 Blackguard Omni Rifle"
+	disk_name = ""
 	icon_state = "blackshield"
 
 	license = 8 //RARE GUN REALLY RARE REALLY GOOD
@@ -313,8 +312,8 @@
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/rushingbull
-	name = ""
-	disk_name = "NM - 20mm Rushingbull Shotgun"
+	name = "NM - 20mm Rushingbull Shotgun"
+	disk_name = ""
 	icon_state = "blackshield"
 
 	license = 8

--- a/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
@@ -1,149 +1,5 @@
 // Disks formated as /designpath = pointcost , if no point cost is specified it defaults to 1.
 // To make a design unprotect use -1
-// Marshal
-/obj/item/computer_hardware/hard_drive/portable/design/security
-	disk_name = "Security Miscellaneous Pack"
-	icon_state = "ironhammer"
-	license = 20
-	designs = list(
-		/datum/design/autolathe/sec/secflashlight,
-		/datum/design/research/item/flash,
-		/datum/design/autolathe/sec/handcuffs,
-		/datum/design/autolathe/sec/zipties = 0,
-		/datum/design/autolathe/sec/electropack,
-		/datum/design/autolathe/misc/taperecorder,
-		/datum/design/autolathe/tool/tacknife,
-		/datum/design/autolathe/tool/combat_shovel,
-		/datum/design/autolathe/sec/beartrap,
-		/datum/design/autolathe/sec/silencer,
-		/datum/design/autolathe/sec/acog,
-		/datum/design/autolathe/sec/gun_case,
-		/datum/design/research/item/light_replacer,
-		/datum/design/autolathe/sec/hailer,
-		/datum/design/research/item/medical/autopsy_scanner,
-		/datum/design/autolathe/gun/cop_mod = 0,
-		/datum/design/autolathe/sec/stunbaton = 5, //balance, we can only make 4
-		/datum/design/autolathe/sec/auto_eject_mod,
-		/datum/design/autolathe/gun/dnalock_mod,
-		/datum/design/autolathe/gun/bipod_mod = 2,
-		/datum/design/autolathe/gun/flare_gun = 3,
-		/datum/design/autolathe/sec/riot = 10,
-		/datum/design/autolathe/sec/buckler = 5,
-		/datum/design/autolathe/ammo/flare_shell,
-		/datum/design/autolathe/ammo/flare_shell_g,
-		/datum/design/autolathe/ammo/flare_shell_b,
-		/datum/design/autolathe/container/ammocan_ih,
-	)
-
-/obj/item/computer_hardware/hard_drive/portable/design/security/hos
-	disk_name = "Security Miscellaneous Factory"
-	license = -1
-
-/obj/item/computer_hardware/hard_drive/portable/design/security/marshal_guns
-	disk_name = "Marshal \"Negotiator\" Pack"
-	icon_state = "ironhammer"
-	license = 20 //1:1 with blackshield guns
-	designs = list(
-		/datum/design/autolathe/gun/glock,
-		/datum/design/autolathe/gun/liberty,
-		/datum/design/autolathe/gun/rev10,
-		/datum/design/autolathe/gun/amnesty = 2,
-		/datum/design/autolathe/gun/judge = 2,
-		//SMGs
-		/datum/design/autolathe/gun/wirbelwind = 2,
-		/datum/design/autolathe/gun/freedom = 2,
-		/datum/design/autolathe/gun/specop = 3,
-		//rifles
-		/datum/design/autolathe/gun/mamba = 3,
-		/datum/design/autolathe/gun/viper = 4,
-		/datum/design/autolathe/gun/ostwind = 5,
-		/datum/design/autolathe/gun/copperhead = 4,
-		//shotguns
-		/datum/design/autolathe/gun/operator = 4,
-		/datum/design/autolathe/gun/riot_shotgun = 4,
-		//machinegun
-		/datum/design/autolathe/gun/dp = 2,
-		/datum/design/autolathe/gun/bastard = 3,
-		//ion
-		/datum/design/autolathe/gun/ion_pistol = 5,
-		//launcher
-		/datum/design/autolathe/gun/grenade_launcher_lenar = 7,
-		//sniper
-		/datum/design/autolathe/gun/python = 5,
-		/datum/design/autolathe/gun/nordwind = 7,
-		//flaregun
-		/datum/design/autolathe/gun/flare_gun,
-		//laser
-		/datum/design/autolathe/gun/sunrise =3,
-		/datum/design/autolathe/gun/peacekeeper =3,
-		/datum/design/autolathe/gun/zwang =2,
-		//Misc
-		/datum/design/autolathe/tool/ironhammer,
-		/datum/design/autolathe/sec/stunbaton/maul,
-		/datum/design/autolathe/sec/riot,
-		/datum/design/autolathe/device/landmine = 0,
-		/datum/design/autolathe/sec/buckler = 0,
-		/datum/design/autolathe/sec/bastion = 0,
-		/datum/design/autolathe/container/ammocan_ih = 0,
-		)
-
-/obj/item/computer_hardware/hard_drive/portable/design/security/marshal_ammo
-	disk_name = "Marshal \"Shoot-out\" Pack"
-	icon_state = "ironhammer"
-	license = 30 //1:1 with blackshield guns
-	designs = list(
-		/datum/design/autolathe/ammo/pistol = 0,
-		/datum/design/autolathe/ammo/pistol_lethal,
-		/datum/design/autolathe/ammo/pistol_rubber,
-		/datum/design/autolathe/ammo/pistol_practice = 0,
-		/datum/design/autolathe/ammo/hpistol = 0,
-		/datum/design/autolathe/ammo/hpistol_lethal,
-		/datum/design/autolathe/ammo/hpistol_rubber,
-		/datum/design/autolathe/ammo/hpistol_practice = 0,
-		/datum/design/autolathe/ammo/smg = 0,
-		/datum/design/autolathe/ammo/smg_rubber,
-		/datum/design/autolathe/ammo/smg_lethal,
-		/datum/design/autolathe/ammo/smg_practice = 0,
-		/datum/design/autolathe/ammo/pistol_35_drum,
-		/datum/design/autolathe/ammo/pistol_35_drum/empty = 0,
-		/datum/design/autolathe/ammo/pistol_35_drum/rubber,
-		/datum/design/autolathe/ammo/pistol_35_drum/lethal,
-		/datum/design/autolathe/ammo/magnum = 0,
-		/datum/design/autolathe/ammo/magnum_rubber,
-		/datum/design/autolathe/ammo/magnum_pepperball,
-		/datum/design/autolathe/ammo/magnum_practice = 0,
-		/datum/design/autolathe/ammo/magnum_lethal,
-		/datum/design/autolathe/ammo/pistol_ammobox = 0,
-		/datum/design/autolathe/ammo/pistol_ammobox_rubber,
-		/datum/design/autolathe/ammo/pistol_ammobox/large,
-		/datum/design/autolathe/ammo/magnum_ammobox = 0,
-		/datum/design/autolathe/ammo/magnum_ammobox_rubber,
-		/datum/design/autolathe/ammo/magnum_ammobox_pepperball,
-		/datum/design/autolathe/ammo/magnum_ammobox_practice = 0,
-		/datum/design/autolathe/ammo/magnum_ammobox/large,
-		/datum/design/autolathe/ammo/kurtz_ammobox_rubber = 0,
-		/datum/design/autolathe/ammo/kurtz_ammobox = 0,
-		/datum/design/autolathe/ammo/kurtz_ammobox_practice = 0,
-		/datum/design/autolathe/ammo/lrifle_ammobox = 1,
-		/datum/design/autolathe/ammo/lrifle_ammobox_lethal = 1,
-		/datum/design/autolathe/ammo/lrifle_ammobox_rubber = 0,
-		/datum/design/autolathe/ammo/lrifle_ammobox_small_practice = 0,
-		/datum/design/autolathe/ammo/rifle_ammobox = 1,
-		/datum/design/autolathe/ammo/rifle_ammobox_lethal = 1,
-		/datum/design/autolathe/ammo/rifle_pk_empty = 0,
-		/datum/design/autolathe/ammo/rifle_pk,
-		/datum/design/autolathe/ammo/lrifle_belt,
-		/datum/design/autolathe/ammo/lrifle_belt_empty = 0,
-		/datum/design/autolathe/ammo/hrifle_ammobox_linked,
-		/datum/design/autolathe/ammo/hrifle_ammobox_linked_rubber,
-		/datum/design/autolathe/ammo/hrifle_ammobox_linked_empty = 0,
-		/datum/design/autolathe/ammo/grenade,
-		/datum/design/autolathe/ammo/grenade/flash,
-		/datum/design/autolathe/ammo/flare_shell = 0,
-		/datum/design/autolathe/ammo/flare_shell_g = 0,
-		/datum/design/autolathe/ammo/flare_shell_b = 0,
-		/datum/design/autolathe/container/ammocan_ih,
-		)
 
 // Magazines and ammo
 
@@ -685,17 +541,6 @@
 
 // .257 carbines
 
-/obj/item/computer_hardware/hard_drive/portable/design/guns/bastard
-	disk_name = "NM - .257 \"Bastard\" Compact Machine Gun"
-	icon_state = "frozenstar"
-
-	license = 8
-	designs = list(
-		/datum/design/autolathe/gun/bastard = 3,
-		/datum/design/autolathe/ammo/lrifle_belt,
-		/datum/design/autolathe/ammo/lrifle_belt_empty = 0,
-	)
-
 /obj/item/computer_hardware/hard_drive/portable/design/guns/sol
 	disk_name = "H&S - .257 \"Solarian\" Carbine"
 	icon_state = "ironhammer"
@@ -1079,15 +924,6 @@ obj/item/computer_hardware/hard_drive/portable/design/guns/china
 		/datum/design/autolathe/cell/medium/high,
 	)
 
-/obj/item/computer_hardware/hard_drive/portable/design/guns/sunrise
-	disk_name = "NM - \"Sunrise\" Laser SMG"
-	icon_state = "blackshield"
-
-	license = 8
-	designs = list(
-		/datum/design/autolathe/gun/sunrise = 3,
-		/datum/design/autolathe/cell/medium/high,
-	)
 
 // PLASMA ARMS
 

--- a/code/game/objects/items/weapons/autolathe_disk/marshal.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/marshal.dm
@@ -1,0 +1,312 @@
+// Disks formated as /designpath = pointcost , if no point cost is specified it defaults to 1.
+// To make a design unprotect use -1
+
+// Marshal
+/obj/item/computer_hardware/hard_drive/portable/design/security
+	disk_name = "Security Miscellaneous Pack"
+	icon_state = "ironhammer"
+	license = 20
+	designs = list(
+		/datum/design/autolathe/sec/secflashlight,
+		/datum/design/research/item/flash,
+		/datum/design/autolathe/sec/handcuffs,
+		/datum/design/autolathe/sec/zipties = 0,
+		/datum/design/autolathe/sec/electropack,
+		/datum/design/autolathe/misc/taperecorder,
+		/datum/design/autolathe/tool/tacknife,
+		/datum/design/autolathe/tool/combat_shovel,
+		/datum/design/autolathe/sec/beartrap,
+		/datum/design/autolathe/sec/silencer,
+		/datum/design/autolathe/sec/acog,
+		/datum/design/autolathe/sec/gun_case,
+		/datum/design/research/item/light_replacer,
+		/datum/design/autolathe/sec/hailer,
+		/datum/design/research/item/medical/autopsy_scanner,
+		/datum/design/autolathe/gun/cop_mod = 0,
+		/datum/design/autolathe/sec/stunbaton = 5, //balance, we can only make 4
+		/datum/design/autolathe/sec/auto_eject_mod,
+		/datum/design/autolathe/gun/dnalock_mod,
+		/datum/design/autolathe/gun/bipod_mod = 2,
+		/datum/design/autolathe/gun/flare_gun = 3,
+		/datum/design/autolathe/sec/riot = 10,
+		/datum/design/autolathe/sec/buckler = 5,
+		/datum/design/autolathe/ammo/flare_shell,
+		/datum/design/autolathe/ammo/flare_shell_g,
+		/datum/design/autolathe/ammo/flare_shell_b,
+		/datum/design/autolathe/container/ammocan_ih,
+	)
+
+/obj/item/computer_hardware/hard_drive/portable/design/security/hos
+	disk_name = "Security Miscellaneous Factory"
+	license = -1
+
+/obj/item/computer_hardware/hard_drive/portable/design/security/marshal_guns
+	disk_name = "Marshal \"Negotiator\" Pack"
+	icon_state = "ironhammer"
+	license = 20 //1:1 with blackshield guns
+	designs = list(
+		/datum/design/autolathe/gun/glock,
+		/datum/design/autolathe/gun/liberty,
+		/datum/design/autolathe/gun/rev10,
+		/datum/design/autolathe/gun/amnesty = 2,
+		/datum/design/autolathe/gun/judge = 2,
+		//SMGs
+		/datum/design/autolathe/gun/wirbelwind = 2,
+		/datum/design/autolathe/gun/freedom = 2,
+		/datum/design/autolathe/gun/specop = 3,
+		//rifles
+		/datum/design/autolathe/gun/mamba = 3,
+		/datum/design/autolathe/gun/viper = 4,
+		/datum/design/autolathe/gun/ostwind = 5,
+		/datum/design/autolathe/gun/copperhead = 4,
+		//shotguns
+		/datum/design/autolathe/gun/operator = 4,
+		/datum/design/autolathe/gun/riot_shotgun = 4,
+		//machinegun
+		/datum/design/autolathe/gun/dp = 2,
+		/datum/design/autolathe/gun/bastard = 3,
+		//ion
+		/datum/design/autolathe/gun/ion_pistol = 5,
+		//launcher
+		/datum/design/autolathe/gun/grenade_launcher_lenar = 7,
+		//sniper
+		/datum/design/autolathe/gun/python = 5,
+		/datum/design/autolathe/gun/nordwind = 7,
+		//flaregun
+		/datum/design/autolathe/gun/flare_gun,
+		//laser
+		/datum/design/autolathe/gun/sunrise =3,
+		/datum/design/autolathe/gun/peacekeeper =3,
+		/datum/design/autolathe/gun/zwang =2,
+		//Misc
+		/datum/design/autolathe/tool/ironhammer,
+		/datum/design/autolathe/sec/stunbaton/maul,
+		/datum/design/autolathe/sec/riot,
+		/datum/design/autolathe/device/landmine = 0,
+		/datum/design/autolathe/sec/buckler = 0,
+		/datum/design/autolathe/sec/bastion = 0,
+		/datum/design/autolathe/container/ammocan_ih = 0,
+		)
+
+/obj/item/computer_hardware/hard_drive/portable/design/security/marshal_ammo
+	disk_name = "Marshal \"Shoot-out\" Pack"
+	icon_state = "ironhammer"
+	license = 30 //1:1 with blackshield guns
+	designs = list(
+		/datum/design/autolathe/ammo/pistol = 0,
+		/datum/design/autolathe/ammo/pistol_lethal,
+		/datum/design/autolathe/ammo/pistol_rubber,
+		/datum/design/autolathe/ammo/pistol_practice = 0,
+		/datum/design/autolathe/ammo/hpistol = 0,
+		/datum/design/autolathe/ammo/hpistol_lethal,
+		/datum/design/autolathe/ammo/hpistol_rubber,
+		/datum/design/autolathe/ammo/hpistol_practice = 0,
+		/datum/design/autolathe/ammo/smg = 0,
+		/datum/design/autolathe/ammo/smg_rubber,
+		/datum/design/autolathe/ammo/smg_lethal,
+		/datum/design/autolathe/ammo/smg_practice = 0,
+		/datum/design/autolathe/ammo/pistol_35_drum,
+		/datum/design/autolathe/ammo/pistol_35_drum/empty = 0,
+		/datum/design/autolathe/ammo/pistol_35_drum/rubber,
+		/datum/design/autolathe/ammo/pistol_35_drum/lethal,
+		/datum/design/autolathe/ammo/magnum = 0,
+		/datum/design/autolathe/ammo/magnum_rubber,
+		/datum/design/autolathe/ammo/magnum_pepperball,
+		/datum/design/autolathe/ammo/magnum_practice = 0,
+		/datum/design/autolathe/ammo/magnum_lethal,
+		/datum/design/autolathe/ammo/pistol_ammobox = 0,
+		/datum/design/autolathe/ammo/pistol_ammobox_rubber,
+		/datum/design/autolathe/ammo/pistol_ammobox/large,
+		/datum/design/autolathe/ammo/magnum_ammobox = 0,
+		/datum/design/autolathe/ammo/magnum_ammobox_rubber,
+		/datum/design/autolathe/ammo/magnum_ammobox_pepperball,
+		/datum/design/autolathe/ammo/magnum_ammobox_practice = 0,
+		/datum/design/autolathe/ammo/magnum_ammobox/large,
+		/datum/design/autolathe/ammo/kurtz_ammobox_rubber = 0,
+		/datum/design/autolathe/ammo/kurtz_ammobox = 0,
+		/datum/design/autolathe/ammo/kurtz_ammobox_practice = 0,
+		/datum/design/autolathe/ammo/lrifle_ammobox = 1,
+		/datum/design/autolathe/ammo/lrifle_ammobox_lethal = 1,
+		/datum/design/autolathe/ammo/lrifle_ammobox_rubber = 0,
+		/datum/design/autolathe/ammo/lrifle_ammobox_small_practice = 0,
+		/datum/design/autolathe/ammo/rifle_ammobox = 1,
+		/datum/design/autolathe/ammo/rifle_ammobox_lethal = 1,
+		/datum/design/autolathe/ammo/rifle_pk_empty = 0,
+		/datum/design/autolathe/ammo/rifle_pk,
+		/datum/design/autolathe/ammo/lrifle_belt,
+		/datum/design/autolathe/ammo/lrifle_belt_empty = 0,
+		/datum/design/autolathe/ammo/hrifle_ammobox_linked,
+		/datum/design/autolathe/ammo/hrifle_ammobox_linked_rubber,
+		/datum/design/autolathe/ammo/hrifle_ammobox_linked_empty = 0,
+		/datum/design/autolathe/ammo/grenade,
+		/datum/design/autolathe/ammo/grenade/flash,
+		/datum/design/autolathe/ammo/flare_shell = 0,
+		/datum/design/autolathe/ammo/flare_shell_g = 0,
+		/datum/design/autolathe/ammo/flare_shell_b = 0,
+		/datum/design/autolathe/container/ammocan_ih,
+		)
+
+// .40 Magnum
+
+/obj/item/computer_hardware/hard_drive/portable/design/guns/liberty
+	disk_name = "NM - .40 Liberty"
+	icon_state = "blackshield"
+
+	license = 8
+	designs = list(
+		/datum/design/autolathe/gun/liberty = 3,
+		/datum/design/autolathe/ammo/magnum_practice = 0,
+		/datum/design/autolathe/ammo/magnum_rubber,
+		/datum/design/autolathe/ammo/magnum,
+		/datum/design/autolathe/ammo/magnum_lethal = 2,
+		)
+
+/obj/item/computer_hardware/hard_drive/portable/design/guns/freedom
+	disk_name = "NM - .40 Freedom SMG"
+	icon_state = "blackshield"
+
+	license = 12
+	designs = list(
+		/datum/design/autolathe/gun/thompson = 4,
+		/datum/design/autolathe/ammo/smg_magnum_40 = 2,
+		/datum/design/autolathe/ammo/smg_magnum_40_rubber = 1,
+		/datum/design/autolathe/ammo/smg_magnum_40_lethal = 3,
+		/datum/design/autolathe/ammo/smg_magnum_40_practice = 0
+		)
+
+// .50 PISTOLS
+
+/obj/item/computer_hardware/hard_drive/portable/design/guns/amnesty
+	disk_name = "NM - .50 Amnesty Handgun"
+	icon_state = "blackshield"
+
+	license = 8
+	designs = list(
+		/datum/design/autolathe/gun/amnesty = 3,
+		/datum/design/autolathe/ammo/kurtz_practice = 0,
+		/datum/design/autolathe/ammo/kurtz_rubber,
+		/datum/design/autolathe/ammo/kurtz,
+		/datum/design/autolathe/ammo/kurtz_lethal = 2,
+		)
+
+// SHOTGUNS
+
+/obj/item/computer_hardware/hard_drive/portable/design/guns/operator
+	disk_name = "NM - 20mm Operator Combat Shotgun"
+	icon_state = "blackshield"
+
+	license = 8
+	designs = list(
+		/datum/design/autolathe/gun/operator = 3,
+		/datum/design/autolathe/ammo/shotgun_beanbag,
+		/datum/design/autolathe/ammo/shotgun_blanks = 0,
+		/datum/design/autolathe/ammo/shotgun_illumination,
+		)
+
+// .257 carbines
+
+/obj/item/computer_hardware/hard_drive/portable/design/guns/bastard
+	disk_name = "NM - .257 \"Bastard\" Compact Machine Gun"
+	icon_state = "blackshield"
+
+	license = 8
+	designs = list(
+		/datum/design/autolathe/gun/bastard = 3,
+		/datum/design/autolathe/ammo/lrifle_belt,
+		/datum/design/autolathe/ammo/lrifle_belt_empty = 0,
+	)
+
+/obj/item/computer_hardware/hard_drive/portable/design/guns/mamba
+	disk_name = "NM - .257 Mamba Carbine"
+	icon_state = "blackshield"
+
+	license = 16
+	designs = list(
+		/datum/design/autolathe/gun/mamba = 6,
+		/datum/design/autolathe/ammo/lrifle_short_practice = 0,
+		/datum/design/autolathe/ammo/lrifle_short_rubber,
+		/datum/design/autolathe/ammo/lrifle_short,
+		/datum/design/autolathe/ammo/lrifle_short_lethal = 2,
+		/datum/design/autolathe/ammo/lrifle_practice = 1,
+		/datum/design/autolathe/ammo/lrifle_rubber = 2,
+		/datum/design/autolathe/ammo/lrifle = 2,
+		/datum/design/autolathe/ammo/lrifle_lethal = 4,
+	)
+
+/obj/item/computer_hardware/hard_drive/portable/design/guns/viper
+	disk_name = "NM - .257 Viper DMR"
+	icon_state = "blackshield"
+
+	license = 16
+	designs = list(
+		/datum/design/autolathe/gun/viper = 6,
+		/datum/design/autolathe/ammo/lrifle_short_practice = 0,
+		/datum/design/autolathe/ammo/lrifle_short_rubber,
+		/datum/design/autolathe/ammo/lrifle_short,
+		/datum/design/autolathe/ammo/lrifle_short_lethal = 2,
+		/datum/design/autolathe/ammo/lrifle_practice = 1,
+		/datum/design/autolathe/ammo/lrifle_rubber = 2,
+		/datum/design/autolathe/ammo/lrifle = 2,
+		/datum/design/autolathe/ammo/lrifle_lethal = 4,
+	)
+
+// 7.5 Rifles
+
+/obj/item/computer_hardware/hard_drive/portable/design/guns/copperhead
+	disk_name = "NM - 7.5 Copperhead Rifle"
+	icon_state = "blackshield"
+
+	license = 16
+	designs = list(
+		/datum/design/autolathe/gun/copperhead = 6,
+		/datum/design/autolathe/ammo/rifle_short_practice = 0,
+		/datum/design/autolathe/ammo/rifle_short_rubber,
+		/datum/design/autolathe/ammo/rifle_short,
+		/datum/design/autolathe/ammo/rifle_short_lethal = 2,
+		/datum/design/autolathe/ammo/rifle_practice = 1,
+		/datum/design/autolathe/ammo/rifle_rubber = 2,
+		/datum/design/autolathe/ammo/rifle = 2,
+		/datum/design/autolathe/ammo/rifle_lethal = 4,
+	)
+
+/obj/item/computer_hardware/hard_drive/portable/design/guns/python
+	disk_name = "NM - 7.5 Python Heavy Rifle"
+	icon_state = "blackshield"
+
+	license = 16
+	designs = list(
+		/datum/design/autolathe/gun/python = 6,
+		/datum/design/autolathe/ammo/rifle_short_practice = 0,
+		/datum/design/autolathe/ammo/rifle_short_rubber,
+		/datum/design/autolathe/ammo/rifle_short,
+		/datum/design/autolathe/ammo/rifle_short_lethal = 2,
+		/datum/design/autolathe/ammo/rifle_practice = 1,
+		/datum/design/autolathe/ammo/rifle_rubber = 2,
+		/datum/design/autolathe/ammo/rifle = 2,
+		/datum/design/autolathe/ammo/rifle_lethal = 4,
+	)
+
+//10mm Guns
+
+/obj/item/computer_hardware/hard_drive/portable/design/guns/specop
+	disk_name = "NM - 10mm Caseless /'Spec-Op/' SMG"
+	icon_state = "blackshield"
+
+	license = 10 //2 guns 2 mags and 1 box
+	designs = list(
+		/datum/design/autolathe/gun/specop = 3,
+		/datum/design/autolathe/ammo/mag_10x24,
+		/datum/design/autolathe/ammo/box_10x24_small = 1,
+	)
+
+// Laser
+
+/obj/item/computer_hardware/hard_drive/portable/design/guns/sunrise
+	disk_name = "NM - \"Sunrise\" Laser SMG"
+	icon_state = "blackshield"
+
+	license = 8
+	designs = list(
+		/datum/design/autolathe/gun/sunrise = 3,
+		/datum/design/autolathe/cell/medium/high,
+	)

--- a/code/game/objects/random/lathe_disks/guns.dm
+++ b/code/game/objects/random/lathe_disks/guns.dm
@@ -12,6 +12,7 @@
 				/obj/random/lathe_disk/grande = 1,
 				/obj/random/lathe_disk/pistol = 6,
 				/obj/random/lathe_disk/rifle = 4,
+				/obj/random/lathe_disk/rifle_heavy = 2,
 				/obj/random/lathe_disk/smg = 3,
 				/obj/random/lathe_disk/lmg = 2,
 				/obj/random/lathe_disk/bolt_gun = 5))
@@ -37,6 +38,7 @@
 				/obj/random/lathe_disk/grande = 4,
 				/obj/random/lathe_disk/pistol = 1,
 				/obj/random/lathe_disk/rifle = 4,
+				/obj/random/lathe_disk/rifle_heavy = 2,
 				/obj/random/lathe_disk/smg = 1,
 				/obj/random/lathe_disk/lmg = 4,
 				/obj/random/lathe_disk/bolt_gun = 1))
@@ -60,8 +62,6 @@
 /obj/random/lathe_disk/bolt_gun/item_to_spawn()
 	return pickweight(list(
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/heavysniper = 1,
-				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/strelki = 3,
-				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/watchtower = 2,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/armstrong = 6,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/custer = 4,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/roe = 4,
@@ -100,14 +100,17 @@
 
 /obj/random/lathe_disk/smg/item_to_spawn()
 	return pickweight(list(
-				/obj/item/computer_hardware/hard_drive/portable/design/guns/wirbelwind = 5,
-				/obj/item/computer_hardware/hard_drive/portable/design/guns/texan = 4,
-				/obj/item/computer_hardware/hard_drive/portable/design/guns/mac = 4,
-				/obj/item/computer_hardware/hard_drive/portable/design/guns/bastard = 2,
-				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/greasegun = 3,
-				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/buckler = 3,
-				/obj/item/computer_hardware/hard_drive/portable/design/guns/thompson = 2,
-				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/triage = 1,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/wirbelwind = 7,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/texan = 6,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/mac = 6,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/bastard = 3,
+				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/greasegun = 5,
+				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/buckler = 5,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/thompson = 4,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/freedom = 2,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/vector = 3,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/specop = 2,
+				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/triage = 2,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/ex_drozd = 1))
 
 /obj/random/lathe_disk/rifle
@@ -126,8 +129,30 @@
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/pulse_rifle = 1,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/sa_kalashnikov = 2,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/tac_kalashnikov = 1,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/python = 1,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/copperhead = 2,
 				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/luger = 3,
-				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/duty = 1,))
+				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/duty = 1,
+				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/strelki = 3,
+				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/watchtower = 2,))
+
+/obj/random/lathe_disk/rifle_heavy
+	name = "random heavy rifle lathe disk"
+	icon_state = "tech-green"
+
+/obj/random/lathe_disk/rifle_heavy/low_chance
+	name = "low chance heavy rifle lathe disk"
+	icon_state = "tech-green-low"
+	spawn_nothing_percentage = 80
+
+/obj/random/lathe_disk/rifle_heavy/item_to_spawn()
+	return pickweight(list(
+				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/blackguard = 1,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/hustler = 4,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/boar = 3,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/sts40 = 6))
+
+
 
 /obj/random/lathe_disk/pistol
 	name = "random pistol lathe disk"
@@ -147,6 +172,7 @@
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/lamia = 2,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/basilisk = 1,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/cheap_guns = 6,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/liberty = 2,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/glock = 2))
 
 /obj/random/lathe_disk/grande

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -1090,6 +1090,7 @@
 #include "code\game\objects\items\weapons\autolathe_disk\guild_disks.dm"
 #include "code\game\objects\items\weapons\autolathe_disk\guns_ammo_sec_disks.dm"
 #include "code\game\objects\items\weapons\autolathe_disk\lonestar_disks.dm"
+#include "code\game\objects\items\weapons\autolathe_disk\marshal.dm"
 #include "code\game\objects\items\weapons\autolathe_disk\soteria_disks.dm"
 #include "code\game\objects\items\weapons\circuitboards\broken.dm"
 #include "code\game\objects\items\weapons\circuitboards\circuitboard.dm"


### PR DESCRIPTION
Adds the missing disks for loot rotation of the 408 omnis and blackguard
Adds in every new marshal gun to a disk as well as in loot rotation
Fixes some names of disks
Fixes some disk location