### PR TITLE
I HATE LIVERMED, I HATE LIVERMED, I HATE LIVERMED!!!

### DIFF
--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -98,13 +98,13 @@
 	icon_state = "combat_surgery_kit"
 	item_state = "combat_surgery_kit"
 	initial_contents = list(
-		/obj/item/tool/bonesetter,
+		/obj/item/tool/bonesetter/adv,
 		/obj/item/tool/saw/circular/medical,
 		/obj/item/tool/hemostat/adv,
 		/obj/item/tool/retractor/adv,
 		/obj/item/tool/scalpel/laser,
 		/obj/item/tool/tape_roll/bonegel,
-		/obj/item/tool/surgicaldrill,
+		/obj/item/tool/surgicaldrill/adv,
 		/obj/item/reagent_containers/syringe/stim/ultra_surgeon,
 		/obj/item/storage/pill_bottle/tramadol,
 		/obj/item/stack/medical/advanced/bruise_pack

--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -130,9 +130,10 @@
 	initial_contents = list(/obj/item/storage/pill_bottle/bicaridine,
 	/obj/item/storage/pill_bottle/dermaline,
 	/obj/item/storage/pill_bottle/dexalin_plus,
-	/obj/item/storage/pill_bottle/dylovene,
+	/obj/item/storage/pill_bottle/carthatoline,
 	/obj/item/storage/pill_bottle/tramadol,
 	/obj/item/storage/pill_bottle/spaceacillin,
+	/obj/item/reagent_containers/hypospray/autoinjector/sanguinum,
 	/obj/item/stack/medical/splint)
 
 //Crates

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -109,7 +109,7 @@
 	new /obj/item/reagent_containers/pill/dexalin(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/quickclot(src)
-	new /obj/item/reagent_containers/hypospray/autoinjector/quickclot(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/sanguinum(src)
 	new /obj/item/reagent_containers/syringe/inaprovaline(src)
 	new /obj/item/device/scanner/health(src)
 
@@ -143,9 +143,10 @@
 	new /obj/item/storage/pill_bottle/bicaridine(src)
 	new /obj/item/storage/pill_bottle/dermaline(src)
 	new /obj/item/storage/pill_bottle/dexalin_plus(src)
-	new /obj/item/storage/pill_bottle/dylovene(src)
+	new /obj/item/storage/pill_bottle/carthatoline(src)
 	new /obj/item/storage/pill_bottle/tramadol(src)
 	new /obj/item/storage/pill_bottle/spaceacillin(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/sanguinum(src)
 	new /obj/item/stack/medical/splint(src)
 
 /obj/item/storage/firstaid/surgery
@@ -564,6 +565,19 @@
     new /obj/item/reagent_containers/pill/dylovene(src)
     new /obj/item/reagent_containers/pill/dylovene(src)
     new /obj/item/reagent_containers/pill/dylovene(src)
+
+/obj/item/storage/pill_bottle/carthatoline
+	name = "bottle of Carthatoline pills"
+	desc = "Contains pills used to counteract severe poisoning and liver failure."
+
+/obj/item/storage/pill_bottle/carthatoline/populate_contents()
+	new /obj/item/reagent_containers/pill/carthatoline(src)
+	new /obj/item/reagent_containers/pill/carthatoline(src)
+	new /obj/item/reagent_containers/pill/carthatoline(src)
+	new /obj/item/reagent_containers/pill/carthatoline(src)
+	new /obj/item/reagent_containers/pill/carthatoline(src)
+	new /obj/item/reagent_containers/pill/carthatoline(src)
+	new /obj/item/reagent_containers/pill/carthatoline(src)
 
 /obj/item/storage/pill_bottle/inaprovaline
 	name = "bottle of Inaprovaline pills"

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -146,7 +146,7 @@
 	new /obj/item/storage/pill_bottle/carthatoline(src)
 	new /obj/item/storage/pill_bottle/tramadol(src)
 	new /obj/item/storage/pill_bottle/spaceacillin(src)
-	new /obj/item/reagent_containers/hypospray/autoinjector/sanguinum(src)
+	new /obj/item/storage/pill_bottle/bloodregen(src)
 	new /obj/item/stack/medical/splint(src)
 
 /obj/item/storage/firstaid/surgery
@@ -656,6 +656,19 @@
 	new /obj/item/reagent_containers/pill/prosurgeon(src)
 	new /obj/item/reagent_containers/pill/prosurgeon(src)
 	new /obj/item/reagent_containers/pill/prosurgeon(src)
+
+/obj/item/storage/pill_bottle/bloodregen
+	name = "bottle of Blood Deficiency supplements"
+	desc = "Contains pills to help speed up natural blood generation."
+
+/obj/item/storage/pill_bottle/bloodregen/populate_contents()
+	new /obj/item/reagent_containers/pill/bloodregen(src)
+	new /obj/item/reagent_containers/pill/bloodregen(src)
+	new /obj/item/reagent_containers/pill/bloodregen(src)
+	new /obj/item/reagent_containers/pill/bloodregen(src)
+	new /obj/item/reagent_containers/pill/bloodregen(src)
+	new /obj/item/reagent_containers/pill/bloodregen(src)
+	new /obj/item/reagent_containers/pill/bloodregen(src)
 
 /*
  * Portable Freezers

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -474,7 +474,7 @@
 	new /obj/item/storage/pill_bottle/bicaridine(src)
 	new /obj/item/storage/pill_bottle/dermaline(src)
 	new /obj/item/storage/pill_bottle/spaceacillin(src)
-	new /obj/item/storage/pill_bottle/antitox(src)
+	new /obj/item/storage/pill_bottle/carthatoline(src)
 	new /obj/item/storage/pill_bottle/prosurgeon(src)
 	new /obj/item/stack/medical/splint(src)
 	new /obj/item/device/scanner/health(src)

--- a/code/game/objects/items/weapons/tools/tape.dm
+++ b/code/game/objects/items/weapons/tools/tape.dm
@@ -86,7 +86,7 @@
 
 /obj/item/tool/tape_roll/bonegel/si
 	name = "bone super gel"
-	desc = "A gel-like calcium composite used as a surgical substitute for broken or missing bone pieces."
+	desc = "An improved gel-like calcium composite formula used as an efficient surgical substitute for broken or missing bone pieces."
 	icon = 'icons/obj/stack/items.dmi'
 	icon_state = "bonegel_SI"
 	matter = list(MATERIAL_PLASTIC = 30, MATERIAL_STEEL = 3)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -238,6 +238,13 @@
 	item_state = "syrette_quickclot"
 	baseline_sprite = "syrette_quickclot"
 
+/obj/item/reagent_containers/hypospray/autoinjector/sanguinum
+	name = "autoinjector (sanguinum)"
+	preloaded_reagents = list("sanguinum" = 5)
+	icon_state = "syrette_red"
+	item_state = "syrette_red"
+	baseline_sprite = "syrette_red"
+
 /obj/item/reagent_containers/hypospray/autoinjector/spaceacillin
 	name = "autoinjector (spaceacillin)"
 	icon_state = "syrette_spacealine"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -208,8 +208,11 @@
 	icon_state = "pill19"
 	preloaded_reagents = list("prosurgeon" = 10)
 
-
-
+/obj/item/reagent_containers/pill/bloodregen
+	name = "Ferritin-Hemosiderin pill"
+	desc = "A pill of iron supplements meant to help the natural restoration of blood."
+	icon_state = "pill5"
+	preloaded_reagents = list("iron" = 10 "protein" = 10) // Sugar does nothing to restore blood, but Protein does!
 
 //Pills with random content
 /obj/item/reagent_containers/pill/floorpill

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -212,7 +212,7 @@
 	name = "Ferritin-Hemosiderin pill"
 	desc = "A pill of iron supplements meant to help the natural restoration of blood."
 	icon_state = "pill5"
-	preloaded_reagents = list("iron" = 10 "protein" = 10) // Sugar does nothing to restore blood, but Protein does!
+	preloaded_reagents = list("iron" = 10, "protein" = 10) // Sugar does nothing to restore blood, but Protein does!
 
 //Pills with random content
 /obj/item/reagent_containers/pill/floorpill

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -68,7 +68,7 @@
 /obj/item/reagent_containers/pill/tox
 	name = "Toxins pill"
 	desc = "Highly toxic."
-	icon_state = "pill5"
+	icon_state = "pill12"
 	preloaded_reagents = list("toxin" = 50)
 
 
@@ -95,112 +95,117 @@
 /obj/item/reagent_containers/pill/kelotane
 	name = "Kelotane pill"
 	desc = "Used to treat burns."
-	icon_state = "pill11"
+	icon_state = "pill7"
 	preloaded_reagents = list("kelotane" = 15)
 
 
 /obj/item/reagent_containers/pill/paracetamol
 	name = "Paracetamol pill"
 	desc = "Tylenol! A painkiller for the ages. Chewables!"
-	icon_state = "pill8"
+	icon_state = "pill9"
 	preloaded_reagents = list("paracetamol" = 15)
 
 
 /obj/item/reagent_containers/pill/tramadol
 	name = "Tramadol pill"
 	desc = "A simple painkiller."
-	icon_state = "pill8"
+	icon_state = "pill10"
 	preloaded_reagents = list("tramadol" = 15)
 
 
 /obj/item/reagent_containers/pill/methylphenidate
 	name = "Methylphenidate pill"
 	desc = "Improves the ability to concentrate."
-	icon_state = "pill8"
+	icon_state = "pill13"
 	preloaded_reagents = list("methylphenidate" = 15)
 
 
 /obj/item/reagent_containers/pill/citalopram
 	name = "Citalopram pill"
 	desc = "Mild anti-depressant."
-	icon_state = "pill8"
+	icon_state = "pill3"
 	preloaded_reagents = list("citalopram" = 15)
 
 
 /obj/item/reagent_containers/pill/inaprovaline
 	name = "Inaprovaline pill"
 	desc = "Used to stabilize patients."
-	icon_state = "pill20"
+	icon_state = "pill3"
 	preloaded_reagents = list("inaprovaline" = 30)
 
 
 /obj/item/reagent_containers/pill/dexalin
 	name = "Dexalin pill"
 	desc = "Used to treat oxygen deprivation."
-	icon_state = "pill16"
+	icon_state = "pill8"
 	preloaded_reagents = list("dexalin" = 15)
 
 
 /obj/item/reagent_containers/pill/dexalin_plus
 	name = "Dexalin Plus pill"
 	desc = "Used to treat extreme oxygen deprivation."
-	icon_state = "pill8"
+	icon_state = "pill16"
 	preloaded_reagents = list("dexalinp" = 15)
 
 
 /obj/item/reagent_containers/pill/dermaline
 	name = "Dermaline pill"
 	desc = "Used to treat burn wounds."
-	icon_state = "pill12"
+	icon_state = "pill15"
 	preloaded_reagents = list("dermaline" = 15)
 
 
 /obj/item/reagent_containers/pill/dylovene
 	name = "Dylovene pill"
 	desc = "A broad-spectrum anti-toxin."
-	icon_state = "pill13"
+	icon_state = "pill11"
 	preloaded_reagents = list("anti_toxin" = 15)
 
+/obj/item/reagent_containers/pill/carthatoline
+	name = "Carthatoline pill"
+	desc = "A powerful anti-toxin and liver restorer."
+	icon_state = "pill17"
+	preloaded_reagents = list("carthatoline" = 15)
 
 /obj/item/reagent_containers/pill/inaprovaline
 	name = "Inaprovaline pill"
 	desc = "Used to stabilize patients."
-	icon_state = "pill20"
+	icon_state = "pill3"
 	preloaded_reagents = list("inaprovaline" = 30)
 
 
 /obj/item/reagent_containers/pill/bicaridine
 	name = "Bicaridine pill"
 	desc = "Used to treat physical injuries."
-	icon_state = "pill18"
+	icon_state = "pill4"
 	preloaded_reagents = list("bicaridine" = 20)
 
 
 /obj/item/reagent_containers/pill/happy
 	name = "Happy pill"
 	desc = "Happy happy joy joy!"
-	icon_state = "pill18"
+	icon_state = "pill8" // Literally Joy
 	preloaded_reagents = list("space_drugs" = 15, "sugar" = 15)
 
 
 /obj/item/reagent_containers/pill/zoom
 	name = "Zoom pill"
 	desc = "Zoooom!"
-	icon_state = "pill18"
+	icon_state = "pill20"
 	preloaded_reagents = list("impedrezene" = 10, "synaptizine" = 5, "hyperzine" = 5)
 
 
 /obj/item/reagent_containers/pill/spaceacillin
 	name = "Spaceacillin pill"
 	desc = "Contains antiviral agents."
-	icon_state = "pill19"
+	icon_state = "pill18"
 	preloaded_reagents = list("spaceacillin" = 15)
 
 
 /obj/item/reagent_containers/pill/prosurgeon
 	name = "ProSurgeon pill"
 	desc = "Contains a stimulating drug that is used to reduce tremor to minimum."
-	icon_state = "pill3"
+	icon_state = "pill19"
 	preloaded_reagents = list("prosurgeon" = 10)
 
 


### PR DESCRIPTION
## My little bandaid fix for current medical issues

- Replaces Dylovene pill bottle on Combat Medical Kit with Carthatoline pill bottle, as every chem inside it already WAS an upgrade over their normal counterparts, making it better at halting toxins damage and preventing liver from killing you. Also adds a bottle of blood restoration pills to help with bloodloss which would cause the former as well.
- Replaces one of the Quicklot syrettes with a Sanguinum syrette on the Oxygen Deprivation First Aid Kit for better treatment of causes of oxyloss.
- Combat surgery kits gain advanced bonesetter and drill (since every other tool except those was already advanced)
- Changes the advanced bone gel item description to make it obvious it's an upgrade.
- Standardizes pill icons based on chem colors across all pre-built pills for easier recognition.


<hr>

## Changelog
:cl:
add: Added a pre-built bottle of Carthatoline pills and a Sanguinum syrette. Adds a blood restoration pill bottle with pre-made pills of iron+protein.
balance: Combat Medical Kits now have a bottle of Carthatoline pills instead of Dylovene, and gain a bottle of blood restoration pills. Oxygen Treatment Kits lose 1 Quicklot syrette but gain 1 Sanguinum syrette. Carthatoline pill bottle also added to the rare blackshield counter-siege treatment kit and deferred combat medical kit. Combat surgery kits now carry advanced bonesetter and drills as well for consistency.
spellcheck: Makes the description of advanced bone gel different to state that it's a better version of its stock counterpart
fix: Pre-built pills icons changed to better reflect the color of their chemicals for easier recognition. Why was a Dermaline pill RED?!
/:cl: