### PR TITLE
Excelsior Guns as Lore Intended

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -43,6 +43,7 @@
 
 	var/fire_sound_text = "gunshot"
 	var/rigged = FALSE
+	var/excelsior = FALSE
 
 	var/datum/recoil/recoil // Reference to the recoil datum in datum/recoil.dm
 	var/list/init_recoil = list(0, 0, 0) // For updating weapon mods
@@ -299,7 +300,16 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 				explosion(get_turf(src), 1, 2, 3, 3)
 				qdel(src)
 			return FALSE
-	return TRUE
+	
+	if(excelsior)
+		if(!is_excelsior(M))
+			if(prob(60 - user.stat_check(STAT_COG)))
+				user.visible_message(
+					SPAN_DANGER("\The [user] pulls the trigger, causing a round to burst in the chamber!"))
+				explosion(get_turf(src), 1, 2, 3, 3)
+				qdel(src)
+				return FALSE
+		return TRUE
 
 /obj/item/gun/emp_act(severity)
 	for(var/obj/O in contents)

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -6,6 +6,7 @@
 	icon_state = "AK"
 	item_state = "AK"
 	item_suffix = ""
+	excelsior = TRUE
 	w_class = ITEM_SIZE_BULKY
 	force = WEAPON_FORCE_PAINFUL
 	caliber = CAL_RIFLE
@@ -32,6 +33,7 @@
 /obj/item/gun/projectile/automatic/ak47/NM_colony
 	name = "polymer \"Kalashnikov\" rifle"
 	desc = " A copy of the Kalashnikov pattern, shortened into a mid-length rifle and chambered in 7.62mm. This is an abysmal, printed copy."
+	excelsior = FALSE
 	origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 1)
 	price_tag = 800
 	serial_type = "NM"
@@ -64,6 +66,7 @@
 	icon_state = "saiga"
 	item_state = "saiga"
 	fire_sound = 'sound/weapons/guns/fire/shotgunp_fire.ogg'
+	excelsior = TRUE
 	caliber = CAL_SHOTGUN
 	origin_tech = list(TECH_COMBAT = 9, TECH_MATERIAL = 1, TECH_ILLEGAL = 4)
 	mag_well = MAG_WELL_RIFLE //Have you ever seen saiga with drum magazine because I haven't
@@ -73,6 +76,7 @@
 /obj/item/gun/projectile/automatic/ak47/saiga/NM_colony
 	name = "\"Saigini 12\" shotgun"
 	desc = "A bulked up and modified version of the kalashnikov made to fire 20mm shotgun slugs, similar to the sol federation SBAW design. Uses 20mm in SBAW magazines."
+	excelsior = FALSE
 	origin_tech = list(TECH_COMBAT = 9, TECH_MATERIAL = 1)
 	price_tag = 800
 	serial_type = "NM"
@@ -84,6 +88,7 @@
 	icon = 'icons/obj/guns/projectile/akl.dmi'
 	icon_state = "AKL"
 	item_state = "AKL"
+	excelsior = FALSE
 	w_class = ITEM_SIZE_NORMAL
 	force = WEAPON_FORCE_NORMAL
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_PLASTIC = 10, MATERIAL_SILVER = 10, MATERIAL_GOLD = 5)
@@ -109,6 +114,7 @@
 	icon = 'icons/obj/guns/projectile/ak_wood.dmi'
 	icon_state = "AK"
 	item_state = "AK"
+	excelsior = FALSE
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 10)
 	price_tag = 900
 	init_recoil = RIFLE_RECOIL(0.9)
@@ -124,6 +130,7 @@
 	icon = 'icons/obj/guns/projectile/sawnoff/ak.dmi'
 	icon_state = "AK"
 	item_state = "AK"
+	excelsior = FALSE
 	w_class = ITEM_SIZE_NORMAL
 	force = WEAPON_FORCE_NORMAL
 	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_PLASTIC = 5)

--- a/code/modules/projectiles/guns/projectile/automatic/drozd.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/drozd.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/guns/projectile/drozd.dmi'
 	icon_state = "drozd"
 	item_state = "drozd"
+	excelsior = TRUE
 	w_class = ITEM_SIZE_NORMAL
 	can_dual = TRUE
 	force = WEAPON_FORCE_PAINFUL
@@ -27,6 +28,7 @@
 	name = "\"Kompleks\" SMG"
 	desc = "An excellent fully automatic submachinegun. Famous for it's perfomance in close quarters. Uses 9mm rounds."
 	icon = 'icons/obj/guns/projectile/drozd.dmi'
+	excelsior = FALSE
 	origin_tech = list(TECH_COMBAT = 4)
 	price_tag = 600
 	serial_type = "NM"

--- a/code/modules/projectiles/guns/projectile/automatic/maxim.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/maxim.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/guns/projectile/maxim.dmi'
 	icon_state = "maxim"
 	item_state = "maxim"
+	excelsior = TRUE
 	w_class = ITEM_SIZE_HUGE
 	force = WEAPON_FORCE_PAINFUL
 	slot_flags = 0

--- a/code/modules/projectiles/guns/projectile/automatic/ppsh.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ppsh.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/guns/projectile/ppsh.dmi'
 	icon_state = "ppsh"
 	item_state = "ppsh"
+	excelsior = TRUE
 	w_class = ITEM_SIZE_BULKY
 	twohanded = TRUE
 	force = WEAPON_FORCE_NORMAL

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/guns/projectile/vintorez.dmi'
 	icon_state = "vintorez"
 	item_state = "vintorez"
+	excelsior = TRUE
 	w_class = ITEM_SIZE_BULKY
 	force = WEAPON_FORCE_PAINFUL
 	caliber = CAL_RIFLE //needs a new caliber type?

--- a/code/modules/projectiles/guns/projectile/revolver/wayfarer.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/wayfarer.dm
@@ -8,6 +8,7 @@
 	icon = 'icons/obj/guns/projectile/wayfarer.dmi'
 	icon_state = "wayfarer"
 	item_state = "wayfarer"
+	excelsior = FALSE
 	drawChargeMeter = FALSE
 	caliber = "10x24"
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Quite shrimple.

Makes non-communists have a 60% chance (minus one's cog skill, so high cog can prevent this mechanic) of exploding if they use an Excelsior branded firearm. This has been lore for awhile and forcefully done by admins on people who use Excelsior gear - so now you have an actual downside that happens. (:

More to come in the future on separate PRs. Planned:
- Make it so upon using an Excelsior weapon with a Cruciform, Psionic organ or Nanogate - you just shoot yourself instantly to prevent the whole: "I can't be implanted so it's safe for me to **use** this!" mentality.
- Make it so armor will hurt you and/or explode if you are shot when worn and non-excelsior.
- Make it so Excel batteries had a chance to explode if not loaded into an excelsior machine or fired from a gun by a non-excel agent.

## Changelog
:cl:
add: You now have a percent chance to explode upon using an Excel weapon. (High cog can reduce this percent chance.)
/:cl:
