### PR TITLE
Gives Salvagers back their cognition bonus

### DIFF
--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -79,7 +79,7 @@
 	stat_modifiers = list(
 		STAT_BIO = 20,
 		STAT_MEC = 20,
-		STAT_COG = 0,
+		STAT_COG = 10,
 		STAT_TGH = 10,
 		STAT_VIG = 10,
 		STAT_ROB = 10


### PR DESCRIPTION
Gives Salvagers their cognition bonus back

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Gives the 10 cognition back to salvagers. For some reason this was removed, causing the technicians to have less cognition than the Prospectors who gained the same bonus. Wouldn't be against having salvagers have more cognition than prospectors, but, for now, they're now equal in cognition stats
	
<hr>
</details>

## Changelog
:cl:
Gave salvagers their 10 cognition bonus back
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
