### PR TITLE
Gun Price Changes

### DIFF
--- a/code/modules/projectiles/guns/energy/cassad.dm
+++ b/code/modules/projectiles/guns/energy/cassad.dm
@@ -11,7 +11,7 @@
 	charge_cost = 40 //20 shots per high medium-sized cell
 	init_recoil = CARBINE_RECOIL(1)
 	origin_tech = list(TECH_COMBAT = 7, TECH_PLASMA = 2)
-	price_tag = 1500
+	price_tag = 1200
 	zoom_factor = null
 	damage_multiplier = 1.1
 	slot_flags = SLOT_BELT|SLOT_BACK

--- a/code/modules/projectiles/guns/energy/cog.dm
+++ b/code/modules/projectiles/guns/energy/cog.dm
@@ -12,7 +12,7 @@
 	projectile_type = /obj/item/projectile/beam
 	fire_delay = 10 //old technology
 	charge_cost = 50
-	price_tag = 900
+	price_tag = 800
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 	init_firemodes = list(
 		WEAPON_NORMAL,

--- a/code/modules/projectiles/guns/energy/disco_vazer.dm
+++ b/code/modules/projectiles/guns/energy/disco_vazer.dm
@@ -15,7 +15,7 @@
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BELT
 	matter = list(MATERIAL_PLASTEEL = 11, MATERIAL_STEEL = 13, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 1, MATERIAL_GLASS = 2)
-	price_tag = 500
+	price_tag = 400
 	damage_multiplier = 0.5 //makeshift laser
 	init_recoil = HANDGUN_RECOIL(0.2)
 	init_offset = 7 //makeshift laser

--- a/code/modules/projectiles/guns/energy/egun.dm
+++ b/code/modules/projectiles/guns/energy/egun.dm
@@ -9,7 +9,7 @@
 	fire_sound = 'sound/weapons/Taser.ogg'
 	charge_cost = 100
 	matter = list(MATERIAL_PLASTEEL = 13, MATERIAL_PLASTIC = 6, MATERIAL_SILVER = 6)
-	price_tag = 750
+	price_tag = 650
 
 	projectile_type = /obj/item/projectile/beam/stun
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
@@ -42,7 +42,7 @@
 	charge_cost = 50
 	origin_tech = list(TECH_COMBAT = 2, TECH_MAGNET = 1)
 	matter = list(MATERIAL_PLASTEEL = 4, MATERIAL_PLASTIC = 4, MATERIAL_SILVER = 2)
-	price_tag = 250
+	price_tag = 300
 	modifystate = null
 	suitable_cell = /obj/item/cell/small
 	cell_type = /obj/item/cell/small
@@ -72,7 +72,7 @@
 	icon_state = "PDWU"
 	charge_cost = 25
 	matter = list(MATERIAL_PLASTEEL = 6, MATERIAL_PLASTIC = 4, MATERIAL_SILVER = 2, MATERIAL_URANIUM = 1)
-	price_tag = 450
+	price_tag = 500
 
 /obj/item/gun/energy/gun/martin/upgraded/update_mode()
 	var/datum/firemode/current_mode = firemodes[sel_mode]
@@ -95,7 +95,7 @@
 	charge_cost = 50
 	can_dual = TRUE
 	matter = list(MATERIAL_PLASTEEL = 4, MATERIAL_WOOD = 4, MATERIAL_SILVER = 2)
-	price_tag = 150
+	price_tag = 200
 	init_firemodes = list(
 		LETHAL,
 		WEAPON_CHARGE

--- a/code/modules/projectiles/guns/energy/glock.dm
+++ b/code/modules/projectiles/guns/energy/glock.dm
@@ -27,7 +27,7 @@
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SIGHT)
 	init_firemodes = list(
 		list(mode_name="plasma bolt", mode_desc="Hard hitting plasma bolts to reduce armor", projectile_type=/obj/item/projectile/plasma, fire_sound='sound/weapons/Laser.ogg', charge_cost=120, fire_delay=8, icon="destroy", projectile_color = "#00AAFF"),
-		list(mode_name="laser", mode_desc="Weak laser to pierce armor and skin", projectile_type=/obj/item/projectile/beam/midlaser, fire_sound='sound/weapons/Taser3.ogg', charge_cost=80, fire_delay=0.5, icon="kill", projectile_color = "#00AAFF"),
+		list(mode_name="laser", mode_desc="Weak laser to pierce armor and skin", projectile_type=/obj/item/projectile/beam, fire_sound='sound/weapons/Taser3.ogg', charge_cost=80, fire_delay=0.5, icon="kill", projectile_color = "#00AAFF"),
 		list(mode_name="ion shot", mode_desc="An iodizing shot to disable cells, electronics and cybernetics ", projectile_type=/obj/item/projectile/ion, fire_sound='sound/effects/supermatter.ogg', fire_delay=12, charge_cost=300, icon="charge", projectile_color = "#ff7f24"),
 	)
 	serial_type = "NM"

--- a/code/modules/projectiles/guns/energy/heavypulserifle.dm
+++ b/code/modules/projectiles/guns/energy/heavypulserifle.dm
@@ -11,7 +11,8 @@
 	origin_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 3, TECH_POWER = 4)
 	w_class = ITEM_SIZE_HUGE
 	force = WEAPON_FORCE_PAINFUL
-	projectile_type = 4000 //1 heavy shot of this with most basic cells. Titanic but with bigger stats basiclly
+	projectile_type = /obj/item/projectile/beam/pulse
+	charge_cost = 4000 //1 heavy shot of this with most basic cells. Titanic but with bigger stats basiclly
 	fire_delay = 36 //Upgrades will make this fire way faster making it something you have to modife more then once to get a real bang out of it
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_SILVER = 10)
 	damage_multiplier = 1.1 //Deals 44~ per shot and can be upgraded. Titanic but with bigger stats basiclly

