### PR TITLE
Adds 2 alt titles for Trauma Team

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -119,7 +119,7 @@
 	difficulty = "Ungratifying."
 	selection_color = "#a8b69a"
 	wage = WAGE_PROFESSIONAL
-	alt_titles = list("Soteria Paramedic", "Soteria Client Recovery Specialist")
+	alt_titles = list("Soteria Client Recovery Specialist")
 	outfit_type = /decl/hierarchy/outfit/job/medical/trauma_team
 
 	health_modifier = 5

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -119,7 +119,7 @@
 	difficulty = "Ungratifying."
 	selection_color = "#a8b69a"
 	wage = WAGE_PROFESSIONAL
-	alt_titles = (null)
+	alt_titles = list("Soteria Paramedic", "Soteria Client Recovery Specialist")
 	outfit_type = /decl/hierarchy/outfit/job/medical/trauma_team
 
 	health_modifier = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Adds the "Soteria Paramedic" and "Soteria Client Recovery Specialist" alt-titles to Trauma Team.
_Why?_
Trauma Team is a cool name, and a nice reference, but a little bit of variety is good to have. Also, I personally (not sure if others feel the same) would prefer to use the non-setting-specific title than one that's explicitly a reference.
	
<hr>
</details>

## Changelog
:cl:
add: Added two alt-titles to Trauma Team
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
