### PR TITLE
Brute & Burn Modifiers Rework

### DIFF
--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -141,16 +141,12 @@
 
 /datum/perk/sanityboost/assign(mob/living/carbon/human/H)
 	..()
-	holder.brute_mod_perk /= 1.2
-	holder.burn_mod_perk /= 1.2
-	holder.oxy_mod_perk /= 1.2
-	holder.toxin_mod_perk /= 1.2
+	holder.maxHealth += 40
+    holder.health += 40
 
 /datum/perk/sanityboost/remove()
-	holder.brute_mod_perk *= 1.2
-	holder.burn_mod_perk *= 1.2
-	holder.oxy_mod_perk *= 1.2
-	holder.toxin_mod_perk *= 1.2
+	holder.maxHealth -= 40
+    holder.health -= 40
 	..()
 
 /datum/perk/sure_step
@@ -482,34 +478,31 @@
 
 /datum/perk/job/blackshield_conditioning
 	name = "Blackshield Conditioning"
-	desc = "Thanks to special and intensive training received in the course of your employment with Blackshield, your body is a bit more resistant to brute force damage and burns due to trauma conditioning."
+	desc = "Thanks to special and intensive training received in the course of your employment with Blackshield, with all the practice gained in space you feel you can jump from greater heights and know when to duck-and-cover."
 
 /datum/perk/blackshield_conditioning/assign(mob/living/carbon/human/H)
 	..()
-	holder.brute_mod_perk -= 0.15
-	holder.burn_mod_perk -= 0.10
+	holder.mob_bomb_defense += 20
+	holder.falls_mod -= 0.4
 
 /datum/perk/blackshield_conditioning/remove()
-	holder.brute_mod_perk += 0.15
-	holder.burn_mod_perk += 0.10
+	holder.mob_bomb_defense -= 20
+	holder.falls_mod += 0.4
 	..()
 
 /datum/perk/job/prospector_conditioning
 	name = "Rough and Tumble"
-	desc = "You've been through it all. Spider bites, random cuts on rusted metal, animal claws, getting shot, and even set on fire. As a result, you resist every type of damage just a little bit better than others not of similar toughness."
+	desc = "You've been through it all. Spider bites, random cuts on rusted metal, animal claws, getting shot, and even set on fire. Hell, even a few used needles in desperate times. You feel as though your body fights off infections and addictions much better than others."
+	perk_shared_ability = PERK_SHARED_SEE_ILLEGAL_REAGENTS
 
 /datum/perk/prospector_conditioning/assign(mob/living/carbon/human/H)
 	..()
-	holder.brute_mod_perk -= 0.10
-	holder.burn_mod_perk -= 0.05
-	holder.oxy_mod_perk -= 0.10
-	holder.toxin_mod_perk -= 0.15
+	if(holder)
+		holder.metabolism_effects.nsa_threshold_base *= 1.25
 
 /datum/perk/prospector_conditioning/remove()
-	holder.brute_mod_perk += 0.10
-	holder.burn_mod_perk += 0.05
-	holder.oxy_mod_perk += 0.10
-	holder.toxin_mod_perk += 0.15
+	if(holder)
+		holder.metabolism_effects.nsa_threshold_base /= 1.25
 	..()
 
 /datum/perk/job/butcher

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -498,11 +498,15 @@
 /datum/perk/prospector_conditioning/assign(mob/living/carbon/human/H)
 	..()
 	if(holder)
+		holder.metabolism_effects.addiction_chance_multiplier = 0.1
 		holder.metabolism_effects.nsa_bonus += 25
+		holder.metabolism_effects.calculate_nsa()
 
 /datum/perk/prospector_conditioning/remove()
 	if(holder)
+		holder.metabolism_effects.addiction_chance_multiplier = 1
 		holder.metabolism_effects.nsa_bonus -= 25
+		holder.metabolism_effects.calculate_nsa()
 	..()
 
 /datum/perk/job/butcher

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -141,12 +141,12 @@
 
 /datum/perk/sanityboost/assign(mob/living/carbon/human/H)
 	..()
-	holder.maxHealth += 40
-    holder.health += 40
+	H.maxHealth += 40
+    H.health += 40
 
 /datum/perk/sanityboost/remove()
-	holder.maxHealth -= 40
-    holder.health -= 40
+	H.maxHealth -= 40
+    H.health -= 40
 	..()
 
 /datum/perk/sure_step

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -141,12 +141,12 @@
 
 /datum/perk/sanityboost/assign(mob/living/carbon/human/H)
 	..()
-	H.maxHealth += 40
-    H.health += 40
+	holder.maxHealth += 40
+	holder.health += 40
 
 /datum/perk/sanityboost/remove()
-	H.maxHealth -= 40
-    H.health -= 40
+	holder.maxHealth -= 40
+	holder.health -= 40
 	..()
 
 /datum/perk/sure_step
@@ -498,11 +498,11 @@
 /datum/perk/prospector_conditioning/assign(mob/living/carbon/human/H)
 	..()
 	if(holder)
-		holder.metabolism_effects.nsa_threshold_base *= 1.25
+		holder.metabolism_effects.nsa_bonus += 25
 
 /datum/perk/prospector_conditioning/remove()
 	if(holder)
-		holder.metabolism_effects.nsa_threshold_base /= 1.25
+		holder.metabolism_effects.nsa_bonus -= 25
 	..()
 
 /datum/perk/job/butcher

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -492,7 +492,7 @@
 
 /datum/perk/job/prospector_conditioning
 	name = "Rough and Tumble"
-	desc = "You've been through it all. Spider bites, random cuts on rusted metal, animal claws, getting shot, and even set on fire. Hell, even a few used needles in desperate times. You feel as though your body fights off infections and addictions much better than others."
+	desc = "You've been through it all. Spider bites, random cuts on rusted metal, animal claws, getting shot, and even set on fire. Hell, even a few used needles in desperate times. You feel as though your body fights off the inflictions of to much NSA and addictions much better than others."
 	perk_shared_ability = PERK_SHARED_SEE_ILLEGAL_REAGENTS
 
 /datum/perk/prospector_conditioning/assign(mob/living/carbon/human/H)

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -36,13 +36,13 @@
 
 /datum/perk/nanite_armor/assign(mob/living/carbon/human/H)
 	..()
-	holder.maxHealth += 40
-    holder.health += 40
+	H.maxHealth += 40
+    H.health += 40
 
 /datum/perk/nanite_armor/remove()
 	..()
-	holder.maxHealth -= 40
-    holder.health -= 40
+	H.maxHealth -= 40
+    H.health -= 40
 
 /datum/perk/nanite_chem
 	name = "Nanite Chemicals"

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -36,13 +36,13 @@
 
 /datum/perk/nanite_armor/assign(mob/living/carbon/human/H)
 	..()
-	H.maxHealth += 40
-    H.health += 40
+	holder.maxHealth += 40
+	holder.health += 40
 
 /datum/perk/nanite_armor/remove()
 	..()
-	H.maxHealth -= 40
-    H.health -= 40
+	holder.maxHealth -= 40
+	holder.health -= 40
 
 /datum/perk/nanite_chem
 	name = "Nanite Chemicals"

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -17,23 +17,32 @@
 /datum/perk/nanite_muscle
 	name = "Nanofiber Muscle Therapy"
 	desc = "Through the use of pain killers, implanted nanofibers, and small dispersed drug therapy to critical areas your nanogate has enhanced your physical movement speed and endurance, allowing you to run for \
-	longer stretches at a faster pace without tiring."
+	longer stretches at a faster pace without tiring. Though you feel that all this strain might make your muscles easier to damage if your were to be injured."
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
+
+/datum/perk/nanite_muscle/assign(mob/living/carbon/human/H)
+	..()
+	holder.brute_mod_perk += 0.10
+
+/datum/perk/nanite_muscle/remove()
+	..()
+	holder.brute_mod_perk -= 0.10
 
 /datum/perk/nanite_armor
 	name = "Nanite Skin-Weave"
 	desc = "Through the use of reactive nanites designed to plate together into a shield your machines can reform at a lightning pace to let you physically resist incoming damage by forming a \
-	mesh weave shield just before a strike connects. Effective, but only against physical brute damage."
+	mesh weave shield just before a strike connects."
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
-	var/armor_mod = 0.2
 
 /datum/perk/nanite_armor/assign(mob/living/carbon/human/H)
 	..()
-	holder?.brute_mod_perk -= armor_mod
+	holder.maxHealth += 40
+    holder.health += 40
 
 /datum/perk/nanite_armor/remove()
 	..()
-	holder?.brute_mod_perk += armor_mod
+	holder.maxHealth -= 40
+    holder.health -= 40
 
 /datum/perk/nanite_chem
 	name = "Nanite Chemicals"

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -17,7 +17,7 @@
 /datum/perk/nanite_muscle
 	name = "Nanofiber Muscle Therapy"
 	desc = "Through the use of pain killers, implanted nanofibers, and small dispersed drug therapy to critical areas your nanogate has enhanced your physical movement speed and endurance, allowing you to run for \
-	longer stretches at a faster pace without tiring. Though you feel that all this strain might make your muscles easier to damage if your were to be injured."
+	longer stretches at a faster pace without tiring. Though you feel that all this strain might make your slightly weaker to physical trauma."
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
 
 /datum/perk/nanite_muscle/assign(mob/living/carbon/human/H)

--- a/code/datums/perks/psionic.dm
+++ b/code/datums/perks/psionic.dm
@@ -7,16 +7,12 @@
 
 /datum/perk/psion/assign(mob/living/carbon/human/H)
 	..()
-	holder.brute_mod_perk *= 1.2
-	holder.burn_mod_perk *= 1.2
-	holder.oxy_mod_perk *= 1.2
-	holder.toxin_mod_perk *= 1.2
+	holder.maxHealth -=30
+	holder.health -=30
 
 /datum/perk/psion/remove()
-	holder.brute_mod_perk /= 1.2
-	holder.burn_mod_perk /= 1.2
-	holder.oxy_mod_perk /= 1.2
-	holder.toxin_mod_perk /= 1.2
+	holder.maxHealth +=30
+	holder.health +=30
 	..()
 
 /datum/perk/psi_mania

--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -77,7 +77,6 @@
 	stat_modifiers = list(
 		STAT_BIO = 20,
 		STAT_MEC = 20,
-		STAT_COG = 10,
 		STAT_TGH = 10,
 		STAT_VIG = 10,
 		STAT_ROB = 10
@@ -123,7 +122,8 @@
 	stat_modifiers = list(
 		STAT_TGH = 20,
 		STAT_VIG = 20,
-		STAT_ROB = 20
+		STAT_ROB = 20,
+		STAT_COG = 10
 	)
 
 	perks = list(/datum/perk/stalker, /datum/perk/job/prospector_conditioning)

--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -77,6 +77,7 @@
 	stat_modifiers = list(
 		STAT_BIO = 20,
 		STAT_MEC = 20,
+		STAT_COG = 0,
 		STAT_TGH = 10,
 		STAT_VIG = 10,
 		STAT_ROB = 10

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -37,7 +37,6 @@
 	perks = list(/datum/perk/ass_of_concrete,
 				 /datum/perk/job/blackshield_conditioning,
 				 /datum/perk/job/bolt_reflect,
-				 /datum/perk/codespeak,
 				 /datum/perk/chem_contraband)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
@@ -99,7 +98,6 @@
 	)
 
 	perks = list(/datum/perk/ass_of_concrete,
-				 /datum/perk/job/bolt_reflect,
 				 /datum/perk/codespeak,
 				 /datum/perk/chem_contraband)
 
@@ -211,7 +209,7 @@
 		STAT_VIG = 25,
 	)
 
-	perks = list(/datum/perk/job/blackshield_conditioning, /datum/perk/job/bolt_reflect, /datum/perk/chem_contraband)
+	perks = list(/datum/perk/job/bolt_reflect, /datum/perk/job/blackshield_conditioning, /datum/perk/chem_contraband)
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/camera_monitor)
@@ -318,7 +316,7 @@
 		STAT_ROB = 10,
 	)
 
-	perks = list(/datum/perk/medicalexpertise)
+	perks = list(/datum/perk/medicalexpertise, /datum/perk/job/blackshield_conditioning)
 				// /datum/perk/chemist -Thanos Voice: "I'm sorry little one..."
 
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -172,7 +172,7 @@
 	name_language = null
 	min_age = 18
 	max_age = 160
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 	hunger_factor = DEFAULT_HUNGER_FACTOR/2
 	taste_sensitivity = TASTE_HYPERSENSITIVE
 
@@ -232,12 +232,11 @@
 	name_language = null
 	min_age = 18
 	max_age = 110
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 	taste_sensitivity = TASTE_HYPERSENSITIVE
 	hunger_factor = DEFAULT_HUNGER_FACTOR * 1.25
 	radiation_mod = 0.5
-	toxins_mod = 0.75
-	brute_mod = 0.75
+	total_health = 150
 	siemens_coefficient = 2
 
 	dark_color = "#ff0000"
@@ -294,7 +293,7 @@
 	name_language = null
 	min_age = 18
 	max_age = 130
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 	taste_sensitivity = TASTE_DULL
 	hunger_factor = DEFAULT_HUNGER_FACTOR * 1.25
 
@@ -337,7 +336,7 @@
 	min_age = 18
 	max_age = 60
 	slowdown = -0.5
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 
 	spawn_flags = CAN_JOIN
 
@@ -371,7 +370,7 @@
 	name_language = null
 	min_age = 18
 	max_age = 80
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 	breath_type = "nitrogen"                        // Non-oxygen gas breathed, if any.
 	poison_type = "oxygen"                        // Poisonous air.
 	exhale_type = "carbon_dioxide"
@@ -412,7 +411,7 @@
 	name_language = null
 	min_age = 18
 	max_age = 120
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 	flags = NO_PAIN
 	spawn_flags = CAN_JOIN
 	taste_sensitivity = TASTE_HYPERSENSITIVE
@@ -497,14 +496,13 @@
 	obligate_form = TRUE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite, /datum/unarmed_attack/tail)
 	num_alternate_languages = 2
+	blurb = "no"
 	name_language = null
 	min_age = 18
 	max_age = 90
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
 	spawn_flags = CAN_JOIN
-	burn_mod = 0.85                    // Burn damage multiplier.
+	total_health = 130                    // Burn damage multiplier.
 	radiation_mod = 0
-	toxins_mod = 0.5
 
 	stat_modifiers = list(
 		STAT_BIO = 2,
@@ -672,7 +670,7 @@
 	obligate_name = FALSE
 	name_plural = "FBPs"
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 	reagent_tag = IS_SYNTHETIC
 	hunger_factor = 0
 	flags = NO_BREATHE | NO_PAIN | NO_BLOOD | NO_SCAN | NO_POISON | NO_MINOR_CUT
@@ -721,7 +719,7 @@
 	obligate_name = FALSE
 	name_plural = "FBPs"
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no"
 	reagent_tag = IS_SYNTHETIC
 	hunger_factor = 0
 	flags = NO_BREATHE | NO_PAIN | NO_BLOOD | NO_SCAN | NO_POISON | NO_MINOR_CUT
@@ -770,7 +768,7 @@
 	obligate_name = TRUE
 	obligate_form = TRUE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 	num_alternate_languages = 3
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
 	min_age = 18
@@ -833,7 +831,7 @@
 	obligate_name = TRUE
 	obligate_form = TRUE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 	num_alternate_languages = 3
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
 	min_age = 18
@@ -894,7 +892,7 @@
 	obligate_name = TRUE
 	obligate_form = TRUE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 	num_alternate_languages = 3
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
 	min_age = 18
@@ -953,7 +951,7 @@
 	obligate_name = TRUE
 	obligate_form = TRUE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 	num_alternate_languages = 3
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
 	min_age = 18
@@ -1013,7 +1011,7 @@
 	obligate_name = TRUE
 	obligate_form = TRUE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite)
-	blurb = "How did you find this? Report this to Kazkin if you're reading it."
+	blurb = "no."
 	num_alternate_languages = 3
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
 	min_age = 18

--- a/code/modules/reagents/reagents/race.dm
+++ b/code/modules/reagents/reagents/race.dm
@@ -15,8 +15,8 @@
 	scannable = 1
 
 /datum/reagent/medicine/sabledone/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	M.add_chemical_effect(CE_PAINKILLER, 10000, TRUE)
-	M.apply_effect(-200, AGONY, 0)
+	M.add_chemical_effect(CE_PAINKILLER, 200, TRUE)
+	M.apply_effect(-50, AGONY, 0)
 
 /datum/reagent/stim/marquatol
 	name = "Marquatol"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Since the fact of Blackshield and Prospectors having **extra damage reduction** was brought up **atop of the bonus health** currently given, I've went about removing the job perk damage reductions. This includes for Prospectors, Church and Blackshield, though they have received a changed perk instead. 

- Prospectors have gained a perk that allows them to be more resilient to drug addiction and a soft-buff to their NSA limit, as well as the ability to see what drugs/chems are in a container. To keep Prospector viable over salvager, I have given them a slight bonus to cognition and removed the salvager's bonus to cog, as their perk is better than the Prospector counterpart by a tad bit now.
- Blackshield have gained a perk that increases their resistance to explosions (Akin to Rough Life, which can stack) and lessens their fall damage. Corpsman has received this perk as well since it no longer is a perk to make Blackshield 'less squishy' but rather fit their niche operations and usages.
- Church have had their overwhelming damage protection given to them by standing near obelisks replaced by bonus health instead of taking over-all less damage. This will be tweaked but currently allowing +40 max health and regular health while near them. _This will require tweaking, but agreed upon in planning as a 'good start value' to test._
- Very minor change to Marshals and BS, I have removed Codespeak from the commander and Bolt-Action Training from the Warrant Officer to keep these two jobs unique from one-another rather than sharing many components.

**Species,** similarly, have had changes. Akin to what Moon mentioned in our development chat, I've removed **some** species' modifiers in exchange for bonus total health, allowing the species to sport more health instead of less incoming damages. Examples include:

- Kriosans have lost their brute-damage modifier in exchange for 150 total health (health-buff of 50)
- Cinderites have lost their burn-damage modifier in exchange for 130 total health (health-buff of 30, kept lower than Krios just due to perks being strong.)
- Other species have mostly been untouched by this, mainly due to Mycus, Ra, and Folken being relatively well balanced via healing or taking bonus damage from other means.

**Nanogate** muscles have received a mildly better rework that you take extra-damage while the legs are activated, since this speed-up **does** stack with others. This encourages tactical usage rather than clicking the funni activate button with no true downsides.

**Psions** now don't take 'increased damage' via tons of different negative modifiers, which allows them to possibly die very, very quickly. Instead they simply now have less starting health of 30; regaining this -30 max health by removing the implant, thus removing their powers. This is done to avoid stacking with other modifiers which may make the player incredibly weak beyond reason.

**_TL;DR_** - **Jobs** have lost their straight-up burn/brute/oxy/toxin damage decreases and gained playstyle/niche perks in their place. **Nanogate muscles** now have a downside using the max-health system. **Psionic users** now use the max-health system rather than damage increases. **Species** such as Kriosan and Cinderites now have bonus health instead of damage modifiers. **Sablekyne Last Stand** perk has been balanced.

## Why this is Good for the Game
Here's my rant section to keep the changes separate from my reasoning. This section isn't normally here in PRs. But I'm going to explain it quite simply. 

Many of these changes, such as the Sable chems, some of the modifiers over-all for Nanogate, etc - have been a complaint of mine and some others for some time now. I've decided to bunch them in to this PR since the discussion happened with the merging of the bonus health PR  #3528 . So, this balances around that PR, fixing the fact some jobs received bonus health atop of damage modifiers reductions. Which is outright unfair, and a power-creep issue for factions; especially since we keep buffing mobs for being 'too weak' meanwhile it's the fact certain jobs or the sort have simply been made **too strong**.

While I don't believe at all this was the intention of the PR to exacerbate this, I do believe it is an oversight that I've noticed. I expect **maximum** salt in this PR. But I'm going to be blunt - you _do not_ need extra brute/burn decrease as a **job** perk, atop of your bonus health you are getting from it.

I disagree with brute/burn job perks that cannot be gotten through non-job means as is, let alone their current state. Starting equipment and the 'quirkiness' of perks and/or return-reward is something at should exist, rather than starting all-powerful. I apply this to all jobs, departments and playstyles. Jobs should feel unique, play unique - but not be exclusive for 'I am better than you'.

## Changelog
:cl:
balance: Removes damage modifiers since the extra-health system is in effect. You do not need both extra health and less incoming damage; especially stacked with species perks and other drugs/affects.
balance: Nanogate muscles now have a small trade-off of more incoming damage when going 0.4 faster; since it lacked balance trade-offs that species had.
balance: Kriosans, Cinderites and others have had some balance changes exchanging modifiers out for bonus over-all health.
balance: Sablekyne under the effect of 'last-stand' no longer _fully_ ignore agony damage and pain, but their perk is still notably better than tramadol or the human 'Tenacity' perk.
tweak: Adjusts messages to DM someone no longer part of server development to avoid their DMs flooded by complaints/code issues.
/:cl:
