### PR TITLE
[APPROVED] Xenobio buffs & Misc map fixes

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -68,11 +68,13 @@
 ********************/
 /obj/machinery/smartfridge/secure/extract
 	name = "\improper slime extract SmartFridge"
-	desc = "A refrigerated storage unit for slime extracts"
+	desc = "A refrigerated storage unit for slime extracts and potions."
 	req_access = list(access_moebius)
 
 /obj/machinery/smartfridge/secure/extract/accept_check(var/obj/item/O as obj)
 	if(istype(O,/obj/item/slime_extract))
+		return 1
+	if(istype(O,/obj/item/slime_potion))
 		return 1
 	return 0
 

--- a/code/game/machinery/xenobio.dm
+++ b/code/game/machinery/xenobio.dm
@@ -56,7 +56,7 @@
 //Dye vat and its various procs and checks
 /obj/machinery/slime_dye_vat
 	name = "slime dye vat"
-	desc = "This machine holds slime that changes color! Makes it easy to apply to clothing."
+	desc = "This machine takes slimes and crayons of different colors to dye clothing! Remember to scrub it to keep it clean after use, or else..."
 	icon = 'icons/obj/xenobio.dmi'
 	icon_state = "slime_vat"
 	density = TRUE

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -1861,7 +1861,7 @@
 				<body>
 				<H1>Reactions and YOU!</H1>
 				So assuming you have never used a slime core before. The process is simple! One of your still living monkeys could do it.
-				Ideally youll want a dropper, syringe and something to store chemicals in for this. Make sure you have these ready!
+				Ideally you'll want a dropper, syringe and something to store chemicals in for this. Make sure you have these ready!
 				Some reactions take 1 unit of chemicals. Others take 5 units. With slime jelly being unique in compressing at 100 units.
 				<ol>
 					<li><a href='#1'>Grey</a></li>
@@ -1885,81 +1885,81 @@
 				</ol>
 				<a name='1'><H3>Grey</H3>
 				Grey slimes are the starting bread and butter of xenobio. Their reactions allow us to keep making monkeys and are vital to keeping the feeding process going.
-				blood is used to create monkey cubes
-				blattadin is used to make roach cubes
-				spider venom is used to make spiderlings.
+				Blood is used to create monkey cubes.
+				Blattedin is used to make roach cubes
+				Spider venom (Pararein) is used to make spiderlings.
 				<a name='2'><H3>Green</H3>
 				Ideally greens will be made when you have someone doing genetics. They are useful for purgers.
-				water will create a ready to use genetics purger
+				Water will create a ready to use genetics purger
 				plasma (more units at once the better) will create mutation toxin. This will turn people into slime people!
 				<a name='3'><h3>Metal</h3>
 				Metal slimes are a workhorse of the material production process. The first step in getting raw mats for our department.
-				plasma will produce metal sheets and the wonderous plasteel! Used in mass quantities by those seeking armaments or a mech.
-				water will produce some plastics. Ready to be molded into various shapes by lathes.
-				radium will produce uranium. Useful for batteries and such. Be careful of the initial burst of radiation. Protection is needed!
+				Plasma will produce metal sheets and the wondrous plasteel! Used in mass quantities by those seeking armaments or a mech.
+				Water will produce some plastic, ready to be molded into various shapes by lathes.
+				Radium will produce uranium. Useful for batteries and such. Be careful of the initial burst of radiation. Protection is needed!
 				<a name='4'><h3>Gold</h3>
-				Gold slimes are the gateway to adamantine slimes and produce the wonderous bars that every dragon dreams of.
-				plasma will produce gold! Wonderous gold.
+				Gold slimes are the gateway to adamantine slimes and produce the wondrous bars that every dragon dreams of.
+				plasma will produce gold! Wondrous gold.
 				nutriment in 5 units will produce honey. Delicious and useful for other reactions.
 				<a name='5'><h3>Silver</h3>
 				Silver slimes are a strange breed. They produce food based items. Not quite sure why. But it tends to be tasty. They can also produce silver! For batteries and such.
-				plasma will create a bright (eye protection suggested) flash before food appears! I've yet to figure out how it can cook such a strange abundance.
-				nutriment will create universal enzyme. A favorite of mine to make my favorite drinks. Sweet sweet curacoa.
-				liquid uranium will create silver bars. Useful and generally needed in decent quantities.
+				Plasma will create a bright (eye protection suggested) flash before food appears! I've yet to figure out how it can cook such a strange abundance.
+				Nutriment will create universal enzyme. A favorite of mine to make my favorite drinks. Sweet sweet curacao.
+				Liquid Uranium will create silver bars. Useful and generally needed in decent quantities.
 				<a name='6'><h3>Blue</h3>
-				Blue slimes are lesser used slime. They are generally used for glass.
-				water will result in frost oil. In large quantities they can make quite a bit. But generally xenoflora grows its own plants for it.
-				plasma will create glass and borosilicate glass. Borosilicate is harder to come by in a reliable manner so it does help with that if really needed.
+				Blue slimes are the least used slimes. They are generally used for glass.
+				Water will result in frost oil. In large quantities they can make quite a bit. But generally xenoflora grows its own plants for it.
+				Plasma will create glass and borosilicate glass. Borosilicate is harder to come by in a reliable manner so it does help with that if really needed.
 				<a name='7'><h3>Dark Blue</h3>
