### PR TITLE
Empty linked box on teleporter

### DIFF
--- a/code/game/machinery/excelsior/blackshield_teleporter.dm
+++ b/code/game/machinery/excelsior/blackshield_teleporter.dm
@@ -44,6 +44,7 @@ var/global/blackshield_max_energy //Maximaum combined energy of all teleporters
 		/obj/item/ammo_magazine/speed_loader_rifle_75 = 15, //More or less for ammo rather then speedloader
 		/obj/item/ammo_magazine/light_rifle_257 = 30,
 		/obj/item/ammo_magazine/rifle_75 = 35,
+		/obj/item/ammo_magazine/rifle_75_linked_box/empty = 65, // Empty linked mag for balance, making the Heroic actually useable if ordered.
 		/obj/item/ammo_magazine/heavy_rifle_408 = 50,
 		/obj/item/ammo_magazine/ammobox/pistol_35 = 75,
 		/obj/item/ammo_magazine/ammobox/magnum_40 = 150,


### PR DESCRIPTION
## About The Pull Request

I added the Heroic to the teleporter, but there's no way to use it if you don't have the right mag (or in this case, linked box) to load it with, unless the armory is open (which means you could instead use the one in the armory) or printed through Guild. This PR adds an **empty** linked 7.62mm ammo box for the Heroic (and the Pulemyot) on the teleporter for 65 power.
	
<hr>

## Changelog
:cl:
add: Adds an EMPTY linked ammo box of 7.62mm to the Blackshield teleporter for 65 power cost.
/:cl: