### PR TITLE
Causes mobs to update their zlevel if they actually change zlevel through forceMove

### DIFF
--- a/code/modules/multiz/shadow.dm
+++ b/code/modules/multiz/shadow.dm
@@ -53,6 +53,8 @@
 	. = ..()
 	check_shadow()
 
+	update_z()
+
 /mob/living/proc/check_shadow()
 	var/mob/M = src
 	if(isturf(M.loc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. This fixes bugs such as mobs not doing AI if they change zlevels.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Mobs now properly change zlevel if they use forcemove
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
