### PR TITLE
Makes mobs wander a little if they can't see you.

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -19,7 +19,7 @@
 	var/advancement = 1
 
 	/// Increments advancement_timer by itself whenever a ranged mob decides to advance.
-	var/advancement_increment = 3
+	var/advancement_increment = 5
 
 	/// Will be incremented advancement_increment ticks whenever a ranged mob decides to advance. If more than world.time, targetting walks will be ignored, to not end the advancement.
 	var/advancement_timer = 0

--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -18,8 +18,8 @@
 	/// How many tiles we will advance forward from our current position if we can't hit our current target.
 	var/advancement = 1
 
-	/// Incrememnts advancement_timer by itself whenever a ranged mob decides to advance.
-	var/advancement_increment = 5
+	/// Increments advancement_timer by itself whenever a ranged mob decides to advance.
+	var/advancement_increment = 3
 
 	/// Will be incremented advancement_increment ticks whenever a ranged mob decides to advance. If more than world.time, targetting walks will be ignored, to not end the advancement.
 	var/advancement_timer = 0
@@ -481,6 +481,10 @@
 			patience = initial(patience)
 		else
 			patience--
+			var/moving_to = pick(cardinal)
+			set_dir(moving_to)
+			step_glide(src, moving_to, DELAY2GLIDESIZE(0.5 SECONDS)) //we can potentially pathfind if we do this
+
 		return
 	else if (projectiletype) // if we can see, let's prepare to see if we can hit
 		if (istype(projectiletype, /obj/item/projectile))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.

This will do two things: 1. If a melee mob is stuck against a wall, it might rub itself over to the left or right and find it's way through a doorway to it's target on the other side. 2. If a ranged mob's can_see is returning false, erronously, which does happen, it might allow it to reposition to a position that lets it actually hit it's target.

One is questionable, but two is just a bugfix.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: Mobs will now wander if they can't see you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
