### PR TITLE
Handmade stripper clips

### DIFF
--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -19,6 +19,24 @@
 		list(QUALITY_SAWING, 15, "time" = 30)
 	)
 
+/datum/craft_recipe/gun/stripper1
+	name = "handmade 6.5mm carbine stripper clip"
+	result = /obj/item/ammo_magazine/speed_loader_light_rifle_257/empty
+	steps = list(
+		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL, "time" = 30),
+		list(QUALITY_SAWING, 10, "time" = 30), // Cut the unneeded corners...
+		list(QUALITY_HAMMERING, 10, "time" = 30) // ...and hammer them into shape!
+	)
+
+/datum/craft_recipe/gun/stripper1
+	name = "handmade 7.62mm rifle stripper clip"
+	result = /obj/item/ammo_magazine/speed_loader_rifle_75/empty
+	steps = list(
+		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL, "time" = 30),
+		list(QUALITY_SAWING, 10, "time" = 30),
+		list(QUALITY_HAMMERING, 10, "time" = 30)
+	)
+
 /datum/craft_recipe/gun/arrows
 	name = "crude arrows"
 	result = /obj/item/ammo_casing/arrow/bulk

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -915,6 +915,10 @@
 	. = ..()
 	update_icon()
 
+/obj/item/ammo_magazine/speed_loader_rifle_75/empty
+	initial_ammo = 0
+	icon_state = "stripper_base"
+
 /obj/item/ammo_magazine/speed_loader_light_rifle_257
 	name = "ammo strip (6.5mm Carbine)"
 	desc = "A 10 round ammo strip for 6.5mm Carbine."
@@ -935,6 +939,10 @@
 /obj/item/ammo_magazine/speed_loader_light_rifle_257/Initialize()
 	. = ..()
 	update_icon()
+
+/obj/item/ammo_magazine/speed_loader_light_rifle_257/empty
+	initial_ammo = 0
+	icon_state = "stripper_base"
 
 /obj/item/ammo_magazine/speed_loader_heavy_rifle_408
 	name = "ammo strip (8.6mm Heavy Rifle)"


### PR DESCRIPTION
## About The Pull Request

- Adds empty 7.62mm rifle and 6.5mm carbine stripper clips to Guns tab of crafting menu

## Why it's good for the ga- hold on this isn't tg

They're cheap, disposable pieces of metal meant to guide bullets quicker into feeding chambers or mags, they should be easy to obtain as a help for those that can't afford more advanced weaponry, in other words...**EVER UPWARD! GUNS FOR THE PEO-**

> -> [ [ [ This PR has been seized by Nadezhda Marshals for fostering Excelsior propaganda, have a good day. ] ] ] <-



<hr>

## Changelog
:cl:
add: Adds craftable stripper clips for 6.5mm carbine and 7.62mm rifle under Guns tab: 1 metal sheet, sawing quality of 10, hammering quality of 10.
/:cl: