### PR TITLE
Makes it so mobs actually use comfy_range for their targetting.

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -84,6 +84,8 @@
 	var/speak_chance = 2 //percentage chance of speaking a line from 'emote_see'
 
 	var/comfy_range = 6 //How far we like to be form are targets when we fire!
+	/// comfy_range - comfy_distance = how far away mobs will try to be from their targets. Not how far they fire from.
+	var/comfy_distance = 1
 
 	var/grabbed_by_friend = FALSE //is this superior_animal being wrangled?
 
@@ -475,12 +477,12 @@
 			return
 		if (!check_if_alive())
 			return
-		if(get_dist(src, targetted_mob) <= 6)
+		if(get_dist(src, targetted_mob) <= comfy_range)
 			prepareAttackPrecursor(targetted_mob, .proc/OpenFire, RANGED_TYPE)
 		else
 			if(weakened) return
 			set_glide_size(DELAY2GLIDESIZE(move_to_delay))
-			walk_to(src, targetted_mob, 4, move_to_delay)
+			walk_to(src, targetted_mob, (comfy_range - comfy_distance), move_to_delay)
 			prepareAttackPrecursor(targetted_mob, .proc/OpenFire, RANGED_TYPE)
 
 /// If critcheck = FALSE, will check if health is more than 0. Otherwise, if is a human, will check if theyre in hardcrit.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mobs will now actually respect their ideal range for firing. Also adds a var that controls how close they move vs how far they fire.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Makes it so mobs respect comfy_range
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