-				Dark blue slimes are a gateway slime to diamonds. Creating a unique jelly inside.
-				plasma results in a time delayed freezing effect that drastically lowers the temperature.
-				honey in 5 units results in the rarer pure slime jelly. A vary small amount is produced per reaction.
+				Dark blue slimes are a gateway slime to diamonds, creating a unique jelly inside.
+				Plasma results in a time delayed freezing effect that drastically lowers the temperature.
+				Honey in 5 units results in the rarer pure slime jelly. A vary small amount is produced per reaction.
 				<a name='8'><h3>Orange</h3>
-				Orange slimes are the way to upgrade clothing of various kinds. They lead to red slimes which in turn lead to oil.
-				water will create a slime jar. This one in particular makes clothing resistant to high temps (Not Flames!) and even pressure resistant.
-				plasma will create a violent reaction that results in mass fire. Be vary careful about doing this. Least you roast yourself or others.
-				blood will create pepper spray! Useful for would be wife poachers or spiders.
+				Orange slimes pave the way to upgrade clothing of various kinds. They lead to red slimes which in turn lead to oil.
+				Water will create a slime jar. This one in particular makes clothing resistant to high temps (Not Flames!) and even pressure resistant.
+				Plasma will create a violent reaction that results in mass fire. Be very careful about doing this, lest you roast yourself or others.
+				Blood will create pepper spray! Useful for would-be wife poachers or spiders.
 				<a name='9'><h3>Yellow</h3>
-				Easily one of my favorite slimes just for the light it creates. Altho dangerous if given blood.
-				blood causes a emp effect with quite a decent size to it. This can kill people with mechanical organs.
-				water creates slime lights! Its like having a floodlight in your pocket that never runs out!
-				plasma will create a slime jar. This one gives clothing a higher resistance to shocks. It might take more then one jar to make it shock proof tho.
+				Easily one of my favorite slimes just for the light it creates. Although dangerous if given blood.
+				Blood causes an EMP effect with quite a decent size to it. This can kill people with mechanical organs.
+				Water creates slime lights! It's like having a floodlight in your pocket that never runs out!
+				Plasma will create a slime jar. This one gives clothing a higher resistance to shocks. It might take more than one jar to make it shock proof though.
 				<a name='10'><h3>Purple</h3>
 				Purple slimes can be a core slime if people want to use slime steroids to produce more cores.
-				plasma creates a slime jar. This one causes baby slimes to split thier core into 3 but only while still alive.
-				suger creates more slime jelly. Usefull if you need to make more slime revival jars.
+				Plasma creates a slime jar. This one causes baby slimes to split their core into 3 but only while still alive.
+				Sugar creates more slime jelly. Usefull if you need to make more slime revival jars.
 				<a name='11'><h3>Dark Purple</h3>
 				Dark purple slimes are a staple. YOU NEED THESE! They are the only way to make more plasma without external shopping, trading or looting.
-				plasma creates more plasma sheets! Grind these down!
-				liquid uranium, gold and silver all at once will create a random tool mod. I havn't figured out how they go about this reaction yet. But its like a roulette on what you get.
+				Plasma creates more plasma sheets! Grind these down!
+				Liquid Uranium, Gold and Silver all at once will create a random tool mod. I havn't figured out how they go about this reaction yet. But its like a roulette on what you get.
 				<a name='12'><h3>Red</h3>
-				A valuable yet vary dangerous slime. They have alot of reactions tho.
-				plasma makes glycerol. A chemical used in nitroglycerin... explosives.
-				frostoil creates the rarely used materials of osmium and metallic hydrogen.
-				water creates a slime jar. This is one of the most wanted things xenobio produces. SPEED jars make armour easier to move in. But it takes alot of them.
-				blood... Never use this. It enrages all the slimes around. They become nothing short of rabid and completly hostile to everything.
+				A valuable yet very dangerous slime. They have a lot of reactions though.
+				Plasma makes Glycerol. A chemical used in Nitroglycerin... explosives.
+				Frost oil creates the rarely used materials of Osmium and Metallic Hydrogen.
+				Water creates a slime jar. This is one of the most wanted things xenobio produces. SPEED jars make armor easier to move in, but it takes alot of them.
+				Blood... Never use this. It enrages all the slimes around. They become nothing short of rabid and completely hostile to everything.
 				<a name='13'><h3>Pink</h3>
 				A slime coveted for making friends.
-				nutriment in 5 units will create a slime jar useful for taming baby slimes
-				honey in 5 units will create a simular slime jar but for adults.
+				Nutriment in 5 units will create a slime jar useful for taming baby slimes.
+				Honey in 5 units will create a similar slime jar but for adults.
 				<a name='14'><h3>Black</h3>
-				plasma will create a mutation toxin thats stronger then greens... It will fully turn someone into a slime... Vary dangerous.
-				advanced mutation toxin will cause a reaction like grey slimes with plasma. Except it can create a wide verity of colors instead of just grey!
+				Plasma will create a mutation toxin that's stronger than greens... It will fully turn someone into a slime... Very dangerous.
+				Advanced Mutation Toxin will cause a reaction like Grey Slimes with Plasma. Except it can create a wide variety of colors instead of just grey!
 				<a name='15'><h3>Oil</h3>
-				Oil slimes are a strange mix. They have few reactions most of which are nothing short of illigal. But the nonslipping power of them makes them wonderful.
-				plasma... This is nothing short of a hellishly strong hand grenade. Blackshield wishes they had fire power like this thing.
-				water will create a intresting mod for weapons. When applied to scopes it gives them thermal vision... which sadly is illigal.
-				lubricant in 5 units will create a reverse friction substance for shoes! NON SLIP SOLES! No more slipping on wet floors!
+				Oil slimes are a strange mix. They have few reactions, most of which are nothing short of illegal. But the nonslipping power of them makes them wonderful.
+				Plasma... This is nothing short of a hellishly strong hand grenade. Blackshield wishes they had fire power like this thing.
+				Water will create a intresting mod for weapons. When applied to scopes it gives them thermal vision... which sadly is illegal.
+				Space Lube in 5 units will create a reverse friction substance for shoes! NON SLIP SOLES! No more slipping on wet floors!
 				<a name='16'><h3>Light Pink</h3>
 				At one time these slimes created slime jars for taming adult slimes. But recently they have shown no reactions. Changes may be coming about with them.
 				<a name='17'><h3>Adamantine</h3>
 				The only source of renewable diamonds. They take alot of work to create regardless due to needing dark blue slimes.
-				plasma will create various strange runes upon the floor. I've worked on deciphering them but havn't fully been able to do so. I've seen golems appear from these runes however.
-				pure slime jelly will create diamonds! This creates some biomatter too leading me to believe the pure slime jelly is actually seperating the core into various aspects somehow.
-				liquid uranium, gold and silver will create platinum. Useful for posicells and a few stronger goods in RnD
+				Plasma will create various strange runes upon the floor. I've worked on deciphering them but haven't fully been able to do so. I've seen golems appear from these runes however.
+				Pure slime jelly will create diamonds! This creates some biomatter too leading me to believe the pure slime jelly is actually seperating the core into various aspects somehow.
+				Liquid Uranium, Gold and Silver at the same time will create Platinum. Useful for posicells and a few stronger goods in RnD
 				<a name='18'><h3>Rainbow</h3>
-				A rare slime that I have been unable to make split and have had difficulty keeping from making a mess. Fun at parties tho.
-				<p>Hopefully these notes can be condenced someday into something that will better help someone. Someday they too will be outdated im sure.
+				A rare slime that I have been unable to make split and have had difficulty keeping from making a mess. Fun at parties though.
+				<p>Hopefully these notes can be condensed someday into something that will better help someone. Someday they too will be outdated I'm sure.
 				</body>
 				</html>
 				"}

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -6794,6 +6794,27 @@
 /obj/item/clipboard,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"bqN" = (
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/obj/machinery/door/window/southleft{
+	pixel_y = -3;
+	name = "shower door"
+	},
+/obj/effect/floor_decal/spline/fancy{
+	pixel_y = 29
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cbo)
 "bqO" = (
 /obj/effect/floor_decal/industrial/stand_clear,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18612,6 +18633,18 @@
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"dJQ" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cbo)
 "dJU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/window_lwall_spawn/reinforced,
@@ -23930,13 +23963,6 @@
 /obj/random/material/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/burned_outpost)
-"eMr" = (
-/obj/effect/window_lwall_spawn/reinforced/polarized{
-	id = "CBO"
-	},
-/obj/structure/curtain/open,
-/turf/simulated/floor/plating,
-/area/nadezhda/command/cbo)
 "eMs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -27032,9 +27058,9 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/quartermaster/miningdock)
 "fpy" = (
-/obj/structure/coatrack,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cro)
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/crew_quarters/sleep/cryo2)
 "fpz" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light{
@@ -44862,10 +44888,6 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
-"iKM" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/crew_quarters/sleep/cryo2)
 "iKN" = (
 /obj/landmark/join/start/psychiatrist,
 /turf/simulated/floor/wood,
@@ -54477,17 +54499,17 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "kzc" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
 /obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
+	dir = 8;
+	pixel_x = -11
+	},
+/obj/structure/mirror{
+	dir = 8;
+	pixel_x = -28;
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cbo)
+/area/nadezhda/command/cro)
 "kzg" = (
 /obj/structure/window/reinforced,
 /obj/machinery/recharge_station,
@@ -59183,6 +59205,10 @@
 /area/nadezhda/rnd/docking{
 	name = "\improper Upper Research Hallway"
 	})
+"lri" = (
+/obj/structure/coatrack,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cro)
 "lrp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -77727,18 +77753,12 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/armoryshop)
 "oPV" = (
-/obj/machinery/shower,
-/obj/structure/railing/grey{
-	dir = 1;
-	pixel_y = 10
-	},
-/obj/structure/curtain/open,
-/obj/effect/floor_decal/corner_techfloor_grid,
-/obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/rnd/docking{
-	name = "\improper Upper Research Hallway"
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/tool/screwdriver/improvised,
+/turf/simulated/floor/plating/under,
+/area/eris/crew_quarters/plasma_tag)
 "oQg" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -78818,17 +78838,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/pros/prep)
 "pcS" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -11
-	},
-/obj/structure/mirror{
-	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
-	},
+/obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
+/area/nadezhda/command/cbo)
 "pcW" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
@@ -85941,6 +85953,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"qvb" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/crew_quarters/sleep/cryo2)
 "qvf" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -90448,11 +90466,18 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rmf" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/shower,
+/obj/structure/railing/grey{
+	dir = 1;
+	pixel_y = 10
 	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/crew_quarters/sleep/cryo2)
+/obj/structure/curtain/open,
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/effect/floor_decal/spline/fancy,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/rnd/docking{
+	name = "\improper Upper Research Hallway"
+	})
 "rmg" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 5
@@ -99958,7 +99983,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/tool/screwdriver/improvised,
+/obj/item/tool/multitool/improvised,
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/plasma_tag)
 "tbv" = (
@@ -101913,12 +101938,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "tvT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/tool/multitool/improvised,
-/turf/simulated/floor/plating/under,
-/area/eris/crew_quarters/plasma_tag)
+/obj/effect/window_lwall_spawn/reinforced/polarized{
+	id = "CBO"
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/plating,
+/area/nadezhda/command/cbo)
 "tvU" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -107487,27 +107512,6 @@
 /obj/structure/sign/departmentold/mining,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/quartermaster/miningdock)
-"uAK" = (
-/obj/machinery/shower{
-	pixel_y = 20
-	},
-/obj/machinery/door/window/southleft{
-	pixel_y = -3;
-	name = "shower door"
-	},
-/obj/effect/floor_decal/spline/fancy{
-	pixel_y = 29
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/curtain/open,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cbo)
 "uAP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard/prospectors{
@@ -114000,10 +114004,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"vKK" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cbo)
 "vKM" = (
 /obj/structure/sign/faction/neotheology{
 	pixel_y = -30
@@ -125454,6 +125454,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/circuitboard/chicken,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
 "xTQ" = (
@@ -137443,7 +137444,7 @@ hfy
 gzB
 gzB
 aGs
-iKM
+fpy
 fKq
 hfy
 hfy
@@ -138051,7 +138052,7 @@ fKq
 oOn
 fKq
 lZZ
-rmf
+qvb
 fAl
 hfy
 hOK
@@ -150936,9 +150937,9 @@ wMU
 nKo
 rYQ
 qRN
-tvT
-wOY
 tbu
+wOY
+oPV
 iEw
 rYQ
 bll
@@ -191584,7 +191585,7 @@ elK
 gLs
 gLs
 gLs
-eMr
+tvT
 elK
 jQF
 jQF
@@ -194407,9 +194408,9 @@ eKe
 lUt
 qPr
 elK
-uAK
+bqN
 ilQ
-vKK
+pcS
 elK
 elK
 elK
@@ -194812,7 +194813,7 @@ sQI
 mnX
 elK
 noY
-kzc
+dJQ
 tAf
 elK
 tzO
@@ -196228,7 +196229,7 @@ sFI
 sFI
 sFI
 eXm
-oPV
+rmf
 qVa
 lcf
 eXm
@@ -197245,7 +197246,7 @@ eXm
 frj
 xAN
 klk
-fpy
+lri
 tPn
 ijt
 gJG
@@ -197654,7 +197655,7 @@ tPn
 vZI
 klk
 xKU
-pcS
+kzc
 vfw
 klk
 xGi

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -8703,9 +8703,6 @@
 /area/nadezhda/medical/morgue)
 "bLv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -9926,7 +9923,9 @@
 	})
 "bZn" = (
 /obj/structure/table/standard,
-/obj/machinery/centrifuge,
+/obj/machinery/centrifuge{
+	pixel_x = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
@@ -13144,7 +13143,9 @@
 	})
 "cEj" = (
 /obj/structure/table/reinforced,
-/obj/machinery/centrifuge,
+/obj/machinery/centrifuge{
+	pixel_x = 1
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
 "cEw" = (
@@ -17760,8 +17761,11 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dAQ" = (
 /obj/structure/table/reinforced,
-/obj/item/tool/baton,
 /obj/machinery/reagentgrinder/portable,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/glass/beaker{
+	preloaded_reagents = list("plasma" = 20)
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "dAR" = (
@@ -24832,6 +24836,10 @@
 /obj/item/book/ritual/cruciform/priest,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"eUo" = (
+/obj/machinery/smartfridge/secure/extract,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/rnd/xenobiology)
 "eUs" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
@@ -29022,9 +29030,10 @@
 /area/nadezhda/command/cro)
 "fGJ" = (
 /obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/slime_dye_vat{
+	pixel_y = 5;
+	pixel_x = 1
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "fGL" = (
@@ -30128,14 +30137,14 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fRY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	id_tag = "riso2";
 	name = "Access Airlock";
 	req_access = list(65)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
 "fSe" = (
@@ -31723,6 +31732,12 @@
 "ggO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
@@ -51060,11 +51075,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jUi" = (
-/obj/machinery/computer/operating{
-	dir = 4;
-	name = "Xenobiology Operating Computer";
-	pixel_x = -3
-	},
+/obj/structure/table/standard,
+/obj/item/tool/saw/circular,
+/obj/item/device/scanner/xenobio,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
 "jUk" = (
@@ -57530,15 +57543,6 @@
 /turf/simulated/open,
 /area/colony)
 "lbp" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "xeno_airlock_control";
-	name = "Xenobiology Access Button";
-	pixel_x = 24;
-	pixel_y = 0;
-	req_access = list(55)
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
@@ -62770,6 +62774,16 @@
 /obj/machinery/door/window/westright,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"mbm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/xenobiology)
 "mbo" = (
 /obj/effect/floor_decal/industrial/outputgate,
 /turf/simulated/floor/fixed/hydrotile,
@@ -67584,6 +67598,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "mUC" = (
@@ -68799,9 +68816,6 @@
 "nha" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/xenobiology)
@@ -72965,9 +72979,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
 "nYb" = (
-/obj/machinery/computer/curer,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/medical/virology)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/structure/medical_stand,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/rnd/xenobiology)
 "nYd" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "17,23"
@@ -80185,12 +80203,14 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "ppZ" = (
-/obj/structure/table/standard,
-/obj/item/tool/saw/circular,
 /obj/machinery/camera/network/research{
 	dir = 4
 	},
-/obj/item/autopsy_scanner,
+/obj/machinery/computer/operating{
+	dir = 4;
+	name = "Xenobiology Operating Computer";
+	pixel_x = -3
+	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
 "pqa" = (
@@ -80291,7 +80311,9 @@
 /turf/simulated/open,
 /area/nadezhda/medical/reception)
 "prM" = (
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater{
+	pixel_y = 4
+	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
@@ -82544,14 +82566,13 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "pOb" = (
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
+/obj/structure/table/reinforced,
+/obj/item/tool/baton,
+/obj/item/tool/baton,
+/obj/item/book/manual/xenobio_recipies,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "pOc" = (
@@ -83230,11 +83251,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "pTD" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/xenobiology)
+/obj/machinery/disease2/isolator,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/medical/virology)
 "pTS" = (
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -91510,13 +91529,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
 "rwb" = (
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/tool/baton,
-/obj/item/stack/material/plasma{
-	layer = 2.9
+/obj/structure/bed/chair{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
@@ -104841,6 +104858,9 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
+/obj/structure/table/standard,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/bag/xenobio,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
 "uaV" = (
@@ -105164,6 +105184,9 @@
 /area/nadezhda/command/bridgebar)
 "ueH" = (
 /obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/storage/fancy/crayons,
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
 "ueI" = (
@@ -115214,12 +115237,12 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "vXf" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/dropper,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "vXk" = (
@@ -117536,12 +117559,6 @@
 	name = "Residential District Maintenance"
 	})
 "wta" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
@@ -155167,7 +155184,7 @@ hBd
 dxK
 lsA
 qLp
-nYb
+reB
 mUB
 qGu
 feH
@@ -155369,7 +155386,7 @@ nMG
 fnY
 wIR
 qLp
-reB
+pTD
 bLv
 iRF
 chZ
@@ -157990,14 +158007,14 @@ aQK
 ppZ
 oiH
 jUi
-aQK
+eUo
 sax
 bNO
 nZF
 jOz
 aQK
 nha
-auY
+nYb
 afJ
 aQK
 gLl
@@ -159810,7 +159827,7 @@ qCC
 fNS
 qQW
 bIQ
-pTD
+fYf
 hsY
 bIQ
 qYi
@@ -160416,7 +160433,7 @@ aJb
 pih
 duQ
 auY
-lDU
+mbm
 vXf
 wTr
 edS

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -4711,6 +4711,7 @@
 /obj/structure/noticeboard/medical{
 	pixel_x = -32
 	},
+/obj/structure/coatrack,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "aXf" = (
@@ -5491,6 +5492,11 @@
 "beu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -11978,6 +11984,7 @@
 /area/nadezhda/crew_quarters/kitchen)
 "cui" = (
 /obj/machinery/washing_machine,
+/obj/item/towel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/smc/quarters)
 "cup" = (
@@ -12821,6 +12828,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/towel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/merchant)
 "cBY" = (
@@ -15473,10 +15481,6 @@
 /area/nadezhda/medical/sleeper)
 "ddX" = (
 /obj/structure/curtain/open,
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/structure/window/reinforced{
@@ -15486,11 +15490,11 @@
 	dir = 4;
 	pixel_x = 0
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/door/window/southleft{
 	name = "shower door"
+	},
+/obj/machinery/shower{
+	pixel_y = 21
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/smc/quarters)
@@ -19322,9 +19326,8 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/xenobiology)
 "dQW" = (
-/obj/machinery/door/airlock/command{
-	name = "Guild Merchant's Office";
-	req_access = list(41)
+/obj/machinery/door/airlock{
+	name = "Bathroom"
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/command/merchant)
@@ -23927,6 +23930,13 @@
 /obj/random/material/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"eMr" = (
+/obj/effect/window_lwall_spawn/reinforced/polarized{
+	id = "CBO"
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/plating,
+/area/nadezhda/command/cbo)
 "eMs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -27022,11 +27032,9 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/quartermaster/miningdock)
 "fpy" = (
-/obj/structure/door_assembly/door_assembly_mai,
-/obj/structure/catwalk,
-/obj/structure/grille,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/obj/structure/coatrack,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cro)
 "fpz" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light{
@@ -28614,9 +28622,9 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "fDE" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
+/obj/structure/table/reinforced,
+/obj/item/soap/deluxe,
+/obj/item/towel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/cro)
 "fDH" = (
@@ -28806,8 +28814,8 @@
 /area/nadezhda/absolutism/vectorrooms)
 "fEJ" = (
 /obj/structure/catwalk,
-/obj/structure/door_assembly/door_assembly_mai,
 /obj/structure/grille,
+/obj/structure/door_assembly/door_assembly_maint_cargo,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "fEL" = (
@@ -36612,10 +36620,10 @@
 "hcg" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/donut,
-/obj/machinery/light/small{
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "hch" = (
@@ -38123,6 +38131,7 @@
 	pixel_x = 0
 	},
 /obj/machinery/door/window/southright,
+/obj/item/towel,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/crew_quarters/dorm4{
 	name = "Dormitory 4"
@@ -44853,6 +44862,10 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
+"iKM" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/crew_quarters/sleep/cryo2)
 "iKN" = (
 /obj/landmark/join/start/psychiatrist,
 /turf/simulated/floor/wood,
@@ -54464,14 +54477,14 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "kzc" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
 	pixel_x = 11;
 	pixel_y = 0
-	},
-/obj/structure/mirror{
-	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/cbo)
@@ -54575,10 +54588,6 @@
 /area/nadezhda/pros/prep)
 "kAs" = (
 /obj/structure/curtain/open,
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/structure/window/reinforced{
@@ -54588,14 +54597,14 @@
 	dir = 4;
 	pixel_x = 0
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/door/window/southleft{
 	name = "shower door"
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/shower{
+	pixel_y = 21
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/gmaster)
@@ -57931,12 +57940,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
 "leR" = (
@@ -59308,6 +59317,7 @@
 /obj/machinery/door/window/westright{
 	dir = 1
 	},
+/obj/item/towel,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/crew_quarters/dorm1{
 	name = "Dormitory 1"
@@ -61925,7 +61935,8 @@
 /area/nadezhda/hallway/side/f2section1)
 "lSs" = (
 /obj/structure/table/standard,
-/obj/structure/bedsheetbin,
+/obj/item/soap,
+/obj/item/towel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/gmaster)
 "lSu" = (
@@ -65746,7 +65757,7 @@
 /obj/machinery/vending/wallmed/lobby{
 	pixel_y = -32
 	},
-/obj/machinery/light/small,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "mCF" = (
@@ -67140,6 +67151,7 @@
 /obj/effect/floor_decal/industrial/arrows/white{
 	dir = 1
 	},
+/obj/item/towel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/captain/quarters)
 "mPM" = (
@@ -71583,6 +71595,7 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/psych)
 "nIS" = (
+/obj/item/towel,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/command/swo/quarters)
 "nIZ" = (
@@ -77580,7 +77593,9 @@
 /area/nadezhda/hallway/side/f2section1)
 "oOW" = (
 /obj/structure/table/standard,
-/obj/machinery/centrifuge,
+/obj/machinery/centrifuge{
+	pixel_x = 1
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "oOZ" = (
@@ -77712,12 +77727,18 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/armoryshop)
 "oPV" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/shower,
+/obj/structure/railing/grey{
+	dir = 1;
+	pixel_y = 10
 	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/command/cbo)
+/obj/structure/curtain/open,
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/effect/floor_decal/spline/fancy,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/rnd/docking{
+	name = "\improper Upper Research Hallway"
+	})
 "oQg" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -78797,12 +78818,17 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/pros/prep)
 "pcS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/tool/multitool/improvised,
-/turf/simulated/floor/plating/under,
-/area/eris/crew_quarters/plasma_tag)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
+	},
+/obj/structure/mirror{
+	dir = 8;
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "pcW" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
@@ -79733,6 +79759,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/towel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/prime)
 "pmi" = (
@@ -86140,9 +86167,6 @@
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
 	},
@@ -86153,6 +86177,9 @@
 	name = "shower door"
 	},
 /obj/item/soap/deluxe,
+/obj/machinery/shower{
+	pixel_y = 21
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/captain/quarters)
 "qxk" = (
@@ -90038,9 +90065,9 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "rip" = (
-/obj/structure/door_assembly/door_assembly_mai,
-/obj/structure/grille,
 /obj/machinery/door/firedoor,
+/obj/structure/door_assembly/door_assembly_maint_cargo,
+/obj/structure/grille,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "riq" = (
@@ -90387,7 +90414,9 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rlO" = (
 /obj/structure/table/standard,
-/obj/machinery/chem_heater,
+/obj/machinery/chem_heater{
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "rlR" = (
@@ -90419,16 +90448,11 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rmf" = (
-/obj/machinery/door/window/southleft{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_techfloor_grid,
-/obj/structure/curtain/open,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cbo)
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/crew_quarters/sleep/cryo2)
 "rmg" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 5
@@ -96240,6 +96264,7 @@
 /obj/machinery/door/window/westright{
 	dir = 1
 	},
+/obj/item/towel,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/crew_quarters/dorm2{
 	name = "Dormitory 2"
@@ -99156,6 +99181,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/reinforced,
+/obj/item/soap/deluxe,
+/obj/item/towel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/cbo)
 "sUr" = (
@@ -99711,25 +99739,18 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "sZw" = (
-/obj/structure/curtain/open,
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/southleft{
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/westleft{
 	name = "shower door"
+	},
+/obj/structure/curtain/open,
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower";
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/cro)
@@ -99937,6 +99958,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/tool/screwdriver/improvised,
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/plasma_tag)
 "tbv" = (
@@ -101891,17 +101913,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "tvT" = (
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/floor_decal/corner_techfloor_grid,
-/obj/machinery/door/window/southleft{
-	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain/open,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cbo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/tool/multitool/improvised,
+/turf/simulated/floor/plating/under,
+/area/eris/crew_quarters/plasma_tag)
 "tvU" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -105589,8 +105606,8 @@
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/hallway/surface/section1)
 "uir" = (
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "uiv" = (
@@ -107470,6 +107487,27 @@
 /obj/structure/sign/departmentold/mining,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/quartermaster/miningdock)
+"uAK" = (
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/obj/machinery/door/window/southleft{
+	pixel_y = -3;
+	name = "shower door"
+	},
+/obj/effect/floor_decal/spline/fancy{
+	pixel_y = 29
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cbo)
 "uAP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard/prospectors{
@@ -111624,9 +111662,6 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/crew_quarters/plasma_tag)
 "vop" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/cable/cyan{
 	d2 = 2;
 	icon_state = "0-2"
@@ -111636,6 +111671,9 @@
 	dir = 1;
 	name = "North APC";
 	pixel_y = 28
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
@@ -111822,6 +111860,10 @@
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
@@ -113958,6 +114000,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"vKK" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cbo)
 "vKM" = (
 /obj/structure/sign/faction/neotheology{
 	pixel_y = -30
@@ -114789,6 +114835,7 @@
 	pixel_x = 0
 	},
 /obj/machinery/door/window/southright,
+/obj/item/towel,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/crew_quarters/dorm3{
 	name = "Dormitory 3"
@@ -117481,7 +117528,7 @@
 /area/nadezhda/command/armory)
 "wss" = (
 /obj/structure/grille,
-/obj/structure/door_assembly/door_assembly_mai,
+/obj/structure/door_assembly/door_assembly_maint_cargo,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "wsu" = (
@@ -118544,11 +118591,11 @@
 /obj/structure/table/standard,
 /obj/random/medical,
 /obj/random/medical,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
@@ -121283,6 +121330,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/towel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/pros/foreman)
 "xfv" = (
@@ -123986,15 +124034,8 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xGf" = (
 /obj/structure/curtain/open,
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 0
@@ -124004,6 +124045,9 @@
 	},
 /obj/machinery/door/window/southleft{
 	name = "shower door"
+	},
+/obj/machinery/shower{
+	pixel_y = 21
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/merchant)
@@ -124457,10 +124501,7 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xKU" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -11
-	},
+/obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/cro)
 "xKY" = (
@@ -132571,7 +132612,7 @@ bYZ
 ujI
 egU
 egU
-fpy
+fEJ
 vzJ
 kTs
 kTs
@@ -137402,7 +137443,7 @@ hfy
 gzB
 gzB
 aGs
-fKq
+iKM
 fKq
 hfy
 hfy
@@ -138010,7 +138051,7 @@ fKq
 oOn
 fKq
 lZZ
-fKq
+rmf
 fAl
 hfy
 hOK
@@ -150895,7 +150936,7 @@ wMU
 nKo
 rYQ
 qRN
-pcS
+tvT
 wOY
 tbu
 iEw
@@ -191543,7 +191584,7 @@ elK
 gLs
 gLs
 gLs
-gLs
+eMr
 elK
 jQF
 jQF
@@ -191745,7 +191786,7 @@ pPl
 nBx
 nBx
 nBx
-oPV
+nBx
 qCM
 qSP
 lRH
@@ -191947,7 +191988,7 @@ wiD
 nBx
 nBx
 nBx
-nWC
+nBx
 qCM
 aHy
 nPs
@@ -192351,7 +192392,7 @@ chk
 mPj
 fSF
 vmC
-nBx
+nWC
 qCM
 cbw
 nPs
@@ -194366,9 +194407,9 @@ eKe
 lUt
 qPr
 elK
-noY
+uAK
 ilQ
-elK
+vKK
 elK
 elK
 elK
@@ -194570,7 +194611,7 @@ fgH
 elK
 sUl
 ilQ
-tvT
+ilQ
 elK
 eXm
 eXm
@@ -194770,9 +194811,9 @@ oYx
 sQI
 mnX
 elK
+noY
 kzc
 tAf
-rmf
 elK
 tzO
 vGR
@@ -196187,7 +196228,7 @@ sFI
 sFI
 sFI
 eXm
-lOu
+oPV
 qVa
 lcf
 eXm
@@ -197204,7 +197245,7 @@ eXm
 frj
 xAN
 klk
-tPn
+fpy
 tPn
 ijt
 gJG
@@ -197613,8 +197654,8 @@ tPn
 vZI
 klk
 xKU
+pcS
 vfw
-tYV
 klk
 xGi
 stw

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -17764,7 +17764,7 @@
 /obj/machinery/reagentgrinder/portable,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/glass/beaker{
-	preloaded_reagents = list("plasma" = 20)
+	preloaded_reagents = list("plasma"=20)
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
@@ -78797,10 +78797,11 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/pros/prep)
 "pcS" = (
-/obj/machinery/floor_light{
-	light_color = COLOR_LIGHTING_CYAN_BRIGHT
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/tool/multitool/improvised,
+/turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/plasma_tag)
 "pcW" = (
 /obj/structure/table/marble,
@@ -109853,9 +109854,7 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "uWm" = (
-/obj/machinery/floor_light{
-	light_color = COLOR_LIGHTING_CYAN_BRIGHT
-	},
+/obj/machinery/floor_light,
 /obj/machinery/camera/network/plasma_tag{
 	dir = 4
 	},
@@ -109866,9 +109865,7 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/crew_quarters/cafeteria)
 "uWA" = (
-/obj/machinery/floor_light{
-	light_color = COLOR_LIGHTING_RED_BRIGHT
-	},
+/obj/machinery/floor_light,
 /obj/machinery/camera/network/plasma_tag{
 	dir = 8
 	},
@@ -111623,9 +111620,7 @@
 	},
 /area/nadezhda/pros/proelav)
 "voj" = (
-/obj/machinery/floor_light{
-	light_color = COLOR_LIGHTING_RED_BRIGHT
-	},
+/obj/machinery/floor_light,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/crew_quarters/plasma_tag)
 "vop" = (
@@ -150091,11 +150086,11 @@ xRk
 lHD
 mcL
 slI
-pcS
+voj
 wxd
 wxd
 wxd
-pcS
+voj
 dcZ
 wxd
 dPK
@@ -150900,7 +150895,7 @@ wMU
 nKo
 rYQ
 qRN
-tbu
+pcS
 wOY
 tbu
 iEw


### PR DESCRIPTION
## Blorb

- Places Slime Dye Vat, "Slime Cores and Reactions" manual, a box of beakers, Dropper, and replaces plasma sheet with a beaker preloaded with 20u of plasma to prevent rendering the department useless if other scientists steal the mats for RND, to the Xenobio lab.
- Small room to the south of Xenobio gets an IV drip, a large beaker, a paper bin and some crayons.
- Xenobio surgery room shifted for ease of use, adds a proper slime storage unit next to it, as well as a table with a xenobio bag and a box of bodybags
- Replaces autopsy scanner for a proper slime scanner
- Virology has the Cure Research Machine removed due to its uselessness, instead replaced by a previously unused Pathogenic Isolator (more useful)
- Slime Storage SmartFridge can now also store slime potions
- Minor typo fixes on slime manual procedure
- Slime dye vat description now properly states what the machine does and what it takes for it to work
- On @Trilbyspaceclone 's request, sets the `light_color` var of floor lights on plasma tag to `null`, maps in a makeshift multitool for people to change the colors as needed.

### Screenshots: 

![image](https://user-images.githubusercontent.com/1294508/174550234-c2f7cd3e-67b5-4805-93ae-71ef9c5ba3e0.png)

![image](https://user-images.githubusercontent.com/1294508/174550266-df7b62a1-6214-423e-a1ca-c7681bfedf8e.png)

![image](https://user-images.githubusercontent.com/1294508/174552747-4c1dc210-5566-49b6-b8a7-89d9b35abf8a.png)

![image](https://user-images.githubusercontent.com/1294508/174599590-6164e01e-6cf8-45f1-a377-dcd6010affd5.png)

![image](https://user-images.githubusercontent.com/1294508/174599607-eb946c27-73ce-484a-9fea-68c8563b8908.png)

![image](https://user-images.githubusercontent.com/1294508/174599625-6b8aa449-9d58-4107-a018-74e90d444b43.png)

![image](https://user-images.githubusercontent.com/1294508/174599651-bd80d1ed-0a8e-4dfe-82ae-73036d622853.png)

![image](https://user-images.githubusercontent.com/1294508/174599669-8a4a1be7-8473-4fb6-906e-2d9bea47929e.png)

![image](https://user-images.githubusercontent.com/1294508/174599987-90325e30-6eb7-4c0e-9f60-566c0ad076bb.png)

![image](https://user-images.githubusercontent.com/1294508/174600005-6ede4ecb-ee06-401b-8644-4cdf9a76cdd2.png)

<hr>

### Approved by Lich:

![image](https://user-images.githubusercontent.com/1294508/174677805-4f1c58c4-9551-405b-a9b1-9fe9ef1d1d77.png)

<hr>

## Changelog
:cl:
add: Added slime dye vat and the xenobio manual to xenobio. Adds a proper slime scanner to the surgery section, as well as a table holding a xenobio bag and a box of bodybags, and moves the sink around for ease of use.
add: Adds a beaker with 20u liquid plasma to xenobio to prevent the whole division from going useless if someone steals it for RND
add: Room in Xenobio south has a paper bin, a box of crayons, an IV drip and a large beaker on it. Changed its door for a window version that lets one see through. Changes the direction of the lightbulb to better illuminate the room.
add: Adds the Pathogenic Isolator to Virology
add: Adds the missing C.H.I.C.K. board to Robotics
add: On popular demand, adds an underwear wardrobe to public restroom. Also light tubes to make it properly illuminated.
del: Removes plasma sheet and autopsy scanner from xenobio
del: Removes Cure Research Machine from Virology
tweak: Slime Core SmartFridge now also takes slime potions
tweak: CBO office's disposals turned around so that it doesn't block window curtains from being closed
tweak: Better illuminated cryogenics (arrivals lift)
fix: Resets floor lights on plasma tag to null, adds a makeshift multitool to set the colors as needed.
fix: Fixes the invisible airlocks on maintenance library to no longer be invisible
fix: Adds mising wiring to Xenoflora lab. Now properly powered!
fix: CEO bathroom's door no longer incorrectly labelled as "Guild Merchant's office"
spellcheck: Fixed a few typos on the Slime Manual
/:cl: