### PR TITLE
dorms nerf

### DIFF
--- a/maps/_HunterLodge/map/_Hunting_Lodge.dmm
+++ b/maps/_HunterLodge/map/_Hunting_Lodge.dmm
@@ -1427,7 +1427,7 @@
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
 	dir = 8;
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -1440,7 +1440,7 @@
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
 	dir = 4;
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -1449,13 +1449,13 @@
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
 	dir = 1;
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
 	dir = 8;
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /obj/structure/sink/puddle,
@@ -1465,7 +1465,7 @@
 "es" = (
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -1474,13 +1474,13 @@
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
 	dir = 4;
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
 	dir = 1;
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /obj/structure/sink/puddle,
@@ -2194,12 +2194,12 @@
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
 	dir = 8;
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /obj/structure/sink/puddle,
@@ -2208,13 +2208,13 @@
 "gJ" = (
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
 	dir = 4;
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /obj/structure/sink/puddle,
@@ -3207,7 +3207,7 @@
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
 	dir = 8;
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /obj/structure/table/woodentable,
@@ -3224,15 +3224,12 @@
 /obj/structure/railing{
 	desc = "A standard wood fence painted in copper color. Prevents live stock from stepping onto crops.";
 	dir = 4;
-	matter = list("wood" = 4);
+	matter = list("wood"=4);
 	name = "wooden fence"
 	},
 /obj/structure/table/woodentable,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/forest/hunting_lodge)
-"jL" = (
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/abandoned_solars/powered)
 "jM" = (
 /obj/structure/table/woodentable,
 /obj/machinery/recharger,
@@ -3317,12 +3314,9 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
-"jW" = (
-/turf/simulated/floor/holofloor/wood,
-/area/nadezhda/outside/forest/hunting_lodge_dark)
 "jX" = (
 /obj/structure/table/bench/wooden,
-/turf/simulated/floor/holofloor/wood,
+/turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "jY" = (
 /obj/machinery/door/unpowered/simple/wood/saloon{
@@ -3336,15 +3330,11 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/holofloor/wood,
-/area/nadezhda/outside/forest/hunting_lodge_dark)
-"ka" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/holofloor/wood,
+/turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "kb" = (
 /obj/structure/flora/pottedplant/bamboo,
-/turf/simulated/floor/holofloor/wood,
+/turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "kc" = (
 /obj/structure/closet,
@@ -3359,14 +3349,14 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/dark/brown_platform,
+/turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "ke" = (
 /obj/structure/table/woodentable,
 /obj/item/towel/random,
 /obj/item/towel/random,
 /obj/item/towel/random,
-/turf/simulated/floor/tiled/dark/brown_platform,
+/turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "kf" = (
 /obj/structure/closet,
@@ -6320,7 +6310,7 @@ aD
 aD
 aD
 aD
-jL
+aD
 at
 at
 at
@@ -6427,7 +6417,7 @@ aD
 aD
 aD
 aD
-jL
+aD
 aD
 at
 at
@@ -12806,14 +12796,14 @@ aP
 aP
 aP
 aP
-jW
-jW
-jW
-jW
-jW
-jW
-jW
-jW
+fv
+fv
+fv
+fv
+fv
+fv
+fv
+fv
 kn
 du
 aM
@@ -12913,13 +12903,13 @@ aV
 eA
 cT
 he
-jW
-jW
-jW
-jW
-jW
-jW
-jW
+fv
+fv
+fv
+fv
+fv
+fv
+fv
 km
 aP
 aM
@@ -13020,13 +13010,13 @@ aV
 eA
 cT
 cT
-jW
-jW
-jW
-jW
-jW
-jW
-jW
+fv
+fv
+fv
+fv
+fv
+fv
+fv
 km
 aP
 aM
@@ -13127,13 +13117,13 @@ bc
 eA
 cT
 he
-jW
-jW
-ka
+fv
+fv
+fw
 kd
 ke
-jW
-jW
+fv
+fv
 km
 aP
 aD
@@ -13342,11 +13332,11 @@ eA
 cU
 bQ
 jX
-jW
+fv
 jX
 bQ
 jX
-jW
+fv
 kj
 jX
 aP
@@ -13449,7 +13439,7 @@ aP
 bQ
 bQ
 jX
-jW
+fv
 jX
 bQ
 jX
@@ -13555,8 +13545,8 @@ at
 aP
 bz
 iT
-jW
-jW
+fv
+fv
 kb
 bQ
 jX
@@ -23934,16 +23924,16 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew
@@ -24041,16 +24031,16 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew
@@ -24143,21 +24133,21 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew
@@ -24250,21 +24240,21 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew
@@ -24357,21 +24347,21 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew
@@ -24464,21 +24454,21 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew
@@ -24571,21 +24561,21 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew
@@ -24678,21 +24668,21 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew
@@ -24785,21 +24775,21 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew
@@ -24895,18 +24885,18 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew
@@ -25002,18 +24992,18 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew
@@ -25109,18 +25099,18 @@ ew
 ew
 ew
 ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
-ew
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
+ex
 ew
 ew
 ew

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -55,6 +55,16 @@
 "aaq" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/security/armory_blackshield)
+"aar" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "aas" = (
 /obj/machinery/newscaster{
 	dir = 8;
@@ -2392,17 +2402,19 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ayP" = (
-/obj/machinery/keycard_auth,
-/obj/item/reagent_containers/enricher,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
 	pixel_y = 0
 	},
-/obj/structure/table/marble,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/turf/simulated/floor/tiled/steel/gray_platform,
+/area/nadezhda/command/gmaster)
 "ayY" = (
 /obj/structure/closet/cabinet{
 	name = "entertainment cabinet"
@@ -3786,12 +3798,13 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "aMS" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/danger,
-/area/nadezhda/medical/genetics)
+/turf/simulated/mineral,
+/area/colony)
 "aMZ" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Core";
@@ -4124,17 +4137,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"aPG" = (
-/obj/structure/closet/chefcloset,
-/obj/item/soap/hunters,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
 "aPI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6364,6 +6366,16 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"bmp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/docking)
 "bms" = (
 /obj/machinery/newscaster{
 	pixel_x = -30;
@@ -6471,25 +6483,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"bnm" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
 "bnn" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -7190,8 +7183,11 @@
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "buz" = (
-/turf/simulated/wall,
-/area/nadezhda/pros/prep)
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "buH" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/railing{
@@ -7687,9 +7683,10 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "byG" = (
-/obj/structure/bed/chair/sofa/black/left,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/obj/item/storage/box/donkpockets,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "byP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -9203,6 +9200,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/section3)
+"bPW" = (
+/obj/machinery/autolathe/loaded,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/gmaster)
 "bPY" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -10780,9 +10781,6 @@
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"cgQ" = (
-/turf/simulated/mineral,
-/area/nadezhda/rnd/robotics)
 "cgU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/crossbow,
@@ -11558,15 +11556,14 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cpp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/docking)
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cbo)
 "cpq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -12066,6 +12063,10 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
+"ctU" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "ctX" = (
 /obj/structure/flora/small/rock5,
 /turf/unsimulated/wall/jungle,
@@ -13549,6 +13550,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/dungeon/outside/abandoned_solars)
+"cIp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "guild_lobby";
+	name = "Guild Lobby shutter control";
+	pixel_y = -21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/engineering/foyer)
 "cIq" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/multiz/ladder,
@@ -14237,9 +14248,11 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "cOK" = (
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "cOR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14572,14 +14585,9 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/panic_room)
 "cTu" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/arrows/white,
+/obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
+/area/nadezhda/command/smc/quarters)
 "cTv" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
@@ -15822,6 +15830,10 @@
 /obj/structure/noticeboard/guild{
 	pixel_x = 32
 	},
+/obj/machinery/atm{
+	dir = 1;
+	pixel_y = -34
+	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/foyer)
 "dgv" = (
@@ -16423,15 +16435,11 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "dmY" = (
-/obj/structure/medical_stand,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/item/tank/anesthetic,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/gun/energy/cog,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "dna" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/borgupload{
@@ -17488,16 +17496,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dwV" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/tool/scalpel/laser{
-	pixel_y = -5
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/turf/simulated/mineral,
+/area/nadezhda/rnd/robotics)
 "dxe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -18146,14 +18146,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"dCT" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/mineral,
-/area/colony)
 "dCV" = (
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -18562,10 +18554,9 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/hallway/surface/section1)
 "dHg" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/medical/genetics)
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/wall,
+/area/asteroid/cave)
 "dHs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/trailrocka1,
@@ -19783,12 +19774,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"dUl" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/gun/energy/cog,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "dUq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -21060,6 +21045,23 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
+"egi" = (
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/computer_hardware/hard_drive/portable/design/circuits,
+/obj/item/computer_hardware/hard_drive/portable/design/components,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/stack/material/steel/full,
+/obj/item/stack/material/glass{
+	amount = 120
+	},
+/obj/item/stack/material/plastic{
+	amount = 120
+	},
+/obj/item/paper/monitorkey,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/gmaster)
 "egs" = (
 /obj/machinery/chem_master/condimaster,
 /turf/simulated/floor/tiled/cafe,
@@ -22071,12 +22073,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"erb" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "erm" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/small/busha1,
@@ -22924,22 +22920,15 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/turret_protected/ai)
 "eAm" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/hangarsupply)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "eAI" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
@@ -23119,7 +23108,7 @@
 	density = 0;
 	dir = 2;
 	icon_state = "shutter0";
-	id = "premier_office";
+	id = "guild_lobby";
 	name = "Office Shutters";
 	opacity = 0
 	},
@@ -26657,12 +26646,11 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "fkp" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/obj/machinery/holoposter{
-	pixel_x = 32
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
+/area/nadezhda/command/cro)
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26891,9 +26879,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "fnd" = (
-/obj/structure/toilet,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/spray/chemsprayer,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "fnf" = (
 /obj/structure/lattice,
 /turf/simulated/floor/plating/under,
@@ -27331,6 +27321,14 @@
 /area/nadezhda/crew_quarters/dorm3{
 	name = "Dormitory 3"
 	})
+"fqN" = (
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/pros/foreman)
 "fqR" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/effect/decal/cleanable/dirt,
@@ -28933,11 +28931,24 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "fEL" = (
-/obj/machinery/camera/network/cargo{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/sechall)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "fER" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/sliceable/bread,
@@ -29744,14 +29755,6 @@
 /obj/item/beehive_assembly,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"fMq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/research)
 "fMs" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc{
@@ -31028,10 +31031,9 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
 "gab" = (
-/obj/structure/catwalk,
-/obj/structure/lattice,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
+/mob/living/simple_animal/soteria_roomba,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cro)
 "gah" = (
 /obj/structure/toilet{
 	dir = 4
@@ -31422,6 +31424,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"gdC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/propis{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/pros/prep)
 "gdD" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled/techmaint,
@@ -36526,6 +36535,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
+"haw" = (
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "haz" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/lakeside)
@@ -40838,6 +40850,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"hVm" = (
+/obj/structure/bed/chair/sofa/black/left,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "hVt" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -41724,6 +41740,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "ieu" = (
@@ -42677,7 +42694,7 @@
 	density = 0;
 	dir = 2;
 	icon_state = "shutter0";
-	id = "premier_office";
+	id = "guild_lobby";
 	name = "Office Shutters";
 	opacity = 0
 	},
@@ -43404,12 +43421,6 @@
 /obj/machinery/camera/network/colony_transition,
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
-"ivN" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
 "ivP" = (
 /obj/effect/floor_decal/border/techfloor,
 /obj/effect/floor_decal/border/techfloor{
@@ -43790,11 +43801,16 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/skyyard)
 "izV" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 8
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
+/obj/item/tool/scalpel/laser{
+	pixel_y = -5
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "izW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/spiders,
@@ -43887,9 +43903,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "iAP" = (
-/obj/structure/closet/secure_closet/reinforced/commander,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/smc/quarters)
+/obj/structure/toilet,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "iAR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -45033,6 +45049,13 @@
 /obj/random/cluster/spiders/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"iMc" = (
+/obj/structure/toilet,
+/obj/machinery/holoposter{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "iMk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -45498,10 +45521,11 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "iQA" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/camera/network/cargo{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/bluecorner,
+/area/nadezhda/security/sechall)
 "iQD" = (
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/maingate{
@@ -45921,7 +45945,7 @@
 	density = 0;
 	dir = 2;
 	icon_state = "shutter0";
-	id = "premier_office";
+	id = "guild_lobby";
 	name = "Office Shutters";
 	opacity = 0
 	},
@@ -46508,10 +46532,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
-"jac" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
 "jae" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -46659,9 +46679,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
-"jbz" = (
-/turf/simulated/mineral,
-/area/nadezhda/rnd/lab)
 "jbH" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -47309,15 +47326,8 @@
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
 "jhS" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/washing_machine,
-/obj/machinery/vending/wallmed/lobby{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
+/turf/simulated/wall,
+/area/nadezhda/pros/foreman)
 "jhW" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/wood/wild5,
@@ -47499,6 +47509,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/effect/floor_decal/spline/fancy,
+/obj/effect/floor_decal/spline/fancy{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "jjy" = (
@@ -47559,10 +47573,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
-"jkb" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
 "jkc" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -48515,6 +48525,16 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"jud" = (
+/obj/structure/sign/levels/stairsdown{
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "jui" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -49569,6 +49589,9 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/crew_quarters/fitness)
+"jEl" = (
+/turf/simulated/wall,
+/area/nadezhda/pros/prep)
 "jEs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -50809,7 +50832,7 @@
 	density = 0;
 	dir = 2;
 	icon_state = "shutter0";
-	id = "premier_office";
+	id = "guild_lobby";
 	name = "Office Shutters";
 	opacity = 0
 	},
@@ -52213,6 +52236,13 @@
 	},
 /turf/unsimulated/mineral,
 /area/asteroid/cave)
+"kdN" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/machinery/holoposter{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "kdS" = (
 /obj/structure/table/standard,
 /obj/item/stack/medical/advanced/bruise_pack,
@@ -53186,20 +53216,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
-"kmK" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/towel,
-/obj/machinery/vending/wallmed/lobby{
-	pixel_y = 25
-	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
 "kmY" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -53212,9 +53228,8 @@
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/hallway/main/stairwell)
 "knb" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
+/turf/simulated/mineral,
+/area/nadezhda/rnd/lab)
 "knd" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -55518,9 +55533,9 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/sleeper)
 "kIk" = (
-/obj/machinery/optable,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/structure/closet/secure_closet/reinforced/commander,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "kIn" = (
 /obj/machinery/light{
 	dir = 4
@@ -58154,6 +58169,11 @@
 /mob/living/simple_animal/chicken,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/hallway/side/f2section1)
+"lgB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/steeldecal/steel_decals_central4,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "lgC" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small{
@@ -59239,27 +59259,9 @@
 	})
 "lri" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "MedbayTotalLockdown";
-	layer = 2.6;
-	name = "Medbay Total Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Organ Laboratory";
-	req_access = list(5)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/rnd/docking)
+/obj/machinery/camera/network/research,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "lrp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -60473,7 +60475,7 @@
 /area/nadezhda/crew_quarters/pool)
 "lDb" = (
 /obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "lDd" = (
@@ -60782,9 +60784,11 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
 "lGo" = (
-/obj/machinery/autolathe/loaded,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/gmaster)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "lGq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard/guild{
@@ -61590,6 +61594,10 @@
 /area/nadezhda/security/maingate{
 	name = "\improper Outdoors - Pad"
 	})
+"lOw" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "lOx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -62090,11 +62098,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"lTh" = (
-/obj/item/storage/box/donkpockets,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
 "lTi" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -63356,6 +63359,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"mfr" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/machinery/camera/network/cargo,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/hangarsupply)
 "mfs" = (
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -63423,6 +63443,10 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"mfO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/medical/genetics)
 "mfT" = (
 /obj/structure/bed/chair/office/light,
 /obj/landmark/join/start/paramedic,
@@ -65680,10 +65704,6 @@
 	pixel_y = 0
 	},
 /obj/structure/cable/cyan,
-/obj/machinery/atm{
-	dir = 1;
-	pixel_y = -34
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -67200,9 +67220,28 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/crew_quarters/plasma_tag)
 "mPf" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "MedbayTotalLockdown";
+	layer = 2.6;
+	name = "Medbay Total Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Organ Laboratory";
+	req_access = list(5)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/rnd/docking)
 "mPj" = (
 /obj/structure/table/woodentable,
 /obj/item/device/megaphone,
@@ -67574,11 +67613,14 @@
 /area/nadezhda/security/range{
 	name = "\improper Blackshield - Firing Range"
 	})
-"mTs" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber,
+"mTr" = (
+/obj/machinery/optable,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/docking)
+"mTs" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "mTy" = (
 /obj/effect/floor_decal/industrial/box/white,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -67635,10 +67677,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
-"mUe" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "mUh" = (
 /obj/machinery/light{
 	dir = 8;
@@ -68459,11 +68497,19 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "ncj" = (
-/obj/machinery/camera/network/research{
+/obj/machinery/washing_machine,
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/obj/item/towel,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "nck" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/effect/decal/cleanable/dirt,
@@ -69170,6 +69216,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"nju" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "njA" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -69225,6 +69277,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
+"nkn" = (
+/turf/simulated/mineral,
+/area/eris/crew_quarters/kitchen_storage)
 "nkv" = (
 /obj/structure/table/steel,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -70184,8 +70239,15 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nuq" = (
-/turf/simulated/mineral,
-/area/nadezhda/command/swo/quarters)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe/bioprinter/med,
+/obj/machinery/button/remote/blast_door{
+	id = "organ_shutter";
+	name = "privacy shutter control";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "nur" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -71404,6 +71466,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"nGx" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/medical/genetics)
 "nGy" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/spider/stickyweb,
@@ -71469,6 +71536,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"nGY" = (
+/obj/structure/table/standard,
+/obj/item/storage/freezer,
+/obj/structure/sink{
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "nHc" = (
 /obj/machinery/microwave,
 /obj/structure/table/marble,
@@ -71678,6 +71753,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/psych)
+"nIS" = (
+/turf/simulated/mineral,
+/area/nadezhda/command/swo/quarters)
 "nIZ" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -73108,14 +73186,6 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"nYy" = (
-/obj/structure/table/standard,
-/obj/item/storage/freezer,
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
 "nYz" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/regular,
@@ -76049,9 +76119,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
-"oyN" = (
-/turf/simulated/wall,
-/area/nadezhda/pros/foreman)
 "oyO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -78285,6 +78352,13 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
+"oUV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "oVd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -78490,6 +78564,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
+"oYx" = (
+/obj/machinery/smartfridge/secure/medbay/organs/stocked,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "organ_shutter";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/docking)
 "oYz" = (
 /obj/effect/floor_decal/border/techfloor,
 /obj/effect/floor_decal/border/techfloor{
@@ -79450,10 +79537,9 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
 "pis" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "piv" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -80705,15 +80791,17 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "pvK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
+/obj/machinery/keycard_auth,
+/obj/item/reagent_containers/enricher,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
+/obj/structure/table/marble,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "pvM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -81295,12 +81383,10 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "pBL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/propis{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/pros/prep)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "pBN" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/floor_decal/spline/plain{
@@ -81502,6 +81588,10 @@
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"pDo" = (
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "pDr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 6;
@@ -81632,17 +81722,6 @@
 /obj/effect/floor_decal/industrial/stand_clear,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"pEj" = (
-/obj/machinery/button/remote/blast_door{
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	pixel_x = 1;
-	pixel_y = 23;
-	req_access = list(29)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "pEo" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -83759,7 +83838,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/r_wall,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "guild_lobby";
+	name = "Office Shutters";
+	opacity = 0
+	},
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/foyer)
 "pYF" = (
 /obj/machinery/light/small,
@@ -84371,7 +84459,7 @@
 	density = 0;
 	dir = 2;
 	icon_state = "shutter0";
-	id = "premier_office";
+	id = "guild_lobby";
 	name = "Office Shutters";
 	opacity = 0
 	},
@@ -85960,6 +86048,14 @@
 /area/eris/crew_quarters/plasma_tag)
 "quD" = (
 /obj/effect/window_lwall_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "guild_lobby";
+	name = "Office Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/foyer)
 "quN" = (
@@ -86574,9 +86670,10 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security)
 "qAb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/medical/genetics)
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "qAh" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -86665,6 +86762,14 @@
 /obj/machinery/door/window/northleft{
 	dir = 4;
 	req_access = list(10)
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "guild_lobby";
+	name = "Office Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/engineering/foyer)
@@ -86808,11 +86913,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/crew_quarters/plasma_tag)
-"qDe" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/rnd/research)
 "qDg" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -88565,14 +88665,17 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
 "qUj" = (
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+/obj/machinery/holoposter{
+	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cyberplant,
+/obj/effect/floor_decal/steeldecal/steel_decals_central6{
+	pixel_y = -10
+	},
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/area/nadezhda/hallway/main/stairwell)
 "qUn" = (
 /obj/structure/window/reinforced,
 /obj/structure/sink{
@@ -88629,12 +88732,16 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "qUE" = (
-/obj/structure/toilet,
-/obj/machinery/holoposter{
-	pixel_y = 30
+/obj/machinery/button/remote/blast_door{
+	id = "Skynet_launch";
+	name = "Mech Bay Door Control";
+	pixel_x = 1;
+	pixel_y = 23;
+	req_access = list(29)
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "qUQ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -89335,8 +89442,11 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
 "raF" = (
-/turf/simulated/mineral,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "raH" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "14,23"
@@ -90607,9 +90717,14 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/security/nuke_storage)
 "rmL" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
+/obj/machinery/camera/network/medbay{
+	dir = 8
+	},
+/obj/structure/closet/wall_mounted{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "rmM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -92190,12 +92305,6 @@
 /area/nadezhda/crew_quarters/dorm2{
 	name = "Dormitory 2"
 	})
-"rBK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
 "rBT" = (
 /obj/structure/multiz/ladder,
 /obj/machinery/light/small{
@@ -92729,6 +92838,11 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
+"rGo" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_pump,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "rGq" = (
 /obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/rock,
@@ -93139,10 +93253,9 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "rKH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/research,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "rKL" = (
 /obj/structure/multiz/stairs,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -93684,12 +93797,6 @@
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
-"rPN" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/medical/genetics)
 "rQd" = (
 /obj/structure/railing/grey{
 	dir = 4;
@@ -94197,10 +94304,19 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "rUO" = (
-/obj/structure/bed/chair/comfy{
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
+	},
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
+/obj/structure/mirror{
+	dir = 8;
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/smc/quarters)
 "rUY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -95640,6 +95756,15 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
+"sij" = (
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cyberplant,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "sik" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "16,17"
@@ -95920,22 +96045,15 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "slm" = (
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/computer_hardware/hard_drive/portable/design/circuits,
-/obj/item/computer_hardware/hard_drive/portable/design/components,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/glass{
-	amount = 120
+/obj/structure/medical_stand,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/item/stack/material/plastic{
-	amount = 120
-	},
-/obj/item/paper/monitorkey,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/gmaster)
+/obj/item/tank/anesthetic,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "slo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -98482,9 +98600,11 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
 "sNY" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/reagent_dispensers/watertank/huge,
-/turf/simulated/floor/tiled/white/techfloor,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
 "sOa" = (
 /obj/machinery/conveyor/east{
@@ -101834,12 +101954,6 @@
 /area/nadezhda/security{
 	name = "Security Training"
 	})
-"tvn" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/spray/chemsprayer,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "tvq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -102063,13 +102177,16 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "twP" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+/obj/structure/closet/chefcloset,
+/obj/item/soap/hunters,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/pros/foreman)
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "twT" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -104524,14 +104641,13 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "tYl" = (
-/obj/machinery/camera/network/medbay{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/structure/closet/wall_mounted{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "tYm" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -107722,10 +107838,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
-"uBN" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/wall,
-/area/asteroid/cave)
 "uBU" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -108163,20 +108275,6 @@
 /obj/structure/flora/small/grassb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"uGo" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/command/gmaster)
 "uGq" = (
 /obj/structure/girder/displaced,
 /obj/effect/decal/cleanable/dirt,
@@ -110715,21 +110813,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
-"vfw" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -11
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/mirror{
-	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
 "vfx" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -110960,15 +111043,14 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/rocinante_shuttle_area)
 "vhU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/bioprinter/med,
-/obj/machinery/button/remote/blast_door{
-	id = "organ_shutter";
-	name = "privacy shutter control";
-	pixel_y = -24
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "via" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -111984,18 +112066,10 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "vrz" = (
-/obj/machinery/smartfridge/secure/medbay/organs/stocked,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "organ_shutter";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/rnd/docking)
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/rnd/research)
 "vrB" = (
 /obj/machinery/camera/network/plasma_tag{
 	dir = 4
@@ -114715,6 +114789,11 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"vRw" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "vRz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/coatrack,
@@ -115904,9 +115983,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/section1)
-"wcK" = (
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
 "wcM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
@@ -121407,9 +121483,10 @@
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "xfm" = (
-/mob/living/simple_animal/soteria_roomba,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cro)
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "xfv" = (
 /obj/structure/railing{
 	dir = 8
@@ -125434,14 +125511,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "xTe" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cbo)
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/medical/genetics)
 "xTj" = (
 /obj/machinery/atm{
 	dir = 1;
@@ -125529,6 +125603,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
+"xUa" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "xUe" = (
 /obj/structure/table/bench/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -126279,6 +126359,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "ybC" = (
@@ -133606,10 +133687,10 @@ kse
 axa
 oGw
 oGw
-nuq
-nuq
-nuq
-nuq
+nIS
+nIS
+nIS
+nIS
 clN
 htx
 wyz
@@ -133802,16 +133883,16 @@ euZ
 fxu
 uCp
 oGw
-jac
+pis
 uqn
 kNT
-jhS
+aar
 oGw
 oGw
-nuq
-nuq
-nuq
-nuq
+nIS
+nIS
+nIS
+nIS
 clN
 pPv
 vgt
@@ -134010,10 +134091,10 @@ otZ
 oGw
 oGw
 oGw
-nuq
-nuq
-nuq
-nuq
+nIS
+nIS
+nIS
+nIS
 clN
 jtl
 vgt
@@ -134212,10 +134293,10 @@ bhK
 xyW
 oGw
 oGw
-nuq
-nuq
-nuq
-nuq
+nIS
+nIS
+nIS
+nIS
 clN
 uVh
 wQo
@@ -136433,7 +136514,7 @@ aZK
 rzW
 ygi
 ths
-fEL
+iQA
 puh
 tmw
 aen
@@ -140903,9 +140984,9 @@ cwr
 efY
 ptB
 vnv
-raF
-raF
-raF
+nkn
+nkn
+nkn
 vnv
 iof
 fNh
@@ -141105,9 +141186,9 @@ cwr
 wLd
 bwh
 vnv
-raF
-raF
-raF
+nkn
+nkn
+nkn
 vnv
 wSq
 gAA
@@ -141307,9 +141388,9 @@ cwr
 cyr
 bwh
 vnv
-raF
-raF
-raF
+nkn
+nkn
+nkn
 vnv
 pLL
 jdf
@@ -141711,9 +141792,9 @@ cwr
 jps
 bwh
 vnv
-aPG
+twP
 rgG
-cOK
+lOw
 vnv
 jdf
 pHC
@@ -144094,7 +144175,7 @@ jIc
 dCw
 koE
 koE
-eAm
+mfr
 sTw
 hdF
 sTw
@@ -150583,12 +150664,12 @@ quV
 ces
 ces
 pEa
-iQA
+pBL
 bwh
 kEP
 pVB
 ryn
-qDe
+vrz
 cqa
 tna
 hWD
@@ -150994,7 +151075,7 @@ gbk
 ryn
 aDp
 wWY
-fMq
+tYl
 mgf
 kgt
 mgf
@@ -151190,7 +151271,7 @@ bwh
 bwh
 dXF
 nyE
-pEj
+qUE
 bwh
 pVB
 rfF
@@ -151385,7 +151466,7 @@ vot
 jVE
 sEU
 vKw
-qUj
+sij
 vKw
 sFC
 mgk
@@ -154023,7 +154104,7 @@ wBQ
 jGM
 mzB
 bxY
-cgQ
+dwV
 bxY
 olZ
 wBQ
@@ -154225,7 +154306,7 @@ nak
 wBQ
 uVq
 bxY
-cgQ
+dwV
 bxY
 xVr
 wBQ
@@ -154427,7 +154508,7 @@ ljg
 aHG
 wXg
 bxY
-cgQ
+dwV
 bxY
 bxY
 bxY
@@ -154817,7 +154898,7 @@ npT
 npT
 qql
 hwH
-jbz
+knb
 pTU
 sLE
 vnK
@@ -155019,7 +155100,7 @@ npT
 npT
 hGh
 hwH
-jbz
+knb
 pTU
 osd
 adZ
@@ -157279,7 +157360,7 @@ kOj
 cAG
 hYY
 qhV
-cpp
+bmp
 sMW
 wEF
 wzo
@@ -157683,8 +157764,8 @@ xxZ
 mrS
 hYY
 hYY
-lri
-vrz
+mPf
+oYx
 hYY
 yhV
 oxv
@@ -157884,9 +157965,9 @@ ihS
 ihS
 gLl
 hYY
-pis
-pvK
-dwV
+rGo
+eAm
+izV
 hYY
 evS
 cSs
@@ -158086,9 +158167,9 @@ ihS
 ihS
 gLl
 hYY
-mTs
-rBK
-vhU
+qAb
+lGo
+nuq
 hYY
 lop
 ffD
@@ -158288,9 +158369,9 @@ ihS
 ihS
 gLl
 hYY
-kIk
-wcK
-nYy
+mTr
+haw
+nGY
 hYY
 lop
 qdj
@@ -158490,9 +158571,9 @@ vnu
 vnu
 vTA
 hYY
-dmY
-tYl
-jkb
+slm
+rmL
+rKH
 hYY
 lop
 qdj
@@ -180432,7 +180513,7 @@ cEg
 iJv
 sFI
 sFI
-dCT
+aMS
 sFI
 sFI
 sFI
@@ -181043,9 +181124,9 @@ hSx
 hSx
 hSx
 ajL
-iAP
+kIk
 cUV
-rUO
+xUa
 vXl
 ajL
 bZz
@@ -181445,7 +181526,7 @@ sFI
 hSx
 ajL
 cui
-vfw
+rUO
 fkR
 iXB
 rsG
@@ -181849,7 +181930,7 @@ sFI
 hSx
 ajL
 ajL
-knb
+cTu
 ajL
 ajL
 ajL
@@ -187953,7 +188034,7 @@ tnX
 gzz
 qHW
 ien
-rSm
+jud
 tnX
 tnX
 tnX
@@ -188155,7 +188236,7 @@ tnX
 wmW
 lBH
 ybv
-uoL
+lgB
 tnX
 tnX
 tnX
@@ -188357,7 +188438,7 @@ oqp
 tZy
 knf
 jjx
-lJJ
+qUj
 tnX
 tnX
 xCT
@@ -188531,7 +188612,7 @@ hSx
 jXV
 kAs
 kCX
-cTu
+vhU
 jXV
 jXV
 jXV
@@ -188557,8 +188638,8 @@ pvV
 gfF
 pGr
 vgG
-vgG
-uoL
+cOK
+oUV
 ezt
 vpQ
 tnX
@@ -188733,7 +188814,7 @@ hSx
 jXV
 lSs
 kCX
-rmL
+ctU
 mmA
 mZG
 mZG
@@ -188963,7 +189044,7 @@ eRx
 kuC
 uFs
 iyT
-iyT
+cIp
 eRx
 eRx
 sFI
@@ -189135,7 +189216,7 @@ hSx
 jXV
 uVy
 nEk
-uGo
+ayP
 nEk
 nEk
 nGc
@@ -189337,7 +189418,7 @@ hSx
 jXV
 dna
 nEk
-lGo
+bPW
 nEk
 nFp
 jXV
@@ -189541,7 +189622,7 @@ iMl
 nEk
 nEk
 nEk
-slm
+egi
 jXV
 jXV
 jXV
@@ -189949,7 +190030,7 @@ jXV
 jXV
 jXV
 nHc
-lTh
+byG
 pdZ
 pef
 jXV
@@ -190344,8 +190425,8 @@ gFp
 gFp
 gFp
 gFp
-gab
-gab
+xfm
+xfm
 eTA
 etI
 eaA
@@ -191802,7 +191883,7 @@ sFI
 sFI
 sFI
 ula
-rKH
+lri
 mJX
 lUt
 lUt
@@ -192004,12 +192085,12 @@ sFI
 sFI
 sFI
 ula
-qAb
+mfO
 vdO
 kYV
 lUt
 erA
-dUl
+dmY
 elK
 wiD
 nBx
@@ -192206,12 +192287,12 @@ sFI
 sFI
 sFI
 ula
-qAb
+mfO
 duz
 pzU
 lUt
 xCY
-ncj
+buz
 elK
 xGJ
 baD
@@ -192408,7 +192489,7 @@ sFI
 sFI
 sFI
 ula
-qAb
+mfO
 vDI
 tHC
 lUt
@@ -192809,8 +192890,8 @@ sFI
 sFI
 ula
 ula
+vRw
 lDb
-sNY
 ula
 iEU
 wpS
@@ -193023,7 +193104,7 @@ iBc
 elK
 sfN
 owe
-ayP
+pvK
 cNm
 aXb
 elK
@@ -193211,7 +193292,7 @@ sFI
 sFI
 sFI
 sFI
-qAb
+mfO
 oou
 gFS
 fMv
@@ -193414,8 +193495,8 @@ sFI
 sFI
 sFI
 ula
-erb
-rPN
+nju
+xTe
 sOu
 hcZ
 dTZ
@@ -193423,7 +193504,7 @@ hcZ
 qNV
 via
 iwx
-tvn
+fnd
 elK
 aRo
 qOO
@@ -193829,10 +193910,10 @@ vUw
 dOH
 xct
 elK
-byG
+hVm
 wGD
 rQQ
-ivN
+raF
 tif
 elK
 cEd
@@ -194025,7 +194106,7 @@ ula
 vLP
 fKY
 eKe
-aMS
+sNY
 eKe
 eKe
 mnX
@@ -194230,7 +194311,7 @@ fHX
 nvm
 jQf
 eKe
-bnm
+fEL
 elK
 elK
 lHP
@@ -194638,7 +194719,7 @@ fgH
 elK
 sUl
 ilQ
-xTe
+cpp
 elK
 eXm
 eXm
@@ -195642,7 +195723,7 @@ ssK
 cZB
 cZB
 hQV
-dHg
+nGx
 xCY
 edz
 rPf
@@ -196465,7 +196546,7 @@ kSF
 bqs
 klk
 ldZ
-xfm
+gab
 mea
 cZm
 klk
@@ -197676,7 +197757,7 @@ aqG
 pPS
 xAN
 klk
-fnd
+iAP
 kzc
 vZI
 klk
@@ -197878,7 +197959,7 @@ eXm
 caY
 emo
 klk
-izV
+fkp
 tYV
 tYV
 xKU
@@ -234823,7 +234904,7 @@ qQZ
 hHU
 riw
 guj
-mUe
+pDo
 qQZ
 gzV
 gUk
@@ -235390,7 +235471,7 @@ kwx
 kwx
 vJb
 rhS
-pBL
+gdC
 jVf
 utl
 utl
@@ -235801,7 +235882,7 @@ wgs
 uvj
 fES
 rjd
-twP
+fqN
 cAC
 eKA
 vbT
@@ -235993,13 +236074,13 @@ rtn
 xdv
 xdv
 xdv
-buz
+jEl
 xdv
 xdv
-buz
+jEl
 xdv
 xdv
-buz
+jEl
 uvj
 gXk
 rjd
@@ -236603,8 +236684,8 @@ veZ
 scG
 scG
 scG
-oyN
-qUE
+jhS
+iMc
 nnM
 uvj
 uvj
@@ -236806,7 +236887,7 @@ veZ
 veZ
 scG
 uvj
-kmK
+ncj
 cyf
 cyf
 pWZ
@@ -237010,7 +237091,7 @@ cPp
 uvj
 uvj
 iVR
-fkp
+kdN
 uvj
 vSU
 lob
@@ -237212,7 +237293,7 @@ cPp
 pwm
 pwm
 pwm
-oyN
+jhS
 uvj
 uvj
 uvj
@@ -237413,11 +237494,11 @@ ukS
 aDO
 lbX
 mDT
-mPf
+mTs
 yjy
 uXK
 uXK
-mPf
+mTs
 vqy
 seQ
 bVD
@@ -238622,7 +238703,7 @@ cAn
 cAn
 cAn
 cAn
-uBN
+dHg
 cAn
 cAn
 hEB

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -56,7 +56,7 @@
 /turf/unsimulated/mineral,
 /area/nadezhda/security/armory_blackshield)
 "aar" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "aas" = (
@@ -2395,6 +2395,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"ayP" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/spray/chemsprayer,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "ayY" = (
 /obj/structure/closet/cabinet{
 	name = "entertainment cabinet"
@@ -2590,6 +2596,16 @@
 /obj/structure/invislight,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
+"aBv" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "aBx" = (
 /obj/effect/floor_decal/industrial/loading,
 /obj/effect/decal/cleanable/dirt,
@@ -3381,13 +3397,10 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
 "aJA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/research)
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/reagent_dispensers/watertank/huge,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "aJG" = (
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/meadow)
@@ -3786,10 +3799,12 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "aMS" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/rnd/research)
+/obj/structure/toilet,
+/obj/machinery/holoposter{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "aMZ" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Core";
@@ -4123,24 +4138,28 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "aPG" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "MedbayTotalLockdown";
+	layer = 2.6;
+	name = "Medbay Total Lockdown";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Organ Laboratory";
+	req_access = list(5)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/rnd/docking)
 "aPI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6371,9 +6390,18 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bmp" = (
-/mob/living/simple_animal/soteria_roomba,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cro)
+/obj/machinery/smartfridge/secure/medbay/organs/stocked,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "organ_shutter";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/docking)
 "bms" = (
 /obj/machinery/newscaster{
 	pixel_x = -30;
@@ -6482,15 +6510,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "bnm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/bioprinter/med,
-/obj/machinery/button/remote/blast_door{
-	id = "organ_shutter";
-	name = "privacy shutter control";
-	pixel_y = -24
+/obj/structure/bed/chair/comfy{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "bnn" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -7687,6 +7711,9 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"byG" = (
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "byP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -9200,12 +9227,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/section3)
-"bPW" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
 "bPY" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -10784,14 +10805,12 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cgQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/machinery/holoposter{
+	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "cgU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/crossbow,
@@ -11860,19 +11879,14 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
 "csb" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/command/gmaster)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos)
 "cse" = (
 /obj/item/toy/junk/inflatable_duck,
 /turf/simulated/floor/beach/water/ocean,
@@ -12051,7 +12065,7 @@
 "ctI" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/engineering/atmos/storage)
 "ctK" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/decal/cleanable/dirt,
@@ -12092,9 +12106,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
 "ctU" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/wall,
-/area/asteroid/cave)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/medical/genetics)
 "ctX" = (
 /obj/structure/flora/small/rock5,
 /turf/unsimulated/wall/jungle,
@@ -13579,9 +13593,13 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "cIp" = (
-/obj/machinery/autolathe/loaded,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/gmaster)
+/obj/structure/table/standard,
+/obj/item/storage/freezer,
+/obj/structure/sink{
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "cIq" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/multiz/ladder,
@@ -14270,11 +14288,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "cOK" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/spray/chemsprayer,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "cOR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14607,14 +14623,9 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/panic_room)
 "cTu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/docking)
 "cTv" = (
 /turf/simulated/wall/r_wall,
@@ -17517,10 +17528,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"dwV" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
 "dxe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -18170,15 +18177,15 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "dCT" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/docking)
 "dCV" = (
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -18587,16 +18594,9 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/hallway/surface/section1)
 "dHg" = (
-/obj/structure/closet/chefcloset,
-/obj/item/soap/hunters,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/structure/toilet,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "dHs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/trailrocka1,
@@ -19652,17 +19652,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	locked = 0;
-	name = "South APC";
-	operating = 1;
-	pixel_y = -28
-	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/construction)
 "dSB" = (
@@ -20720,9 +20709,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "edD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "edH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21102,10 +21093,24 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "egi" = (
-/obj/item/storage/box/donkpockets,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "egs" = (
 /obj/machinery/chem_master/condimaster,
 /turf/simulated/floor/tiled/cafe,
@@ -22115,12 +22120,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
-"erb" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
 "erm" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/small/busha1,
@@ -22968,11 +22974,11 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/turret_protected/ai)
 "eAm" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 32
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "eAI" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
@@ -25810,7 +25816,11 @@
 "fbx" = (
 /obj/machinery/pipedispenser,
 /obj/effect/floor_decal/industrial/box/red,
-/obj/machinery/camera/network/engineering,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "fbz" = (
@@ -25911,6 +25921,7 @@
 "fcl" = (
 /obj/machinery/pipedispenser/disposal,
 /obj/effect/floor_decal/industrial/box/red,
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "fcr" = (
@@ -26689,17 +26700,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
-"fkp" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/tool/scalpel/laser{
-	pixel_y = -5
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26927,6 +26927,29 @@
 /obj/structure/flora/small/trailrocka1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"fnd" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "fnf" = (
 /obj/structure/lattice,
 /turf/simulated/floor/plating/under,
@@ -27365,11 +27388,10 @@
 	name = "Dormitory 3"
 	})
 "fqN" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "fqR" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/effect/decal/cleanable/dirt,
@@ -28972,8 +28994,16 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "fEL" = (
-/turf/simulated/mineral,
-/area/nadezhda/rnd/robotics)
+/obj/structure/closet/chefcloset,
+/obj/item/soap/hunters,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "fER" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/sliceable/bread,
@@ -29781,17 +29811,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "fMq" = (
-/obj/machinery/keycard_auth,
-/obj/item/reagent_containers/enricher,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/structure/table/marble,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/construction)
 "fMs" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc{
@@ -31458,9 +31479,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
 "gdC" = (
-/obj/structure/sign/department/atmos,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/atmos/storage)
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "gdD" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled/techmaint,
@@ -32311,28 +32334,9 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
 "gkI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "MedbayTotalLockdown";
-	layer = 2.6;
-	name = "Medbay Total Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Organ Laboratory";
-	req_access = list(5)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/rnd/docking)
+/obj/item/caution/cone,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/command/teleporter)
 "gkM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -36429,6 +36433,11 @@
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
@@ -40899,13 +40908,15 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "hVm" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/mineral,
-/area/colony)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "hVt" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -41618,10 +41629,12 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
 "icP" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/reagent_dispensers/watertank/huge,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "icS" = (
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
@@ -42676,6 +42689,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "ior" = (
@@ -43479,11 +43497,14 @@
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
 "ivN" = (
-/obj/machinery/camera/network/engineering{
-	dir = 4
+/obj/machinery/camera/network/medbay{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/closet/wall_mounted{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "ivP" = (
 /obj/effect/floor_decal/border/techfloor,
 /obj/effect/floor_decal/border/techfloor{
@@ -43828,12 +43849,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/main/stairwell)
 "izx" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/smc/quarters)
 "izE" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/effect/floor_decal/spline/plain{
@@ -43870,11 +43888,6 @@
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/skyyard)
-"izV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/steeldecal/steel_decals_central4,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
 "izW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/spiders,
@@ -43967,16 +43980,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "iAP" = (
-/obj/machinery/button/remote/blast_door{
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	pixel_x = 1;
-	pixel_y = 23;
-	req_access = list(29)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "iAR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -45121,12 +45127,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "iMc" = (
-/obj/structure/toilet,
-/obj/machinery/holoposter{
-	pixel_y = 30
+/obj/machinery/camera/network/research{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "iMk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -45296,6 +45301,11 @@
 	dir = 1
 	},
 /obj/machinery/meter,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "iNV" = (
@@ -45592,11 +45602,10 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "iQA" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/smc/quarters)
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/nadezhda/engineering/construction)
 "iQD" = (
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/maingate{
@@ -46603,6 +46612,10 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
+"jac" = (
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "jae" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -46750,6 +46763,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
+"jbz" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/tool/scalpel/laser{
+	pixel_y = -5
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "jbH" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -47396,6 +47420,12 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
+"jhS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "jhW" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/wood/wild5,
@@ -47642,9 +47672,11 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "jkb" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/camera/network/cargo{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/bluecorner,
+/area/nadezhda/security/sechall)
 "jkc" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -48227,6 +48259,11 @@
 	dir = 4;
 	name = "Supply to Waste"
 	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "jqE" = (
@@ -48597,6 +48634,12 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"jud" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/gun/energy/cog,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "jui" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -49652,9 +49695,15 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/crew_quarters/fitness)
 "jEl" = (
-/obj/structure/closet/secure_closet/reinforced/commander,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/smc/quarters)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "guild_lobby";
+	name = "Guild Lobby shutter control";
+	pixel_y = -21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/engineering/foyer)
 "jEs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -50280,6 +50329,11 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 2;
 	name = "Port to Supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -51024,22 +51078,11 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jRF" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/hangarsupply)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/construction)
 "jRG" = (
 /obj/random/furniture/pottedplant,
 /obj/structure/extinguisher_cabinet{
@@ -52317,9 +52360,15 @@
 /turf/unsimulated/mineral,
 /area/asteroid/cave)
 "kdN" = (
-/obj/item/caution/cone,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/command/teleporter)
+/obj/structure/medical_stand,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/item/tank/anesthetic,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "kdS" = (
 /obj/structure/table/standard,
 /obj/item/stack/medical/advanced/bruise_pack,
@@ -52742,6 +52791,11 @@
 /area/nadezhda/security/tactical_blackshield)
 "khR" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "khY" = (
@@ -53294,15 +53348,14 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
 "kmK" = (
-/obj/structure/sign/levels/stairsdown{
-	pixel_y = -30
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "kmY" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -53314,12 +53367,6 @@
 "kna" = (
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/hallway/main/stairwell)
-"knb" = (
-/obj/machinery/camera/network/cargo{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/sechall)
 "knd" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -54820,13 +54867,14 @@
 	},
 /area/shuttle/surface_transport_lz)
 "kAK" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cyberplant,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "kAN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard,
@@ -55631,6 +55679,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/sleeper)
+"kIk" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/danger,
+/area/nadezhda/medical/genetics)
 "kIn" = (
 /obj/machinery/light{
 	dir = 4
@@ -57313,6 +57368,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kYA" = (
@@ -57737,6 +57797,11 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "lbC" = (
 /obj/machinery/light/floor,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "lbO" = (
@@ -58266,10 +58331,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "lgB" = (
 /obj/structure/table/standard,
-/obj/item/storage/freezer,
-/obj/structure/sink{
-	pixel_y = -22
-	},
+/obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/docking)
 "lgC" = (
@@ -59356,14 +59418,15 @@
 	name = "\improper Upper Research Hallway"
 	})
 "lri" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32
+/obj/structure/sign/levels/stairsdown{
+	pixel_y = -30
 	},
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cbo)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "lrp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -60885,6 +60948,9 @@
 "lGg" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
+"lGo" = (
+/turf/simulated/wall,
+/area/nadezhda/pros/foreman)
 "lGq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard/guild{
@@ -61691,11 +61757,13 @@
 	name = "\improper Outdoors - Pad"
 	})
 "lOw" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/gun/energy/cog,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/pros/foreman)
 "lOx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -62196,6 +62264,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"lTh" = (
+/turf/simulated/mineral,
+/area/nadezhda/rnd/lab)
 "lTi" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -63457,11 +63528,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"mfr" = (
-/obj/structure/catwalk,
-/obj/structure/lattice,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "mfs" = (
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -63530,12 +63596,9 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
 "mfO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
+/obj/structure/bed/chair/sofa/black/left,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "mfT" = (
 /obj/structure/bed/chair/office/light,
 /obj/landmark/join/start/paramedic,
@@ -67308,6 +67371,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/crew_quarters/plasma_tag)
+"mPf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "mPj" = (
 /obj/structure/table/woodentable,
 /obj/item/device/megaphone,
@@ -67681,14 +67751,10 @@
 	})
 "mTr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/propis{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/pros/prep)
-"mTs" = (
-/turf/simulated/wall,
-/area/nadezhda/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "mTy" = (
 /obj/effect/floor_decal/industrial/box/white,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -67746,10 +67812,19 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
 "mUe" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/machinery/washing_machine,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/towel,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "mUh" = (
 /obj/machinery/light{
 	dir = 8;
@@ -68183,9 +68258,8 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "mXT" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/mineral,
+/area/eris/crew_quarters/kitchen_storage)
 "mXY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/decal/cleanable/dirt,
@@ -68573,6 +68647,17 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"ncj" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "nck" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/effect/decal/cleanable/dirt,
@@ -69280,15 +69365,9 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nju" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/washing_machine,
-/obj/machinery/vending/wallmed/lobby{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "njA" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -69345,15 +69424,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
 "nkn" = (
-/obj/structure/medical_stand,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/item/tank/anesthetic,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/machinery/door/airlock/glass,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/medical/genetics)
 "nkv" = (
 /obj/structure/table/steel,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -70313,8 +70387,14 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nuq" = (
-/turf/simulated/mineral,
-/area/nadezhda/command/swo/quarters)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/construction)
 "nur" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -71533,19 +71613,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"nGx" = (
-/obj/machinery/smartfridge/secure/medbay/organs/stocked,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "organ_shutter";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/rnd/docking)
 "nGy" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/spider/stickyweb,
@@ -71611,10 +71678,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"nGY" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "nHc" = (
 /obj/machinery/microwave,
 /obj/structure/table/marble,
@@ -71825,10 +71888,17 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/psych)
 "nIS" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/medical/genetics)
+/obj/machinery/keycard_auth,
+/obj/item/reagent_containers/enricher,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/structure/table/marble,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "nIZ" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -73260,9 +73330,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nYy" = (
-/obj/machinery/optable,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/mob/living/simple_animal/soteria_roomba,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cro)
 "nYz" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/regular,
@@ -76197,19 +76267,15 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
 "oyN" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
 	},
-/obj/item/towel,
-/obj/machinery/vending/wallmed/lobby{
-	pixel_y = 25
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "oyO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -77600,9 +77666,7 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "oLT" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/tiled/white/monofloor,
+/turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/docking)
 "oLU" = (
 /obj/structure/table/woodentable,
@@ -78448,15 +78512,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
-"oUV" = (
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
-/obj/structure/closet/wall_mounted{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
 "oVd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -78663,15 +78718,9 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
 "oYx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/docking)
+/obj/structure/closet/secure_closet/reinforced/commander,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "oYz" = (
 /obj/effect/floor_decal/border/techfloor,
 /obj/effect/floor_decal/border/techfloor{
@@ -79632,28 +79681,22 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
 "pis" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/computer_hardware/hard_drive/portable/design/circuits,
+/obj/item/computer_hardware/hard_drive/portable/design/components,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/stack/material/steel/full,
+/obj/item/stack/material/glass{
+	amount = 120
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/stack/material/plastic{
+	amount = 120
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos/storage)
+/obj/item/paper/monitorkey,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/gmaster)
 "piv" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -80905,12 +80948,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "pvK" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/danger,
-/area/nadezhda/medical/genetics)
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/construction)
 "pvM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -81492,9 +81532,9 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "pBL" = (
-/obj/structure/bed/chair/sofa/black/left,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "pBN" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/floor_decal/spline/plain{
@@ -81697,14 +81737,23 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "pDo" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 2;
+	locked = 0;
+	name = "South APC";
+	operating = 1;
+	pixel_y = -28
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/construction)
 "pDr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 6;
@@ -81835,6 +81884,11 @@
 /obj/effect/floor_decal/industrial/stand_clear,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"pEj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/rnd/research)
 "pEo" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82758,9 +82812,8 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/construction)
 "pNf" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/command/teleporter)
+/turf/simulated/mineral,
+/area/nadezhda/command/swo/quarters)
 "pNn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -86787,20 +86840,22 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security)
 "qAb" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -11
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/mirror{
-	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/machinery/camera/network/cargo,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/hangarsupply)
 "qAh" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -87040,11 +87095,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/crew_quarters/plasma_tag)
-"qDe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/research,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
 "qDg" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -88796,6 +88846,12 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qUj" = (
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "qUn" = (
 /obj/structure/window/reinforced,
 /obj/structure/sink{
@@ -88852,9 +88908,15 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "qUE" = (
-/obj/structure/toilet,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe/bioprinter/med,
+/obj/machinery/button/remote/blast_door{
+	id = "organ_shutter";
+	name = "privacy shutter control";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "qUQ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -89554,6 +89616,10 @@
 /obj/structure/cyberplant,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
+"raF" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/command/teleporter)
 "raH" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "14,23"
@@ -90823,9 +90889,6 @@
 /obj/item/pen/multi,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/security/nuke_storage)
-"rmL" = (
-/turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/atmos/storage)
 "rmM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -91690,6 +91753,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
+"ruQ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "ruS" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -92407,11 +92474,12 @@
 	name = "Dormitory 2"
 	})
 "rBK" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/propis{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/pros/prep)
 "rBT" = (
 /obj/structure/multiz/ladder,
 /obj/machinery/light/small{
@@ -92946,8 +93014,10 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rGo" = (
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/research,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "rGq" = (
 /obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/rock,
@@ -93357,6 +93427,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
+"rKH" = (
+/obj/machinery/autolathe/loaded,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/gmaster)
 "rKL" = (
 /obj/structure/multiz/stairs,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -94409,11 +94483,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "rUO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "rUY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/fact_plaque,
@@ -95853,22 +95926,20 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "sij" = (
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/computer_hardware/hard_drive/portable/design/circuits,
-/obj/item/computer_hardware/hard_drive/portable/design/components,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/glass{
-	amount = 120
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
 	},
-/obj/item/stack/material/plastic{
-	amount = 120
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/item/paper/monitorkey,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/gmaster)
+/obj/structure/mirror{
+	dir = 8;
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/smc/quarters)
 "sik" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "16,17"
@@ -96149,10 +96220,9 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "slm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/construction)
 "slo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -97381,9 +97451,16 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/genetics)
 "sye" = (
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/machinery/button/remote/blast_door{
+	id = "Skynet_launch";
+	name = "Mech Bay Door Control";
+	pixel_x = 1;
+	pixel_y = 23;
+	req_access = list(29)
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "syp" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -98703,8 +98780,10 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
 "sNY" = (
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/obj/item/storage/box/donkpockets,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "sOa" = (
 /obj/machinery/conveyor/east{
 	id = "disposals grinder"
@@ -100919,7 +100998,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/engineering/atmos/storage)
 "tiQ" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
@@ -102054,9 +102133,10 @@
 	name = "Security Training"
 	})
 "tvn" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/steeldecal/steel_decals_central4,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "tvq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -102280,12 +102360,13 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "twP" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/obj/machinery/holoposter{
-	pixel_x = 32
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
+/turf/simulated/mineral,
+/area/colony)
 "twT" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -104739,11 +104820,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"tYl" = (
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/nadezhda/engineering/construction)
 "tYm" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -107935,11 +108011,8 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "uBN" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/medical/genetics)
+/turf/simulated/mineral,
+/area/nadezhda/rnd/robotics)
 "uBU" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -108378,8 +108451,9 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "uGo" = (
-/turf/simulated/mineral,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/wall,
+/area/asteroid/cave)
 "uGq" = (
 /obj/structure/girder/displaced,
 /obj/effect/decal/cleanable/dirt,
@@ -109100,7 +109174,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "uNP" = (
-/turf/simulated/floor/tiled/dark/techfloor,
+/turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos/storage)
 "uNR" = (
 /obj/effect/decal/cleanable/rubble,
@@ -110922,8 +110996,11 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "vfw" = (
-/turf/simulated/mineral,
-/area/nadezhda/rnd/lab)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/medical/genetics)
 "vfx" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -111154,11 +111231,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/rocinante_shuttle_area)
 "vhU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/construction)
 "via" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -112173,15 +112248,6 @@
 	icon_state = "13,15"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"vrz" = (
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cyberplant,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "vrB" = (
 /obj/machinery/camera/network/plasma_tag{
 	dir = 4
@@ -114777,7 +114843,7 @@
 "vQv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/engineering/atmos/storage)
 "vQy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/chair/office/light{
@@ -114902,9 +114968,13 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vRw" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "vRz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/coatrack,
@@ -121593,10 +121663,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
-"xfm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/medical/genetics)
 "xfv" = (
 /obj/structure/railing{
 	dir = 8
@@ -121932,11 +121998,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xjC" = (
-/obj/machinery/camera/network/research{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/obj/structure/sign/department/atmos,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/atmos/storage)
 "xjG" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/nuke_storage{
@@ -124523,6 +124587,17 @@
 /obj/structure/flora/rock,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"xIj" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "xIn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -125626,6 +125701,15 @@
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
+"xTe" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cbo)
 "xTj" = (
 /obj/machinery/atm{
 	dir = 1;
@@ -125714,15 +125798,19 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
 "xUa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/machinery/button/remote/blast_door{
-	id = "guild_lobby";
-	name = "Guild Lobby shutter control";
-	pixel_y = -21
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/engineering/foyer)
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/steel/gray_platform,
+/area/nadezhda/command/gmaster)
 "xUe" = (
 /obj/structure/table/bench/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -133801,10 +133889,10 @@ kse
 axa
 oGw
 oGw
-nuq
-nuq
-nuq
-nuq
+pNf
+pNf
+pNf
+pNf
 clN
 htx
 wyz
@@ -133997,16 +134085,16 @@ euZ
 fxu
 uCp
 oGw
-erb
+pBL
 uqn
 kNT
-nju
+aBv
 oGw
 oGw
-nuq
-nuq
-nuq
-nuq
+pNf
+pNf
+pNf
+pNf
 clN
 pPv
 vgt
@@ -134205,10 +134293,10 @@ otZ
 oGw
 oGw
 oGw
-nuq
-nuq
-nuq
-nuq
+pNf
+pNf
+pNf
+pNf
 clN
 jtl
 vgt
@@ -134407,10 +134495,10 @@ bhK
 xyW
 oGw
 oGw
-nuq
-nuq
-nuq
-nuq
+pNf
+pNf
+pNf
+pNf
 clN
 uVh
 wQo
@@ -136628,7 +136716,7 @@ aZK
 rzW
 ygi
 ths
-knb
+jkb
 puh
 tmw
 aen
@@ -141098,9 +141186,9 @@ cwr
 efY
 ptB
 vnv
-uGo
-uGo
-uGo
+mXT
+mXT
+mXT
 vnv
 iof
 fNh
@@ -141300,9 +141388,9 @@ cwr
 wLd
 bwh
 vnv
-uGo
-uGo
-uGo
+mXT
+mXT
+mXT
 vnv
 wSq
 gAA
@@ -141502,9 +141590,9 @@ cwr
 cyr
 bwh
 vnv
-uGo
-uGo
-uGo
+mXT
+mXT
+mXT
 vnv
 pLL
 jdf
@@ -141906,9 +141994,9 @@ cwr
 jps
 bwh
 vnv
-dHg
+fEL
 rgG
-sye
+cOK
 vnv
 jdf
 pHC
@@ -144289,7 +144377,7 @@ jIc
 dCw
 koE
 koE
-jRF
+qAb
 sTw
 hdF
 sTw
@@ -150778,12 +150866,12 @@ quV
 ces
 ces
 pEa
-slm
+fqN
 bwh
 kEP
 pVB
 ryn
-aMS
+pEj
 cqa
 tna
 hWD
@@ -151189,7 +151277,7 @@ gbk
 ryn
 aDp
 wWY
-aJA
+vRw
 mgf
 kgt
 mgf
@@ -151385,7 +151473,7 @@ bwh
 bwh
 dXF
 nyE
-iAP
+sye
 bwh
 pVB
 rfF
@@ -151580,7 +151668,7 @@ vot
 jVE
 sEU
 vKw
-vrz
+kAK
 vKw
 sFC
 mgk
@@ -154218,7 +154306,7 @@ wBQ
 jGM
 mzB
 bxY
-fEL
+uBN
 bxY
 olZ
 wBQ
@@ -154420,7 +154508,7 @@ nak
 wBQ
 uVq
 bxY
-fEL
+uBN
 bxY
 xVr
 wBQ
@@ -154622,7 +154710,7 @@ ljg
 aHG
 wXg
 bxY
-fEL
+uBN
 bxY
 bxY
 bxY
@@ -155012,7 +155100,7 @@ npT
 npT
 qql
 hwH
-vfw
+lTh
 pTU
 sLE
 vnK
@@ -155214,7 +155302,7 @@ npT
 npT
 hGh
 hwH
-vfw
+lTh
 pTU
 osd
 adZ
@@ -155611,7 +155699,7 @@ tBu
 xtr
 hwH
 gfQ
-pNf
+raF
 bFV
 sUU
 vNF
@@ -155621,7 +155709,7 @@ bFV
 vNF
 gfQ
 kFt
-kdN
+gkI
 edf
 gfQ
 uKJ
@@ -155813,8 +155901,8 @@ dWy
 dWy
 hwH
 gfQ
-pNf
-pNf
+raF
+raF
 iei
 vNF
 ddm
@@ -156016,7 +156104,7 @@ xCe
 hwH
 gfQ
 ink
-pNf
+raF
 vNF
 vNF
 gfQ
@@ -156228,7 +156316,7 @@ vNF
 vNF
 liV
 bFV
-pNf
+raF
 gfQ
 emn
 eXK
@@ -156430,7 +156518,7 @@ vNF
 iei
 bFV
 vNF
-pNf
+raF
 gfQ
 uKJ
 eXK
@@ -156632,7 +156720,7 @@ vNF
 bFV
 bFV
 vNF
-pNf
+raF
 gfQ
 emn
 eXK
@@ -156823,7 +156911,7 @@ dWy
 wvV
 hwH
 gfQ
-pNf
+raF
 bFV
 uhv
 kKh
@@ -156834,7 +156922,7 @@ iei
 djA
 vNF
 liV
-pNf
+raF
 gfQ
 cal
 eXK
@@ -157036,7 +157124,7 @@ vNF
 gfQ
 bFV
 vNF
-pNf
+raF
 gfQ
 emn
 eXK
@@ -157474,7 +157562,7 @@ kOj
 cAG
 hYY
 qhV
-oYx
+dCT
 sMW
 wEF
 wzo
@@ -157878,8 +157966,8 @@ xxZ
 mrS
 hYY
 hYY
-gkI
-nGx
+aPG
+bmp
 hYY
 yhV
 oxv
@@ -158079,9 +158167,9 @@ ihS
 ihS
 gLl
 hYY
-oLT
-cTu
-fkp
+lgB
+hVm
+jbz
 hYY
 evS
 cSs
@@ -158281,9 +158369,9 @@ ihS
 ihS
 gLl
 hYY
-mUe
-rUO
-bnm
+cTu
+jhS
+qUE
 hYY
 lop
 ffD
@@ -158483,9 +158571,9 @@ ihS
 ihS
 gLl
 hYY
-nYy
-rGo
-lgB
+iAP
+oLT
+cIp
 hYY
 lop
 qdj
@@ -158685,8 +158773,8 @@ vnu
 vnu
 vTA
 hYY
-nkn
-oUV
+kdN
+ivN
 rPN
 hYY
 lop
@@ -180627,7 +180715,7 @@ cEg
 iJv
 sFI
 sFI
-hVm
+twP
 sFI
 sFI
 sFI
@@ -181238,9 +181326,9 @@ hSx
 hSx
 hSx
 ajL
-jEl
+oYx
 cUV
-iQA
+bnm
 vXl
 ajL
 bZz
@@ -181640,7 +181728,7 @@ sFI
 hSx
 ajL
 cui
-qAb
+sij
 fkR
 iXB
 rsG
@@ -182044,7 +182132,7 @@ sFI
 hSx
 ajL
 ajL
-tvn
+izx
 ajL
 ajL
 ajL
@@ -188148,7 +188236,7 @@ tnX
 gzz
 qHW
 ien
-kmK
+lri
 tnX
 tnX
 tnX
@@ -188350,7 +188438,7 @@ tnX
 wmW
 lBH
 ybv
-izV
+tvn
 tnX
 tnX
 tnX
@@ -188726,7 +188814,7 @@ hSx
 jXV
 kAs
 kCX
-pDo
+kmK
 jXV
 jXV
 jXV
@@ -188752,8 +188840,8 @@ pvV
 gfF
 pGr
 vgG
-vhU
-mfO
+mTr
+icP
 ezt
 vpQ
 tnX
@@ -188928,7 +189016,7 @@ hSx
 jXV
 lSs
 kCX
-dwV
+ruQ
 mmA
 mZG
 mZG
@@ -189158,7 +189246,7 @@ eRx
 kuC
 uFs
 iyT
-xUa
+jEl
 eRx
 eRx
 sFI
@@ -189330,7 +189418,7 @@ hSx
 jXV
 uVy
 nEk
-csb
+xUa
 nEk
 nEk
 nGc
@@ -189532,7 +189620,7 @@ hSx
 jXV
 dna
 nEk
-cIp
+rKH
 nEk
 nFp
 jXV
@@ -189736,7 +189824,7 @@ iMl
 nEk
 nEk
 nEk
-sij
+pis
 jXV
 jXV
 jXV
@@ -190144,7 +190232,7 @@ jXV
 jXV
 jXV
 nHc
-egi
+sNY
 pdZ
 pef
 jXV
@@ -190539,8 +190627,8 @@ gFp
 gFp
 gFp
 gFp
-mfr
-mfr
+rUO
+rUO
 eTA
 etI
 eaA
@@ -191997,7 +192085,7 @@ sFI
 sFI
 sFI
 ula
-qDe
+rGo
 mJX
 lUt
 lUt
@@ -192199,12 +192287,12 @@ sFI
 sFI
 sFI
 ula
-xfm
+ctU
 vdO
 kYV
 lUt
 erA
-lOw
+jud
 elK
 wiD
 nBx
@@ -192401,12 +192489,12 @@ sFI
 sFI
 sFI
 ula
-xfm
+ctU
 duz
 pzU
 lUt
 xCY
-xjC
+iMc
 elK
 xGJ
 baD
@@ -192603,7 +192691,7 @@ sFI
 sFI
 sFI
 ula
-xfm
+ctU
 vDI
 tHC
 lUt
@@ -193005,7 +193093,7 @@ sFI
 ula
 ula
 lDb
-icP
+aJA
 ula
 iEU
 wpS
@@ -193218,7 +193306,7 @@ iBc
 elK
 sfN
 owe
-fMq
+nIS
 cNm
 aXb
 elK
@@ -193406,7 +193494,7 @@ sFI
 sFI
 sFI
 sFI
-xfm
+ctU
 oou
 gFS
 fMv
@@ -193609,8 +193697,8 @@ sFI
 sFI
 sFI
 ula
-fqN
-uBN
+edD
+vfw
 sOu
 hcZ
 dTZ
@@ -193618,7 +193706,7 @@ hcZ
 qNV
 via
 iwx
-cOK
+ayP
 elK
 aRo
 qOO
@@ -194024,10 +194112,10 @@ vUw
 dOH
 xct
 elK
-pBL
+mfO
 wGD
 rQQ
-eAm
+gdC
 tif
 elK
 cEd
@@ -194184,12 +194272,12 @@ eyR
 eyR
 eyR
 eyR
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
 eyR
 eyR
 eyR
@@ -194220,7 +194308,7 @@ ula
 vLP
 fKY
 eKe
-pvK
+kIk
 eKe
 eKe
 mnX
@@ -194386,12 +194474,12 @@ crV
 crV
 crV
 crV
-rmL
+uNP
 qjd
 qUs
 eYh
-rmL
-rmL
+uNP
+uNP
 sap
 suz
 sUk
@@ -194425,7 +194513,7 @@ fHX
 nvm
 jQf
 eKe
-aPG
+egi
 elK
 elK
 lHP
@@ -194588,12 +194676,12 @@ kIJ
 crV
 crV
 crV
-rmL
+uNP
 qjd
 pvj
 pvj
-rmL
-rmL
+uNP
+uNP
 sds
 swU
 sUT
@@ -194790,12 +194878,12 @@ kIJ
 crV
 crV
 crV
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
 rDH
-rmL
-rmL
+uNP
+uNP
 sap
 suz
 sWf
@@ -194833,7 +194921,7 @@ fgH
 elK
 sUl
 ilQ
-lri
+xTe
 elK
 eXm
 eXm
@@ -194992,12 +195080,12 @@ mcp
 crV
 crV
 crV
-rmL
+uNP
 qnl
 qXK
 pvj
-rmL
-rmL
+uNP
+uNP
 eyR
 syO
 sWk
@@ -195194,12 +195282,12 @@ hCc
 crV
 htp
 crV
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
 rFs
-rmL
-rmL
+uNP
+uNP
 eyR
 szY
 tbJ
@@ -195396,21 +195484,21 @@ hDG
 fnf
 htp
 crV
-rmL
+uNP
 qnl
 qXK
 eCB
-rmL
-rmL
+uNP
+uNP
 eyR
 sDt
 tbW
 eyR
-rmL
+uNP
 uPV
 vHa
 wFS
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -195598,21 +195686,21 @@ hFt
 foZ
 crV
 crV
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
 vld
-rmL
-rmL
+uNP
+uNP
 eyR
 eyR
 eyR
 eyR
-rmL
+uNP
 tiM
 ult
 wFu
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -195802,19 +195890,19 @@ nfA
 fJR
 ogf
 plt
-uNP
-uNP
-ivN
-dCT
+byG
+byG
+qUj
+oyN
 tuU
 vZd
 bYE
 jPJ
 iVn
-uNP
+byG
 ult
 uYr
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -195837,7 +195925,7 @@ ssK
 cZB
 cZB
 hQV
-nIS
+nkn
 xCY
 edz
 rPf
@@ -196016,7 +196104,7 @@ sVf
 uQF
 vHx
 wGk
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -196204,21 +196292,21 @@ hLF
 gBS
 lac
 fJR
-gdC
+xjC
 oOj
 pqj
 pSN
 qAI
 rbA
 rKf
-rmL
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
+uNP
 tiM
 vHy
 bVn
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -196406,21 +196494,21 @@ hLF
 gBS
 lac
 fsR
-rmL
+uNP
 oOj
 pqj
 pSN
 qAI
 rbA
 rKf
-rmL
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
+uNP
 tfh
 vHy
 uYr
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -196608,21 +196696,21 @@ mcr
 gBS
 lac
 fKn
-rmL
+uNP
 oOj
 pqj
 pWO
 qBj
 rbA
 rKf
-rmL
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
+uNP
 tfh
 vHy
 uYr
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -196660,7 +196748,7 @@ kSF
 bqs
 klk
 ldZ
-bmp
+nYy
 mea
 cZm
 klk
@@ -196817,14 +196905,14 @@ crV
 crV
 crV
 crV
-rmL
+uNP
 epg
 tKp
 dvQ
 gNi
 uOb
 cSt
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -197006,7 +197094,7 @@ iKo
 crV
 crV
 crV
-kcA
+ncj
 gLk
 mdt
 mBn
@@ -197019,14 +197107,14 @@ qnP
 qYk
 qqy
 crV
-rmL
 uNP
-edD
+byG
+vQv
 qeK
-edD
+vQv
 vIm
 cSt
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -197208,7 +197296,7 @@ iKT
 jmY
 crV
 kbC
-kdA
+xIj
 gLk
 mcI
 gLk
@@ -197221,14 +197309,14 @@ qqy
 qYD
 rHH
 crV
-rmL
-edD
-edD
-edD
 uNP
+vQv
+vQv
+vQv
+byG
 uOb
 cSt
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -197388,16 +197476,16 @@ hSx
 sFI
 aXo
 czX
-vQv
+aar
 iNR
 aXo
-tYl
-tYl
+iQA
+iQA
 nWT
-tYl
+iQA
 aXo
 cDI
-vQv
+aar
 edQ
 crV
 crV
@@ -197410,7 +197498,7 @@ iKZ
 jnp
 jIv
 kcA
-fJR
+lac
 lDl
 mdD
 mCF
@@ -197423,14 +197511,14 @@ qrF
 qqy
 qqy
 crV
-rmL
+uNP
 cAU
 tKp
 dvQ
 uWe
 uOb
 hSq
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -197598,7 +197686,7 @@ frE
 sDA
 cSu
 dkl
-nGY
+vhU
 fIX
 ega
 crV
@@ -197612,7 +197700,7 @@ iLo
 jpd
 jIA
 kdA
-fJR
+lac
 lET
 hLF
 ftq
@@ -197625,14 +197713,14 @@ crV
 crV
 crV
 crV
-rmL
+uNP
 jiD
 tKp
 uim
 uWK
 uOb
 nja
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -197792,7 +197880,7 @@ hSx
 sFI
 aXo
 mHa
-vQv
+aar
 ycE
 aXo
 wMn
@@ -197814,7 +197902,7 @@ iMv
 iWb
 fDb
 keJ
-fJR
+lac
 lGT
 mdD
 mDc
@@ -197827,14 +197915,14 @@ crV
 crV
 crV
 crV
-rmL
 uNP
-edD
-edD
-edD
+byG
+vQv
+vQv
+vQv
 jkc
 cSt
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -197871,7 +197959,7 @@ aqG
 pPS
 xAN
 klk
-qUE
+dHg
 kzc
 vZI
 klk
@@ -197994,7 +198082,7 @@ hSx
 sFI
 aXo
 mHa
-sNY
+fMq
 ycE
 aXo
 wMn
@@ -198016,7 +198104,7 @@ iNA
 jpM
 jKc
 khq
-fJR
+lac
 fJR
 hLF
 mEp
@@ -198029,14 +198117,14 @@ crV
 crV
 crV
 crV
-rmL
+uNP
 aqp
-edD
-edD
-edD
+vQv
+vQv
+vQv
 uOb
 cSt
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -198073,7 +198161,7 @@ eXm
 caY
 emo
 klk
-bPW
+eAm
 tYV
 tYV
 xKU
@@ -198196,9 +198284,9 @@ hSx
 sFI
 aXo
 ezW
-vQv
+aar
 ycE
-tYl
+iQA
 fwb
 ipN
 wMn
@@ -198207,12 +198295,12 @@ dkl
 iYq
 tXC
 eqY
-crV
+csb
 fbx
-fJR
-fJR
+rau
+rau
 gYu
-gBS
+elv
 iom
 iNU
 jqj
@@ -198231,14 +198319,14 @@ crV
 crV
 crV
 crV
-rmL
+uNP
 sCP
 tKp
 uim
 uWe
 vIm
 cSt
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -198401,14 +198489,14 @@ aXo
 ceS
 svA
 aXo
-tYl
-tYl
+iQA
+iQA
 cGr
-tYl
+iQA
 dku
 dAV
-ctI
-pDA
+pvK
+pDo
 crV
 fcl
 fJR
@@ -198433,14 +198521,14 @@ crV
 crV
 crV
 crV
-rmL
+uNP
 epg
 tKp
 dvQ
 uWK
 vMK
 pBF
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -198600,7 +198688,7 @@ hSx
 sFI
 sFI
 aXo
-vQv
+aar
 uhD
 gcc
 eOZ
@@ -198609,7 +198697,7 @@ cHc
 fRt
 wpH
 iYq
-sNY
+fMq
 pDA
 crV
 faL
@@ -198635,14 +198723,14 @@ crV
 crV
 crV
 crV
-rmL
+uNP
 iRm
-edD
-edD
-edD
+vQv
+vQv
+vQv
 jkc
 cSt
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -198802,11 +198890,11 @@ hSx
 sFI
 sFI
 aXo
-vQv
+aar
 uhD
 vkn
 uap
-vQv
+aar
 ycE
 fRt
 vkn
@@ -198837,14 +198925,14 @@ crV
 crV
 crV
 crV
-rmL
+uNP
 ozO
-edD
-edD
-edD
+vQv
+vQv
+vQv
 jkc
 nmW
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -199006,12 +199094,12 @@ sFI
 aXo
 sOI
 oLP
-sNY
-ctI
-vQv
+fMq
+pvK
+aar
 cLN
-sNY
-vQv
+fMq
+aar
 uTf
 dSI
 aXo
@@ -199039,14 +199127,14 @@ qsu
 qZy
 qsL
 crV
-rmL
+uNP
 qzn
 tKp
 dvQ
 uWe
 vIm
 nja
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -199241,14 +199329,14 @@ qsL
 qZS
 rHX
 crV
-rmL
+uNP
 cAU
 dvQ
 tKp
 tQX
 vIm
 cSt
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -199414,7 +199502,7 @@ opP
 mOI
 opP
 llv
-vQv
+aar
 lgi
 fga
 dTL
@@ -199443,14 +199531,14 @@ qvf
 qsL
 qsL
 crV
-rmL
-edD
+uNP
+vQv
 qeK
-edD
-edD
+vQv
+vQv
 jkc
 cSt
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -199618,7 +199706,7 @@ lIO
 xYJ
 vHb
 dmz
-vQv
+aar
 dUb
 aXo
 eHm
@@ -199645,14 +199733,14 @@ crV
 crV
 crV
 crV
-rmL
 uNP
-edD
-edD
-edD
+byG
+vQv
+vQv
+vQv
 vIm
 cSt
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -199813,14 +199901,14 @@ sFI
 sFI
 aXo
 oLP
-vQv
-vQv
-cgQ
-sNY
-cgQ
+aar
+aar
+nuq
+fMq
+nuq
 daX
 doc
-vQv
+aar
 dUb
 aXo
 crV
@@ -199847,14 +199935,14 @@ edv
 edv
 edv
 edv
-rmL
+uNP
 sCP
 dvQ
 dvQ
 uWe
 uOb
 hSq
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -200018,16 +200106,16 @@ nYP
 pJa
 pJa
 pJs
-aar
+slm
 xYJ
 pJa
 dsf
 iaX
 dVz
 aXo
-rmL
+uNP
 fkz
-rmL
+uNP
 crV
 hrW
 ibB
@@ -200045,18 +200133,18 @@ crV
 crV
 edv
 edv
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-pis
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+fnd
 cSt
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -200216,7 +200304,7 @@ hSx
 sFI
 sFI
 aXo
-tiO
+jRF
 puU
 mXQ
 hbL
@@ -200227,9 +200315,9 @@ fDK
 yew
 uvV
 aXo
-rmL
+uNP
 fkz
-rmL
+uNP
 crV
 crV
 foZ
@@ -200247,18 +200335,18 @@ crV
 crV
 edv
 edv
-rmL
+uNP
 qFu
 ktS
 rdn
 gWS
 bMY
-rmL
+uNP
 nzt
 vaJ
 vWJ
 qRU
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -200429,9 +200517,9 @@ rXb
 hTt
 mpd
 aXo
-rmL
+uNP
 fkz
-rmL
+uNP
 crV
 crV
 fnf
@@ -200449,18 +200537,18 @@ crV
 crV
 edv
 edv
-rmL
+uNP
 dhV
-edD
+vQv
 nfR
 lHh
 voJ
-rmL
+uNP
 vFD
-rmL
+uNP
 gnF
 hmw
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -200631,9 +200719,9 @@ rXb
 vUX
 dSy
 aXo
-rmL
+uNP
 fkz
-rmL
+uNP
 crV
 htp
 crV
@@ -200651,18 +200739,18 @@ crV
 crV
 edv
 edv
-rmL
-izx
-edD
+uNP
+mPf
+vQv
 nfR
 xQh
 gAJ
-rmL
+uNP
 dZR
-rmL
+uNP
 vYR
 tMg
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -200833,9 +200921,9 @@ rXb
 wCw
 eRZ
 aXo
-rmL
+uNP
 fkz
-rmL
+uNP
 crV
 crV
 rdU
@@ -200853,9 +200941,9 @@ crV
 crV
 edv
 edv
-rmL
 uNP
-edD
+byG
+vQv
 kpB
 msY
 kXq
@@ -200864,7 +200952,7 @@ lBf
 knO
 eaB
 tMg
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -201035,9 +201123,9 @@ aXo
 iiD
 jGP
 aXo
-rmL
+uNP
 fkz
-rmL
+uNP
 crV
 crV
 rdU
@@ -201055,18 +201143,18 @@ crV
 crV
 edv
 edv
-rmL
-mXT
-edD
-bLa
 uNP
-edD
+ctI
+vQv
+bLa
+byG
+vQv
 oaM
 lvl
 vcB
 vZm
 tZv
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -201237,9 +201325,9 @@ aXo
 sFa
 hFA
 aXo
-rmL
+uNP
 gPx
-rmL
+uNP
 crV
 crV
 rdU
@@ -201257,20 +201345,20 @@ edv
 edv
 edv
 edv
-rmL
-rBK
+uNP
+tiO
 ogj
 don
 rNo
 rFl
-rmL
+uNP
 dZR
-rmL
+uNP
 iyq
 tMg
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
 sFI
 sFI
 sFI
@@ -201439,9 +201527,9 @@ aXo
 ebi
 kCU
 aXo
-rmL
+uNP
 fkz
-rmL
+uNP
 crV
 crV
 crV
@@ -201460,19 +201548,19 @@ edv
 ohm
 qbq
 cnc
-edD
+vQv
 hCV
-edD
+vQv
 vhk
-edD
-rmL
+vQv
+uNP
 vFD
-rmL
+uNP
 tIO
 tMg
 xBY
 rBT
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -201641,9 +201729,9 @@ aXo
 ebi
 kCU
 aXo
-rmL
+uNP
 fkz
-rmL
+uNP
 crV
 crV
 crV
@@ -201661,20 +201749,20 @@ ohm
 edv
 edv
 qbK
-rmL
-edD
+uNP
+vQv
 oAd
 kco
 qVq
 lGq
-rmL
+uNP
 vFD
-rmL
+uNP
 kRM
 gat
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
 sFI
 sFI
 sFI
@@ -201843,40 +201931,40 @@ aXo
 ebi
 kCU
 aXo
-rmL
+uNP
 fkz
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
 lqr
-rmL
+uNP
 wbB
 yju
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
 sFI
 sFI
 sFI
@@ -202045,7 +202133,7 @@ aXo
 ebi
 kCU
 aXo
-rmL
+uNP
 flD
 fRn
 fRn
@@ -202078,7 +202166,7 @@ wdc
 dpo
 wOZ
 xCQ
-rmL
+uNP
 sFI
 sFI
 sFI
@@ -202247,40 +202335,40 @@ aXo
 ebi
 hFA
 aXo
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
-rmL
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
+uNP
 sFI
 sFI
 sFI
@@ -235018,7 +235106,7 @@ qQZ
 hHU
 riw
 guj
-jkb
+jac
 qQZ
 gzV
 gUk
@@ -235585,7 +235673,7 @@ kwx
 kwx
 vJb
 rhS
-mTr
+rBK
 jVf
 utl
 utl
@@ -235996,7 +236084,7 @@ wgs
 uvj
 fES
 rjd
-kAK
+lOw
 cAC
 eKA
 vbT
@@ -236798,8 +236886,8 @@ veZ
 scG
 scG
 scG
-mTs
-iMc
+lGo
+aMS
 nnM
 uvj
 uvj
@@ -237001,7 +237089,7 @@ veZ
 veZ
 scG
 uvj
-oyN
+mUe
 cyf
 cyf
 pWZ
@@ -237205,7 +237293,7 @@ cPp
 uvj
 uvj
 iVR
-twP
+cgQ
 uvj
 vSU
 lob
@@ -237407,7 +237495,7 @@ cPp
 pwm
 pwm
 pwm
-mTs
+lGo
 uvj
 uvj
 uvj
@@ -237608,11 +237696,11 @@ ukS
 aDO
 lbX
 mDT
-vRw
+nju
 yjy
 uXK
 uXK
-vRw
+nju
 vqy
 seQ
 bVD
@@ -238817,7 +238905,7 @@ cAn
 cAn
 cAn
 cAn
-ctU
+uGo
 cAn
 cAn
 hEB

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -2391,6 +2391,16 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"ayP" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "ayY" = (
 /obj/structure/closet/cabinet{
 	name = "entertainment cabinet"
@@ -2586,12 +2596,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
-"aBv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
 "aBx" = (
 /obj/effect/floor_decal/industrial/loading,
 /obj/effect/decal/cleanable/dirt,
@@ -3383,13 +3387,12 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
 "aJA" = (
-/obj/structure/table/standard,
-/obj/item/storage/freezer,
-/obj/structure/sink{
-	pixel_y = -22
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/machinery/holoposter{
+	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "aJG" = (
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/meadow)
@@ -3787,6 +3790,17 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"aMS" = (
+/obj/machinery/button/remote/blast_door{
+	id = "Skynet_launch";
+	name = "Mech Bay Door Control";
+	pixel_x = 1;
+	pixel_y = 23;
+	req_access = list(29)
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "aMZ" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Core";
@@ -6349,9 +6363,10 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bmp" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_pump,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "bms" = (
 /obj/machinery/newscaster{
 	pixel_x = -30;
@@ -6460,9 +6475,19 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "bnm" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/washing_machine,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/towel,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "bnn" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -7162,10 +7187,6 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"buz" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "buH" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/railing{
@@ -7660,6 +7681,12 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"byG" = (
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "byP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -9174,9 +9201,8 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/section3)
 "bPW" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
+/turf/simulated/mineral,
+/area/nadezhda/rnd/robotics)
 "bPY" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -10754,12 +10780,6 @@
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"cgQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/medical/genetics)
 "cgU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/crossbow,
@@ -11815,10 +11835,6 @@
 "crV" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
-"csb" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/wall,
-/area/asteroid/cave)
 "cse" = (
 /obj/item/toy/junk/inflatable_duck,
 /turf/simulated/floor/beach/water/ocean,
@@ -12037,6 +12053,12 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
+"ctU" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "ctX" = (
 /obj/structure/flora/small/rock5,
 /turf/unsimulated/wall/jungle,
@@ -13520,6 +13542,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/dungeon/outside/abandoned_solars)
+"cIp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "cIq" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/multiz/ladder,
@@ -14208,8 +14236,10 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "cOK" = (
-/turf/simulated/wall,
-/area/nadezhda/pros/foreman)
+/obj/machinery/door/airlock/glass,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/medical/genetics)
 "cOR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14541,14 +14571,6 @@
 /obj/item/bedsheet/rd,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/panic_room)
-"cTu" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/pros/foreman)
 "cTv" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
@@ -17446,12 +17468,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"dwV" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
 "dxe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -18100,20 +18116,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"dCT" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/towel,
-/obj/machinery/vending/wallmed/lobby{
-	pixel_y = 25
-	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
 "dCV" = (
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -18521,12 +18523,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/hallway/surface/section1)
-"dHg" = (
-/obj/machinery/camera/network/research{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
 "dHs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/trailrocka1,
@@ -19744,6 +19740,12 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"dUl" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "dUq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22026,6 +22028,16 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"erb" = (
+/obj/structure/medical_stand,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/item/tank/anesthetic,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "erm" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/small/busha1,
@@ -22873,10 +22885,12 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/turret_protected/ai)
 "eAm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/danger,
+/area/nadezhda/medical/genetics)
 "eAI" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
@@ -26595,7 +26609,7 @@
 /area/nadezhda/absolutism/vectorrooms)
 "fkp" = (
 /turf/simulated/mineral,
-/area/nadezhda/rnd/lab)
+/area/eris/crew_quarters/kitchen_storage)
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26824,12 +26838,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "fnd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/bioprinter/med,
-/obj/machinery/button/remote/blast_door{
-	id = "organ_shutter";
-	name = "privacy shutter control";
-	pixel_y = -24
+/obj/structure/table/standard,
+/obj/item/storage/freezer,
+/obj/structure/sink{
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/docking)
@@ -27270,6 +27282,12 @@
 /area/nadezhda/crew_quarters/dorm3{
 	name = "Dormitory 3"
 	})
+"fqN" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/gun/energy/cog,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "fqR" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/effect/decal/cleanable/dirt,
@@ -28871,6 +28889,14 @@
 /obj/structure/door_assembly/door_assembly_maint_cargo,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"fEL" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/mineral,
+/area/colony)
 "fER" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/sliceable/bread,
@@ -29677,15 +29703,6 @@
 /obj/item/beehive_assembly,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"fMq" = (
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
-/obj/structure/closet/wall_mounted{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
 "fMs" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc{
@@ -31351,15 +31368,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"gdC" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cbo)
 "gdD" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled/techmaint,
@@ -32211,6 +32219,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
+"gkI" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "gkM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -33060,6 +33073,10 @@
 /area/nadezhda/security/nuke_storage{
 	name = "\improper Clinic"
 	})
+"gsp" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "gsr" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -36464,6 +36481,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
+"haw" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/tool/scalpel/laser{
+	pixel_y = -5
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "haz" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/lakeside)
@@ -40777,13 +40805,11 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "hVm" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/mineral,
-/area/colony)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/spray/chemsprayer,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "hVt" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -43351,14 +43377,13 @@
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
 "ivN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/camera/network/medbay{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/structure/closet/wall_mounted{
+	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/white/brown_perforated,
+/turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/docking)
 "ivP" = (
 /obj/effect/floor_decal/border/techfloor,
@@ -43704,16 +43729,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/main/stairwell)
 "izx" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/tool/scalpel/laser{
-	pixel_y = -5
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "izE" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/effect/floor_decal/spline/plain{
@@ -43750,6 +43768,10 @@
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/skyyard)
+"izV" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "izW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/spiders,
@@ -44985,9 +45007,14 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "iMc" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cyberplant,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "iMk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -45453,9 +45480,9 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "iQA" = (
-/obj/structure/toilet,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
+/obj/structure/bed/chair/sofa/black/left,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "iQD" = (
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/maingate{
@@ -46462,6 +46489,14 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
+"jac" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "jae" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -47256,17 +47291,8 @@
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
 "jhS" = (
-/obj/machinery/smartfridge/secure/medbay/organs/stocked,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "organ_shutter";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/docking)
 "jhW" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -47509,6 +47535,10 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"jkb" = (
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "jkc" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -48461,6 +48491,20 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"jud" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/steel/gray_platform,
+/area/nadezhda/command/gmaster)
 "jui" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -50886,11 +50930,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"jRF" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "jRG" = (
 /obj/random/furniture/pottedplant,
 /obj/structure/extinguisher_cabinet{
@@ -52168,10 +52207,11 @@
 /turf/unsimulated/mineral,
 /area/asteroid/cave)
 "kdN" = (
-/obj/item/storage/box/donkpockets,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/medical/genetics)
 "kdS" = (
 /obj/structure/table/standard,
 /obj/item/stack/medical/advanced/bruise_pack,
@@ -53144,6 +53184,9 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/lab)
+"kmK" = (
+/turf/simulated/mineral,
 /area/nadezhda/rnd/lab)
 "kmY" = (
 /obj/structure/table/steel_reinforced,
@@ -58092,16 +58135,17 @@
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/hallway/side/f2section1)
 "lgB" = (
-/obj/machinery/button/remote/blast_door{
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	pixel_x = 1;
-	pixel_y = 23;
-	req_access = list(29)
+/obj/machinery/keycard_auth,
+/obj/item/reagent_containers/enricher,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/table/marble,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "lgC" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small{
@@ -60706,11 +60750,6 @@
 "lGg" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
-"lGo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/rnd/research)
 "lGq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard/guild{
@@ -61517,10 +61556,14 @@
 	name = "\improper Outdoors - Pad"
 	})
 "lOw" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/medical/genetics)
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "lOx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -62021,20 +62064,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"lTh" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/command/gmaster)
 "lTi" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -63296,6 +63325,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"mfr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe/bioprinter/med,
+/obj/machinery/button/remote/blast_door{
+	id = "organ_shutter";
+	name = "privacy shutter control";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "mfs" = (
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -63364,15 +63403,9 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
 "mfO" = (
-/obj/structure/medical_stand,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/item/tank/anesthetic,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/mob/living/simple_animal/soteria_roomba,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cro)
 "mfT" = (
 /obj/structure/bed/chair/office/light,
 /obj/landmark/join/start/paramedic,
@@ -67150,16 +67183,8 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/crew_quarters/plasma_tag)
 "mPf" = (
-/obj/structure/closet/chefcloset,
-/obj/item/soap/hunters,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "mPj" = (
 /obj/structure/table/woodentable,
 /obj/item/device/megaphone,
@@ -67532,15 +67557,8 @@
 	name = "\improper Blackshield - Firing Range"
 	})
 "mTr" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/gun/energy/cog,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
-"mTs" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/medical/genetics)
+/turf/simulated/wall,
+/area/nadezhda/pros/foreman)
 "mTy" = (
 /obj/effect/floor_decal/industrial/box/white,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -67597,10 +67615,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
-"mUe" = (
-/mob/living/simple_animal/soteria_roomba,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cro)
 "mUh" = (
 /obj/machinery/light{
 	dir = 8;
@@ -68034,11 +68048,10 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "mXT" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "mXY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/decal/cleanable/dirt,
@@ -68426,10 +68439,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"ncj" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
 "nck" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/effect/decal/cleanable/dirt,
@@ -69136,6 +69145,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"nju" = (
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "njA" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -70150,22 +70165,8 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nuq" = (
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/computer_hardware/hard_drive/portable/design/circuits,
-/obj/item/computer_hardware/hard_drive/portable/design/components,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/glass{
-	amount = 120
-	},
-/obj/item/stack/material/plastic{
-	amount = 120
-	},
-/obj/item/paper/monitorkey,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/gmaster)
+/turf/simulated/mineral,
+/area/nadezhda/command/swo/quarters)
 "nur" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -71384,6 +71385,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"nGx" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "nGy" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/spider/stickyweb,
@@ -71449,6 +71456,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"nGY" = (
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/computer_hardware/hard_drive/portable/design/circuits,
+/obj/item/computer_hardware/hard_drive/portable/design/components,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/stack/material/steel/full,
+/obj/item/stack/material/glass{
+	amount = 120
+	},
+/obj/item/stack/material/plastic{
+	amount = 120
+	},
+/obj/item/paper/monitorkey,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/gmaster)
 "nHc" = (
 /obj/machinery/microwave,
 /obj/structure/table/marble,
@@ -71659,8 +71683,10 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/psych)
 "nIS" = (
-/turf/simulated/mineral,
-/area/nadezhda/command/swo/quarters)
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "nIZ" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -73092,9 +73118,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nYy" = (
-/obj/structure/closet/secure_closet/reinforced/commander,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/smc/quarters)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/research,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "nYz" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/regular,
@@ -76028,6 +76055,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
+"oyN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/docking)
 "oyO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -77418,11 +77455,12 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "oLT" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
+/obj/structure/toilet,
+/obj/machinery/holoposter{
+	pixel_y = 30
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/smc/quarters)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "oLU" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -78267,15 +78305,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
-"oUV" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
 "oVd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -78481,11 +78510,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
-"oYx" = (
-/obj/structure/catwalk,
-/obj/structure/lattice,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "oYz" = (
 /obj/effect/floor_decal/border/techfloor,
 /obj/effect/floor_decal/border/techfloor{
@@ -81276,9 +81300,22 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "pBL" = (
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/machinery/camera/network/cargo,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/hangarsupply)
 "pBN" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/floor_decal/spline/plain{
@@ -81481,9 +81518,9 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "pDo" = (
-/obj/machinery/autolathe/loaded,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/gmaster)
+/obj/structure/closet/secure_closet/reinforced/commander,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "pDr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 6;
@@ -81614,11 +81651,6 @@
 /obj/effect/floor_decal/industrial/stand_clear,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"pEj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/research,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
 "pEo" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -82541,10 +82573,6 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
-"pNf" = (
-/obj/structure/bed/chair/sofa/black/left,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
 "pNn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -85215,7 +85243,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/camera/network/cargo,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "qmO" = (
@@ -86555,17 +86582,9 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security)
 "qAb" = (
-/obj/machinery/keycard_auth,
-/obj/item/reagent_containers/enricher,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/structure/table/marble,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/wall,
+/area/asteroid/cave)
 "qAh" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -86798,9 +86817,10 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/crew_quarters/plasma_tag)
 "qDe" = (
-/obj/machinery/optable,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "qDg" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -88552,13 +88572,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
-"qUj" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/obj/machinery/holoposter{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
 "qUn" = (
 /obj/structure/window/reinforced,
 /obj/structure/sink{
@@ -88615,8 +88628,12 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "qUE" = (
-/turf/simulated/mineral,
-/area/nadezhda/rnd/robotics)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/propis{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/pros/prep)
 "qUQ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -89316,6 +89333,10 @@
 /obj/structure/cyberplant,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
+"raF" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "raH" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "14,23"
@@ -91449,6 +91470,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
+"ruQ" = (
+/obj/machinery/autolathe/loaded,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/gmaster)
 "ruS" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -92698,6 +92723,16 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
+"rGo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "rGq" = (
 /obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/rock,
@@ -93107,15 +93142,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
-"rKH" = (
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cyberplant,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "rKL" = (
 /obj/structure/multiz/stairs,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -93657,11 +93683,6 @@
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
-"rPN" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
 "rQd" = (
 /obj/structure/railing/grey{
 	dir = 4;
@@ -94168,6 +94189,17 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/abandoned_solars)
+"rUO" = (
+/obj/structure/closet/chefcloset,
+/obj/item/soap/hunters,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "rUY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/fact_plaque,
@@ -95886,12 +95918,9 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "slm" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/danger,
-/area/nadezhda/medical/genetics)
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/smc/quarters)
 "slo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -98437,16 +98466,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
-"sNY" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/washing_machine,
-/obj/machinery/vending/wallmed/lobby{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
 "sOa" = (
 /obj/machinery/conveyor/east{
 	id = "disposals grinder"
@@ -98621,6 +98640,9 @@
 	},
 /obj/item/clothing/mask/breath{
 	pixel_x = 4
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/detectives_office)
@@ -100500,7 +100522,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/security,
 /obj/item/device/radio/intercom{
 	dir = 2;
 	pixel_y = 24
@@ -101793,6 +101814,19 @@
 /area/nadezhda/security{
 	name = "Security Training"
 	})
+"tvn" = (
+/obj/machinery/smartfridge/secure/medbay/organs/stocked,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "organ_shutter";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/docking)
 "tvq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -102016,10 +102050,8 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "twP" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/spray/chemsprayer,
-/turf/simulated/floor/tiled/white/techfloor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall,
 /area/nadezhda/medical/genetics)
 "twT" = (
 /obj/effect/floor_decal/spline/wood{
@@ -107665,9 +107697,27 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "uBN" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled/white/monofloor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "MedbayTotalLockdown";
+	layer = 2.6;
+	name = "Medbay Total Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Organ Laboratory";
+	req_access = list(5)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/docking)
 "uBU" = (
 /obj/machinery/power/apc{
@@ -108107,8 +108157,9 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "uGo" = (
-/turf/simulated/mineral,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/structure/toilet,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "uGq" = (
 /obj/structure/girder/displaced,
 /obj/effect/decal/cleanable/dirt,
@@ -108829,13 +108880,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "uNP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/newscaster{
 	dir = 8;
-	icon_state = "pipe-c"
+	pixel_x = -30;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/research)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/pros/foreman)
 "uNR" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/sign/warningnew/danger{
@@ -110884,13 +110935,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/rocinante_shuttle_area)
-"vhU" = (
-/obj/structure/toilet,
-/obj/machinery/holoposter{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
 "via" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -111907,10 +111951,9 @@
 /area/shuttle/rocinante_shuttle_area)
 "vrz" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/rnd/research)
 "vrB" = (
 /obj/machinery/camera/network/plasma_tag{
 	dir = 4
@@ -114630,29 +114673,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"vRw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "MedbayTotalLockdown";
-	layer = 2.6;
-	name = "Medbay Total Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Organ Laboratory";
-	req_access = list(5)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/rnd/docking)
 "vRz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/coatrack,
@@ -115842,6 +115862,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/section1)
+"wcK" = (
+/obj/item/storage/box/donkpockets,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "wcM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
@@ -121341,6 +121366,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
+"xfm" = (
+/obj/machinery/camera/network/cargo{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/bluecorner,
+/area/nadezhda/security/sechall)
 "xfv" = (
 /obj/structure/railing{
 	dir = 8
@@ -121676,15 +121707,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xjC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/docking)
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cbo)
 "xjG" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/nuke_storage{
@@ -124272,20 +124302,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "xIj" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -11
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/mirror{
-	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "xIn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -125389,13 +125408,6 @@
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
-"xTe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/propis{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/pros/prep)
 "xTj" = (
 /obj/machinery/atm{
 	dir = 1;
@@ -125484,8 +125496,20 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
 "xUa" = (
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/mirror{
+	dir = 8;
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/smc/quarters)
 "xUe" = (
 /obj/structure/table/bench/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -133563,10 +133587,10 @@ kse
 axa
 oGw
 oGw
-nIS
-nIS
-nIS
-nIS
+nuq
+nuq
+nuq
+nuq
 clN
 htx
 wyz
@@ -133759,16 +133783,16 @@ euZ
 fxu
 uCp
 oGw
-bmp
+gsp
 uqn
 kNT
-sNY
+ayP
 oGw
 oGw
-nIS
-nIS
-nIS
-nIS
+nuq
+nuq
+nuq
+nuq
 clN
 pPv
 vgt
@@ -133967,10 +133991,10 @@ otZ
 oGw
 oGw
 oGw
-nIS
-nIS
-nIS
-nIS
+nuq
+nuq
+nuq
+nuq
 clN
 jtl
 vgt
@@ -134169,10 +134193,10 @@ bhK
 xyW
 oGw
 oGw
-nIS
-nIS
-nIS
-nIS
+nuq
+nuq
+nuq
+nuq
 clN
 uVh
 wQo
@@ -136390,7 +136414,7 @@ aZK
 rzW
 ygi
 ths
-odw
+xfm
 puh
 tmw
 aen
@@ -140860,9 +140884,9 @@ cwr
 efY
 ptB
 vnv
-uGo
-uGo
-uGo
+fkp
+fkp
+fkp
 vnv
 iof
 fNh
@@ -141062,9 +141086,9 @@ cwr
 wLd
 bwh
 vnv
-uGo
-uGo
-uGo
+fkp
+fkp
+fkp
 vnv
 wSq
 gAA
@@ -141264,9 +141288,9 @@ cwr
 cyr
 bwh
 vnv
-uGo
-uGo
-uGo
+fkp
+fkp
+fkp
 vnv
 pLL
 jdf
@@ -141668,9 +141692,9 @@ cwr
 jps
 bwh
 vnv
-mPf
+rUO
 rgG
-pBL
+izV
 vnv
 jdf
 pHC
@@ -144051,7 +144075,7 @@ jIc
 dCw
 koE
 koE
-kYK
+pBL
 sTw
 hdF
 sTw
@@ -150540,12 +150564,12 @@ quV
 ces
 ces
 pEa
-eAm
+qDe
 bwh
 kEP
 pVB
 ryn
-lGo
+vrz
 cqa
 tna
 hWD
@@ -150951,7 +150975,7 @@ gbk
 ryn
 aDp
 wWY
-uNP
+jac
 mgf
 kgt
 mgf
@@ -151147,7 +151171,7 @@ bwh
 bwh
 dXF
 nyE
-lgB
+aMS
 bwh
 pVB
 rfF
@@ -151342,7 +151366,7 @@ vot
 jVE
 sEU
 vKw
-rKH
+iMc
 vKw
 sFC
 mgk
@@ -153980,7 +154004,7 @@ wBQ
 jGM
 mzB
 bxY
-qUE
+bPW
 bxY
 olZ
 wBQ
@@ -154182,7 +154206,7 @@ nak
 wBQ
 uVq
 bxY
-qUE
+bPW
 bxY
 xVr
 wBQ
@@ -154384,7 +154408,7 @@ ljg
 aHG
 wXg
 bxY
-qUE
+bPW
 bxY
 bxY
 bxY
@@ -154774,7 +154798,7 @@ npT
 npT
 qql
 hwH
-fkp
+kmK
 pTU
 sLE
 vnK
@@ -154976,7 +155000,7 @@ npT
 npT
 hGh
 hwH
-fkp
+kmK
 pTU
 osd
 adZ
@@ -157236,7 +157260,7 @@ kOj
 cAG
 hYY
 qhV
-xjC
+oyN
 sMW
 wEF
 wzo
@@ -157640,8 +157664,8 @@ xxZ
 mrS
 hYY
 hYY
-vRw
-jhS
+uBN
+tvn
 hYY
 yhV
 oxv
@@ -157841,9 +157865,9 @@ ihS
 ihS
 gLl
 hYY
-rPN
-ivN
-izx
+bmp
+rGo
+haw
 hYY
 evS
 cSs
@@ -158043,9 +158067,9 @@ ihS
 ihS
 gLl
 hYY
-uBN
-aBv
-fnd
+mXT
+cIp
+mfr
 hYY
 lop
 ffD
@@ -158245,9 +158269,9 @@ ihS
 ihS
 gLl
 hYY
-qDe
-xUa
-aJA
+jhS
+mPf
+fnd
 hYY
 lop
 qdj
@@ -158447,9 +158471,9 @@ vnu
 vnu
 vTA
 hYY
-mfO
-fMq
-iMc
+erb
+ivN
+raF
 hYY
 lop
 qdj
@@ -180389,7 +180413,7 @@ cEg
 iJv
 sFI
 sFI
-hVm
+fEL
 sFI
 sFI
 sFI
@@ -181000,9 +181024,9 @@ hSx
 hSx
 hSx
 ajL
-nYy
+pDo
 cUV
-oLT
+nGx
 vXl
 ajL
 bZz
@@ -181402,7 +181426,7 @@ sFI
 hSx
 ajL
 cui
-xIj
+xUa
 fkR
 iXB
 rsG
@@ -181806,7 +181830,7 @@ sFI
 hSx
 ajL
 ajL
-bPW
+slm
 ajL
 ajL
 ajL
@@ -188488,7 +188512,7 @@ hSx
 jXV
 kAs
 kCX
-oUV
+lOw
 jXV
 jXV
 jXV
@@ -188690,7 +188714,7 @@ hSx
 jXV
 lSs
 kCX
-ncj
+izx
 mmA
 mZG
 mZG
@@ -189092,7 +189116,7 @@ hSx
 jXV
 uVy
 nEk
-lTh
+jud
 nEk
 nEk
 nGc
@@ -189294,7 +189318,7 @@ hSx
 jXV
 dna
 nEk
-pDo
+ruQ
 nEk
 nFp
 jXV
@@ -189498,7 +189522,7 @@ iMl
 nEk
 nEk
 nEk
-nuq
+nGY
 jXV
 jXV
 jXV
@@ -189906,7 +189930,7 @@ jXV
 jXV
 jXV
 nHc
-kdN
+wcK
 pdZ
 pef
 jXV
@@ -190301,8 +190325,8 @@ gFp
 gFp
 gFp
 gFp
-oYx
-oYx
+nIS
+nIS
 eTA
 etI
 eaA
@@ -191759,7 +191783,7 @@ sFI
 sFI
 sFI
 ula
-pEj
+nYy
 mJX
 lUt
 lUt
@@ -191961,12 +191985,12 @@ sFI
 sFI
 sFI
 ula
-mTs
+twP
 vdO
 kYV
 lUt
 erA
-mTr
+fqN
 elK
 wiD
 nBx
@@ -192163,12 +192187,12 @@ sFI
 sFI
 sFI
 ula
-mTs
+twP
 duz
 pzU
 lUt
 xCY
-dHg
+nju
 elK
 xGJ
 baD
@@ -192365,7 +192389,7 @@ sFI
 sFI
 sFI
 ula
-mTs
+twP
 vDI
 tHC
 lUt
@@ -192766,7 +192790,7 @@ sFI
 sFI
 ula
 ula
-jRF
+gkI
 lDb
 ula
 iEU
@@ -192980,7 +193004,7 @@ iBc
 elK
 sfN
 owe
-qAb
+lgB
 cNm
 aXb
 elK
@@ -193168,7 +193192,7 @@ sFI
 sFI
 sFI
 sFI
-mTs
+twP
 oou
 gFS
 fMv
@@ -193371,8 +193395,8 @@ sFI
 sFI
 sFI
 ula
-vrz
-cgQ
+ctU
+kdN
 sOu
 hcZ
 dTZ
@@ -193380,7 +193404,7 @@ hcZ
 qNV
 via
 iwx
-twP
+hVm
 elK
 aRo
 qOO
@@ -193786,10 +193810,10 @@ vUw
 dOH
 xct
 elK
-pNf
+iQA
 wGD
 rQQ
-dwV
+byG
 tif
 elK
 cEd
@@ -193982,7 +194006,7 @@ ula
 vLP
 fKY
 eKe
-slm
+eAm
 eKe
 eKe
 mnX
@@ -194595,7 +194619,7 @@ fgH
 elK
 sUl
 ilQ
-gdC
+xjC
 elK
 eXm
 eXm
@@ -195599,7 +195623,7 @@ ssK
 cZB
 cZB
 hQV
-lOw
+cOK
 xCY
 edz
 rPf
@@ -196422,7 +196446,7 @@ kSF
 bqs
 klk
 ldZ
-mUe
+mfO
 mea
 cZm
 klk
@@ -197633,7 +197657,7 @@ aqG
 pPS
 xAN
 klk
-iQA
+uGo
 kzc
 vZI
 klk
@@ -197835,7 +197859,7 @@ eXm
 caY
 emo
 klk
-mXT
+dUl
 tYV
 tYV
 xKU
@@ -234780,7 +234804,7 @@ qQZ
 hHU
 riw
 guj
-buz
+jkb
 qQZ
 gzV
 gUk
@@ -235347,7 +235371,7 @@ kwx
 kwx
 vJb
 rhS
-xTe
+qUE
 jVf
 utl
 utl
@@ -235758,7 +235782,7 @@ wgs
 uvj
 fES
 rjd
-cTu
+uNP
 cAC
 eKA
 vbT
@@ -236560,8 +236584,8 @@ veZ
 scG
 scG
 scG
-cOK
-vhU
+mTr
+oLT
 nnM
 uvj
 uvj
@@ -236763,7 +236787,7 @@ veZ
 veZ
 scG
 uvj
-dCT
+bnm
 cyf
 cyf
 pWZ
@@ -236967,7 +236991,7 @@ cPp
 uvj
 uvj
 iVR
-qUj
+aJA
 uvj
 vSU
 lob
@@ -237169,7 +237193,7 @@ cPp
 pwm
 pwm
 pwm
-cOK
+mTr
 uvj
 uvj
 uvj
@@ -237370,11 +237394,11 @@ ukS
 aDO
 lbX
 mDT
-bnm
+xIj
 yjy
 uXK
 uXK
-bnm
+xIj
 vqy
 seQ
 bVD
@@ -238579,7 +238603,7 @@ cAn
 cAn
 cAn
 cAn
-csb
+qAb
 cAn
 cAn
 hEB

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -55,9 +55,6 @@
 "aaq" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/security/armory_blackshield)
-"aar" = (
-/turf/unsimulated/mineral,
-/area/nadezhda/command/gmaster)
 "aas" = (
 /obj/machinery/newscaster{
 	dir = 8;
@@ -1489,7 +1486,6 @@
 	dir = 8;
 	icon_state = "pipe-s"
 	},
-/obj/structure/closet/secure_closet/freezer/blood,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
 "aoq" = (
@@ -1727,6 +1723,9 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "arx" = (
+/obj/structure/closet/wall_mounted{
+	pixel_x = 32
+	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/pros/prep)
 "arA" = (
@@ -2264,10 +2263,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "axa" = (
-/obj/structure/noticeboard/marshal{
-	pixel_x = -32
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "shower";
+	pixel_x = 0;
+	pixel_y = 0
 	},
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/item/towel,
+/turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/command/swo/quarters)
 "axb" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2387,10 +2391,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"ayP" = (
-/obj/structure/closet/secure_closet/reinforced/foreman,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/pros/foreman)
 "ayY" = (
 /obj/structure/closet/cabinet{
 	name = "entertainment cabinet"
@@ -2587,9 +2587,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
 "aBv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/medical/genetics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "aBx" = (
 /obj/effect/floor_decal/industrial/loading,
 /obj/effect/decal/cleanable/dirt,
@@ -2672,8 +2674,8 @@
 	density = 0;
 	dir = 2;
 	icon_state = "shutter0";
-	id = "research_shutters";
-	name = "Office Shutters";
+	id = "organ_shutter";
+	name = "Privacy Shutters";
 	opacity = 0
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -2760,28 +2762,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "aDp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
+/obj/machinery/disposal,
+/obj/machinery/newscaster{
 	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 30
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/effect/floor_decal/industrial/box/red,
 /obj/machinery/light{
-	dir = 1;
+	dir = 4;
 	light_color = "#0892d0"
 	},
-/turf/simulated/floor/tiled/dark/danger,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "aDv" = (
 /obj/structure/flora/small/trailrockb5,
@@ -3391,10 +3383,13 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
 "aJA" = (
-/obj/item/bedsheet/captaindouble,
-/obj/structure/bed/double/padded,
-/turf/simulated/floor/carpet/blucarpet,
-/area/nadezhda/command/cbo)
+/obj/structure/table/standard,
+/obj/item/storage/freezer,
+/obj/structure/sink{
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "aJG" = (
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/meadow)
@@ -3792,10 +3787,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"aMS" = (
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/medical/genetics)
 "aMZ" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Core";
@@ -4128,15 +4119,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"aPG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/command/gmaster)
 "aPI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5333,11 +5315,6 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "bch" = (
@@ -6372,13 +6349,9 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bmp" = (
-/obj/structure/closet/chefcloset,
-/obj/item/soap/hunters,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/simulated/floor/carpet/turcarpet,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "bms" = (
 /obj/machinery/newscaster{
 	pixel_x = -30;
@@ -6487,12 +6460,9 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "bnm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/medical/genetics)
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "bnn" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -6791,7 +6761,7 @@
 	dir = 8;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
@@ -7116,9 +7086,8 @@
 /area/eris/crew_quarters/plasma_tag)
 "btw" = (
 /obj/structure/table/reinforced,
-/obj/item/tool/baton,
-/obj/item/hand_labeler,
-/turf/simulated/floor/tiled/white/brown_perforated,
+/obj/machinery/recharger/industrial,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "btG" = (
 /obj/structure/bed/chair{
@@ -7194,11 +7163,9 @@
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "buz" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet,
-/obj/machinery/light/small,
-/turf/simulated/floor/wood/wild2,
-/area/nadezhda/pros/prep)
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "buH" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/railing{
@@ -7693,15 +7660,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"byG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/alarm{
-	pixel_y = 27
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/spray/chemsprayer,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "byP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -8198,10 +8156,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
 "bFc" = (
+/obj/structure/bed/chair/sofa/black/right,
+/mob/living/simple_animal/cat/fluff/Runtime,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/bed/chair/sofa/black/left,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "bFe" = (
@@ -9215,12 +9174,9 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/section3)
 "bPW" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/pros/foreman)
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/smc/quarters)
 "bPY" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -10799,9 +10755,11 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cgQ" = (
-/obj/machinery/holoposter,
-/turf/simulated/wall,
-/area/nadezhda/pros/prep)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/medical/genetics)
 "cgU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/crossbow,
@@ -11403,13 +11361,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
 "cmR" = (
-/obj/machinery/door/airlock{
-	name = "Chef's room";
-	req_access = list(28)
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/gray_perforated,
+/turf/simulated/wall,
 /area/eris/crew_quarters/kitchen_storage)
 "cmV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11566,23 +11519,21 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "cpb" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 6;
-	pixel_y = -24
-	},
-/turf/simulated/floor/wood,
+/obj/random/booze,
+/obj/random/booze,
+/obj/random/booze,
+/obj/random/booze,
+/obj/random/booze,
+/obj/random/booze,
+/obj/random/booze,
+/obj/structure/closet/cabinet,
+/obj/item/storage/case/donut,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/command/swo/quarters)
 "cph" = (
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"cpp" = (
-/obj/machinery/atm{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/research)
 "cpq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -11865,10 +11816,9 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
 "csb" = (
-/obj/structure/bed/double/padded,
-/obj/item/bedsheet/captaindouble,
-/turf/simulated/floor/carpet/turcarpet,
-/area/nadezhda/command/captain/quarters)
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/wall,
+/area/asteroid/cave)
 "cse" = (
 /obj/item/toy/junk/inflatable_duck,
 /turf/simulated/floor/beach/water/ocean,
@@ -12087,21 +12037,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
-"ctU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/soteria_roomba,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cro)
 "ctX" = (
 /obj/structure/flora/small/rock5,
 /turf/unsimulated/wall/jungle,
@@ -13585,13 +13520,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/dungeon/outside/abandoned_solars)
-"cIp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
 "cIq" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/multiz/ladder,
@@ -13909,12 +13837,13 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "cLm" = (
+/obj/structure/toilet{
+	dir = 4
+	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/table/woodentable,
-/obj/item/biosyphon,
-/turf/simulated/floor/carpet/blucarpet,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/swo/quarters)
 "cLn" = (
 /obj/structure/cable/green{
@@ -14263,6 +14192,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "cOJ" = (
@@ -14276,10 +14208,8 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "cOK" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/medical/genetics)
+/turf/simulated/wall,
+/area/nadezhda/pros/foreman)
 "cOR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14612,10 +14542,13 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/panic_room)
 "cTu" = (
-/obj/structure/bed/chair/sofa/black/right,
-/mob/living/simple_animal/cat/fluff/Runtime,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/pros/foreman)
 "cTv" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
@@ -16075,7 +16008,6 @@
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
 "diQ" = (
-/obj/random/furniture/pottedplant,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -16459,16 +16391,6 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"dmY" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -11
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
 "dna" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/borgupload{
@@ -17525,11 +17447,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dwV" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 5
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32
 	},
 /turf/simulated/floor/wood,
-/area/nadezhda/pros/prep)
+/area/nadezhda/command/cbo)
 "dxe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -17925,7 +17847,7 @@
 /obj/machinery/reagentgrinder/portable,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/glass/beaker{
-	preloaded_reagents = list("plasma" = 20)
+	preloaded_reagents = list("plasma"=20)
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
@@ -18179,11 +18101,19 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "dCT" = (
-/obj/structure/mirror{
-	pixel_x = 28
+/obj/machinery/washing_machine,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/towel,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
+/area/nadezhda/pros/foreman)
 "dCV" = (
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -18592,13 +18522,11 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/hallway/surface/section1)
 "dHg" = (
-/obj/structure/table/woodentable,
-/obj/machinery/keycard_auth,
-/obj/item/stamp/cmo,
-/obj/item/modular_computer/laptop/preset/records,
-/obj/item/reagent_containers/enricher,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/command/cbo)
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "dHs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/trailrocka1,
@@ -19816,12 +19744,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"dUl" = (
-/obj/item/clothing/suit/rank/chef/classic,
-/obj/structure/table/marble,
-/obj/item/clipboard,
-/turf/simulated/floor/carpet/turcarpet,
-/area/eris/crew_quarters/kitchen_storage)
 "dUq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -19840,6 +19762,9 @@
 	pixel_y = 0
 	},
 /obj/machinery/hologram/holopad,
+/obj/structure/noticeboard/marshal{
+	pixel_x = -32
+	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/command/swo/quarters)
 "dUz" = (
@@ -20124,21 +20049,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"dXD" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
 "dXF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/colony_underground{
@@ -20727,12 +20637,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
-"edD" = (
-/obj/machinery/door/airlock/freezer{
-	req_access = list(28)
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/eris/crew_quarters/kitchen_storage)
 "edH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21111,13 +21015,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"egi" = (
-/obj/machinery/camera/network/research{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
 "egs" = (
 /obj/machinery/chem_master/condimaster,
 /turf/simulated/floor/tiled/cafe,
@@ -21406,17 +21303,18 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "ejZ" = (
-/obj/machinery/power/wall_obelisk{
-	pixel_x = 32
-	},
-/obj/structure/bed/double/padded,
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 26;
 	pixel_y = 0
 	},
-/obj/item/bedsheet/greendouble,
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 0;
+	pixel_y = 28
+	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/crew_quarters/barquarters)
 "ekm" = (
@@ -21615,14 +21513,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	pixel_x = 1;
-	pixel_y = 23;
-	plane = 1;
-	req_access = list(29)
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -22136,11 +22026,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"erb" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/prep)
 "erm" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/small/busha1,
@@ -22275,19 +22160,19 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "esA" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/camera/network/research{
-	dir = 8
-	},
-/obj/machinery/newscaster{
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
 	dir = 4;
-	pixel_x = 30
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/violetcorener,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/research)
 "esG" = (
 /obj/random/mob/nightmare,
@@ -22988,12 +22873,10 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/turret_protected/ai)
 "eAm" = (
-/obj/machinery/chemical_dispenser,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "eAI" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
@@ -25647,8 +25530,8 @@
 	density = 0;
 	dir = 2;
 	icon_state = "shutter0";
-	id = "research_shutters";
-	name = "Office Shutters";
+	id = "organ_shutter";
+	name = "Privacy Shutters";
 	opacity = 0
 	},
 /obj/structure/cable/green{
@@ -26711,20 +26594,8 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "fkp" = (
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
-	},
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
-	},
-/turf/simulated/floor/carpet/turcarpet,
-/area/eris/crew_quarters/kitchen_storage)
+/turf/simulated/mineral,
+/area/nadezhda/rnd/lab)
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26953,11 +26824,15 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "fnd" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe/bioprinter/med,
+/obj/machinery/button/remote/blast_door{
+	id = "organ_shutter";
+	name = "privacy shutter control";
+	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/medical/genetics)
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "fnf" = (
 /obj/structure/lattice,
 /turf/simulated/floor/plating/under,
@@ -27395,13 +27270,6 @@
 /area/nadezhda/crew_quarters/dorm3{
 	name = "Dormitory 3"
 	})
-"fqN" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
 "fqR" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/effect/decal/cleanable/dirt,
@@ -29003,10 +28871,6 @@
 /obj/structure/door_assembly/door_assembly_maint_cargo,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"fEL" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/carpet/turcarpet,
-/area/eris/crew_quarters/kitchen_storage)
 "fER" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/sliceable/bread,
@@ -29119,6 +28983,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/item/storage/secure/safe{
+	pixel_x = 6;
+	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
@@ -29297,16 +29165,16 @@
 /area/colony)
 "fHy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "fHz" = (
@@ -29810,12 +29678,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "fMq" = (
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/machinery/camera/network/medbay{
+	dir = 8
 	},
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/carpet/blucarpet,
-/area/nadezhda/command/swo/quarters)
+/obj/structure/closet/wall_mounted{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "fMs" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc{
@@ -30001,9 +29871,6 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fOP" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
@@ -31094,13 +30961,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
-"gab" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
 "gah" = (
 /obj/structure/toilet{
 	dir = 4
@@ -31245,11 +31105,6 @@
 /area/nadezhda/rnd/research)
 "gbk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -31497,10 +31352,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "gdC" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white/danger,
-/area/nadezhda/medical/genetics)
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cbo)
 "gdD" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled/techmaint,
@@ -32352,18 +32211,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
-"gkI" = (
-/obj/structure/cyberplant,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "gkM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -33213,10 +33060,6 @@
 /area/nadezhda/security/nuke_storage{
 	name = "\improper Clinic"
 	})
-"gsp" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/prep)
 "gsr" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -33557,6 +33400,10 @@
 "gwI" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lamp/green,
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 0;
+	pixel_y = -28
+	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/command/cro)
 "gwL" = (
@@ -34933,7 +34780,7 @@
 	input_tag = "tox_in";
 	name = "Plasma Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -36617,14 +36464,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
-"haw" = (
-/obj/random/booze,
-/obj/random/junkfood/onlypizza,
-/obj/random/junkfood/onlyburger,
-/obj/random/junkfood,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
 "haz" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/lakeside)
@@ -37566,6 +37405,9 @@
 /area/nadezhda/outside/forest)
 "hkK" = (
 /obj/machinery/genetics/gene_analyzer,
+/obj/machinery/camera/network/research{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/genetics)
 "hkM" = (
@@ -39743,6 +39585,9 @@
 /obj/structure/bed/chair/sofa/black/left{
 	dir = 8
 	},
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32
+	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm3{
 	name = "Dormitory 3"
@@ -40932,21 +40777,13 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "hVm" = (
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0";
-	tag = "icon-railing0 (NORTH)"
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/turf/simulated/mineral,
+/area/colony)
 "hVt" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -41111,6 +40948,10 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "hWS" = (
@@ -41160,11 +41001,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -41659,17 +41495,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
-"icP" = (
-/obj/machinery/button/remote/blast_door{
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	pixel_x = 1;
-	pixel_y = 23;
-	req_access = list(29)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/rnd/robotics)
 "icS" = (
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
@@ -43526,16 +43351,15 @@
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
 "ivN" = (
-/obj/structure/table/rack/shelf,
-/obj/item/storage/briefcase/crimekit,
-/obj/item/device/eftpos{
-	eftpos_name = "Marshal EFTPOS scanner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/command/swo/quarters)
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "ivP" = (
 /obj/effect/floor_decal/border/techfloor,
 /obj/effect/floor_decal/border/techfloor{
@@ -43880,9 +43704,16 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/main/stairwell)
 "izx" = (
-/mob/living/simple_animal/hostile/dino/tagilla,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/pros/foreman)
+/obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/tool/scalpel/laser{
+	pixel_y = -5
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "izE" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/effect/floor_decal/spline/plain{
@@ -43919,13 +43750,6 @@
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/skyyard)
-"izV" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/smc/quarters)
 "izW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/spiders,
@@ -44017,15 +43841,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
-"iAP" = (
-/obj/structure/bed/double/padded,
-/obj/item/bedsheet/browndouble,
-/obj/item/toy/plushie/lizard,
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 32
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/command/merchant)
 "iAR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -44063,9 +43878,10 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/security/detectives_office)
 "iBc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/bioprinter/med,
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/structure/table/reinforced,
+/obj/item/tool/baton,
+/obj/item/hand_labeler,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "iBz" = (
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -44434,6 +44250,8 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "iEU" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/reagent_dispensers/bidon/protein_can/si,
 /obj/structure/railing{
 	anchored = 1;
 	dir = 4;
@@ -44441,8 +44259,6 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "iFb" = (
@@ -45169,9 +44985,9 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "iMc" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/pros/prep)
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "iMk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -45637,13 +45453,9 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "iQA" = (
-/obj/machinery/newscaster{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/computer/prisoner,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/smc/quarters)
+/obj/structure/toilet,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "iQD" = (
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/maingate{
@@ -45985,10 +45797,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/colony)
 "iTL" = (
+/obj/machinery/chemical_dispenser,
 /obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/white/gray_platform,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "iTO" = (
 /obj/structure/table/bench/wooden,
@@ -46142,14 +45953,12 @@
 /area/nadezhda/dungeon/outside/campground)
 "iVl" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
 /obj/machinery/keycard_auth{
 	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/table/woodentable,
+/obj/item/modular_computer/laptop/preset/records,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "iVn" = (
@@ -46468,7 +46277,7 @@
 	input_tag = "waste_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "waste_out";
-	sensors = list("waste_sensor" = "Tank")
+	sensors = list("waste_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -46653,13 +46462,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
-"jac" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	dir = 4;
-	pixel_x = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/medical/genetics)
 "jae" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -46807,10 +46609,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
-"jbz" = (
-/obj/landmark/join/start/foreman,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/pros/foreman)
 "jbH" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -46928,13 +46726,13 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics)
 "jcB" = (
-/obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "jcJ" = (
@@ -47458,20 +47256,18 @@
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
 "jhS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
+/obj/machinery/smartfridge/secure/medbay/organs/stocked,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "organ_shutter";
+	name = "Privacy Shutters";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/loading/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/medical/genetics)
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/docking)
 "jhW" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/wood/wild5,
@@ -47548,7 +47344,7 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -47713,14 +47509,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
-"jkb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
 "jkc" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -48673,14 +48461,6 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"jud" = (
-/obj/structure/table/woodentable,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/machinery/newscaster{
-	pixel_y = 34
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/pros/foreman)
 "jui" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -49463,13 +49243,13 @@
 	dir = 10
 	},
 /obj/structure/table/woodentable,
-/obj/machinery/recharger,
 /obj/machinery/holoposter{
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	pixel_y = -10
 	},
+/obj/item/pen,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barquarters)
 "jBt" = (
@@ -49736,10 +49516,7 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/crew_quarters/fitness)
 "jEl" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet,
-/obj/machinery/light/small,
-/turf/simulated/floor/wood/wild5,
+/turf/simulated/wall,
 /area/nadezhda/pros/prep)
 "jEs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -51110,18 +50887,9 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jRF" = (
-/obj/machinery/door/window/westleft{
-	name = "Genetics Pen Access";
-	req_one_access = list(55)
-	},
-/obj/machinery/door/blast/regular/open{
-	id = "genetics1";
-	name = "containment blast door"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/danger,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "jRG" = (
 /obj/random/furniture/pottedplant,
@@ -51739,8 +51507,11 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "jYd" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 5
+/obj/structure/bed/padded,
+/obj/item/bedsheet,
+/obj/machinery/light/small,
+/obj/machinery/holoposter{
+	pixel_x = 32
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/pros/prep)
@@ -52230,6 +52001,12 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "kbR" = (
+/obj/structure/closet/wall_mounted{
+	pixel_x = 32
+	},
+/obj/machinery/holoposter{
+	pixel_x = 32
+	},
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/prep)
 "kcb" = (
@@ -52391,9 +52168,10 @@
 /turf/unsimulated/mineral,
 /area/asteroid/cave)
 "kdN" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/swo/quarters)
+/obj/item/storage/box/donkpockets,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "kdS" = (
 /obj/structure/table/standard,
 /obj/item/stack/medical/advanced/bruise_pack,
@@ -52783,11 +52561,6 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
 "khA" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
@@ -52898,6 +52671,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atm{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "kiE" = (
@@ -53369,21 +53145,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
-"kmK" = (
-/obj/structure/window/reinforced,
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/red/corners,
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
 "kmY" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -53395,11 +53156,6 @@
 "kna" = (
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/hallway/main/stairwell)
-"knb" = (
-/obj/structure/bed/double/padded,
-/obj/item/bedsheet/rddouble,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cro)
 "knd" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -54899,20 +54655,6 @@
 	tag = "icon-escpodwall19"
 	},
 /area/shuttle/surface_transport_lz)
-"kAK" = (
-/obj/machinery/door/window/westleft{
-	name = "Genetics Pen Access";
-	req_one_access = list(55)
-	},
-/obj/machinery/door/blast/regular/open{
-	id = "genetics2";
-	name = "containment blast door"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/danger,
-/area/nadezhda/medical/genetics)
 "kAN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard,
@@ -55716,11 +55458,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/sleeper)
-"kIk" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/pros/prep)
 "kIn" = (
 /obj/machinery/light{
 	dir = 4
@@ -57417,9 +57154,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/bed/chair/comfy/blue{
-	dir = 1
-	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barquarters)
 "kYK" = (
@@ -58358,17 +58092,16 @@
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/hallway/side/f2section1)
 "lgB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
+/obj/machinery/button/remote/blast_door{
+	id = "Skynet_launch";
+	name = "Mech Bay Door Control";
+	pixel_x = 1;
+	pixel_y = 23;
+	req_access = list(29)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/loading/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/medical/genetics)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "lgC" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small{
@@ -58639,7 +58372,7 @@
 	name = "Mixed Air Supply Control";
 	output_tag = "air_out";
 	pressure_setting = 2000;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -59182,7 +58915,6 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "los" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/holoposter{
 	pixel_x = 32
 	},
@@ -59190,6 +58922,7 @@
 	dir = 4;
 	pixel_x = 8
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "loz" = (
@@ -59306,6 +59039,9 @@
 /obj/item/device/radio/intercom{
 	dir = 2;
 	pixel_y = 24
+	},
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = -32
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm4{
@@ -59449,10 +59185,6 @@
 /area/nadezhda/rnd/docking{
 	name = "\improper Upper Research Hallway"
 	})
-"lri" = (
-/obj/structure/coatrack,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cro)
 "lrp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -60253,6 +59985,9 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = -32
+	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm1{
 	name = "Dormitory 1"
@@ -60522,7 +60257,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -60662,10 +60397,9 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/pool)
 "lDb" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/reagent_dispensers/watertank/huge,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "lDd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -60973,15 +60707,10 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
 "lGo" = (
-/obj/item/bedsheet/captaindouble,
-/obj/structure/bed/double/padded,
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = 25
-	},
-/obj/random/booze/low_chance,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/pros/foreman)
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/rnd/research)
 "lGq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard/guild{
@@ -61788,12 +61517,10 @@
 	name = "\improper Outdoors - Pad"
 	})
 "lOw" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#0892d0"
-	},
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/command/gmaster)
+/obj/machinery/door/airlock/glass,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/medical/genetics)
 "lOx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -62295,13 +62022,19 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "lTh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/steel/gray_platform,
+/area/nadezhda/command/gmaster)
 "lTi" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -63563,22 +63296,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"mfr" = (
-/obj/structure/low_wall,
-/obj/machinery/button/remote/blast_door{
-	id = "genetics2";
-	name = "Containment Cell 2 Blast Doors";
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "genetics1";
-	name = "Containment Cell 1 Blast Doors";
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/medical/genetics)
 "mfs" = (
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -63647,10 +63364,15 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
 "mfO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/obj/structure/medical_stand,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/item/tank/anesthetic,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "mfT" = (
 /obj/structure/bed/chair/office/light,
 /obj/landmark/join/start/paramedic,
@@ -64330,11 +64052,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock{
-	name = "Bartender's Bedroom";
-	req_access = list(25)
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/sandstone{
+	name = "Dormitory";
+	id_tag = "BD2"
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/barquarters)
 "mmm" = (
@@ -65989,9 +65711,10 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "mBP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "mBS" = (
@@ -66791,6 +66514,7 @@
 	pixel_x = 0;
 	pixel_y = -28
 	},
+/mob/living/simple_animal/hostile/dino/tagilla,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
 "mII" = (
@@ -67068,7 +66792,6 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "mLS" = (
-/obj/random/furniture/pottedplant,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -67225,6 +66948,9 @@
 	id = "mcshutters";
 	name = "Shutter control";
 	pixel_x = -6
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
@@ -67424,21 +67150,16 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/crew_quarters/plasma_tag)
 "mPf" = (
-/obj/random/booze,
-/obj/random/booze,
-/obj/random/booze,
-/obj/random/booze,
-/obj/random/booze,
-/obj/random/booze,
-/obj/random/booze,
-/obj/structure/closet/cabinet,
+/obj/structure/closet/chefcloset,
+/obj/item/soap/hunters,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+	pixel_y = 23
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/command/smc/quarters)
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "mPj" = (
 /obj/structure/table/woodentable,
 /obj/item/device/megaphone,
@@ -67667,9 +67388,8 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
 	},
-/obj/structure/table/rack/shelf,
-/obj/random/junk/low_chance,
-/obj/random/toolbox/low_chance,
+/obj/structure/bed/double,
+/obj/item/bedsheet/bluedouble,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barquarters)
 "mRT" = (
@@ -67812,32 +67532,15 @@
 	name = "\improper Blackshield - Firing Range"
 	})
 "mTr" = (
-/obj/structure/table/reinforced,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/computer_hardware/hard_drive/portable/design/circuits,
-/obj/item/computer_hardware/hard_drive/portable/design/components,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/glass{
-	amount = 120
-	},
-/obj/item/stack/material/plastic{
-	amount = 120
-	},
-/obj/item/paper/monitorkey,
-/obj/machinery/button/remote/airlock{
-	dir = 8;
-	id = "securestorage";
-	name = "Door Bolt Control";
-	pixel_x = -22;
-	specialfunctions = 4
-	},
-/turf/simulated/floor/tiled/techmaint_cargo,
-/area/nadezhda/command/gmaster)
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/gun/energy/cog,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "mTs" = (
-/obj/item/modular_computer/console/preset/command,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/command/gmaster)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/medical/genetics)
 "mTy" = (
 /obj/effect/floor_decal/industrial/box/white,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -67895,9 +67598,9 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
 "mUe" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/smc/quarters)
+/mob/living/simple_animal/soteria_roomba,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cro)
 "mUh" = (
 /obj/machinery/light{
 	dir = 8;
@@ -68157,11 +67860,17 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "mVJ" = (
+/obj/machinery/button/remote/airlock{
+	id = "securestorage";
+	name = "Door Bolt Control";
+	specialfunctions = 4;
+	pixel_y = 32
+	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/autolathe/loaded,
-/turf/simulated/floor/wood,
+/obj/item/modular_computer/console/preset/command,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/gmaster)
 "mVT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -68325,12 +68034,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "mXT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/light{
-	name = "The Bun Warmer"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/turcarpet,
-/area/eris/crew_quarters/kitchen_storage)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "mXY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/decal/cleanable/dirt,
@@ -68643,6 +68351,9 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32
+	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm2{
 	name = "Dormitory 2"
@@ -68716,10 +68427,9 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "ncj" = (
-/obj/structure/table/reinforced,
-/obj/random/toy/action_figure_onlymoebius,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "nck" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/effect/decal/cleanable/dirt,
@@ -69113,7 +68823,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -69426,21 +69136,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"nju" = (
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/newscaster{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/structure/reagent_dispensers/bidon/protein_can/si,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "njA" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -69496,9 +69191,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
-"nkn" = (
-/turf/simulated/floor/carpet/turcarpet,
-/area/eris/crew_quarters/kitchen_storage)
 "nkv" = (
 /obj/structure/table/steel,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -69578,6 +69270,16 @@
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_y = 0
+	},
+/obj/structure/bed/chair/comfy/blue{
+	dir = 1
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "BD1";
+	name = "Door Bolt Control";
+	pixel_x = 20;
+	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/crew_quarters/barquarters)
@@ -70275,7 +69977,7 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -70448,15 +70150,22 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nuq" = (
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/computer_hardware/hard_drive/portable/design/circuits,
+/obj/item/computer_hardware/hard_drive/portable/design/components,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/stack/material/steel/full,
+/obj/item/stack/material/glass{
+	amount = 120
 	},
-/obj/effect/floor_decal/corner_techfloor_grid,
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/command/swo/quarters)
+/obj/item/stack/material/plastic{
+	amount = 120
+	},
+/obj/item/paper/monitorkey,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/gmaster)
 "nur" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -71675,16 +71384,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"nGx" = (
-/obj/structure/bed/double/padded,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/bedsheet/cedouble,
-/obj/structure/bed/double/padded,
-/obj/structure/bed/double/padded,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/command/gmaster)
 "nGy" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/spider/stickyweb,
@@ -71750,14 +71449,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"nGY" = (
-/obj/item/storage/box/donkpockets,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
 "nHc" = (
 /obj/machinery/microwave,
 /obj/structure/table/marble,
@@ -71968,8 +71659,7 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/psych)
 "nIS" = (
-/obj/item/towel,
-/turf/simulated/floor/tiled/white/techfloor_grid,
+/turf/simulated/mineral,
 /area/nadezhda/command/swo/quarters)
 "nIZ" = (
 /obj/structure/closet/l3closet,
@@ -73402,12 +73092,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nYy" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
+/obj/structure/closet/secure_closet/reinforced/commander,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "nYz" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/regular,
@@ -74382,6 +74069,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/stamp/cmo,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "ogf" = (
@@ -74724,7 +74412,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
+/turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
 "oji" = (
 /obj/machinery/power/breakerbox{
@@ -75225,10 +74913,12 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/security/nuke_storage)
 "oou" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white/brown_perforated,
+/obj/structure/table/reinforced,
+/obj/random/toy/action_figure_onlymoebius,
+/obj/structure/sign/genetics{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "ooE" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -75446,6 +75136,9 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "oqt" = (
+/obj/structure/closet/wall_mounted{
+	pixel_x = 32
+	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/pros/prep)
 "oqC" = (
@@ -75625,11 +75318,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/camera/network/colony_underground{
 	dir = 1
 	},
@@ -76038,12 +75726,7 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "owe" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
+/obj/structure/table/marble,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "owo" = (
@@ -76345,17 +76028,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
-"oyN" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cro)
 "oyO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -77746,11 +77418,11 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "oLT" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/bed/chair/comfy{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "oLU" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -78280,13 +77952,13 @@
 	dir = 10
 	},
 /obj/structure/table/woodentable,
-/obj/machinery/recharger,
 /obj/machinery/holoposter{
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	pixel_y = -10
 	},
+/obj/item/pen,
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/crew_quarters/barquarters)
 "oRV" = (
@@ -78596,16 +78268,14 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
 "oUV" = (
-/obj/random/booze,
-/obj/random/booze,
-/obj/random/booze,
-/obj/random/booze,
-/obj/random/booze,
-/obj/random/booze,
-/obj/random/booze,
-/obj/structure/closet/cabinet,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/command/swo/quarters)
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "oVd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -78812,10 +78482,10 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
 "oYx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/danger,
-/area/nadezhda/medical/genetics)
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "oYz" = (
 /obj/effect/floor_decal/border/techfloor,
 /obj/effect/floor_decal/border/techfloor{
@@ -79276,10 +78946,11 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/gmaster)
 "pdZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/random/junkfood/low_chance{
+	pixel_x = -1;
+	pixel_y = 3
 	},
+/obj/structure/table/marble,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/gmaster)
 "pea" = (
@@ -79774,17 +79445,6 @@
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
-"pis" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/research,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/medical/genetics)
 "piv" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -81035,12 +80695,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"pvK" = (
-/obj/structure/table/woodentable,
-/obj/random/lathe_disk/low_chance,
-/obj/item/toy/junk/bosunwhistle,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/gmaster)
 "pvM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -81299,11 +80953,12 @@
 /area/nadezhda/crew_quarters/janitor)
 "pyD" = (
 /obj/structure/table/woodentable,
+/obj/random/lathe_disk/low_chance,
+/obj/item/toy/junk/bosunwhistle,
 /obj/item/modular_computer/telescreen/preset/generic{
 	pixel_x = 0;
 	pixel_y = -28
 	},
-/obj/machinery/recharger,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
 "pyG" = (
@@ -81445,7 +81100,8 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "pAe" = (
-/obj/machinery/light,
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
 "pAg" = (
@@ -81587,6 +81243,11 @@
 	dir = 8;
 	icon_state = "pipe-s"
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/gmaster)
 "pBy" = (
@@ -81615,12 +81276,9 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "pBL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "pBN" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/floor_decal/spline/plain{
@@ -81772,6 +81430,8 @@
 	pixel_x = 30;
 	pixel_y = 0
 	},
+/obj/item/biosyphon,
+/obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
 "pCQ" = (
@@ -81821,17 +81481,8 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "pDo" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/random/junkfood/low_chance{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
+/obj/machinery/autolathe/loaded,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/gmaster)
 "pDr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -81964,12 +81615,9 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "pEj" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
+/obj/machinery/camera/network/research,
+/turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "pEo" = (
 /obj/structure/cable/yellow{
@@ -82894,15 +82542,9 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
 "pNf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
+/obj/structure/bed/chair/sofa/black/left,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "pNn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -83481,8 +83123,10 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "pRw" = (
-/obj/machinery/smartfridge/secure/medbay/organs/stocked,
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/item/modular_computer/console/preset/medical/monitor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "pRJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -83834,11 +83478,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "pVK" = (
@@ -84202,13 +83841,13 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/meeting_room)
 "pZy" = (
-/obj/structure/table/woodentable,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+/obj/machinery/newscaster{
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/obj/item/rig/combat/blackshield/equipped,
+/obj/machinery/computer/prisoner{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
 "pZz" = (
@@ -84435,7 +84074,7 @@
 	input_tag = null;
 	name = "Coolant Tank Control";
 	output_tag = null;
-	sensors = list("coolant_sensor" = "Tank")
+	sensors = list("coolant_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
@@ -86889,9 +86528,8 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
 	},
-/obj/structure/table/rack/shelf,
-/obj/random/junk/low_chance,
-/obj/random/toolbox/low_chance,
+/obj/structure/bed/double,
+/obj/item/bedsheet/greendouble,
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/crew_quarters/barquarters)
 "qzW" = (
@@ -86917,9 +86555,17 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security)
 "qAb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/medical/genetics)
+/obj/machinery/keycard_auth,
+/obj/item/reagent_containers/enricher,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/structure/table/marble,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "qAh" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -87152,9 +86798,9 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/crew_quarters/plasma_tag)
 "qDe" = (
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "qDg" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -88907,14 +88553,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
 "qUj" = (
-/obj/structure/table/reinforced,
-/obj/machinery/camera/network/research{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/machinery/holoposter{
+	pixel_x = 32
 	},
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "qUn" = (
 /obj/structure/window/reinforced,
 /obj/structure/sink{
@@ -88971,11 +88615,8 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "qUE" = (
-/obj/machinery/light/floor{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/medical/genetics)
+/turf/simulated/mineral,
+/area/nadezhda/rnd/robotics)
 "qUQ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -89675,14 +89316,6 @@
 /obj/structure/cyberplant,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
-"raF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/obj/structure/table/rack,
-/turf/simulated/floor/carpet/turcarpet,
-/area/eris/crew_quarters/kitchen_storage)
 "raH" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "14,23"
@@ -90450,10 +90083,6 @@
 	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/propis{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
 "rhU" = (
@@ -90956,16 +90585,6 @@
 /obj/item/pen/multi,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/security/nuke_storage)
-"rmL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/medical/genetics)
 "rmM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -91830,11 +91449,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
-"ruQ" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/green,
-/turf/simulated/floor/carpet/turcarpet,
-/area/eris/crew_quarters/kitchen_storage)
 "ruS" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -92208,8 +91822,8 @@
 	density = 0;
 	dir = 2;
 	icon_state = "shutter0";
-	id = "research_shutters";
-	name = "Office Shutters";
+	id = "organ_shutter";
+	name = "Privacy Shutters";
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
@@ -92551,10 +92165,6 @@
 /area/nadezhda/crew_quarters/dorm2{
 	name = "Dormitory 2"
 	})
-"rBK" = (
-/obj/structure/closet/secure_closet/reinforced/commander,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/smc/quarters)
 "rBT" = (
 /obj/structure/multiz/ladder,
 /obj/machinery/light/small{
@@ -93088,10 +92698,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
-"rGo" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
 "rGq" = (
 /obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/rock,
@@ -93502,12 +93108,14 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "rKH" = (
-/obj/machinery/light/small,
-/obj/structure/noticeboard/lonestar_service{
-	pixel_y = -31
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
 	},
-/turf/simulated/floor/carpet/turcarpet,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cyberplant,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "rKL" = (
 /obj/structure/multiz/stairs,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -94050,19 +93658,10 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
 "rPN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_pump,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "rQd" = (
 /obj/structure/railing/grey{
 	dir = 4;
@@ -94226,17 +93825,18 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
 "rRK" = (
-/obj/machinery/power/wall_obelisk{
-	pixel_x = 32
-	},
-/obj/structure/bed/double/padded,
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 26;
 	pixel_y = 0
 	},
-/obj/item/bedsheet/bluedouble,
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 0;
+	pixel_y = 28
+	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barquarters)
 "rRM" = (
@@ -94568,16 +94168,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/abandoned_solars)
-"rUO" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/genetics/cloner,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/medical/genetics)
 "rUY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/fact_plaque,
@@ -95396,15 +94986,11 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "sdf" = (
-/obj/structure/bed/double/padded{
-	dir = 4
-	},
-/obj/item/bedsheet/captaindouble{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -25
+/obj/item/rig/combat/blackshield/equipped,
+/obj/structure/table/woodentable,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
@@ -95689,9 +95275,11 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/bar)
 "seM" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
@@ -96018,13 +95606,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
-"sij" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/command/gmaster)
 "sik" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "16,17"
@@ -96305,23 +95886,12 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "slm" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/machinery/vending/wallmed/lobby{
-	pixel_y = 25
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
+/obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/danger,
+/area/nadezhda/medical/genetics)
 "slo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -96862,6 +96432,7 @@
 "sqS" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/reagent_dispensers/watertank/huge,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "sqU" = (
@@ -97548,10 +97119,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/genetics)
-"sye" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
-/area/nadezhda/command/merchant)
 "syp" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -98426,11 +97993,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock{
-	name = "Chef's Bedroom";
-	req_access = list(28)
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/sandstone{
+	name = "Dormitory";
+	id_tag = "BD1"
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/barquarters)
 "sJr" = (
@@ -98871,17 +98438,15 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
 "sNY" = (
-/obj/effect/window_lwall_spawn/plasma/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/washing_machine,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = -32
 	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/medical/genetics)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "sOa" = (
 /obj/machinery/conveyor/east{
 	id = "disposals grinder"
@@ -100517,13 +100082,17 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/engineering/atmos)
 "tcR" = (
-/obj/structure/closet/secure_closet/freezer,
-/obj/random/junkfood/onlyburger,
-/obj/random/junkfood/onlyburger,
-/obj/random/junkfood/onlypizza,
-/obj/random/junkfood,
-/obj/random/junkfood,
-/turf/simulated/floor/wood,
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/smc/quarters)
 "tdb" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -102028,7 +101597,6 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/engineering/engine_room)
 "ttm" = (
-/obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -102037,6 +101605,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "ttA" = (
@@ -102224,18 +101793,6 @@
 /area/nadezhda/security{
 	name = "Security Training"
 	})
-"tvn" = (
-/obj/item/modular_computer/console/preset/medical/monitor{
-	dir = 4
-	},
-/obj/machinery/holoposter{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	pixel_y = 10
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/medical/genetics)
 "tvq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -102404,7 +101961,10 @@
 	name = "North APC";
 	pixel_y = 28
 	},
-/obj/item/storage/case/donut,
+/obj/item/storage/briefcase/crimekit,
+/obj/item/device/eftpos{
+	eftpos_name = "Marshal EFTPOS scanner"
+	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/swo/quarters)
 "twx" = (
@@ -102456,11 +102016,11 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "twP" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/spray/chemsprayer,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "twT" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -103881,13 +103441,13 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/courtroom)
 "tLY" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "tMg" = (
@@ -104005,6 +103565,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
+/obj/landmark/join/start/foreman,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
 "tNK" = (
@@ -104855,7 +104416,7 @@
 	input_tag = null;
 	name = "Coolant Tank Control";
 	output_tag = null;
-	sensors = list("coolant_sensor" = "Tank")
+	sensors = list("coolant_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -104913,12 +104474,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"tYl" = (
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
 "tYm" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -106048,7 +105603,6 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "uiv" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
 	},
@@ -106346,9 +105900,6 @@
 "uma" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microscope,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "umg" = (
@@ -106686,9 +106237,16 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "uqn" = (
-/obj/structure/bed/double/padded,
-/obj/item/bedsheet/captaindouble,
-/turf/simulated/floor/carpet/blucarpet,
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/swo/quarters)
 "uqu" = (
 /obj/effect/decal/cleanable/rubble,
@@ -106737,7 +106295,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
-/obj/random/furniture/pottedplant,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "uqQ" = (
@@ -108108,21 +107665,10 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "uBN" = (
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/cyancorner,
-/area/nadezhda/medical/sleeper)
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "uBU" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -108561,20 +108107,7 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "uGo" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/toy/figure/character/civilian/chef,
-/obj/structure/table/marble,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/turf/simulated/floor/carpet/turcarpet,
+/turf/simulated/mineral,
 /area/eris/crew_quarters/kitchen_storage)
 "uGq" = (
 /obj/structure/girder/displaced,
@@ -109296,19 +108829,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "uNP" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 8
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/structure/catwalk,
-/obj/structure/window/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/medical/genetics)
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "uNR" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/sign/warningnew/danger{
@@ -109723,15 +109250,14 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "uRw" = (
-/obj/structure/bed/double/padded,
 /obj/item/modular_computer/telescreen/preset/generic{
 	pixel_x = 0;
 	pixel_y = 28
 	},
-/obj/item/bedsheet/browndouble,
 /obj/machinery/light_switch{
 	pixel_x = 28
 	},
+/obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
 "uRx" = (
@@ -110140,6 +109666,7 @@
 /obj/machinery/camera/network/propis{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/reinforced/foreman,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
 "uVe" = (
@@ -110475,15 +110002,17 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "uYx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "uYz" = (
@@ -110720,6 +110249,16 @@
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_y = 0
+	},
+/obj/structure/bed/chair/comfy/blue{
+	dir = 1
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "BD2";
+	name = "Door Bolt Control";
+	pixel_x = 20;
+	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barquarters)
@@ -111116,12 +110655,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
-"vfw" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
 "vfx" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -111352,10 +110885,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/rocinante_shuttle_area)
 "vhU" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/rd,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/eris/crew_quarters/barbackroom)
+/obj/structure/toilet,
+/obj/machinery/holoposter{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "via" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -112372,14 +111907,9 @@
 /area/shuttle/rocinante_shuttle_area)
 "vrz" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/tool/scalpel/laser{
-	pixel_y = -5
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "vrB" = (
 /obj/machinery/camera/network/plasma_tag{
@@ -115040,6 +114570,13 @@
 /obj/random/mecha/low_chance,
 /obj/machinery/mech_recharger,
 /obj/machinery/camera/network/research,
+/obj/machinery/button/remote/blast_door{
+	id = "Skynet_launch";
+	name = "Mech Bay Door Control";
+	pixel_x = 1;
+	pixel_y = 23;
+	req_access = list(29)
+	},
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/robotics)
 "vQZ" = (
@@ -115094,14 +114631,28 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vRw" = (
-/obj/effect/window_lwall_spawn/plasma/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "MedbayTotalLockdown";
+	layer = 2.6;
+	name = "Medbay Total Lockdown";
+	opacity = 0
 	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/medical/genetics)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Organ Laboratory";
+	req_access = list(5)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/rnd/docking)
 "vRz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/coatrack,
@@ -115202,7 +114753,13 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/security/tactical_blackshield)
 "vSU" = (
-/turf/simulated/floor/carpet/oracarpet,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/structure/table/woodentable,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
 "vSW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -115989,12 +115546,13 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/meeting_room)
 "vZI" = (
-/obj/structure/extinguisher_cabinet{
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
 	pixel_x = 0;
-	pixel_y = -30
+	pixel_y = -32
 	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/cro)
 "vZL" = (
 /obj/structure/catwalk,
@@ -116284,14 +115842,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/section1)
-"wcK" = (
-/obj/effect/window_lwall_spawn/plasma/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/medical/genetics)
 "wcM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
@@ -116678,8 +116228,11 @@
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/crew_quarters/barbackroom)
 "wgs" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 5
+/obj/structure/bed/padded,
+/obj/item/bedsheet,
+/obj/machinery/light/small,
+/obj/machinery/holoposter{
+	pixel_x = 32
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/pros/prep)
@@ -120061,6 +119614,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red,
+/obj/item/storage/secure/safe{
+	pixel_x = 34
+	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
 "wNH" = (
@@ -120089,11 +119645,10 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "wOa" = (
-/obj/item/bedsheet/captain,
-/obj/structure/bed/padded,
 /obj/machinery/camera/network/command{
 	dir = 1
 	},
+/obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/fo)
 "wOc" = (
@@ -120856,17 +120411,15 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "wWY" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	dir = 1;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
@@ -121109,6 +120662,9 @@
 	icon_state = "grey_railing0"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/colony_underground{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "wZd" = (
@@ -121785,14 +121341,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
-"xfm" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/towel,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
 "xfv" = (
 /obj/structure/railing{
 	dir = 8
@@ -121872,9 +121420,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/obj/structure/bed/chair/comfy/green{
-	dir = 1
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/crew_quarters/barquarters)
@@ -122131,14 +121676,15 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xjC" = (
-/obj/structure/table/reinforced,
-/obj/structure/closet/wall_mounted{
-	pixel_x = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/item/gun/energy/cog,
-/obj/machinery/recharger/industrial,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/docking)
 "xjG" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/nuke_storage{
@@ -124726,10 +124272,20 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "xIj" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet,
-/turf/simulated/floor/wood/wild2,
-/area/nadezhda/pros/prep)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/mirror{
+	dir = 8;
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/smc/quarters)
 "xIn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -125239,6 +124795,10 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/engineering/workshop)
 "xNa" = (
+/obj/structure/sign/department/medbay{
+	pixel_x = 28;
+	name = "Organ Laboratory"
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "xNf" = (
@@ -125715,18 +125275,16 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
 "xRZ" = (
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
-	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/reagent_dispensers/bidon/protein_can/si,
 /obj/structure/railing{
 	dir = 1;
 	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
-/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "xSh" = (
@@ -125832,9 +125390,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "xTe" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/propis{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/pros/prep)
 "xTj" = (
 /obj/machinery/atm{
 	dir = 1;
@@ -125848,6 +125409,9 @@
 	id = "genetics3";
 	name = "Containment Cell 3 Blast Doors";
 	pixel_y = 4
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/genetics)
@@ -125920,17 +125484,8 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
 "xUa" = (
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/structure/railing,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/reagent_dispensers/bidon/protein_can/si,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "xUe" = (
 /obj/structure/table/bench/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -126798,7 +126353,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ydf" = (
-/obj/structure/bed/chair/office/dark,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -134005,14 +133559,14 @@ uCp
 oGw
 oGw
 cLm
-tVe
+kse
 axa
-gVT
-ivN
 oGw
 oGw
-oGw
-oGw
+nIS
+nIS
+nIS
+nIS
 clN
 htx
 wyz
@@ -134205,16 +133759,16 @@ euZ
 fxu
 uCp
 oGw
-oGw
+bmp
 uqn
-tVe
-bhK
-bhK
-kdN
+kNT
+sNY
 oGw
-dXD
-kmK
-nuq
+oGw
+nIS
+nIS
+nIS
+nIS
 clN
 pPv
 vgt
@@ -134408,14 +133962,14 @@ fxu
 uCp
 oGw
 oGw
-fMq
-tVe
-bhK
-bhK
-bhK
+oGw
 otZ
-pNf
-kse
+oGw
+oGw
+oGw
+nIS
+nIS
+nIS
 nIS
 clN
 jtl
@@ -134609,16 +134163,16 @@ euZ
 fxu
 uCp
 oGw
-oGw
+gVT
+bhK
+bhK
 xyW
-bhK
-bhK
-haw
-oUV
 oGw
-slm
-kNT
-nYy
+oGw
+nIS
+nIS
+nIS
+nIS
 clN
 uVh
 wQo
@@ -134811,8 +134365,8 @@ pWD
 fxu
 uCp
 oGw
-oGw
 oJI
+bhK
 bhK
 cpb
 oGw
@@ -135046,10 +134600,10 @@ gEI
 gEI
 gEI
 hfy
-hfy
-hfy
-hfy
-hfy
+cjP
+cjP
+cjP
+cjP
 hfy
 shB
 shB
@@ -135247,9 +134801,9 @@ kiZ
 gEI
 gEI
 gEI
-hfy
-hfy
-hfy
+cjP
+cjP
+cjP
 hfy
 hfy
 hfy
@@ -136268,7 +135822,7 @@ pZl
 hfy
 hfy
 hfy
-hfy
+cjP
 hfy
 uCp
 uCp
@@ -141306,9 +140860,9 @@ cwr
 efY
 ptB
 vnv
-dUl
-nkn
-fkp
+uGo
+uGo
+uGo
 vnv
 iof
 fNh
@@ -141509,8 +141063,8 @@ wLd
 bwh
 vnv
 uGo
-mXT
-rKH
+uGo
+uGo
 vnv
 wSq
 gAA
@@ -141710,9 +141264,9 @@ cwr
 cyr
 bwh
 vnv
-raF
-nkn
-fEL
+uGo
+uGo
+uGo
 vnv
 pLL
 jdf
@@ -141912,9 +141466,9 @@ cwr
 dqF
 mFH
 vnv
-bmp
-nkn
-ruQ
+vnv
+vnv
+vnv
 vnv
 rDw
 bgK
@@ -142114,9 +141668,9 @@ cwr
 jps
 bwh
 vnv
-vnv
-edD
-vnv
+mPf
+rgG
+pBL
 vnv
 jdf
 pHC
@@ -142479,13 +142033,13 @@ mMP
 koE
 koE
 tfU
+tfU
 xGf
 vXa
 tfU
-syJ
 mHA
 cMX
-sye
+syJ
 qpz
 tfU
 hPI
@@ -142681,10 +142235,10 @@ iuY
 koE
 koE
 tfU
+tfU
 cBX
 kWL
 dQW
-vLf
 vLf
 tou
 osA
@@ -142883,13 +142437,13 @@ iuY
 koE
 koE
 tfU
+tfU
 lDJ
 kWL
 tfU
 oig
 nGC
 ugI
-iAP
 uiv
 tfU
 vvT
@@ -143366,7 +142920,7 @@ lCI
 eOx
 eOx
 eOx
-csb
+jwy
 ici
 qkJ
 tyz
@@ -150986,12 +150540,12 @@ quV
 ces
 ces
 pEa
-nyE
+eAm
 bwh
 kEP
 pVB
 ryn
-gix
+lGo
 cqa
 tna
 hWD
@@ -151389,15 +150943,15 @@ drz
 drz
 drz
 drz
-gkI
+drz
 ttm
 emm
 rhU
 gbk
-rfF
+ryn
 aDp
 wWY
-rpx
+uNP
 mgf
 kgt
 mgf
@@ -151592,14 +151146,14 @@ bwh
 bwh
 bwh
 dXF
-bxY
-mcQ
-kah
-jBl
-sQO
+nyE
+lgB
+bwh
+pVB
+rfF
 sQO
 kbd
-rpx
+cqa
 ykS
 cqa
 mgf
@@ -151788,18 +151342,18 @@ vot
 jVE
 sEU
 vKw
-vKw
+rKH
 vKw
 sFC
 mgk
 mgk
 wZb
 bxY
-icP
-pow
-uFi
-wBQ
-ssR
+mcQ
+kah
+jBl
+bxY
+sQO
 kiD
 uYx
 qKv
@@ -151998,11 +151552,11 @@ sXG
 aZc
 bxY
 vQY
-wBQ
+pow
 uFi
 wBQ
-sQO
-cpp
+ssR
+cqa
 esA
 coO
 xNj
@@ -154426,7 +153980,7 @@ wBQ
 jGM
 mzB
 bxY
-bxY
+qUE
 bxY
 olZ
 wBQ
@@ -154628,7 +154182,7 @@ nak
 wBQ
 uVq
 bxY
-bxY
+qUE
 bxY
 xVr
 wBQ
@@ -154830,7 +154384,7 @@ ljg
 aHG
 wXg
 bxY
-bxY
+qUE
 bxY
 bxY
 bxY
@@ -155021,9 +154575,9 @@ cwr
 cwr
 cwr
 cwr
+cwr
+cwr
 aMz
-cwr
-cwr
 cwr
 bxY
 bxY
@@ -155220,10 +154774,10 @@ npT
 npT
 qql
 hwH
+fkp
 pTU
 sLE
 vnK
-wvL
 wvL
 wvL
 wvL
@@ -155422,10 +154976,10 @@ npT
 npT
 hGh
 hwH
+fkp
 pTU
 osd
 adZ
-wvL
 wvL
 nJC
 cLn
@@ -155625,9 +155179,9 @@ aXo
 aXo
 aXo
 aXo
-fpY
-fpY
 aXo
+fpY
+fpY
 aXo
 aXo
 apH
@@ -155827,9 +155381,9 @@ eHH
 pcz
 bFV
 vNF
+aXo
 gfQ
 kFt
-vNF
 edf
 aXo
 uKJ
@@ -157241,7 +156795,7 @@ aXo
 bFV
 pcz
 vNF
-bFV
+aXo
 bFV
 vNF
 ebi
@@ -157682,7 +157236,7 @@ kOj
 cAG
 hYY
 qhV
-sMW
+xjC
 sMW
 wEF
 wzo
@@ -158086,8 +157640,8 @@ xxZ
 mrS
 hYY
 hYY
-hYY
-hYY
+vRw
+jhS
 hYY
 yhV
 oxv
@@ -158287,9 +157841,9 @@ ihS
 ihS
 gLl
 hYY
-sFI
-sFI
-sFI
+rPN
+ivN
+izx
 hYY
 evS
 cSs
@@ -158489,9 +158043,9 @@ ihS
 ihS
 gLl
 hYY
-sFI
-sFI
-sFI
+uBN
+aBv
+fnd
 hYY
 lop
 ffD
@@ -158691,9 +158245,9 @@ ihS
 ihS
 gLl
 hYY
-sFI
-sFI
-sFI
+qDe
+xUa
+aJA
 hYY
 lop
 qdj
@@ -158893,9 +158447,9 @@ vnu
 vnu
 vTA
 hYY
-sFI
-sFI
-sFI
+mfO
+fMq
+iMc
 hYY
 lop
 qdj
@@ -180631,16 +180185,16 @@ iJv
 cEg
 iiY
 iJv
-hSx
-hSx
-hSx
-hSx
-hSx
-hSx
-hSx
-hSx
-hSx
-hSx
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 hSx
 hSx
 hSx
@@ -180833,12 +180387,12 @@ iJv
 tBK
 cEg
 iJv
-hSx
-hSx
-hSx
-hSx
-hSx
-hSx
+sFI
+sFI
+hVm
+sFI
+sFI
+sFI
 hSx
 hSx
 hSx
@@ -180912,8 +180466,8 @@ aPb
 loz
 ilT
 xbx
-vhU
 ttL
+gfn
 gfn
 sFI
 sFI
@@ -181035,13 +180589,13 @@ iJv
 qdI
 snn
 iJv
+sFI
+sFI
+sFI
+sFI
+sFI
 hSx
 hSx
-hSx
-ajL
-ajL
-ajL
-ajL
 ajL
 ajL
 ajL
@@ -181237,14 +180791,14 @@ iJv
 qdI
 snn
 iJv
+sFI
+sFI
+sFI
+sFI
+sFI
 hSx
 ajL
 ajL
-ajL
-ajL
-ajL
-rBK
-mUe
 pZy
 sdf
 bgY
@@ -181439,16 +180993,16 @@ iJv
 iiY
 pbZ
 iJv
+sFI
+sFI
+hSx
+hSx
+hSx
 hSx
 ajL
-ajL
-ajL
-ajL
-iQA
-svM
+nYy
 cUV
-cUV
-cUV
+oLT
 vXl
 ajL
 bZz
@@ -181641,17 +181195,17 @@ iJv
 ujT
 iGr
 iJv
+sFI
+sFI
 hSx
 ajL
 ajL
 ajL
 ajL
 ajL
-svM
-hso
 aBX
 cUV
-izV
+hso
 ajL
 cUV
 dVW
@@ -181843,14 +181397,14 @@ iJv
 snn
 cEg
 iJv
+sFI
+sFI
 hSx
 ajL
 cui
-dmY
+xIj
 fkR
 iXB
-svM
-svM
 rsG
 kXd
 kXd
@@ -182045,14 +181599,14 @@ iJv
 tBK
 cEg
 iJv
+sFI
+sFI
 hSx
 ajL
 ddX
-dCT
-fqN
-ajL
+fkR
 tcR
-mPf
+ajL
 fOP
 rbo
 uGf
@@ -182247,12 +181801,12 @@ iJv
 cEg
 snn
 iJv
+sFI
+sFI
 hSx
 ajL
 ajL
-ajL
-ajL
-ajL
+bPW
 ajL
 ajL
 ajL
@@ -182449,13 +182003,13 @@ iJv
 cEg
 snn
 iJv
-hSx
 sFI
 sFI
 sFI
 sFI
-sFI
-sFI
+xGi
+xGi
+xGi
 wBa
 siB
 dRq
@@ -188122,13 +187676,13 @@ uoL
 aat
 wVp
 tnX
-xCT
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+ncI
+hSx
+hSx
+hSx
+hSx
+hSx
+hSx
 sFI
 sFI
 sFI
@@ -188324,11 +187878,11 @@ uog
 wii
 wWc
 tnX
-xCT
-sFI
-sFI
+ncI
 hSx
-sFI
+hSx
+hSx
+hSx
 hSx
 hSx
 hSx
@@ -188526,12 +188080,12 @@ eeI
 tnX
 tnX
 tnX
-xCT
-sFI
-sFI
-hSx
-hSx
-hSx
+ncI
+jXV
+jXV
+jXV
+jXV
+jXV
 hSx
 hSx
 hSx
@@ -188726,19 +188280,19 @@ tnX
 tnX
 tnX
 tnX
-xCT
-xCT
-xCT
-sFI
-sFI
+ncI
+ncI
+ncI
+jXV
+kzt
+lrG
+lRd
+jXV
 hSx
 hSx
-jXV
-jXV
-jXV
-jXV
-jXV
-jXV
+hSx
+hSx
+hSx
 jXV
 jXV
 jXV
@@ -188931,16 +188485,16 @@ sFI
 sFI
 sFI
 hSx
-hSx
-hSx
-hSx
-hSx
 jXV
-mTr
-mZG
-ohw
-mZG
-pvK
+kAs
+kCX
+oUV
+jXV
+jXV
+jXV
+jXV
+jXV
+jXV
 jXV
 qDl
 rbK
@@ -189126,21 +188680,21 @@ sFI
 sFI
 sFI
 sFI
-hSx
-hSx
-hSx
-hSx
+sFI
+sFI
+sFI
+sFI
 hSx
 hSx
 hSx
 jXV
-jXV
-jXV
-jXV
-jXV
-mTs
+lSs
+kCX
+ncj
+mmA
 mZG
-ohA
+mZG
+ohw
 mZG
 pyD
 jXV
@@ -189327,22 +188881,22 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 hSx
-aar
 jXV
 jXV
 jXV
 jXV
 jXV
 jXV
-jXV
-kzt
-lrG
-lRd
 jXV
 mVJ
 mZG
-mZG
+ohA
 mZG
 pAe
 jXV
@@ -189529,19 +189083,19 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 hSx
 jXV
-jXV
+uVy
+nEk
+lTh
 nEk
 nEk
-sij
-aPG
-nFp
-jXV
-kAs
-kCX
-kCX
-mmA
+nGc
 mZG
 mZG
 ohE
@@ -189731,21 +189285,21 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 hSx
 jXV
-lOw
+dna
 nEk
+pDo
 nEk
-nEk
-nEk
-nEk
-nGc
-kCX
-kCX
-lSs
+nFp
+jXV
 jXV
 nbu
-nGx
 ojh
 pcs
 pAZ
@@ -189933,18 +189487,18 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 hSx
 jXV
-dna
-uVy
 iMl
-lcV
-idO
-qms
-jXV
-jXV
-jXV
-jXV
+nEk
+nEk
+nEk
+nuq
 jXV
 jXV
 jXV
@@ -190135,18 +189689,18 @@ sFI
 eaA
 eaA
 eaA
+eaA
+eaA
+eaA
+eaA
+eaA
 etI
-eyR
-eyR
-eyR
-eyR
-eyR
-eyR
-eyR
-eyR
-eaA
-eaA
-eaA
+jXV
+jXV
+jXV
+lcV
+idO
+qms
 jXV
 jXV
 nGB
@@ -190345,16 +189899,16 @@ etI
 etI
 etI
 etI
-etI
-etI
-eaA
-eaA
 jXV
 jXV
-nGY
-kCX
+jXV
+jXV
+jXV
+jXV
+nHc
+kdN
 pdZ
-pBL
+pef
 jXV
 jXV
 riJ
@@ -190546,17 +190100,17 @@ eTA
 eTA
 eTA
 eTA
-eTA
-eVx
+etI
+etI
 etI
 eaA
 eaA
 jXV
 jXV
-nHc
-kCX
-pef
-pDo
+jXV
+jXV
+jXV
+jXV
 jXV
 jXV
 riQ
@@ -190747,8 +190301,8 @@ gFp
 gFp
 gFp
 gFp
-gFp
-gFp
+oYx
+oYx
 eTA
 etI
 eaA
@@ -190783,14 +190337,14 @@ xDZ
 sDG
 rgK
 sFI
-ula
-smu
-smu
-smu
-ula
-smu
-smu
-smu
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 ula
 smu
 smu
@@ -190940,7 +190494,7 @@ sFI
 sFI
 sFI
 sFI
-eaA
+etI
 etI
 eTA
 fmO
@@ -190985,15 +190539,15 @@ aRA
 gmz
 rgK
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 vwW
-aBA
-sri
-sri
-vRw
-aBA
-qUE
-sri
-vRw
 aBA
 sri
 sri
@@ -191142,7 +190696,7 @@ sFI
 sFI
 sFI
 sFI
-eaA
+etI
 eyR
 eUM
 fmO
@@ -191187,15 +190741,15 @@ rgK
 rgK
 rgK
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 syb
-ieM
-sri
-ieM
-wcK
-aMS
-phh
-sri
-wcK
 sri
 sri
 ieM
@@ -191344,7 +190898,7 @@ sFI
 sFI
 sFI
 sFI
-eaA
+etI
 etI
 eTA
 fmO
@@ -191389,15 +190943,15 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 syb
-sri
-phh
-sri
-wcK
-ieM
-sri
-ieM
-wcK
 ieM
 sri
 phh
@@ -191591,16 +191145,16 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 syb
 sri
-sri
-ieM
-wcK
-sri
-sri
-sri
-wcK
-jac
 sri
 sri
 smu
@@ -191793,14 +191347,14 @@ sFI
 sFI
 sFI
 sFI
-pzy
-dHF
-jRF
-smu
-pzy
-sNY
-kAK
-smu
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+ula
 pzy
 dHF
 ouw
@@ -191995,14 +191549,14 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 ula
-uNP
-qgE
-oLT
-mfr
-nrI
-qgE
-oLT
 xTq
 nrI
 qgE
@@ -192197,18 +191751,18 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 ula
-pis
-xCY
-lUt
-xCY
-mJX
-xCY
-lUt
-lUt
+pEj
 mJX
 lUt
-lTh
+lUt
 ula
 ula
 elK
@@ -192399,20 +191953,20 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 ula
+mTs
 vdO
-pEj
-sQI
-lUt
-lgB
-aBv
-lUt
-lUt
-jhS
 kYV
-egi
-ula
-ula
+lUt
+erA
+mTr
 elK
 wiD
 nBx
@@ -192601,20 +192155,20 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 ula
+mTs
 duz
 pzU
 lUt
 xCY
-rUO
-pzU
-lUt
-lUt
-duz
-pzU
-lUt
-ula
-ula
+dHg
 elK
 xGJ
 baD
@@ -192803,19 +192357,19 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 ula
+mTs
 vDI
-fnd
-lUt
-lUt
-bnm
-aBv
-lUt
-lUt
-rmL
 tHC
 lUt
-erA
+xCY
 lZl
 elK
 chk
@@ -193005,14 +192559,14 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
+sFI
 ula
-rPN
-mBP
-mBP
-cIp
-jkb
-mBP
-mBP
+ula
+ula
+ula
 mBP
 tLY
 ksD
@@ -193166,7 +192720,7 @@ sFI
 sFI
 sFI
 sFI
-eaA
+etI
 etI
 eTA
 gFp
@@ -193207,14 +192761,14 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
+sFI
 ula
 ula
-ula
-nju
-xUa
+jRF
 lDb
-lDb
-hVm
+ula
 iEU
 wpS
 cTU
@@ -193368,7 +192922,7 @@ sFI
 sFI
 sFI
 sFI
-eaA
+etI
 eyR
 eUM
 gFp
@@ -193410,23 +192964,23 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
 ula
-ula
-tvn
 btw
-cZB
+fMv
 fMv
 hkK
 skc
 fMv
 wjJ
 pRw
-vrz
+oQl
 iBc
 elK
 sfN
 owe
-qOO
+qAb
 cNm
 aXb
 elK
@@ -193570,7 +193124,7 @@ sFI
 sFI
 sFI
 sFI
-eaA
+etI
 etI
 eTA
 gFp
@@ -193612,21 +193166,21 @@ sFI
 sFI
 sFI
 sFI
-ula
-eAm
-cZB
+sFI
+sFI
+mTs
 oou
-cZB
-cZB
+gFS
+fMv
 fMv
 cZB
-cZB
+fQH
 wjJ
 fQH
 tjy
 iTL
 elK
-aRo
+rLx
 uCE
 hss
 eHB
@@ -193814,11 +193368,11 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
 ula
-byG
-fMv
-gFS
-cZB
+vrz
+cgQ
 sOu
 hcZ
 dTZ
@@ -193826,9 +193380,9 @@ hcZ
 qNV
 via
 iwx
-oQl
+twP
 elK
-cTu
+aRo
 qOO
 iXw
 oga
@@ -194016,11 +193570,11 @@ sFI
 sFI
 sFI
 sFI
+sFI
+sFI
 ula
 ula
-ncj
-qUj
-xjC
+ula
 ula
 sqY
 hvI
@@ -194218,24 +193772,24 @@ sFI
 sFI
 sFI
 sFI
-ula
-ula
-ula
-ula
+sFI
+sFI
+sFI
+sFI
 ula
 ula
 naT
+xCY
 dRT
-mfO
 dNj
 vUw
 dOH
 xct
 elK
-mSy
+pNf
 wGD
 rQQ
-qOO
+dwV
 tif
 elK
 cEd
@@ -194423,24 +193977,24 @@ sFI
 sFI
 sFI
 sFI
+sFI
 ula
 vLP
 fKY
 eKe
-gab
-lUt
-lUt
-lUt
+slm
+eKe
+eKe
 mnX
 xct
 elK
+mSy
 qOO
-rLx
 koC
-nBx
-nBx
 elK
-uBN
+elK
+elK
+cEd
 nPs
 nqg
 bVe
@@ -194625,22 +194179,22 @@ sFI
 sFI
 sFI
 sFI
+sFI
 ula
 huY
 nPB
 fHX
-lUt
 nvm
+jQf
 eKe
-lUt
 mnX
 elK
 elK
 lHP
 elK
 elK
-dHg
-aJA
+elK
+elK
 elK
 cbw
 nPs
@@ -194827,14 +194381,14 @@ sFI
 sFI
 sFI
 sFI
+sFI
 ula
 nzq
 nvm
 nvm
-lUt
-gdC
+nvm
 eKe
-lUt
+eKe
 qPr
 elK
 bqN
@@ -195029,19 +194583,19 @@ sFI
 sFI
 sFI
 sFI
+sFI
 ula
 jdY
 aeU
 aeU
+xCY
 lUt
-jQf
-eKe
 lUt
 fgH
 elK
 sUl
 ilQ
-ilQ
+gdC
 elK
 eXm
 eXm
@@ -195231,13 +194785,13 @@ sFI
 sFI
 sFI
 sFI
+sFI
 ula
 aeU
 joT
 aeU
-xCY
-eKe
-oYx
+lUt
+sQI
 sQI
 mnX
 elK
@@ -195433,11 +194987,11 @@ sFI
 sFI
 sFI
 sFI
+sFI
 ula
 eTR
 aeU
 aeU
-qDe
 los
 fuy
 lTB
@@ -195635,11 +195189,11 @@ sFI
 sFI
 sFI
 sFI
+sFI
 ula
 ula
 ula
 ula
-cOK
 ula
 ula
 cOx
@@ -195837,11 +195391,11 @@ sFI
 sFI
 sFI
 sFI
-ula
+sFI
 ula
 uma
 hQV
-qAb
+xKq
 aIB
 ula
 lUt
@@ -196039,14 +195593,14 @@ sFI
 sFI
 sFI
 sFI
-ula
+sFI
 ula
 ssK
 cZB
 cZB
-xKq
-ula
-tYl
+hQV
+lOw
+xCY
 edz
 rPf
 tAe
@@ -196241,7 +195795,7 @@ sFI
 sFI
 sFI
 sFI
-ula
+sFI
 ula
 guh
 oSD
@@ -196443,7 +195997,7 @@ sFI
 sFI
 sFI
 sFI
-ula
+sFI
 ula
 hdW
 aEs
@@ -196868,7 +196422,7 @@ kSF
 bqs
 klk
 ldZ
-tPn
+mUe
 mea
 cZm
 klk
@@ -197273,7 +196827,7 @@ xAN
 klk
 ewa
 tPn
-ctU
+mea
 tKm
 gwI
 xGi
@@ -197675,7 +197229,7 @@ eXm
 frj
 xAN
 klk
-lri
+uOG
 tPn
 ijt
 gJG
@@ -197877,14 +197431,14 @@ eXm
 hrR
 wqP
 klk
-uOG
-tPn
-tPn
+klk
+klk
+aDZ
 klk
 klk
 klk
-klk
-klk
+sFI
+sFI
 xGi
 stw
 lPT
@@ -198079,14 +197633,14 @@ aqG
 pPS
 xAN
 klk
-uOG
-tPn
+iQA
+kzc
 vZI
 klk
-xKU
-kzc
-vfw
 klk
+sFI
+sFI
+sFI
 xGi
 stw
 lPT
@@ -198281,14 +197835,14 @@ eXm
 caY
 emo
 klk
-uOG
-tPn
-tPn
-aDZ
+mXT
 tYV
 tYV
-xTe
+xKU
 klk
+sFI
+sFI
+sFI
 xGi
 cUd
 lPT
@@ -198483,14 +198037,14 @@ eXm
 pwp
 emo
 klk
-klk
-knb
-oyN
-klk
 sZw
 fDE
 seq
 klk
+klk
+sFI
+sFI
+sFI
 xGi
 cUd
 xGi
@@ -198689,10 +198243,10 @@ klk
 klk
 klk
 klk
-klk
-klk
-klk
-klk
+sFI
+sFI
+sFI
+sFI
 xGi
 stw
 xGi
@@ -235226,7 +234780,7 @@ qQZ
 hHU
 riw
 guj
-qQZ
+buz
 qQZ
 gzV
 gUk
@@ -235793,7 +235347,7 @@ kwx
 kwx
 vJb
 rhS
-wyH
+xTe
 jVf
 utl
 utl
@@ -235991,14 +235545,14 @@ wbP
 fZb
 xdv
 xdv
-xdv
-gsp
-xdv
-xdv
-iMc
+qbj
 xdv
 xdv
 qbj
+xdv
+xdv
+qbj
+xdv
 xdv
 xdv
 fsx
@@ -236194,7 +235748,7 @@ rXX
 xdv
 xdv
 kbR
-dwV
+tIh
 xdv
 oqt
 jYd
@@ -236204,7 +235758,7 @@ wgs
 uvj
 fES
 rjd
-fSf
+cTu
 cAC
 eKA
 vbT
@@ -236395,14 +235949,14 @@ wbP
 rtn
 xdv
 xdv
-erb
-tIh
 xdv
-kIk
 jEl
 xdv
-xIj
-buz
+xdv
+jEl
+xdv
+xdv
+jEl
 uvj
 gXk
 rjd
@@ -236596,15 +236150,15 @@ cAn
 and
 qVe
 xdv
-xdv
-xdv
-cgQ
-xdv
-xdv
-cgQ
-xdv
-cgQ
-xdv
+veZ
+veZ
+scG
+scG
+scG
+scG
+scG
+scG
+scG
 uvj
 dEE
 uKx
@@ -236798,15 +236352,15 @@ cAn
 vsz
 flk
 cAn
-cAn
+veZ
 veZ
 scG
 scG
+bIh
 scG
-scG
-scG
-scG
-cAn
+uvj
+uvj
+uvj
 uvj
 xCK
 caW
@@ -237006,12 +236560,12 @@ veZ
 scG
 scG
 scG
-scG
-cAn
-cAn
+cOK
+vhU
+nnM
 uvj
-ayP
-izx
+uvj
+fSf
 fSf
 ewW
 fSf
@@ -237208,12 +236762,12 @@ veZ
 veZ
 veZ
 scG
-cPp
-cAn
-cAn
 uvj
-lGo
-jbz
+dCT
+cyf
+cyf
+pWZ
+fSf
 fSf
 pZA
 fSf
@@ -237410,14 +236964,14 @@ veZ
 veZ
 veZ
 cPp
-bIh
-veZ
-cAn
 uvj
-jud
+uvj
+iVR
+qUj
+uvj
 vSU
 lob
-bPW
+fSf
 uVa
 wNG
 uvj
@@ -237615,9 +237169,9 @@ cPp
 pwm
 pwm
 pwm
+cOK
 uvj
 uvj
-pWZ
 uvj
 uvj
 uvj
@@ -237816,11 +237370,11 @@ ukS
 aDO
 lbX
 mDT
-mAu
-iVR
-nnM
-cyf
-uvj
+bnm
+yjy
+uXK
+uXK
+bnm
 vqy
 seQ
 bVD
@@ -238019,10 +237573,10 @@ scG
 pwm
 rou
 pwm
-xfm
-rGo
-twP
-uvj
+yjy
+uXK
+uXK
+pwm
 rou
 pwm
 pwm
@@ -238221,10 +237775,10 @@ scG
 pwm
 twn
 pwm
-uvj
-uvj
-uvj
-uvj
+yjy
+pwm
+uXK
+pwm
 rou
 pwm
 veZ
@@ -239025,7 +238579,7 @@ cAn
 cAn
 cAn
 cAn
-hEB
+csb
 cAn
 cAn
 hEB

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -10184,6 +10184,12 @@
 /area/nadezhda/outside/forest)
 "bZT" = (
 /obj/structure/flora/rock/variant1,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/hallway/side/f2section1)
 "cae" = (
@@ -14011,6 +14017,13 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/reception)
+"cMg" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/hallway/side/f2section1)
 "cMn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 9
@@ -16936,7 +16949,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dqP" = (
-/obj/structure/railing/grey,
 /obj/structure/table/bench/padded,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -18602,6 +18614,13 @@
 /obj/structure/flora/small/trailrocka1,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"dHt" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/hallway/side/f2section1)
 "dHA" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -19362,6 +19381,9 @@
 /area/nadezhda/security/tactical_blackshield)
 "dPz" = (
 /obj/structure/flora/ausbushes/palebush,
+/obj/structure/railing/grey{
+	dir = 1
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
 "dPK" = (
@@ -22100,6 +22122,12 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/bar)
+"eqG" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/beach/sand,
+/area/nadezhda/hallway/side/f2section1)
 "eqK" = (
 /obj/structure/closet/secure_closet/freezer,
 /obj/random/junkfood,
@@ -26221,13 +26249,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "ffX" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/railing/grey{
 	dir = 4;
 	icon_state = "grey_railing0"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
 "fga" = (
 /obj/machinery/atmospherics/valve,
@@ -30763,6 +30790,12 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
+"fXk" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/beach/sand,
+/area/nadezhda/hallway/side/f2section1)
 "fXl" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -32816,10 +32849,6 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "goX" = (
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor{
 	dir = 4
@@ -32934,6 +32963,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"gpN" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/hallway/side/f2section1)
 "gpR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -33809,7 +33845,6 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "gzI" = (
-/obj/structure/railing/grey,
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
 	dir = 4;
@@ -34392,6 +34427,9 @@
 /area/nadezhda/command/tcommsat/computer)
 "gFo" = (
 /obj/structure/flora/ausbushes/reedbush,
+/obj/structure/railing/grey{
+	dir = 8
+	},
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/hallway/side/f2section1)
 "gFp" = (
@@ -48020,12 +48058,13 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "joj" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/railing/grey{
 	dir = 4;
 	icon_state = "grey_railing0"
 	},
-/turf/simulated/floor/tiled/steel/cyancorner,
+/obj/structure/railing/grey,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
 "jon" = (
 /obj/effect/decal/cleanable/dirt,
@@ -49029,6 +49068,14 @@
 /area/nadezhda/crew_quarters/dorm2{
 	name = "Dormitory 2"
 	})
+"jyg" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/hallway/side/f2section1)
 "jyh" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -51742,7 +51789,6 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jYA" = (
-/obj/structure/railing/grey,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
@@ -53017,12 +53063,12 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/merchant)
 "kjU" = (
+/obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
+/obj/structure/railing/grey,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
 "kjV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -59495,6 +59541,14 @@
 /obj/random/toolbox,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/abandoned_solars)
+"lsb" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/hallway/side/f2section1)
 "lsg" = (
 /obj/structure/table/standard,
 /obj/random/contraband/low_chance,
@@ -59818,6 +59872,11 @@
 	icon_state = "13,15"
 	},
 /area/nadezhda/hallway/main/stairwell)
+"lvT" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/railing/grey,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/hallway/side/f2section1)
 "lvX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -69382,11 +69441,12 @@
 	name = "\improper Upper Research Hallway"
 	})
 "njU" = (
+/obj/structure/flora/ausbushes/leafybush,
 /obj/structure/railing/grey{
-	dir = 8
+	dir = 4;
+	icon_state = "grey_railing0"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
 "njW" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -76905,6 +76965,11 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/side/f2section1)
+"oFa" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/railing/grey,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/hallway/side/f2section1)
 "oFb" = (
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/box/red,
@@ -83351,9 +83416,6 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
 "pRk" = (
-/obj/structure/railing/grey{
-	dir = 8
-	},
 /obj/machinery/light/floor{
 	dir = 8
 	},
@@ -86968,6 +87030,17 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
+"qBh" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/hallway/side/f2section1)
 "qBj" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/camera/network/engineering{
@@ -98490,6 +98563,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"sKD" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/hallway/side/f2section1)
 "sKF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/flora/pottedplant/small,
@@ -106235,6 +106315,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/chemistry)
+"ulU" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/railing/grey,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/hallway/side/f2section1)
 "ulY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -119721,6 +119806,10 @@
 /area/nadezhda/rnd/lab)
 "wKu" = (
 /obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
 "wKy" = (
@@ -126584,6 +126673,13 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/quartermaster/miningdock)
+"ybR" = (
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/hallway/side/f2section1)
 "ybT" = (
 /obj/random/mob/nightmare,
 /turf/simulated/floor/rock,
@@ -126752,11 +126848,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ydM" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/reedbush,
 /obj/structure/railing/grey{
-	dir = 8
+	dir = 1
 	},
-/turf/simulated/floor/tiled/steel/cyancorner,
+/turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/hallway/side/f2section1)
 "ydT" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -148452,14 +148548,14 @@ nZo
 rBV
 bwh
 qAq
-joj
-joj
-vKw
-vKw
+bwh
+bwh
+bwh
+bwh
 goX
-ffX
-vKw
-ffX
+jlJ
+bwh
+jlJ
 bwh
 bGH
 jlJ
@@ -148656,13 +148752,13 @@ mCh
 jYA
 bZT
 gFo
-wHv
-aZc
-wKu
-sXG
-kZg
-qMU
+eqG
+cMg
+gpN
+dHt
+sKD
 kjU
+bwh
 bGH
 jlJ
 gtY
@@ -148856,15 +148952,15 @@ qAq
 rBV
 bwh
 gzI
-gFo
+ydM
 sIA
 wHv
 opl
 drS
 kZg
 qMU
-opl
-kjU
+ulU
+bwh
 nZo
 cho
 bcq
@@ -149058,15 +149154,15 @@ qAq
 aye
 pnI
 cwr
-wHv
+fXk
 bvg
 eTk
 qSl
 eqL
 mpF
 kZg
-qSl
-kjU
+lvT
+bwh
 nZo
 bwh
 gtY
@@ -149267,8 +149363,8 @@ vQq
 opl
 iuH
 qSl
-iuH
-kjU
+oFa
+bwh
 nZo
 bwh
 gtY
@@ -149462,15 +149558,15 @@ qAq
 rxl
 jlJ
 dqP
-aZc
+qBh
 wKu
-vQq
-drS
-aZc
-kZg
-qMU
-qSl
-kjU
+ybR
+njU
+ffX
+lsb
+jyg
+joj
+bwh
 nZo
 bwh
 gtY
@@ -149664,14 +149760,14 @@ aMP
 aNW
 mCh
 jlJ
-njU
-ydM
-ydM
-ydM
+bwh
+bwh
+bwh
+bwh
 pRk
-ydM
-njU
-ydM
+bwh
+bwh
+bwh
 bwh
 qAq
 tgi

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -56,15 +56,9 @@
 /turf/unsimulated/mineral,
 /area/nadezhda/security/armory_blackshield)
 "aar" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/washing_machine,
-/obj/machinery/vending/wallmed/lobby{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/construction)
 "aas" = (
 /obj/machinery/newscaster{
 	dir = 8;
@@ -1624,7 +1618,7 @@
 	pixel_y = 27
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "aqx" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -2401,20 +2395,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"ayP" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/command/gmaster)
 "ayY" = (
 /obj/structure/closet/cabinet{
 	name = "entertainment cabinet"
@@ -3069,7 +3049,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "aFY" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/industrial/hatch,
@@ -3400,6 +3380,14 @@
 /obj/structure/sign/warning/internals_required/small2,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
+"aJA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "aJG" = (
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/meadow)
@@ -3798,13 +3786,10 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "aMS" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/mineral,
-/area/colony)
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/rnd/research)
 "aMZ" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Core";
@@ -4137,6 +4122,25 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"aPG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "aPI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5227,7 +5231,7 @@
 	icon_state = "box_corners_red"
 	},
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "bbx" = (
 /obj/item/clothing/gloves/thick/handmade,
 /obj/structure/table/rack/shelf,
@@ -6367,15 +6371,9 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bmp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/docking)
+/mob/living/simple_animal/soteria_roomba,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cro)
 "bms" = (
 /obj/machinery/newscaster{
 	pixel_x = -30;
@@ -6482,7 +6480,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
+"bnm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe/bioprinter/med,
+/obj/machinery/button/remote/blast_door{
+	id = "organ_shutter";
+	name = "privacy shutter control";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "bnn" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -7183,11 +7191,8 @@
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "buz" = (
-/obj/machinery/camera/network/research{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/turf/simulated/wall,
+/area/nadezhda/pros/prep)
 "buH" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/railing{
@@ -7682,11 +7687,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"byG" = (
-/obj/item/storage/box/donkpockets,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
 "byP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -8287,7 +8287,7 @@
 /area/nadezhda/quartermaster/miningdock)
 "bFV" = (
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "bFW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8762,7 +8762,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "bLc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/marble,
@@ -8944,7 +8944,7 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "bNk" = (
 /obj/machinery/vending/wallmed/lobby{
 	pixel_y = -32
@@ -9201,9 +9201,11 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/section3)
 "bPW" = (
-/obj/machinery/autolathe/loaded,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/gmaster)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "bPY" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -9666,7 +9668,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "bVp" = (
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/dirt,
@@ -9971,7 +9973,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "bYL" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -10554,7 +10556,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "ces" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -10606,7 +10608,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "ceX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -10763,7 +10765,7 @@
 "cgv" = (
 /obj/structure/flora/rock/variant2,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "cgB" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -10781,6 +10783,15 @@
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"cgQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/construction)
 "cgU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/crossbow,
@@ -11409,7 +11420,7 @@
 "cnc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "cnh" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/church,
@@ -11556,14 +11567,17 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cpp" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
+/obj/machinery/holoposter{
 	pixel_y = -32
 	},
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cbo)
+/obj/effect/floor_decal/steeldecal/steel_decals_central6{
+	pixel_y = -10
+	},
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "cpq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -11845,6 +11859,20 @@
 "crV" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
+"csb" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/steel/gray_platform,
+/area/nadezhda/command/gmaster)
 "cse" = (
 /obj/item/toy/junk/inflatable_duck,
 /turf/simulated/floor/beach/water/ocean,
@@ -12023,7 +12051,7 @@
 "ctI" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "ctK" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/decal/cleanable/dirt,
@@ -12064,9 +12092,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
 "ctU" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/wall,
+/area/asteroid/cave)
 "ctX" = (
 /obj/structure/flora/small/rock5,
 /turf/unsimulated/wall/jungle,
@@ -12686,7 +12714,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/suit_storage_unit/engineering/atmos,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "czZ" = (
 /obj/structure/table/standard,
 /obj/structure/extinguisher_cabinet{
@@ -12830,7 +12858,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "cAW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13185,7 +13213,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "cDJ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -13435,7 +13463,7 @@
 /obj/effect/window_lwall_spawn/smartspawnplasma,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "cGt" = (
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
@@ -13484,7 +13512,7 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "cHl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13551,15 +13579,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "cIp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/machinery/button/remote/blast_door{
-	id = "guild_lobby";
-	name = "Guild Lobby shutter control";
-	pixel_y = -21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/engineering/foyer)
+/obj/machinery/autolathe/loaded,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/gmaster)
 "cIq" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/multiz/ladder,
@@ -13950,7 +13972,7 @@
 /obj/effect/floor_decal/industrial/box,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "cLW" = (
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/wood/wild5,
@@ -13977,7 +13999,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "cMp" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/big/bush1,
@@ -14248,11 +14270,11 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "cOK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/spray/chemsprayer,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "cOR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14480,7 +14502,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "cSu" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
@@ -14488,7 +14510,7 @@
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "cSy" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/busha1,
@@ -14585,9 +14607,15 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/panic_room)
 "cTu" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "cTv" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
@@ -14634,7 +14662,7 @@
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "cTQ" = (
 /obj/structure/catwalk,
 /obj/machinery/conveyor_switch{
@@ -14675,7 +14703,7 @@
 	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "cUa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -15289,7 +15317,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "daY" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -15502,7 +15530,7 @@
 "ddm" = (
 /obj/structure/firedoor_assembly,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "dds" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
@@ -15627,7 +15655,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "dei" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -15968,7 +15996,7 @@
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "dib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16121,7 +16149,7 @@
 "djA" = (
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "djO" = (
 /obj/effect/damagedfloor/rust,
 /turf/simulated/floor/plating/under,
@@ -16188,7 +16216,7 @@
 /obj/effect/window_lwall_spawn/smartspawnplasma,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dkm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -16200,7 +16228,7 @@
 "dku" = (
 /obj/structure/sign/warning/compressed_gas,
 /turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dkw" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 10
@@ -16386,7 +16414,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dmD" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/golden,
@@ -16434,12 +16462,6 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"dmY" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/gun/energy/cog,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "dna" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/borgupload{
@@ -16571,7 +16593,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dof" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -16590,7 +16612,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "dop" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/ash,
@@ -16709,7 +16731,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "dpq" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Telecommunications";
@@ -17075,7 +17097,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dsi" = (
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/detectives_office)
@@ -17411,7 +17433,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "dvZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair{
@@ -17496,8 +17518,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dwV" = (
-/turf/simulated/mineral,
-/area/nadezhda/rnd/robotics)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "dxe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -17912,7 +17935,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dAW" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -17965,7 +17988,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dBK" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
@@ -18146,6 +18169,16 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"dCT" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "dCV" = (
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -18554,9 +18587,16 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/hallway/surface/section1)
 "dHg" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/wall,
-/area/asteroid/cave)
+/obj/structure/closet/chefcloset,
+/obj/item/soap/hunters,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "dHs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/trailrocka1,
@@ -19299,7 +19339,7 @@
 "dOT" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dPb" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/machinery/door/firedoor,
@@ -19611,8 +19651,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	locked = 0;
+	name = "South APC";
+	operating = 1;
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dSB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -19622,7 +19674,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dSI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19633,7 +19685,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dSL" = (
 /obj/machinery/slotmachine,
 /obj/structure/table/woodentable,
@@ -19721,7 +19773,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dTH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -19743,7 +19795,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dTZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19768,7 +19820,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dUc" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
@@ -19935,7 +19987,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dVH" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -20180,7 +20232,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "dYI" = (
 /obj/machinery/bodyscanner,
 /obj/effect/decal/cleanable/cobweb,
@@ -20288,7 +20340,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "dZq" = (
 /obj/machinery/door/airlock/glass{
 	name = "Sauna"
@@ -20333,7 +20385,7 @@
 /obj/effect/window_lwall_spawn,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "dZU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/landmark/join/start/officer,
@@ -20397,7 +20449,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "eaH" = (
 /obj/structure/table/rack/shelf,
 /obj/random/lowkeyrandom,
@@ -20613,7 +20665,7 @@
 /obj/structure/catwalk,
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "edh" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -20667,6 +20719,10 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"edD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "edH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20704,7 +20760,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "edR" = (
 /obj/structure/flora/rock/variant1,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -21001,7 +21057,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "egd" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -21046,21 +21102,9 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "egi" = (
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/computer_hardware/hard_drive/portable/design/circuits,
-/obj/item/computer_hardware/hard_drive/portable/design/components,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/glass{
-	amount = 120
-	},
-/obj/item/stack/material/plastic{
-	amount = 120
-	},
-/obj/item/paper/monitorkey,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/steel/gray_perforated,
+/obj/item/storage/box/donkpockets,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/gmaster)
 "egs" = (
 /obj/machinery/chem_master/condimaster,
@@ -21153,7 +21197,7 @@
 /obj/effect/window_lwall_spawn/smartspawnplasma,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "ehy" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lamp,
@@ -21192,7 +21236,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "ehY" = (
 /obj/random/scrap/dense_even,
 /obj/effect/decal/cleanable/cobweb2,
@@ -21826,7 +21870,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "epm" = (
 /obj/structure/table/woodentable,
 /obj/random/card_carp/pelt,
@@ -21984,7 +22028,7 @@
 	pixel_y = -23
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "eqk" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1;
@@ -22072,7 +22116,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
+"erb" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "erm" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/small/busha1,
@@ -22178,7 +22226,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "esw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
@@ -22529,7 +22577,7 @@
 "evz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "evD" = (
 /obj/random/boxes,
 /obj/effect/decal/cleanable/rubble,
@@ -22901,7 +22949,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/generator,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "eAi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/medical_stand,
@@ -22920,15 +22968,11 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/turret_protected/ai)
 "eAm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "eAI" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
@@ -23089,7 +23133,7 @@
 	},
 /obj/effect/floor_decal/industrial/arrows/white,
 /turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "eCH" = (
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -23186,7 +23230,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "eDW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -23347,7 +23391,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "eFP" = (
 /obj/structure/flora/big/rocks2,
 /turf/unsimulated/wall/jungle,
@@ -23504,7 +23548,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "eHs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -23538,7 +23582,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/firedoor_assembly,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "eHJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -24303,7 +24347,7 @@
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "ePe" = (
 /obj/machinery/door/window/westleft,
 /obj/structure/closet{
@@ -24673,7 +24717,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "eSm" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -25428,7 +25472,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "eYl" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushb3,
@@ -25836,7 +25880,7 @@
 "fbZ" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "fcc" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -26178,7 +26222,7 @@
 /obj/machinery/atmospherics/valve,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "fgb" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light,
@@ -26646,11 +26690,16 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "fkp" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 8
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
+/obj/item/tool/scalpel/laser{
+	pixel_y = -5
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26692,7 +26741,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "fkB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wall_mounted/firecloset{
@@ -26717,7 +26766,7 @@
 "fkM" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "fkR" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/smc/quarters)
@@ -26789,7 +26838,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "flI" = (
 /obj/structure/multiz/stairs/enter,
 /obj/structure/window/reinforced{
@@ -26878,12 +26927,6 @@
 /obj/structure/flora/small/trailrocka1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"fnd" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/spray/chemsprayer,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "fnf" = (
 /obj/structure/lattice,
 /turf/simulated/floor/plating/under,
@@ -27094,7 +27137,7 @@
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "fpl" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/catwalk,
@@ -27112,7 +27155,7 @@
 /obj/machinery/door/airlock/external,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "fpo" = (
 /obj/structure/bookcase/metal,
 /obj/item/book/manual/fiction/aroundtheworld,
@@ -27222,7 +27265,7 @@
 	anchored = 1
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "fqb" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -27322,13 +27365,11 @@
 	name = "Dormitory 3"
 	})
 "fqN" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/pros/foreman)
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "fqR" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/effect/decal/cleanable/dirt,
@@ -27437,7 +27478,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "frI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27879,7 +27920,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "fwc" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -28783,7 +28824,7 @@
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "fDO" = (
 /obj/structure/salvageable/computer{
 	pixel_y = 10
@@ -28931,24 +28972,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "fEL" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/turf/simulated/mineral,
+/area/nadezhda/rnd/robotics)
 "fER" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/sliceable/bread,
@@ -29392,7 +29417,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "fJi" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29755,6 +29780,18 @@
 /obj/item/beehive_assembly,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"fMq" = (
+/obj/machinery/keycard_auth,
+/obj/item/reagent_containers/enricher,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/structure/table/marble,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "fMs" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc{
@@ -30217,12 +30254,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "fRt" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "fRx" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -31030,10 +31067,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
-"gab" = (
-/mob/living/simple_animal/soteria_roomba,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cro)
 "gah" = (
 /obj/structure/toilet{
 	dir = 4
@@ -31069,7 +31102,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "gav" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31281,7 +31314,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "gce" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -31324,7 +31357,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "gcF" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small,
@@ -31423,14 +31456,11 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "gdC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/propis{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/pros/prep)
+/obj/structure/sign/department/atmos,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/atmos/storage)
 "gdD" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled/techmaint,
@@ -31763,10 +31793,8 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "gfQ" = (
-/obj/item/caution/cone,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/turf/simulated/wall/r_wall,
+/area/nadezhda/command/teleporter)
 "gfR" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/curtain/open/bed,
@@ -32282,6 +32310,29 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
+"gkI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "MedbayTotalLockdown";
+	layer = 2.6;
+	name = "Medbay Total Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Organ Laboratory";
+	req_access = list(5)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/rnd/docking)
 "gkM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -32618,7 +32669,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "gnP" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -33883,7 +33934,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "gAO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/woodentable,
@@ -35226,7 +35277,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "gNm" = (
 /obj/vehicle/train/cargo/engine,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -35476,7 +35527,7 @@
 	},
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "gPD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -36120,7 +36171,7 @@
 /obj/structure/table/standard,
 /obj/item/tool/multitool,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "gWU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -36535,9 +36586,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
-"haw" = (
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
 "haz" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/lakeside)
@@ -36575,7 +36623,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "hbn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -36634,7 +36682,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "hbM" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -37700,7 +37748,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "hmz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -38413,7 +38461,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /mob/living/simple_animal/hostile/scarybat,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "hug" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
@@ -39230,7 +39278,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "hCW" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -39430,7 +39478,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "hFN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4;
@@ -39446,7 +39494,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "hFY" = (
 /obj/machinery/door/airlock/multi_tile/metal/mait,
 /obj/random/traps/low_chance,
@@ -40591,7 +40639,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "hSw" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/suit/armor/vest/handmade_black/full,
@@ -40711,7 +40759,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "hTz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -40851,9 +40899,13 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "hVm" = (
-/obj/structure/bed/chair/sofa/black/left,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/mineral,
+/area/colony)
 "hVt" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -41408,7 +41460,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/valve,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "ibp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -41565,6 +41617,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
+"icP" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/reagent_dispensers/watertank/huge,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "icS" = (
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
@@ -41692,7 +41749,7 @@
 	})
 "iei" = (
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "iek" = (
 /obj/item/device/radio/intercom{
 	dir = 2;
@@ -42061,7 +42118,7 @@
 /obj/machinery/door/airlock/external,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "iiI" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -42512,7 +42569,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/science/low_chance,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "inm" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/machinery/door/firedoor,
@@ -42582,7 +42639,7 @@
 "inW" = (
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "ioe" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -42705,7 +42762,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "ipO" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 6;
@@ -43421,6 +43478,12 @@
 /obj/machinery/camera/network/colony_transition,
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
+"ivN" = (
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "ivP" = (
 /obj/effect/floor_decal/border/techfloor,
 /obj/effect/floor_decal/border/techfloor{
@@ -43653,7 +43716,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "iyv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
@@ -43764,6 +43827,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/main/stairwell)
+"izx" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "izE" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/effect/floor_decal/spline/plain{
@@ -43801,16 +43871,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/skyyard)
 "izV" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/tool/scalpel/laser{
-	pixel_y = -5
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/steeldecal/steel_decals_central4,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "izW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/spiders,
@@ -43903,9 +43967,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "iAP" = (
-/obj/structure/toilet,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
+/obj/machinery/button/remote/blast_door{
+	id = "Skynet_launch";
+	name = "Mech Bay Door Control";
+	pixel_x = 1;
+	pixel_y = 23;
+	req_access = list(29)
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "iAR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -43919,7 +43990,7 @@
 "iAT" = (
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "iAU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -44868,7 +44939,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "iJQ" = (
 /obj/structure/flora/small/busha2,
 /obj/random/flora/jungle_tree,
@@ -45199,7 +45270,7 @@
 	light_color = "#b9e8ea"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "iNS" = (
 /obj/machinery/door/airlock/command{
 	name = "Front Desk";
@@ -45384,7 +45455,7 @@
 "iPk" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/yggdrasil,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "iPt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -45521,11 +45592,11 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "iQA" = (
-/obj/machinery/camera/network/cargo{
-	dir = 1
+/obj/structure/bed/chair/comfy{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/sechall)
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "iQD" = (
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/maingate{
@@ -45651,7 +45722,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "iRr" = (
 /obj/structure/fireaxecabinet{
 	pixel_x = -30
@@ -46039,7 +46110,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "iVt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/manmade/road,
@@ -46359,7 +46430,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "iYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -47325,9 +47396,6 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
-"jhS" = (
-/turf/simulated/wall,
-/area/nadezhda/pros/foreman)
 "jhW" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/wood/wild5,
@@ -47387,7 +47455,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "jiH" = (
 /obj/structure/table/steel,
 /obj/item/clothing/mask/gas/old,
@@ -47573,6 +47641,10 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"jkb" = (
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "jkc" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -47588,7 +47660,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "jkf" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/floor/tiled/dark/golden,
@@ -48525,16 +48597,6 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"jud" = (
-/obj/structure/sign/levels/stairsdown{
-	pixel_y = -30
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
 "jui" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -49590,8 +49652,9 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/crew_quarters/fitness)
 "jEl" = (
-/turf/simulated/wall,
-/area/nadezhda/pros/prep)
+/obj/structure/closet/secure_closet/reinforced/commander,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "jEs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -49835,7 +49898,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "jGX" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -50818,7 +50881,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "jPL" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall29";
@@ -50960,6 +51023,23 @@
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"jRF" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/machinery/camera/network/cargo,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/hangarsupply)
 "jRG" = (
 /obj/random/furniture/pottedplant,
 /obj/structure/extinguisher_cabinet{
@@ -51160,7 +51240,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /mob/living/simple_animal/hostile/scarybat,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "jTZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard,
@@ -52133,7 +52213,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "kcr" = (
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -52237,12 +52317,9 @@
 /turf/unsimulated/mineral,
 /area/asteroid/cave)
 "kdN" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/obj/machinery/holoposter{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
+/obj/item/caution/cone,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/command/teleporter)
 "kdS" = (
 /obj/structure/table/standard,
 /obj/item/stack/medical/advanced/bruise_pack,
@@ -53216,6 +53293,16 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
+"kmK" = (
+/obj/structure/sign/levels/stairsdown{
+	pixel_y = -30
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "kmY" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -53228,8 +53315,11 @@
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/hallway/main/stairwell)
 "knb" = (
-/turf/simulated/mineral,
-/area/nadezhda/rnd/lab)
+/obj/machinery/camera/network/cargo{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/bluecorner,
+/area/nadezhda/security/sechall)
 "knd" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -53363,7 +53453,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "knP" = (
 /obj/structure/catwalk,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -53640,7 +53730,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "kpQ" = (
 /obj/structure/flora/small/lavarock3,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -53651,7 +53741,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "kpT" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/scrap/dense_weighted/low_chance,
@@ -53911,7 +54001,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "ksJ" = (
 /obj/structure/bed{
 	dir = 4
@@ -54039,7 +54129,7 @@
 /obj/item/am_shielding_container,
 /obj/item/am_shielding_container,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "ktX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54522,7 +54612,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "kyV" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -54729,6 +54819,14 @@
 	tag = "icon-escpodwall19"
 	},
 /area/shuttle/surface_transport_lz)
+"kAK" = (
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/pros/foreman)
 "kAN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard,
@@ -54986,7 +55084,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "kCW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
@@ -55261,8 +55359,9 @@
 /area/nadezhda/security/sechall)
 "kFt" = (
 /obj/item/caution/cone,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "kFQ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -55532,10 +55631,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/sleeper)
-"kIk" = (
-/obj/structure/closet/secure_closet/reinforced/commander,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/smc/quarters)
 "kIn" = (
 /obj/machinery/light{
 	dir = 4
@@ -55691,7 +55786,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "kKm" = (
 /obj/machinery/constructable_frame/machine_frame/vertical,
 /obj/random/mecha_equipment/low_chance,
@@ -56477,7 +56572,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "kRS" = (
 /obj/structure/boulder,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -57139,7 +57234,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "kXv" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -58163,17 +58258,20 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "lgp" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/chicken,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/hallway/side/f2section1)
 "lgB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/steeldecal/steel_decals_central4,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
+/obj/structure/table/standard,
+/obj/item/storage/freezer,
+/obj/structure/sink{
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "lgC" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small{
@@ -58239,7 +58337,7 @@
 	},
 /obj/structure/lattice,
 /turf/simulated/floor/asteroid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "lhy" = (
 /obj/structure/bed/chair/sofa/teal/right{
 	dir = 4
@@ -58400,7 +58498,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "liX" = (
 /obj/effect/floor_decal/border/techfloor,
 /obj/effect/floor_decal/border/techfloor{
@@ -58513,7 +58611,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "ljX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -58658,7 +58756,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "llx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -59158,7 +59256,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "lqg" = (
 /obj/machinery/door/airlock/centcom,
 /obj/effect/decal/cleanable/blood/oil,
@@ -59198,7 +59296,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "lqs" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -59258,10 +59356,14 @@
 	name = "\improper Upper Research Hallway"
 	})
 "lri" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/research,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cbo)
 "lrp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -59618,7 +59720,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "lvq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -60242,7 +60344,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "lBg" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush2,
@@ -60475,7 +60577,7 @@
 /area/nadezhda/crew_quarters/pool)
 "lDb" = (
 /obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/reagent_dispensers/watertank/huge,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "lDd" = (
@@ -60656,7 +60758,7 @@
 /obj/machinery/camera/network/engineering,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "lEH" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -60783,19 +60885,13 @@
 "lGg" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
-"lGo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
 "lGq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard/guild{
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "lGG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/penguin/baby{
@@ -60862,7 +60958,7 @@
 "lHh" = (
 /obj/item/modular_computer/console/preset/engineering,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "lHp" = (
 /obj/random/tool/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -61064,7 +61160,7 @@
 "lIO" = (
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "lIR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -61595,9 +61691,11 @@
 	name = "\improper Outdoors - Pad"
 	})
 "lOw" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/gun/energy/cog,
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "lOx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -62508,7 +62606,7 @@
 "lXa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "lXd" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -62899,7 +62997,7 @@
 	},
 /obj/machinery/door/window/westright,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "mbm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -63360,22 +63458,10 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "mfr" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/hangarsupply)
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "mfs" = (
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -63445,8 +63531,11 @@
 /area/nadezhda/engineering/atmos)
 "mfO" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/medical/genetics)
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "mfT" = (
 /obj/structure/bed/chair/office/light,
 /obj/landmark/join/start/paramedic,
@@ -64563,7 +64652,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "mpl" = (
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
 	pixel_y = 32
@@ -64925,7 +65014,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "mtl" = (
 /obj/effect/floor_decal/industrial/caution,
 /turf/simulated/floor/tiled/steel,
@@ -66434,7 +66523,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/binary/circulator,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "mHf" = (
 /obj/structure/table/woodentable,
 /obj/machinery/recharger,
@@ -67178,7 +67267,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "mON" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/vending/serbomat,
@@ -67219,29 +67308,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/crew_quarters/plasma_tag)
-"mPf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "MedbayTotalLockdown";
-	layer = 2.6;
-	name = "Medbay Total Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Organ Laboratory";
-	req_access = list(5)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/rnd/docking)
 "mPj" = (
 /obj/structure/table/woodentable,
 /obj/item/device/megaphone,
@@ -67614,13 +67680,15 @@
 	name = "\improper Blackshield - Firing Range"
 	})
 "mTr" = (
-/obj/machinery/optable,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/propis{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/pros/prep)
 "mTs" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/wall,
+/area/nadezhda/pros/foreman)
 "mTy" = (
 /obj/effect/floor_decal/industrial/box/white,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -67677,6 +67745,11 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
+"mUe" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "mUh" = (
 /obj/machinery/light{
 	dir = 8;
@@ -68108,7 +68181,11 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
+"mXT" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "mXY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/decal/cleanable/dirt,
@@ -68496,20 +68573,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"ncj" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/towel,
-/obj/machinery/vending/wallmed/lobby{
-	pixel_y = 25
-	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
 "nck" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/effect/decal/cleanable/dirt,
@@ -68836,7 +68899,7 @@
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "nfU" = (
 /obj/structure/toilet{
 	dir = 1
@@ -69177,7 +69240,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "nje" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/big/bush2,
@@ -69217,11 +69280,15 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nju" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "njA" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -69245,7 +69312,7 @@
 "njW" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "nkb" = (
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/psych)
@@ -69278,8 +69345,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
 "nkn" = (
-/turf/simulated/mineral,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/structure/medical_stand,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/item/tank/anesthetic,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "nkv" = (
 /obj/structure/table/steel,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -69519,7 +69593,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "nmX" = (
 /obj/structure/closet/wall_mounted{
 	pixel_x = -32
@@ -70239,15 +70313,8 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nuq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/bioprinter/med,
-/obj/machinery/button/remote/blast_door{
-	id = "organ_shutter";
-	name = "privacy shutter control";
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/turf/simulated/mineral,
+/area/nadezhda/command/swo/quarters)
 "nur" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -70736,7 +70803,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "nzz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -70864,7 +70931,7 @@
 /obj/item/device/scanner/gas,
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "nAD" = (
 /obj/structure/table/rack/shelf,
 /obj/item/gun/projectile/grenade/lenar,
@@ -71403,7 +71470,7 @@
 	},
 /obj/structure/lattice,
 /turf/unsimulated/mineral,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "nFY" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/spider/stickyweb,
@@ -71467,10 +71534,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "nGx" = (
-/obj/machinery/door/airlock/glass,
+/obj/machinery/smartfridge/secure/medbay/organs/stocked,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/medical/genetics)
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "organ_shutter";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/docking)
 "nGy" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/spider/stickyweb,
@@ -71537,13 +71612,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "nGY" = (
-/obj/structure/table/standard,
-/obj/item/storage/freezer,
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/construction)
 "nHc" = (
 /obj/machinery/microwave,
 /obj/structure/table/marble,
@@ -71754,8 +71825,10 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/psych)
 "nIS" = (
-/turf/simulated/mineral,
-/area/nadezhda/command/swo/quarters)
+/obj/machinery/door/airlock/glass,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/medical/genetics)
 "nIZ" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -73030,7 +73103,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "nWN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/landmark/join/start/officer,
@@ -73044,7 +73117,7 @@
 	req_one_access = list(24,10)
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "nWU" = (
 /obj/machinery/optable,
 /obj/machinery/camera/network/mining,
@@ -73186,6 +73259,10 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"nYy" = (
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "nYz" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/regular,
@@ -73200,7 +73277,7 @@
 	id_tag = "coolant_sensor"
 	},
 /turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "nYD" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering";
@@ -73260,7 +73337,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "nYR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/mining{
@@ -73503,7 +73580,7 @@
 	},
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "oaN" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -74171,7 +74248,7 @@
 	req_one_access = list(24,10)
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "ogi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -74188,7 +74265,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "ogl" = (
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -75150,7 +75227,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "opS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -76119,6 +76196,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
+"oyN" = (
+/obj/machinery/washing_machine,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/towel,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "oyO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -76229,7 +76320,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "ozP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -76255,7 +76346,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "oAm" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -76431,7 +76522,7 @@
 "oBK" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "oBL" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall20";
@@ -76869,7 +76960,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "oFT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -77098,7 +77189,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "oIu" = (
 /obj/structure/table/rack/shelf,
 /obj/random/lowkeyrandom/low_chance,
@@ -77500,7 +77591,7 @@
 /obj/effect/floor_decal/industrial/box,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "oLQ" = (
 /obj/machinery/suit_storage_unit/medical,
 /obj/machinery/light{
@@ -77508,6 +77599,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
+"oLT" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_pump,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "oLU" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -77679,7 +77775,7 @@
 "oOj" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "oOn" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -78353,12 +78449,14 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
 "oUV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
+/obj/machinery/camera/network/medbay{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
+/obj/structure/closet/wall_mounted{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "oVd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -78565,17 +78663,14 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
 "oYx" = (
-/obj/machinery/smartfridge/secure/medbay/organs/stocked,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "organ_shutter";
-	name = "Privacy Shutters";
-	opacity = 0
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "oYz" = (
 /obj/effect/floor_decal/border/techfloor,
@@ -78898,7 +78993,7 @@
 "pcz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "pcH" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -79537,9 +79632,28 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
 "pis" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "piv" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -79801,7 +79915,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "plu" = (
 /obj/structure/flora/small/trailrockb4,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -80355,7 +80469,7 @@
 "pqj" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "pqr" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/random/closet_maintloot/low_chance,
@@ -80373,7 +80487,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "pqy" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
@@ -80701,7 +80815,7 @@
 	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "puV" = (
 /obj/structure/table/reinforced,
 /obj/random/powercell,
@@ -80730,7 +80844,7 @@
 /area/nadezhda/outside/pond)
 "pvj" = (
 /turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "pvp" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stack/material/wood/random,
@@ -80791,17 +80905,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "pvK" = (
-/obj/machinery/keycard_auth,
-/obj/item/reagent_containers/enricher,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
-/obj/structure/table/marble,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/danger,
+/area/nadezhda/medical/genetics)
 "pvM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -81270,7 +81379,7 @@
 /obj/machinery/meter,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "pAw" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
@@ -81374,7 +81483,7 @@
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "pBI" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 2;
@@ -81383,10 +81492,9 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "pBL" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/bed/chair/sofa/black/left,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "pBN" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/floor_decal/spline/plain{
@@ -81589,9 +81697,14 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "pDo" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "pDr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 6;
@@ -81640,7 +81753,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "pDF" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -82271,7 +82384,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "pJg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/security{
@@ -82288,7 +82401,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "pJv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -82643,7 +82756,11 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
+"pNf" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/command/teleporter)
 "pNn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -83322,7 +83439,7 @@
 "pSN" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "pSZ" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -83667,7 +83784,7 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "pWR" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -83869,7 +83986,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "pYX" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -84086,7 +84203,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "qaR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -84185,7 +84302,7 @@
 	sensors = list("coolant_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "qbK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -84417,7 +84534,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "qeM" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -84657,7 +84774,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "qgq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -84915,7 +85032,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "qjf" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/dirt,
@@ -85369,7 +85486,7 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "qnt" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -85906,7 +86023,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "qtB" = (
 /turf/unsimulated/mineral,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "qtC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -86562,7 +86679,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "qzw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -86670,10 +86787,20 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security)
 "qAb" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/mirror{
+	dir = 8;
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/smc/quarters)
 "qAh" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -86721,7 +86848,7 @@
 "qAI" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "qAM" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/beach/sand,
@@ -86792,7 +86919,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "qBq" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -86913,6 +87040,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/crew_quarters/plasma_tag)
+"qDe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/research,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "qDg" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -87156,7 +87288,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/am_control_unit,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "qFw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/reinforced,
@@ -88395,7 +88527,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "qRZ" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -88664,18 +88796,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
-"qUj" = (
-/obj/machinery/holoposter{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	pixel_y = -10
-	},
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/main/stairwell)
 "qUn" = (
 /obj/structure/window/reinforced,
 /obj/structure/sink{
@@ -88693,7 +88813,7 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "qUt" = (
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -88732,16 +88852,9 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "qUE" = (
-/obj/machinery/button/remote/blast_door{
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	pixel_x = 1;
-	pixel_y = 23;
-	req_access = list(29)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/toilet,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "qUQ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -88829,7 +88942,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "qVw" = (
 /obj/structure/sign/department/shield{
 	name = "SHIELD GENERATOR";
@@ -89113,7 +89226,7 @@
 	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "qXO" = (
 /obj/structure/barricade,
 /obj/structure/grille,
@@ -89441,12 +89554,6 @@
 /obj/structure/cyberplant,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
-"raF" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
 "raH" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "14,23"
@@ -89543,7 +89650,7 @@
 "rbA" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "rbB" = (
 /obj/structure/grille,
 /obj/structure/barricade,
@@ -89778,7 +89885,7 @@
 /obj/item/am_containment,
 /obj/item/am_containment,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "rdp" = (
 /obj/structure/flora/small/trailrockb1,
 /turf/simulated/floor/rock,
@@ -90576,7 +90683,7 @@
 	},
 /obj/structure/lattice,
 /turf/simulated/floor/asteroid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "rlA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -90717,14 +90824,8 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/security/nuke_storage)
 "rmL" = (
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
-/obj/structure/closet/wall_mounted{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/atmos/storage)
 "rmM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -92305,6 +92406,12 @@
 /area/nadezhda/crew_quarters/dorm2{
 	name = "Dormitory 2"
 	})
+"rBK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "rBT" = (
 /obj/structure/multiz/ladder,
 /obj/machinery/light/small{
@@ -92312,7 +92419,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "rBV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -92557,7 +92664,7 @@
 "rDH" = (
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "rDJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/industrial/danger{
@@ -92723,7 +92830,7 @@
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "rFq" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -92740,7 +92847,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "rFu" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -92839,9 +92946,7 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rGo" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/tiled/white/monofloor,
+/turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/docking)
 "rGq" = (
 /obj/structure/reagent_dispensers/watertank/huge,
@@ -93168,7 +93273,7 @@
 "rKf" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "rKi" = (
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/centcom,
@@ -93252,10 +93357,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
-"rKH" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
 "rKL" = (
 /obj/structure/multiz/stairs,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -93476,7 +93577,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "rNq" = (
 /obj/machinery/computer{
 	dir = 4
@@ -93797,6 +93898,10 @@
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
+"rPN" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "rQd" = (
 /obj/structure/railing/grey{
 	dir = 4;
@@ -94067,7 +94172,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "rSp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/pottedplant/dead,
@@ -94304,20 +94409,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "rUO" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -11
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/mirror{
-	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "rUY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/fact_plaque,
@@ -94533,7 +94629,7 @@
 "rXb" = (
 /obj/structure/low_wall,
 /turf/simulated/floor/plating,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "rXi" = (
 /obj/structure/table/rack/shelf,
 /obj/item/roller{
@@ -94813,7 +94909,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "rZe" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -95150,7 +95246,7 @@
 	state = 2
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "sdl" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
@@ -95567,7 +95663,7 @@
 	req_access = list(5)
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "sgd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
@@ -95757,14 +95853,22 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "sij" = (
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/computer_hardware/hard_drive/portable/design/circuits,
+/obj/item/computer_hardware/hard_drive/portable/design/components,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/stack/material/steel/full,
+/obj/item/stack/material/glass{
+	amount = 120
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cyberplant,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/item/stack/material/plastic{
+	amount = 120
+	},
+/obj/item/paper/monitorkey,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/gmaster)
 "sik" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "16,17"
@@ -96045,15 +96149,10 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "slm" = (
-/obj/structure/medical_stand,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/item/tank/anesthetic,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "slo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -97049,7 +97148,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "svB" = (
 /obj/item/device/lighting/toggleable/lantern,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -97281,6 +97380,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/genetics)
+"sye" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "syp" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -97643,7 +97746,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/salvageable/server,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "sCQ" = (
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
@@ -97683,7 +97786,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "sDD" = (
 /obj/structure/flora/small/bushb1,
 /obj/random/flora/small_jungle_tree,
@@ -97777,7 +97880,7 @@
 	pixel_y = 29
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "sFd" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -98600,12 +98703,8 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
 "sNY" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/danger,
-/area/nadezhda/medical/genetics)
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/construction)
 "sOa" = (
 /obj/machinery/conveyor/east{
 	id = "disposals grinder"
@@ -98708,7 +98807,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "sOJ" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -99277,7 +99376,7 @@
 /area/nadezhda/command/panic_room)
 "sTU" = (
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "sTW" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
@@ -99441,7 +99540,7 @@
 "sUU" = (
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "sVa" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/random/closet_tech/low_chance,
@@ -99462,7 +99561,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "sVB" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = -32
@@ -100242,7 +100341,7 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "tcR" = (
 /obj/structure/toilet{
 	dir = 8
@@ -100448,7 +100547,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "tfk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -100814,13 +100913,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "tiO" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "tiQ" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
@@ -101925,7 +102024,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "tuV" = (
 /obj/machinery/light{
 	dir = 8
@@ -101954,6 +102053,10 @@
 /area/nadezhda/security{
 	name = "Security Training"
 	})
+"tvn" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/smc/quarters)
 "tvq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -102177,16 +102280,12 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "twP" = (
-/obj/structure/closet/chefcloset,
-/obj/item/soap/hunters,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/machinery/holoposter{
+	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "twT" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -103291,7 +103390,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "tIP" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 2;
@@ -103457,7 +103556,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "tKq" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/structure/cable/green{
@@ -103624,7 +103723,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "tMh" = (
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -104095,7 +104194,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/salvageable/server,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "tRb" = (
 /obj/structure/table/rack/shelf,
 /obj/item/reagent_containers/spray/cleaner,
@@ -104585,7 +104684,7 @@
 	sensors = list("coolant_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "tXJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -104641,13 +104740,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "tYl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/research)
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/nadezhda/engineering/construction)
 "tYm" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -104807,7 +104903,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "tZx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -104939,7 +105035,7 @@
 	},
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "uaw" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/port_gen/pacman/super/anchored,
@@ -105669,7 +105765,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "uhw" = (
 /obj/structure/barricade,
 /turf/simulated/wall/r_wall,
@@ -105709,7 +105805,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "uhF" = (
 /obj/machinery/camera/network/security{
 	dir = 4
@@ -105755,7 +105851,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/salvageable/server,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "uio" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/ids{
@@ -106002,7 +106098,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "ulw" = (
 /obj/structure/table/rack,
 /obj/item/tank/jetpack/oxygen,
@@ -107079,7 +107175,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "uvX" = (
 /obj/machinery/light{
 	dir = 8;
@@ -107838,6 +107934,12 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
+"uBN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/medical/genetics)
 "uBU" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -108275,6 +108377,9 @@
 /obj/structure/flora/small/grassb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"uGo" = (
+/turf/simulated/mineral,
+/area/eris/crew_quarters/kitchen_storage)
 "uGq" = (
 /obj/structure/girder/displaced,
 /obj/effect/decal/cleanable/dirt,
@@ -108994,6 +109099,9 @@
 "uNO" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"uNP" = (
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "uNR" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/sign/warningnew/danger{
@@ -109026,7 +109134,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "uOA" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/dark/golden,
@@ -109266,7 +109374,7 @@
 	},
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "uPX" = (
 /obj/structure/table/standard,
 /obj/item/storage/makeshift_grinder,
@@ -109339,7 +109447,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "uQI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -109591,7 +109699,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "uTj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -109970,7 +110078,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "uWm" = (
 /obj/machinery/floor_light,
 /obj/machinery/camera/network/plasma_tag{
@@ -109998,7 +110106,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "uWQ" = (
 /mob/living/simple_animal/cow{
 	name = "Betsy"
@@ -110158,7 +110266,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "uYx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -110429,7 +110537,7 @@
 /obj/effect/window_lwall_spawn,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vaK" = (
 /obj/structure/catwalk,
 /obj/random/cluster/spiders/low_chance,
@@ -110444,7 +110552,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vaT" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos/surface)
@@ -110604,7 +110712,7 @@
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "vcB" = (
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vcD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted,
@@ -110646,7 +110754,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vdm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -110813,6 +110921,9 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
+"vfw" = (
+/turf/simulated/mineral,
+/area/nadezhda/rnd/lab)
 "vfx" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -110988,7 +111099,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vhq" = (
 /obj/structure/table/woodentable,
 /obj/random/rations/low_chance,
@@ -111043,14 +111154,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/rocinante_shuttle_area)
 "vhU" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/main/stairwell)
 "via" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -111276,7 +111384,7 @@
 /obj/effect/floor_decal/industrial/box,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "vkp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -111385,7 +111493,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vli" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -111820,7 +111928,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "voK" = (
 /obj/machinery/camera/network/command{
 	dir = 1
@@ -112066,10 +112174,14 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "vrz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/rnd/research)
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cyberplant,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "vrB" = (
 /obj/machinery/camera/network/plasma_tag{
 	dir = 4
@@ -113131,7 +113243,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vBd" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -113550,7 +113662,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vFG" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/toolbox/electrical,
@@ -113739,13 +113851,13 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vHb" = (
 /obj/machinery/atmospherics/binary/pump/high_power,
 /obj/effect/floor_decal/industrial/box,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "vHf" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
@@ -113783,7 +113895,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vHy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -113799,7 +113911,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vHJ" = (
 /obj/structure/salvageable/computer,
 /turf/simulated/floor/tiled/cafe,
@@ -113850,7 +113962,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vIw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -114290,7 +114402,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vMQ" = (
 /obj/machinery/newscaster{
 	pixel_x = -30;
@@ -114373,7 +114485,7 @@
 "vNF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "vNG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -114403,7 +114515,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vNL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -114510,7 +114622,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "vPc" = (
 /obj/machinery/door/airlock/vault/bolted{
 	name = "LaunchRail Elevator maint"
@@ -114665,7 +114777,7 @@
 "vQv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "vQy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/chair/office/light{
@@ -114765,7 +114877,7 @@
 "vRh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "vRo" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -114790,10 +114902,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vRw" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "vRz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/coatrack,
@@ -115158,7 +115269,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "vVf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -115346,7 +115457,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vWQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junkfood/rotten/low_chance,
@@ -115611,7 +115722,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vYT" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/quartermaster/disposaldrop)
@@ -115625,7 +115736,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vZg" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 8
@@ -115657,7 +115768,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "vZq" = (
 /obj/structure/table/standard,
 /obj/random/tool,
@@ -115838,7 +115949,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "wbD" = (
 /obj/structure/catwalk,
 /obj/random/scrap/dense_weighted,
@@ -116010,7 +116121,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "wdj" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1;
@@ -117136,7 +117247,7 @@
 /area/nadezhda/medical/cryo)
 "woq" = (
 /turf/simulated/floor/asteroid,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "wow" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -117293,7 +117404,7 @@
 /obj/effect/floor_decal/industrial/box,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "wpL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -117765,7 +117876,7 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "wtE" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -117837,7 +117948,7 @@
 	pixel_x = 31
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "wum" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -118609,7 +118720,7 @@
 "wAV" = (
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/engineering/construction)
+/area/nadezhda/command/teleporter)
 "wBa" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/tactical_blackshield)
@@ -118767,7 +118878,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "wCC" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/item/device/kit/paint/rust_ivan,
@@ -119085,7 +119196,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "wFw" = (
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/asteroid/dirt,
@@ -119121,7 +119232,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "wFV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -119159,7 +119270,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "wGm" = (
 /obj/structure/table/rack/shelf,
 /obj/random/costume,
@@ -119664,7 +119775,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "wMt" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 1
@@ -119860,7 +119971,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "wPb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -121483,10 +121594,9 @@
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "xfm" = (
-/obj/structure/catwalk,
-/obj/structure/lattice,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/medical/genetics)
 "xfv" = (
 /obj/structure/railing{
 	dir = 8
@@ -121821,6 +121931,12 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"xjC" = (
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "xjG" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/nuke_storage{
@@ -123650,7 +123766,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "xCb" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/asteroid/grass,
@@ -123788,7 +123904,7 @@
 	icon_state = "32-1"
 	},
 /turf/simulated/open,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "xCR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -125131,7 +125247,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "xOT" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -125253,7 +125369,7 @@
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/electrical,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "xQm" = (
 /obj/structure/catwalk,
 /obj/random/cluster/spiders,
@@ -125510,12 +125626,6 @@
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
-"xTe" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/medical/genetics)
 "xTj" = (
 /obj/machinery/atm{
 	dir = 1;
@@ -125604,11 +125714,15 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
 "xUa" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "guild_lobby";
+	name = "Guild Lobby shutter control";
+	pixel_y = -21
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/smc/quarters)
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/engineering/foyer)
 "xUe" = (
 /obj/structure/table/bench/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -126171,7 +126285,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "xYO" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
@@ -126442,7 +126556,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "ycP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -126627,7 +126741,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/construction)
 "yex" = (
 /obj/structure/table/woodentable,
 /obj/item/clothing/accessory/magatama,
@@ -127067,7 +127181,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/atmos/storage)
 "yjy" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
@@ -133687,10 +133801,10 @@ kse
 axa
 oGw
 oGw
-nIS
-nIS
-nIS
-nIS
+nuq
+nuq
+nuq
+nuq
 clN
 htx
 wyz
@@ -133883,16 +133997,16 @@ euZ
 fxu
 uCp
 oGw
-pis
+erb
 uqn
 kNT
-aar
+nju
 oGw
 oGw
-nIS
-nIS
-nIS
-nIS
+nuq
+nuq
+nuq
+nuq
 clN
 pPv
 vgt
@@ -134091,10 +134205,10 @@ otZ
 oGw
 oGw
 oGw
-nIS
-nIS
-nIS
-nIS
+nuq
+nuq
+nuq
+nuq
 clN
 jtl
 vgt
@@ -134293,10 +134407,10 @@ bhK
 xyW
 oGw
 oGw
-nIS
-nIS
-nIS
-nIS
+nuq
+nuq
+nuq
+nuq
 clN
 uVh
 wQo
@@ -136514,7 +136628,7 @@ aZK
 rzW
 ygi
 ths
-iQA
+knb
 puh
 tmw
 aen
@@ -140984,9 +141098,9 @@ cwr
 efY
 ptB
 vnv
-nkn
-nkn
-nkn
+uGo
+uGo
+uGo
 vnv
 iof
 fNh
@@ -141186,9 +141300,9 @@ cwr
 wLd
 bwh
 vnv
-nkn
-nkn
-nkn
+uGo
+uGo
+uGo
 vnv
 wSq
 gAA
@@ -141388,9 +141502,9 @@ cwr
 cyr
 bwh
 vnv
-nkn
-nkn
-nkn
+uGo
+uGo
+uGo
 vnv
 pLL
 jdf
@@ -141792,9 +141906,9 @@ cwr
 jps
 bwh
 vnv
-twP
+dHg
 rgG
-lOw
+sye
 vnv
 jdf
 pHC
@@ -144175,7 +144289,7 @@ jIc
 dCw
 koE
 koE
-mfr
+jRF
 sTw
 hdF
 sTw
@@ -150664,12 +150778,12 @@ quV
 ces
 ces
 pEa
-pBL
+slm
 bwh
 kEP
 pVB
 ryn
-vrz
+aMS
 cqa
 tna
 hWD
@@ -151075,7 +151189,7 @@ gbk
 ryn
 aDp
 wWY
-tYl
+aJA
 mgf
 kgt
 mgf
@@ -151271,7 +151385,7 @@ bwh
 bwh
 dXF
 nyE
-qUE
+iAP
 bwh
 pVB
 rfF
@@ -151466,7 +151580,7 @@ vot
 jVE
 sEU
 vKw
-sij
+vrz
 vKw
 sFC
 mgk
@@ -154104,7 +154218,7 @@ wBQ
 jGM
 mzB
 bxY
-dwV
+fEL
 bxY
 olZ
 wBQ
@@ -154306,7 +154420,7 @@ nak
 wBQ
 uVq
 bxY
-dwV
+fEL
 bxY
 xVr
 wBQ
@@ -154508,7 +154622,7 @@ ljg
 aHG
 wXg
 bxY
-dwV
+fEL
 bxY
 bxY
 bxY
@@ -154898,7 +155012,7 @@ npT
 npT
 qql
 hwH
-knb
+vfw
 pTU
 sLE
 vnK
@@ -155100,7 +155214,7 @@ npT
 npT
 hGh
 hwH
-knb
+vfw
 pTU
 osd
 adZ
@@ -155294,20 +155408,20 @@ hwH
 hwH
 hwH
 hwH
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 fpY
 fpY
-aXo
-aXo
+gfQ
+gfQ
 apH
 eXK
 tdk
@@ -155496,8 +155610,8 @@ kPM
 tBu
 xtr
 hwH
-aXo
-ebi
+gfQ
+pNf
 bFV
 sUU
 vNF
@@ -155505,11 +155619,11 @@ eHH
 pcz
 bFV
 vNF
-aXo
 gfQ
 kFt
+kdN
 edf
-aXo
+gfQ
 uKJ
 eXK
 rlO
@@ -155698,9 +155812,9 @@ muL
 dWy
 dWy
 hwH
-aXo
-ebi
-ebi
+gfQ
+pNf
+pNf
 iei
 vNF
 ddm
@@ -155711,7 +155825,7 @@ vNF
 bFV
 vNF
 edf
-aXo
+gfQ
 uKJ
 eXK
 kNz
@@ -155900,12 +156014,12 @@ lnY
 pTT
 xCe
 hwH
-aXo
+gfQ
 ink
-ebi
+pNf
 vNF
 vNF
-aXo
+gfQ
 bFV
 wAV
 bFV
@@ -155913,7 +156027,7 @@ vNF
 oBK
 vNF
 sdg
-aXo
+gfQ
 emn
 eXK
 mRe
@@ -156102,20 +156216,20 @@ gMd
 gMd
 mAO
 hwH
-aXo
+gfQ
 dYD
 nWL
 eDL
 bFV
-aXo
+gfQ
 pcz
 vNF
 vNF
 vNF
 liV
 bFV
-ebi
-aXo
+pNf
+gfQ
 emn
 eXK
 oOW
@@ -156304,20 +156418,20 @@ gMd
 gnf
 jSx
 hwH
-aXo
+gfQ
 hbk
 iAT
 eDL
 kKh
-aXo
+gfQ
 vNF
 bFV
 vNF
 iei
 bFV
 vNF
-ebi
-aXo
+pNf
+gfQ
 uKJ
 eXK
 eXK
@@ -156506,20 +156620,20 @@ ybt
 wOU
 jTJ
 hwH
-aXo
+gfQ
 eHn
 eDL
 eDL
 kKh
-aXo
+gfQ
 iJO
 vNF
 vNF
 bFV
 bFV
 vNF
-ebi
-aXo
+pNf
+gfQ
 emn
 eXK
 eXK
@@ -156708,20 +156822,20 @@ dWy
 dWy
 wvV
 hwH
-aXo
-ebi
+gfQ
+pNf
 bFV
 uhv
 kKh
-aXo
+gfQ
 vNF
 sUU
 iei
 djA
 vNF
 liV
-ebi
-aXo
+pNf
+gfQ
 cal
 eXK
 eXK
@@ -156910,20 +157024,20 @@ dWy
 dWy
 uhx
 hwH
-aXo
-aXo
+gfQ
+gfQ
 sgc
 sgc
-aXo
-aXo
+gfQ
+gfQ
 bFV
 pcz
 vNF
-aXo
+gfQ
 bFV
 vNF
-ebi
-aXo
+pNf
+gfQ
 emn
 eXK
 uqW
@@ -157117,15 +157231,15 @@ nyx
 hxQ
 mBY
 nyx
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 uKJ
 eXK
 uqW
@@ -157360,7 +157474,7 @@ kOj
 cAG
 hYY
 qhV
-bmp
+oYx
 sMW
 wEF
 wzo
@@ -157764,8 +157878,8 @@ xxZ
 mrS
 hYY
 hYY
-mPf
-oYx
+gkI
+nGx
 hYY
 yhV
 oxv
@@ -157965,9 +158079,9 @@ ihS
 ihS
 gLl
 hYY
-rGo
-eAm
-izV
+oLT
+cTu
+fkp
 hYY
 evS
 cSs
@@ -158167,9 +158281,9 @@ ihS
 ihS
 gLl
 hYY
-qAb
-lGo
-nuq
+mUe
+rUO
+bnm
 hYY
 lop
 ffD
@@ -158369,9 +158483,9 @@ ihS
 ihS
 gLl
 hYY
-mTr
-haw
-nGY
+nYy
+rGo
+lgB
 hYY
 lop
 qdj
@@ -158571,9 +158685,9 @@ vnu
 vnu
 vTA
 hYY
-slm
-rmL
-rKH
+nkn
+oUV
+rPN
 hYY
 lop
 qdj
@@ -180513,7 +180627,7 @@ cEg
 iJv
 sFI
 sFI
-aMS
+hVm
 sFI
 sFI
 sFI
@@ -181124,9 +181238,9 @@ hSx
 hSx
 hSx
 ajL
-kIk
+jEl
 cUV
-xUa
+iQA
 vXl
 ajL
 bZz
@@ -181526,7 +181640,7 @@ sFI
 hSx
 ajL
 cui
-rUO
+qAb
 fkR
 iXB
 rsG
@@ -181930,7 +182044,7 @@ sFI
 hSx
 ajL
 ajL
-cTu
+tvn
 ajL
 ajL
 ajL
@@ -188034,7 +188148,7 @@ tnX
 gzz
 qHW
 ien
-jud
+kmK
 tnX
 tnX
 tnX
@@ -188236,7 +188350,7 @@ tnX
 wmW
 lBH
 ybv
-lgB
+izV
 tnX
 tnX
 tnX
@@ -188438,7 +188552,7 @@ oqp
 tZy
 knf
 jjx
-qUj
+cpp
 tnX
 tnX
 xCT
@@ -188612,7 +188726,7 @@ hSx
 jXV
 kAs
 kCX
-vhU
+pDo
 jXV
 jXV
 jXV
@@ -188638,8 +188752,8 @@ pvV
 gfF
 pGr
 vgG
-cOK
-oUV
+vhU
+mfO
 ezt
 vpQ
 tnX
@@ -188814,7 +188928,7 @@ hSx
 jXV
 lSs
 kCX
-ctU
+dwV
 mmA
 mZG
 mZG
@@ -189044,7 +189158,7 @@ eRx
 kuC
 uFs
 iyT
-cIp
+xUa
 eRx
 eRx
 sFI
@@ -189216,7 +189330,7 @@ hSx
 jXV
 uVy
 nEk
-ayP
+csb
 nEk
 nEk
 nGc
@@ -189418,7 +189532,7 @@ hSx
 jXV
 dna
 nEk
-bPW
+cIp
 nEk
 nFp
 jXV
@@ -189622,7 +189736,7 @@ iMl
 nEk
 nEk
 nEk
-egi
+sij
 jXV
 jXV
 jXV
@@ -190030,7 +190144,7 @@ jXV
 jXV
 jXV
 nHc
-byG
+egi
 pdZ
 pef
 jXV
@@ -190425,8 +190539,8 @@ gFp
 gFp
 gFp
 gFp
-xfm
-xfm
+mfr
+mfr
 eTA
 etI
 eaA
@@ -191883,7 +191997,7 @@ sFI
 sFI
 sFI
 ula
-lri
+qDe
 mJX
 lUt
 lUt
@@ -192085,12 +192199,12 @@ sFI
 sFI
 sFI
 ula
-mfO
+xfm
 vdO
 kYV
 lUt
 erA
-dmY
+lOw
 elK
 wiD
 nBx
@@ -192287,12 +192401,12 @@ sFI
 sFI
 sFI
 ula
-mfO
+xfm
 duz
 pzU
 lUt
 xCY
-buz
+xjC
 elK
 xGJ
 baD
@@ -192489,7 +192603,7 @@ sFI
 sFI
 sFI
 ula
-mfO
+xfm
 vDI
 tHC
 lUt
@@ -192890,8 +193004,8 @@ sFI
 sFI
 ula
 ula
-vRw
 lDb
+icP
 ula
 iEU
 wpS
@@ -193104,7 +193218,7 @@ iBc
 elK
 sfN
 owe
-pvK
+fMq
 cNm
 aXb
 elK
@@ -193292,7 +193406,7 @@ sFI
 sFI
 sFI
 sFI
-mfO
+xfm
 oou
 gFS
 fMv
@@ -193495,8 +193609,8 @@ sFI
 sFI
 sFI
 ula
-nju
-xTe
+fqN
+uBN
 sOu
 hcZ
 dTZ
@@ -193504,7 +193618,7 @@ hcZ
 qNV
 via
 iwx
-fnd
+cOK
 elK
 aRo
 qOO
@@ -193910,10 +194024,10 @@ vUw
 dOH
 xct
 elK
-hVm
+pBL
 wGD
 rQQ
-raF
+eAm
 tif
 elK
 cEd
@@ -194070,12 +194184,12 @@ eyR
 eyR
 eyR
 eyR
-crV
-crV
-crV
-crV
-crV
-eyR
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
 eyR
 eyR
 eyR
@@ -194106,7 +194220,7 @@ ula
 vLP
 fKY
 eKe
-sNY
+pvK
 eKe
 eKe
 mnX
@@ -194272,12 +194386,12 @@ crV
 crV
 crV
 crV
-crV
+rmL
 qjd
 qUs
 eYh
-crV
-crV
+rmL
+rmL
 sap
 suz
 sUk
@@ -194311,7 +194425,7 @@ fHX
 nvm
 jQf
 eKe
-fEL
+aPG
 elK
 elK
 lHP
@@ -194474,12 +194588,12 @@ kIJ
 crV
 crV
 crV
-crV
+rmL
 qjd
 pvj
 pvj
-crV
-crV
+rmL
+rmL
 sds
 swU
 sUT
@@ -194676,12 +194790,12 @@ kIJ
 crV
 crV
 crV
-crV
-crV
-crV
+rmL
+rmL
+rmL
 rDH
-crV
-crV
+rmL
+rmL
 sap
 suz
 sWf
@@ -194719,7 +194833,7 @@ fgH
 elK
 sUl
 ilQ
-cpp
+lri
 elK
 eXm
 eXm
@@ -194878,12 +194992,12 @@ mcp
 crV
 crV
 crV
-crV
+rmL
 qnl
 qXK
 pvj
-crV
-crV
+rmL
+rmL
 eyR
 syO
 sWk
@@ -195080,12 +195194,12 @@ hCc
 crV
 htp
 crV
-crV
-crV
-crV
+rmL
+rmL
+rmL
 rFs
-crV
-crV
+rmL
+rmL
 eyR
 szY
 tbJ
@@ -195282,21 +195396,21 @@ hDG
 fnf
 htp
 crV
-crV
+rmL
 qnl
 qXK
 eCB
-crV
-crV
+rmL
+rmL
 eyR
 sDt
 tbW
 eyR
-crV
+rmL
 uPV
 vHa
 wFS
-crV
+rmL
 sFI
 sFI
 sFI
@@ -195484,21 +195598,21 @@ hFt
 foZ
 crV
 crV
-crV
-crV
-crV
+rmL
+rmL
+rmL
 vld
-crV
-crV
+rmL
+rmL
 eyR
 eyR
 eyR
 eyR
-crV
+rmL
 tiM
 ult
 wFu
-crV
+rmL
 sFI
 sFI
 sFI
@@ -195688,19 +195802,19 @@ nfA
 fJR
 ogf
 plt
-fJR
-fJR
-nfA
-fJl
+uNP
+uNP
+ivN
+dCT
 tuU
 vZd
 bYE
 jPJ
 iVn
-fJR
+uNP
 ult
 uYr
-crV
+rmL
 sFI
 sFI
 sFI
@@ -195723,7 +195837,7 @@ ssK
 cZB
 cZB
 hQV
-nGx
+nIS
 xCY
 edz
 rPf
@@ -195902,7 +196016,7 @@ sVf
 uQF
 vHx
 wGk
-crV
+rmL
 sFI
 sFI
 sFI
@@ -196090,21 +196204,21 @@ hLF
 gBS
 lac
 fJR
-eXx
+gdC
 oOj
 pqj
 pSN
 qAI
 rbA
 rKf
-crV
-crV
-crV
-crV
+rmL
+rmL
+rmL
+rmL
 tiM
 vHy
 bVn
-crV
+rmL
 sFI
 sFI
 sFI
@@ -196292,21 +196406,21 @@ hLF
 gBS
 lac
 fsR
-crV
+rmL
 oOj
 pqj
 pSN
 qAI
 rbA
 rKf
-crV
-crV
-crV
-crV
+rmL
+rmL
+rmL
+rmL
 tfh
 vHy
 uYr
-crV
+rmL
 sFI
 sFI
 sFI
@@ -196494,21 +196608,21 @@ mcr
 gBS
 lac
 fKn
-crV
+rmL
 oOj
 pqj
 pWO
 qBj
 rbA
 rKf
-crV
-crV
-crV
-crV
+rmL
+rmL
+rmL
+rmL
 tfh
 vHy
 uYr
-crV
+rmL
 sFI
 sFI
 sFI
@@ -196546,7 +196660,7 @@ kSF
 bqs
 klk
 ldZ
-gab
+bmp
 mea
 cZm
 klk
@@ -196672,13 +196786,13 @@ sFI
 sFI
 sFI
 sFI
-crV
-crV
-crV
-crV
-crV
-crV
-crV
+aXo
+aXo
+aXo
+aXo
+aXo
+aXo
+aXo
 crV
 crV
 fzC
@@ -196703,14 +196817,14 @@ crV
 crV
 crV
 crV
-crV
+rmL
 epg
 tKp
 dvQ
 gNi
 uOb
 cSt
-crV
+rmL
 sFI
 sFI
 sFI
@@ -196874,13 +196988,13 @@ sFI
 sFI
 sFI
 sFI
-crV
+aXo
 kpR
 eFO
 evz
 fpj
-crV
-crV
+aXo
+aXo
 crV
 crV
 fDb
@@ -196905,14 +197019,14 @@ qnP
 qYk
 qqy
 crV
-crV
-fJR
-vQv
+rmL
+uNP
+edD
 qeK
-vQv
+edD
 vIm
 cSt
-crV
+rmL
 sFI
 sFI
 sFI
@@ -197070,19 +197184,19 @@ hSx
 hSx
 hSx
 sFI
-crV
-crV
-crV
-crV
-crV
-crV
-crV
+aXo
+aXo
+aXo
+aXo
+aXo
+aXo
+aXo
 mbk
-crV
-crV
+aXo
+aXo
 bnl
-crV
-crV
+aXo
+aXo
 crV
 crV
 fDm
@@ -197107,14 +197221,14 @@ qqy
 qYD
 rHH
 crV
-crV
-vQv
-vQv
-vQv
-fJR
+rmL
+edD
+edD
+edD
+uNP
 uOb
 cSt
-crV
+rmL
 sFI
 sFI
 sFI
@@ -197272,16 +197386,16 @@ hSx
 hSx
 hSx
 sFI
-crV
+aXo
 czX
 vQv
 iNR
-crV
-rdU
-rdU
+aXo
+tYl
+tYl
 nWT
-rdU
-crV
+tYl
+aXo
 cDI
 vQv
 edQ
@@ -197309,14 +197423,14 @@ qrF
 qqy
 qqy
 crV
-crV
+rmL
 cAU
 tKp
 dvQ
 uWe
 uOb
 hSq
-crV
+rmL
 sFI
 sFI
 sFI
@@ -197474,8 +197588,8 @@ hSx
 hSx
 hSx
 sFI
-crV
-crV
+aXo
+aXo
 lEE
 wtC
 ehu
@@ -197484,7 +197598,7 @@ frE
 sDA
 cSu
 dkl
-jyi
+nGY
 fIX
 ega
 crV
@@ -197511,14 +197625,14 @@ crV
 crV
 crV
 crV
-crV
+rmL
 jiD
 tKp
 uim
 uWK
 uOb
 nja
-crV
+rmL
 sFI
 sFI
 sFI
@@ -197676,16 +197790,16 @@ hSx
 hSx
 hSx
 sFI
-crV
+aXo
 mHa
 vQv
 ycE
-crV
+aXo
 wMn
 wMn
 nYB
 wMn
-crV
+aXo
 cTX
 dOT
 ehJ
@@ -197713,14 +197827,14 @@ crV
 crV
 crV
 crV
-crV
-fJR
-vQv
-vQv
-vQv
+rmL
+uNP
+edD
+edD
+edD
 jkc
 cSt
-crV
+rmL
 sFI
 sFI
 sFI
@@ -197757,7 +197871,7 @@ aqG
 pPS
 xAN
 klk
-iAP
+qUE
 kzc
 vZI
 klk
@@ -197878,16 +197992,16 @@ hSx
 hSx
 hSx
 sFI
-crV
+aXo
 mHa
-fJR
+sNY
 ycE
-crV
+aXo
 wMn
 wMn
 wMn
 wMn
-crV
+aXo
 dZp
 dOT
 eqj
@@ -197915,14 +198029,14 @@ crV
 crV
 crV
 crV
-crV
+rmL
 aqp
-vQv
-vQv
-vQv
+edD
+edD
+edD
 uOb
 cSt
-crV
+rmL
 sFI
 sFI
 sFI
@@ -197959,7 +198073,7 @@ eXm
 caY
 emo
 klk
-fkp
+bPW
 tYV
 tYV
 xKU
@@ -198080,11 +198194,11 @@ hSx
 hSx
 hSx
 sFI
-crV
+aXo
 ezW
 vQv
 ycE
-rdU
+tYl
 fwb
 ipN
 wMn
@@ -198117,14 +198231,14 @@ crV
 crV
 crV
 crV
-crV
+rmL
 sCP
 tKp
 uim
 uWe
 vIm
 cSt
-crV
+rmL
 sFI
 sFI
 sFI
@@ -198282,15 +198396,15 @@ hSx
 hSx
 hSx
 sFI
-crV
-crV
+aXo
+aXo
 ceS
 svA
-crV
-rdU
-rdU
+aXo
+tYl
+tYl
 cGr
-rdU
+tYl
 dku
 dAV
 ctI
@@ -198319,14 +198433,14 @@ crV
 crV
 crV
 crV
-crV
+rmL
 epg
 tKp
 dvQ
 uWK
 vMK
 pBF
-crV
+rmL
 sFI
 sFI
 sFI
@@ -198485,7 +198599,7 @@ hSx
 hSx
 sFI
 sFI
-crV
+aXo
 vQv
 uhD
 gcc
@@ -198495,7 +198609,7 @@ cHc
 fRt
 wpH
 iYq
-fJR
+sNY
 pDA
 crV
 faL
@@ -198521,14 +198635,14 @@ crV
 crV
 crV
 crV
-crV
+rmL
 iRm
-vQv
-vQv
-vQv
+edD
+edD
+edD
 jkc
 cSt
-crV
+rmL
 sFI
 sFI
 sFI
@@ -198687,7 +198801,7 @@ hSx
 hSx
 sFI
 sFI
-crV
+aXo
 vQv
 uhD
 vkn
@@ -198723,14 +198837,14 @@ crV
 crV
 crV
 crV
-crV
+rmL
 ozO
-vQv
-vQv
-vQv
+edD
+edD
+edD
 jkc
 nmW
-crV
+rmL
 sFI
 sFI
 sFI
@@ -198889,18 +199003,18 @@ hSx
 hSx
 sFI
 sFI
-crV
+aXo
 sOI
 oLP
-fJR
+sNY
 ctI
 vQv
 cLN
-fJR
+sNY
 vQv
 uTf
 dSI
-crV
+aXo
 crV
 fcr
 fKt
@@ -198925,14 +199039,14 @@ qsu
 qZy
 qsL
 crV
-crV
+rmL
 qzn
 tKp
 dvQ
 uWe
 vIm
 nja
-crV
+rmL
 sFI
 sFI
 sFI
@@ -199091,7 +199205,7 @@ hSx
 hSx
 sFI
 sFI
-crV
+aXo
 cer
 pAr
 lIO
@@ -199102,7 +199216,7 @@ uTf
 uTf
 uTf
 dTG
-crV
+aXo
 eEy
 wbv
 fea
@@ -199127,14 +199241,14 @@ qsL
 qZS
 rHX
 crV
-crV
+rmL
 cAU
 dvQ
 tKp
 tQX
 vIm
 cSt
-crV
+rmL
 sFI
 sFI
 sFI
@@ -199293,7 +199407,7 @@ hSx
 hSx
 sFI
 sFI
-crV
+aXo
 uTf
 uTf
 opP
@@ -199329,14 +199443,14 @@ qvf
 qsL
 qsL
 crV
-crV
-vQv
+rmL
+edD
 qeK
-vQv
-vQv
+edD
+edD
 jkc
 cSt
-crV
+rmL
 sFI
 sFI
 sFI
@@ -199495,7 +199609,7 @@ hSx
 hSx
 sFI
 sFI
-crV
+aXo
 cTP
 kyL
 lIO
@@ -199506,7 +199620,7 @@ vHb
 dmz
 vQv
 dUb
-crV
+aXo
 eHm
 fio
 fNR
@@ -199531,14 +199645,14 @@ crV
 crV
 crV
 crV
-crV
-fJR
-vQv
-vQv
-vQv
+rmL
+uNP
+edD
+edD
+edD
 vIm
 cSt
-crV
+rmL
 sFI
 sFI
 sFI
@@ -199697,18 +199811,18 @@ hSx
 hSx
 sFI
 sFI
-crV
+aXo
 oLP
 vQv
 vQv
-uYr
-fJR
-uYr
+cgQ
+sNY
+cgQ
 daX
 doc
 vQv
 dUb
-crV
+aXo
 crV
 fkv
 crV
@@ -199733,14 +199847,14 @@ edv
 edv
 edv
 edv
-crV
+rmL
 sCP
 dvQ
 dvQ
 uWe
 uOb
 hSq
-crV
+rmL
 sFI
 sFI
 sFI
@@ -199899,21 +200013,21 @@ hSx
 hSx
 sFI
 sFI
-crV
+aXo
 nYP
 pJa
 pJa
 pJs
-gNL
+aar
 xYJ
 pJa
 dsf
 iaX
 dVz
-crV
-crV
+aXo
+rmL
 fkz
-crV
+rmL
 crV
 hrW
 ibB
@@ -199931,18 +200045,18 @@ crV
 crV
 edv
 edv
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-uOb
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+pis
 cSt
-crV
+rmL
 sFI
 sFI
 sFI
@@ -200101,7 +200215,7 @@ hSx
 hSx
 sFI
 sFI
-crV
+aXo
 tiO
 puU
 mXQ
@@ -200112,10 +200226,10 @@ aFU
 fDK
 yew
 uvV
-crV
-crV
+aXo
+rmL
 fkz
-crV
+rmL
 crV
 crV
 foZ
@@ -200133,18 +200247,18 @@ crV
 crV
 edv
 edv
-crV
+rmL
 qFu
 ktS
 rdn
 gWS
 bMY
-crV
+rmL
 nzt
 vaJ
 vWJ
 qRU
-crV
+rmL
 sFI
 sFI
 sFI
@@ -200303,21 +200417,21 @@ hSx
 hSx
 sFI
 sFI
-crV
-crV
-crV
-crV
-crV
+aXo
+aXo
+aXo
+aXo
+aXo
 nAC
 lXa
 qgn
 rXb
 hTt
 mpd
-crV
-crV
+aXo
+rmL
 fkz
-crV
+rmL
 crV
 crV
 fnf
@@ -200335,18 +200449,18 @@ crV
 crV
 edv
 edv
-crV
+rmL
 dhV
-vQv
+edD
 nfR
 lHh
 voJ
-crV
+rmL
 vFD
-crV
+rmL
 gnF
 hmw
-crV
+rmL
 sFI
 sFI
 sFI
@@ -200509,17 +200623,17 @@ sFI
 sFI
 sFI
 sFI
-crV
+aXo
 qbD
 qaO
 pYQ
 rXb
 vUX
 dSy
-crV
-crV
+aXo
+rmL
 fkz
-crV
+rmL
 crV
 htp
 crV
@@ -200537,18 +200651,18 @@ crV
 crV
 edv
 edv
-crV
-sOI
-vQv
+rmL
+izx
+edD
 nfR
 xQh
 gAJ
-crV
+rmL
 dZR
-crV
+rmL
 vYR
 tMg
-crV
+rmL
 sFI
 sFI
 sFI
@@ -200711,17 +200825,17 @@ sFI
 sFI
 sFI
 sFI
-crV
+aXo
 ljT
 bbw
 pNb
 rXb
 wCw
 eRZ
-crV
-crV
+aXo
+rmL
 fkz
-crV
+rmL
 crV
 crV
 rdU
@@ -200739,9 +200853,9 @@ crV
 crV
 edv
 edv
-crV
-fJR
-vQv
+rmL
+uNP
+edD
 kpB
 msY
 kXq
@@ -200750,7 +200864,7 @@ lBf
 knO
 eaB
 tMg
-crV
+rmL
 sFI
 sFI
 sFI
@@ -200913,17 +201027,17 @@ sFI
 sFI
 sFI
 sFI
-crV
-crV
-crV
-crV
-crV
+aXo
+aXo
+aXo
+aXo
+aXo
 iiD
 jGP
-crV
-crV
+aXo
+rmL
 fkz
-crV
+rmL
 crV
 crV
 rdU
@@ -200941,18 +201055,18 @@ crV
 crV
 edv
 edv
-crV
-ctI
-vQv
+rmL
+mXT
+edD
 bLa
-fJR
-vQv
+uNP
+edD
 oaM
 lvl
 vcB
 vZm
 tZv
-crV
+rmL
 sFI
 sFI
 sFI
@@ -201119,13 +201233,13 @@ sFI
 sFI
 sFI
 sFI
-crV
+aXo
 sFa
 hFA
-crV
-crV
+aXo
+rmL
 gPx
-crV
+rmL
 crV
 crV
 rdU
@@ -201143,20 +201257,20 @@ edv
 edv
 edv
 edv
-crV
-tiO
+rmL
+rBK
 ogj
 don
 rNo
 rFl
-crV
+rmL
 dZR
-crV
+rmL
 iyq
 tMg
-crV
-crV
-crV
+rmL
+rmL
+rmL
 sFI
 sFI
 sFI
@@ -201321,13 +201435,13 @@ sFI
 sFI
 sFI
 sFI
-crV
-gBS
+aXo
+ebi
 kCU
-crV
-crV
+aXo
+rmL
 fkz
-crV
+rmL
 crV
 crV
 crV
@@ -201346,19 +201460,19 @@ edv
 ohm
 qbq
 cnc
-vQv
+edD
 hCV
-vQv
+edD
 vhk
-vQv
-crV
+edD
+rmL
 vFD
-crV
+rmL
 tIO
 tMg
 xBY
 rBT
-crV
+rmL
 sFI
 sFI
 sFI
@@ -201523,13 +201637,13 @@ sFI
 sFI
 sFI
 sFI
-crV
-gBS
+aXo
+ebi
 kCU
-crV
-crV
+aXo
+rmL
 fkz
-crV
+rmL
 crV
 crV
 crV
@@ -201547,20 +201661,20 @@ ohm
 edv
 edv
 qbK
-crV
-vQv
+rmL
+edD
 oAd
 kco
 qVq
 lGq
-crV
+rmL
 vFD
-crV
+rmL
 kRM
 gat
-crV
-crV
-crV
+rmL
+rmL
+rmL
 sFI
 sFI
 sFI
@@ -201725,44 +201839,44 @@ sFI
 sFI
 sFI
 sFI
-crV
-gBS
+aXo
+ebi
 kCU
-crV
-crV
+aXo
+rmL
 fkz
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
 lqr
-crV
+rmL
 wbB
 yju
-crV
-crV
-crV
+rmL
+rmL
+rmL
 sFI
 sFI
 sFI
@@ -201927,11 +202041,11 @@ sFI
 sFI
 sFI
 sFI
-crV
-gBS
+aXo
+ebi
 kCU
-crV
-crV
+aXo
+rmL
 flD
 fRn
 fRn
@@ -201964,7 +202078,7 @@ wdc
 dpo
 wOZ
 xCQ
-crV
+rmL
 sFI
 sFI
 sFI
@@ -202129,44 +202243,44 @@ sFI
 sFI
 sFI
 sFI
-crV
-gBS
+aXo
+ebi
 hFA
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
-crV
+aXo
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
+rmL
 sFI
 sFI
 sFI
@@ -202331,10 +202445,10 @@ sFI
 sFI
 sFI
 sFI
-crV
+aXo
 fpm
 jGP
-crV
+aXo
 sFI
 sFI
 sFI
@@ -202533,10 +202647,10 @@ sFI
 sFI
 sFI
 sFI
-crV
+aXo
 wuc
 xOR
-crV
+aXo
 sFI
 sFI
 sFI
@@ -202735,10 +202849,10 @@ sFI
 sFI
 sFI
 sFI
-crV
-crV
+aXo
+aXo
 gcA
-crV
+aXo
 sFI
 sFI
 sFI
@@ -234904,7 +235018,7 @@ qQZ
 hHU
 riw
 guj
-pDo
+jkb
 qQZ
 gzV
 gUk
@@ -235471,7 +235585,7 @@ kwx
 kwx
 vJb
 rhS
-gdC
+mTr
 jVf
 utl
 utl
@@ -235882,7 +235996,7 @@ wgs
 uvj
 fES
 rjd
-fqN
+kAK
 cAC
 eKA
 vbT
@@ -236074,13 +236188,13 @@ rtn
 xdv
 xdv
 xdv
-jEl
+buz
 xdv
 xdv
-jEl
+buz
 xdv
 xdv
-jEl
+buz
 uvj
 gXk
 rjd
@@ -236684,7 +236798,7 @@ veZ
 scG
 scG
 scG
-jhS
+mTs
 iMc
 nnM
 uvj
@@ -236887,7 +237001,7 @@ veZ
 veZ
 scG
 uvj
-ncj
+oyN
 cyf
 cyf
 pWZ
@@ -237091,7 +237205,7 @@ cPp
 uvj
 uvj
 iVR
-kdN
+twP
 uvj
 vSU
 lob
@@ -237293,7 +237407,7 @@ cPp
 pwm
 pwm
 pwm
-jhS
+mTs
 uvj
 uvj
 uvj
@@ -237494,11 +237608,11 @@ ukS
 aDO
 lbX
 mDT
-mTs
+vRw
 yjy
 uXK
 uXK
-mTs
+vRw
 vqy
 seQ
 bVD
@@ -238703,7 +238817,7 @@ cAn
 cAn
 cAn
 cAn
-dHg
+ctU
 cAn
 cAn
 hEB

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -2392,15 +2392,17 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ayP" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/keycard_auth,
+/obj/item/reagent_containers/enricher,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
 	},
-/obj/machinery/washing_machine,
-/obj/machinery/vending/wallmed/lobby{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
+/obj/structure/table/marble,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "ayY" = (
 /obj/structure/closet/cabinet{
 	name = "entertainment cabinet"
@@ -3386,13 +3388,6 @@
 /obj/structure/sign/warning/internals_required/small2,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
-"aJA" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/obj/machinery/holoposter{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
 "aJG" = (
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/meadow)
@@ -3791,16 +3786,12 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "aMS" = (
-/obj/machinery/button/remote/blast_door{
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	pixel_x = 1;
-	pixel_y = 23;
-	req_access = list(29)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/tiled/white/danger,
+/area/nadezhda/medical/genetics)
 "aMZ" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Core";
@@ -4133,6 +4124,17 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"aPG" = (
+/obj/structure/closet/chefcloset,
+/obj/item/soap/hunters,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/tool_upgrade/productivity/whetstone,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "aPI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6362,11 +6364,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"bmp" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
 "bms" = (
 /obj/machinery/newscaster{
 	pixel_x = -30;
@@ -6475,19 +6472,24 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "bnm" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/towel,
-/obj/machinery/vending/wallmed/lobby{
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "bnn" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -7187,6 +7189,9 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"buz" = (
+/turf/simulated/wall,
+/area/nadezhda/pros/prep)
 "buH" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/railing{
@@ -7682,9 +7687,7 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "byG" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 32
-	},
+/obj/structure/bed/chair/sofa/black/left,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "byP" = (
@@ -9200,9 +9203,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/section3)
-"bPW" = (
-/turf/simulated/mineral,
-/area/nadezhda/rnd/robotics)
 "bPY" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -10780,6 +10780,9 @@
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"cgQ" = (
+/turf/simulated/mineral,
+/area/nadezhda/rnd/robotics)
 "cgU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/crossbow,
@@ -11554,6 +11557,16 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"cpp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/docking)
 "cpq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -12053,12 +12066,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
-"ctU" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "ctX" = (
 /obj/structure/flora/small/rock5,
 /turf/unsimulated/wall/jungle,
@@ -13542,12 +13549,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/dungeon/outside/abandoned_solars)
-"cIp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
 "cIq" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/multiz/ladder,
@@ -14236,10 +14237,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "cOK" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/medical/genetics)
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/eris/crew_quarters/kitchen_storage)
 "cOR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14571,6 +14571,15 @@
 /obj/item/bedsheet/rd,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/panic_room)
+"cTu" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "cTv" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
@@ -16413,6 +16422,16 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"dmY" = (
+/obj/structure/medical_stand,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/item/tank/anesthetic,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "dna" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/borgupload{
@@ -17468,6 +17487,17 @@
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"dwV" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/tool/scalpel/laser{
+	pixel_y = -5
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "dxe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -18116,6 +18146,14 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"dCT" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/mineral,
+/area/colony)
 "dCV" = (
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -18523,6 +18561,11 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/hallway/surface/section1)
+"dHg" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/medical/genetics)
 "dHs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/trailrocka1,
@@ -19741,11 +19784,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "dUl" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/gun/energy/cog,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "dUq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22029,15 +22072,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "erb" = (
-/obj/structure/medical_stand,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/item/tank/anesthetic,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "erm" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/small/busha1,
@@ -22885,12 +22924,22 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/turret_protected/ai)
 "eAm" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/danger,
-/area/nadezhda/medical/genetics)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/random/lowkeyrandom,
+/obj/machinery/camera/network/cargo,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/quartermaster/hangarsupply)
 "eAI" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
@@ -26608,8 +26657,12 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "fkp" = (
-/turf/simulated/mineral,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/machinery/holoposter{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26838,13 +26891,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "fnd" = (
-/obj/structure/table/standard,
-/obj/item/storage/freezer,
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/structure/toilet,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "fnf" = (
 /obj/structure/lattice,
 /turf/simulated/floor/plating/under,
@@ -27282,12 +27331,6 @@
 /area/nadezhda/crew_quarters/dorm3{
 	name = "Dormitory 3"
 	})
-"fqN" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/gun/energy/cog,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "fqR" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/effect/decal/cleanable/dirt,
@@ -28890,13 +28933,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "fEL" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/obj/machinery/camera/network/cargo{
+	dir = 1
 	},
-/turf/simulated/mineral,
-/area/colony)
+/turf/simulated/floor/tiled/dark/bluecorner,
+/area/nadezhda/security/sechall)
 "fER" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/sliceable/bread,
@@ -29703,6 +29744,14 @@
 /obj/item/beehive_assembly,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"fMq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "fMs" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc{
@@ -30978,6 +31027,11 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"gab" = (
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "gah" = (
 /obj/structure/toilet{
 	dir = 4
@@ -32219,11 +32273,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
-"gkI" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "gkM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -33073,10 +33122,6 @@
 /area/nadezhda/security/nuke_storage{
 	name = "\improper Clinic"
 	})
-"gsp" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/swo/quarters)
 "gsr" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -36481,17 +36526,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
-"haw" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/tool/scalpel/laser{
-	pixel_y = -5
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
 "haz" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/lakeside)
@@ -40804,12 +40838,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"hVm" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/spray/chemsprayer,
-/turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/medical/genetics)
 "hVt" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -43377,14 +43405,11 @@
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
 "ivN" = (
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
-/obj/structure/closet/wall_mounted{
+/obj/item/modular_computer/telescreen/preset/generic{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cbo)
 "ivP" = (
 /obj/effect/floor_decal/border/techfloor,
 /obj/effect/floor_decal/border/techfloor{
@@ -43728,10 +43753,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/main/stairwell)
-"izx" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
 "izE" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/effect/floor_decal/spline/plain{
@@ -43769,9 +43790,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/skyyard)
 "izV" = (
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cro)
 "izW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/spiders,
@@ -43863,6 +43886,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"iAP" = (
+/obj/structure/closet/secure_closet/reinforced/commander,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "iAR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -45006,15 +45033,6 @@
 /obj/random/cluster/spiders/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"iMc" = (
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cyberplant,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "iMk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -45480,9 +45498,10 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "iQA" = (
-/obj/structure/bed/chair/sofa/black/left,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "iQD" = (
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/maingate{
@@ -46490,13 +46509,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "jac" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/research)
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "jae" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -46644,6 +46659,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
+"jbz" = (
+/turf/simulated/mineral,
+/area/nadezhda/rnd/lab)
 "jbH" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -47291,9 +47309,15 @@
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
 "jhS" = (
-/obj/machinery/optable,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/swo/quarters)
 "jhW" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/wood/wild5,
@@ -47536,9 +47560,9 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "jkb" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "jkc" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -48491,20 +48515,6 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"jud" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/command/gmaster)
 "jui" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -49559,9 +49569,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/crew_quarters/fitness)
-"jEl" = (
-/turf/simulated/wall,
-/area/nadezhda/pros/prep)
 "jEs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -52206,12 +52213,6 @@
 	},
 /turf/unsimulated/mineral,
 /area/asteroid/cave)
-"kdN" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/medical/genetics)
 "kdS" = (
 /obj/structure/table/standard,
 /obj/item/stack/medical/advanced/bruise_pack,
@@ -53186,8 +53187,19 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
 "kmK" = (
-/turf/simulated/mineral,
-/area/nadezhda/rnd/lab)
+/obj/machinery/washing_machine,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/towel,
+/obj/machinery/vending/wallmed/lobby{
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "kmY" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -53199,6 +53211,10 @@
 "kna" = (
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/hallway/main/stairwell)
+"knb" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/smc/quarters)
 "knd" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -55501,6 +55517,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/sleeper)
+"kIk" = (
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "kIn" = (
 /obj/machinery/light{
 	dir = 4
@@ -58134,18 +58154,6 @@
 /mob/living/simple_animal/chicken,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/hallway/side/f2section1)
-"lgB" = (
-/obj/machinery/keycard_auth,
-/obj/item/reagent_containers/enricher,
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/obj/structure/table/marble,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cbo)
 "lgC" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small{
@@ -59229,6 +59237,29 @@
 /area/nadezhda/rnd/docking{
 	name = "\improper Upper Research Hallway"
 	})
+"lri" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "MedbayTotalLockdown";
+	layer = 2.6;
+	name = "Medbay Total Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Organ Laboratory";
+	req_access = list(5)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/rnd/docking)
 "lrp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -60442,7 +60473,7 @@
 /area/nadezhda/crew_quarters/pool)
 "lDb" = (
 /obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/reagent_dispensers/watertank/huge,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "lDd" = (
@@ -60750,6 +60781,10 @@
 "lGg" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
+"lGo" = (
+/obj/machinery/autolathe/loaded,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/gmaster)
 "lGq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard/guild{
@@ -61555,15 +61590,6 @@
 /area/nadezhda/security/maingate{
 	name = "\improper Outdoors - Pad"
 	})
-"lOw" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
 "lOx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -62064,6 +62090,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"lTh" = (
+/obj/item/storage/box/donkpockets,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "lTi" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -63325,16 +63356,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"mfr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/bioprinter/med,
-/obj/machinery/button/remote/blast_door{
-	id = "organ_shutter";
-	name = "privacy shutter control";
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
 "mfs" = (
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -63402,10 +63423,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"mfO" = (
-/mob/living/simple_animal/soteria_roomba,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/cro)
 "mfT" = (
 /obj/structure/bed/chair/office/light,
 /obj/landmark/join/start/paramedic,
@@ -67183,8 +67200,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/crew_quarters/plasma_tag)
 "mPf" = (
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "mPj" = (
 /obj/structure/table/woodentable,
 /obj/item/device/megaphone,
@@ -67556,9 +67574,11 @@
 /area/nadezhda/security/range{
 	name = "\improper Blackshield - Firing Range"
 	})
-"mTr" = (
-/turf/simulated/wall,
-/area/nadezhda/pros/foreman)
+"mTs" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "mTy" = (
 /obj/effect/floor_decal/industrial/box/white,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -67615,6 +67635,10 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
+"mUe" = (
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mUh" = (
 /obj/machinery/light{
 	dir = 8;
@@ -68047,11 +68071,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"mXT" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
 "mXY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/decal/cleanable/dirt,
@@ -68439,6 +68458,12 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"ncj" = (
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "nck" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/effect/decal/cleanable/dirt,
@@ -69145,12 +69170,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"nju" = (
-/obj/machinery/camera/network/research{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
 "njA" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -71385,12 +71404,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"nGx" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/smc/quarters)
 "nGy" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/spider/stickyweb,
@@ -71456,23 +71469,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"nGY" = (
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/computer_hardware/hard_drive/portable/design/circuits,
-/obj/item/computer_hardware/hard_drive/portable/design/components,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/glass{
-	amount = 120
-	},
-/obj/item/stack/material/plastic{
-	amount = 120
-	},
-/obj/item/paper/monitorkey,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/gmaster)
 "nHc" = (
 /obj/machinery/microwave,
 /obj/structure/table/marble,
@@ -71682,11 +71678,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/psych)
-"nIS" = (
-/obj/structure/catwalk,
-/obj/structure/lattice,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "nIZ" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -73118,10 +73109,13 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nYy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/research,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/medical/genetics)
+/obj/structure/table/standard,
+/obj/item/storage/freezer,
+/obj/structure/sink{
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "nYz" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/regular,
@@ -76056,15 +76050,8 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
 "oyN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/rnd/docking)
+/turf/simulated/wall,
+/area/nadezhda/pros/foreman)
 "oyO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -77454,13 +77441,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
-"oLT" = (
-/obj/structure/toilet,
-/obj/machinery/holoposter{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/pros/foreman)
 "oLU" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -79469,6 +79449,11 @@
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
+"pis" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_pump,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "piv" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/machinery/portable_atmospherics/hydroponics/soil,
@@ -80719,6 +80704,16 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"pvK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "pvM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -81300,22 +81295,12 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "pBL" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/random/lowkeyrandom,
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/quartermaster/hangarsupply)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/propis{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/pros/prep)
 "pBN" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/floor_decal/spline/plain{
@@ -81517,10 +81502,6 @@
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"pDo" = (
-/obj/structure/closet/secure_closet/reinforced/commander,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/smc/quarters)
 "pDr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 6;
@@ -81651,6 +81632,17 @@
 /obj/effect/floor_decal/industrial/stand_clear,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"pEj" = (
+/obj/machinery/button/remote/blast_door{
+	id = "Skynet_launch";
+	name = "Mech Bay Door Control";
+	pixel_x = 1;
+	pixel_y = 23;
+	req_access = list(29)
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "pEo" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -86582,9 +86574,9 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security)
 "qAb" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/wall,
-/area/asteroid/cave)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/medical/genetics)
 "qAh" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -86817,10 +86809,10 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/crew_quarters/plasma_tag)
 "qDe" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/rnd/research)
 "qDg" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -88572,6 +88564,15 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qUj" = (
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cyberplant,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "qUn" = (
 /obj/structure/window/reinforced,
 /obj/structure/sink{
@@ -88628,12 +88629,12 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "qUE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/propis{
-	dir = 8
+/obj/structure/toilet,
+/obj/machinery/holoposter{
+	pixel_y = 30
 	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/pros/prep)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/pros/foreman)
 "qUQ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -89334,9 +89335,8 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
 "raF" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/rnd/docking)
+/turf/simulated/mineral,
+/area/eris/crew_quarters/kitchen_storage)
 "raH" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "14,23"
@@ -90606,6 +90606,10 @@
 /obj/item/pen/multi,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/security/nuke_storage)
+"rmL" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/gmaster)
 "rmM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -91470,10 +91474,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
-"ruQ" = (
-/obj/machinery/autolathe/loaded,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/gmaster)
 "ruS" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -92190,6 +92190,12 @@
 /area/nadezhda/crew_quarters/dorm2{
 	name = "Dormitory 2"
 	})
+"rBK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "rBT" = (
 /obj/structure/multiz/ladder,
 /obj/machinery/light/small{
@@ -92723,16 +92729,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
-"rGo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/rnd/docking)
 "rGq" = (
 /obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/rock,
@@ -93142,6 +93138,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
+"rKH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/research,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/medical/genetics)
 "rKL" = (
 /obj/structure/multiz/stairs,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -93683,6 +93684,12 @@
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
+"rPN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/medical/genetics)
 "rQd" = (
 /obj/structure/railing/grey{
 	dir = 4;
@@ -94190,16 +94197,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "rUO" = (
-/obj/structure/closet/chefcloset,
-/obj/item/soap/hunters,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/tool_upgrade/productivity/whetstone,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/structure/bed/chair/comfy{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/smc/quarters)
 "rUY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/fact_plaque,
@@ -95918,9 +95920,22 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "slm" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/computer_hardware/hard_drive/portable/design/circuits,
+/obj/item/computer_hardware/hard_drive/portable/design/components,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/item/stack/material/steel/full,
+/obj/item/stack/material/glass{
+	amount = 120
+	},
+/obj/item/stack/material/plastic{
+	amount = 120
+	},
+/obj/item/paper/monitorkey,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/gmaster)
 "slo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -98466,6 +98481,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
+"sNY" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/reagent_dispensers/watertank/huge,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "sOa" = (
 /obj/machinery/conveyor/east{
 	id = "disposals grinder"
@@ -101815,18 +101835,11 @@
 	name = "Security Training"
 	})
 "tvn" = (
-/obj/machinery/smartfridge/secure/medbay/organs/stocked,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "organ_shutter";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/rnd/docking)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/spray/chemsprayer,
+/turf/simulated/floor/tiled/white/techfloor,
+/area/nadezhda/medical/genetics)
 "tvq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -102050,9 +102063,13 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "twP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/medical/genetics)
+/obj/machinery/newscaster{
+	dir = 8;
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/pros/foreman)
 "twT" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -104506,6 +104523,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"tYl" = (
+/obj/machinery/camera/network/medbay{
+	dir = 8
+	},
+/obj/structure/closet/wall_mounted{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "tYm" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -107697,28 +107723,9 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "uBN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "MedbayTotalLockdown";
-	layer = 2.6;
-	name = "Medbay Total Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Organ Laboratory";
-	req_access = list(5)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/rnd/docking)
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/wall,
+/area/asteroid/cave)
 "uBU" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -108157,9 +108164,19 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "uGo" = (
-/obj/structure/toilet,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cro)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/steel/gray_platform,
+/area/nadezhda/command/gmaster)
 "uGq" = (
 /obj/structure/girder/displaced,
 /obj/effect/decal/cleanable/dirt,
@@ -108879,14 +108896,6 @@
 "uNO" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"uNP" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/pros/foreman)
 "uNR" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/sign/warningnew/danger{
@@ -110706,6 +110715,21 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
+"vfw" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/mirror{
+	dir = 8;
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/smc/quarters)
 "vfx" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -110935,6 +110959,16 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/rocinante_shuttle_area)
+"vhU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe/bioprinter/med,
+/obj/machinery/button/remote/blast_door{
+	id = "organ_shutter";
+	name = "privacy shutter control";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/rnd/docking)
 "via" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -111950,10 +111984,18 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "vrz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/rnd/research)
+/obj/machinery/smartfridge/secure/medbay/organs/stocked,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "organ_shutter";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/rnd/docking)
 "vrB" = (
 /obj/machinery/camera/network/plasma_tag{
 	dir = 4
@@ -115863,10 +115905,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/section1)
 "wcK" = (
-/obj/item/storage/box/donkpockets,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/gmaster)
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/rnd/docking)
 "wcM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
@@ -121367,11 +121407,9 @@
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "xfm" = (
-/obj/machinery/camera/network/cargo{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/sechall)
+/mob/living/simple_animal/soteria_roomba,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/cro)
 "xfv" = (
 /obj/structure/railing{
 	dir = 8
@@ -121706,15 +121744,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"xjC" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/cbo)
 "xjG" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/nuke_storage{
@@ -124301,10 +124330,6 @@
 /obj/structure/flora/rock,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"xIj" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
 "xIn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -125408,6 +125433,15 @@
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
+"xTe" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/cbo)
 "xTj" = (
 /obj/machinery/atm{
 	dir = 1;
@@ -125495,21 +125529,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
-"xUa" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -11
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/mirror{
-	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/smc/quarters)
 "xUe" = (
 /obj/structure/table/bench/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -133783,10 +133802,10 @@ euZ
 fxu
 uCp
 oGw
-gsp
+jac
 uqn
 kNT
-ayP
+jhS
 oGw
 oGw
 nuq
@@ -136414,7 +136433,7 @@ aZK
 rzW
 ygi
 ths
-xfm
+fEL
 puh
 tmw
 aen
@@ -140884,9 +140903,9 @@ cwr
 efY
 ptB
 vnv
-fkp
-fkp
-fkp
+raF
+raF
+raF
 vnv
 iof
 fNh
@@ -141086,9 +141105,9 @@ cwr
 wLd
 bwh
 vnv
-fkp
-fkp
-fkp
+raF
+raF
+raF
 vnv
 wSq
 gAA
@@ -141288,9 +141307,9 @@ cwr
 cyr
 bwh
 vnv
-fkp
-fkp
-fkp
+raF
+raF
+raF
 vnv
 pLL
 jdf
@@ -141692,9 +141711,9 @@ cwr
 jps
 bwh
 vnv
-rUO
+aPG
 rgG
-izV
+cOK
 vnv
 jdf
 pHC
@@ -144075,7 +144094,7 @@ jIc
 dCw
 koE
 koE
-pBL
+eAm
 sTw
 hdF
 sTw
@@ -150564,12 +150583,12 @@ quV
 ces
 ces
 pEa
-qDe
+iQA
 bwh
 kEP
 pVB
 ryn
-vrz
+qDe
 cqa
 tna
 hWD
@@ -150975,7 +150994,7 @@ gbk
 ryn
 aDp
 wWY
-jac
+fMq
 mgf
 kgt
 mgf
@@ -151171,7 +151190,7 @@ bwh
 bwh
 dXF
 nyE
-aMS
+pEj
 bwh
 pVB
 rfF
@@ -151366,7 +151385,7 @@ vot
 jVE
 sEU
 vKw
-iMc
+qUj
 vKw
 sFC
 mgk
@@ -154004,7 +154023,7 @@ wBQ
 jGM
 mzB
 bxY
-bPW
+cgQ
 bxY
 olZ
 wBQ
@@ -154206,7 +154225,7 @@ nak
 wBQ
 uVq
 bxY
-bPW
+cgQ
 bxY
 xVr
 wBQ
@@ -154408,7 +154427,7 @@ ljg
 aHG
 wXg
 bxY
-bPW
+cgQ
 bxY
 bxY
 bxY
@@ -154798,7 +154817,7 @@ npT
 npT
 qql
 hwH
-kmK
+jbz
 pTU
 sLE
 vnK
@@ -155000,7 +155019,7 @@ npT
 npT
 hGh
 hwH
-kmK
+jbz
 pTU
 osd
 adZ
@@ -157260,7 +157279,7 @@ kOj
 cAG
 hYY
 qhV
-oyN
+cpp
 sMW
 wEF
 wzo
@@ -157664,8 +157683,8 @@ xxZ
 mrS
 hYY
 hYY
-uBN
-tvn
+lri
+vrz
 hYY
 yhV
 oxv
@@ -157865,9 +157884,9 @@ ihS
 ihS
 gLl
 hYY
-bmp
-rGo
-haw
+pis
+pvK
+dwV
 hYY
 evS
 cSs
@@ -158067,9 +158086,9 @@ ihS
 ihS
 gLl
 hYY
-mXT
-cIp
-mfr
+mTs
+rBK
+vhU
 hYY
 lop
 ffD
@@ -158269,9 +158288,9 @@ ihS
 ihS
 gLl
 hYY
-jhS
-mPf
-fnd
+kIk
+wcK
+nYy
 hYY
 lop
 qdj
@@ -158471,9 +158490,9 @@ vnu
 vnu
 vTA
 hYY
-erb
-ivN
-raF
+dmY
+tYl
+jkb
 hYY
 lop
 qdj
@@ -180413,7 +180432,7 @@ cEg
 iJv
 sFI
 sFI
-fEL
+dCT
 sFI
 sFI
 sFI
@@ -181024,9 +181043,9 @@ hSx
 hSx
 hSx
 ajL
-pDo
+iAP
 cUV
-nGx
+rUO
 vXl
 ajL
 bZz
@@ -181426,7 +181445,7 @@ sFI
 hSx
 ajL
 cui
-xUa
+vfw
 fkR
 iXB
 rsG
@@ -181830,7 +181849,7 @@ sFI
 hSx
 ajL
 ajL
-slm
+knb
 ajL
 ajL
 ajL
@@ -188512,7 +188531,7 @@ hSx
 jXV
 kAs
 kCX
-lOw
+cTu
 jXV
 jXV
 jXV
@@ -188714,7 +188733,7 @@ hSx
 jXV
 lSs
 kCX
-izx
+rmL
 mmA
 mZG
 mZG
@@ -189116,7 +189135,7 @@ hSx
 jXV
 uVy
 nEk
-jud
+uGo
 nEk
 nEk
 nGc
@@ -189318,7 +189337,7 @@ hSx
 jXV
 dna
 nEk
-ruQ
+lGo
 nEk
 nFp
 jXV
@@ -189522,7 +189541,7 @@ iMl
 nEk
 nEk
 nEk
-nGY
+slm
 jXV
 jXV
 jXV
@@ -189930,7 +189949,7 @@ jXV
 jXV
 jXV
 nHc
-wcK
+lTh
 pdZ
 pef
 jXV
@@ -190325,8 +190344,8 @@ gFp
 gFp
 gFp
 gFp
-nIS
-nIS
+gab
+gab
 eTA
 etI
 eaA
@@ -191783,7 +191802,7 @@ sFI
 sFI
 sFI
 ula
-nYy
+rKH
 mJX
 lUt
 lUt
@@ -191985,12 +192004,12 @@ sFI
 sFI
 sFI
 ula
-twP
+qAb
 vdO
 kYV
 lUt
 erA
-fqN
+dUl
 elK
 wiD
 nBx
@@ -192187,12 +192206,12 @@ sFI
 sFI
 sFI
 ula
-twP
+qAb
 duz
 pzU
 lUt
 xCY
-nju
+ncj
 elK
 xGJ
 baD
@@ -192389,7 +192408,7 @@ sFI
 sFI
 sFI
 ula
-twP
+qAb
 vDI
 tHC
 lUt
@@ -192790,8 +192809,8 @@ sFI
 sFI
 ula
 ula
-gkI
 lDb
+sNY
 ula
 iEU
 wpS
@@ -193004,7 +193023,7 @@ iBc
 elK
 sfN
 owe
-lgB
+ayP
 cNm
 aXb
 elK
@@ -193192,7 +193211,7 @@ sFI
 sFI
 sFI
 sFI
-twP
+qAb
 oou
 gFS
 fMv
@@ -193395,8 +193414,8 @@ sFI
 sFI
 sFI
 ula
-ctU
-kdN
+erb
+rPN
 sOu
 hcZ
 dTZ
@@ -193404,7 +193423,7 @@ hcZ
 qNV
 via
 iwx
-hVm
+tvn
 elK
 aRo
 qOO
@@ -193810,10 +193829,10 @@ vUw
 dOH
 xct
 elK
-iQA
+byG
 wGD
 rQQ
-byG
+ivN
 tif
 elK
 cEd
@@ -194006,7 +194025,7 @@ ula
 vLP
 fKY
 eKe
-eAm
+aMS
 eKe
 eKe
 mnX
@@ -194211,7 +194230,7 @@ fHX
 nvm
 jQf
 eKe
-mnX
+bnm
 elK
 elK
 lHP
@@ -194619,7 +194638,7 @@ fgH
 elK
 sUl
 ilQ
-xjC
+xTe
 elK
 eXm
 eXm
@@ -195623,7 +195642,7 @@ ssK
 cZB
 cZB
 hQV
-cOK
+dHg
 xCY
 edz
 rPf
@@ -196446,7 +196465,7 @@ kSF
 bqs
 klk
 ldZ
-mfO
+xfm
 mea
 cZm
 klk
@@ -197657,7 +197676,7 @@ aqG
 pPS
 xAN
 klk
-uGo
+fnd
 kzc
 vZI
 klk
@@ -197859,7 +197878,7 @@ eXm
 caY
 emo
 klk
-dUl
+izV
 tYV
 tYV
 xKU
@@ -234804,7 +234823,7 @@ qQZ
 hHU
 riw
 guj
-jkb
+mUe
 qQZ
 gzV
 gUk
@@ -235371,7 +235390,7 @@ kwx
 kwx
 vJb
 rhS
-qUE
+pBL
 jVf
 utl
 utl
@@ -235782,7 +235801,7 @@ wgs
 uvj
 fES
 rjd
-uNP
+twP
 cAC
 eKA
 vbT
@@ -235974,13 +235993,13 @@ rtn
 xdv
 xdv
 xdv
-jEl
+buz
 xdv
 xdv
-jEl
+buz
 xdv
 xdv
-jEl
+buz
 uvj
 gXk
 rjd
@@ -236584,8 +236603,8 @@ veZ
 scG
 scG
 scG
-mTr
-oLT
+oyN
+qUE
 nnM
 uvj
 uvj
@@ -236787,7 +236806,7 @@ veZ
 veZ
 scG
 uvj
-bnm
+kmK
 cyf
 cyf
 pWZ
@@ -236991,7 +237010,7 @@ cPp
 uvj
 uvj
 iVR
-aJA
+fkp
 uvj
 vSU
 lob
@@ -237193,7 +237212,7 @@ cPp
 pwm
 pwm
 pwm
-mTr
+oyN
 uvj
 uvj
 uvj
@@ -237394,11 +237413,11 @@ ukS
 aDO
 lbX
 mDT
-xIj
+mPf
 yjy
 uXK
 uXK
-xIj
+mPf
 vqy
 seQ
 bVD
@@ -238603,7 +238622,7 @@ cAn
 cAn
 cAn
 cAn
-qAb
+uBN
 cAn
 cAn
 hEB

--- a/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
@@ -80,7 +80,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "ax" = (
-/obj/structure/flora/big/bush3,
+/obj/random/junk/cigbutt,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"az" = (
+/obj/random/junk/cigbutt,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "aA" = (
@@ -126,10 +131,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
-"aJ" = (
-/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "aL" = (
 /obj/structure/table/glass,
 /obj/random/booze/low_chance,
@@ -425,11 +426,6 @@
 "bJ" = (
 /turf/simulated/shuttle/floor/mining,
 /area/turbolift/mountain/solars)
-"bK" = (
-/obj/random/junk/cigbutt,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "bL" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -476,17 +472,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"bX" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/machinery/telecomms/relay/preset/telecomms,
-/obj/machinery/door/window/northleft{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
 "ca" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/engineering{
@@ -556,9 +541,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/engineering/dorm)
-"cm" = (
-/turf/space,
 /area/nadezhda/engineering/dorm)
 "cn" = (
 /obj/structure/cable{
@@ -1032,6 +1014,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"ge" = (
+/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "gr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -1089,6 +1075,11 @@
 /obj/structure/flora/small/grassa2,
 /obj/structure/flora/small/grassa2,
 /obj/structure/flora/small/busha3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"iM" = (
+/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
+/obj/structure/flora/small/bushc3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "iY" = (
@@ -1166,12 +1157,8 @@
 /obj/structure/boulder,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"lT" = (
+"mf" = (
 /obj/random/flora/small_jungle_tree/low,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
-"mo" = (
-/obj/random/flora/jungle_tree/low,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "mz" = (
@@ -1233,6 +1220,16 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
+"nV" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/ntnet_relay,
+/obj/machinery/door/window/northleft{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/dorm)
 "nZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1278,6 +1275,10 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
+"pS" = (
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "ql" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted,
@@ -1362,16 +1363,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"tE" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/ntnet_relay,
-/obj/machinery/door/window/northleft{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
 "ug" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/mineral,
@@ -1441,10 +1432,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
-"wZ" = (
-/obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "xb" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
@@ -1462,10 +1449,6 @@
 "xk" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/rock,
-/area/nadezhda/outside/mountainsolars)
-"xZ" = (
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "yc" = (
 /obj/random/scrap/sparse_even/low_chance,
@@ -1537,6 +1520,17 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
+"Bj" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/machinery/telecomms/relay/preset/telecomms,
+/obj/machinery/door/window/northleft{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/dorm)
 "BI" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/effect/decal/cleanable/rubble,
@@ -1575,6 +1569,12 @@
 /area/nadezhda/outside/mountainsolars)
 "Di" = (
 /obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/oracarpet,
+/area/nadezhda/engineering/dorm)
+"Dl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
 "Dt" = (
@@ -1660,6 +1660,12 @@
 /obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"FP" = (
+/obj/structure/bed/chair,
+/obj/item/storage/fancy/cigarettes/toha,
+/obj/item/flame/lighter/zippo/brass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "FR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1682,12 +1688,6 @@
 	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
-"GO" = (
-/obj/structure/bed/chair,
-/obj/item/storage/fancy/cigarettes/toha,
-/obj/item/flame/lighter/zippo/brass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "GU" = (
@@ -1783,6 +1783,14 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"KF" = (
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"KT" = (
+/obj/structure/flora/small/bushc2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "KX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1871,6 +1879,10 @@
 /obj/random/scrap/moderate_weighted,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"NT" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "Og" = (
 /obj/structure/low_wall,
 /turf/simulated/floor/plating,
@@ -1923,22 +1935,11 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"Pr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm)
 "PE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/mountainsolars)
-"PL" = (
-/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
-/obj/structure/flora/small/bushc3,
-/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "PX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1988,10 +1989,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
-"Rt" = (
-/obj/structure/flora/small/bushc2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "RK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -2007,6 +2004,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
+"Sw" = (
+/obj/random/flora/jungle_tree/low,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "SE" = (
 /obj/random/tool_upgrade/low_chance,
@@ -2029,10 +2030,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/outside/mountainsolars)
-"TX" = (
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "Uc" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -7248,9 +7245,9 @@ al
 av
 av
 al
-wZ
+NT
 al
-Rt
+KT
 ac
 ac
 ac
@@ -7550,11 +7547,11 @@ ab
 ab
 ac
 ac
-Rt
+KT
 al
-ax
+KF
 al
-ax
+KF
 aQ
 av
 al
@@ -7652,14 +7649,14 @@ ab
 ab
 ac
 al
-TX
-PL
+pS
+iM
 aS
 TD
-PL
-ax
+iM
+KF
 al
-mo
+Sw
 ac
 ac
 ab
@@ -7755,10 +7752,10 @@ ab
 ac
 aS
 al
-xZ
+az
 aS
-GO
-bK
+FP
+ax
 aS
 Ye
 ac
@@ -7857,9 +7854,9 @@ ab
 ac
 ac
 al
-lT
-xZ
-aJ
+mf
+az
+ge
 al
 al
 ac
@@ -7960,9 +7957,9 @@ ac
 ac
 al
 al
-ax
+KF
 aS
-wZ
+NT
 ac
 ac
 ab
@@ -8063,7 +8060,7 @@ ac
 ac
 aS
 aS
-Rt
+KT
 ac
 ac
 ab
@@ -8383,7 +8380,7 @@ Um
 DS
 Di
 aE
-Pr
+Dl
 cn
 cK
 ak
@@ -8889,7 +8886,7 @@ ab
 ab
 aa
 nt
-cm
+Um
 DS
 Di
 Cm
@@ -9398,7 +9395,7 @@ ab
 ab
 aa
 nt
-tE
+nV
 QL
 HT
 wU
@@ -9500,7 +9497,7 @@ ab
 ab
 aa
 nt
-bX
+Bj
 jH
 nl
 aB

--- a/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
@@ -80,7 +80,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "ax" = (
-/obj/random/junk/cigbutt,
+/obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "aA" = (
@@ -126,6 +126,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
+"aJ" = (
+/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "aL" = (
 /obj/structure/table/glass,
 /obj/random/booze/low_chance,
@@ -167,6 +171,10 @@
 /obj/random/toolbox,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
+"aQ" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "aR" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/cable{
@@ -417,6 +425,11 @@
 "bJ" = (
 /turf/simulated/shuttle/floor/mining,
 /area/turbolift/mountain/solars)
+"bK" = (
+/obj/random/junk/cigbutt,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "bL" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -463,6 +476,17 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
+"bX" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/machinery/telecomms/relay/preset/telecomms,
+/obj/machinery/door/window/northleft{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/dorm)
 "ca" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/engineering{
@@ -1116,10 +1140,6 @@
 /obj/effect/floor_decal/industrial/box,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
-"kG" = (
-/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "kO" = (
 /obj/structure/flora/small/bushc3,
 /turf/simulated/floor/asteroid/grass,
@@ -1146,16 +1166,14 @@
 /obj/structure/boulder,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"mv" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/ntnet_relay,
-/obj/machinery/door/window/northleft{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
+"lT" = (
+/obj/random/flora/small_jungle_tree/low,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"mo" = (
+/obj/random/flora/jungle_tree/low,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "mz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1260,12 +1278,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
-"qa" = (
-/obj/structure/bed/chair,
-/obj/item/storage/fancy/cigarettes/toha,
-/obj/item/flame/lighter/zippo/brass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "ql" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted,
@@ -1287,12 +1299,12 @@
 /obj/item/storage/pill_bottle/dice,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
-"qU" = (
-/obj/structure/flora/small/rock4,
+"qQ" = (
+/obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"rm" = (
-/obj/random/flora/small_jungle_tree/low,
+"qU" = (
+/obj/structure/flora/small/rock4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "rF" = (
@@ -1328,12 +1340,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
-"so" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm)
 "sS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1356,6 +1362,16 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"tE" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/ntnet_relay,
+/obj/machinery/door/window/northleft{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/dorm)
 "ug" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/mineral,
@@ -1425,6 +1441,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
+"wZ" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "xb" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
@@ -1442,6 +1462,10 @@
 "xk" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/rock,
+/area/nadezhda/outside/mountainsolars)
+"xZ" = (
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "yc" = (
 /obj/random/scrap/sparse_even/low_chance,
@@ -1561,10 +1585,6 @@
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"DE" = (
-/obj/random/flora/jungle_tree/low,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "DS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1662,6 +1682,12 @@
 	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"GO" = (
+/obj/structure/bed/chair,
+/obj/item/storage/fancy/cigarettes/toha,
+/obj/item/flame/lighter/zippo/brass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "GU" = (
@@ -1897,11 +1923,22 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
+"Pr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/oracarpet,
+/area/nadezhda/engineering/dorm)
 "PE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/mountainsolars)
+"PL" = (
+/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
+/obj/structure/flora/small/bushc3,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "PX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1951,6 +1988,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
+"Rt" = (
+/obj/structure/flora/small/bushc2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "RK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -1988,6 +2029,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"TX" = (
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "Uc" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2050,17 +2095,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"Wc" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/machinery/telecomms/relay/preset/telecomms,
-/obj/machinery/door/window/northleft{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
 "Wo" = (
 /obj/vehicle/train/cargo/trolley,
 /turf/simulated/floor/asteroid/dirt,
@@ -2125,6 +2159,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
+"Ye" = (
+/obj/structure/flora/small/bushb2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "YM" = (
 /obj/machinery/power/apc/hyper{
 	dir = 1;
@@ -7210,16 +7248,16 @@ al
 av
 av
 al
+wZ
 al
-al
-al
+Rt
 ac
 ac
 ac
 ac
 ac
-al
-al
+Ye
+aQ
 al
 ac
 ac
@@ -7313,17 +7351,17 @@ av
 bL
 aS
 al
+qQ
 al
 al
+aS
+av
+qQ
 al
+av
+aS
 al
-al
-al
-al
-al
-al
-al
-al
+Ye
 ac
 ac
 aG
@@ -7414,12 +7452,12 @@ ac
 av
 av
 bT
+Ye
+aS
+cR
 al
-al
-al
-al
-al
-al
+cR
+Ye
 ac
 ac
 ac
@@ -7512,15 +7550,15 @@ ab
 ab
 ac
 ac
+Rt
 al
+ax
 al
+ax
+aQ
+av
 al
-al
-al
-al
-al
-al
-al
+aS
 ac
 ac
 aa
@@ -7614,14 +7652,14 @@ ab
 ab
 ac
 al
-al
-kG
+TX
+PL
 aS
 TD
-kG
+PL
+ax
 al
-al
-DE
+mo
 ac
 ac
 ab
@@ -7715,14 +7753,14 @@ ab
 ab
 ab
 ac
-al
-al
-ax
 aS
-qa
-ax
 al
-al
+xZ
+aS
+GO
+bK
+aS
+Ye
 ac
 ac
 ac
@@ -7819,9 +7857,9 @@ ab
 ac
 ac
 al
-rm
-ax
-kG
+lT
+xZ
+aJ
 al
 al
 ac
@@ -7922,9 +7960,9 @@ ac
 ac
 al
 al
-al
+ax
 aS
-al
+wZ
 ac
 ac
 ab
@@ -8025,7 +8063,7 @@ ac
 ac
 aS
 aS
-al
+Rt
 ac
 ac
 ab
@@ -8345,7 +8383,7 @@ Um
 DS
 Di
 aE
-so
+Pr
 cn
 cK
 ak
@@ -9360,7 +9398,7 @@ ab
 ab
 aa
 nt
-mv
+tE
 QL
 HT
 wU
@@ -9462,7 +9500,7 @@ ab
 ab
 aa
 nt
-Wc
+bX
 jH
 nl
 aB

--- a/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
@@ -58,11 +58,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"ai" = (
-/obj/structure/table/woodentable,
-/obj/random/powercell/low_chance,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/one)
 "aj" = (
 /turf/simulated/wall,
 /area/nadezhda/outside/mountainsolars)
@@ -77,22 +72,6 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
-"aq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "au" = (
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
@@ -101,14 +80,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "ax" = (
-/turf/simulated/wall,
-/area/nadezhda/engineering/dorm/one)
-"ay" = (
-/turf/simulated/wall,
-/area/nadezhda/engineering/dorm/two)
-"az" = (
-/turf/simulated/wall,
-/area/nadezhda/engineering/dorm/three)
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "aA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -116,32 +90,6 @@
 "aB" = (
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
-"aC" = (
-/turf/simulated/wall,
-/area/nadezhda/engineering/dorm/four)
-"aD" = (
-/obj/structure/curtain/open,
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/floor_decal/corner_techfloor_grid,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/southleft{
-	name = "shower door"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "aE" = (
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
@@ -178,12 +126,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
-"aJ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "aL" = (
 /obj/structure/table/glass,
 /obj/random/booze/low_chance,
@@ -225,15 +167,6 @@
 /obj/random/toolbox,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
-"aQ" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "aR" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/cable{
@@ -256,16 +189,6 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"aV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm)
 "aW" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -398,12 +321,6 @@
 /obj/map_data/nadezda_solars,
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/mountainsolars)
-"bv" = (
-/obj/structure/table/rack/shelf,
-/obj/random/junk/low_chance,
-/obj/random/tool/low_chance,
-/turf/simulated/floor/tiled/techmaint_cargo,
-/area/nadezhda/engineering/dorm/one)
 "bw" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -422,21 +339,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"by" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/woodentable,
-/obj/item/paper_bin{
-	pixel_x = 0;
-	pixel_y = 3
-	},
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
 "bz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -450,10 +352,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"bA" = (
-/obj/item/modular_computer/console/preset/engineering,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
 "bB" = (
 /obj/structure/railing{
 	dir = 1;
@@ -519,14 +417,6 @@
 "bJ" = (
 /turf/simulated/shuttle/floor/mining,
 /area/turbolift/mountain/solars)
-"bK" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/noticeboard{
-	pixel_y = 30
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
 "bL" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -573,44 +463,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"bW" = (
-/obj/structure/curtain/open,
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/floor_decal/corner_techfloor_grid,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/southleft{
-	name = "shower door"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
-"bX" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
-"bY" = (
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
-"bZ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
 "ca" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/engineering{
@@ -634,12 +486,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
-"cf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "cg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -688,13 +534,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
 "cm" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
+/turf/space,
 /area/nadezhda/engineering/dorm)
 "cn" = (
 /obj/structure/cable{
@@ -740,15 +580,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"cs" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "ct" = (
 /obj/structure/railing{
 	dir = 8;
@@ -756,31 +587,10 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"cv" = (
-/obj/structure/table/rack/shelf,
-/obj/random/junk/low_chance,
-/obj/random/tool/low_chance,
-/turf/simulated/floor/tiled/techmaint_cargo,
-/area/nadezhda/engineering/dorm/two)
 "cw" = (
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"cx" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/woodentable,
-/obj/item/paper_bin{
-	pixel_x = 0;
-	pixel_y = 3
-	},
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
 "cy" = (
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/asteroid/grass,
@@ -803,10 +613,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"cC" = (
-/obj/item/modular_computer/console/preset/engineering,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
 "cD" = (
 /obj/structure/railing{
 	dir = 8;
@@ -827,14 +633,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
-"cG" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/noticeboard{
-	pixel_y = 30
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
 "cH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1143,48 +941,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"ef" = (
-/obj/item/storage/box/donkpockets,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
-"eg" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
-"el" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "em" = (
 /obj/structure/catwalk,
 /obj/item/caution,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"eq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
 "eA" = (
 /obj/structure/railing{
 	dir = 1;
@@ -1206,26 +967,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/nadezhda/outside/mountainsolars)
-"eT" = (
-/obj/machinery/button/remote/airlock{
-	id = "engdorm4";
-	name = "Door Bolt Control";
-	pixel_y = -28;
-	specialfunctions = 4
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/closet/crate/bin,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
-"fk" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "fn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -1251,31 +992,11 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"fs" = (
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
 "fH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
-"fJ" = (
-/obj/item/storage/box/donkpockets,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "fK" = (
 /obj/random/toolbox,
 /obj/structure/table/standard,
@@ -1287,35 +1008,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"gd" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
-"ge" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/machinery/telecomms/relay/preset/telecomms,
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
-"gn" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
 "gr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"gD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "gS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -1328,9 +1025,6 @@
 /obj/effect/floor_decal/industrial/box,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
-"hb" = (
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/three)
 "hy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1354,21 +1048,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
-"in" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/woodentable,
-/obj/item/paper_bin{
-	pixel_x = 0;
-	pixel_y = 3
-	},
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
 "is" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/rock,
@@ -1378,9 +1057,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/engineering/dorm)
-"iD" = (
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/two)
 "iH" = (
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
@@ -1391,14 +1067,6 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"iM" = (
-/obj/random/booze,
-/obj/random/junkfood/onlypizza,
-/obj/random/junkfood/onlyburger,
-/obj/random/junkfood,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "iY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
@@ -1421,16 +1089,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/outside/mountainsolars)
-"jv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "jE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -1440,15 +1098,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
-"jF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "jH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -1462,39 +1111,15 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/mineral,
 /area/nadezhda/outside/mountainsolars)
-"km" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	id_tag = "engdorm3";
-	name = "Adept Dorm 3";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "kq" = (
 /obj/structure/closet/crate/solar,
 /obj/effect/floor_decal/industrial/box,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
 "kG" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
-"kN" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
+/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "kO" = (
 /obj/structure/flora/small/bushc3,
 /turf/simulated/floor/asteroid/grass,
@@ -1511,69 +1136,26 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/nadezhda/outside/mountainsolars)
-"lu" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
 "lx" = (
 /obj/structure/sign/department/atmos,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/outside/mountainsolars)
-"lH" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
 "lI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"lT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
-"lU" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
-"md" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"mf" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"mo" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"mr" = (
-/turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/dorm)
 "mv" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/ntnet_relay,
+/obj/machinery/door/window/northleft{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/dorm)
 "mz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1583,15 +1165,6 @@
 "mI" = (
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/mountainsolars)
-"mR" = (
-/turf/unsimulated/mineral,
-/area/nadezhda/engineering/dorm/three)
-"nc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
 "ng" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -1611,12 +1184,6 @@
 "nt" = (
 /turf/simulated/wall,
 /area/nadezhda/engineering/dorm)
-"nw" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
 "nx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -1630,26 +1197,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"nA" = (
-/obj/machinery/button/remote/airlock{
-	id = "engdorm1";
-	name = "Door Bolt Control";
-	pixel_x = 0;
-	pixel_y = -28;
-	specialfunctions = 4
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/closet/crate/bin,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
-"nF" = (
-/obj/item/storage/lunchbox,
-/obj/item/hand_labeler,
-/obj/item/storage/briefcase,
-/obj/random/toy/plushie,
-/obj/structure/closet/secure_closet/personal/engineering_personal,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/one)
 "nJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -1668,19 +1215,7 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"nV" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "nZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holoposter{
@@ -1688,25 +1223,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
-"ol" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = -32;
-	pixel_y = 24
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
-"ou" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
-"ox" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
 "oG" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
@@ -1730,31 +1246,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/outside/mountainsolars)
-"oW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
-"pj" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"pm" = (
-/obj/structure/bed/double/padded,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/bedsheet/orangedouble,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/one)
 "pp" = (
 /obj/structure/railing{
 	dir = 8
@@ -1762,69 +1253,24 @@
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
 "pq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
-"pw" = (
-/turf/unsimulated/mineral,
-/area/nadezhda/engineering/dorm/two)
-"pS" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "qa" = (
-/obj/item/modular_computer/console/preset/engineering,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
-"qc" = (
-/obj/structure/table/standard,
-/obj/structure/bedsheetbin,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"qj" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
+/obj/structure/bed/chair,
+/obj/item/storage/fancy/cigarettes/toha,
+/obj/item/flame/lighter/zippo/brass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "ql" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"qm" = (
-/obj/structure/table/standard,
-/obj/random/junkfood/low_chance{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"qu" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
-"qw" = (
-/obj/machinery/door/window/northleft,
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
 "qB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1841,38 +1287,14 @@
 /obj/item/storage/pill_bottle/dice,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
-"qQ" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "qU" = (
 /obj/structure/flora/small/rock4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"qV" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
 "rm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
-"rp" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
-"rE" = (
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
+/obj/random/flora/small_jungle_tree/low,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "rF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1897,14 +1319,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
-"rZ" = (
-/obj/item/storage/lunchbox,
-/obj/item/hand_labeler,
-/obj/item/storage/briefcase,
-/obj/random/toy/plushie,
-/obj/structure/closet/secure_closet/personal/engineering_personal,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/three)
 "sh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1914,71 +1328,11 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
-"si" = (
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
 "so" = (
-/obj/structure/curtain/open,
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/floor_decal/corner_techfloor_grid,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/southleft{
-	name = "shower door"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
-"su" = (
-/obj/random/booze,
-/obj/random/junkfood/onlypizza,
-/obj/random/junkfood/onlyburger,
-/obj/random/junkfood,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
-"sw" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"sx" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
-"sN" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/noticeboard{
-	pixel_y = 30
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
-"sQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/holoposter{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
 "sS" = (
 /obj/structure/cable{
@@ -2002,85 +1356,24 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"tx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	id_tag = "engdorm1";
-	name = "Adept Dorm 1";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
-"tE" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "ug" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/mountainsolars)
-"uh" = (
-/obj/structure/table/standard,
-/obj/random/booze/low_chance,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
-"ul" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "ut" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
-"vg" = (
-/obj/machinery/microwave,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
 "vl" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"vO" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
 "vR" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
-"vS" = (
-/obj/item/storage/box/donkpockets,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "vU" = (
 /obj/machinery/light{
 	dir = 4
@@ -2088,14 +1381,6 @@
 /obj/machinery/vending/engivend,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/engineering/dorm)
-"vW" = (
-/obj/structure/table/standard,
-/obj/random/junkfood/low_chance{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "wi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2140,18 +1425,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
-"wZ" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "xb" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
@@ -2160,12 +1433,6 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
 "xh" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
 	pixel_y = 22
@@ -2176,21 +1443,6 @@
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/mountainsolars)
-"xH" = (
-/obj/structure/table/standard,
-/obj/structure/bedsheetbin,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
-"xX" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
-"xZ" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
 "yc" = (
 /obj/random/scrap/sparse_even/low_chance,
 /turf/simulated/floor/asteroid/dirt,
@@ -2220,18 +1472,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"yt" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/secure/safe{
-	pixel_x = 34
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/one)
-"yF" = (
-/obj/structure/table/standard,
-/obj/random/booze/low_chance,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "yG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2240,12 +1480,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"yI" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "yK" = (
 /obj/machinery/vending/cola,
 /obj/effect/decal/cleanable/dirt,
@@ -2254,40 +1488,10 @@
 "yU" = (
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
-"zd" = (
-/obj/structure/table/standard,
-/obj/random/junkfood/low_chance{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "zi" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"zj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"zz" = (
-/obj/structure/table/standard,
-/obj/random/booze/low_chance,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"zD" = (
-/obj/structure/table/standard,
-/obj/random/junkfood/low_chance{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "zI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2299,62 +1503,16 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"Ai" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = -32;
-	pixel_y = 24
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
-"AA" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
 "AB" = (
 /obj/structure/table/rack/shelf,
 /obj/random/powercell/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
-"AQ" = (
-/obj/machinery/button/remote/airlock{
-	id = "engdorm2";
-	name = "Door Bolt Control";
-	pixel_x = 0;
-	pixel_y = -28;
-	specialfunctions = 4
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/closet/crate/bin,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "Bi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"Bj" = (
-/obj/item/storage/lunchbox,
-/obj/item/hand_labeler,
-/obj/item/storage/briefcase,
-/obj/random/toy/plushie,
-/obj/structure/closet/secure_closet/personal/engineering_personal,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/two)
-"Bu" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
-"BC" = (
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/one)
-"BG" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
 "BI" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/effect/decal/cleanable/rubble,
@@ -2369,37 +1527,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/mountainsolars)
-"Ce" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/noticeboard{
-	pixel_y = 30
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
-"Ch" = (
-/obj/structure/curtain/open,
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/floor_decal/corner_techfloor_grid,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/southleft{
-	name = "shower door"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
 "Cm" = (
 /obj/structure/table/glass,
 /obj/item/device/lighting/toggleable/lamp/green,
@@ -2413,30 +1540,10 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"Ct" = (
-/obj/structure/table/standard,
-/obj/structure/bedsheetbin,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
-"Cy" = (
-/obj/machinery/microwave,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
-"CB" = (
-/obj/structure/table/rack/shelf,
-/obj/random/junk/low_chance,
-/obj/random/tool/low_chance,
-/turf/simulated/floor/tiled/techmaint_cargo,
-/area/nadezhda/engineering/dorm/three)
 "CE" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"CZ" = (
-/obj/item/modular_computer/console/preset/engineering,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
 "Dg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2446,23 +1553,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
-"Dl" = (
-/obj/item/storage/box/donkpockets,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
 "Dt" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/fixed/hydrotile,
@@ -2472,18 +1562,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "DE" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
-"DL" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
+/obj/random/flora/jungle_tree/low,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "DS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2494,14 +1575,6 @@
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"Ei" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
 "En" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -2514,40 +1587,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/nadezhda/outside/mountainsolars)
-"Et" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = -32;
-	pixel_y = 24
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
-"Ev" = (
-/obj/random/booze,
-/obj/random/junkfood/onlypizza,
-/obj/random/junkfood/onlyburger,
-/obj/random/junkfood,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"Ey" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/woodentable,
-/obj/item/paper_bin{
-	pixel_x = 0;
-	pixel_y = 3
-	},
-/obj/item/pen{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
-"EF" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/unsimulated/mineral,
 /area/nadezhda/outside/mountainsolars)
 "EI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2571,12 +1610,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/nadezhda/outside/mountainsolars)
-"Fe" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
 "Fm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2607,27 +1640,11 @@
 /obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"FP" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
 "FR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
-"FS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "FX" = (
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt,
@@ -2647,30 +1664,11 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"GO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
 "GU" = (
 /obj/structure/closet/crate/solar,
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
-"Hl" = (
-/obj/structure/table/rack/shelf,
-/obj/random/junk/low_chance,
-/obj/random/tool/low_chance,
-/turf/simulated/floor/tiled/techmaint_cargo,
-/area/nadezhda/engineering/dorm/four)
-"Ho" = (
-/obj/structure/table/standard,
-/obj/random/booze/low_chance,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "Hw" = (
 /obj/structure/railing{
 	anchored = 1;
@@ -2685,18 +1683,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"HD" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "HP" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -2739,28 +1725,6 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
-"Jx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
-"JF" = (
-/obj/machinery/light,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"JI" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
 "JU" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/grass,
@@ -2785,20 +1749,6 @@
 "Kn" = (
 /turf/simulated/floor/plating,
 /area/nadezhda/outside/mountainsolars)
-"Kv" = (
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
-"KA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "KB" = (
 /obj/structure/railing{
 	dir = 1;
@@ -2807,19 +1757,6 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"KF" = (
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
-"KK" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = -32;
-	pixel_y = 24
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
-"KT" = (
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
 "KX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2846,21 +1783,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/mountainsolars)
-"Lg" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/engineering,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
-"Lk" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
 "Lv" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -2878,32 +1800,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/nadezhda/outside/mountainsolars)
-"LC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
-"LM" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
-"LP" = (
-/obj/machinery/light,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "LS" = (
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/grass,
@@ -2918,17 +1814,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"Mv" = (
-/obj/machinery/button/remote/airlock{
-	id = "engdorm3";
-	name = "Door Bolt Control";
-	pixel_y = -28;
-	specialfunctions = 4
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/closet/crate/bin,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
 "My" = (
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/dirt,
@@ -2937,52 +1822,14 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"MH" = (
-/obj/structure/table/woodentable,
-/obj/random/powercell/low_chance,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/three)
-"MK" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
-"MW" = (
-/obj/structure/table/woodentable,
-/obj/random/powercell/low_chance,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/two)
-"Nh" = (
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/four)
-"Nn" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "Nq" = (
 /obj/structure/flora/small/trailrocka4,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
 "Nt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
-"Ny" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
+/turf/simulated/wall,
+/area/nadezhda/outside/mountainsolars)
 "NK" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -2993,29 +1840,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/outside/mountainsolars)
-"NO" = (
-/obj/structure/table/woodentable,
-/obj/random/powercell/low_chance,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/four)
 "NQ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/scrap/moderate_weighted,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"NT" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/secure/safe{
-	pixel_x = 34
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/four)
-"Oa" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
 "Og" = (
 /obj/structure/low_wall,
 /turf/simulated/floor/plating,
@@ -3045,11 +1874,6 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"OB" = (
-/obj/structure/table/standard,
-/obj/structure/bedsheetbin,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "OC" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
@@ -3068,63 +1892,22 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
-"OU" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
-"OY" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/ntnet_relay,
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
 "Pd" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"Pr" = (
-/obj/structure/bed/double/padded,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/bedsheet/orangedouble,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/three)
 "PE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"PK" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
-"PL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "PX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"Qa" = (
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "Qh" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3135,73 +1918,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/outside/mountainsolars)
-"Qn" = (
-/obj/machinery/microwave,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "Qq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/mineral,
 /area/nadezhda/outside/mountainsolars)
-"QD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
-"QE" = (
-/obj/machinery/light,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/two)
 "QH" = (
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"QJ" = (
-/obj/item/storage/lunchbox,
-/obj/item/hand_labeler,
-/obj/item/storage/briefcase,
-/obj/random/toy/plushie,
-/obj/structure/closet/secure_closet/personal/engineering_personal,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/four)
 "QL" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
-"QT" = (
-/obj/machinery/light,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "QX" = (
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
-"Rb" = (
-/obj/structure/bed/double/padded,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/bedsheet/orangedouble,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/four)
 "Ri" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3213,43 +1951,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
-"Rq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
-"Rr" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
-"Rt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "RK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -3257,12 +1958,6 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
 "RO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -3272,49 +1967,10 @@
 /obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"Sa" = (
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
-"So" = (
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
-"Sw" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
 "SE" = (
 /obj/random/tool_upgrade/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
-"SL" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/secure/safe{
-	pixel_x = 34
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/two)
-"Tf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
 "Tq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3323,26 +1979,9 @@
 /area/nadezhda/outside/mountainsolars)
 "TD" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/unsimulated/mineral,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"TE" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
-"TJ" = (
-/obj/random/booze,
-/obj/random/junkfood/onlypizza,
-/obj/random/junkfood/onlyburger,
-/obj/random/junkfood,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
 "TO" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/engineering{
@@ -3350,22 +1989,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"TS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/two)
-"TX" = (
-/obj/structure/bed/double/padded,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/bedsheet/orangedouble,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/two)
 "Uc" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -3411,19 +2034,7 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"Vv" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/three)
 "VL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
 /obj/machinery/holoposter{
 	pixel_y = 32
 	},
@@ -3440,34 +2051,20 @@
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
 "Wc" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
 	},
-/obj/structure/mirror{
-	pixel_x = -28
+/obj/machinery/telecomms/relay/preset/telecomms,
+/obj/machinery/door/window/northleft{
+	dir = 2
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
-"Wi" = (
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/three)
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/dorm)
 "Wo" = (
 /obj/vehicle/train/cargo/trolley,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"Ww" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "WE" = (
 /obj/structure/railing{
 	dir = 1;
@@ -3481,14 +2078,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"WQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
 "WR" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -3512,18 +2101,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"Xl" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "Xp" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/engineering,
@@ -3539,11 +2116,6 @@
 /obj/structure/low_wall,
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/dorm)
-"XL" = (
-/obj/machinery/microwave,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/four)
 "XR" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3553,52 +2125,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
-"Yd" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/four)
-"Ye" = (
-/turf/simulated/floor/wood,
-/area/nadezhda/engineering/dorm/one)
-"Ys" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/engineering/dorm/one)
-"Yv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "YM" = (
 /obj/machinery/power/apc/hyper{
 	dir = 1;
 	environ = 1;
 	equipment = 1;
 	pixel_y = 26
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -3617,20 +2149,6 @@
 	pixel_x = 0
 	},
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/engineering/dorm)
-"YY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	id_tag = "engdorm4";
-	name = "Adept Dorm 4";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
 "Zj" = (
 /obj/structure/cable{
@@ -3651,13 +2169,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"Zs" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/secure/safe{
-	pixel_x = 34
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm/three)
 "Zx" = (
 /obj/structure/railing{
 	anchored = 1;
@@ -3675,20 +2186,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/nadezhda/outside/mountainsolars)
-"ZQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	id_tag = "engdorm2";
-	name = "Adept Dorm 2";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 
 (1,1,1) = {"
 aa
@@ -8608,23 +7105,23 @@ ab
 ac
 ac
 av
-bN
-av
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-FX
-FX
-FX
-FX
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 bx
 ac
 ac
@@ -8712,21 +7209,21 @@ ac
 al
 av
 av
-aa
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ak
-ak
-ak
-ak
-FX
+al
+al
+al
+al
+ac
+ac
+ac
+ac
+ac
+al
+al
+al
+ac
+ac
+ac
 aG
 ac
 ac
@@ -8814,21 +7311,21 @@ ac
 al
 av
 bL
-EF
-ax
-aD
-Wc
-xH
-ax
-TJ
-qQ
-Ys
-nt
-xg
-yU
-AB
-ak
-FX
+aS
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+al
+ac
+ac
 aG
 ac
 ac
@@ -8916,21 +7413,21 @@ ac
 ac
 av
 av
-aa
-ax
-aJ
-KF
-pS
-ax
-fJ
-FS
-LP
-nt
-GU
-Ot
-En
-ak
+bT
+al
+al
+al
+al
+al
+al
+ac
+ac
+ac
 FX
+FX
+FX
+ac
+ac
 Ib
 ac
 bb
@@ -9018,19 +7515,19 @@ ac
 al
 al
 al
+al
+al
+al
+al
+al
+al
+ac
+ac
 aa
-ax
-aQ
-KF
-ul
-ax
-Qn
-DE
-zd
-nt
-OM
-Ot
-Ot
+aj
+ak
+ak
+ak
 ak
 aj
 aR
@@ -9118,21 +7615,21 @@ ab
 ac
 al
 al
-al
+kG
 aS
 TD
-ax
-ax
-Bu
-ax
-ax
-Ho
+kG
+al
+al
 DE
-nA
+ac
+ac
+ab
+aa
 nt
-jH
-jH
-jH
+xg
+yU
+AB
 aF
 aN
 ci
@@ -9220,21 +7717,21 @@ ab
 ac
 al
 al
-al
-aS
-aa
 ax
-bv
-Ye
-Tf
-Ye
-Ai
-lH
-WQ
-tx
-rm
-KA
-Um
+aS
+qa
+ax
+al
+al
+ac
+ac
+ac
+ab
+aa
+nt
+GU
+Ot
+En
 aI
 aO
 cj
@@ -9322,21 +7819,21 @@ ab
 ac
 ac
 al
-al
-al
-aa
+rm
 ax
-bv
-Ye
-Ye
-nc
-bZ
-Ye
-Sa
+kG
+al
+al
+ac
+ac
+ac
+ab
+ab
+aa
 nt
-cm
-Um
-jH
+OM
+Ot
+Ot
 cd
 aP
 rF
@@ -9426,15 +7923,15 @@ ac
 al
 al
 al
-EF
-ax
-by
-Ye
-Lk
-ax
-ax
-Ny
-ax
+aS
+al
+ac
+ac
+ab
+ab
+ab
+ab
+aa
 nt
 nZ
 DS
@@ -9528,18 +8025,18 @@ ac
 ac
 aS
 aS
+al
+ac
+ac
+ab
+ab
+ab
+ab
+ab
 aa
-ax
-bA
-bX
-Ye
-ax
-BC
-BC
-ai
 nt
-jv
 jH
+Gd
 jH
 aA
 ch
@@ -9629,18 +8126,18 @@ ab
 ac
 ac
 aS
-aS
+ac
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ax
-bK
-Ye
-JI
-ax
-nF
-pm
-yt
 nt
-cm
+Um
 Gd
 Og
 jH
@@ -9732,17 +8229,17 @@ ab
 ac
 ac
 ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
 nt
-jv
+Um
 jH
 QX
 aE
@@ -9834,21 +8331,21 @@ ab
 ac
 ac
 ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ay
-bW
-Nn
-OB
-ay
-iM
-el
-HD
 nt
-Yv
+Um
 DS
 Di
 aE
-FR
+so
 cn
 cK
 ak
@@ -9936,17 +8433,17 @@ ab
 ab
 ab
 ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ay
-cf
-bY
-rp
-ay
-ef
-gD
-QE
 nt
-cm
+Um
 DS
 aE
 FR
@@ -10038,15 +8535,15 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ay
-cs
-bY
-eg
-ay
-Cy
-QD
-zD
 nt
 xh
 jH
@@ -10140,17 +8637,17 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ay
-ay
-nV
-ay
-ay
-yF
-QD
-AQ
 nt
-Yv
+DS
 Um
 Di
 aM
@@ -10242,17 +8739,17 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ay
-cv
-fs
-lU
-fs
-ol
-kN
-TS
-ZQ
-aq
+nt
+Um
 iY
 aE
 aL
@@ -10344,22 +8841,22 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ay
-cv
-fs
-fs
-qj
-nw
-fs
-So
 nt
 cm
 DS
 Di
 Cm
 OC
-aV
+dB
 tc
 ak
 Oq
@@ -10446,15 +8943,15 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ay
-cx
-fs
-gd
-ay
-ay
-ou
-ay
 nt
 RO
 DS
@@ -10548,17 +9045,17 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ay
-cC
-vO
-fs
-ay
-iD
-iD
-MW
 nt
-jv
+jH
 Um
 rL
 aE
@@ -10650,15 +9147,15 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ay
-cG
-fs
-qV
-ay
-Bj
-TX
-SL
 nt
 VL
 jH
@@ -10752,15 +9249,15 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-ay
-ay
-ay
-ay
-ay
-ay
-ay
-ay
+nt
 nt
 YM
 jH
@@ -10854,16 +9351,16 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-pw
-ay
-ay
-ay
-ay
-ay
-ay
-ay
 nt
+mv
 QL
 HT
 wU
@@ -10956,17 +9453,17 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-pw
-ay
-ay
-ay
-ay
-ay
-ay
-ay
 nt
-Nt
+Wc
+jH
 nl
 aB
 aA
@@ -11058,17 +9555,17 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-mR
-az
-az
-az
-az
-az
-az
-az
 nt
-Nt
+nt
+jH
 DS
 JX
 JX
@@ -11160,15 +9657,15 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-az
-az
-az
-az
-az
-az
-az
-az
+aa
 nt
 pq
 jH
@@ -11262,18 +9759,18 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-az
-Ch
-Sw
-qc
-az
-Ev
-ox
-Rr
-nt
+aa
+aj
 Nt
-jH
+Nt
 aj
 ak
 ak
@@ -11364,19 +9861,19 @@ ab
 ab
 ab
 ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
-az
-mo
-si
-mf
-az
-Dl
-md
-JF
-nt
-Nt
-DS
-ak
+aa
+aa
+aa
+aa
 FX
 FX
 aZ
@@ -11466,20 +9963,20 @@ ab
 ab
 ab
 ab
-aa
-az
-pj
-si
-Vv
-az
-vg
-zj
-qm
-nt
-Nt
-jH
-ak
-Oq
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+al
 al
 aZ
 be
@@ -11568,20 +10065,20 @@ aa
 ab
 ab
 ab
-aa
-az
-az
-sw
-az
-az
-zz
-zj
-Mv
-nt
-oW
-DS
-ak
-Oq
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+al
 al
 cp
 be
@@ -11670,20 +10167,20 @@ aa
 ab
 ab
 ab
-aa
-az
-CB
-rE
-Fe
-rE
-KK
-OU
-Ei
-km
-Rt
-jH
-ak
-Oq
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+al
 al
 cp
 be
@@ -11772,20 +10269,20 @@ aa
 ab
 ab
 ab
-aa
-az
-CB
-rE
-rE
-eq
-BG
-rE
-Wi
-nt
-Nt
-jH
-ak
-Oq
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+al
 al
 aZ
 be
@@ -11874,19 +10371,19 @@ aa
 ab
 ab
 ab
-aa
-az
-Ey
-rE
-xX
-az
-az
-gn
-az
-nt
-Nt
-DS
-aj
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 al
 ac
 aZ
@@ -11976,19 +10473,19 @@ aa
 ab
 ab
 ab
-aa
-az
-CZ
-xZ
-rE
-az
-hb
-hb
-MH
-nt
-Lg
-jH
-aj
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ac
 ac
 ac
@@ -12078,19 +10575,19 @@ aa
 ab
 ab
 ab
-aa
-az
-sN
-rE
-AA
-az
-rZ
-Pr
-Zs
-nt
-Jx
-DS
-aj
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ac
@@ -12180,19 +10677,19 @@ aa
 ab
 ab
 ab
-aa
-az
-az
-az
-az
-az
-az
-az
-az
-nt
-PL
-Gd
-nt
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -12282,19 +10779,19 @@ aa
 ab
 ab
 ab
-aa
-aC
-so
-wZ
-Ct
-aC
-su
-tE
-Xl
-nt
-Nt
-DS
-nt
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -12385,18 +10882,18 @@ aa
 aa
 aa
 aa
-aC
-sx
-Qa
-mv
-aC
-vS
-lT
-QT
-nt
-Nt
-Gd
-nt
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -12487,18 +10984,18 @@ aa
 aa
 aa
 aa
-aC
-fk
-Qa
-yI
-aC
-XL
-jF
-vW
-nt
-sQ
-jH
-nt
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -12589,18 +11086,18 @@ aa
 aa
 aa
 aa
-aC
-aC
-Ww
-aC
-aC
-uh
-jF
-eT
-nt
-TE
-DS
-nt
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -12691,18 +11188,18 @@ aa
 aa
 aa
 aa
-aC
-Hl
-KT
-Oa
-KT
-Et
-FP
-GO
-YY
-LC
-DS
-nt
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -12793,20 +11290,20 @@ aa
 aa
 aa
 aa
-aC
-Hl
-KT
-KT
-PK
-kG
-KT
-Kv
-nt
-jH
-Gd
-mr
-mr
-mr
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 aZ
@@ -12895,20 +11392,20 @@ aa
 aa
 aa
 aa
-aC
-in
-KT
-DL
-aC
-aC
-MK
-aC
-nt
-jH
-DS
-LM
-OY
-mr
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 ab
 ab
 ac
@@ -12997,20 +11494,20 @@ aa
 aa
 aa
 aa
-aC
-qa
-lu
-KT
-aC
-Nh
-Nh
-NO
-nt
-Gd
-DS
-qw
-Rq
-mr
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
@@ -13099,20 +11596,20 @@ aa
 aa
 aa
 aa
-aC
-Ce
-KT
-Yd
-aC
-QJ
-Rb
-NT
-nt
-jH
-jH
-qu
-ge
-mr
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
@@ -13201,20 +11698,20 @@ aa
 aa
 aa
 aa
-aC
-aC
-aC
-aC
-aC
-aC
-aC
-aC
-nt
-nt
-nt
-mr
-mr
-mr
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa

--- a/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
@@ -80,12 +80,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "ax" = (
-/obj/random/junk/cigbutt,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
-"az" = (
-/obj/random/junk/cigbutt,
+/obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "aA" = (
@@ -95,6 +90,10 @@
 "aB" = (
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
+"aD" = (
+/obj/structure/flora/small/busha1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "aE" = (
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
@@ -196,6 +195,10 @@
 /area/nadezhda/outside/mountainsolars)
 "aU" = (
 /obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"aV" = (
+/obj/random/flora/small_jungle_tree/low,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "aW" = (
@@ -952,6 +955,16 @@
 /obj/item/caution,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"eq" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/ntnet_relay,
+/obj/machinery/door/window/northleft{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/dorm)
 "eA" = (
 /obj/structure/railing{
 	dir = 1;
@@ -972,6 +985,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
+/area/nadezhda/outside/mountainsolars)
+"eT" = (
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "fn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1014,10 +1031,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"ge" = (
-/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "gr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -1034,6 +1047,13 @@
 /obj/structure/closet/crate/solar,
 /obj/effect/floor_decal/industrial/box,
 /turf/simulated/floor/tiled/steel,
+/area/nadezhda/engineering/dorm)
+"hb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
 "hy" = (
 /obj/structure/cable{
@@ -1075,11 +1095,6 @@
 /obj/structure/flora/small/grassa2,
 /obj/structure/flora/small/grassa2,
 /obj/structure/flora/small/busha3,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
-"iM" = (
-/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
-/obj/structure/flora/small/bushc3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "iY" = (
@@ -1157,10 +1172,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"mf" = (
-/obj/random/flora/small_jungle_tree/low,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "mz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1220,16 +1231,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"nV" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/ntnet_relay,
-/obj/machinery/door/window/northleft{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
 "nZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1238,6 +1239,10 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
+"ox" = (
+/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "oG" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
@@ -1275,10 +1280,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
-"pS" = (
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "ql" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted,
@@ -1300,12 +1301,12 @@
 /obj/item/storage/pill_bottle/dice,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
-"qQ" = (
-/obj/structure/flora/small/busha1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "qU" = (
 /obj/structure/flora/small/rock4,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"rm" = (
+/obj/random/flora/jungle_tree/low,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "rF" = (
@@ -1363,10 +1364,25 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"tE" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/machinery/telecomms/relay/preset/telecomms,
+/obj/machinery/door/window/northleft{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/dorm)
 "ug" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/mountainsolars)
+"ul" = (
+/obj/structure/closet/secure_closet/personal/engineering_personal,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/engineering/dorm)
 "ut" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1381,6 +1397,12 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
+"vS" = (
+/obj/structure/bed/chair,
+/obj/item/storage/fancy/cigarettes/toha,
+/obj/item/flame/lighter/zippo/brass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "vU" = (
 /obj/machinery/light{
 	dir = 4
@@ -1441,8 +1463,8 @@
 /area/nadezhda/engineering/dorm)
 "xh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	pixel_y = 22
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
@@ -1510,6 +1532,10 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"AA" = (
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "AB" = (
 /obj/structure/table/rack/shelf,
 /obj/random/powercell/low_chance,
@@ -1520,17 +1546,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
-"Bj" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/machinery/telecomms/relay/preset/telecomms,
-/obj/machinery/door/window/northleft{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/dorm)
 "BI" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/effect/decal/cleanable/rubble,
@@ -1569,12 +1584,6 @@
 /area/nadezhda/outside/mountainsolars)
 "Di" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/oracarpet,
-/area/nadezhda/engineering/dorm)
-"Dl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
 "Dt" = (
@@ -1659,12 +1668,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/outside/mountainsolars)
-"FP" = (
-/obj/structure/bed/chair,
-/obj/item/storage/fancy/cigarettes/toha,
-/obj/item/flame/lighter/zippo/brass,
-/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "FR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1783,14 +1786,6 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
-"KF" = (
-/obj/structure/flora/big/bush3,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
-"KT" = (
-/obj/structure/flora/small/bushc2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
 "KX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1856,6 +1851,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
+"Nh" = (
+/obj/structure/flora/small/bushc2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "Nq" = (
 /obj/structure/flora/small/trailrocka4,
 /turf/simulated/floor/asteroid/dirt,
@@ -1877,10 +1876,6 @@
 "NQ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/scrap/moderate_weighted,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
-"NT" = (
-/obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "Og" = (
@@ -1930,6 +1925,10 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
+"OU" = (
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "Pd" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/scrap/dense_weighted,
@@ -1946,6 +1945,12 @@
 /obj/structure/boulder,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"Qa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/oracarpet,
+/area/nadezhda/engineering/dorm)
 "Qh" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -1978,6 +1983,11 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
+"Rb" = (
+/obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
+/obj/structure/flora/small/bushc3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "Ri" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1988,6 +1998,11 @@
 "Rm" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/mountainsolars)
+"Rq" = (
+/obj/random/junk/cigbutt,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "RK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2004,10 +2019,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/outside/mountainsolars)
-"Sw" = (
-/obj/random/flora/jungle_tree/low,
-/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "SE" = (
 /obj/random/tool_upgrade/low_chance,
@@ -2160,6 +2171,14 @@
 /obj/structure/flora/small/bushb2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"Yv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "YM" = (
 /obj/machinery/power/apc/hyper{
 	dir = 1;
@@ -7245,9 +7264,9 @@ al
 av
 av
 al
-NT
+ax
 al
-KT
+Nh
 ac
 ac
 ac
@@ -7348,12 +7367,12 @@ av
 bL
 aS
 al
-qQ
+aD
 al
 al
 aS
 av
-qQ
+aD
 al
 av
 aS
@@ -7547,11 +7566,11 @@ ab
 ab
 ac
 ac
-KT
+Nh
 al
-KF
+OU
 al
-KF
+OU
 aQ
 av
 al
@@ -7649,14 +7668,14 @@ ab
 ab
 ac
 al
-pS
-iM
+eT
+Rb
 aS
 TD
-iM
-KF
+Rb
+OU
 al
-Sw
+rm
 ac
 ac
 ab
@@ -7752,10 +7771,10 @@ ab
 ac
 aS
 al
-az
+AA
 aS
-FP
-ax
+vS
+Rq
 aS
 Ye
 ac
@@ -7854,9 +7873,9 @@ ab
 ac
 ac
 al
-mf
-az
-ge
+aV
+AA
+ox
 al
 al
 ac
@@ -7957,9 +7976,9 @@ ac
 ac
 al
 al
-KF
+OU
 aS
-NT
+ax
 ac
 ac
 ab
@@ -8060,17 +8079,17 @@ ac
 ac
 aS
 aS
-KT
+Nh
 ac
 ac
-ab
 ab
 ab
 ab
 ab
 aa
 nt
-jH
+nt
+xh
 Gd
 jH
 aA
@@ -8169,10 +8188,10 @@ ab
 ab
 ab
 ab
-ab
 aa
 nt
-Um
+ul
+Gd
 Gd
 Og
 jH
@@ -8271,10 +8290,10 @@ ab
 ab
 ab
 ab
-ab
 aa
 nt
-Um
+ul
+jH
 jH
 QX
 aE
@@ -8373,14 +8392,14 @@ ab
 ab
 ab
 ab
-ab
 aa
 nt
-Um
+ul
+DS
 DS
 Di
 aE
-Dl
+Qa
 cn
 cK
 ak
@@ -8475,10 +8494,10 @@ ab
 ab
 ab
 ab
-ab
 aa
 nt
-Um
+ul
+DS
 DS
 aE
 FR
@@ -8577,8 +8596,8 @@ ab
 ab
 ab
 ab
-ab
 aa
+nt
 nt
 xh
 jH
@@ -8679,10 +8698,10 @@ ab
 ab
 ab
 ab
-ab
+aa
 aa
 nt
-DS
+Yv
 Um
 Di
 aM
@@ -9090,7 +9109,7 @@ ab
 ab
 aa
 nt
-jH
+xh
 Um
 rL
 aE
@@ -9395,7 +9414,7 @@ ab
 ab
 aa
 nt
-nV
+eq
 QL
 HT
 wU
@@ -9497,7 +9516,7 @@ ab
 ab
 aa
 nt
-Bj
+tE
 jH
 nl
 aB
@@ -9703,7 +9722,7 @@ aa
 aa
 nt
 pq
-jH
+hb
 HW
 yK
 ix


### PR DESCRIPTION
All heads of staff have lost their bed, heads of staff rooms has also been shrunk as well
Genetics has been reduced to 1/3d its size
Organ Theater has been made its own room
Fixes a few errors in map like doble stacked lockers or wall items
Fixes Wall lockers that could not be closed
Lighting/cameras on low walls have been corrected (that i know of)
Guild lobby now has shutters and a proper line

Fixes floors and missing roof in the hunting lodge