### PR TITLE
Fixes Language Intelligibility & Adds Written Languages

### DIFF
--- a/code/modules/mob/language/ancient_latin.dm
+++ b/code/modules/mob/language/ancient_latin.dm
@@ -10,6 +10,7 @@
 		LANGUAGE_COMMON = 5
 	)
 	space_chance = 80
+	has_written_form = TRUE
 	speech_verb = list("states")
 	ask_verb = list("implores")
 	exclaim_verb = list("intently states")
@@ -26,3 +27,4 @@
                      "expono", "flamma", "flumen", "gladius", "gratus", "homo hominis", "horrendus", "illud", "imitor", "infeste", "iuro", \
                      "laeto letor", "laganum", "lector", "maneo", "mille", "missa", "medica", "optimus", "cedo", "comiter", "quia", "rumor", \
                      "siccus", "sano", "eruo", "denuo", "decor", "corona", "compostio", "color", "bellum", "bestia", "audax", "similis", "tres tria")
+

--- a/code/modules/mob/language/esperanto.dm
+++ b/code/modules/mob/language/esperanto.dm
@@ -4,6 +4,7 @@
 	speech_verb = list("insinuates")
 	ask_verb = list("implores")
 	exclaim_verb = list("posits")
+	has_written_form = TRUE
 	colour = "brass"
 	key = "e"
 	shorthand = "ES"

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -4,6 +4,7 @@
 	desc = "Noises"
 	key = ""
 	flags = RESTRICTED|NONGLOBAL|INNATE|NO_TALK_MSG|NO_STUTTER
+	has_written_form = FALSE
 
 /datum/language/noise/format_message(message, verb)
 	return "<span class='message'><span class='[colour]'>[message]</span></span>"

--- a/code/modules/mob/language/german.dm
+++ b/code/modules/mob/language/german.dm
@@ -9,6 +9,7 @@
 		LANGUAGE_KRIOSAN = 75
 	)
 	space_chance = 80
+	has_written_form = TRUE
 	shorthand = "GE"
 	syllables = list("Frau", "Mann", "Waffe", "Schiff", "Bombe", "Explosion", "Grenze", "Strasse", "Halle", "Pistole", "Gewehr", "Uniform", "Kind", "Arzt", \
 					 "und", "ja", "nein", "vielleicht", "ob", "man", "Faust", "Auto", "fliegen", "Asteroid", "Hose", "laufen", "fahren","Raumschiff", \

--- a/code/modules/mob/language/jana.dm
+++ b/code/modules/mob/language/jana.dm
@@ -11,6 +11,7 @@
 		LANGUAGE_COMMON = 5
 	)
 	space_chance = 80
