### PR TITLE
Makes voidwolf reavers flash immune

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/voidwolf/voidwolf.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/voidwolf/voidwolf.dm
@@ -218,7 +218,7 @@
 	mag_type = /obj/item/ammo_magazine/rifle_223/empty
 	mags_left = 3
 
-	casingtype = /obj/item/ammo_casing/beam/ap/spent
+	flash_resistances = 20 //no.
 
 	armor = list(melee = 60, bullet = 55, energy = 50, bomb = 75, bio = 100, rad = 25) //Legitmently their armor
 
@@ -235,6 +235,8 @@
 /mob/living/carbon/superior_animal/human/voidwolf/elite/laserak
 	projectiletype = /obj/item/projectile/beam/weak/ap/reaver
 	drop_items = list(/obj/item/gun/projectile/automatic/ak47/akl/reaver_modded)
+
+	casingtype = /obj/item/ammo_casing/beam/ap/spent
 
 	mag_type = /obj/item/ammo_magazine/rifle_223/empty
 	mags_left = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Flashes are a crutch that let you cheese mobs and do combat with zero risk.

This combat should not have zero risk.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
balance: Reavers are now immune to flashes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
