### PR TITLE
GOATMed: Toxic Rot

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -222,6 +222,15 @@
 			amount *= 0.5
 		..(amount)
 
+								//// TOXIN ORGAN ROT ////
+		if (ishuman(src))
+			if ((src.getToxLoss() > 75) && (amount>0)) // If toxloss is above a certain threshhold, more toxin damage will cause internal organ damage. For reference: 50 is DANGEROUS TOXIN LEVELS DETECTED
+				var/obj/item/organ/internal/targeted_organ
+				var/list/listed_organs  = list("brain",OP_EYES,"heart","lungs","stomach","liver","kidneys","appendix","psionic organ")
+				targeted_organ = src.random_organ_by_process(pick(listed_organs))
+				if (targeted_organ.nature !=MODIFICATION_SILICON) // If randomly chosen organ is prothestic, no damage.
+					targeted_organ.damage += rand (5,10) // How much damage is dealt to each organ. Please adjust for balance
+
 /mob/living/carbon/human/setToxLoss(var/amount)
 	if(!(species.flags & NO_POISON) && !isSynthetic())
 		adjustToxLoss(amount-getToxLoss())

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -252,6 +252,16 @@ default behaviour is:
 		return FALSE	//godmode
 	toxloss = min(max(toxloss + amount, 0),(maxHealth*2))
 
+	//// TOXIN ORGAN ROT ////
+	var/mob/living/carbon/human/A = src
+	if (ishuman(A))
+		if ((toxloss > 75) && (amount>0)) // If toxloss is above a certain threshhold, more toxin damage will cause internal organ damage. For reference: 50 is DANGEROUS TOXIN LEVELS DETECTED
+			var/obj/item/organ/internal/targeted_organ
+			var/list/listed_organs  = list("brain",OP_EYES,"heart","lungs","stomach","liver","kidneys","appendix","psionic organ")
+			targeted_organ = A.random_organ_by_process(pick(listed_organs))
+			if (targeted_organ.nature !=MODIFICATION_SILICON) // If randomly chosen organ is prothestic, no damage.
+				targeted_organ.damage = rand (5,10) // How much damage is dealt to each organ. Please adjust for balance
+
 /mob/living/proc/setToxLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -252,15 +252,6 @@ default behaviour is:
 		return FALSE	//godmode
 	toxloss = min(max(toxloss + amount, 0),(maxHealth*2))
 
-	//// TOXIN ORGAN ROT ////
-	var/mob/living/carbon/human/A = src
-	if (ishuman(A))
-		if ((toxloss > 75) && (amount>0)) // If toxloss is above a certain threshhold, more toxin damage will cause internal organ damage. For reference: 50 is DANGEROUS TOXIN LEVELS DETECTED
-			var/obj/item/organ/internal/targeted_organ
-			var/list/listed_organs  = list("brain",OP_EYES,"heart","lungs","stomach","liver","kidneys","appendix","psionic organ")
-			targeted_organ = A.random_organ_by_process(pick(listed_organs))
-			if (targeted_organ.nature !=MODIFICATION_SILICON) // If randomly chosen organ is prothestic, no damage.
-				targeted_organ.damage = rand (5,10) // How much damage is dealt to each organ. Please adjust for balance
 
 /mob/living/proc/setToxLoss(var/amount)
 	if(status_flags & GODMODE)


### PR DESCRIPTION
GOATMed

If someone has more than 75 Toxin Damage total running through their system, their day is going to get worse because as their internal organs begin to be damaged from the sheer amount of poisons running through your system.

Note:
Vaguely Tested. It works, however I don't know anything in regard to live server balance. 

I very helpfully labeled the variables to modify for balance reasons.