### PR TITLE
Medical Perk-Checking

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -135,3 +135,6 @@
 							   PERK_STRANGTH, \
 							   PERK_IRON_WILL, \
 							   PERK_SNACKIVORE)
+
+	//Temporary drug perks
+#define PERK_ULTRASURGEON /datum/perk/drug/ultrasurgeon

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -449,6 +449,8 @@
 	name = "Market Professional"
 	desc = "You've become an excellent appraiser of goods over the years. Just by looking at the item, you can know how much it would sell for in today's market rates."
 
+//Medical perks - relates to surgery and all
+
 /datum/perk/surgical_master
 	name = "Surgery Training"
 	desc = "While you may not know the more advanced medical procedures, your mandatory training on surgery for implantation purposes allows you to perform basic surgical procedures with ease."
@@ -460,7 +462,6 @@
 /datum/perk/robotics_expert
 	name = "Robotics Expert"
 	desc = "Your formal training and experience in advanced mech construction and complex devices has made you more adept at working with them."
-
 
 /datum/perk/robotics_expert/assign(mob/living/carbon/human/H)
 	..()

--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -297,3 +297,13 @@
 	holder.stats.changeStat(STAT_MEC, -10)
 	..()
 
+
+//////////////
+//Drug Perks//
+//////////////
+
+//Basically for drugs to apply a perk for a set amount of time..
+
+/datum/perk/drug/ultrasurgeon
+	name = "Ultrasurgeon Knowledge"
+	desc = "After your fix of ultrasurgeon you can feel your mind ease just as your muscles relax."

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -134,7 +134,7 @@
 		STAT_TGH = 20,
 		STAT_ROB = 20,
 		STAT_VIG = 10,
-		STAT_BIO = 15
+		STAT_BIO = 20
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/chem_catalog,

--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -77,7 +77,7 @@
 	)
 
 	stat_modifiers = list(
-		STAT_BIO = 20,
+		STAT_BIO = 15,
 		STAT_MEC = 20,
 		STAT_COG = 10,
 		STAT_TGH = 10,

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -312,7 +312,7 @@
 	)
 
 	stat_modifiers = list(
-		STAT_BIO = 30,
+		STAT_BIO = 25,
 		STAT_TGH = 10,
 		STAT_VIG = 15,
 		STAT_ROB = 10,

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -363,7 +363,7 @@
 	perk_required = TRUE
 	needed_perk = PERK_MEDICAL_EXPERT
 	needed_perk_alt = PERK_SURGICAL_MASTER
-	bio_requirement = 75
+	bio_requirement = 25
 	stacktype_alt = /obj/item/stack/medical/advanced/bruise_pack/large
 	disinfectant  = TRUE
 
@@ -512,7 +512,7 @@
 	perk_required = TRUE
 	needed_perk = PERK_MEDICAL_EXPERT
 	needed_perk_alt = PERK_SURGICAL_MASTER
-	bio_requirement = 75
+	bio_requirement = 25
 	stacktype_alt = /obj/item/stack/medical/advanced/ointment/large
 	disinfectant  = TRUE
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -42,7 +42,7 @@
 	update_icon()
 
 /obj/item/reagent_containers/syringe/attack_self(mob/user as mob)
-	if(!user.stat_check(STAT_BIO, 10) && !user.stat_check(STAT_COG, 30) && !user.stats.getPerk(PERK_ADDICT))
+	if(!user.stat_check(STAT_BIO, 10) && !user.stat_check(STAT_COG, 20) && !user.stats.getPerk(PERK_ADDICT))
 		to_chat(user, SPAN_WARNING("You have no idea how to properly use this syringe!"))
 		return
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -42,7 +42,7 @@
 	update_icon()
 
 /obj/item/reagent_containers/syringe/attack_self(mob/user as mob)
-	if(user.stats.getStat(STAT_BIO) < 15 && !usr.stat_check(STAT_COG, 30) && !usr.stats.getPerk(PERK_ADDICT))
+	if(!user.stat_check(STAT_BIO, 10) && !user.stat_check(STAT_COG, 30) && !user.stats.getPerk(PERK_ADDICT))
 		to_chat(user, SPAN_WARNING("You have no idea how to properly use this syringe!"))
 		return
 

--- a/code/modules/reagents/reagents/stims.dm
+++ b/code/modules/reagents/reagents/stims.dm
@@ -249,6 +249,13 @@
 	nerve_system_accumulations = 30
 	addiction_chance = 30
 
+/datum/reagent/stim/ultra_surgeon/on_mob_add(mob/living/carbon/M, alien, effect_multiplier)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.stats.addPerk(PERK_ULTRASURGEON)
+		addtimer(CALLBACK(H.stats, /datum/stat_holder/proc/removePerk, PERK_ULTRASURGEON), 600 * volume)
+	. = ..()
+
 /datum/reagent/stim/ultra_surgeon/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_BIO, STAT_LEVEL_ADEPT, STIM_TIME, "ultra_surgeon")
 	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, STIM_TIME, "ultra_surgeon")

