### PR TITLE
Bay Port - Mutual Language Understanding

### DIFF
--- a/code/modules/mob/language/ancient_latin.dm
+++ b/code/modules/mob/language/ancient_latin.dm
@@ -6,7 +6,8 @@
 	partial_understanding = list(
 		LANGUAGE_ESPERANTO = 30,
 		LANGUAGE_CULT = 40,
-		LANGUAGE_OCCULT = 40
+		LANGUAGE_OCCULT = 40,
+		LANGUAGE_COMMON = 5
 	)
 	space_chance = 80
 	speech_verb = list("states")

--- a/code/modules/mob/language/ancient_latin.dm
+++ b/code/modules/mob/language/ancient_latin.dm
@@ -3,6 +3,9 @@
 	desc = "An ancient language once used by most of europe but now mainly used by followers of the Church of Absolute."
 	colour = "latin"
 	key = "l"
+	partial_understanding = list(
+		LANGUAGE_ESPERANTO = 30
+	)
 	space_chance = 80
 	speech_verb = list("states")
 	ask_verb = list("implores")

--- a/code/modules/mob/language/ancient_latin.dm
+++ b/code/modules/mob/language/ancient_latin.dm
@@ -4,7 +4,9 @@
 	colour = "latin"
 	key = "l"
 	partial_understanding = list(
-		LANGUAGE_ESPERANTO = 30
+		LANGUAGE_ESPERANTO = 30,
+		LANGUAGE_CULT = 40,
+		LANGUAGE_OCCULT = 40
 	)
 	space_chance = 80
 	speech_verb = list("states")

