### PR TITLE
The Armor_Overpentration Revolution & Its Consequences 

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -37,7 +37,7 @@
 
 	if(armor_overpenetration > 0 && damagetype == BURN) //did we even over-penitrate?
 		if(istype(src,/mob/living/simple_animal/) || istype(src,/mob/living/carbon/superior_animal/)) //We only overpenitrate mobs.
-			effective_damage += max(0,round((armor_overpenetration - src.getarmor(def_zone, "energy"))) * 0.8) //We re-check are armor we over-pentrated, and then deal 2x damage do to being a laser, thus weaker then most bullets and most mobs having less engery armor.
+			effective_damage += max(0,round((armor_overpenetration - src.getarmor(def_zone, "energy"))) * 1) //We re-check are armor we over-pentrated, and then deal 2x damage do to being a laser, thus weaker then most bullets and most mobs having less engery armor.
 
 
 	//Here we can remove edge or sharpness from the blow

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -37,7 +37,7 @@
 
 	if(armor_overpenetration > 0 && damagetype == BURN) //did we even over-penitrate?
 		if(istype(src,/mob/living/simple_animal/) || istype(src,/mob/living/carbon/superior_animal/)) //We only overpenitrate mobs.
-			effective_damage += max(0,round((armor_overpenetration - src.getarmor(def_zone, "energy"))) * 1) //We re-check are armor we over-pentrated, and then deal 2x damage do to being a laser, thus weaker then most bullets and most mobs having less engery armor.
+			effective_damage += max(0,round((armor_overpenetration - src.getarmor(def_zone, "energy")))) //We re-check are armor we over-pentrated, and then deal 2x damage do to being a laser, thus weaker then most bullets and most mobs having less engery armor.
 
 
 	//Here we can remove edge or sharpness from the blow

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -33,11 +33,11 @@
 
 	if(armor_overpenetration > 0 && damagetype == BRUTE) //did we even over-penitrate?
 		if(istype(src,/mob/living/simple_animal/) || istype(src,/mob/living/carbon/superior_animal/)) //We only overpenitrate mobs.
-			effective_damage += max(0,round(armor_overpenetration - src.getarmor(def_zone, "bullet")) * 0.8) //We re-check are armor we over-pentrated, this counts both melee and bullets. We reduce are over AP as bullets tend to have a lot
+			effective_damage += max(0,round(armor_overpenetration - src.getarmor(def_zone, "bullet")) * 0.8) //We re-check are armor we over-pentrated and reduce the effective damage by 0.8, this counts both melee and bullets. We reduce are over AP as bullets tend to have a lot
 
 	if(armor_overpenetration > 0 && damagetype == BURN) //did we even over-penitrate?
 		if(istype(src,/mob/living/simple_animal/) || istype(src,/mob/living/carbon/superior_animal/)) //We only overpenitrate mobs.
-			effective_damage += max(0,round((armor_overpenetration - src.getarmor(def_zone, "energy")))) //We re-check are armor we over-pentrated, and then deal 2x damage do to being a laser, thus weaker then most bullets and most mobs having less engery armor.
+			effective_damage += max(0,round((armor_overpenetration - src.getarmor(def_zone, "energy")))) //We re-check are armor we over-pentrated and deal the extra damage accordingly.
 
 
 	//Here we can remove edge or sharpness from the blow

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -33,11 +33,11 @@
 
 	if(armor_overpenetration > 0 && damagetype == BRUTE) //did we even over-penitrate?
 		if(istype(src,/mob/living/simple_animal/) || istype(src,/mob/living/carbon/superior_animal/)) //We only overpenitrate mobs.
-			effective_damage += max(0,round(armor_overpenetration - src.getarmor(def_zone, "bullet"))) //We re-check are armor we over-pentrated, this counts both melee and bullets. We reduce are over AP as bullets tend to have a lot
+			effective_damage += max(0,round(armor_overpenetration - src.getarmor(def_zone, "bullet")) * 0.8) //We re-check are armor we over-pentrated, this counts both melee and bullets. We reduce are over AP as bullets tend to have a lot
 
 	if(armor_overpenetration > 0 && damagetype == BURN) //did we even over-penitrate?
 		if(istype(src,/mob/living/simple_animal/) || istype(src,/mob/living/carbon/superior_animal/)) //We only overpenitrate mobs.
-			effective_damage += max(0,round((armor_overpenetration - src.getarmor(def_zone, "energy")) * 2)) //We re-check are armor we over-pentrated, and then deal 2x damage do to being a laser, thus weaker then most bullets and most mobs having less engery armor.
+			effective_damage += max(0,round((armor_overpenetration - src.getarmor(def_zone, "energy"))) * 0.8) //We re-check are armor we over-pentrated, and then deal 2x damage do to being a laser, thus weaker then most bullets and most mobs having less engery armor.
 
 
 	//Here we can remove edge or sharpness from the blow


### PR DESCRIPTION
## About The Pull Request
Balances ballistic and energy overpen. Instead of energy doing 2x the normal over-pen damage, they only do the normal amount. Ballistics, since some bullet types and/or modifications to guns can shoot into multiple targets, have received a 0.8 modifier; making them do less overpen.
	
This is done due to the fact that overpen system has created a snowball effect of mob difficulty. Staff/Devs of the past saw players shoot their mobs with 8.6mm/.408s, which are doing 50+ damage to mobs every bullet due to their overpen modifier (Or worse - energy guns with high AP), and thinking: "Wow, my mob is shit" only to buff it. Not seeing what lower-end weapons do the the mob, as a 9mm/.35 round can only do roughly ~16 damage per hit on a mob with no armor; overpen included.

This should make it so:
1. Energy weapons are no longer a hard meta against mobs. They will still be **slightly** better than ballistics per-target, but as stated, some ballistic calibers/bullet types do shoot through single targets.
2. HP rounds should be **slightly** more viable as HV ammo types will no longer have large quantities of damage over HPs.
3. Certain mobs that sport armor types should no longer be as weak as they were. This won't be too noticeable on some, but other mobs with high armors should take a few extra shots before they die now to higher AP ammunition. (HPs actually may be slightly better than them now. Will require more testing on that front to figure out, not major anyway.)

While I wish I could fully remove this system I've been told not to due to balance issues - since I'd have to go redo all mob health all over again. Curse you.

## Changelog
:cl:
balance: Redoes how much armor pen happens, modfiying brute by x 0.8 (x 1.0 prior) and lasers by x 1.0 (x 2.0 prior)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
