### PR TITLE
Allows Artificer Nanogate/Cultured Psionic Organ to be taken by Premier, Steward and Colonist

### DIFF
--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -36,8 +36,6 @@
 	restricted_jobs = list(
 		/datum/job/doctor,
 		/datum/job/trauma_team,
-		/datum/job/premier,
-		/datum/job/pg,
 		/datum/job/chaplain,
 		/datum/job/chief_engineer,
 		/datum/job/merchant,
@@ -46,7 +44,7 @@
 		/datum/job/swo
 	) // The way to restrict this to one job could be done cleaner but this way easier so fuck it. -Kaz
 	allow_modifications = FALSE
-	restricted_depts = SECURITY | PROSPECTORS | ENGINEERING | SCIENCE | CHURCH | INDEPENDENT | CIVILIAN | LSS
+	restricted_depts = SECURITY | PROSPECTORS | ENGINEERING | SCIENCE | CHURCH | INDEPENDENT | LSS
 	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_MYCUS, FORM_FOLKEN, FORM_CHTMANT)
 
 /datum/category_item/setup_option/core_implant/nanogate
@@ -66,8 +64,6 @@
 	implant_organ_type = "artificer nanogate"
 	restricted_jobs = list(
 		/datum/job/outsider, // Nanogates are only available to colonist or allies.
-		/datum/job/premier,
-		/datum/job/pg,
 		/datum/job/chaplain,
 		/datum/job/cmo,
 		/datum/job/merchant,
@@ -77,7 +73,7 @@
 		)
 	allow_modifications = TRUE
 	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_FBP, FORM_UNBRANDED, FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH)
-	restricted_depts = SECURITY | PROSPECTORS | MEDICAL | SCIENCE | CHURCH | INDEPENDENT | CIVILIAN | LSS
+	restricted_depts = SECURITY | PROSPECTORS | MEDICAL | SCIENCE | CHURCH | INDEPENDENT | LSS
 
 /datum/category_item/setup_option/core_implant/opifex_nanogate
 	name = "Opifex Nanogate"

--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -44,7 +44,7 @@
 		/datum/job/swo
 	) // The way to restrict this to one job could be done cleaner but this way easier so fuck it. -Kaz
 	allow_modifications = FALSE
-	restricted_depts = SECURITY | PROSPECTORS | ENGINEERING | SCIENCE | CHURCH | INDEPENDENT | LSS
+	restricted_depts = SECURITY | PROSPECTORS | ENGINEERING | SCIENCE | CHURCH | INDEPENDENT | CIVILIAN | LSS
 	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_MYCUS, FORM_FOLKEN, FORM_CHTMANT)
 
 /datum/category_item/setup_option/core_implant/nanogate
@@ -73,7 +73,7 @@
 		)
 	allow_modifications = TRUE
 	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_FBP, FORM_UNBRANDED, FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH)
-	restricted_depts = SECURITY | PROSPECTORS | MEDICAL | SCIENCE | CHURCH | INDEPENDENT | LSS
+	restricted_depts = SECURITY | PROSPECTORS | MEDICAL | SCIENCE | CHURCH | INDEPENDENT | CIVILIAN | LSS
 
 /datum/category_item/setup_option/core_implant/opifex_nanogate
 	name = "Opifex Nanogate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>
The Premier, Steward and Colonist roles can now select Artificer Nanogates and Cultured Psionic Organs (restricted to the Guild and Psychiatrist/CBO, respectively) during character setup.

_Why?_
Premier, Steward and Colonist are all roles that can be undertaken by crew - the former two are volunteer roles performed by councilmembers or experienced colonists, while the latter is often used as an "off-duty" role. There's no reason that being a Guildmaster with an Artificer Nanogate should lock you out of playing Premier. 
While this could potentially let someone who _usually_ plays another department "game the system" by taking these restricted core implants when they play Premier/Steward/Colonist, this would require them to constantly swap back and forth in character setup, and I _personally_ do not think it's likely enough to be abused that we need to lock _everyone_ with one of these implants out of being Premier or just going off-duty for a shift.
	
<hr>
</details>

## Changelog
:cl:
tweak: Premier, Steward and Colonist can take Artificer Nanogates/Cultured Psionic Organs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