--- a/code/modules/surgery/organic_damage.dm
+++ b/code/modules/surgery/organic_damage.dm
@@ -7,7 +7,7 @@
 		/obj/item/stack/medical/bruise_pack = 20,
 		/obj/item/stack/medical/advanced/bruise_pack/mending_ichor = 100,
 	)
-
+	requires_perk = TRUE
 	duration = 80
 
 /datum/surgery_step/fix_organ/require_tool_message(mob/living/user)
@@ -56,6 +56,7 @@
 	target_organ_type = /obj/item/organ/internal/bone
 	required_tool_quality = QUALITY_BONE_GRAFTING
 	duration = 80
+	requires_perk = TRUE
 
 /datum/surgery_step/fix_bone/require_tool_message(mob/living/user)
 	to_chat(user, SPAN_WARNING("You need a Bone Gel, or item capable of [required_tool_quality]"))
@@ -169,6 +170,7 @@
 	duration = 100
 	blood_level = 1
 	can_infect = TRUE
+	requires_perk = TRUE
 
 /datum/surgery_step/fix_face/can_use(mob/living/user, obj/item/organ/external/head/organ, obj/item/tool)
 	return istype(organ) && organ.is_open() && organ.disfigured

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -5,10 +5,13 @@
 	var/list/allowed_tools = null
 	var/required_tool_quality = null
 	var/target_organ_type = /obj/item/organ/external
+	var/perk_i_need = PERK_SURGICAL_MASTER
+	var/perk_i_need_alt = PERK_MASTER_HERBALIST
 
 	var/difficulty = FAILCHANCE_HARD
 	var/required_stat = STAT_BIO
 	var/duration = 60
+	var/requires_perk = FALSE
 
 	// Can the step transfer germs?
 	var/can_infect = FALSE
@@ -88,6 +91,11 @@
 /obj/item/organ/proc/try_surgery_step(step_type, mob/living/user, obj/item/tool, target, no_tool_message = FALSE)
 	var/datum/surgery_step/S = GLOB.surgery_steps[step_type]
 
+	if(S.requires_perk)
+		if(!(user.stats.getPerk(S.perk_i_need) || user.stats.getPerk(S.perk_i_need_alt)) || !user.stats.getStat(STAT_BIO) >= 120)
+			to_chat(user, SPAN_WARNING("You do not have the training necessessary to do this surgery!"))
+			return FALSE
+
 	if(!S.is_valid_target(src, target))
 		SSnano.update_uis(src)
 		return FALSE
@@ -128,14 +136,14 @@
 
 	// Self-surgery increases failure chance
 	if(owner && user == owner)
-		difficulty_adjust = 60
-		time_adjust = 20
+		difficulty_adjust = 120
+		time_adjust = 40
 
 		// ...unless you are a carrion
 		// It makes sense that carrions have a way of making their flesh cooperate
 		if(is_carrion(user))
-			difficulty_adjust = -150
-			time_adjust = -40
+			difficulty_adjust = -300
+			time_adjust = -80
 
 	if(user.stats.getPerk(PERK_ROBOTICS_EXPERT) && S.is_robotic)
 		difficulty_adjust = -90

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -97,6 +97,10 @@
 			to_chat(user, SPAN_WARNING("You do not have the training necessessary to do this surgery!"))
 			return FALSE
 
+	if(status & ORGAN_SPLINTED)
+		to_chat(user, SPAN_WARNING("You need to remove the brace first!"))
+		return FALSE
+
 	if(!S.is_valid_target(src, target))
 		SSnano.update_uis(src)
 		return FALSE
@@ -112,7 +116,7 @@
 		return FALSE
 
 	if (istype(tool,/obj/item/stack/medical/advanced/bruise_pack))
-		if (tool.icon_state == "traumakit" && (!(user.stats.getPerk(PERK_ADVANCED_MEDICAL) || user.stats.getPerk(PERK_SURGICAL_MASTER) || user.stats.getStat(STAT_BIO) >= 25)))
+		if (tool.icon_state == "traumakit" && (!(user.stats.getPerk(PERK_ADVANCED_MEDICAL) || user.stats.getPerk(PERK_SURGICAL_MASTER) || user.stats.getStat(STAT_BIO) >= 50)))
 			to_chat(user, SPAN_WARNING("You do not have the training to use an Advanced Trauma Kit in this way."))
 			return FALSE
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -5,8 +5,9 @@
 	var/list/allowed_tools = null
 	var/required_tool_quality = null
 	var/target_organ_type = /obj/item/organ/external
-	var/perk_i_need = PERK_SURGICAL_MASTER
+	var/perk_i_need = PERK_ADVANCED_MEDICAL					//Basically set up to check for specific surgery perks.
 	var/perk_i_need_alt = PERK_MASTER_HERBALIST
+	var/perk_drug = PERK_ULTRASURGEON
 
 	var/difficulty = FAILCHANCE_HARD
 	var/required_stat = STAT_BIO
