### PR TITLE
syndacat trade beacon buffs

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -5,7 +5,7 @@
 	organ_efficiency = list(OP_HEART = 100)
 	parent_organ_base = BP_CHEST
 	dead_icon = "heart-off"
-	price_tag = 3000
+	price_tag = 1200
 	specific_organ_size = 2
 	oxygen_req = 10
 	nutriment_req = 10
@@ -41,7 +41,7 @@
 	icon_state = "heart_huge"
 	organ_efficiency = list(OP_HEART = 150)
 	specific_organ_size = 2.3
-	price_tag = 4500
+	price_tag = 1500
 	max_blood_storage = 100
 	nutriment_req = 15
 	dead_icon = "heart_huge"

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -8,7 +8,7 @@
 	max_blood_storage = 7.5
 	oxygen_req = 2.5
 	nutriment_req = 2
-	price_tag = 1500
+	price_tag = 500
 	w_class =  ITEM_SIZE_TINY
 
 /obj/item/organ/internal/kidney/left
@@ -20,14 +20,14 @@
 	icon_state = "kidney_left_cindar"
 	desc = "A dense set of tightly packed kidneys that work twice as better than a standard kidney.\
 	Likely worth more on the black market."
-	price_tag = 5000
+	price_tag = 2000
 	organ_efficiency = list(OP_KIDNEYS = 100)
 
 /obj/item/organ/internal/kidney/right/cindarite
 	icon_state = "kidney_right_cindar"
 	desc = "A dense set of tightly packed kidneys that work twice as better than a standard kidney.\
 	Likely worth more on the black market."
-	price_tag = 5000 //The right kidney should be worth as much as the left one.
+	price_tag = 1000 //The right kidney should be worth as much as the left one.
 
 /obj/item/organ/internal/kidney/prosthetic
 	name = "prosthetic kidneys"
@@ -47,7 +47,7 @@
 	icon_state = "kidney_left"
 	desc = "A dense set of Artisinal kidneys. Works twice as well as a common peasant's kidney.\
 	Likely worth more on the black market."
-	price_tag = 4000
+	price_tag = 1000
 	organ_efficiency = list(OP_KIDNEYS = 150)
 
 /obj/item/organ/internal/kidney/right/exalt
@@ -55,5 +55,5 @@
 	icon_state = "kidney_right"
 	desc = "A dense set of Artisinal kidneys. Works twice as well as a common peasant's kidney.\
 	Likely worth more on the black market."
-	price_tag = 4000
+	price_tag = 1000
 	organ_efficiency = list(OP_KIDNEYS = 150)

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -7,7 +7,7 @@
 	max_blood_storage = 25
 	oxygen_req = 7
 	nutriment_req = 5
-	price_tag = 1800
+	price_tag = 800
 	w_class = ITEM_SIZE_SMALL
 
 //We got it covered in Process with more detailed thing
@@ -28,6 +28,7 @@
 	icon_state = "liver_big"
 	organ_efficiency = list(OP_LIVER = 150)
 	specific_organ_size = 1.2
+	price_tag = 900
 
 /obj/item/organ/internal/liver/big/exalt
 	name = "exalt liver"

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -6,7 +6,7 @@
 	organ_efficiency = list(OP_LUNGS = 100)
 	parent_organ_base = BP_CHEST
 	specific_organ_size = 2
-	price_tag = 1500
+	price_tag = 700
 	blood_req = 10
 	max_blood_storage = 50
 	nutriment_req = 10
@@ -24,7 +24,7 @@
 	name = "prosthetic lungs"
 	desc = "Lungs made out of metal. Still work just as well as normal lungs."
 	icon_state = "lungs-prosthetic"