+	has_written_form = TRUE
 	syllables = list(
 		"a", "ai", "an", "ang", "ao", "ba", "bai", "ban", "bang", "bao", "bei", "ben", "beng", "bi", "bian", "biao",
 		"bie", "bin", "bing", "bo", "bu", "ca", "cai", "can", "cang", "cao", "ce", "cei", "cen", "ceng", "cha", "chai",

--- a/code/modules/mob/language/jive.dm
+++ b/code/modules/mob/language/jive.dm
@@ -6,6 +6,7 @@
 	key = "s"
 	flags = SIGNLANG | NO_STUTTER | NONVERBAL
 	shorthand = "JI"
+	has_written_form = FALSE
 
 //To maintain an air of informality, jive does not force capitalization
 /datum/language/jive/format_message(message, verb)

--- a/code/modules/mob/language/monkey.dm
+++ b/code/modules/mob/language/monkey.dm
@@ -5,6 +5,7 @@
 	partial_understanding = list(
 		LANGUAGE_COMMON = 5			//hehe le monkey
 	)
+	has_written_form = FALSE //No monke write......
 	speech_verb = list("chimpers")
 	ask_verb = list("chimpers")
 	exclaim_verb = list("screeches")

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -9,6 +9,7 @@
 	flags = RESTRICTED
 	syllables = list("sss","sSs","SSS")
 	shorthand = "Xeno"
+	has_written_form = FALSE
 
 /*
 /datum/language/xenos
@@ -43,6 +44,7 @@
 	key = "x"
 	flags = RESTRICTED | HIVEMIND
 	shorthand = "N/A"
+	has_written_form = FALSE
 
 /datum/language/corticalborer/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
 
@@ -68,6 +70,7 @@
 	key = "f"
 	flags = RESTRICTED
 	space_chance = 100
+	has_written_form = TRUE		//I҉̵̴̢҉̶̸̴̵̸̷̷̴̷̷̶̷̴̵̡̨̡̢̧̨̧̡̛̛̛̛̛̀́̀́̀̀̕͘̕͜͢͢͢͜͜͢͜͢͡͞͠͠͠͝͠͡͠͠͞͠ ͜͢҉̴̷̵̨̧̢̛̛̛͝͏̧́̀́̀̕̕͘̕͘͜͢͠͡͏̴̸̶̴̧̛́́́͟͢͡͞͠͞͏̴̴̵̵̵̵̢̨̢̧͟͟͠͞͡͠͞͝͡ḉ̷̸̶̧̢̧̀́͟͢͟͟͢͜͠͡҉̢̛͟͏̷̶̸̡̡̨̡̛̛́͘͢͜͢͠͏̡̧̕͝͏̸̶́́̀͢͢͢͢͡͠͠ ͞͞͏̷̷̀̕͠҉͡͏̸̶̸̷̨̧̨̢̨̨̨́́̀̕̕͜͞͡͏͏̵̴̶̸̀́͟͠u̶̵̡̢̧̕͟͢͝͏̵̶҉̧҉̛͠͝͡҉̶̸̴̶̨̡̀́̀̀́̀͢͢͡͝͝͡͞͡
 	syllables = list("ire","ego","nahlizet","certum","veri","jatkaa","mgar","balaq", "karazet", "geeri", \
 		"orkan", "allaq", "sas'so", "c'arta", "forbici", "tarem", "n'ath", "reth", "sh'yro", "eth", "d'raggathnor", \
 		"mah'weyh", "pleggh", "at", "e'ntrath", "tok-lyr", "rqa'nap", "g'lt-ulotf", "ta'gh", "fara'qha", "fel", "d'amar det", \
@@ -90,6 +93,7 @@
 		LANGUAGE_YASSARI = 15
 	)
 	space_chance = 100
+	has_written_form = TRUE
 	syllables = list("ire","ego","nahlizet","certum","veri","jatkaa","mgar","balaq", "karazet", "geeri", \
 		"orkan", "allaq", "sas'so", "c'arta", "forbici", "tarem", "n'ath", "reth", "sh'yro", "eth", "d'raggathnor", \
 		"mah'weyh", "pleggh", "at", "e'ntrath", "tok-lyr", "rqa'nap", "g'lt-ulotf", "ta'gh", "fara'qha", "fel", "d'amar det", \
@@ -109,6 +113,7 @@
 	key = "y"
 	flags = RESTRICTED | HIVEMIND
 	shorthand = "N/A"
+	has_written_form = FALSE	//Hiveminds don't get a written language.
 
 /datum/language/chtmant
 	name = LANGUAGE_CHTMANT
@@ -120,6 +125,7 @@
 	key = "o"
 	flags = RESTRICTED | HIVEMIND
 	shorthand = "N/A"
+	has_written_form = FALSE	//Hiveminds don't get a written language.
 
 /datum/language/kriosan
 	name = LANGUAGE_KRIOSAN
@@ -130,6 +136,7 @@
 	colour = "kriosan"
 	key = "k"
 	flags = RESTRICTED
+	has_written_form = FALSE	//Lore reason - Creolized German and their ancient native language. Therefor their written language is 'dead' effectively.
 	partial_understanding = list(
 		LANGUAGE_GERMAN = 75,
 		LANGUAGE_COMMON = 10

--- a/code/modules/mob/language/serbian.dm
+++ b/code/modules/mob/language/serbian.dm
@@ -5,6 +5,7 @@
 	colour = "serbian"
 	key = "x"
 	space_chance = 80
+	has_written_form = TRUE
 	partial_understanding = list(
 		LANGUAGE_CYRILLIC = 60,
 		LANGUAGE_ESPERANTO = 20

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -14,6 +14,7 @@
 	)
 	flags = RESTRICTED
 	shorthand = "CO"
+	has_written_form = TRUE
 
 
 	//syllables are at the bottom of the file

--- a/code/modules/mob/language/synthetic.dm
+++ b/code/modules/mob/language/synthetic.dm
@@ -8,6 +8,7 @@
 	key = "b"
 	flags = RESTRICTED | HIVEMIND
 	var/drone_only
+	has_written_form = FALSE
 
 /datum/language/binary/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
 

--- a/code/modules/mob/language/yassari.dm
+++ b/code/modules/mob/language/yassari.dm
@@ -10,6 +10,7 @@
 		LANGUAGE_OPIFEXEE = 15
 	)
 	space_chance = 100
+	has_written_form = TRUE
 	shorthand = "YI"
 	syllables = list("laa", "naaam", "masaa' alkhayr", "haydi bakalim", "hal yumkinuk", "hadduth bibut'", "afham tamaaman", "maafi mushki", "habeebti", "hala", "ahlan wa sahlan", \
 				"merhaba", "shukran", "mahbrook", "min fadlak", "sayh'rah", "al-mar'ah", "yadhab 'ila", "ata nahw", "tanzuru", "bin salamosu", "bagagah sagirah", "'innaha imr", "waghun qabih", \

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -422,7 +422,7 @@ mob/proc/format_say_message(var/message = null)
 					message = pick(S.speak)
 			else
 				if(language)
-					message = language.scramble(message)
+					message = language.scramble(message, languages)
 				else
 					message = stars(message)
 
@@ -458,7 +458,7 @@ mob/proc/format_say_message(var/message = null)
 						return
 				else
 					if(language)
-						message = language.scramble(message)
+						message = language.scramble(message, languages)
 					else
 						message = stars(message)
 

--- a/code/modules/modular_computers/file_system/programs/generic/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/configurator.dm
@@ -46,6 +46,10 @@
 		data["battery_rating"] = movable.cell.maxcharge
 		data["battery_percent"] = round(movable.cell.percent())
 
+	// Configurable stuff
+	var/obj/item/computer_hardware/printer/printer = computer.printer(/obj/item/computer_hardware/printer)
+	data["print_language"] = printer ? printer.print_language : null
+
 	var/list/all_entries[0]
 	for(var/obj/item/computer_hardware/H in hardware)
 		all_entries.Add(list(list(
@@ -63,3 +67,23 @@
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()
+	
+/datum/nano_module/program/computer_configurator/Topic(href, href_list)
+	. = ..()
+	if (.)
+		return
+
+	if (href_list["edit_language"])
+		var/obj/item/computer_hardware/printer/printer = computer.printer(/obj/item/computer_hardware/printer)
+		if (!printer)
+			to_chat(usr, SPAN_WARNING("No printer found, unable to update language."))
+			return TOPIC_REFRESH
+		var/list/selectable_languages = list()
+		for (var/datum/language/L in usr.languages)
+			if (L.has_written_form)
+				selectable_languages += L
+		var/new_language = input(usr, "What language do you want to print in?", "Change language", printer.print_language) as null|anything in selectable_languages
+		if (!new_language)
+			return TOPIC_HANDLED
+		printer.print_language = new_language
+		return TOPIC_REFRESH

--- a/code/modules/modular_computers/file_system/programs/generic/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/configurator.dm
@@ -47,7 +47,7 @@
 		data["battery_percent"] = round(movable.cell.percent())
 
 	// Configurable stuff
-	var/obj/item/computer_hardware/printer/printer = computer.printer(/obj/item/computer_hardware/printer)
+	var/obj/item/computer_hardware/printer/printer = movable.printer
 	data["print_language"] = printer ? printer.print_language : null
 
 	var/list/all_entries[0]
@@ -67,14 +67,14 @@
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()
-	
+
 /datum/nano_module/program/computer_configurator/Topic(href, href_list)
 	. = ..()
 	if (.)
 		return
 
 	if (href_list["edit_language"])
-		var/obj/item/computer_hardware/printer/printer = computer.printer(/obj/item/computer_hardware/printer)
+		var/obj/item/computer_hardware/printer/printer = movable.printer
 		if (!printer)
 			to_chat(usr, SPAN_WARNING("No printer found, unable to update language."))
 			return TOPIC_REFRESH

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -7,6 +7,8 @@
 	hardware_size = 1
 	var/stored_paper = 10
 	var/max_paper = 10
+	var/last_print
+	var/print_language = LANGUAGE_COMMON
 
 /obj/item/computer_hardware/printer/diagnostics(var/mob/user)
 	..()
@@ -23,7 +25,7 @@
 	// Damaged printer causes the resulting paper to be somewhat harder to read.
 	if(damage > damage_malfunction)
 		text_to_print = stars(text_to_print, 100-malfunction_probability)
-	new/obj/item/paper(drop_location(), text_to_print, paper_title)
+	new/obj/item/paper(drop_location(), text_to_print, paper_title, print_language)
 
 	stored_paper--
 	return 1

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -40,6 +40,7 @@
 		var/obj/item/paper/carbon/c = src
 		var/copycontents = html_decode(c.info)
 		var/obj/item/paper/carbon/copy = new /obj/item/paper/carbon (usr.loc)
+		copy.language = language
 		// <font>
 		if(info)
 			copycontents = replacetext(copycontents, "<font face=\"[c.deffont]\" color=", "<font face=\"[c.deffont]\" nocolor=")	//state of the art techniques in action

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -83,17 +83,19 @@
 		info = parsepencode(info)
 		return
 
-/obj/item/paper/New(loc, text,title)
+/obj/item/paper/New(loc, text,title, datum/language/L = null)
 	..(loc)
 	pixel_y = rand(-8, 8)
 	pixel_x = rand(-9, 9)
 	set_content(text ? text : info, title)
 
+	if (L)
+		language = L
+
 	var/old_language = language
-	language = global.all_languages[language]
-	if (!language)
+	if (!set_language(language, TRUE))
 		log_debug("[src] ([type]) initialized with invalid or missing language `[old_language]` defined.")
-		language = global.all_languages[LANGUAGE_COMMON]
+		set_language(LANGUAGE_COMMON, TRUE)
 
 /obj/item/paper/proc/set_content(text,title)
 	if(title)
@@ -103,6 +105,18 @@
 	update_icon()
 	update_space(info)
 	updateinfolinks()
+
+/obj/item/paper/proc/set_language(datum/language/new_language, force = FALSE)
+	if (!new_language || (info && !force))
+		return FALSE
+
+	if (!istype(new_language))
+		new_language = global.all_languages[new_language]
+	if (!istype(new_language))
+		return FALSE
+
+	language = new_language
+	return TRUE
 
 /obj/item/paper/update_icon()
 	if (icon_state == "paper_talisman")
@@ -125,7 +139,7 @@
 	else
 		to_chat(user, "<span class='notice'>You have to go closer if you want to read it.</span>")
 
-/obj/item/paper/verb/set_language()
+/obj/item/paper/verb/user_set_language()
 	set name = "Set writing language"
 	set category = "Object"
 	set src in usr
@@ -158,7 +172,7 @@
 	if (!admin_force && !Adjacent(src, user) && !CanInteract(user, GLOB.deep_inventory_state))
 		to_chat(user, SPAN_WARNING("You must remain next to or continue holding \the [src] to do that."))
 		return
-	language = new_language
+	set_language(new_language)
 
 /obj/item/paper/proc/show_content(mob/user, forceshow, editable = FALSE)
 	var/can_read = (istype(user, /mob/living/carbon/human) || isghost(user) || istype(user, /mob/living/silicon)) || forceshow

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -33,6 +33,7 @@
 	var/rigged = 0
 	var/spam_flag = 0
 	var/crumpled = FALSE
+	var/datum/language/language = LANGUAGE_COMMON // Language the paper was written in. Editable by users up until something's actually written
 
 	var/const/deffont = "Verdana"
 	var/const/signfont = "Times New Roman"
@@ -88,6 +89,12 @@
 	pixel_x = rand(-9, 9)
 	set_content(text ? text : info, title)
 
+	var/old_language = language
+	language = global.all_languages[language]
+	if (!language)
+		log_debug("[src] ([type]) initialized with invalid or missing language `[old_language]` defined.")
+		language = global.all_languages[LANGUAGE_COMMON]
+
 /obj/item/paper/proc/set_content(text,title)
 	if(title)
 		name = title
@@ -118,13 +125,79 @@
 	else
 		to_chat(user, "<span class='notice'>You have to go closer if you want to read it.</span>")
 
-/obj/item/paper/proc/show_content(mob/user, forceshow)
+/obj/item/paper/verb/set_language()
+	set name = "Set writing language"
+	set category = "Object"
+	set src in usr
+
+	choose_language(usr)
+
+/obj/item/paper/proc/choose_language(mob/user, admin_force = FALSE)
+	if (info)
+		to_chat(user, SPAN_WARNING("\The [src] already has writing on it and cannot have its language changed."))
+		return
+	if (!admin_force && !user.languages.len)
+		to_chat(user, SPAN_WARNING("You don't know any languages to choose from."))
+		return
+
+	var/list/selectable_languages = list()
+	if (admin_force)
+		for (var/key in global.all_languages)
+			var/datum/language/L = global.all_languages[key]
+			if (L.has_written_form)
+				selectable_languages += L
+	else
+		for (var/datum/language/L in user.languages)
+			if (L.has_written_form)
+				selectable_languages += L
+
+	var/new_language = input(user, "What language do you want to write in?", "Change language", language) as null|anything in selectable_languages
+	if (!new_language || new_language == language)
+		to_chat(user, SPAN_NOTICE("You decide to leave the language as [language.name]."))
+		return
+	if (!admin_force && !Adjacent(src, user) && !CanInteract(user, GLOB.deep_inventory_state))
+		to_chat(user, SPAN_WARNING("You must remain next to or continue holding \the [src] to do that."))
+		return
+	language = new_language
+
+/obj/item/paper/proc/show_content(mob/user, forceshow, editable = FALSE)
 	var/can_read = (istype(user, /mob/living/carbon/human) || isghost(user) || istype(user, /mob/living/silicon)) || forceshow
 	if(!forceshow && istype(user,/mob/living/silicon/ai))
 		var/mob/living/silicon/ai/AI = user
 		can_read = get_dist(src, AI.camera) < 2
 	user << browse("<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY bgcolor='[color]'>[can_read ? info : stars(info)][stamps]</BODY></HTML>", "window=[name]")
+
+	var/html = "<html><head><title>[name]</title></head><body bgcolor='[color]'>"
+	var/body
+	if (can_read && editable)
+		body = info_links
+		if (isobserver(user) || (language in user.languages))
+			if (info)
+				html += "<p><i>This paper is written in [language.name].</i></p>"
+			else
+				html += "<p><i>You are writing in <a href='?src=\ref[src];change_language=1'>[language]</a>.</i></p>"
+		else
+			html += "<p style=\"color: red;\"><i>This paper is written in a language you don't understand.</i></p>"
+			body = language.scramble(info, user.languages)
+	else if (!can_read)
+		html += "<p style=\"color:red;\"><i>The paper is too far away to read.</i></p>"
+	else
+		body = info
+		if (isobserver(user) || (language in user.languages))
+			html += "<p><i>This paper is written in [language.name].</i></p>"
+		else
+			html += "<p style=\"color: red;\"><i>This paper is written in a language you don't understand.</i></p>"
+			body = language.scramble(body, user.languages)
+
+	html += "<hr />"
+	html += body + stamps
+	html += "</body></html>"
+	show_browser(user, html, "window=[name]")
+
 	onclose(user, "[name]")
+
+/obj/item/paper/proc/write_content(mob/user)
+
 
 /obj/item/paper/verb/rename()
 	set name = "Rename paper"
@@ -325,6 +398,11 @@
 	if(!usr || (usr.stat || usr.restrained()))
 		return
 
+	if (href_list["change_language"])
+		choose_language(usr)
+		show_content(usr, editable = TRUE)
+		return
+
 	if(href_list["write"])
 		var/id = href_list["write"]
 		//var/t = strip_html_simple(input(usr, "What text do you wish to add to " + (id=="end" ? "the end of the paper" : "field "+id) + "?", "[name]", null),8192) as message
@@ -482,6 +560,33 @@
 /*
  * Premade paper
  */
+/obj/item/paper/german
+	language = LANGUAGE_GERMAN
+
+/obj/item/paper/russian
+	language = LANGUAGE_CYRILLIC
+
+/obj/item/paper/warcrime
+	language = LANGUAGE_SERBIAN
+
+/obj/item/paper/jana
+	language = LANGUAGE_JANA
+
+/obj/item/paper/yassari
+	language = LANGUAGE_YASSARI
+
+/obj/item/paper/opifex
+	language = LANGUAGE_OPIFEXEE
+
+/obj/item/paper/latin
+	language = LANGUAGE_LATIN
+
+/obj/item/paper/esperanto
+	language = LANGUAGE_ESPERANTO
+
+/obj/item/paper/cult
+	language = LANGUAGE_CULT	//May god save your soul.
+
 /obj/item/paper/Court
 	name = "Judgement"
 	info = "For crimes against the Nadezhda colony, the offender is sentenced to:<BR>\n<BR>\n"


### PR DESCRIPTION
## About The Pull Request
Ported a bunch of Bay's language code system to make the partially intelligible language system work properly. Language users now will properly be able to understand one another within the probability values given previously.

Also ported the system from Bay allowing languages to be written on paper. Computer tablets and consoles, that sport a printer that is, can be configured via program to allow printing of documents in specific languages as well.

Written language system (Serbian speaker -> Russian speaker - 60% Understanding)
![image](https://user-images.githubusercontent.com/47883419/184558759-95e4aaec-ca90-4ea7-b84a-4f07891d9ca2.png)

Verbal language system (Serbian speaker -> Russian speaker - 60% Understanding)
![image](https://user-images.githubusercontent.com/47883419/184558702-a16a7bf7-6f8e-4edf-8cc4-9c02348f890f.png)

Future to-do: Make it so scanners/copy machines can copy into different languages. Not urgent so I'd prefer this be merged first since that will take time to do.

## Changelog
:cl:
fixes: Language Intelligibility
adds: Written Languages
/:cl:
