### PR TITLE
Nerfs durable membrane

### DIFF
--- a/code/modules/aberrants/organs/mods/5_upgrades.dm
+++ b/code/modules/aberrants/organs/mods/5_upgrades.dm
@@ -32,9 +32,10 @@
 /obj/item/modification/organ/internal/stromal/improvement/durability/New()
 	var/datum/component/modification/organ/stromal/M = AddComponent(/datum/component/modification/organ/stromal)
 
-	M.min_bruised_damage_multiplier = 0.40
-	M.min_broken_damage_multiplier = 0.40
-	M.max_damage_multiplier = 0.40
+	M.specific_organ_size_mod = 0.5
+	M.min_bruised_damage_multiplier = 0.20
+	M.min_broken_damage_multiplier = 0.20
+	M.max_damage_multiplier = 0.20
 	M.prefix = "durable"
 	..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Health buff down to 20% from 40%, specific organ size increased by 0.5

## Changelog
:cl:
balance: Durable membrane damage threshold buff reduced to 20%, added specific size mod of 0.5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
