### PR TITLE
Psionic Range Nerf

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -3,7 +3,7 @@
 
 	This needs more thinking out, but I might as well.
 */
-var/const/tk_maxrange = 11
+var/const/tk_maxrange = 7 //Do not increase further - stops abusing of TK mechanics using scopes and/or binoculars.
 
 /*
 	Telekinetic attack:


### PR DESCRIPTION
## About The Pull Request
Does what #3815 does but separates the Nanogate nerf and Psionic nerf instead. People apparently have still been abusing this and not it's not being merged because of complaints over nanogates not going to FBPs.

## Changelog
:cl:
fixes: Psionic exploit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