--- a/code/modules/mob/language/esperanto.dm
+++ b/code/modules/mob/language/esperanto.dm
@@ -8,7 +8,11 @@
 	key = "e"
 	shorthand = "ES"
 	partial_understanding = list(
-		LANGUAGE_LATIN = 30
+		LANGUAGE_LATIN = 30,
+		LANGUAGE_CYRILLIC = 20,
+		LANGUAGE_SERBIAN = 20,
+		LANGUAGE_GERMAN = 25,
+		LANGUAGE_COMMON = 10
 	)
 	space_chance = 70
 	syllables = list(

--- a/code/modules/mob/language/esperanto.dm
+++ b/code/modules/mob/language/esperanto.dm
@@ -7,6 +7,9 @@
 	colour = "brass"
 	key = "e"
 	shorthand = "ES"
+	partial_understanding = list(
+		LANGUAGE_LATIN = 30
+	)
 	space_chance = 70
 	syllables = list(
 		"adapti", "adiau", "afabla", "ah", "aj", "ajn", "akcepti", "alveni", "alia", "angla", "apud", "audi", "bani", "bela", "bati", "bona",

--- a/code/modules/mob/language/german.dm
+++ b/code/modules/mob/language/german.dm
@@ -3,6 +3,10 @@
 	desc = "Language used by the descendants of Europe."
 	colour = "german"
 	key = "q"
+	partial_understanding = list(
+		LANGUAGE_ESPERANTO = 20,
+		LANGUAGE_COMMON = 25
+	)
 	space_chance = 80
 	shorthand = "GE"
 	syllables = list("Frau", "Mann", "Waffe", "Schiff", "Bombe", "Explosion", "Grenze", "Strasse", "Halle", "Pistole", "Gewehr", "Uniform", "Kind", "Arzt", \

--- a/code/modules/mob/language/jana.dm
+++ b/code/modules/mob/language/jana.dm
@@ -7,6 +7,9 @@
 	colour = "brass"
 	key = "j"
 	shorthand = "JA"
+	partial_understanding = list(
+		LANGUAGE_COMMON = 5
+	)
 	space_chance = 80
 	syllables = list(
 		"a", "ai", "an", "ang", "ao", "ba", "bai", "ban", "bang", "bao", "bei", "ben", "beng", "bi", "bian", "biao",

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -20,6 +20,7 @@
 	var/list/space_chance = 55        			// Likelihood of getting a space in the random scramble string
 	var/machine_understands = 1 		  		// Whether machines can parse and understand this language
 	var/shorthand = "CO"						// Shorthand that shows up in chat for this language.
+	var/list/partial_understanding				// List of languages that can /somehwat/ understand it, format is: name = chance of understanding a word
 
 	//Random name lists
 	var/name_lists = FALSE
@@ -67,7 +68,12 @@
 /datum/language
 	var/list/scramble_cache = list()
 
-/datum/language/proc/scramble(var/input)
+/datum/language/proc/scramble(var/input, var/list/known_languages)
+
+	var/understand_chance = 0
+	for(var/datum/language/L in known_languages)
+		if(LAZYACCESS(partial_understanding, L.name))
+			understand_chance += partial_understanding[L.name]
 
 	if(!syllables || !syllables.len)
 		return stars(input)

--- a/code/modules/mob/language/monkey.dm
+++ b/code/modules/mob/language/monkey.dm
@@ -2,6 +2,9 @@
 	name = LANGUAGE_MONKEY
 	desc = "Ook ook ook."
 	colour = "monkey"
+	partial_understanding = list(
+		LANGUAGE_COMMON = 5			//hehe le monkey
+	)
 	speech_verb = list("chimpers")
 	ask_verb = list("chimpers")
 	exclaim_verb = list("screeches")

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -86,6 +86,9 @@
 	colour = "cult"
 	key = "f"
 	flags = RESTRICTED
+	partial_understanding = list(
+		LANGUAGE_YASSARI = 15
+	)
 	space_chance = 100
 	syllables = list("ire","ego","nahlizet","certum","veri","jatkaa","mgar","balaq", "karazet", "geeri", \
 		"orkan", "allaq", "sas'so", "c'arta", "forbici", "tarem", "n'ath", "reth", "sh'yro", "eth", "d'raggathnor", \

--- a/code/modules/mob/language/serbian.dm
+++ b/code/modules/mob/language/serbian.dm
@@ -292,7 +292,7 @@
 "Gracanin",
 "Grba",
 "Grlic",
-"Grmu�a",
+"Grmuša",
 "Grol",
 "Grujicic",
 "Horvat",

--- a/code/modules/mob/language/serbian.dm
+++ b/code/modules/mob/language/serbian.dm
@@ -306,7 +306,7 @@
 "Jerkov",
 "Jigovic",
 "Jorgic",
-"Karad�ic",
+"Karadžic",
 "Kadijevic",
 "Kajosevic",
 "Kalicanin",

--- a/code/modules/mob/language/serbian.dm
+++ b/code/modules/mob/language/serbian.dm
@@ -6,7 +6,8 @@
 	key = "x"
 	space_chance = 80
 	partial_understanding = list(
-		LANGUAGE_CYRILLIC = 60
+		LANGUAGE_CYRILLIC = 60,
+		LANGUAGE_ESPERANTO = 20
 	)
 	shorthand = "SB"
 	syllables = list("zena", "rob", "macka", "tvoj", "ruke", "jebote", "placenik", "tsatsh", "da", "zivim", "cich", "jovan", "be", "ot", \

--- a/code/modules/mob/language/serbian.dm
+++ b/code/modules/mob/language/serbian.dm
@@ -272,7 +272,7 @@
 "Cubrilovic",
 "Cvijic",
 "Cvijovic",
-"�ajic",
+"Đajic",
 "Damjenic",
 "Davidovic",
 "Djapic",

--- a/code/modules/mob/language/serbian.dm
+++ b/code/modules/mob/language/serbian.dm
@@ -5,6 +5,9 @@
 	colour = "serbian"
 	key = "x"
 	space_chance = 80
+	partial_understanding = list(
+		LANGUAGE_CYRILLIC = 60
+	)
 	shorthand = "SB"
 	syllables = list("zena", "rob", "macka", "tvoj", "ruke", "jebote", "placenik", "tsatsh", "da", "zivim", "cich", "jovan", "be", "ot", \
 					 "ja", "tamo", "moj", "za", "gdje", "su", "brodove", "noge", "da", "ne", "svemirskog", "pochemu", "zasto","ljubav", \
@@ -268,7 +271,7 @@
 "Cubrilovic",
 "Cvijic",
 "Cvijovic",
-"Ðajic",
+"ï¿½ajic",
 "Damjenic",
 "Davidovic",
 "Djapic",
@@ -288,7 +291,7 @@
 "Gracanin",
 "Grba",
 "Grlic",
-"Grmuša",
+"Grmuï¿½a",
 "Grol",
 "Grujicic",
 "Horvat",
@@ -302,7 +305,7 @@
 "Jerkov",
 "Jigovic",
 "Jorgic",
-"Karadžic",
+"Karadï¿½ic",
 "Kadijevic",
 "Kajosevic",
 "Kalicanin",

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -3,7 +3,13 @@
 	desc = "Most popular language in Canis Majoris constellation, thanks to many USA colonial ships arrived there in distant past."
 	key = "0"
 	partial_understanding = list(
-		LANGUAGE_MONKEY = 5			//hehe le monkey
+		LANGUAGE_MONKEY = 5,			//hehe le monkey
+		LANGUAGE_LATIN = 5,
+		LANGUAGE_JANA = 10,
+		LANGUAGE_ESPERANTO = 10,
+		LANGUAGE_GERMAN = 20,
+		LANGUAGE_CYRILLIC = 5,
+		LANGUAGE_SERBIAN = 5
 	)
 	flags = RESTRICTED
 	shorthand = "CO"
@@ -88,7 +94,8 @@
 	colour = "russian"
 	key = "r"
 	partial_understanding = list(
-		LANGUAGE_SERBIAN = 60
+		LANGUAGE_SERBIAN = 60,
+		LANGUAGE_ESPERANTO = 20
 	)
 	space_chance = 80
 	syllables = list("zhena", "reb", "kot", "tvoy", "vodka", "blyad", "verbovka", "ponimat", "zhit", "kley", "sto", "yat", "si", "det", \

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -5,7 +5,7 @@
 	partial_understanding = list(
 		LANGUAGE_MONKEY = 5,			//hehe le monkey
 		LANGUAGE_LATIN = 5,
-		LANGUAGE_JANA = 10,
+		LANGUAGE_JANA = 5,
 		LANGUAGE_ESPERANTO = 10,
 		LANGUAGE_GERMAN = 20,
 		LANGUAGE_CYRILLIC = 5,

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -2,6 +2,9 @@
 	name = LANGUAGE_COMMON
 	desc = "Most popular language in Canis Majoris constellation, thanks to many USA colonial ships arrived there in distant past."
 	key = "0"
+	partial_understanding = list(
+		LANGUAGE_MONKEY = 5			//hehe le monkey
+	)
 	flags = RESTRICTED
 	shorthand = "CO"
 
@@ -84,6 +87,9 @@
 	desc = "Ancient language of Russian colonists, rusted with time and bastardized with technical terms in everyday use."
 	colour = "russian"
 	key = "r"
+	partial_understanding = list(
+		LANGUAGE_SERBIAN = 60
+	)
 	space_chance = 80
 	syllables = list("zhena", "reb", "kot", "tvoy", "vodka", "blyad", "verbovka", "ponimat", "zhit", "kley", "sto", "yat", "si", "det", \
 					 "re", "be", "nok", "chto", "techno", "kak", "govor", "navernoe", "da", "net", "horosho", "pochemu", "privet","lubov", \

--- a/code/modules/mob/language/yassari.dm
+++ b/code/modules/mob/language/yassari.dm
@@ -6,6 +6,9 @@
 	exclaim_verb = list("rambles")
 	colour = "yassari"
 	key = "y"
+	partial_understanding = list(
+		LANGUAGE_OPIFEXEE = 15
+	)
 	space_chance = 100
 	shorthand = "YI"
 	syllables = list("laa", "naaam", "masaa' alkhayr", "haydi bakalim", "hal yumkinuk", "hadduth bibut'", "afham tamaaman", "maafi mushki", "habeebti", "hala", "ahlan wa sahlan", \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports over simple language understanding code. For an example of how this works:
	
Say a person speaks Serbian and the other speaks Russian. When speaking their languages, they have a 60% chance to understand **each** word from them. (I.E - they type "How are you today good sir?" - it may come up as "Vodka blyad cheeki good cyka?" or any combination as each word you type is a probability chance of 60 to understand)

Added a lot here, so I suggest reading the files changed per-langauge.
## Changelog
:cl:
add: Adds Bay's mutual understanding chance to languages. Ranging from 5% intelligibility between Latin and Common/English to 60% between Russian and Serbian.
/:cl: