### PR TITLE
Better bears

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -114,3 +114,6 @@
 	var/momentum_speed = 0 // The amount of run-up
 	var/momentum_dir = 0 // Direction of run-up
 	var/momentum_reduction_timer
+
+
+	var/added_movedelay = 0 //Used for humans only

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -135,3 +135,7 @@
 /mob/living/carbon/human/proc/calc_momentum()
 	momentum_speed--
 	update_momentum()
+
+
+/mob/living/carbon/human/proc/clear_movement_delay(movement_clearing = 0)
+	added_movedelay -= movement_clearing

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -65,6 +65,9 @@
 	if(slowdown)
 		tally += 1
 
+	if(added_movedelay)
+		tally += added_movedelay
+
 	tally += (r_hand?.slowdown_hold + l_hand?.slowdown_hold)
 
 	return tally

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -49,6 +49,7 @@
 						H.stats.addTempStat(STAT_ROB, STAT_LEVEL_ADEPT, 30 SECONDS, "fear_of_bear")
 						H.stats.addTempStat(STAT_TGH, STAT_LEVEL_ADEPT, 30 SECONDS, "fear_of_bear")
 						H.added_movedelay -= 0.5
+						addtimer(CALLBACK(H, /mob/living/carbon/human/proc/clear_movement_delay, 0.5), 60)
 						to_chat(H, SPAN_WARNING("The bears rawrs make the feeling of fight or flight all the more apparent."))
 					else
 						to_chat(H, SPAN_NOTICE("The natural insticts of fear become apparent, but you ingore such things."))
@@ -56,6 +57,7 @@
 						H.stats.addTempStat(STAT_TGH, STAT_LEVEL_ADEPT, 30 SECONDS, "fear_of_bear")
 						H.stats.addTempStat(STAT_ROB, STAT_LEVEL_ADEPT, 30 SECONDS, "fear_of_bear")
 						H.added_movedelay -= 0.5
+						addtimer(CALLBACK(H, /mob/living/carbon/human/proc/clear_movement_delay, 0.5), 60)
 
 		anchored = TRUE
 		addtimer(CALLBACK(src, .proc/unanchor), 10)

--- a/code/modules/mob/living/simple_animal/hostile/big.dm
+++ b/code/modules/mob/living/simple_animal/hostile/big.dm
@@ -74,7 +74,7 @@
 	walk_to(src,0)
 	movement_target = null
 	icon_state = icon_dead
-	density = 0
+	density = FALSE
 	return ..(gibbed,deathmessage)
 
 
@@ -286,22 +286,27 @@
 	bones_amount = 10
 	mob_size = MOB_LARGE
 	inherent_mutations = list(MUTATION_GIGANTISM, MUTATION_CLUMSY, MUTATION_IMBECILE, MUTATION_RAND_UNSTABLE)
+	var/alerted = FALSE
 
-/mob/living/simple_animal/hostile/retaliate/croakerlord/adjustBruteLoss(var/damage)
+/mob/living/simple_animal/hostile/retaliate/croakerlord/adjustBruteLoss(damage)
 	..()
-	visible_emote("slowly begins to open its many eyes as it looses an angered croak...")
-	icon_state = "leaper_alert"
-	icon_living = "leaper_alert"
+	if(!alerted)
+		visible_emote("slowly begins to open its many eyes as it looses an angered croak...")
+		icon_state = "leaper_alert"
+		icon_living = "leaper_alert"
+		alerted = TRUE
 
 /mob/living/simple_animal/hostile/retaliate/croakerlord/LoseTarget()
 	..()
 	icon_state = "leaper"
 	icon_living = "leaper"
+	alerted = FALSE
 
 /mob/living/simple_animal/hostile/retaliate/croakerlord/LostTarget()
 	..()
 	icon_state = "leaper"
 	icon_living = "leaper"
