### PR TITLE
Controversial PR #2: Soteria Nerf

### DIFF
--- a/code/game/mecha/equipment/weapons/ranged/laser_weapons.dm
+++ b/code/game/mecha/equipment/weapons/ranged/laser_weapons.dm
@@ -92,8 +92,9 @@
 	name = "\improper Mech-mounted Hydrogen-Plasma Cannon"
 	desc = "A Sollex-Pattern hydrogen-plasma cannon, modified to fit on combat exosuits. Unlike its hand-held counter-part, this one doesn't need cooling, as it use the Exosuit's systems for that purpose."
 	icon_state = "hydrogen_cannon"
-	energy_drain = 600
-	matter = list(MATERIAL_PLASTEEL = 15, MATERIAL_MHYDROGEN = 3, MATERIAL_TRITIUM = 1)
+	energy_drain = 1000
+	fire_delay = 20
+	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_MHYDROGEN = 6, MATERIAL_TRITIUM = 6)
 	origin_tech = list(TECH_COMBAT = 9, TECH_MATERIAL = 7, TECH_PLASMA = 10)
 	projectile = /obj/item/projectile/hydrogen/cannon/max
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'

--- a/code/game/mecha/equipment/weapons/ranged/laser_weapons.dm
+++ b/code/game/mecha/equipment/weapons/ranged/laser_weapons.dm
@@ -93,7 +93,7 @@
 	desc = "A Sollex-Pattern hydrogen-plasma cannon, modified to fit on combat exosuits. Unlike its hand-held counter-part, this one doesn't need cooling, as it use the Exosuit's systems for that purpose."
 	icon_state = "hydrogen_cannon"
 	energy_drain = 1000
-	fire_delay = 20
+	fire_cooldown = 25
 	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_MHYDROGEN = 6, MATERIAL_TRITIUM = 6)
 	origin_tech = list(TECH_COMBAT = 9, TECH_MATERIAL = 7, TECH_PLASMA = 10)
 	projectile = /obj/item/projectile/hydrogen/cannon/max


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Does the PR for ApplePlastic but alternative way of fixing it. Instead of hard-removing I added a higher fire delay, charge cost and creation cost to the hydrogen mech weapon. Wacky how the weapon that does an explosion and 100 damage has no extra fire delay and low as shit cost. Quirky.
</summary>
</details>

## Changelog
:cl:
balances: Mech hydrogen cannon is no longer as broken-powerful. Even Trilby confirmed it had improper values.
/:cl: