### PR TITLE
hivemind tweaks mk II

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -11,6 +11,9 @@
 #define JOBS_NONHUMAN "AI","Robot","pAI"
 #define JOBS_INDEPENDENT "Lodge Hunt Master","Lodge Hunter","Lodge Herbalist","Outsider"
 
+#define JOBS_ANTI_HIVEMIND "Blackshield Commander","Warrant Officer","Supply Specialist","Ranger","Corpsman","Blackshield Trooper","Marshal Officer","Sergeant","Prime","Vector","Foreman","Salvager","Prospector","Premier","Steward","AI","Janitor","Soteria Trauma Team","Soteria Roboticist","Lonestar Miner"
+
+
 #define CREDITS "&cent;"
 #define CREDS "&cent;"
 

--- a/code/game/gamemodes/events/hivemind_controller.dm
+++ b/code/game/gamemodes/events/hivemind_controller.dm
@@ -6,7 +6,8 @@ GLOBAL_LIST_INIT(hive_data_bool, list(
 	"allow_tyrant_spawn"			= TRUE,
 	"tyrant_death_kills_hive"		= FALSE,
 	"all_church_to_battle"			= FALSE,
-	"gibbing_dead"					= FALSE))
+	"gibbing_dead"					= FALSE,
+	"pop_lock"						= TRUE))
 
 GLOBAL_LIST_INIT(hive_data_float, list(
 	"maximum_controlled_areas"		= 0, // Stop expansion when controlling certain number of areas, 0 to disable
@@ -111,7 +112,8 @@ GLOBAL_VAR_INIT(hivemind_panel, new /datum/hivemind_panel)
 	data += "<br>Allow Hivemind Gibbing Dead Victims: [GLOB.hive_data_bool["gibbing_dead"] ? "Enabled" : "Disabled"] \
 	<a href='?src=\ref[src];toggle_gibbing_dead=1'>\[TOGGLE\]</a>"
 
-
+	data += "<br>Allow Events Below 15 Pop: [GLOB.hive_data_bool["pop_lock"] ? "Enabled" : "Disabled"] \
+	<a href='?src=\ref[src];toggle_pop_lock=1'>\[TOGGLE\]</a>"
 
 	data += "</td></tr></table>"
 	usr << browse(data, "window=hive_main;size=600x600")
@@ -200,6 +202,10 @@ GLOBAL_VAR_INIT(hivemind_panel, new /datum/hivemind_panel)
 
 	if(href_list["toggle_gibbing_dead"])
 		GLOB.hive_data_bool["gibbing_dead"] = !GLOB.hive_data_bool["gibbing_dead"]
+
+	if(href_list["toggle_pop_lock"])
+		GLOB.hive_data_bool["pop_lock"] = !GLOB.hive_data_bool["pop_lock"]
+
 
 	if(href_list["toggle_inquisitors"])
 		GLOB.hive_data_bool["all_church_to_battle"] = !GLOB.hive_data_bool["all_church_to_battle"]

--- a/code/game/gamemodes/events/hivemind_invasion.dm
+++ b/code/game/gamemodes/events/hivemind_invasion.dm
@@ -25,6 +25,11 @@
 
 /datum/event/hivemind/start()
 	var/turf/start_location
+	var/active_players = 0
+	for(var/mob/M in GLOB.player_list)
+		if(M.mind.assigned_role in list(JOBS_ANTI_HIVEMIND))
+			active_players++
+
 	for(var/i=1 to 100)
 		var/area/A = random_ship_area(filter_players = TRUE, filter_maintenance = TRUE, filter_critical = TRUE)
 		start_location = A.random_space()
@@ -34,6 +39,12 @@
 			return
 		if(start_location)
 			break
+
+	if(GLOB.hive_data_bool["pop_lock"])
+		if(active_players > 10)
+			log_and_message_admins("Hivemind failed to spawn as their was less then 10 active players exspected to combat the hivemind..")
+			kill()
+			return
 
 	message_admins("Hivemind spawned at \the [jumplink(start_location)]")
 	new /obj/machinery/hivemind_machine/node(start_location)

--- a/code/modules/hivemind/objects.dm
+++ b/code/modules/hivemind/objects.dm
@@ -6,7 +6,7 @@
 	name = "electrolyzed goo"
 	icon = 'icons/obj/hivemind.dmi'
 	icon_state = "goo_proj"
-	damage_types = list(BURN = 15)
+	damage_types = list(BURN = 10) //Shot in large amounts and stacks a bit with its toxin damage
 	check_armour = ARMOR_ENERGY //Unlike Bio, it's not either 0% or 100%. Strong Energy armour isn't common, But most of armour has some protection against energy.
 	step_delay = 2
 
@@ -15,7 +15,7 @@
 	. = ..()
 	if( isliving(target) && !issilicon(target) )
 		var/mob/living/L = target
-		L.damage_through_armor(15, TOX, attack_flag = ARMOR_RAD)
+		L.damage_through_armor(10, TOX, attack_flag = ARMOR_RAD)
 	if(!(locate(/obj/effect/decal/cleanable/spiderling_remains) in target.loc))
 		var/obj/effect/decal/cleanable/spiderling_remains/goo = new /obj/effect/decal/cleanable/spiderling_remains(target.loc)
 		goo.name = "electrolyzed goo" //from "acrid goo" to "acidic goo", and from "acidic goo" to "electrolyzed goo"


### PR DESCRIPTION
Hivemind now can only spawn if their is 10 active jobs that are counted as "Anti-Hivemind"
All Blackshield/Marshals count to this
All Prospectors count to this
All Church counts to this
AI, Premier Steward, Trauma Tream, Robotics, Janitor and Miner count to this as well

Eletro Goo that hivemind and some other mobs shoot have been nerfed heavilly in line with other projectile damages of its same type.