### PR TITLE
Revert "Health through Stats"

### DIFF
--- a/code/__DEFINES/mob_stats.dm
+++ b/code/__DEFINES/mob_stats.dm
@@ -6,11 +6,8 @@
 #define STAT_ROB			"Robustness"
 #define STAT_TGH			"Toughness"
 #define STAT_VIG			"Vigilance"
-#define STAT_VIV			"Vivification"
-#define STAT_ANA			"Anatomy"
 
-#define ALL_STATS	list(STAT_MEC,STAT_COG,STAT_BIO,STAT_ROB,STAT_TGH,STAT_VIG,STAT_VIV,STAT_ANA)
-#define ALL_STATS_FOR_LEVEL_UP	list(STAT_MEC,STAT_COG,STAT_BIO,STAT_ROB,STAT_TGH,STAT_VIG,STAT_ANA) //Cant naturally gain more viv
+#define ALL_STATS	list(STAT_MEC,STAT_COG,STAT_BIO,STAT_ROB,STAT_TGH,STAT_VIG)
 
 #define STAT_LEVEL_NONE     0
 #define STAT_LEVEL_BASIC    15

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -420,9 +420,6 @@ SUBSYSTEM_DEF(job)
 		H.stats.changeStat(STAT_ROB, H.client.prefs.ROBMOD)
 		H.stats.changeStat(STAT_TGH, H.client.prefs.TGHMOD)
 		H.stats.changeStat(STAT_VIG, H.client.prefs.VIGMOD)
-		H.stats.changeStat(STAT_VIV, H.client.prefs.VIVMOD)
-		H.stats.changeStat(STAT_ANA, H.client.prefs.ANAMOD)
-		H.give_health_via_stats()
 		// This could be cleaner and better, however it should apply your stats once on spawn properly if here. If anyone wants to do this in a cleaner manner be my guest.
 
 		BITSET(H.hud_updateflag, ID_HUD)

--- a/code/controllers/subsystems/staverbs.dm
+++ b/code/controllers/subsystems/staverbs.dm
@@ -55,10 +55,6 @@ SUBSYSTEM_DEF(statverbs)
 				to_chat(user, SPAN_WARNING("You're not smart enough to do that!"))
 			if(STAT_VIG)
 				to_chat(user, SPAN_WARNING("You're not perceptive enough to do that!"))
-			if(STAT_VIV)
-				to_chat(user, SPAN_WARNING("Your nerves can't handle this!"))
-			if(STAT_ANA)
-				to_chat(user, SPAN_WARNING("You're not healthy enough to do this!"))
 		return FALSE
 
 	action(user, target)

--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -238,15 +238,6 @@
 	name = STAT_VIG
 	desc = "Here, paranoia is nothing but a useful trait. Improves your ability to control recoil on guns, helps you resist insanity."
 
-/datum/stat/vivification
-	name = STAT_VIV
-	desc = "The body can take only so much stimulation under normal circumstances. It takes a lot to train the body to handle drugs, be they helpful or harmful."
-
-/datum/stat/anatomy
-	name = STAT_ANA
-	desc = "The body itself; the more you know about how far you can push it, the easier it becomes to edge closer towards death's door."
-
-
 // Use to perform stat checks
 /mob/proc/stat_check(stat_path, needed)
 	var/points = src.stats.getStat(stat_path)

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -17,7 +17,6 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	playtimerequired = 2500
 	wage = WAGE_COMMAND
 
-	health_modifier = 1
 	ideal_character_age = 50 // Old geezer captains ftw
 	minimum_character_age = 35
 	outfit_type = /decl/hierarchy/outfit/job/captain
@@ -41,9 +40,7 @@ Treat your command officers with respect, and listen to their council. Try not t
 		STAT_BIO = 15,
 		STAT_MEC = 15,
 		STAT_VIG = 25,
-		STAT_COG = 15,
-		STAT_VIV = 1,
-		STAT_ANA = 1
+		STAT_COG = 15
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
@@ -86,7 +83,6 @@ Treat your command officers with respect, and listen to their council. Try not t
 	ideal_character_age = 35
 	minimum_character_age = 30
 
-	health_modifier = 5
 	description = "The Steward is the loyal right-hand of the Premier. Serving as a personal guard, follow him wherever he goes.<br>\
 	Your primary, and perhaps only, responsibility is to ensure the safety of the Premier at all costs - even your own life if necessary.<br>\
 	However, you are an adviser as well as a bodyguard. Discreetly inform him of mistakes. Make sure he follows the law and remains popular.<br>\
@@ -117,9 +113,7 @@ Treat your command officers with respect, and listen to their council. Try not t
 		STAT_ROB = 25,
 		STAT_BIO = 25,
 		STAT_MEC = 25,
-		STAT_COG = 25,
-		STAT_VIV = 2,
-		STAT_ANA = 2
+		STAT_COG = 25
 	)
 
 /obj/landmark/join/start/pg

--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -15,7 +15,6 @@
 	playtimerequired = 1200
 	also_known_languages = list(LANGUAGE_LATIN = 100)
 	security_clearance = CLEARANCE_CLERGY
-	health_modifier = 10
 	access = list(
 		access_nt_preacher, access_nt_disciple, access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels, access_RC_announce, access_keycard_auth, access_heads, access_sec_doors
 	)
@@ -32,7 +31,7 @@
 		STAT_TGH = 10,
 	)
 
-	perks = list(/datum/perk/neat, /datum/perk/greenthumb, /datum/perk/channeling
+	perks = list(/datum/perk/neat, /datum/perk/greenthumb, /datum/perk/channeling 
 		//, /datum/perk/chemist -Thanos Voice: "A small price to pay for salvation."
 	)
 
@@ -79,7 +78,7 @@
 	also_known_languages = list(LANGUAGE_LATIN = 100)
 	security_clearance = CLEARANCE_COMMON
 	alt_titles = list("Divisor","Factorial","Monomial","Lemniscate","Tessellate")
-	health_modifier = 5
+
 	stat_modifiers = list(
 	STAT_MEC = 25,
 	STAT_BIO = 10,

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -13,7 +13,6 @@
 	access = list(access_hydroponics, access_bar, access_kitchen)
 	initial_balance = 3000
 	wage = WAGE_LABOUR_DUMB // Makes his own money via tips and selling drinks
-	health_modifier = -10
 	stat_modifiers = list(
 		STAT_ROB = 15,
 		STAT_TGH = 15,
@@ -48,7 +47,6 @@
 	difficulty = "Easy."
 	alt_titles = list("Culinary Artist","Cook")
 	selection_color = "#dddddd"
-	health_modifier = -10
 	access = list(access_hydroponics, access_bar, access_kitchen)
 	initial_balance = 750
 	wage = WAGE_LABOUR_DUMB //They should get paid by making food.
@@ -87,7 +85,6 @@
 	difficulty = "Easy."
 	selection_color = "#dddddd"
 	alt_titles = list("Hydroponicist")
-	health_modifier = -10
 	also_known_languages = list(LANGUAGE_CYRILLIC = 15, LANGUAGE_JIVE = 80)
 	access = list(access_hydroponics, access_bar, access_kitchen)
 	wage = WAGE_LABOUR_DUMB //The gardener can make money selling his fruits to the church or to the chef and bartender.
@@ -171,7 +168,6 @@
 	alt_titles = list("Custodian","Sanitation Technician")
 	access = list(access_janitor, access_maint_tunnels, access_morgue, access_hydroponics, access_bar, access_kitchen)
 	wage = WAGE_PROFESSIONAL
-	health_modifier = 5
 	outfit_type = /decl/hierarchy/outfit/job/service/janitor
 
 	perks = list(/datum/perk/market_prof, /datum/perk/job/jingle_jangle, /datum/perk/neat) //Union has revoked their chemistry privileges

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -15,7 +15,6 @@
 	wage = WAGE_COMMAND
 	ideal_character_age = 50
 	minimum_character_age = 30
-	health_modifier = 5
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/exultant
 

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -21,7 +21,6 @@
 	ideal_character_age = 40
 	minimum_character_age = 30
 	playtimerequired = 1200
-	health_modifier = 5
 
 	stat_modifiers = list(
 		STAT_ROB = 10,
@@ -72,7 +71,6 @@ Counsel the council on directing the colony towards profitable opportunities."
 	wage = WAGE_LABOUR_DUMB
 	department_account_access = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/cargo/cargo_tech
-	health_modifier = -10
 
 	access = list(
 		access_mailsorting, access_cargo, access_cargo_bot, access_mining,
@@ -122,7 +120,6 @@ Avoid the deeper tunnels unless otherwise instructed, however - this domain is h
 	alt_titles = list("Lonestar Drill Technician","Lonestar Digger","Mining Specialist","Junior Lonestar Miner","Ameridian Gatherer")
 	selection_color = "#c3b9a6"
 	wage = WAGE_LABOUR_HAZARD //The miners union is stubborn
-	health_modifier = 5
 
 	outfit_type = /decl/hierarchy/outfit/job/cargo/mining
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -47,10 +47,7 @@
 	//Character stats modifers
 	var/list/stat_modifiers = list()
 
-	// Sojourn Additions
-
-	//Changes max hp
-	var/health_modifier = 0
+ 	// Sojourn Additions
 
 	//Does not display this job on the occupation setup screen
 	var/latejoin_only = 0
@@ -84,9 +81,6 @@
 		target.stats.changeStat(name, stat_modifiers[name])
 	for(var/perk in perks)
 		target.stats.addPerk(perk)
-
-	target.health += health_modifier
-	target.maxHealth += health_modifier
 
 	return TRUE
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -13,7 +13,6 @@
 	req_admin_notify = 1
 	wage = WAGE_COMMAND
 	outfit_type = /decl/hierarchy/outfit/job/medical/cmo
-	health_modifier = -10
 
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_genetics, access_heads,
@@ -75,7 +74,6 @@
 	alt_titles = list("Soteria Nurse", "Soteria Emergency Physician", "Soteria Surgeon", "Soteria Medical Student")
 	outfit_type = /decl/hierarchy/outfit/job/medical/doctor
 	department_account_access = TRUE
-	health_modifier = -15
 
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology,
@@ -123,7 +121,6 @@
 	alt_titles = (null)
 	outfit_type = /decl/hierarchy/outfit/job/medical/trauma_team
 
-	health_modifier = 5
 	perks = list(/datum/perk/medicalexpertise, /datum/perk/chemist) // Can treat people well but can't do surgery or chemistry as good as a doctor.
 
 	access = list(
@@ -178,7 +175,6 @@
 	selection_color = "#a8b69a"
 	alt_titles = list("Soteria Psychologist", "Soteria Empath")
 	outfit_type = /decl/hierarchy/outfit/job/medical/psychiatrist
-	health_modifier = -15
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_psychiatrist, access_chemistry, access_medical_suits
 	)

--- a/code/game/jobs/job/offcolony.dm
+++ b/code/game/jobs/job/offcolony.dm
@@ -13,7 +13,6 @@
 	create_record = 0
 	wage = WAGE_NONE
 	outfit_type = /decl/hierarchy/outfit/job/off_colony/hunt_master
-	health_modifier = 15
 
 	perks = list(/datum/perk/job/butcher)
 	access = list(access_huntmaster, access_hunter)
@@ -55,7 +54,6 @@
 	create_record = 0
 	wage = WAGE_NONE
 	outfit_type = /decl/hierarchy/outfit/job/off_colony/hunter
-	health_modifier = 10
 
 	perks = list(/datum/perk/job/butcher)
 	access = list(access_hunter)
@@ -97,7 +95,6 @@
 	create_record = 0
 	wage = WAGE_NONE
 	outfit_type = /decl/hierarchy/outfit/job/off_colony/herbalist
-	health_modifier = 5
 
 	perks = list(/datum/perk/job/butcher, /datum/perk/job/master_herbalist, /datum/perk/greenthumb)
 	access = list(access_hunter)

--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -13,7 +13,6 @@
 	req_admin_notify = 1
 	wage = WAGE_COMMAND
 	department_account_access = TRUE
-	health_modifier = 15
 
 	outfit_type = /decl/hierarchy/outfit/job/foreman
 	playtimerequired = 1200
@@ -68,8 +67,6 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/salv
 
-	health_modifier = 5
-
 	access = list(
 		access_prospector, access_external_airlocks, access_eva, access_maint_tunnels
 	)
@@ -114,7 +111,6 @@
 	wage = WAGE_LABOUR_DUMB
 
 	outfit_type = /decl/hierarchy/outfit/job/pro
-	health_modifier = 10
 
 	access = list(
 		access_prospector, access_external_airlocks, access_eva, access_maint_tunnels

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -12,7 +12,6 @@
 	selection_color = "#b39aaf"
 	req_admin_notify = 1
 	wage = WAGE_COMMAND
-	health_modifier = -10
 
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
 	playtimerequired = 1200
@@ -71,7 +70,6 @@
 	difficulty = "Medium."
 	selection_color = "#bdb1bb"
 	wage = WAGE_PROFESSIONAL
-	health_modifier = -15
 
 	alt_titles = list("Soteria Xenobiologist", "Soteria Xenoarcheologist", "Soteria Xenobotanist", "Soteria Research Fabricator", "Soteria Geneticist", "Soteria Research Student")
 	outfit_type = /decl/hierarchy/outfit/job/science/scientist
@@ -121,7 +119,6 @@
 	selection_color = "#bdb1bb"
 	wage = WAGE_PROFESSIONAL
 	department_account_access = TRUE
-	health_modifier = -15
 
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -16,7 +16,6 @@
 	minimum_character_age = 30
 	department_account_access = TRUE
 	playtimerequired = 2500
-	health_modifier = 25
 
 	outfit_type = /decl/hierarchy/outfit/job/security/smc
 
@@ -80,7 +79,6 @@
 	minimum_character_age = 30
 	department_account_access = TRUE
 	playtimerequired = 2500
-	health_modifier = 25
 
 	outfit_type = /decl/hierarchy/outfit/job/security/swo
 
@@ -140,7 +138,6 @@
 	wage = WAGE_LABOUR_HAZARD
 	minimum_character_age = 25
 	playtimerequired = 1200
-	health_modifier = 20
 
 	outfit_type = /decl/hierarchy/outfit/job/security/gunserg
 
@@ -195,7 +192,6 @@
 	wage = WAGE_LABOUR_HAZARD
 	minimum_character_age = 25
 	playtimerequired = 1200
-	health_modifier = 20
 
 	outfit_type = /decl/hierarchy/outfit/job/security/serg
 
@@ -247,7 +243,6 @@
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
 	playtimerequired = 1200
-	health_modifier = 5
 
 	outfit_type = /decl/hierarchy/outfit/job/security/inspector
 
@@ -302,7 +297,6 @@
 	alt_titles = list("Combat Medic","Combat Surgeon")
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
-	health_modifier = 5
 
 	outfit_type = /decl/hierarchy/outfit/job/security/medspec
 
@@ -356,7 +350,6 @@
 	alt_titles = list("Blackshield Cadet", "Blackshield Militiamen")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
-	health_modifier = 10
 
 	outfit_type = /decl/hierarchy/outfit/job/security/troop
 
@@ -407,7 +400,6 @@
 	alt_titles = list("Marshal Civil Servant", "Field Training Marshal")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
-	health_modifier = 10
 
 	outfit_type = /decl/hierarchy/outfit/job/security/ihoper
 

--- a/code/game/objects/items/oddities_faction.dm
+++ b/code/game/objects/items/oddities_faction.dm
@@ -213,7 +213,7 @@
 	item_state = "techno_tribalism"
 	origin_tech = list(TECH_MATERIAL = 8, TECH_ENGINEERING = 7, TECH_POWER = 2)
 	price_tag = 20000
-	var/list/oddity_stats = list(STAT_MEC = 0, STAT_COG = 0, STAT_BIO = 0, STAT_ROB = 0, STAT_TGH = 0, STAT_VIG = 0, STAT_VIV = 0, STAT_ANA = 0)
+	var/list/oddity_stats = list(STAT_MEC = 0, STAT_COG = 0, STAT_BIO = 0, STAT_ROB = 0, STAT_TGH = 0, STAT_VIG = 0)
 	var/last_produce = -30 MINUTES
 	var/items_count = 0
 /*
@@ -250,35 +250,25 @@ No more of that.
 				oddity_stats[STAT_COG] += 3
 				oddity_stats[STAT_BIO] += 3
 				oddity_stats[STAT_MEC] += 3
-				oddity_stats[STAT_ANA] += 1
-				oddity_stats[STAT_VIV] += 1
 			else if(GLOB.all_faction_items[W] == GLOB.department_security)
 				oddity_stats[STAT_VIG] += 3
 				oddity_stats[STAT_TGH] += 3
 				oddity_stats[STAT_ROB] += 3
-				oddity_stats[STAT_ANA] += 1
-				oddity_stats[STAT_VIV] += 1
 			else if(GLOB.all_faction_items[W] == GLOB.department_church)
 				oddity_stats[STAT_BIO] += 3
 				oddity_stats[STAT_COG] += 2
 				oddity_stats[STAT_VIG] += 2
 				oddity_stats[STAT_TGH] += 2
-				oddity_stats[STAT_ANA] += 1
-				oddity_stats[STAT_VIV] += 1
 			else if(GLOB.all_faction_items[W] == GLOB.department_guild)
 				oddity_stats[STAT_COG] += 3
 				oddity_stats[STAT_MEC] += 3
 				oddity_stats[STAT_ROB] += 1
 				oddity_stats[STAT_VIG] += 2
-				oddity_stats[STAT_ANA] += 1
-				oddity_stats[STAT_VIV] += 1
 			else if(GLOB.all_faction_items[W] == GLOB.department_engineering)
 				oddity_stats[STAT_MEC] += 5
 				oddity_stats[STAT_COG] += 2
 				oddity_stats[STAT_TGH] += 1
 				oddity_stats[STAT_VIG] += 1
-				oddity_stats[STAT_ANA] += 1
-				oddity_stats[STAT_VIV] += 1
 			else if(GLOB.all_faction_items[W] == GLOB.department_command)
 				oddity_stats[STAT_ROB] += 2
 				oddity_stats[STAT_TGH] += 1
@@ -286,8 +276,6 @@ No more of that.
 				oddity_stats[STAT_MEC] += 1
 				oddity_stats[STAT_VIG] += 3
 				oddity_stats[STAT_COG] += 1
-				oddity_stats[STAT_ANA] += 1
-				oddity_stats[STAT_VIV] += 1
 			else
 				CRASH("[W], incompatible department")
 

--- a/code/modules/client/preference_setup/general/07_stats.dm
+++ b/code/modules/client/preference_setup/general/07_stats.dm
@@ -7,8 +7,6 @@
 	var/ROBMOD = 0
 	var/TGHMOD = 0
 	var/VIGMOD = 0
-	var/VIVMOD = 0
-	var/ANAMOD = 0
 
 /datum/category_item/player_setup_item/background/education
 	name = "Skills"
@@ -21,8 +19,6 @@
 	from_file(S["ROBMOD"],pref.ROBMOD)
 	from_file(S["TGHMOD"],pref.TGHMOD)
 	from_file(S["VIGMOD"],pref.VIGMOD)
-	from_file(S["VIVMOD"],pref.VIVMOD)
-	from_file(S["ANAMOD"],pref.ANAMOD)
 
 /datum/category_item/player_setup_item/background/education/save_character(var/savefile/S)
 	to_file(S["BIOMOD"],pref.BIOMOD)
@@ -31,8 +27,6 @@
 	to_file(S["ROBMOD"],pref.ROBMOD)
 	to_file(S["TGHMOD"],pref.TGHMOD)
 	to_file(S["VIGMOD"],pref.VIGMOD)
-	to_file(S["VIVMOD"],pref.VIVMOD)
-	to_file(S["ANAMOD"],pref.ANAMOD)
 
 /datum/category_item/player_setup_item/background/education/sanitize_character()
 	pref.BIOMOD             = sanitize_integer(pref.BIOMOD, -10, 15, initial(pref.BIOMOD))
@@ -41,8 +35,6 @@
 	pref.ROBMOD             = sanitize_integer(pref.ROBMOD, -10, 15, initial(pref.ROBMOD))
 	pref.TGHMOD             = sanitize_integer(pref.TGHMOD, -10, 15, initial(pref.TGHMOD))
 	pref.VIGMOD             = sanitize_integer(pref.VIGMOD, -10, 15, initial(pref.VIGMOD))
-	pref.VIVMOD             = sanitize_integer(pref.VIVMOD, -10, 15, initial(pref.VIVMOD))
-	pref.ANAMOD             = sanitize_integer(pref.ANAMOD, -10, 15, initial(pref.ANAMOD))
 	if(calculatetotalpoints() > 15)
 		pref.BIOMOD = 0
 		pref.COGMOD = 0
@@ -50,8 +42,6 @@
 		pref.ROBMOD = 0
 		pref.TGHMOD = 0
 		pref.VIGMOD = 0
-		pref.VIVMOD = 0
-		pref.ANAMOD = 0
 
 /datum/category_item/player_setup_item/background/education/content(var/mob/user)
 	. = list()
@@ -62,14 +52,12 @@
 	. += "Robustness:  <a href='?src=\ref[src];robmod=1'>[pref.ROBMOD]</a><br>"
 	. += "Toughness:  <a href='?src=\ref[src];tghmod=1'>[pref.TGHMOD]</a><br>"
 	. += "Vigilance:  <a href='?src=\ref[src];vigmod=1'>[pref.VIGMOD]</a><br>"
-	. += "Vivification:  <a href='?src=\ref[src];vivmod=1'>[pref.VIVMOD]</a><br>"
-	. += "Anatomy:  <a href='?src=\ref[src];anamod=1'>[pref.ANAMOD]</a><br>"
 	. += "<br/>"
-	. += "You have used [pref.BIOMOD + round(pref.COGMOD/2) + pref.MECMOD + pref.ROBMOD + pref.TGHMOD + pref.VIGMOD + pref.VIVMOD  + round(pref.ANAMOD*5)] / 15 skill points"
+	. += "You have used [pref.BIOMOD + round(pref.COGMOD/2) + pref.MECMOD + pref.ROBMOD + pref.TGHMOD + pref.VIGMOD] / 15 skill points"
 	. = jointext(.,null)
 
 /datum/category_item/player_setup_item/background/education/proc/calculatetotalpoints()
-	return (pref.BIOMOD + round(pref.COGMOD/2) + pref.MECMOD + pref.ROBMOD + pref.TGHMOD + pref.VIGMOD + pref.VIVMOD + round(pref.ANAMOD*5))
+	return (pref.BIOMOD + round(pref.COGMOD/2) + pref.MECMOD + pref.ROBMOD + pref.TGHMOD + pref.VIGMOD)
 
 /datum/category_item/player_setup_item/background/education/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["biomod"])
@@ -130,26 +118,6 @@
 			pref.VIGMOD = max(min(round(new_vig), 15), -10)
 			if(calculatetotalpoints() > 15)
 				pref.VIGMOD = old_vig
-			return TOPIC_REFRESH
-
-	else if(href_list["vivmod"])
-		var/new_viv = 0
-		new_viv = input(user, "Enter a value between -10 and 15 for your vivification.", CHARACTER_PREFERENCE_INPUT_TITLE, pref.VIVMOD) as num
-		if(CanUseTopic(user))
-			var/old_viv = pref.VIVMOD
-			pref.VIVMOD = max(min(round(new_viv), 15), -10)
-			if(calculatetotalpoints() > 15)
-				pref.VIVMOD = old_viv
-			return TOPIC_REFRESH
-
-	else if(href_list["anamod"])
-		var/new_ana = 0
-		new_ana = input(user, "Enter a value between -3 and 5 for your anatomy  (Anatomy 500% the cost of other stats).", CHARACTER_PREFERENCE_INPUT_TITLE, pref.ANAMOD) as num
-		if(CanUseTopic(user))
-			var/old_ana = pref.ANAMOD
-			pref.ANAMOD = max(min(round(new_ana), 5), -3)
-			if(calculatetotalpoints() > 15)
-				pref.ANAMOD = old_ana
 			return TOPIC_REFRESH
 
 	return ..()

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -350,13 +350,6 @@
 		job_desc += "</ul>"
 	else
 		job_desc += "None"
-	job_desc += "<h1 style='padding: 0px;'>Added Health:</h1>"
-	if(job.health_modifier)
-		job_desc += "<ul>"
-		job_desc += "<li>[job.health_modifier]</li>"
-		job_desc += "</ul>"
-	else
-		job_desc += "None"
 	job_desc +="</div>"
 
 	if(job.alt_titles)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1403,11 +1403,3 @@ mob/proc/yank_out_object()
 
 		if(!ai_in_use && !is_in_use)
 			in_use = 0
-
-
-//SoJ
-
-/mob/proc/give_health_via_stats()
-	if(stats)
-		health += src.stats.getStat(STAT_ANA)
-		maxHealth += src.stats.getStat(STAT_ANA)

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -32,7 +32,6 @@
 	var/list/nerve_system_accumulations = list() // Nerve system accumulations
 	var/nsa_threshold = 100
 	var/nsa_bonus = 0 //For various perks and organs affecting the nsa threshhold
-	var/nsa_viv = 0   //For stats increases
 	var/nsa_chem_bonus = 0 //For chems (detox in specific) affecting the nsa threshhold
 	var/nsa_mult = 1 //Multiplier for nsa, used by specific perks. Added so the number doesn't fuck with other numbers.
 	var/nsa_organ_bonus = 0 //For efficiency modifiers on the nerves
@@ -51,11 +50,10 @@
 //Must be called WHENEVER you modify nsa_bonus, nsa_chem_bonus, nsa_mult, or when you change nerve efficiency.
 //calc_nerves: Activates nerve efficiency recalculation, so its not recalculated every time.
 /datum/metabolism_effects/proc/calculate_nsa(calc_nerves = FALSE)
-	nsa_viv = parent.stats.getStat(STAT_VIV)
 	if(calc_nerves && ishuman(parent))
 		var/mob/living/carbon/human/parent_human = parent
 		nsa_organ_bonus = (parent_human.get_organ_efficiency(OP_NERVE) - 700) / 2
-	nsa_threshold = round((100 + nsa_bonus + nsa_chem_bonus + nsa_organ_bonus + nsa_viv) * nsa_mult)
+	nsa_threshold = round((100 + nsa_bonus + nsa_chem_bonus + nsa_organ_bonus) * nsa_mult)
 	nsa_threshold = max(nsa_threshold, NSA_THRESHOLD_MINIMUM) //Can't be below for any reason. Keeps
 	return nsa_threshold
 

--- a/code/modules/sanity/inspiration_component.dm
+++ b/code/modules/sanity/inspiration_component.dm
@@ -72,12 +72,6 @@
 			if("Cognition")
 				stat_noun = pick("cognition", "intelligence", "knowledge")
 				stat_adjective = pick("smart", "intelligent", "concentrated", "knowledgable")
-			if("Vivification")
-				stat_noun = pick("invigoration", "vigorous", "healthy", "fit")
-				stat_adjective = pick("vitality", "vigour")
-			if("Anatomy")
-				stat_noun = pick("physique", "soma", "build", "frame")
-				stat_adjective = pick("morphological", "physical")
 		switch(stats[stat])
 			if(30 to INFINITY)
 				a_or_an = "an"

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -239,7 +239,7 @@
 
 	var/stat_pool = resting * 15
 	while(stat_pool--)
-		LAZYAPLUS(stat_change, pick(ALL_STATS_FOR_LEVEL_UP), 1)
+		LAZYAPLUS(stat_change, pick(ALL_STATS), 1)
 
 	for(var/stat in stat_change)
 		owner.stats.changeStat(stat, stat_change[stat])
@@ -253,8 +253,6 @@
 		to_chat(owner, SPAN_NOTICE("You have satisfied your cravings and improved your stats."))
 	owner.playsound_local(get_turf(owner), 'sound/sanity/rest.ogg', 100)
 	owner.pick_individual_objective()
-	owner.give_health_via_stats()
-	owner.metabolism_effects.calculate_nsa(TRUE) //So
 	resting = 0
 
 /datum/sanity/proc/oddity_stat_up(multiplier)


### PR DESCRIPTION
Reverts sojourn-13/sojourn-station#3528

This... completely changed our balance, specifically involving more aggressive storytellers (which now work again).

Look, I'm not going to sugarcoat it

What the actual fuck? I leave the dev-team for more than a week and Trilby massively changes how the game works again? Including decreasing the health of every non-combat role by 10? And then making it a stat?

I'm sorry - but what was the actual intent of this? What meth are you smoking?