### PR TITLE
Revert "Balance to Limb Damage"

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -410,7 +410,7 @@ This function restores all organs.
 						/////BRUTE FORCE TRAUMA/////
 			var/mob/living/carbon/human/A = src
 			if (ishuman(A)) // Is the mob being damaged human?
-				if ((organ.name in list("left arm","right arm","left leg","right leg")) && (organ.brute_dam >=45))
+				if ((organ.name in list("left arm","right arm","left leg","right leg")) && (organ.brute_dam >=25))
 					if ((!sharp) && (!edge)) // Blunt Weapon Smash Bone
 						for (var/obj/item/organ/internal/bone/boneHit in organ.internal_organs)
 							boneHit.take_damage(damage)
@@ -441,7 +441,7 @@ This function restores all organs.
 						/////NERVE BURN DAMAGE/////
 			var/mob/living/carbon/human/A = src
 			if (ishuman(A)) // Is the mob being damaged human?
-				if ((organ.nature != MODIFICATION_SILICON) && (organ.burn_dam >=45)) // Is the organ a limb? Is it not synthetic? Is it severely damaged?
+				if ((organ.nature != MODIFICATION_SILICON) && (organ.burn_dam >=25)) // Is the organ a limb? Is it not synthetic? Is it severely damaged?
 					for (var/obj/item/organ/internal/nerve/N in organ.internal_organs) // Check every nerve in the person
 						N.take_damage(damage) // Damage
 


### PR DESCRIPTION
This was a huge mistake for a variety of reasons, from the new PR balancing how job health/etc works to the fact the player that made this was removed from the server months ago and has had absolutely no idea of our recent balance changes nor their effects on gameplay.

Very strange.

But yeah, this was a mistake.

(it also massively decreased the fun both medical doctors and the average player had, as they either needed to rush peridax 5 minutes in or suffer immensely due to having to manually repair each and every limb that took over 40% of its health as damage... Which can be as little as a single empress/emperor/ogre bite as a botanist, for example)