### PR TITLE
Fixes psi loot spawns

### DIFF
--- a/code/game/objects/random/psi_loot.dm
+++ b/code/game/objects/random/psi_loot.dm
@@ -4,7 +4,7 @@
 	icon_state = "armor-blue"
 	spawn_nothing_percentage = 20
 
-/obj/random/rig/item_to_spawn()
+/obj/random/psi/item_to_spawn()
 	return pickweight(list(
 	//Swords and hammers
 	/obj/item/tool/sword/cult/deepmaints = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

The list of psi loot spawns was named /obj/random/rig/item_to_spawn for some reason, meaning most of the spawns (i.e. non weapon-specific spawns) just straight up didn't work. There was no list to pull from.
	
<hr>
</details>

## Changelog
:cl:
fix: Psi loot should spawn properly now, allowing you to find more of it, as well as more variety.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
