### PR TITLE
Klutz balance pass

### DIFF
--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -98,6 +98,6 @@
 		to_chat(user, SPAN_WARNING("\The [src] accidentally slips out of your hand."))
 		user.drop_from_inventory(src)
 		user.take_organ_damage(2)
-		user.Paralyse(2)
+		user.Weaken(1)
 		return
 	return ..()

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -557,7 +557,7 @@
 	if ((CLUMSY in user.mutations) && prob(15))
 		to_chat(user, SPAN_WARNING("You accidentally bash yourself with the [src]."))
 		user.damage_through_armor(10, BURN, user.hand)
-		user.Weaken(1 * force)
+		user.Weaken(0.5 * force)
 	active = !active
 	if (active)
 		force = WEAPON_FORCE_PAINFUL

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -557,7 +557,7 @@
 	if ((CLUMSY in user.mutations) && prob(15))
 		to_chat(user, SPAN_WARNING("You accidentally bash yourself with the [src]."))
 		user.damage_through_armor(10, BURN, user.hand)
-		user.Weaken(0.5 * force)
+		user.Weaken(3)
 	active = !active
 	if (active)
 		force = WEAPON_FORCE_PAINFUL

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -38,7 +38,7 @@
 	if ((CLUMSY in user.mutations) && prob(10))
 		to_chat(user, SPAN_WARNING("You club yourself over the head."))
 		playsound(src.loc, 'sound/effects/woodhit.ogg', 50, 1, -1)
-		user.Weaken(3 * force)
+		user.Weaken(0.2 * force)
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			H.damage_through_armor(2 * force, BRUTE, BP_HEAD, ARMOR_MELEE)
@@ -124,7 +124,7 @@
 
 		if ((CLUMSY in user.mutations) && prob(10))
 			to_chat(user, SPAN_WARNING("You club yourself over the head."))
-			user.Weaken(3 * force)
+			user.Weaken(0.1 * force)
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.damage_through_armor(2 * force, BRUTE, BP_HEAD, ARMOR_MELEE)

--- a/code/game/objects/items/weapons/tools/stunbatons.dm
+++ b/code/game/objects/items/weapons/tools/stunbatons.dm
@@ -149,7 +149,7 @@
 /obj/item/tool/baton/attack(mob/M, mob/user)
 	if(switched_on && (CLUMSY in user.mutations) && prob(50))
 		to_chat(user, SPAN_DANGER("You accidentally hit yourself with the [src]!"))
-		user.Weaken(30)
+		apply_hit_effect(user, user, BP_HEAD)
 		deductcharge(hitcost)
 		return
 	return ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -282,7 +282,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 					SPAN_DANGER("\The [user] fumbles with \the [src] and shoot themselves in the foot with \the [src]!"),
 					SPAN_DANGER("You fumble with the gun and accidentally shoot yourself in the foot with \the [src]!")
 					)
-				M.drop_item()
+				currently_firing = FALSE
 		else
 			handle_click_empty(user)
 		return FALSE
@@ -296,7 +296,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 					SPAN_DANGER("As \the [user] pulls the trigger on \the [src], a bullet fires backwards out of it"),
 					SPAN_DANGER("Your \the [src] fires backwards, shooting you in the face!")
 					)
-				user.drop_item()
+				currently_firing = FALSE
 			if(rigged > TRUE)
 				explosion(get_turf(src), 1, 2, 3, 3)
 				qdel(src)
@@ -308,6 +308,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 			if(P)
 				if(process_projectile(P, user, user, BP_HEAD))
 					handle_post_fire(user, user)
+					currently_firing = FALSE
 					user.visible_message(
 						SPAN_DANGER("As \the [user] pulls the trigger on \the [src], a bullet fires backwards out of it"),
 						SPAN_DANGER("Your \the [src] fires backwards, shooting you in the face!")


### PR DESCRIPTION
Kltuz has been relooked at in its hard stuns to be less long and more in line with how are combat works rather then being down and out of the count for 10 seconds well waiting for your ticket to decide that you can infact get up

Shooting yourself with a rigged/klutz gun no longer drops and bricks the gun
Shooting yourself with a rigged/klutz gun no longer drops at all

Testing: Made sure it complies
Performance: Stunbatons klutz takes more performance everything else is the same