### PR TITLE
Civilian Mech Price Increase

### DIFF
--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -5,7 +5,7 @@
 	initial_icon = "odysseus"
 	step_in = 1
 	max_temperature = 15000
-	price_tag = 6000
+	price_tag = 12000
 	health = 320
 	wreckage = /obj/effect/decal/mecha_wreckage/odysseus
 	internal_damage_threshold = 35

--- a/code/game/mecha/working/hoverpod.dm
+++ b/code/game/mecha/working/hoverpod.dm
@@ -8,7 +8,7 @@
 	step_energy_drain = 10
 	max_temperature = 20000
 	health = 150
-	price_tag = 2000
+	price_tag = 4000
 	infra_luminosity = 6
 	wreckage = /obj/effect/decal/mecha_wreckage/hoverpod
 	cargo_capacity = 5

--- a/code/game/mecha/working/ivan.dm
+++ b/code/game/mecha/working/ivan.dm
@@ -7,7 +7,7 @@
 	step_energy_drain = 10
 	max_temperature = 20000
 	health = 400
-	price_tag = 2500 // Relatively cheap
+	price_tag = 5000 // Relatively cheap
 	infra_luminosity = 6
 	cargo_capacity = 3
 	max_equip = 3

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -5,7 +5,7 @@
 	initial_icon = "ripley"
 	step_in = 2
 	max_temperature = 20000
-	price_tag = 5000
+	price_tag = 10000
 	health = 500
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley
 	cargo_capacity = 10

--- a/code/modules/trade/datums/trade_stations_presets/3-rare/mecha.dm
+++ b/code/modules/trade/datums/trade_stations_presets/3-rare/mecha.dm
@@ -65,6 +65,7 @@
 			/obj/item/mecha_parts/mecha_equipment/thruster
 		)
 	)
+/*
 	hidden_inventory = list(
 		"Pre-Made Mechs" = list(
 			/obj/mecha/working/hoverpod/cargo_imported = custom_good_amount_range(list(1, 2)),
@@ -72,6 +73,7 @@
 			/obj/mecha/working/ivan/cargo_imported = custom_good_amount_range(list(-1,2))
 		)
 	)
+*/
 
 	offer_types = list(
 		/obj/item/mech_ammo_box/scattershot = offer_data("LBX AC 10 ammunition box", 350, 5),


### PR DESCRIPTION
## About The Pull Request

<summary>
This PR increases the price of all four of the civilian mechs (Hoverpod, Ivan, Ripley, and Odysseus) by double amount to make the creation of mechs actually worth the time, parts, and materials. As the current prices are to reflect the old creation of mechs which didn't have the timed actions, and requirement of extra parts/tool mods to create.

Hoverpod: 2000 -> 4000

Ivan: 2500 -> 5000

Ripley: 5000 -> 10,000

Odysseus: 6000 -> 12,000

Also considering that most combat mechs start at the price range of 25k to 40k, this would help bridge that gap a little too.

Considering that most mechs are mostly kept within robotics storage, this would make exporting mechs via Lonestar actually worthwhile for Soteria and Lonestar since Lonestar and Robotics are now connected to one another within the recent map changes. As since people actually buying mechs is incredibly rare and hardly used outside Code Red situations, this would give Robotics another option to engage in more RP with others, and make their role worthwhile.

Side Note for Players: To export mechs, you have to activate maintenance mode, use a wrench so it becomes unanchored (the state in which it can be pulled around alike a locker), which then can be exported.
</summary>
<hr>

<hr>

