### PR TITLE
Better balance Of story Tellers

### DIFF
--- a/code/game/gamemodes/events/blob.dm
+++ b/code/game/gamemodes/events/blob.dm
@@ -20,7 +20,7 @@
 //============================================
 
 /datum/event/blob
-	announceWhen	= 12
+	announceWhen	= 6
 
 	var/obj/effect/blob/core/Blob
 

--- a/code/game/gamemodes/events/carp_migration.dm
+++ b/code/game/gamemodes/events/carp_migration.dm
@@ -61,7 +61,8 @@
 	var/list/spawn_locations = pickweight_mult(viable_turfs, number)
 
 	for(var/turf/T in spawn_locations)
-		spawned_carp.Add(new /obj/random/mob/carp(T))
+		if(prob(50)) //coin flip to spawn the carp or not, should still always have a few but not a hoard
+			spawned_carp.Add(new /obj/random/mob/carp(T))
 
 /datum/event/carp_migration/end()
 	for(var/mob/living/simple_animal/hostile/C in spawned_carp)

--- a/code/game/gamemodes/events/electrical_storm.dm
+++ b/code/game/gamemodes/events/electrical_storm.dm
@@ -1,3 +1,7 @@
+/*
+
+Just not fun
+
 /datum/storyevent/electrical_storm
 	id = "elec_storm"
 	name = "Electrical Storm"
@@ -10,7 +14,7 @@
 	ocurrences_max = 2 //Can only do this twice as its more annoying then fun
 
 	tags = list(TAG_SCARY, TAG_TARGETED, TAG_NEGATIVE)
-
+*/
 ////////////////////////////////////////////////
 
 /datum/event/electrical_storm

--- a/code/game/gamemodes/events/infestation.dm
+++ b/code/game/gamemodes/events/infestation.dm
@@ -25,6 +25,7 @@ It focuses on spawning large numbers of moderate-to-weak monsters, and includes 
 #define INFESTATION_SPIDERLINGS "spiderlings"
 #define INFESTATION_SPIDERS "spider"
 #define INFESTATION_ROACHES "large insects"
+#define INFESTATION_TERMIE "large borrowing insects"
 #define INFESTATION_HIVEBOTS "ancient synthetics"
 #define INFESTATION_SLIMES "slimes"
 #define INFESTATION_YITHIAN "yithian"
@@ -172,6 +173,7 @@ It focuses on spawning large numbers of moderate-to-weak monsters, and includes 
 			chosen_verb = "have burrowed into"
 			chosen_mob_classification[/obj/effect/spider/spiderling] = 1
 			chosen_mob_classification[/obj/effect/spider/eggcluster] = 0.2
+			chosen_mob_classification[/obj/structure/spider_nest] = 0.1
 		if(INFESTATION_SPIDERS)
 			event_name = "Spider Infestation"
 			chosen_verb = "have burrowed into"
@@ -180,6 +182,10 @@ It focuses on spawning large numbers of moderate-to-weak monsters, and includes 
 			event_name = "Giant Roach Infestation"
 			chosen_verb = "have burrowed into"
 			chosen_mob_classification += /obj/random/mob/roaches
+		if(INFESTATION_TERMIE)
+			event_name = "Giant Termite Infestation"
+			chosen_verb = "have burrowed into"
+			chosen_mob_classification += /obj/random/mob/termite_no_despawn
 		if(INFESTATION_YITHIAN)
 			unidentified = TRUE
 			chosen_mob_classification += /mob/living/simple_animal/yithian

--- a/code/game/gamemodes/storytellers/chronicler.dm
+++ b/code/game/gamemodes/storytellers/chronicler.dm
@@ -5,9 +5,9 @@
 	welcome = "Today will be a glorious day!"
 	description = "A storyteller with a focus on player vs player combat. Spawns lots of antagonists, but fewer random events."
 
-	gain_mult_mundane = 0.8
-	gain_mult_moderate = 0.8
-	gain_mult_major = 0.8
+	gain_mult_mundane = 0.7
+	gain_mult_moderate = 0.7
+	gain_mult_major = 0.7
 	gain_mult_roleset = 1.5
 
 	//Less combat-oriented events, so that we'll not be fighting NPC monsters much

--- a/code/game/gamemodes/storytellers/healer.dm
+++ b/code/game/gamemodes/storytellers/healer.dm
@@ -4,10 +4,10 @@
 	welcome = "Welcome to the Nadezhda colony! We hope you enjoy your stay!"
 	description = "Peaceful and relaxed storyteller who will try to help the colony a little."
 
-	gain_mult_mundane = 1.2
-	gain_mult_moderate = 0.8
-	gain_mult_major = 0.8
-	gain_mult_roleset = 0.8
+	gain_mult_mundane = 1.1
+	gain_mult_moderate = 0.7
+	gain_mult_major = 0.7
+	gain_mult_roleset = 0.7
 
 	repetition_multiplier = 0.95
 	tag_weight_mults = list(TAG_COMBAT = 0.75, TAG_NEGATIVE = 0.5, TAG_POSITIVE = 2)

--- a/code/game/gamemodes/storytellers/jester.dm
+++ b/code/game/gamemodes/storytellers/jester.dm
@@ -4,9 +4,9 @@
 	welcome = "Welcome to the house of fun. We're all mad here!"
 	description = "Aggressive and chaotic storyteller who generates a larger quantity of random events."
 
-	gain_mult_mundane = 1.85
-	gain_mult_moderate = 1.65
-	gain_mult_major = 1.65
+	gain_mult_mundane = 1.2
+	gain_mult_moderate = 1.2
+	gain_mult_major = 1.2
 
 	variance = 0.25
 	repetition_multiplier = 0.65

--- a/code/game/gamemodes/storytellers/mime.dm
+++ b/code/game/gamemodes/storytellers/mime.dm
@@ -2,8 +2,8 @@
 	config_tag = "mime"
 	name = "The Mime"
 	welcome = "Welcome to the Nadezhda colony! We hope you enjoy your stay!"
-	description = "A storyteller which will not do anything. Designed for admin events."
-	votable = FALSE //admin-only
+	description = "A storyteller which will not do anything."
+	votable = TRUE //For lower pops
 
 /datum/storyteller/mime/handle_points() //the mime does not run any events, and points are frozen while the mime is in charge.
 	return

--- a/code/game/gamemodes/storytellers/sleeper.dm
+++ b/code/game/gamemodes/storytellers/sleeper.dm
@@ -4,7 +4,7 @@
 	welcome = "Welcome to the Nadezhda colony! It's going to be a quiet day"
 	description = "A passive storyteller that does almost nothing. It will be a very uneventful day."
 
-	gain_mult_mundane = 0.75
-	gain_mult_moderate = 0.5
-	gain_mult_major = 0.5
+	gain_mult_mundane = 0.7
+	gain_mult_moderate = 0.4
+	gain_mult_major = 0.4
 	gain_mult_roleset = 0.5

--- a/code/game/gamemodes/storytellers/warrior.dm
+++ b/code/game/gamemodes/storytellers/warrior.dm
@@ -4,9 +4,9 @@
 	welcome = "Ready your weapons, and prepare for battle..."
 	description = "Aggressive storyteller with a focus on generating monsters and antagonists that will do battle with the colonists."
 
-	gain_mult_moderate = 1.25
-	gain_mult_major = 1.25
-	gain_mult_roleset = 1.25
+	gain_mult_moderate = 1.1
+	gain_mult_major = 1.1
+	gain_mult_roleset = 1.1
 
 	tag_weight_mults = list(TAG_COMBAT = 1.75)
 


### PR DESCRIPTION
Enables voting for "Mime" Story teller. This disables story teller actions, used for when people want a more traditional "Green shift"

Reduces carp spawn in carp events.

Massively lowers jestors and warriors point gain
Lowers i.g most story teller point gains
Removes eletro storm form even triggering
Reducies time for blob to announce it is morbing out
Added Termites to story teller mob spawning
Added spider nests to story teller mob spawning