@@ -92,7 +93,7 @@
 	var/datum/surgery_step/S = GLOB.surgery_steps[step_type]
 
 	if(S.requires_perk)
-		if(!(user.stats.getPerk(S.perk_i_need) || user.stats.getPerk(S.perk_i_need_alt)) || !user.stats.getStat(STAT_BIO) >= 120)
+		if(!(user.stats.getPerk(S.perk_i_need) || user.stats.getPerk(S.perk_i_need_alt) || user.stats.getPerk(S.perk_drug)) || !user.stats.getStat(STAT_BIO) >= 50)
 			to_chat(user, SPAN_WARNING("You do not have the training necessessary to do this surgery!"))
 			return FALSE
 
@@ -111,7 +112,7 @@
 		return FALSE
 
 	if (istype(tool,/obj/item/stack/medical/advanced/bruise_pack))
-		if (tool.icon_state == "traumakit" && (!(user.stats.getPerk(PERK_ADVANCED_MEDICAL) || user.stats.getPerk(PERK_SURGICAL_MASTER) || user.stats.getStat(STAT_BIO) >= 120)))
+		if (tool.icon_state == "traumakit" && (!(user.stats.getPerk(PERK_ADVANCED_MEDICAL) || user.stats.getPerk(PERK_SURGICAL_MASTER) || user.stats.getStat(STAT_BIO) >= 25)))
 			to_chat(user, SPAN_WARNING("You do not have the training to use an Advanced Trauma Kit in this way."))
 			return FALSE
 

--- a/code/modules/surgery/surgery_ui.dm
+++ b/code/modules/surgery/surgery_ui.dm
@@ -164,7 +164,7 @@
 			if(istype(usr, /mob/living))
 				var/mob/living/user = usr
 				var/target_stat = BP_IS_ROBOTIC(src) ? STAT_MEC : STAT_BIO
-				var/removal_time = 50 * usr.stats.getMult(target_stat, STAT_LEVEL_PROF)
+				var/removal_time = 70 * usr.stats.getMult(target_stat, STAT_LEVEL_PROF)
 				var/target = get_surgery_target()
 				var/obj/item/I = user.get_active_hand()
 
@@ -181,7 +181,7 @@
 					wait = do_after(user, removal_time, target, needhand = FALSE)
 
 				if(wait)
-					if(prob(40 + (FAILCHANCE_VERY_EASY + usr.stats.getStat(target_stat)))) //30 bio or mech will make you never fail when doing surgery
+					if(prob(FAILCHANCE_NORMAL + usr.stats.getStat(target_stat))) //Relatively easy skill-check, but still chance to fail if under 40 Bio. 0 Bio = 60% success rate, 40 bio = 100% success rate, etc.
 						for(var/obj/item/material/shard/shrapnel/shrapnel in src.implants)
 							implants -= shrapnel
 							shrapnel.loc = get_turf(src)


### PR DESCRIPTION
## About The Pull Request
Adds code to check for Medical's surgery perk (Or herbalist for hunters) to do surgeries or a bio of 50+. Some surgeries are locked behind this - mostly relate to organ repair, bone grafting and other surgery types. This 'lock' can be bypassed by using Ultrasurgeon, granting a temporary perk atop of its increase in biology allowing you to attempt surgery. Shrapnel removal has seen a **slight** increase in difficulty - but still has a 100% success rate if the person has 40 bio skill basically. Self surgery has also been penalized **heavily** by having a doubled fail-rate from what it was and a doubled time-wait.

As every 'balancing' PR is a take-and-give, I've lowered the requirement to use the advanced kits **heavily**. People who are non-Soteria with a bio skill of 25 (instead of 75) can now use it. This may be adjusted but I felt it's fair since the Absolute ones are 15 bio skill and syringes are also 15 bio skill.

This should make Soteria's job more focused on as it requires people to either use splints to temporarily reduce an injuries' penalty or to go to Soteria. This is mostly a start of my intentions, as I believe allowing players to freely heal themselves of non-major injuries and requiring Soteria or a heavy stat-bypass for more serious injuries. 

## Changelog
:cl:
add: Stat/Perk 'locks' for certain surgery types. Only really involves 'complex' surgeries that are not life-saving or simple.
tweak: Edits shrapnel surgery to actually have a tad bit of low-risk 'randomness' to it to encourage people with actual biology skills to do it.
tweak: (?) No idea if it was broken by code-line, but added a new check to prevent surgery on splinted limbs. Just remove the splint though and you can do surgery as normal.
balance: Allows advanced kits to be used again by those of at least 25 bio. (Subject possibly to reduction if needed.) 
balance: Reduces biology needed by syringes by 5, allowing someone with a bio of 10 to now use syringes.
balance: TT has received 5 extra bio skill since it took Orderly's bio skill and not paramedic. To prevent heavy stat-powergame at round start to bypass the checks, 5 biology has been removed from Corpsman and Salvager.
balance: Because people enjoyed doing self-surgery to avoid medical fees, the difficulty and time of self-surgery has been doubled! Yipieeeeee!!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
