### PR TITLE
Hopefully fixes mobs avoiding dead mobs in pathfinding, fixes mobs not being able to rest under eachother

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -782,9 +782,12 @@ All Canmove setting in this proc is temporary. This var should not be set from h
 		canmove = FALSE //TODO: Remove this
 
 	if(lying)
-		set_density(TRUE)
-		if(l_hand) unEquip(l_hand)
-		if(r_hand) unEquip(r_hand)
+		if(l_hand)
+			unEquip(l_hand)
+		if(r_hand)
+			unEquip(r_hand)
+		if (!is_dead(src)) //to prevent dead mobs from always being set to dense. not sure if this is going to have consequences, but it hopefully shouldnt?
+			set_density(TRUE)
 	else
 		canmove = TRUE
 		set_density(initial(density))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -9,8 +9,7 @@
 
 
 /mob
-	var/moving           = FALSE
-
+	var/moving = FALSE
 
 /mob/proc/set_move_cooldown(var/timeout)
 	var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)
@@ -18,13 +17,14 @@
 		delay.SetDelay(timeout)
 
 /mob/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0)) return 1
+	if(air_group || (height==0))
+		return TRUE
 
 	if(ismob(mover))
 		var/mob/moving_mob = mover
 		if ((other_mobs && moving_mob.other_mobs))
-			return 1
-		return (!mover.density || !density || lying)
+			return TRUE
+		return (!mover.density || !density || (lying || moving_mob.lying)) // The 2nd lying check is a Soj Edit by niko, i have no fucking idea if this will break anything
 	else
 		return (!mover.density || !density || lying)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Problem: Mobs had density set to TRUE on death, all of them, and mobs couldn't rest under one another

Fix: Putting set_density behind a deadcheck, so deadmobs dont have this set. NOTE, this may cause unforseen consequences in certain parts of this spaghetti of a mobcode. Also, adding (lying || moving_mob.lying) to /mob.canPass(), which is true if either of the mobs are resting. 

WARNING. The canpass change might break shit, it probably won't but jesus christ this code is so fucked it might fucking delete the entire database if we're unlucky.

Testing steps:
1. Spawn in as BST and turn on ruin_everything mode
2. Run around and kill some roaches
3. Lead roaches through the corpses of their allies. They don't avoid them. This is good

1. Spawn 2 BSTs in
2. Try to rest under one
3. Success

Fixes https://github.com/sojourn-13/sojourn-station/issues/3839

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: Mobs now properly pathfind around dead mobs
fix: You can now rest under mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