--- a/code/modules/projectiles/guns/energy/heavypulserifle.dm
+++ b/code/modules/projectiles/guns/energy/heavypulserifle.dm
@@ -12,7 +12,7 @@
 	w_class = ITEM_SIZE_HUGE
 	force = WEAPON_FORCE_PAINFUL
 	projectile_type = /obj/item/projectile/beam/pulse
-	charge_cost = 4000 //1 heavy shot of this with most basic cells. Titanic but with bigger stats basiclly
+	charge_cost = 6000 //1 heavy shot of this with most basic cells. Titanic but with bigger stats basiclly
 	fire_delay = 36 //Upgrades will make this fire way faster making it something you have to modife more then once to get a real bang out of it
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_SILVER = 10)
 	damage_multiplier = 1.1 //Deals 44~ per shot and can be upgraded. Titanic but with bigger stats basiclly

--- a/code/modules/projectiles/guns/energy/heavypulserifle.dm
+++ b/code/modules/projectiles/guns/energy/heavypulserifle.dm
@@ -11,8 +11,7 @@
 	origin_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 3, TECH_POWER = 4)
 	w_class = ITEM_SIZE_HUGE
 	force = WEAPON_FORCE_PAINFUL
-	projectile_type = /obj/item/projectile/beam/pulse
-	charge_cost = 6000 //1 heavy shot of this with most basic cells. Titanic but with bigger stats basiclly
+	projectile_type = 4000 //1 heavy shot of this with most basic cells. Titanic but with bigger stats basiclly
 	fire_delay = 36 //Upgrades will make this fire way faster making it something you have to modife more then once to get a real bang out of it
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_SILVER = 10)
 	damage_multiplier = 1.1 //Deals 44~ per shot and can be upgraded. Titanic but with bigger stats basiclly

--- a/code/modules/projectiles/guns/energy/ionrifle.dm
+++ b/code/modules/projectiles/guns/energy/ionrifle.dm
@@ -39,7 +39,7 @@
 	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_HOLSTER
 	charge_cost = 400
 	matter = list(MATERIAL_PLASTEEL = 16, MATERIAL_PLASTIC = 5, MATERIAL_SILVER = 8)
-	price_tag = 1400
+	price_tag = 1250
 	projectile_type = /obj/item/projectile/ion
 	init_recoil = CARBINE_RECOIL(1)
 	twohanded = FALSE

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -11,7 +11,7 @@
 	force = WEAPON_FORCE_NORMAL
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 5)
-	price_tag = 1250
+	price_tag = 550
 	projectile_type = /obj/item/projectile/beam/midlaser
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 	init_firemodes = list(
@@ -54,7 +54,7 @@
 	name = "OT LG \"Lightfall\" - P"
 	desc = "A modified version of \"Old Testament\" brand laser carbine, this one fires less concentrated energy bolts, designed for target practice."
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 2)
-	price_tag = 500
+	price_tag = 250
 	projectile_type = /obj/item/projectile/beam/practice
 
 /obj/item/gun/energy/captain
@@ -96,7 +96,7 @@
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	slot_flags = SLOT_BELT
 	matter = list(MATERIAL_PLASTEEL = 13, MATERIAL_STEEL = 15, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_GLASS = 4)
-	price_tag = 1100
+	price_tag = 850
 	damage_multiplier = 0.8
 	init_recoil = CARBINE_RECOIL(0.2)
 	projectile_type = /obj/item/projectile/beam
@@ -158,7 +158,7 @@
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_STEEL = 8, MATERIAL_SILVER = 10, MATERIAL_GOLD = 2)
 	charge_cost = 120
 	fire_delay = 10
-	price_tag = 1200
+	price_tag = 950
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 	init_firemodes = list(
 		WEAPON_NORMAL
@@ -223,7 +223,7 @@
 	init_recoil = CARBINE_RECOIL(0.1)
 	damage_multiplier = 0.75
 	penetration_multiplier = 1.0
-	price_tag = 3000
+	price_tag = 1500
 	charge_cost = 20
 	gun_tags = list(GUN_LASER, GUN_ENERGY)
 	init_firemodes = list(
@@ -340,7 +340,7 @@
 	can_dual = TRUE
 	charge_cost = 160
 	matter = list(MATERIAL_PLASTEEL = 13, MATERIAL_PLASTIC = 6, MATERIAL_SILVER = 6)
-	price_tag = 1600
+	price_tag = 1400
 
 	init_firemodes = list(
 		list(mode_name="stunshot", projectile_type=/obj/item/projectile/energy/electrode/stunshot, fire_sound = 'sound/weapons/Taser.ogg', fire_delay=80, icon="stun"),

--- a/code/modules/projectiles/guns/energy/laser_cannon.dm
+++ b/code/modules/projectiles/guns/energy/laser_cannon.dm
@@ -13,7 +13,7 @@
 	charge_cost = 100
 	fire_delay = 20
 	matter = list(MATERIAL_STEEL = 25, MATERIAL_SILVER = 6)
-	price_tag = 500
+	price_tag = 650
 	init_recoil = CARBINE_RECOIL(1)
 	twohanded = TRUE
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/energy/mindflayer.dm
+++ b/code/modules/projectiles/guns/energy/mindflayer.dm
@@ -5,7 +5,7 @@
 	icon_state = "xray"
 	projectile_type = /obj/item/projectile/beam/mindflayer
 	fire_sound = 'sound/weapons/Laser.ogg'
-	price_tag = 1500
+	price_tag = 1250
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 	can_dual = FALSE
 	serial_type = "INDEX"

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -10,7 +10,7 @@
 	self_recharge = 1
 	modifystate = null
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_URANIUM = 10)
-	price_tag = 2000
+	price_tag = 1700
 	charge_cost = 50
 	can_dual = FALSE
 	twohanded = TRUE

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -73,7 +73,7 @@
 	matter = list(MATERIAL_STEEL = 2, "biomatter" = 20)
 	disposable = TRUE
 	origin_tech = list(TECH_COMBAT = 1, TECH_PLASMA = 1)
-	price_tag = 200
+	price_tag = 250
 	fire_sound = 'sound/weapons/Laser.ogg'
 	cell_type = /obj/item/cell/small //can't recharge this one
 	sel_mode = 2

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -14,7 +14,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_RIFLE
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 10)
-	price_tag = 1500
+	price_tag = 1000
 	fire_sound = 'sound/weapons/guns/fire/ltrifle_fire.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
@@ -88,7 +88,7 @@
 	force = WEAPON_FORCE_NORMAL
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_PLASTIC = 10, MATERIAL_SILVER = 10, MATERIAL_GOLD = 5)
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_MAGNET = 3, TECH_POWER = 5)
-	price_tag = 2000
+	price_tag = 1500
 	init_recoil = RIFLE_RECOIL(0.4)
 	damage_multiplier = 1.2 //We hold less ammo but deal about the same damage
 	saw_off = FALSE
