### PR TITLE
spider tweaks and rng

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -185,7 +185,7 @@
 	burn_overlay = "eggs_burning"
 	var/amount_grown = 0
 	var/spiderlings_lower = 2
-	var/spiderlings_upper = 4
+	var/spiderlings_upper = 3
 
 /obj/effect/spider/eggcluster/minor
 	amount_grown = 20
@@ -234,13 +234,14 @@
 	var/obj/machinery/atmospherics/unary/vent_pump/entry_vent
 	var/travelling_in_vent = 0
 	var/spawn_type = /obj/random/mob/spiders
+	var/death_prob = 20 //20% to just die rather then grow up, sad
+	var/age_prob = 30   //30% per processing tick to gain an grow amount
 
 /obj/effect/spider/spiderling/New(var/location, var/atom/parent)
 	pixel_x = rand(6,-6)
 	pixel_y = rand(6,-6)
 	START_PROCESSING(SSobj, src)
-	//50% chance to grow up
-	if(prob(50))
+	if(prob(age_prob))
 		amount_grown = 1
 	get_light_and_color(parent)
 	..()
@@ -337,6 +338,9 @@
 					break
 
 		if(amount_grown >= 100)
+			if(prob(death_prob)) //Sometimes we just dont make it past childhood
+				die()
+				return
 			new spawn_type(src.loc, src) //This spawns the random mob spawner that the spiderling grows into
 			qdel(src)
 	else if(isorgan(loc))
@@ -394,3 +398,5 @@
 /obj/effect/spider/spiderling/near_grown
 	amount_grown = 80
 	spawn_type = /obj/random/mob/spiders/spider_ling //This one cant spawn carrons
+	age_prob = 50 //coin flip if we grow up or not
+	death_prob = 10 //10% to just die rather then grow up, sad

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/spider_armor.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/spider_armor.dm
@@ -22,7 +22,7 @@
   //So, at the very end, result = list(brute = 0, burn = 5)
 */
 /mob/living/carbon/superior_animal/giant_spider/pick_armor()
-	switch (pickweight(list("basic" = 5, "padded" = 1, "lustrous" = 1, "durable" = 3)))
+	switch (pickweight(list("basic" = 5, "padded" = 1, "lustrous" = 1, "durable" = 3, "young" = 2, "old" = 2)))
 
 		if("basic") //No changes, we are base level
 			return
@@ -38,6 +38,8 @@
 			agony = 15 //Rubbers deal way less to us!
 			)
 			gives_prefex = TRUE
+			maxHealth += 10
+			health += 10
 			prefex = "padded"
 			return
 
@@ -70,5 +72,41 @@
 			gives_prefex = TRUE
 			armor_penetration += 5
 			flash_resistances += 1
+			maxHealth += 20
+			health += 20
 			prefex = "durable"
+			return
+
+		if("young")
+			add_armor = list(
+			melee = -5,
+			bullet = -5,
+			energy = -5,
+			bomb = 0,
+			bio = 0,
+			rad = 0,
+			agony = -5 //Rubbers deal way less to us!
+			)
+			gives_prefex = TRUE
+			maxHealth -= 10 //0 hardship yet
+			health -= 10
+			move_to_delay -= 0.5 // faster
+			prefex = "young"
+			return
+
+		if("old")
+			add_armor = list(
+			melee = 5,
+			bullet = 5,
+			energy = 0,
+			bomb = 10,
+			bio = 0,
+			rad = 0,
+			agony = 20 //just cant feel it
+			)
+			gives_prefex = TRUE
+			maxHealth += 20 //life already seen them by
+			health += 20
+			move_to_delay += 1 // Very slow
+			prefex = "aged"
 			return

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
@@ -99,8 +99,8 @@
 	desc = "Furry and black, it makes you shudder to look at it. This one is an absolute unit of chitin, armor, and chittering horror."
 	icon_state = "tarantula"
 	icon_living = "tarantula"
-	maxHealth = 200
-	health = 200
+	maxHealth = 160
+	health = 160
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 	emote_see = list("chitters.","rubs its legs.","thumps its many legs on the ground.")
@@ -201,6 +201,8 @@
 	icon_living = "ogre"
 	poison_per_bite = 4
 	move_to_delay = 4
+	maxHealth = 180
+	health = 180
 
 /mob/living/carbon/superior_animal/giant_spider/tarantula/pit
 	name = "pit snapper spider"
@@ -218,6 +220,8 @@
 	icon_state = "burrowing"
 	icon_living = "burrowing"
 	poison_type = "stoxin"
+	maxHealth = 140
+	health = 140
 
 /mob/living/carbon/superior_animal/giant_spider/tarantula/emperor
 	name = "emperor spider"

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -74,8 +74,6 @@
 			new /obj/effect/spider/spiderling/near_grown(src.loc)
 			new /obj/effect/spider/spiderling/near_grown(src.loc)
 			new /obj/effect/spider/spiderling/near_grown(src.loc)
-			new /obj/effect/spider/spiderling/near_grown(src.loc)
-			new /obj/effect/spider/spiderling/near_grown(src.loc)
 			has_made_spiderlings = TRUE
 
 		density = 0


### PR DESCRIPTION
Spider eggs now lay 1 less spiderling
Carrier spiders now drop 3 spiders rather then 5
Spiders now have 2 more armor groups, young and aged
Aged gives more health and better armor at the cost of speed!
Young removes health and armor, but has increased speed
Spiderlings now have odds to rather then grow up, just die
Spiderlings now take longer to grow as well.