### PR TITLE
Allows More Jobs for FBPs

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -84,7 +84,6 @@ Treat your command officers with respect, and listen to their council. Try not t
 	wage = WAGE_COMMAND
 	ideal_character_age = 35
 	minimum_character_age = 30
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 
 	health_modifier = 5
 	description = "The Steward is the loyal right-hand of the Premier. Serving as a personal guard, follow him wherever he goes.<br>\

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -19,7 +19,6 @@
 		STAT_TGH = 15,
 		STAT_VIG = 15,
 	)
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_NASHEF)
 
 	perks = list(/datum/perk/market_prof, /datum/perk/bartender)
 
@@ -58,7 +57,6 @@
 		STAT_TGH = 10,
 		STAT_BIO = 10, // They need it to butcher animals without hurting themselves.
 	)
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_NASHEF)
 
 	perks = list(/datum/perk/market_prof, /datum/perk/bartender, /datum/perk/foodappraise)
 
@@ -94,7 +92,6 @@
 	access = list(access_hydroponics, access_bar, access_kitchen)
 	wage = WAGE_LABOUR_DUMB //The gardener can make money selling his fruits to the church or to the chef and bartender.
 
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_NASHEF)
 	outfit_type = /decl/hierarchy/outfit/job/service/gardener
 	stat_modifiers = list(
 		STAT_BIO = 15,
@@ -180,7 +177,6 @@
 	wage = WAGE_PROFESSIONAL
 	health_modifier = 5
 	outfit_type = /decl/hierarchy/outfit/job/service/janitor
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_NASHEF)
 
 	perks = list(/datum/perk/market_prof, /datum/perk/job/jingle_jangle, /datum/perk/neat) //Union has revoked their chemistry privileges
 

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -75,8 +75,6 @@ Counsel the council on directing the colony towards profitable opportunities."
 	department_account_access = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/cargo/cargo_tech
 
-	disallow_species = list(FORM_SOTSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
-
 
 	access = list(
 		access_mailsorting, access_cargo, access_cargo_bot, access_mining,

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -75,7 +75,7 @@ Counsel the council on directing the colony towards profitable opportunities."
 	department_account_access = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/cargo/cargo_tech
 
-	disallow_species = list(FORM_BSSYNTH, FORM_CHURCHSYNTH)
+	disallow_species = list(FORM_BSSYNTH)
 
 
 	access = list(

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -75,6 +75,8 @@ Counsel the council on directing the colony towards profitable opportunities."
 	department_account_access = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/cargo/cargo_tech
 
+	disallow_species = list(FORM_BSSYNTH, FORM_CHURCHSYNTH)
+
 
 	access = list(
 		access_mailsorting, access_cargo, access_cargo_bot, access_mining,
@@ -126,7 +128,7 @@ Avoid the deeper tunnels unless otherwise instructed, however - this domain is h
 	wage = WAGE_LABOUR_HAZARD //The miners union is stubborn
 	health_modifier = 5
 
-	disallow_species = list(FORM_SOTSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_BSSYNTH, FORM_CHURCHSYNTH)
 	outfit_type = /decl/hierarchy/outfit/job/cargo/mining
 
 	description = "The Miner is a professional resource procurer, acquiring valuable minerals for Lonestar Shipping Solutions.<br>\

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -123,7 +123,7 @@
 	wage = WAGE_PROFESSIONAL
 	alt_titles = list("Soteria Emergency Medical Technician")
 	outfit_type = /decl/hierarchy/outfit/job/medical/recovery_team
-	disallow_species = list(FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_AGSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 
 	health_modifier = 5
 	perks = list(/datum/perk/medicalexpertise, /datum/perk/chemist) // Can treat people well but can't do surgery or chemistry as good as a doctor.

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -13,7 +13,7 @@
 	req_admin_notify = 1
 	wage = WAGE_COMMAND
 	outfit_type = /decl/hierarchy/outfit/job/medical/cmo
-	disallow_species = list(FORM_UNBRANDED, FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_genetics, access_heads,

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -12,7 +12,7 @@
 	selection_color = "#b39aaf"
 	req_admin_notify = 1
 	wage = WAGE_COMMAND
-	disallow_species = list(FORM_UNBRANDED, FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 
 
 	outfit_type = /decl/hierarchy/outfit/job/science/rd

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -17,7 +17,7 @@
 	department_account_access = TRUE
 	playtimerequired = 2500
 	health_modifier = 25
-	disallow_species = list(FORM_UNBRANDED, FORM_SOTSYNTH, FORM_AGSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/smc
 
@@ -81,7 +81,7 @@
 	department_account_access = TRUE
 	playtimerequired = 2500
 	health_modifier = 25
-	disallow_species = list(FORM_UNBRANDED, FORM_SOTSYNTH, FORM_AGSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/swo
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simply put - changes the jobs Synths can do somewhat.
- Most synthetics can be a cargo tech since I doubt LS lore-wise would care and there's not much they can abuse. (BS due to possibly replacing prospectors.)
- BS synths can now play Trauma Team. Makes sense since it's a combat-oriented role, usually, and BS synths can be corpsmen anyway.
- All synthetics can be a bartender, chef or janitor.
- Steward is no longer locked to only combat synths since it is a role that just handles finance _and_ body-guarding. (Personally - I'd argue Premier should be only unlocked to unbranded but I lost the argument of biased premiers ages ago.)
- Unbrandeds can now be heads of all departments (Except Prime, you need a cruciform - dumby) since regular FBPs can be heads anyway. 

## Changelog
:cl:
balance: (?) Allows FBPs to play more 'service level' jobs so they aren't locked to a singular department at the least.
balance: Unlocks Cargo Tech for most FBPs. (Except BS for abuse concerns.)
balance: Unlocks Recovery Team from BS synths.
balance: Mostly a minor/lore thing, unbrandeds are no longer restricted from job heads. (Besides Prime)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
