### PR TITLE
Adds a var to shield generators that controls if it will report it's damage or not.

### DIFF
--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -651,14 +651,15 @@
 	if (report_scheduled)
 		return
 
-	report_scheduled = TRUE
-	addtimer(CALLBACK(src, .proc/report_damage), report_delay)
+	if (reportDamage)
+		report_scheduled = TRUE
+
+		addtimer(CALLBACK(src, .proc/report_damage), report_delay)
+
+
 
 //This proc sends reports for shield damage
 /obj/machinery/power/shield_generator/proc/report_damage()
-
-	if (!reportDamage)
-		return
 
 	var/do_report = FALSE //We only report if this is true
 	report_scheduled = FALSE //Reset this regardless of what we do here

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -45,6 +45,9 @@
 	var/list/default_modes = list()
 	var/generatingShield = FALSE //true when shield tiles are in process of being generated
 
+	/// If true, will allow report_damage() to be called.
+	var/reportDamage = TRUE
+
 	// The shield mode flags which should be enabled on this generator by default
 
 	var/list/allowed_modes = list(MODEFLAG_HYPERKINETIC,
@@ -649,11 +652,14 @@
 		return
 
 	report_scheduled = TRUE
-	spawn(report_delay)
-		report_damage()
+	addtimer(CALLBACK(src, .proc/report_damage), report_delay)
 
 //This proc sends reports for shield damage
 /obj/machinery/power/shield_generator/proc/report_damage()
+
+	if (!reportDamage)
+		return
+
 	var/do_report = FALSE //We only report if this is true
 	report_scheduled = FALSE //Reset this regardless of what we do here
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I want to use one of these in an event at some point abut I can't if they'll constantly scream about their damage status.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
tweak: Added a var to shield gens that allows them to not report it's damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
