### PR TITLE
Adds firing offsets to mobs.

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -102,6 +102,10 @@
 #define COMSIG_HUMAN_HEALTH "human_health"					   //from human/updatehealth()
 #define COMSIG_HUMAN_SANITY "human_sanity"						//from /datum/sanity/proc/onLife()
 #define COMSIG_HUMAN_INSTALL_IMPLANT "human_install_implant"
+
+// /mob/living/carbon/superior_animal signals
+#define COMSIG_SUPERIOR_FIRED_PROJECTILE "superior_fired_projectile"
+
 // /datum/species signals
 
 // /obj signals

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -86,6 +86,9 @@
 // Used for calculating the radioactive strength falloff
 #define INVERSE_SQUARE(initial_strength,cur_distance,initial_distance) ( (initial_strength)*((initial_distance)**2/(cur_distance)**2) )
 
+// Inverts the sign of the given number.
+#define INVERT_SIGN(number) ((number)*-1)
+
 // Vector algebra.
 #define SQUAREDNORM(x, y) (x**2 + y**)
 

--- a/code/modules/mob/living/carbon/superior_animal/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/attack.dm
@@ -161,7 +161,10 @@
 						penetrator.force_penetration_on += penetrated
 
 		if (do_we_shoot)
-			A.launch(target, def_zone, firer_arg = src)
+			var/offset_temp = right_before_firing()
+			A.launch(target, def_zone, firer_arg = src, angle_offset = offset_temp) //this is where we actually shoot the projectile
+			right_after_firing()
+			SEND_SIGNAL(src, COMSIG_SUPERIOR_FIRED_PROJECTILE, src, A)
 			visible_message(SPAN_DANGER("<b>[src]</b> [fire_verb] at [target]!"))
 			if(casingtype)
 				new casingtype(get_turf(src))
@@ -180,6 +183,26 @@
 				qdel(new_trace.penetration_holder)
 				new_trace.penetration_holder = null
 			QDEL_NULL(new_trace)
+
+/// Ran right before A.launch in /mob/living/carbon/superior_animal/proc/Shoot. On base, is used for firing offset calculations.
+/mob/living/carbon/superior_animal/proc/right_before_firing(offset_positive = current_firing_offset, round_offset = FALSE)
+	if (round_offset)
+		offset_positive = round(offset_positive) //just to be safe
+
+	offset_positive = abs(offset_positive) //it should be positive, but lets just be safe
+
+	if (!offset_positive) //the rest of the code doesnt matter if we're just 0 or null
+		return offset_positive
+
+	var/offset_negative = INVERT_SIGN(offset_positive) //invert the sign, so it becomes negative
+
+	var/offset_to_return = rand(offset_negative, offset_positive) //now get a random value from between the two. the numbers between positive and negative are now our firing arc
+
+	return offset_to_return
+
+/// Ran right after A.launch in /mob/living/carbon/superior_animal/proc/Shoot. On base, does nothing.
+/mob/living/carbon/superior_animal/proc/right_after_firing()
+	return FALSE
 
 /mob/living/carbon/superior_animal/MiddleClickOn(mob/targetDD as mob) //Letting Mobs Fire when middle clicking as someone controlling it.
 	if(weakened) return

--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -160,6 +160,18 @@
 		canmove = TRUE
 		set_density(initial(density))
 
+/mob/living/carbon/superior_animal/proc/adjustFiringOffset(var/value)
+
+	current_firing_offset += value
+
+	return TRUE
+
+/mob/living/carbon/superior_animal/proc/resetFiringOffset()
+
+	current_firing_offset = initial_firing_offset
+
+	return TRUE
+
 /mob/living/carbon/superior_animal/proc/handle_ai()
 
 	if(weakened)

--- a/code/modules/mob/living/carbon/superior_animal/superior_defines.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_defines.dm
@@ -277,3 +277,12 @@
 	delay_for_rapid_range = 0.75 SECONDS
 	delay_for_melee = 0 SECONDS
 	delay_for_all = 0.5 SECONDS
+
+	/// Used in proc/shoot to determine the inaccuracy of the projectile. Initial value.
+	var/initial_firing_offset = 2 // By default, two degrees of inaccuracy.
+	/**
+	 * Used in proc/shoot to determine the inaccuracy of the projectile. Used value.
+	 * A value between this and the sign-inverted (5 becomes -5) version of itself will be picked at random when the mob fires a projectile, and THAT will be the
+	 * final offset of the projectile. Make sure to sync with initial_firing_offset.
+	**/
+	var/current_firing_offset = 2

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1147,7 +1147,7 @@
  * atom/movable/firer: The source of the bullet, will be set as trace.firer.
  * proj: The typepath of the projectile to simulate.
 **/
-/proc/check_trajectory_raytrace(atom/movable/target, atom/movable/firer, var/proj)
+/proc/check_trajectory_raytrace(atom/movable/target, atom/movable/firer, var/proj, var/offset = 0)
 	var/obj/item/projectile/trace = new proj(get_turf(firer))
 	trace.testing = TRUE
 	trace.invisibility = INFINITY //nobody can see it
@@ -1157,7 +1157,7 @@
 
 	trace.firer = firer
 
-	trace.launch(target)
+	trace.launch(target, angle_offset = offset) // offset is by default null
 
 	return trace
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.

Just lets us give mobs inaccuracy.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
code: Added the ability for mobs to be inaccurate with shots.
balance: Mobs now have 2 degrees of firing offset by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
