### PR TITLE
Adds a new admin tool, var copies, that allow admins to copypaste var editted atoms.

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -1,3 +1,12 @@
+/// Vars that are strictly forbidden from being used when making a var copy.
+GLOBAL_LIST_INIT(banned_vars, list(
+	"client",
+	"ckey",
+	"key",
+	"lastKnownIP",
+	"loc"
+))
+
 //A set of constants used to determine which type of mute an admin wishes to apply:
 //Please read and understand the muting/automuting stuff before changing these. MUTE_IC_AUTO etc = (MUTE_IC << 1)
 //Therefore there needs to be a gap between the flags for the automute flags

--- a/code/__DEFINES/topic.dm
+++ b/code/__DEFINES/topic.dm
@@ -1,3 +1,10 @@
+/**
+ * Associative list of var copies, key being their name, value being the list of vars they hold.
+ *
+ * Used with the "var saving" system, where admins can use VV to save a "var copy" of an atom, and later use the Spawn Copy verb to
+ * first spawn the type of the original atom, and then apply any vars the admin chose to add to the var copy. This is a method of
+ * copypasting varedited atoms with ease.
+**/
 GLOBAL_LIST_EMPTY(var_copies)
 
 #define TOPIC_NOACTION 0

--- a/code/__DEFINES/topic.dm
+++ b/code/__DEFINES/topic.dm
@@ -1,3 +1,5 @@
+GLOBAL_LIST_EMPTY(var_copies)
+
 #define TOPIC_NOACTION 0
 #define TOPIC_HANDLED 1
 #define TOPIC_REFRESH 2

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -975,7 +975,38 @@ ADMIN_VERB_ADD(/datum/admins/proc/spawn_atom, R_DEBUG, FALSE)
 
 	log_and_message_admins("spawned [chosen] at ([usr.x],[usr.y],[usr.z])")
 
+ADMIN_VERB_ADD(/datum/admins/proc/remove_var_copy, R_ADMIN|R_DEBUG, TRUE)
+/datum/admins/proc/remove_var_copy()
+	set name = "Remove Copy"
+	set category = "Fun"
 
+	if(!check_rights(R_ADMIN || R_DEBUG))
+		return
+
+	var/target_copy = stripped_input(usr, "What is the name of the slot you want to delete?")
+	if (target_copy in GLOB.var_copies)
+		GLOB.var_copies -= target_copy
+		to_chat(usr, "<span class='warning'>[target_copy] deleted.</span>")
+	else
+		to_chat(usr, "<span class='warning'>[target_copy] does not exist. Did you type it correctly?</span>")
+
+ADMIN_VERB_ADD(/datum/admins/proc/spawn_var_copy, R_ADMIN|R_DEBUG, TRUE)
+/datum/admins/proc/spawn_var_copy()
+	set name = "Spawn Copy"
+	set category = "Fun"
+
+	if(!check_rights(R_ADMIN || R_DEBUG))
+		return
+
+	var/target_copy = stripped_input(usr, "What is the name of the copy you want to spawn?")
+	if (target_copy in GLOB.var_copies)
+		var/atom/spawn_target = GLOB.var_copies[target_copy[type]]
+
+		var/atom/newItem = new spawn_target(usr.loc)
+
+		newItem.vars = GLOB.var_copies[target_copy]
+	else
+		to_chat(usr, "<span class='warning'>[target_copy] does not exist. Did you type it correctly?</span>")
 // -Removed due to rare practical use. Moved to debug verbs ~Errorage,
 //ADMIN_VERB_ADD(/datum/admins/proc/show_traitor_panel, R_ADMIN, TRUE)
 //interface which shows a mob's mind

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -975,38 +975,79 @@ ADMIN_VERB_ADD(/datum/admins/proc/spawn_atom, R_DEBUG, FALSE)
 
 	log_and_message_admins("spawned [chosen] at ([usr.x],[usr.y],[usr.z])")
 
-ADMIN_VERB_ADD(/datum/admins/proc/remove_var_copy, R_ADMIN|R_DEBUG, TRUE)
-/datum/admins/proc/remove_var_copy()
+ADMIN_VERB_ADD(/datum/admins/proc/remove_var_copy, R_ADMIN|R_DEBUG|R_FUN, TRUE)
+/**
+ * Removes a var copy from the global list that contains them, effectively the same as deletion.
+ * Automatically executes if a text argument is given, assuming it is the name of the copy to delete.
+ *
+ * Args:
+ * target_copy: Text. The proc will assume this is the key, or the name, of the var copy, and will search GLOB.var_copies for it's value.
+**/
+/datum/admins/proc/remove_var_copy(var/target_copy as text)
 	set name = "Remove Copy"
+	set desc = "Remove a vareditted var template"
 	set category = "Fun"
 
-	if(!check_rights(R_ADMIN || R_DEBUG))
+	if(!check_rights(R_ADMIN | R_DEBUG | R_FUN))
 		return
 
-	var/target_copy = stripped_input(usr, "What is the name of the slot you want to delete?")
+	if (!(length(target_copy) > 0)) //did they send anything?
+		target_copy = stripped_input(usr, "What is the name of the slot you want to delete?")
 	if (target_copy in GLOB.var_copies)
 		GLOB.var_copies -= target_copy
 		to_chat(usr, "<span class='warning'>[target_copy] deleted.</span>")
+		log_and_message_admins("<span class='notice'> deleted a var copy, named [target_copy].</span>")
 	else
 		to_chat(usr, "<span class='warning'>[target_copy] does not exist. Did you type it correctly?</span>")
 
-ADMIN_VERB_ADD(/datum/admins/proc/spawn_var_copy, R_ADMIN|R_DEBUG, TRUE)
-/datum/admins/proc/spawn_var_copy()
+ADMIN_VERB_ADD(/datum/admins/proc/spawn_var_copy, R_ADMIN|R_DEBUG|R_FUN, TRUE)
+/**
+ * Spawns a atom on the location of the user, using the type variable within GLOB.var_copies[target_copy], using the target_copy argument.
+ * Then searches said list for any variables. If any variables are present, they will be applied to the newly created atom.
+ *
+ * Automatically executes if a text argument is given, assuming it is the name of the copy to delete.
+ *
+ * Args:
+ * target_copy: Text. The proc will assume this is the key, or the name, of the var copy, and will search GLOB.var_copies for it's value.
+**/
+/datum/admins/proc/spawn_var_copy(var/target_copy as text)
 	set name = "Spawn Copy"
+	set desc = "Spawn a atom with a vareditted var template"
 	set category = "Fun"
 
-	if(!check_rights(R_ADMIN || R_DEBUG))
+	if(!check_rights(R_ADMIN | R_DEBUG | R_FUN))
 		return
 
-	var/target_copy = stripped_input(usr, "What is the name of the copy you want to spawn?")
+	if (!(length(target_copy) > 0)) //did they send anything?
+		target_copy = stripped_input(usr, "What is the name of the copy you want to spawn?")
 	if (target_copy in GLOB.var_copies)
-		var/atom/spawn_target = GLOB.var_copies[target_copy[type]]
+		var/list/spawn_variables = GLOB.var_copies[target_copy]
+		var/atom/spawn_target = spawn_variables["type"]
 
 		var/atom/newItem = new spawn_target(usr.loc)
 
-		newItem.vars = GLOB.var_copies[target_copy]
+		for(var/variable in newItem.vars)
+			if (variable == "type") //type is read-only, we will runtime if we don't have this check
+				continue
+			if (variable in spawn_variables) // if a var exists in this, an admin wanted it to be carried over, so let's apply it
+				newItem.vars[variable] = spawn_variables[variable]
 	else
 		to_chat(usr, "<span class='warning'>[target_copy] does not exist. Did you type it correctly?</span>")
+
+ADMIN_VERB_ADD(/datum/admins/proc/list_var_copies, R_ADMIN|R_DEBUG|R_FUN, TRUE)
+/// Will list the keys/names of all var copies currently saved into the GLOB.var_copies.
+/datum/admins/proc/list_var_copies()
+	set name = "List Copy Names"
+	set desc = "List the names of all currently saved var copies"
+	set category = "Fun"
+
+	if(!check_rights(R_ADMIN | R_DEBUG | R_FUN))
+		return
+
+	to_chat(usr, "<b>Names of all var copies currently saved:</b>")
+	for (var/key_to_print in GLOB.var_copies)
+		to_chat(usr, key_to_print) //prints the keys, not the values
+
 // -Removed due to rare practical use. Moved to debug verbs ~Errorage,
 //ADMIN_VERB_ADD(/datum/admins/proc/show_traitor_panel, R_ADMIN, TRUE)
 //interface which shows a mob's mind

--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -84,6 +84,8 @@
 	. = ..()
 	if(reagents)
 		. += "<option value='?_src_=vars;addreagent=\ref[src]'>Add reagent</option>"
+	. += "<option value='?_src_=vars;saveCopy=\ref[src]'>Save as Copy</option>"
+
 
 
 /atom/movable/get_view_variables_options()

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -688,6 +688,19 @@
 
 		usr.forceMove(get_turf(A))
 
+	else if (href_list["saveCopy"])
+		if(!check_rights(R_DEBUG|R_ADMIN))
+			return
+
+		var/atom/copy_target = locate(href_list["saveCopy"])
+
+		var/name = stripped_input(usr, "What will the name of this save slot be?")
+		if (name in GLOB.var_copies)
+			to_chat(usr, "<span class='warning'>A save with that name already exists! Try the remove save verb if you really want the name.</span>")
+			return
+		GLOB.var_copies[name] = copy_target.vars //IDEA: make it so you have to type out the vars you want to add instead of adding all
+		to_chat(usr, "<span class='warning'>Copy creation successful.</span>")
+
 	if(href_list["datumrefresh"])
 		var/datum/DAT = locate(href_list["datumrefresh"])
 		if(istype(DAT, /datum) || istype(DAT, /client))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Everything below is active to R_FUN, R_DEBUG, and R_ADMIN.

VV will now have a new drop-down feature on /atom: Save as copy. This will prompt the admin to first name the var copy, and then type, case-senstive, the name/key of every var they wish to save. Typing stop will end the loop and prompt the code to save the name as a key and the vars given into a associative global list.

This global list can be accessed by 3 verbs: Spawn Copy, which spawns a copy of whatever item you made a copy out of and then applies the vars you added to the list to it. Remove Copy, which remove a copy from the global list (please do this to save memory, if youre not going to use a copy). List Copy Names, which generates a list of the name/key of every copy that is currently saved.

To prevent exploits, a global blacklist is available to prevent certain vars from being saved.

Tested, it functions, with no runtimes. I'm really proud of this PR tbh.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
admin: New admin tool: Var copies. See github for more information.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
