### PR TITLE
Ameridian weak to explosions

### DIFF
--- a/code/modules/ameridian/ameridian_crystal.dm
+++ b/code/modules/ameridian/ameridian_crystal.dm
@@ -82,6 +82,10 @@
 	else
 		..()
 
+/obj/structure/ameridian_crystal/ex_act(severity)
+	if(severity) //If all fails, blow it up
+		qdel(src) //Don't expect any rewards!
+
 // This proc handle the growth & spread of the crystal
 /obj/structure/ameridian_crystal/proc/handle_growth()
 	if(growth >= max_growth) // If we are at max growth.


### PR DESCRIPTION
Makes amerdian qdel on any explosion severity to make bombs and explosion the ultimate nuke option if everything else fails.
Should do the job nicely as a last resort



## Changelog
:cl:
tweak: Ameridian is weak to explosions now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
