### PR TITLE
Laser ammo rebalance

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -46,25 +46,31 @@ In pvp they also have more lasting damages, such as infections, and pain form bu
 
 /obj/item/projectile/beam/weak/pistol_35
 	damage_types = list(BURN = 12)
+	armor_penetration = 5
 	recoil = 1
 
 /obj/item/projectile/beam/weak/light_rifle_257
-	damage_types = list(BURN = 13)
+	damage_types = list(BURN = 18)
+	armor_penetration = 15
 
 /obj/item/projectile/beam/weak/rifle_75
 	damage_types = list(BURN = 22)
+	armor_penetration = 20
 	recoil = 4
 
 /obj/item/projectile/beam/weak/heavy_rifle_408
-	damage_types = list(BURN = 16)
+	damage_types = list(BURN = 20)
+	armor_penetration = 30
 	recoil = 3
 
 /obj/item/projectile/beam/weak/magnum_40
 	damage_types = list(BURN = 20)
+	armor_penetration = 10
 	recoil = 3
 
 /obj/item/projectile/beam/weak/kurtz_50
-	damage_types = list(BURN = 40)
+	damage_types = list(BURN = 30)
+	armor_penetration = 15
 	recoil = 5
 
 /obj/item/projectile/beam/weak/smg
@@ -79,8 +85,8 @@ In pvp they also have more lasting damages, such as infections, and pain form bu
 	armor_penetration = 25
 
 /obj/item/projectile/beam/shotgun
-	damage_types = list(BURN = 35) //Normal slugs deal 45
-	armor_penetration = 10
+	damage_types = list(BURN = 48) //Normal slugs deal 45 - Not anymore! Even scrap dealt more with 48!
+	armor_penetration = 25
 	recoil = 2
 
 /obj/item/projectile/beam/shotgun/strong


### PR DESCRIPTION
Laser ammo has been adjusted to use the AP value of the standard ammunition type while using the damage value of the scrap ammo.

In its current state some laser ammunition variants have the issue where even the scrap bullet variant were performing better than the vastly more expensive laser variant. Even when there is no guild around there is little incentive to use this type of ammo over by simply handcrafting it using 9 steel and 1 cardboard. 

The main goal of this PR is to position laser ammo to be right between scrap and guild ammo. Giving them more of a reason to be used all while still leaving guilds ammo throne untouched. 

## Changelog
:cl:
balance: Laser ammo now use the AP of standard bullets all while using the damage of scrap bullets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
