### PR TITLE
Slightly slower but more danger

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -208,6 +208,7 @@
 	. = ..()
 
 /obj/effect/spider/eggcluster/Process()
+	..() //handle burning
 	amount_grown += rand(0,2)
 	if(amount_grown >= 100)
 		var/num = rand(spiderlings_lower,spiderlings_upper)

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/attack.dm
@@ -1,11 +1,13 @@
-/mob/living/carbon/superior_animal/giant_spider/UnarmedAttack(var/atom/A, var/proximity)
+/mob/living/carbon/superior_animal/giant_spider/UnarmedAttack(atom/A, proximity)
 	. = ..()
 	if(!.)
 		return
 
-	if(isliving(A))
-		var/mob/living/L = A
-		if(istype(L) && L.reagents)
-			var/zone_armor =  L.getarmor(targeted_organ, ARMOR_MELEE)
-			var/poison_injected = zone_armor ? poison_per_bite * (-0.01 * zone_armor + 1) : poison_per_bite
-			L.reagents.add_reagent(poison_type, poison_injected)
+	if(poison_per_bite > 0)
+
+		if(isliving(A))
+			var/mob/living/L = A
+			if(istype(L) && L.reagents)
+				var/zone_armor =  L.getarmor(targeted_organ, ARMOR_MELEE)
+				var/poison_injected = zone_armor ? poison_per_bite * (-0.01 * zone_armor + 1) : poison_per_bite
+				L.reagents.add_reagent(poison_type, poison_injected)

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/giant_spider.dm
@@ -20,9 +20,9 @@
 	give_randomized_armor = TRUE //We get randomized addition armor
 	armor_penetration = 5
 
-	armor = list(melee = 5, bullet = 5, energy = 0, bomb = 5, bio = 10, rad = 25)
+	armor = list(melee = 5, bullet = 5, energy = 5, bomb = 5, bio = 10, rad = 25)
 
-	move_to_delay = 4
+	move_to_delay = 4.5
 	turns_per_move = 5
 	see_in_dark = 10
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/spider

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/spider_armor.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/spider_armor.dm
@@ -10,19 +10,9 @@
 			armor[key] += add_armor[key]
 		else
 			armor[key] = add_armor[key]
-/*
-//We'll assume that damage is list(brute = 5, burn = 5) and armor is a list(brute = 5, toxin = 5)
-	var/list/result = list() //Creates a new list
-	for(var/key in damage) //gets every entry in the damage list and sets 'key' to it one at a time. Because of how byond lists work, however, key will be set to 'brute' for the first loop, then 'burn'
-		if(key in armor) //brute is in armor too
-			result[key] = max(damage[key] - armor[key], 0) //So you just take the difference between them and put the result in the result list.
-		else //burn is not in armor
-			result[key] = damage[key] //So you just deal the damage directly to the player's life points.
-  //You'll notice that at no point did toxin matter. Yes, armor blocks toxin, but because no toxin damage was actually done, in the end we didn't need to add it to the result damage list.
-  //So, at the very end, result = list(brute = 0, burn = 5)
-*/
+
 /mob/living/carbon/superior_animal/giant_spider/pick_armor()
-	switch (pickweight(list("basic" = 5, "padded" = 1, "lustrous" = 1, "durable" = 3, "young" = 2, "old" = 2)))
+	switch (pickweight(list("basic" = 6, "padded" = 1, "lustrous" = 2, "durable" = 3, "young" = 2, "old" = 3, "venomous" = 1, "brutish" = 1)))
 
 		if("basic") //No changes, we are base level
 			return
@@ -91,6 +81,7 @@
 			maxHealth -= 10 //0 hardship yet
 			health -= 10
 			move_to_delay -= 0.5 // faster
+			poison_per_bite -= 1
 			prefex = "young"
 			return
 
@@ -108,5 +99,40 @@
 			maxHealth += 20 //life already seen them by
 			health += 20
 			move_to_delay += 1 // Very slow
+			poison_per_bite -= 1
 			prefex = "aged"
+			return
+
+		if("venomous")
+			add_armor = list(
+			melee = 0,
+			bullet = 0,
+			energy = 0,
+			bomb = 5,
+			bio = 15,
+			rad = 15,
+			agony = 10
+			)
+			gives_prefex = TRUE
+			poison_per_bite += 1
+			prefex = "venomous"
+			return
+
+		if("brutish")
+			add_armor = list(
+			melee = 5,
+			bullet = 5,
+			energy = -5,
+			bomb = 5,
+			bio = 0,
+			rad = 0,
+			agony = 15
+			)
+			melee_damage_lower += 2
+			melee_damage_upper += 2
+			maxHealth += 5
+			health += 5
+			armor_penetration += 2
+			gives_prefex = TRUE
+			prefex = "brutish"
 			return

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/hunter.dm
@@ -9,7 +9,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	poison_per_bite = 4
-	move_to_delay = 3.5
+	move_to_delay = 4.5
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/spider/hunter
 	meat_amount = 4
 	emote_see = list("chitters.","rubs its legs.","bounces in place.")
@@ -18,7 +18,7 @@
 	name = "cloaker spider"
 	desc = "Furry and black, it makes you shudder to look at it. This one has a weaker chameleonic chitin that makes it hard to see."
 	alpha = 50
-	armor = list(melee = 5, bullet = 0, energy = 0, bomb = 0, bio = 10, rad = 25, agony = 0)
+	armor = list(melee = 5, bullet = 0, energy = 5, bomb = 0, bio = 10, rad = 25, agony = 0)
 
 
 /mob/living/carbon/superior_animal/giant_spider/hunter/cloaker/death() //We are now unable to chameleonic chitin do to being dead
