### PR TITLE
Medfixes and ports

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -263,8 +263,28 @@
 		if(temp.dislocated == 2)
 			wound_flavor_text["[temp.name]"] += "<span class='warning'>[His] [temp.joint] is dislocated!</span><br>"
 		if(((temp.status & ORGAN_BROKEN) && temp.brute_dam > temp.min_broken_damage) || (temp.status & ORGAN_MUTATED))
-			wound_flavor_text["[temp.name]"] += "<span class='warning'>[His] [temp.name] is dented and swollen!</span><br>"
-
+			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is mangled!</span><br>"
+		if(temp.germ_level > INFECTION_LEVEL_ONE && temp.germ_level < INFECTION_LEVEL_TWO)//Occulus Edit: Infection status on examine
+			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is discolored!</span><br>"
+		else if(temp.germ_level > INFECTION_LEVEL_TWO && temp.germ_level < INFECTION_LEVEL_THREE)
+			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is oozing pus!</span><br>"
+		else if(temp.germ_level > INFECTION_LEVEL_THREE)
+			wound_flavor_text["[temp.name]"] += "<span class='danger'>[T.His] [temp.name] is covered in decaying tissue!</span><br>"
+		if(temp.status & ORGAN_DEAD)
+			wound_flavor_text["[temp.name]"] += "<span class='danger'>[T.His] [temp.name] is necrotic!</span><br>"//Occulus Edit End
+		for(var/obj/item/organ/internal/blood_vessel/BV in temp.internal_organs)//Occulus Edit: Ruptured Blood Vessel
+			if(BV.damage > 4)//occulus Edit: Ruptured blood vessel that is above the self-heal threshold
+				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] swollen and discolored!</span><br>"//Occulus Edit: Ruptured Blood vessel
+//Edited out form occulus port but this is good to have in case we ever add back in sanity
+/*
+	if(user.stats.getPerk(PERK_EMPATH))
+		if(sanity.level <= 40 && sanity.level > 20)
+			msg += "[T.He] looks stressed out.\n"
+		else if(sanity.level <= 20 && sanity.level > 0)
+			msg += "<span class='warning'>[T.He] looks ready to do something rash!</span>\n"
+		else if(sanity.level == 0)
+			msg += "<span class ='danger'>[T.He] needs help! Now! Something is wrong!\n"
+*/
 	//Handles the text strings being added to the actual description.
 	//If they have something that covers the limb, and it is not missing, put flavortext.  If it is covered but bleeding, add other flavortext.
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -41,7 +41,7 @@
 	var/hair_col
 
 	// Wound and structural data.
-	var/wound_update_accuracy = 1		// how often wounds should be updated, a higher number means less often
+	var/wound_update_accuracy = 3		// how often wounds should be updated, a higher number means less often Occulus Edit: only update wounds every 3 ticks (potential lag reduction)
 	var/list/wounds = list()			// wound datum list.
 	var/number_wounds = 0				// number of wounds, which is NOT wounds.len!
 	var/list/children = list()			// Sub-limbs.
@@ -222,7 +222,7 @@
 			nerve = new /obj/item/organ/internal/nerve/sensitive_nerve/exalt
 		else
 			nerve = new /obj/item/organ/internal/nerve/sensitive_nerve/exalt_leg
-		
+
 	else if(nature < MODIFICATION_SILICON)
 		nerve = new /obj/item/organ/internal/nerve
 	else
@@ -350,10 +350,10 @@
 
 /obj/item/organ/external/proc/is_dislocated()
 	if(dislocated > 0)
-		return 1
+		return TRUE
 	if(parent)
 		return parent.is_dislocated()
-	return 0
+	return FALSE
 
 /obj/item/organ/external/proc/dislocate(var/primary)
 	if(dislocated != -1)
@@ -482,17 +482,19 @@ This function completely restores a damaged organ to perfect condition.
 //Determines if we even need to process this organ.
 /obj/item/organ/external/proc/need_process()
 	if(status & (ORGAN_CUT_AWAY|ORGAN_BLEEDING|ORGAN_BROKEN|ORGAN_DESTROYED|ORGAN_SPLINTED|ORGAN_DEAD|ORGAN_MUTATED))
-		return 1
+		return TRUE
 	if((brute_dam || burn_dam) && !BP_IS_ROBOTIC(src)) //Robot limbs don't autoheal and thus don't need to process when damaged
-		return 1
+		return TRUE
 	if(last_dam != brute_dam + burn_dam) // Process when we are fully healed up.
 		last_dam = brute_dam + burn_dam
-		return 1
+		return TRUE
 	else
 		last_dam = brute_dam + burn_dam
 	if(germ_level)
-		return 1
-	return 0
+		return TRUE
+	if(wounds)//Occulus Edit - Need this to process wound healing over time!
+		return TRUE//Occulus Edit - Need this to process wound healing over time!
+	return FALSE
 
 /obj/item/organ/external/Process()
 	if(owner)
@@ -639,7 +641,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	for(var/datum/wound/W in wounds)
 		// wounds can disappear after 10 minutes at the earliest
-		if(W.damage <= 0 && W.created + 10 * 10 * 60 <= world.time)
+		if(W.damage <= 0 && W.salved == 1 && W.bandaged == 1)//Occulus Edit: Wounds that have no damage, are salved, and are bandaged will disappear
 			wounds -= W
 			continue
 			// let the GC handle the deletion of the wound
@@ -724,8 +726,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/n_is = damage_state_text()
 	if (n_is != damage_state)
 		damage_state = n_is
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 // new damage icon system
 // returns just the brute/burn damage code
@@ -757,7 +759,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 //****************************************************/
 
 /obj/item/organ/external/proc/is_stump()
-	return 0
+	return FALSE
 
 /obj/item/organ/external/proc/release_restraints(var/mob/living/carbon/human/holder)
 	if(!holder)
@@ -780,24 +782,24 @@ Note that amputating the affected organ does in fact remove the infection from t
 	for(var/datum/wound/W in wounds)
 		if(W.internal) continue
 		if(!W.bandaged)
-			return 0
-	return 1
+			return FALSE
+	return TRUE
 
 // checks if all wounds on the organ are salved
 /obj/item/organ/external/proc/is_salved()
 	for(var/datum/wound/W in wounds)
 		if(W.internal) continue
 		if(!W.salved)
-			return 0
-	return 1
+			return FALSE
+	return TRUE
 
 // checks if all wounds on the organ are disinfected
 /obj/item/organ/external/proc/is_disinfected()
 	for(var/datum/wound/W in wounds)
 		if(W.internal) continue
 		if(!W.disinfected)
-			return 0
-	return 1
+			return FALSE
+	return TRUE
 
 /obj/item/organ/external/proc/bandage()
 	var/rval = 0
@@ -877,8 +879,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/proc/has_infected_wound()
 	for(var/datum/wound/W in wounds)
 		if(W.germ_level > INFECTION_LEVEL_ONE)
-			return 1
-	return 0
+			return TRUE
+	return FALSE
 
 /obj/item/organ/external/proc/is_malfunctioning()
 	return (BP_IS_ROBOTIC(src) && (brute_dam + burn_dam) >= 40 && prob(brute_dam + burn_dam))

--- a/code/modules/surgery/autodoc.dm
+++ b/code/modules/surgery/autodoc.dm
@@ -93,7 +93,7 @@
 				patchnote.surgery_operations |= AUTODOC_FRACTURE
 		if(AUTODOC_EMBED_OBJECT in possible_operations)
 			if(external.implants)
-				if(/obj/item/material/shard/shrapnel in external.implants)
+				if(locate(/obj/item/material/shard/shrapnel) in external.implants)
 					patchnote.surgery_operations |= AUTODOC_EMBED_OBJECT
 
 		if(external.wounds.len)
@@ -152,9 +152,8 @@
 
 	else if(patchnote.surgery_operations & AUTODOC_EMBED_OBJECT)
 		to_chat(patient, SPAN_NOTICE("Removing embedded objects from the patients [external]."))
-		for(var/obj/item/material/shard/shrapnel/shrapnel in external.implants)
-			external.implants -= shrapnel
-			shrapnel.loc = get_turf(patient)
+		for(var/obj/item/material/shard/shrapnel/shrap in external.implants)
+			external.remove_item(shrap, patient, FALSE)
 		patchnote.surgery_operations &= ~AUTODOC_EMBED_OBJECT
 
 	else if(patchnote.surgery_operations & AUTODOC_OPEN_WOUNDS)

--- a/code/modules/surgery/robotic_damage.dm
+++ b/code/modules/surgery/robotic_damage.dm
@@ -45,6 +45,8 @@
 
 /datum/surgery_step/robotic/fix_brute/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	if(..())
+		if(organ.owner.wearing_rig)
+			return FALSE
 		if(organ.brute_dam <= 0)
 			to_chat(user, SPAN_NOTICE("The hull of [organ.get_surgery_name()] is undamaged!"))
 			return SURGERY_FAILURE

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -258,8 +258,8 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 				return TRUE
 
 			if(QUALITY_WELDING)
-				try_surgery_step(/datum/surgery_step/robotic/fix_brute, user, tool)
-				return TRUE
+				if(try_surgery_step(/datum/surgery_step/robotic/fix_brute, user, tool))
+					return TRUE
 
 			if(ABORT_CHECK)
 				return TRUE


### PR DESCRIPTION
[By Jamini](https://github.com/sojourn-13/sojourn-station/commit/2beaebd2e6575a063137d74375cf359f1d6a81cc) 

tweak: Wounds now process every third tick
tweak: Wounds that are fully healed, bandaged, and salved will no longer show on examine
tweak: examine text now shows infections on external organs, as well as severity
tweak: adjusted examine text for broken limbs
tweak: blood vessel damage now only shows IB text if you have above 5 blood vessel damage
tweak: infections now show on examine if they are above infection level 1
[By MLGTASTICa](https://github.com/sojourn-13/sojourn-station/commit/a92b05a9573977459b7d7034ac332d36a3311316) 

fix: Fixed autodoc shrapnel removal not working properly.
fix: FIxed hardsuits not being removeable from FBP's backs.


Testing: Made sure it complied
Performance: Slight improvements but mostly more costs that are non-notable