### PR TITLE
Steward hard suit changes

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -445,3 +445,36 @@ Technomancer RIG
 		/obj/item/rig_module/grenade_launcher,
 		/obj/item/rig_module/mounted/taser
 		)
+/obj/item/rig/hazard/steward
+	name = "hazard hardsuit control module"
+	suit_type = "hazard hardsuit"
+	desc = "A modification of the traditional hazard rig built for equal parts utility and defense. Marked with a seal of two Armstrong rifles crossing each other in a X at the base of the neck."
+	icon_state = "hazard_rig"
+	armor_list = list(
+		melee = 40,
+		bullet = 40,
+		energy = 40,
+		bomb = 90,
+		bio = 100,
+		rad = 100
+	)
+	slowdown = 0.3
+	drain = 3.5
+	offline_slowdown = 3
+	offline_vision_restriction = 1
+
+	helm_type = /obj/item/clothing/head/helmet/space/rig/hazard
+	max_upgrades = 1
+	req_access = list(access_hop)
+	req_one_access = list()
+
+
+	initial_modules = list(
+		/obj/item/rig_module/mounted/taser,
+		/obj/item/rig_module/device/flash,
+		/obj/item/rig_module/vision/medhud,
+		/obj/item/rig_module/device/healthscanner,
+		/obj/item/rig_module/modular_injector/medical,
+		/obj/item/rig_module/ai_container,
+		/obj/item/rig_module/storage
+		)

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -89855,7 +89855,7 @@
 "rek" = (
 /obj/structure/table/rack,
 /obj/random/rig_module/low_chance,
-/obj/item/rig/light/hacker/steward,
+/obj/item/rig/hazard/steward,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/fo)
 "ret" = (


### PR DESCRIPTION
Swapped out the old stewards suit which was the SI 'Retainer' control module with a hazard suit loaded with the same modules.  New suit offers better protection and may result in it getting used rather than collecting dust as the current one does.
![Screenshot (149)](https://user-images.githubusercontent.com/75400579/183155917-9b381d72-d181-4b5c-b2fc-450f8832783a.png)
![Screenshot (150)](https://user-images.githubusercontent.com/75400579/183155928-ecc55e94-7370-4aeb-8992-5364091707f0.png)