@@ -110,7 +110,7 @@
 	icon_state = "AK"
 	item_state = "AK"
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
-	price_tag = 1200
+	price_tag = 900
 	init_recoil = RIFLE_RECOIL(0.9)
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	saw_off = TRUE
@@ -128,7 +128,7 @@
 	force = WEAPON_FORCE_NORMAL
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 5)
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
-	price_tag = 850
+	price_tag = 800
 	init_recoil = RIFLE_RECOIL(1)
 	damage_multiplier = 1
 	saw_off = FALSE

--- a/code/modules/projectiles/guns/projectile/automatic/bren.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/bren.dm
@@ -13,7 +13,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_STANMAG
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 3, MATERIAL_WOOD = 12)
-	price_tag = 1100
+	price_tag = 900
 	damage_multiplier = 0.9
 	fire_sound = 'sound/weapons/guns/fire/ltrifle_fire.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/buckler.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/buckler.dm
@@ -16,7 +16,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_SMG|MAG_WELL_PISTOL|MAG_WELL_DRUM
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 12, MATERIAL_GLASS = 5)
-	price_tag = 700
+	price_tag = 600
 	damage_multiplier = 0.9
 	penetration_multiplier = 1.1
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SILENCABLE, GUN_SCOPE, GUN_CALIBRE_9MM)

--- a/code/modules/projectiles/guns/projectile/automatic/dp.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dp.dm
@@ -17,7 +17,7 @@
 	mag_well = MAG_WELL_PAN
 	tac_reloads = FALSE
 	matter = list(MATERIAL_PLASTEEL = 50, MATERIAL_PLASTIC = 15, MATERIAL_WOOD = 10, MATERIAL_STEEL = 20)
-	price_tag = 2500
+	price_tag = 1600
 	unload_sound 	= 'sound/weapons/guns/interact/lmg_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/lmg_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/lmg_cock.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/drozd.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/drozd.dm
@@ -12,7 +12,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_PISTOL|MAG_WELL_SMG|MAG_WELL_H_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 3)
-	price_tag = 1000
+	price_tag = 750
 	damage_multiplier = 0.95
 	init_recoil = SMG_RECOIL(0.4)
 	twohanded = FALSE

--- a/code/modules/projectiles/guns/projectile/automatic/duty.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/duty.dm
@@ -16,6 +16,7 @@
 	mag_well = MAG_WELL_STANMAG
 	load_method = SINGLE_CASING|SPEEDLOADER|MAGAZINE
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 25)
+	price_tag = 800
 	damage_multiplier = 1.1
 	penetration_multiplier = 1.1
 	init_recoil = CARBINE_RECOIL(0.9)

--- a/code/modules/projectiles/guns/projectile/automatic/freedom.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/freedom.dm
@@ -12,7 +12,7 @@
 	caliber = CAL_MAGNUM
 	mag_well = MAG_WELL_SMG|MAG_WELL_PISTOL
 	can_dual = TRUE
-	price_tag = 900
+	price_tag = 800
 	matter = list(MATERIAL_PLASTEEL = 14, MATERIAL_PLASTIC = 8)
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
@@ -13,7 +13,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_SMG
 	matter = list(MATERIAL_PLASTEEL = 28, MATERIAL_PLASTIC = 10)
-	price_tag = 950
+	price_tag = 800
 	penetration_multiplier = 1.2
 	init_recoil = SMG_RECOIL(0.8)
 	fire_sound = 'sound/weapons/guns/fire/grease_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -16,7 +16,7 @@
 	caliber = CAL_RIFLE
 	tac_reloads = FALSE
 	matter = list(MATERIAL_PLASTEEL = 40, MATERIAL_PLASTIC = 15, MATERIAL_WOOD = 5)
-	price_tag = 2500
+	price_tag = 2000
 	unload_sound 	= 'sound/weapons/guns/interact/lmg_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/lmg_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/lmg_cock.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/luger.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/luger.dm
@@ -9,7 +9,7 @@
 	caliber = CAL_PISTOL
 	mag_well = MAG_WELL_PISTOL|MAG_WELL_SMG|MAG_WELL_H_PISTOL|MAG_WELL_DRUM
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_WOOD = 6, MATERIAL_STEEL = 10)
-	price_tag = 650
+	price_tag = 600
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_9MM)
 	damage_multiplier = 1
 	init_recoil = SMG_RECOIL(0.9)

--- a/code/modules/projectiles/guns/projectile/automatic/mac.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/mac.dm
@@ -12,7 +12,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_SMG|MAG_WELL_H_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 16, MATERIAL_PLASTIC = 4)
-	price_tag = 1000
+	price_tag = 700
 	damage_multiplier = 0.9
 	gun_tags = list(GUN_PROJECTILE,GUN_SILENCABLE, GUN_CALIBRE_9MM, GUN_MAGWELL)
 	init_recoil = SMG_RECOIL(0.7)

--- a/code/modules/projectiles/guns/projectile/automatic/mamba.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/mamba.dm
@@ -17,6 +17,7 @@
 	damage_multiplier = 1.0
 	penetration_multiplier = 1.0
 	zoom_factor = 0.4
+	price_tag = 900
 	init_recoil = CARBINE_RECOIL(1)
 	folding_stock = TRUE
 	can_dual = FALSE //please god please please NO MORE NO MORE GOD, PLEASE
@@ -66,6 +67,7 @@
 	icon_state = "viper"
 	item_state = "viper"
 	matter = list(MATERIAL_PLASTEEL = 17, MATERIAL_PLASTIC = 9)
+	price_tag = 1000
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.2
 	extra_damage_mult_scoped = 0.2
@@ -92,6 +94,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_RIFLE
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 10)
+	price_tag = 1000
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.1
 	zoom_factor = 0.4
@@ -160,6 +163,7 @@
 	caliber = CAL_RIFLE
 	mag_well = MAG_WELL_RIFLE
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 12)
+	price_tag = 1400
 	fire_delay = 15
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.4

--- a/code/modules/projectiles/guns/projectile/automatic/maxim.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/maxim.dm
@@ -15,7 +15,7 @@
 	mag_well = MAG_WELL_PAN
 	tac_reloads = FALSE
 	matter = list(MATERIAL_PLASTEEL = 42, MATERIAL_PLASTIC = 15, MATERIAL_WOOD = 5)
-	price_tag = 3000
+	price_tag = 2500
 	unload_sound 	= 'sound/weapons/guns/interact/lmg_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/lmg_magin.ogg'
 	cocked_sound 	= 'sound/weapons/guns/interact/lmg_cock.ogg'
@@ -35,7 +35,7 @@
 /obj/item/gun/projectile/automatic/maxim/NM_colony
 	name = "\"Maxim\" machine gun"
 	desc = "An old and surprisingly deprecated gun from the Excelsior. One of their more dangerous weapons, effective at dealing with crowds or suppressing firing lines."
-	price_tag = 1000
+	price_tag = 2000
 	serial_type = "NM"
 
 /obj/item/gun/projectile/automatic/maxim/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/nail_gun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/nail_gun.dm
@@ -14,7 +14,7 @@
 	mag_well = MAG_WELL_STANMAG
 	auto_eject = TRUE
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_PLASTIC = 25, MATERIAL_PLATINUM = 20)
-	price_tag = 2500
+	price_tag = 2000
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/sfrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/sfrifle_magin.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/nordwind.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/nordwind.dm
@@ -42,7 +42,7 @@
 	mag_well = MAG_WELL_RIFLE
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SIGHT)
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 10)
-	price_tag = 750
+	price_tag = 800
 	zoom_factor = 0.8
 	damage_multiplier = 1 //Little bit better Strelki
 	extra_damage_mult_scoped = 0.3
@@ -67,7 +67,7 @@
 	mag_well = MAG_WELL_RIFLE
 	gun_tags = list(GUN_PROJECTILE)
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 10, MATERIAL_WOOD = 10)
-	price_tag = 750
+	price_tag = 700
 	zoom_factor = 0.6
 	damage_multiplier = 0.9
 	extra_damage_mult_scoped = 0.3

--- a/code/modules/projectiles/guns/projectile/automatic/ostwind.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ostwind.dm
@@ -13,7 +13,7 @@
 	mag_well = MAG_WELL_STANMAG
 	auto_eject = 1
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 10)
-	price_tag = 2000
+	price_tag = 1750
 	fire_sound = 'sound/weapons/guns/fire/ltrifle_fire.ogg'
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/ppsh.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ppsh.dm
@@ -14,7 +14,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_DRUM
 	matter = list(MATERIAL_PLASTEEL = 28, MATERIAL_PLASTIC = 10)
-	price_tag = 1500
+	price_tag = 1000
 	penetration_multiplier = 1.2
 	fire_sound = 'sound/weapons/guns/fire/grease_fire.ogg'
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_9MM)
@@ -54,7 +54,7 @@
 	item_state = "ppv"
 	mag_well = MAG_WELL_SMG|MAG_WELL_DRUM
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2)
-	price_tag = 1200
+	price_tag = 800
 	damage_multiplier = 0.9
 	penetration_multiplier = 1.0
 	init_recoil = SMG_RECOIL(1.3)

--- a/code/modules/projectiles/guns/projectile/automatic/pulse_rifle.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/pulse_rifle.dm
@@ -15,7 +15,7 @@
 	mag_well = MAG_WELL_PULSE
 	auto_eject = 1
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 15)
-	price_tag = 3000 //99 rounds of pure pain and destruction served in auto-fire, so it basically an upgraded LMG
+	price_tag = 2200 //99 rounds of pure pain and destruction served in auto-fire, so it basically an upgraded LMG
 	fire_sound = 'sound/weapons/guns/fire/m41_shoot.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/m41_reload.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/scaffold.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/scaffold.dm
@@ -14,7 +14,7 @@
 	mag_well = MAG_WELL_PULSE
 	auto_eject = TRUE
 	matter = list(MATERIAL_PLASTEEL = 35, MATERIAL_PLASTIC = 35, MATERIAL_PLATINUM = 20)
-	price_tag = 2500
+	price_tag = 2000
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/sfrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/sfrifle_magin.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/solmarine.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/solmarine.dm
@@ -9,7 +9,7 @@
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 6)
 	mag_well = MAG_WELL_STANMAG
 	caliber = CAL_LRIFLE
-	price_tag = 1250
+	price_tag = 1100
 	damage_multiplier = 1.0
 	penetration_multiplier = 1.2
 	init_recoil = CARBINE_RECOIL(1.1)