@@ -105,7 +105,7 @@
 	melee_damage_upper = 25
 	emote_see = list("chitters.","rubs its legs.","thumps its many legs on the ground.")
 	mob_size = MOB_LARGE
-	armor = list(melee = 15, bullet = 15, energy = 0, bomb = 5, bio = 10, rad = 25, agony = 0)
+	armor = list(melee = 15, bullet = 15, energy = 5, bomb = 5, bio = 10, rad = 25, agony = 0)
 
 
 /mob/living/carbon/superior_animal/giant_spider/tarantula/UnarmedAttack(var/atom/A, var/proximity)
@@ -200,19 +200,18 @@
 	icon_state = "ogre"
 	icon_living = "ogre"
 	poison_per_bite = 4
-	move_to_delay = 4
 	maxHealth = 180
 	health = 180
 
 /mob/living/carbon/superior_animal/giant_spider/tarantula/pit
 	name = "pit snapper spider"
-	desc = "Furry and orange, it makes you shudder to look at it. What it lacks in toxins, it makes up for in its immense bone-snapping mandibles."
+	desc = "Furry and orange, it makes you shudder to look at it. Normally it lacks in toxins but makes up for in its immense bone-snapping mandibles. "
 	icon_state = "pit"
 	icon_living = "pit"
 	poison_per_bite = 0
-	move_to_delay = 4
 	melee_damage_lower = 35
 	melee_damage_upper = 40
+	poison_type = "aranecolmin" //Shockingly this is more deadly then normal as it makes metaball faster
 
 /mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing
 	name = "trapdoor spider"
@@ -240,7 +239,7 @@
 	flash_resistances = 3 //For balance against are speedy fello
 	poison_type = "party drops"
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/spider/emperor
-	armor = list(melee = 25, bullet = 25, energy = 10, bomb = 25, bio = 10, rad = 25, agony = 0)
+	armor = list(melee = 25, bullet = 25, energy = 15, bomb = 25, bio = 10, rad = 25, agony = 0)
 	armor_penetration = 25
 
 	give_randomized_armor = FALSE //Were not getting armor

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -22,7 +22,7 @@
 	emote_see = list("chitters.","rubs its legs.","trails webs through its hairs.","screeches.")
 	var/web_activity = 30
 	move_to_delay = 4 //slightly faster than guardians but slower than hunters
-	armor = list(melee = 0, bullet = 0, energy = 0, bomb = 5, bio = 10, rad = 25, agony = 0)
+	armor = list(melee = 0, bullet = 0, energy = 5, bomb = 5, bio = 10, rad = 25, agony = 0)
 	var/egg_inject_chance = 0 //AHAHAHAHAHAHAHAAHAHAH, no
 	life_cycles_before_sleep = 3000 //We need more time to eat and web
 	inherent_mutations = list(MUTATION_PROT_MILK, MUTATION_SPIDER_FRIEND, MUTATION_NERVOUSNESS, MUTATION_DEAF)
@@ -87,8 +87,8 @@
 	icon_state = "webslinger"
 	icon_living = "webslinger"
 	emote_see = list("chitters.","rubs its legs.","trails webs through its hairs.","screeches.","bounces happily in place!")
-	web_activity = 90
-	armor = list(melee = 15, bullet = 10, energy = 0, bomb = 5, bio = 10, rad = 25, agony = 0)
+	web_activity = 70
+	armor = list(melee = 15, bullet = 10, energy = 5, bomb = 5, bio = 10, rad = 25, agony = 0)
 
 /mob/living/carbon/superior_animal/giant_spider/nurse/recluse
 	name = "recluse spider"
@@ -126,7 +126,7 @@
 	egg_inject_chance = 10 //Likely
 	//Giving the queen her own meat type which contains MENACE.
 	mob_size = MOB_LARGE
-	armor = list(melee = 15, bullet = 10, energy = 0, bomb = 5, bio = 10, rad = 25, agony = 0)
+	armor = list(melee = 15, bullet = 10, energy = 5, bomb = 5, bio = 10, rad = 25, agony = 0)
 	inherent_mutations = list(MUTATION_GIGANTISM, MUTATION_SPIDER_FRIEND, MUTATION_RAND_UNSTABLE, MUTATION_RAND_UNSTABLE, MUTATION_RAND_UNSTABLE)
 	armor_penetration = 35
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/roach_armor.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach_armor.dm
@@ -11,8 +11,6 @@
 		else
 			armor[key] = add_armor[key]
 
-
-
 /mob/living/carbon/superior_animal/roach/pick_armor()
 	switch (pickweight(list("basic" = 15, "Biosilicified" = 5, "Lambertian" = 3, "Durable" = 4)))
 


### PR DESCRIPTION
Spiders have been lowered speed wise by 0.5
Spiders now have +5 energy armor to help them have a bit more survivability against basic laser arms to still stay a threat in those cases
Spiders now have 2 additonal armor prefixes,
venomous = +1 toxins per inject, 5 bomb armor 15 bio and rad armor and 10 pain armor
brutish = -5 energy armor 15 pain armor +2 damage +2 ap +5 health + 5 melee bullet bomb armor
Aged spiders now have 1 less toxin per bite
Young spiders have additionally 1 more toxin per bite
Pit snapper now has aranecolmin as its toxin

Bug fix: burning spider eggs now accully works

Orb weavers are less active in webbing/making a mess by 18~% (like 15 but what ever)