### PR TITLE
Fixes a issue with pathmode's dead movement

### DIFF
--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -194,8 +194,8 @@
 	var/respect_override = FALSE
 	/// Are our walks temporary, do they expire on their own?
 	var/temporary_walks = TRUE
-	/// Do we move dead mobs?
-	var/move_dead = FALSE
+	/// Do we forbid dead movement?
+	var/deathcheck = TRUE
 
 	Click(location, control, params)
 		var/list/pa = params2list(params)
@@ -323,8 +323,8 @@
 							respect_override = (!(respect_override))
 							to_chat(usr, "Toggled respect override to [respect_override].")
 						else if (pa.Find("shift"))
-							move_dead = (!(move_dead))
-							to_chat(usr, "Toggled dead movement to [move_dead].")
+							deathcheck = (!(deathcheck))
+							to_chat(usr, "Toggled dead movement to [!deathcheck].")
 					else
 						override_movement = (!(override_movement))
 						to_chat(usr, "Toggled movement override to [override_movement].")

--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -497,7 +497,7 @@
 
 						if (move_to_target)
 							held.set_glide_size(DELAY2GLIDESIZE(held.move_to_delay))
-							walk_to_wrapper(held, object, distance, held.move_to_delay, deathcheck = holder.buildmode.move_dead, respect_override = holder.buildmode.respect_override, override = holder.buildmode.override_movement, temporary_walk = holder.buildmode.temporary_walks)
+							walk_to_wrapper(held, object, distance, held.move_to_delay, deathcheck = holder.buildmode.deathcheck, respect_override = holder.buildmode.respect_override, override = holder.buildmode.override_movement, temporary_walk = holder.buildmode.temporary_walks)
 						held.AI_inactive = 0
 						held.life_cycles_before_scan = initial(held.life_cycles_before_scan)
 						held.life_cycles_before_sleep = initial(held.life_cycles_before_sleep)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously, dead movement was on by default because I misunderstood my own proc. It is now off by default.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Pathmode now defaults to having dead movement off
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