--- a/code/modules/projectiles/guns/projectile/automatic/specop.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/specop.dm
@@ -13,6 +13,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well =  MAG_WELL_RIFLE
 	matter = list(MATERIAL_PLASTEEL = 14, MATERIAL_STEEL = 6, MATERIAL_PLASTIC = 8)
+	price_tag = 1150
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	damage_multiplier = 1.2

--- a/code/modules/projectiles/guns/projectile/automatic/sts.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts.dm
@@ -12,7 +12,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_STANMAG
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 12)
-	price_tag = 1650
+	price_tag = 850
 	fire_sound = 'sound/weapons/guns/fire/ltrifle_fire.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/ltrifle_magin.ogg'
@@ -55,7 +55,7 @@
 	icon = 'icons/obj/guns/projectile/sts25.dmi'
 	icon_state = "sts"
 	item_state = "sts"
-	price_tag = 1250
+	price_tag = 850
 	gun_tags = list(GUN_PROJECTILE,GUN_SILENCABLE, GUN_MAGWELL)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 12)
 	saw_off = TRUE
@@ -104,7 +104,7 @@
 	icon = 'icons/obj/guns/projectile/sts30.dmi'
 	icon_state = "sts"
 	item_state = "sts"
-	price_tag = 1500
+	price_tag = 1000
 	w_class = ITEM_SIZE_HUGE
 	caliber = CAL_RIFLE
 	mag_well = MAG_WELL_RIFLE
@@ -127,6 +127,7 @@
 	icon = 'icons/obj/guns/projectile/sawnoff/sts30.dmi'
 	icon_state = "sts"
 	item_state = "sts"
+	price_tag = 800
 	w_class = ITEM_SIZE_BULKY
 	caliber = CAL_RIFLE
 	mag_well = MAG_WELL_RIFLE
@@ -193,7 +194,7 @@
 	w_class = ITEM_SIZE_HUGE
 	caliber = CAL_HRIFLE
 	mag_well = MAG_WELL_HRIFLE|MAG_WELL_DRUM
-	price_tag = 1750
+	price_tag = 1500
 	penetration_multiplier = 1.1
 	damage_multiplier = 1.1
 	init_recoil = RIFLE_RECOIL(1.7)
@@ -211,6 +212,7 @@
 	icon = 'icons/obj/guns/projectile/sts40.dmi'
 	icon_state = "sts"
 	item_state = "sts"
+	price_tag = 1125
 	w_class = ITEM_SIZE_BULKY
 	penetration_multiplier = 0.8
 	damage_multiplier = 1

--- a/code/modules/projectiles/guns/projectile/automatic/tommygun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/tommygun.dm
@@ -15,7 +15,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_SMG|MAG_WELL_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_STEEL = 14, MATERIAL_WOOD = 12)
-	price_tag = 1500
+	price_tag = 850
 	penetration_multiplier = 0.8
 	init_recoil = SMG_RECOIL(0.8)
 	fire_sound = 'sound/weapons/guns/fire/grease_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/triage.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/triage.dm
@@ -15,7 +15,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_SMG|MAG_WELL_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_STEEL = 14, MATERIAL_PLASTIC = 12, MATERIAL_PLATINUM = 3)
-	price_tag = 1850
+	price_tag = 900
 	penetration_multiplier = 1.2
 	init_recoil = SMG_RECOIL(0.6)
 	fire_sound_silenced = 'sound/weapons/guns/fire/grease_fire.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/vector.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vector.dm
@@ -19,7 +19,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_SMG|MAG_WELL_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 12, MATERIAL_GLASS = 5, MATERIAL_SILVER = 3, MATERIAL_PLASMA = 2, MATERIAL_GOLD = 1) //Some rare ones so they dont just mass make this shift start without some good rng
-	price_tag = 1100
+	price_tag = 1000
 	damage_multiplier = 0.7 //Not the best gun in the world
 	init_recoil = SMG_RECOIL(1)
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SILENCABLE, GUN_SCOPE)

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -13,7 +13,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_RIFLE //need a new magwell type?
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 5)
-	price_tag = 2000
+	price_tag = 1125
 	zoom_factor = 0.8 // double as IH_heavy
 	penetration_multiplier = 1.2
 	damage_multiplier = 1.2

--- a/code/modules/projectiles/guns/projectile/automatic/wirbelwind.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wirbelwind.dm
@@ -13,7 +13,7 @@
 	auto_eject = 1
 	can_dual = TRUE
 	matter = list(MATERIAL_PLASTEEL = 16, MATERIAL_PLASTIC = 4)
-	price_tag = 1500 //good smg with normal recoil and silencer possibility
+	price_tag = 750
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	damage_multiplier = 0.9
 	init_recoil = SMG_RECOIL(1.1)

--- a/code/modules/projectiles/guns/projectile/boltgun/anti_materiel_sniper.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/anti_materiel_sniper.dm
@@ -17,7 +17,7 @@
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/rifle_load.ogg'
 	matter = list(MATERIAL_PLASTEEL = 40, MATERIAL_PLASTIC = 20, MATERIAL_DIAMOND = 3, MATERIAL_OSMIUM = 5, MATERIAL_URANIUM = 2)
-	price_tag = 5000
+	price_tag = 7500
 	damage_multiplier = 0.9
 	zoom_factor = 2.0
 	twohanded = TRUE

--- a/code/modules/projectiles/guns/projectile/boltgun/anti_materiel_sniper.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/anti_materiel_sniper.dm
@@ -17,7 +17,7 @@
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/rifle_load.ogg'
 	matter = list(MATERIAL_PLASTEEL = 40, MATERIAL_PLASTIC = 20, MATERIAL_DIAMOND = 3, MATERIAL_OSMIUM = 5, MATERIAL_URANIUM = 2)
-	price_tag = 10000
+	price_tag = 5000
 	damage_multiplier = 0.9
 	zoom_factor = 2.0
 	twohanded = TRUE

--- a/code/modules/projectiles/guns/projectile/boltgun/armstrong.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/armstrong.dm
@@ -8,7 +8,7 @@
 	force = WEAPON_FORCE_PAINFUL
 	caliber = CAL_MAGNUM
 	max_shells = 11
-	price_tag = 750
+	price_tag = 650
 	init_recoil = HMG_RECOIL(0.4)
 	damage_multiplier = 1.2
 	penetration_multiplier  = 1.1
@@ -26,6 +26,6 @@
 	item_state = "custer"
 	caliber = CAL_HRIFLE
 	max_shells = 7
-	price_tag = 1150
+	price_tag = 1250
 	init_recoil = HMG_RECOIL(0.6)
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 15, MATERIAL_WOOD = 10)

--- a/code/modules/projectiles/guns/projectile/boltgun/baroque.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/baroque.dm
@@ -31,7 +31,7 @@ Own a musket for department defense, since that's what the founding hunters inte
 	fire_sound = 'sound/weapons/guns/fire/sniper_fire.ogg'
 	reload_sound 	= 'sound/weapons/guns/interact/rifle_load.ogg'
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_BONE = 20)
-	price_tag = 750
+	price_tag = 1750
 	extra_damage_mult_scoped = 0.4
 	zoom_factor = 1.4
 	twohanded = TRUE

--- a/code/modules/projectiles/guns/projectile/boltgun/novakovic.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/novakovic.dm
@@ -7,7 +7,7 @@
 	icon_state = "boltgun"
 	item_state = "boltgun"
 	max_shells = 5
-	price_tag = 300
+	price_tag = 450
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_WOOD = 10)
 	saw_off = TRUE
 	sawn = /obj/item/gun/projectile/boltgun/sawn/sa

--- a/code/modules/projectiles/guns/projectile/boltgun/roe_sika.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/roe_sika.dm
@@ -7,7 +7,7 @@
 	max_shells = 10
 	zoom_factor = 2.0
 	init_recoil = HMG_RECOIL(0.5)
-	price_tag = 1000
+	price_tag = 750
 	damage_multiplier = 1.25
 	sharp = FALSE
 	force = WEAPON_FORCE_PAINFUL
@@ -44,7 +44,7 @@
 	max_shells = 10
 	init_recoil = HMG_RECOIL(0.5)
 	zoom_factor = 2.0
-	price_tag = 1000
+	price_tag = 750
 	damage_multiplier = 1.25
 	force = WEAPON_FORCE_PAINFUL
 	sharp = FALSE

--- a/code/modules/projectiles/guns/projectile/boltgun/star_striker.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/star_striker.dm
@@ -7,7 +7,7 @@
 	icon_state = "starstriker"
 	item_state = "starstriker"
 	max_shells = 10
-	price_tag = 450
+	price_tag = 250 //Massprintable form rnd, prevents it form being exported on mass for to cheap
 	damage_multiplier = 1.4 //So were worth using
 	extra_damage_mult_scoped = 0.5
 	force = WEAPON_FORCE_PAINFUL

--- a/code/modules/projectiles/guns/projectile/boltgun/star_striker.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/star_striker.dm
@@ -7,7 +7,7 @@
 	icon_state = "starstriker"
 	item_state = "starstriker"
 	max_shells = 10
-	price_tag = 250 //no...
+	price_tag = 450
 	damage_multiplier = 1.4 //So were worth using
 	extra_damage_mult_scoped = 0.5
 	force = WEAPON_FORCE_PAINFUL

--- a/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
@@ -9,7 +9,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 8)
-	price_tag = 1200 //Still worth alot despite being shit.
+	price_tag = 750 //Still worth alot despite being shit.
 	can_dual = TRUE
 	damage_multiplier = 1
 	penetration_multiplier = 0.9

--- a/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
@@ -10,7 +10,7 @@
 	silenced = 0
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	matter = list(MATERIAL_PLASTEEL = 8, MATERIAL_PLASTIC = 6)
-	price_tag = 250
+	price_tag = 200
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_PISTOL | MAG_WELL_H_PISTOL | MAG_WELL_DRUM
@@ -51,7 +51,7 @@
 	icon_state = "makarov"
 	damage_multiplier = 1.1
 	init_recoil = HANDGUN_RECOIL(0.4)
-	price_tag = 700
+	price_tag = 500
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_ILLEGAL = 3)
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -12,7 +12,7 @@
 	can_dual = TRUE
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_PISTOL | MAG_WELL_H_PISTOL
-	damage_multiplier = 1.2
+	damage_multiplier = 1.1
 	init_recoil = HANDGUN_RECOIL(0.4)
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_9MM, GUN_SILENCABLE, GUN_MAGWELL)
 	serial_type = "H&S"
@@ -24,6 +24,7 @@
 	item_state = "colt"
 	caliber = CAL_PISTOL
 	mag_well = MAG_WELL_PISTOL | MAG_WELL_H_PISTOL
+	price_tag = 500
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 5)
@@ -41,12 +42,12 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_PISTOL
 	matter = list(MATERIAL_PLASTEEL = 18, MATERIAL_PLASTIC = 8)
-	price_tag = 900
+	price_tag = 550
 	fire_sound = 'sound/weapons/guns/fire/hpistol_fire.ogg'
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL
 	init_recoil = HANDGUN_RECOIL(0.5)
-	damage_multiplier = 1.1
+	damage_multiplier = 1.2
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SILENCABLE)
 	serial_type = "SA"
 
@@ -66,7 +67,7 @@
 	icon_state = "liberty"
 	item_state = "liberty"
 	caliber = CAL_MAGNUM
-	price_tag = 750
+	price_tag = 650
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6)
 	damage_multiplier = 1.0
 	penetration_multiplier = 1.3

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -12,7 +12,7 @@
 	can_dual = TRUE
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_PISTOL | MAG_WELL_H_PISTOL
-	damage_multiplier = 1.1
+	damage_multiplier = 1.2
 	init_recoil = HANDGUN_RECOIL(0.4)
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_9MM, GUN_SILENCABLE, GUN_MAGWELL)
 	serial_type = "H&S"
@@ -47,7 +47,7 @@
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL
 	init_recoil = HANDGUN_RECOIL(0.5)
-	damage_multiplier = 1.2
+	damage_multiplier = 1.1
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SILENCABLE)
 	serial_type = "SA"
 

--- a/code/modules/projectiles/guns/projectile/pistol/glock.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/glock.dm
@@ -7,7 +7,7 @@
 	caliber = CAL_PISTOL
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6)
-	price_tag = 800
+	price_tag = 600
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	can_dual = TRUE
 	load_method = SINGLE_CASING|MAGAZINE

--- a/code/modules/projectiles/guns/projectile/pistol/judiciary.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/judiciary.dm
@@ -8,7 +8,7 @@
 	caliber = CAL_PISTOL
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6)
-	price_tag = 800
+	price_tag = 550
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	can_dual = TRUE
 	load_method = SINGLE_CASING|MAGAZINE

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -57,7 +57,7 @@
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	zoom_factor = 0.4
 	init_recoil = HANDGUN_RECOIL(1)
-	price_tag = 1250
+	price_tag = 1100
 	serial_type = "SD GmbH"
 
 /obj/item/gun/projectile/lamia/scoped/dark
@@ -70,7 +70,7 @@
 	init_recoil = HANDGUN_RECOIL(0.7)
 	damage_multiplier = 1.3
 	penetration_multiplier = 1.2
-	price_tag = 1100
+	price_tag = 1200
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	serial_type = "Sol Fed"
@@ -86,7 +86,7 @@
 	init_recoil = HANDGUN_RECOIL(0.1)
 	damage_multiplier = 0.9
 	penetration_multiplier = 1.2
-	price_tag = 1250
+	price_tag = 1300
 	serial_type = "Sol Fed"
 
 /obj/item/gun/projectile/lamia/akurra
@@ -99,7 +99,7 @@
 	silenced = TRUE
 	damage_multiplier = 0.95
 	penetration_multiplier = 1.2
-	price_tag = 1250
+	price_tag = 1400
 	serial_type = "SA"
 
 /obj/item/gun/projectile/lamia/amnesty

--- a/code/modules/projectiles/guns/projectile/pistol/mk58.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mk58.dm
@@ -7,7 +7,7 @@
 	caliber = CAL_PISTOL
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6)
-	price_tag = 650
+	price_tag = 450
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	can_dual = TRUE
 	load_method = SINGLE_CASING|MAGAZINE
@@ -42,7 +42,7 @@
 	icon_state = "mk58"
 	item_state = "mk58"
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
-	price_tag = 750
+	price_tag = 550
 	mag_well = MAG_WELL_PISTOL
 	caliber = CAL_MAGNUM
 	damage_multiplier = 0.9

--- a/code/modules/projectiles/guns/projectile/pistol/silenced.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/silenced.dm
@@ -10,7 +10,7 @@
 	silenced = TRUE
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6)
-	price_tag = 750
+	price_tag = 800
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_PISTOL
 	proj_step_multiplier = 0.8

--- a/code/modules/projectiles/guns/projectile/pistol/spring.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/spring.dm
@@ -12,7 +12,6 @@
 	can_dual = TRUE
 	silenced = FALSE
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6, MATERIAL_PLATINUM = 6)
-	price_tag = 850
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_PISTOL | MAG_WELL_H_PISTOL | MAG_WELL_DRUM

--- a/code/modules/projectiles/guns/projectile/revolver/breakaction.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/breakaction.dm
@@ -10,7 +10,7 @@
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2)
 	max_shells = 6
 	matter = list(MATERIAL_PLASTEEL = 14, MATERIAL_WOOD = 6)
-	price_tag = 800
+	price_tag = 700
 	damage_multiplier = 1.4
 	penetration_multiplier = 1.3
 	init_recoil = HANDGUN_RECOIL(1.2)
@@ -49,7 +49,7 @@
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	fire_sound = 'sound/weapons/Gunshot_light.ogg'
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_WOOD = 6)
-	price_tag = 350
+	price_tag = 300
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.3
 	init_recoil = HANDGUN_RECOIL(1.1)

--- a/code/modules/projectiles/guns/projectile/revolver/deckard.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/deckard.dm
@@ -7,7 +7,7 @@
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	max_shells = 5
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
-	price_tag = 1400 //one of most robust revolvers here
+	price_tag = 1300 //one of most robust revolvers here
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.5
 	init_recoil = HANDGUN_RECOIL(1.5)

--- a/code/modules/projectiles/guns/projectile/revolver/judge.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/judge.dm
@@ -9,7 +9,7 @@
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
 	max_shells = 5
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 6)
-	price_tag = 1500
+	price_tag = 1400
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.4
 	init_recoil = HANDGUN_RECOIL(1.5)

--- a/code/modules/projectiles/guns/projectile/revolver/mistral.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/mistral.dm
@@ -10,7 +10,7 @@
 	max_shells = 6
 	ammo_type = /obj/item/ammo_casing/magnum_40/rubber
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 8)
-	price_tag = 900
+	price_tag = 850
 	damage_multiplier = 1.3
 	penetration_multiplier = 1.5
 	init_recoil = RIFLE_RECOIL(0.6)

--- a/code/modules/projectiles/guns/projectile/revolver/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/revolver.dm
@@ -16,7 +16,7 @@
 	cocked_sound 	= 'sound/weapons/guns/interact/rev_cock.ogg'
 	fire_sound = 'sound/weapons/guns/fire/revolver_fire.ogg'
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 8)
-	price_tag = 800
+	price_tag = 650
 	fire_delay = 3 //all revolvers can fire faster, but have huge recoil
 	damage_multiplier = 1.2
 	armor_penetration = 0.65 // Insanely powerful handcannon, but worthless against heavy armor

--- a/code/modules/projectiles/guns/projectile/revolver/tacticool_revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/tacticool_revolver.dm
@@ -9,7 +9,7 @@
 	fire_delay = 4
 	drawChargeMeter = FALSE
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)
-	price_tag = 1500 //more op and rare than miller, hits harder, but have fun with hittin anything
+	price_tag = 1300 //more op and rare than miller, hits harder, but have fun with hittin anything
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.25
 	zoom_factor = 1.4

--- a/code/modules/projectiles/guns/projectile/revolver/wayfarer.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/wayfarer.dm
@@ -15,7 +15,7 @@
 	ammo_type = /obj/item/ammo_magazine/c10x24
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 5, MATERIAL_IRON = 5, MATERIAL_WOOD = 3)
 	can_dual = TRUE
-	price_tag = 1750
+	price_tag = 1400
 	damage_multiplier = 1.6
 	penetration_multiplier = 2
 	init_recoil = RIFLE_RECOIL(0.1)

--- a/code/modules/projectiles/guns/projectile/shotgun/bull.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bull.dm
@@ -17,7 +17,7 @@
 	var/reload = 1
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 4)
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 6)
-	price_tag = 1200 //gives tactical advantage with beanbags, but consumes more ammo and hits less harder with lethal ammo, so Gladstone or Regulator would be better for lethal takedowns in general
+	price_tag = 1000
 	damage_multiplier = 0.75
 	penetration_multiplier = 0.75
 	init_recoil = RIFLE_RECOIL(1.8)
@@ -41,7 +41,7 @@
 	item_state = "PW"
 	max_shells = 8
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 10)
-	price_tag = 1750
+	price_tag = 1500
 	damage_multiplier = 0.85
 	penetration_multiplier = 0.85
 	init_recoil = RIFLE_RECOIL(1.6)

--- a/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
@@ -19,7 +19,7 @@
 	bulletinsert_sound 	= 'sound/weapons/guns/interact/shotgun_insert.ogg'
 	fire_sound = 'sound/weapons/guns/fire/max_sawn_off.ogg' //Actual double barrel sound
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
-	price_tag = 650
+	price_tag = 600
 	init_recoil = RIFLE_RECOIL(1.3)
 	var/bolt_open = 0
 	burst_delay = 0

--- a/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
@@ -29,7 +29,7 @@
 	damage_multiplier = 0.8
 	penetration_multiplier = 0.9
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 6)
-	price_tag = 450
+	price_tag = 550
 	init_recoil = RIFLE_RECOIL(2.4)
 	saw_off = FALSE
 

--- a/code/modules/projectiles/guns/projectile/shotgun/pug.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/pug.dm
@@ -12,7 +12,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_DRUM //Made for drums, this way it can't be OP despite being literal traitor shotgun
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 10)
-	price_tag = 1750
+	price_tag = 1250
 	fire_sound = 'sound/weapons/guns/fire/riot_shotgun.ogg' //Meatier sound
 	unload_sound = 'sound/weapons/guns/interact/ltrifle_magout.ogg'
 	reload_sound = 'sound/weapons/guns/interact/ltrifle_magin.ogg'

--- a/code/modules/projectiles/guns/projectile/shotgun/rushing_bull.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/rushing_bull.dm
@@ -21,7 +21,7 @@
 	fire_sound = 'sound/weapons/guns/fire/rushingbull.ogg'
 	bulletinsert_sound 	= 'sound/weapons/guns/interact/shotgun_insert.ogg'
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLASTIC = 10)
-	price_tag = 600
+	price_tag = 800
 	penetration_multiplier = 2
 	pierce_multiplier = 2
 	damage_multiplier = 0.6 //Most AP and pens walls but least damage out of any shotgun

--- a/code/modules/projectiles/guns/projectile/shotgun/swat.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/swat.dm
@@ -11,7 +11,7 @@
 	max_shells = 7 //Same as the gladstone
 	ammo_type = /obj/item/ammo_casing/shotgun
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 12)
-	price_tag = 1250
+	price_tag = 1500
 	damage_multiplier = 1.3
 	penetration_multiplier = 1.3
 	init_recoil = RIFLE_RECOIL(0.6)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bunch of files changed but relatively simple PR. Simply makes guns more affordable and reasonable. Most guns have received lower prices while others have had their prices slightly increase. Mostly to make shitty 6.5 carbines, or pistol caliber SMGs, no longer equal to price of the more powerful 8.6 guns.
	
A prime example was the **STS-25**, the **Breacher AK** and the **Hustler Omnirfile**:

All three cost the same price, 1250. Despite the STS-25 being the weakest of the gang chambered in 6.5. The Breacher AK being one of the best AK models in 7.62 with a shotgun slung to it as well. And the Hustler being a great 8.6 rifle that slaps hard.

In turn the prices have been brought more into line. STS-25 being roughly 900, the breacher at 1100, and the omni staying 1250. Their pricing increasing as their effective damage and material cost increases per-gun. Making selling, buying and bartering more accurate to their 'de-facto' value rather than their 'de-jure' value.

## Why is this Drafted????

Simply put, **I have marked this PR as a draft for the moment until people can give me feedback.** This will have _mild_ effects on import and export as well as the grind some people go through to get weapons. I do wish to hear if people think these prices are fair or too high or too low.

Do note, this affects market prices, not individuals selling guns at lower than market or higher than market prices.

**If anyone has feedback on the prices and how to balance them, please leave a comment on this PR or @ me in the discord's dev or general chat.**

## Changelog
:cl:
tweak: Changes gun prices to be a lot more in-line, affordable in terms of 'worse' guns and some guns have received a higher value as they are rare spawns or very effective weapons.
balance: Fixes Galaxy's mid-laser to be a regular beam. I was an idiot back when I designed this and assumed that was the regular laser-rifle path. Adjusted so it's no longer weaker than a Martin's laser but costs more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
