### PR TITLE
Bagless Buff

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -104,6 +104,7 @@
 #define APPEARANCE_ALL       0xFFFF
 
 // Click cooldown
+#define DEFAULT_LONG_COOLDOWN   16//Extra long timeout for some gear
 #define DEFAULT_ATTACK_COOLDOWN 8 //Default timeout for aggressive actions
 #define DEFAULT_QUICK_COOLDOWN  4
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -173,7 +173,16 @@
 	return 1
 
 /mob/proc/setClickCooldown(var/timeout)
-	next_click = max(world.time + timeout, next_click)
+	next_click = max(world.time + (timeout + gather_click_delay(src)), next_click)
+
+/mob/proc/gather_click_delay(mob/living/M as mob)
+	var/gathered = 0
+	if(ishuman(M))
+		var/mob/living/carbon/human/back_pack_checker = M
+		if(!back_pack_checker.back)
+			gathered -= 1
+	gathered += click_delay_addition
+	return gathered
 
 /mob/proc/can_click()
 	if(next_click <= world.time)

--- a/code/game/objects/items/weapons/tools/hammer.dm
+++ b/code/game/objects/items/weapons/tools/hammer.dm
@@ -143,7 +143,7 @@
 
 /obj/item/tool/hammer/ironhammer/attack()
 	..()
-	usr.setClickCooldown(DEFAULT_ATTACK_COOLDOWN*2.2)
+	usr.setClickCooldown(DEFAULT_LONG_COOLDOWN)
 
 /obj/item/tool/hammer/mace
 	name = "mace"

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -217,3 +217,5 @@ While it would be entirely possible to check the mob's move handlers list for th
 	var/list/planes_visible = null	// List of atom planes that are logically visible/interactable (list of actual plane numbers).
 
 	var/obj/effect/gibspawner/gibspawner = /obj/effect/gibspawner/generic // for xeno gibs, originally
+
+	var/click_delay_addition = 0


### PR DESCRIPTION
Hello hello /soj/ers and robust graytide alike. Down in the aether above talking with the lovely gods above we had relised that being bagless only really affecting underplating wasnt enuff to make it common outside running away form things. Well today with the help form those above I have decided to make it also now decrease click delay, yes thats right by sacrificing not waring things on your back you will be slightly faster on click cooldowns making a bagless ruin run much more viable as you gain more DPS and attack ecomics. This even is modular for admins to tweak for mobs or additional to perks in the further

With this additon ive also taken the liberty of standardizing the Seinemetall Defense \"Ironhammer\" Breaching Hammer to only be 2x slower then normal attacks rather then 2.2x slower. After all your not taking a main weapon that has any range so it being viable to handle smaller issues is needed like 4 spiders vs a guns abitly to handle 9