### PR TITLE
matterforge no longer takes ammo

### DIFF
--- a/code/game/machinery/autolathe/matterforge.dm
+++ b/code/game/machinery/autolathe/matterforge.dm
@@ -327,6 +327,12 @@
 				if(istype(O, /obj/item/stack/material/cyborg))
 					return //Prevents borgs throwing their stuff into it
 
+				if(istype(O, /obj/item/ammo_magazine))
+					return //Prevents people from shoving in ammo to get matter
+
+				if(istype(O, /obj/item/ammo_casing))
+					return //Prevents people from shoving in ammo to get matter 
+					
 				if(istype(O, /obj/item/stack))
 					var/obj/item/stack/material/stack = O
 					total_material *= stack.get_amount()


### PR DESCRIPTION
Was asked by Rebel if I could look into this after being told guild was using the ammo fab to print off ammo and get back more compressed matter than it took to print. This change makes it so the forge no longer takes ammo.

