### PR TITLE
NSA lower threshold balance

### DIFF
--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -1,4 +1,4 @@
-#define NSA_THRESHOLD_MINIMUM 20 //The lowest someone's NSA Threshhold can reach
+#define NSA_THRESHOLD_MINIMUM 50 //The lowest someone's NSA Threshhold can reach
 
 /datum/reagents/metabolism
 	var/metabolism_class //CHEM_TOUCH, CHEM_INGEST, or CHEM_BLOOD


### PR DESCRIPTION
increases NSA lower cap so when a nerve gets fried people arn't stuck at 20 NSA till the nerve gets fixed. Instead increases it to 50 so people don't suddenly start dropping instantly from one bad nerve in the arm.