### PR TITLE
Return of some Health to Psionics

### DIFF
--- a/code/datums/perks/psionic.dm
+++ b/code/datums/perks/psionic.dm
@@ -7,12 +7,12 @@
 
 /datum/perk/psion/assign(mob/living/carbon/human/H)
 	..()
-	holder.maxHealth -=30
-	holder.health -=30
+	holder.maxHealth -=20
+	holder.health -=20
 
 /datum/perk/psion/remove()
-	holder.maxHealth +=30
-	holder.health +=30
+	holder.maxHealth +=20
+	holder.health +=20
 	..()
 
 /datum/perk/psi_mania


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Gives some health back to Psionics as-per feedback given on the previous PR that traded their brute/burn modifiers in for instead overall health. (This was done to avoid stacking brute/burn modifiers making them incredibly weak in some cases.)
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
balance: Changes psionic negative health from -30 -> -20 instead to be more fair.
/:cl:
