### PR TITLE
simple targeting tweaks

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/ai.dm
@@ -25,6 +25,8 @@
 	var/turf/our_turf = get_turf(src)
 	if (our_turf) //If we're not in anything, continue
 		for(var/mob/living/target_mob in hearers(src, viewRange))
+			if(target_mob.target_dummy) //Target me over anyone else
+				return target_mob
 			if (isValidAttackTarget(target_mob))
 				filteredTargets += target_mob
 
@@ -78,8 +80,6 @@
 
 	if (isliving(O))
 		var/mob/living/L = O
-		if(L.target_dummy) //Target me over anyone else
-			return 1
 		if((L.stat != CONSCIOUS) || (L.health <= (ishuman(L) ? HEALTH_THRESHOLD_CRIT : 0)) || (!attack_same && (L.faction == src.faction)) || (L in friends))
 			return
 		if(L.friendly_to_colony && src.friendly_to_colony) //If are target and areselfs have the friendly to colony tag, used for chtmant protection

--- a/code/modules/mob/living/carbon/superior_animal/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/ai.dm
@@ -25,9 +25,9 @@
 	var/turf/our_turf = get_turf(src)
 	if (our_turf) //If we're not in anything, continue
 		for(var/mob/living/target_mob in hearers(src, viewRange))
-			if(target_mob.target_dummy) //Target me over anyone else
-				return target_mob
 			if (isValidAttackTarget(target_mob))
+				if(target_mob.target_dummy) //Target me over anyone else
+					return target_mob
 				filteredTargets += target_mob
 
 	for (var/obj/mecha/M in GLOB.mechas_list)

--- a/code/modules/mob/living/carbon/superior_animal/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/ai.dm
@@ -78,6 +78,8 @@
 
 	if (isliving(O))
 		var/mob/living/L = O
+		if(L.target_dummy) //Target me over anyone else
+			return 1
 		if((L.stat != CONSCIOUS) || (L.health <= (ishuman(L) ? HEALTH_THRESHOLD_CRIT : 0)) || (!attack_same && (L.faction == src.faction)) || (L in friends))
 			return
 		if(L.friendly_to_colony && src.friendly_to_colony) //If are target and areselfs have the friendly to colony tag, used for chtmant protection

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
@@ -228,7 +228,7 @@
 	health = 400
 	move_to_delay = 1
 	turns_per_move = 7
-	viewRange = 12
+	viewRange = 9
 	melee_damage_lower = 20
 	melee_damage_upper = 30
 	poison_per_bite = 4

--- a/code/modules/mob/living/carbon/superior_animal/lodge/lodge.dm
+++ b/code/modules/mob/living/carbon/superior_animal/lodge/lodge.dm
@@ -14,3 +14,4 @@
 	follow_distance = 3
 	meat_type = /obj/item/reagent_containers/food/snacks/meat
 	attack_sound = 'sound/xenomorph/alien_bite1.ogg'
+	target_dummy = TRUE

--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/church/types/rook.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/church/types/rook.dm
@@ -18,3 +18,4 @@
 	drop1 = /obj/item/stack/material/gold/random
 	drop2 = /obj/item/book/ritual/cruciform
 	armor = list(melee = 75, bullet = 25, energy = 20, bomb = 30, bio = 100, rad = 100, agony = 100)
+	target_dummy = TRUE

--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/greyson/types/friendly.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/greyson/types/friendly.dm
@@ -162,3 +162,4 @@ I was too lazy to put the friendly roombas with the handmade drones, so now they
 	melee_damage_upper = 25
 	colony_friend = TRUE
 	friendly_to_colony = TRUE
+	target_dummy = TRUE

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
@@ -15,7 +15,7 @@ var/datum/xenomorph/xenomorph_ai
 	cant_be_pulled = TRUE
 
 	mob_size = MOB_LARGE
-	viewRange = 12
+	viewRange = 8
 	armor = list(melee = 20, bullet = 10, energy = 5, bomb = 30, bio = 100, rad = 100)
 
 	maxHealth = 30

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -96,6 +96,8 @@
 
 	var/list/drop_items = list() //Held items a creature can drop when they die. Accessed through drop_death_loot()
 
+	var/target_dummy = FALSE // Simple yes no if we are when spotted targeted over **everything** esle, used for simple and super mobs.
+
 	//Redays to make mobs faster or slower on attacking
 	var/delay_for_range = 0 SECONDS
 	var/delay_for_rapid_range = 0 SECONDS

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -56,6 +56,8 @@ var/list/mydirs = list(NORTH, SOUTH, EAST, WEST, SOUTHWEST, NORTHWEST, NORTHEAST
 
 		if(isliving(A))
 			var/mob/living/L = A
+			if(L.target_dummy)
+				return L
 			if(L.faction == src.faction && !attack_same)
 				continue
 			if(L.colony_friend && src.colony_friend)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -56,14 +56,16 @@ var/list/mydirs = list(NORTH, SOUTH, EAST, WEST, SOUTHWEST, NORTHWEST, NORTHEAST
 
 		if(isliving(A))
 			var/mob/living/L = A
-			if(L.target_dummy)
-				return L
 			if(L.faction == src.faction && !attack_same)
 				continue
 			if(L.colony_friend && src.colony_friend)
 				continue
 			else if(L in friends)
 				continue
+			else if(L.target_dummy) //So we target these over normal lists
+				if(!SA_attackable(L))
+					stance = HOSTILE_STANCE_ATTACK
+					T = L
 			else
 				if(!SA_attackable(L))
 					stance = HOSTILE_STANCE_ATTACK


### PR DESCRIPTION
Makes scavs junkbots, churchs golem rooks, and all hunting lodge mobs have increased pritory targeting over anything else when a mob agros
Reduces xenos and a hunter spiders view range to not be as insainly large of an area