### PR TITLE
Anomaly find range request

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/artifact.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact.dm
@@ -8,7 +8,7 @@
 	var/artifact_detect_range
 
 /datum/artifact_find/New()
-	artifact_detect_range = rand(5,300)
+	artifact_detect_range = rand(100,500)
 
 	artifact_id = "[pick("kappa","sigma","antaeres","beta","omicron","iota","epsilon","omega","gamma","delta","tau","alpha")]-[rand(100,999)]"
 


### PR DESCRIPTION
Had a request to make anomalies not have a find range of potentially only 2.5 tiles. Ups the minimum scanner detection range to 50 tiles and the upper limit to 250. EVERY FIND PICKS RANDOMALY BETWEEN THESE TWO NUMBERS.