### PR TITLE
More Mech Weapons: The Balance Edition

### DIFF
--- a/code/game/mecha/equipment/weapons/melee.dm
+++ b/code/game/mecha/equipment/weapons/melee.dm
@@ -18,8 +18,8 @@
 	structure_damage_factor = 2
 	hitsound = 'sound/weapons/heavysmash.ogg'
 	var/icon/melee_overlay //Currently dosnt do anything but is here for sake of constancey
-	force = 30
-	matter = list(MATERIAL_STEEL = 5) //Its only 30 damage compared to the 15 steel 60 damage sword
+	force = 45
+	matter = list(MATERIAL_STEEL = 15) //Its only 30 damage compared to the 15 steel 60 damage sword
 
 /obj/item/mecha_parts/mecha_equipment/melee_weapon/sword
 	name = "mech sword"
@@ -50,7 +50,7 @@
 	icon_state = "mecha_cutlass"
 	sharp = TRUE
 	edge = TRUE
-	tool_qualities = list(QUALITY_CUTTING = 30,  QUALITY_WIRE_CUTTING = 20, QUALITY_WELDING = 1, QUALITY_CAUTERIZING = 1) //Same as E-cutlasses
+	tool_qualities = list(QUALITY_CUTTING = 30,  QUALITY_WIRE_CUTTING = 20) //Same as E-cutlasses
 	origin_tech = list(TECH_MAGNET = 5, TECH_POWER = 6, TECH_COMBAT = 3) //Same as E-cutlasses
 	matter = list(MATERIAL_STEEL = 15, MATERIAL_SILVER = 1, MATERIAL_GOLD = 1) //WAY LESS then normal E-cutlasses do to the only being 5 more damage
 	armor_penetration = ARMOR_PEN_DEEP

--- a/code/game/mecha/equipment/weapons/ranged/bullet_weapons.dm
+++ b/code/game/mecha/equipment/weapons/ranged/bullet_weapons.dm
@@ -188,8 +188,8 @@
 	desc = "Gun ammunition stored in a shiny new box. You can see caliber information on the label."
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "boxhrifle-practice"
-	ammo_amount_left = 10
-	ammo_max_amout = 10
+	ammo_amount_left = 25
+	ammo_max_amout = 25
 	amount_per_click = 3
 	ammo_type = ".460"
 	price_tag = 30
@@ -201,10 +201,10 @@
 	matter = list(MATERIAL_STEEL = 25, MATERIAL_PLASTEEL = 15)
 	projectile = /obj/item/projectile/bullet/auto_460
 	fire_sound = 'sound/weapons/guns/fire/chaingun_fire.ogg'
-	projectiles = 10
-	max_ammo = 10
-	projectiles_per_shot = 1
-	deviation = 1 
+	projectiles = 25
+	max_ammo = 25
+	projectiles_per_shot = 2
+	deviation = 2 
 	fire_cooldown = 2
 	ammo_type = ".460"
 
@@ -218,11 +218,11 @@
 	equip_cooldown = 20
 	projectile = /obj/item/projectile/bullet/auto_460/scrap
 	fire_sound = 'sound/weapons/guns/fire/payload_fire.ogg'
-	projectiles = 20
-	max_ammo = 20
-	projectiles_per_shot = 2
+	projectiles = 25
+	max_ammo = 25
+	projectiles_per_shot = 3
 	deviation = 3
-	fire_cooldown = 3
+	fire_cooldown = 3.5
 	required_type = list(/obj/mecha/combat, /obj/mecha/working)
 
 /obj/item/mecha_parts/mecha_equipment/ranged_weapon/ballistic/cannon/scrap/loaded


### PR DESCRIPTION

## About The Pull Request
<summery>

This PR firstly adjusts the Autocannon and its jury rigged version taking into account of player given feedback, however would require someone to review the balance. Also removed the welding ability of the mech energy cutlass as it was preventing people from putting it on the mech...and pretty sure could be used to repair other mechs with your own mech due to the welding ability. Considering the limb plating that allows mechs to punch shit is considered a combat weapon and thus illegal without permit on a mech, I have increased its damage and material cost. 

<hr>
</summery>

