### PR TITLE
Removes negative health modifiers

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -17,7 +17,6 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	playtimerequired = 2500
 	wage = WAGE_COMMAND
 
-	health_modifier = 1
 	ideal_character_age = 50 // Old geezer captains ftw
 	minimum_character_age = 35
 	outfit_type = /decl/hierarchy/outfit/job/captain

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -72,7 +72,6 @@ Counsel the council on directing the colony towards profitable opportunities."
 	wage = WAGE_LABOUR_DUMB
 	department_account_access = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/cargo/cargo_tech
-	health_modifier = -10
 
 	access = list(
 		access_mailsorting, access_cargo, access_cargo_bot, access_mining,

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -13,7 +13,6 @@
 	req_admin_notify = 1
 	wage = WAGE_COMMAND
 	outfit_type = /decl/hierarchy/outfit/job/medical/cmo
-	health_modifier = -10
 
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_genetics, access_heads,
@@ -75,7 +74,6 @@
 	alt_titles = list("Soteria Nurse", "Soteria Emergency Physician", "Soteria Surgeon", "Soteria Medical Student")
 	outfit_type = /decl/hierarchy/outfit/job/medical/doctor
 	department_account_access = TRUE
-	health_modifier = -15
 
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology,
@@ -178,7 +176,6 @@
 	selection_color = "#a8b69a"
 	alt_titles = list("Soteria Psychologist", "Soteria Empath")
 	outfit_type = /decl/hierarchy/outfit/job/medical/psychiatrist
-	health_modifier = -15
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_psychiatrist, access_chemistry, access_medical_suits
 	)

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -12,7 +12,6 @@
 	selection_color = "#b39aaf"
 	req_admin_notify = 1
 	wage = WAGE_COMMAND
-	health_modifier = -10
 
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
 	playtimerequired = 1200
@@ -71,7 +70,6 @@
 	difficulty = "Medium."
 	selection_color = "#bdb1bb"
 	wage = WAGE_PROFESSIONAL
-	health_modifier = -15
 
 	alt_titles = list("Soteria Xenobiologist", "Soteria Xenoarcheologist", "Soteria Xenobotanist", "Soteria Research Fabricator", "Soteria Geneticist", "Soteria Research Student")
 	outfit_type = /decl/hierarchy/outfit/job/science/scientist
@@ -121,7 +119,6 @@
 	selection_color = "#bdb1bb"
 	wage = WAGE_PROFESSIONAL
 	department_account_access = TRUE
-	health_modifier = -15
 
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Basically does similar to #3565 but only removes negative health modifiers. This is a compromise alternative, fixing the major issue most players took in having negative health. In my opinion, I don't think jobs should have positive or negative health at all - but this PR makes 0 extra health baseline for non-combat/non-command position jobs (instead of -10) and keeps any added health to others jobs (ex prospector, marshal, etc)
</summary>
<hr>
</details>

## Changelog
:cl:
tweak: Removes any negative health added by jobs while not reverting positive health - as a compromise since most players voiced complaints about having negative health rather than the system itself.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