-	price_tag = 1500
+	price_tag = 1000
 	price_tag = 100
 	nature = MODIFICATION_SILICON
 	matter = list(MATERIAL_STEEL = 1)

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
@@ -53,6 +53,10 @@
 		)
 	)
 	offer_types = list(
-		/obj/item/organ/internal/kidney = offer_data("kidney", 800, 8),					// base price: 400
-		/obj/item/organ/internal/liver = offer_data("liver", 1800, 8)					// base price: 900
+		/obj/item/organ/internal/kidney = offer_data("kidney", 800, 2),
+		/obj/item/organ/internal/liver/big = offer_data("liver", 1200, 1),
+		/obj/item/organ/internal/heart/huge = offer_data("heart", 2000, 1),
+		/obj/item/organ/internal/lungs/long = offer_data("long lungs", 1650, 1),
+		/obj/item/organ/internal/nerve/sensitive_nerve  = offer_data("sensitive nerve", 2650, 1),
+		/obj/item/organ/internal/blood_vessel/extensive   = offer_data("extensive blood vessels", 2650, 1)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
@@ -21,7 +21,15 @@
 			/obj/item/clothing/suit/space/syndicate = custom_good_amount_range(list(1, 1)),
 			/obj/item/clothing/head/helmet/space/syndicate = custom_good_amount_range(list(1, 1)),
 			/obj/item/clothing/suit/space/void/merc = custom_good_amount_range(list(1, 1)),
-			/obj/item/gun/projectile/clarissa/makarov = custom_good_amount_range(list(1, 1))
+			/obj/item/gun/projectile/clarissa/makarov = custom_good_amount_range(list(1, 1)),
+			/obj/item/gun/projectile/lamia/akurra = custom_good_amount_range(list(1, 1))
+		),
+		"Sol Fed Stockpiles" = list(
+			/obj/item/gun/projectile/automatic/thompson = custom_good_amount_range(list(1, 3)),
+			/obj/item/gun/projectile/lamia/dark/sf = custom_good_amount_range(list(1, 1)),
+			/obj/item/gun/projectile/colt/ten/dark = custom_good_amount_range(list(1, 1)),
+			/obj/item/gun/projectile/automatic/omnirifle/omnicarbine/solmarine = custom_good_amount_range(list(1, 1)),
+			/obj/item/gun/projectile/automatic/greasegun = custom_good_amount_range(list(1, 1))
 		),
 		"Useful Stuff" = list(
 			// Autoinjectors defined in hypospray.dm

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon2.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon2.dm
@@ -24,7 +24,9 @@
 			/obj/item/plastique,
 			/obj/item/clothing/glasses/powered/thermal/syndi,
 			/obj/item/noslipmodule,
-			/obj/item/storage/box/syndie_kit/imp_compress
+			/obj/item/storage/box/syndie_kit/imp_compress,
+			/obj/item/grenade/empgrenade,
+			/obj/item/storage/backpack/military = good_data("MOLLE pack", list(3, 8), 1000)
 		),
 		"Weapons" = list(
 			/obj/item/melee/energy/sword,
@@ -44,8 +46,17 @@
 			/obj/item/rig_module/fabricator/energy_net
 		),
 		"Software" = list(
-			/obj/item/computer_hardware/hard_drive/portable/advanced/shady = good_data("old data disk", list(1, 1), 900)
-		)
+			/obj/item/computer_hardware/hard_drive/portable/advanced/shady = good_data("old data disk", list(1, 1), 900),
+			/obj/item/computer_hardware/hard_drive/portable/design/guns/china = good_data("China Lake Disk", list(1, 1), 1100)
+		),
+		"Grenade Shells" = list(
+			/obj/item/ammo_casing/grenade = good_data("Baton Shell", list(4, 8), 100),
+			/obj/item/ammo_casing/grenade/blast = good_data("Blast Shell", list(2, 3), 800),
+			/obj/item/ammo_casing/grenade/frag = good_data("Frag Shell", list(2, 3), 800),
+			/obj/item/ammo_casing/grenade/frag/stinger = good_data("Stinger Shell", list(4, 8), 1200),
+			/obj/item/ammo_casing/grenade/emp = good_data("EMP Shell", list(1, 1), 1800),
+			/obj/item/ammo_casing/grenade/flash = good_data("Flash Shell", list(4, 8), 100)
+		),
 	)
 	offer_types = list(
 		/obj/item/stack/telecrystal = offer_data("telecrystal x50", 100000, 1)

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon2.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon2.dm
@@ -59,5 +59,7 @@
 		),
 	)
 	offer_types = list(
-		/obj/item/stack/telecrystal = offer_data("telecrystal x50", 100000, 1)
+		/obj/item/stack/telecrystal = offer_data("telecrystal x50", 100000, 1),
+		/obj/item/device/radio/uplink = offer_data("Radio Uplink", 10000, 1),
+		/obj/item/card/emag = offer_data("Cryptographic Sequencer", 5000, 1)
 	)


### PR DESCRIPTION
Adds in more into both Arua and Introversion weapons and gear so that when you unlock them you have more things to buy
This also includes a MOLLE pack and some emps (that you already can get form other trade stations)
Sol Fed branded gear (Note: These are not the super op admin only ones)
China lake and the ammo for it

Organs no longer sell for insain amounts
The Arua now asks for advanced organs rather then basics (other then kidneys)
Introversion now wants uplinks and emags

Testing: Made sure it complied
Preformance: More stuff to stock in trade ships