+	alerted = FALSE
 
 // Credit to SlapDrink#0083 for the sprite.
 /mob/living/simple_animal/hostile/hell_pig

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -101,7 +101,7 @@ var/list/mydirs = list(NORTH, SOUTH, EAST, WEST, SOUTHWEST, NORTHWEST, NORTHEAST
 /mob/living/simple_animal/hostile/proc/MoveToTarget()
 	var/mob/living/targetted_mob = (target_mob?.resolve())
 
-	stop_automated_movement = 1
+	stop_automated_movement = TRUE
 	if(!targetted_mob || SA_attackable(targetted_mob))
 		stance = HOSTILE_STANCE_IDLE
 	if(targetted_mob in ListTargets(10))
@@ -111,28 +111,11 @@ var/list/mydirs = list(NORTH, SOUTH, EAST, WEST, SOUTHWEST, NORTHWEST, NORTHEAST
 			else
 				set_glide_size(DELAY2GLIDESIZE(move_to_delay))
 				walk_to(src, targetted_mob, 1, move_to_delay)
-			if(ranged && istype(src, /mob/living/simple_animal/hostile/megafauna))
-				var/mob/living/simple_animal/hostile/megafauna/megafauna = src
-				sleep(rand(megafauna.megafauna_min_cooldown,megafauna.megafauna_max_cooldown))
-				if(istype(src, /mob/living/simple_animal/hostile/megafauna/one_star))
-					if(prob(rand(15,25)))
-						stance = HOSTILE_STANCE_ATTACKING
-						set_glide_size(DELAY2GLIDESIZE(move_to_delay))
-						walk_to(src, targetted_mob, 1, move_to_delay)
-					else
-						OpenFire(targetted_mob)
-				else
-					if(prob(45))
-						stance = HOSTILE_STANCE_ATTACKING
-						set_glide_size(DELAY2GLIDESIZE(move_to_delay))
-						walk_to(src, targetted_mob, 1, move_to_delay)
-					else
-						OpenFire(targetted_mob)
 		else
 			stance = HOSTILE_STANCE_ATTACKING
 			set_glide_size(DELAY2GLIDESIZE(move_to_delay))
 			walk_to(src, targetted_mob, 1, move_to_delay)
-	return 0
+	return FALSE
 
 /mob/living/simple_animal/hostile/proc/DestroyPathToTarget()
 	var/mob/living/targetted_mob = (target_mob?.resolve())

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -27,6 +27,38 @@
 
 	needs_environment = FALSE
 
+//More complicated verson of movement and targeting fire
+/mob/living/simple_animal/hostile/megafauna/MoveToTarget()
+	var/mob/living/targetted_mob = (target_mob?.resolve())
+
+	stop_automated_movement = TRUE
+	if(!targetted_mob || SA_attackable(targetted_mob))
+		stance = HOSTILE_STANCE_IDLE
+	if(targetted_mob in ListTargets(10))
+		if(ranged)
+			var/mob/living/simple_animal/hostile/megafauna/megafauna = src
+			sleep(rand(megafauna.megafauna_min_cooldown,megafauna.megafauna_max_cooldown))
+			if(istype(src, /mob/living/simple_animal/hostile/megafauna/one_star))
+				if(prob(rand(15,25)))
+					stance = HOSTILE_STANCE_ATTACKING
+					set_glide_size(DELAY2GLIDESIZE(move_to_delay))
+					walk_to(src, targetted_mob, 1, move_to_delay)
+				else
+					OpenFire(targetted_mob)
+			else
+				if(prob(45))
+					stance = HOSTILE_STANCE_ATTACKING
+					set_glide_size(DELAY2GLIDESIZE(move_to_delay))
+					walk_to(src, targetted_mob, 1, move_to_delay)
+				else
+					OpenFire(targetted_mob)
+		else
+			stance = HOSTILE_STANCE_ATTACKING
+			set_glide_size(DELAY2GLIDESIZE(move_to_delay))
+			walk_to(src, targetted_mob, 1, move_to_delay)
+	return FALSE
+
+
 /mob/living/simple_animal/hostile/megafauna/Initialize(mapload)
 	. = ..()
 	for(var/action_type in attack_action_types)


### PR DESCRIPTION
Hello /soj/ again its I the devil catto here to add fun and nerf storage somehow. Today in the lava moats stiring up a hellish nerf for storage I thought `Bears are hecken boring` and so ive decided to add the spice of life to them to make them more uniquic, in a fair way. Thus they now will have a temp statis affect that loses stats, and gives some in other spots but also speed you up unless you pass the vig check, in that case its pure benefits. This should make them less of a slog bording thing to fight.

Cleans up some simple mob code to be more optimized
Fixes a small bug with icon states for croaker lord

Improves bears by making them now when they find a target they stand still and do a rawr emote thing that if humans are around in a 5 tile area will have to make a vig check to not be spooked by bears
Well doing this emote they will not move but still can attack if in melee distance 
The spooked affect gives players a small speed boost and some TGH/ROB at the cost of most other stats, unless they win the vig check to not be spooked, in this case they only get the benefits, with addition to more temp vig

All these affects last for 30 seconds 