### PR TITLE
New church maping

### DIFF
--- a/maps/_DeepForest/map/_River_Forest.dmm
+++ b/maps/_DeepForest/map/_River_Forest.dmm
@@ -4558,6 +4558,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock/grey,
 /area/nadezhda/outside/forest/river_forest_underground)
+"Zi" = (
+/obj/effect/shuttle_landmark/river_forest,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest/river_forest_light)
 "Zm" = (
 /obj/effect/decal/cleanable/rubble,
 /mob/living/carbon/superior_animal/wurm,
@@ -78072,7 +78076,7 @@ lB
 xa
 xa
 xa
-xa
+Zi
 xa
 xa
 xa

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -1830,24 +1830,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"asE" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
 "asG" = (
 /obj/structure/scrap_cube,
 /obj/effect/decal/cleanable/dirt,
@@ -2524,14 +2506,25 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "aAw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "aAy" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/outside/meadow)
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "aAN" = (
 /obj/structure/table/rack/shelf,
 /obj/random/junk/low_chance,
@@ -2874,14 +2867,10 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "aED" = (
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "aEL" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -2997,11 +2986,11 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/detectives_office)
 "aFL" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/item/tool/knife/neotritual,
+/obj/item/clothing/gloves/psionic_ring,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "aFM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3391,8 +3380,11 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/prisoncells)
 "aJN" = (
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/catwalk,
+/obj/structure/invislight,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/meadow)
 "aJP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5091,14 +5083,14 @@
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
 "bal" = (
-/obj/structure/multiz/stairs/active{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "bam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
@@ -5710,19 +5702,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bfZ" = (
-/obj/structure/multiz/stairs/active{
-	dir = 1
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/sign/levels/stairsdown{
-	pixel_y = -30;
-	pixel_x = 32
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "bgc" = (
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -6356,18 +6342,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bmx" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/smartspawnplasma,
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
 "bmy" = (
 /obj/structure/railing{
@@ -6624,11 +6605,10 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
 "boU" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/box/white,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "boY" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "WO"
@@ -6751,6 +6731,11 @@
 /obj/machinery/door/unpowered/simple/wood/saloon,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/cafeteria)
+"bqh" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "bqj" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -7221,20 +7206,14 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "buS" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "buT" = (
 /obj/effect/window_lwall_spawn,
 /turf/simulated/floor/plating/under,
@@ -7303,12 +7282,17 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "bvz" = (
-/obj/structure/table/woodentable,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "bvA" = (
 /obj/structure/railing{
 	dir = 4;
@@ -7438,9 +7422,25 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bwG" = (
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "bwJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -7746,6 +7746,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
+"bAa" = (
+/obj/machinery/vending/theomat,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "bAb" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/asteroid/dirt,
@@ -9092,18 +9102,10 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "bPm" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/urn/veteran{
-	pixel_x = 7
-	},
-/obj/item/oddity/nt/pyramid{
-	pixel_x = -9
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/light,
+/obj/machinery/vending/fortune,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "bPp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9122,19 +9124,12 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/quartermaster/disposaldrop)
 "bPu" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "bPJ" = (
 /obj/structure/flora/small/busha1,
@@ -10098,18 +10093,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "bZJ" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/camera/network/church{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "bZL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10408,12 +10395,15 @@
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/plasma_tag)
 "ccn" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "cco" = (
 /obj/machinery/light{
 	dir = 1;
@@ -10643,10 +10633,15 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cfH" = (
-/obj/structure/table/woodentable,
-/obj/item/device/lighting/toggleable/lantern/censer,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "cfK" = (
 /obj/machinery/camera/xray/security{
 	dir = 9
@@ -11500,8 +11495,13 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cox" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/biomatter,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "coC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12460,10 +12460,14 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "cxF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "cxN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12520,8 +12524,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cye" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/church_reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "cyf" = (
 /turf/simulated/floor/tiled/cafe,
@@ -12619,9 +12626,15 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
 "czb" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/hallway/side/f2section1)
 "czd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -13165,12 +13178,17 @@
 	name = "Dormitory 1"
 	})
 "cDx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/power/eotp,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "cDF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13381,15 +13399,22 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/command/bridgebar)
 "cFP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable/yellow{
+	d1 = 32;
+	icon_state = "32-1"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/catwalk,
+/turf/simulated/open,
+/area/nadezhda/absolutism/storage)
 "cFR" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/blast/regular/open{
@@ -13498,15 +13523,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
-"cHs" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
 "cHz" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/big/bush2,
@@ -13782,21 +13798,20 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/bridge)
 "cKd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "cKe" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -14140,13 +14155,14 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/surface/section1)
 "cNE" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "cNF" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/unsimulated/wall/jungle,
@@ -14403,12 +14419,17 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "cRj" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
 	},
-/obj/machinery/smartfridge/kitchen/church,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "cRq" = (
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark/panels,
@@ -14621,8 +14642,13 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
 "cTB" = (
-/obj/effect/floor_decal/industrial/loading/white,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "cTE" = (
 /obj/structure/closet/wall_mounted/emcloset{
@@ -14746,11 +14772,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "cUo" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "cUx" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 1
@@ -15190,17 +15219,11 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
 "cZV" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "dar" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/railing/grey{
@@ -15555,10 +15578,10 @@
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
 "ddN" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/plating,
 /area/nadezhda/absolutism/chapel)
 "ddR" = (
 /obj/structure/ore_box,
@@ -15710,19 +15733,12 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "deL" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "deM" = (
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/structure/table/standard,
@@ -16070,6 +16086,17 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
+"diH" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "diQ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16404,10 +16431,15 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "dmD" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/disposal/deliveryChute{
+	dir = 4;
+	name = "biomatter chute"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "dmG" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/camera/network/medbay{
@@ -16495,10 +16527,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
 "dnk" = (
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "dnl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -16616,19 +16662,17 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "doA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "doD" = (
 /obj/structure/catwalk,
 /obj/random/cluster/roaches/low_chance,
@@ -17225,18 +17269,22 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
 "dtG" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "dup" = (
@@ -17798,17 +17846,9 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dzK" = (
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "dzS" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "16,9"
@@ -17976,12 +18016,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "dBr" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/disposal/deliveryChute{
+	dir = 1;
+	name = "trash chute"
 	},
-/turf/simulated/floor/plating/under,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "dBt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -17996,15 +18036,11 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "dBR" = (
-/obj/structure/mirror{
-	pixel_x = 0;
-	pixel_y = -28
+/obj/structure/table/woodentable,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "dBU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18130,14 +18166,20 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/bridgebar)
 "dCC" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "dCH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -19154,16 +19196,10 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "dNo" = (
-/obj/machinery/camera/network/church{
-	dir = 1
+/obj/machinery/light_switch{
+	pixel_x = -20
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
+/obj/machinery/smartfridge/kitchen/church,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "dNp" = (
@@ -19214,35 +19250,10 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "dNI" = (
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey,
-/obj/structure/sign/faction/derelict1{
-	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
-	name = "NOTICE: Dangerous Biohazard";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "dNK" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,18"
@@ -20134,7 +20145,13 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "dXG" = (
-/obj/machinery/vending/cigarette,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "dXJ" = (
@@ -20935,11 +20952,16 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
 "efu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_room)
 "efv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21044,14 +21066,17 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "egd" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/pistachios,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "egg" = (
 /obj/structure/table/rack/shelf,
 /obj/random/pack/cloth/low_chance,
@@ -21274,10 +21299,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "eit" = (
-/obj/structure/disposalpipe/segment,
-/obj/random/scrap/dense_weighted/low_chance,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/open,
 /area/nadezhda/hallway/surface/section1)
 "eix" = (
 /obj/structure/table/steel,
@@ -21370,17 +21395,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ejM" = (
-/obj/structure/bed/chair/sofa/black/right{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 32
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "ejZ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -21437,10 +21457,19 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "ekD" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "ekF" = (
 /obj/structure/table/rack/shelf,
 /obj/random/mecha_equipment/low_chance,
@@ -21893,12 +21922,25 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "epB" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Prime's Office";
+	departmentType = 22;
+	name = "Prime's RC";
+	pixel_x = 30;
+	pixel_y = 0
+	},
+/obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Prime's Office"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "epH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22188,14 +22230,9 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "esz" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "esA" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -23649,19 +23686,23 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "eIV" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 1;
+	pixel_y = 0
 	},
-/obj/structure/sign/levels/stairsup{
-	pixel_x = 32;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "eIZ" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,22"
@@ -24101,14 +24142,14 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/crew_quarters/kitchen_storage)
 "eMx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/light/small,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "eMB" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/extinguisher_cabinet{
@@ -24132,18 +24173,17 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory_blackshield)
 "eMK" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/vectorrooms)
 "eMS" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -24681,13 +24721,11 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/construction)
 "eSm" = (
-/obj/structure/closet/secure_closet/reinforced/preacher,
-/obj/item/device/taperecorder,
-/obj/item/device/camera,
-/obj/item/device/camera_film,
-/obj/item/clothing/mask/gas/germanmask,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "eSv" = (
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/effect/floor_decal/border/techfloor{
@@ -24853,21 +24891,11 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/main/stairwell)
 "eTj" = (
-/obj/structure/cable/yellow{
-	d1 = 32;
-	icon_state = "32-1"
-	},
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/catwalk,
-/turf/simulated/open,
+/obj/structure/mopbucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/soap/deluxe,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
 "eTk" = (
 /obj/structure/flora/ausbushes/stalkybush,
@@ -25148,11 +25176,22 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "eVP" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "eVQ" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -26183,12 +26222,22 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "fgb" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "fgf" = (
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/hallway/main/stairwell)
@@ -26278,15 +26327,15 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "fgM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
+/obj/structure/cable/yellow{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "fgN" = (
 /obj/structure/cable/green{
@@ -26646,11 +26695,12 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fkm" = (
-/obj/machinery/atmospherics/unary/vent_pump{
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27279,12 +27329,19 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "fqE" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/sign/faction/neotheology{
-	pixel_x = 32
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "fqF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -27466,17 +27523,9 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
 "fsi" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "fsk" = (
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm4{
@@ -27807,16 +27856,9 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "fuZ" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0";
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "fvc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -28033,9 +28075,13 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "fxv" = (
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/sign/faction/neotheology{
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "fxy" = (
 /obj/machinery/door/airlock/maintenance_security{
 	req_access = list(1)
@@ -28102,10 +28148,9 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "fyb" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/closet/coffin,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "fyc" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
@@ -28346,12 +28391,8 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical)
 "fAA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "fAG" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/simulated/floor/bluegrid{
@@ -28393,14 +28434,22 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "fBw" = (
-/obj/machinery/camera/network/church{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
 /obj/structure/cable/green{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -28493,11 +28542,13 @@
 	name = "Dormitory 3"
 	})
 "fBV" = (
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "fBY" = (
 /obj/structure/multiz/stairs/active{
 	dir = 1
@@ -28536,15 +28587,11 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/cryo)
 "fCn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "fCp" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -28879,12 +28926,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "fEH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = 32
+/obj/machinery/power/nt_obelisk,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
 	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "fEJ" = (
 /obj/structure/catwalk,
 /obj/structure/grille,
@@ -29903,6 +29950,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
 	},
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/smc/quarters)
 "fOQ" = (
@@ -29926,9 +29976,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fPi" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "fPo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -30027,24 +30078,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "fPE" = (
-/obj/structure/cable/green{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9;
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "fPG" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/camera/network/cev_eris,
@@ -31340,12 +31387,9 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/abandoned_solars/powered)
 "gdn" = (
-/obj/machinery/light_switch{
-	pixel_x = 28
-	},
-/obj/structure/bed/chair/comfy/black,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/atmos/storage)
 "gdr" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -31761,12 +31805,19 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ggs" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "ggt" = (
 /obj/machinery/power/nt_obelisk,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -32600,13 +32651,11 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "gnT" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "gnW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -32647,12 +32696,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
 "gou" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/structure/catwalk,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/skyyard)
 "gow" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -33220,18 +33269,9 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "guj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "chudorm4";
-	name = "Church Dorm 2";
-	req_access = list(70)
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "gum" = (
@@ -33404,6 +33444,19 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
 /area/colony)
+"gwj" = (
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "gwv" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -33465,17 +33518,12 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "gxd" = (
-/obj/structure/bed/chair/sofa/black/left{
+/obj/structure/railing,
+/obj/machinery/camera/network/church{
 	dir = 8
 	},
-/obj/structure/noticeboard/church{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "gxg" = (
 /obj/structure/closet/l3closet,
 /turf/simulated/floor/tiled/white,
@@ -34201,18 +34249,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/captain)
-"gEc" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/vectorrooms)
 "gEm" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/tiled/dark/danger,
@@ -34565,19 +34601,15 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "gHI" = (
-/obj/machinery/camera/network/church{
-	dir = 1
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/chapel)
 "gHJ" = (
 /obj/structure/flora/small/rock2,
 /turf/simulated/floor/asteroid/grass,
@@ -35644,14 +35676,11 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "gRP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "gRQ" = (
 /obj/random/material/low_chance,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -35684,17 +35713,14 @@
 	name = "Dormitory 2"
 	})
 "gSa" = (
-/obj/machinery/light/small{
+/obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/item/storage/fancy/crayons,
-/obj/structure/table/woodentable,
-/obj/item/storage/fancy/crayons,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "gSb" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -36256,25 +36282,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "gXz" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light_switch{
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/random/scrap/dense_weighted/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "gXB" = (
 /obj/structure/sink/kitchen{
 	name = "utility sink";
@@ -36617,10 +36630,13 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/turret_protected/ai_upload)
 "hbi" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "hbk" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -37555,9 +37571,14 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "hkR" = (
-/obj/structure/flora/small/grassb1,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "hkW" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -37701,19 +37722,19 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "hmj" = (
-/obj/machinery/light,
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -28
+/obj/structure/flora/small/grassa5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
+"hmk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
-"hmk" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/obj/structure/invislight,
-/turf/simulated/floor/plating,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "hmp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -37955,19 +37976,13 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "hpc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/structure/invislight,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/vectorrooms)
 "hpe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -37988,15 +38003,8 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/absolutism/bioreactor)
 "hpq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/power/eotp,
+/obj/structure/reagent_dispensers/biomatter,
+/obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "hpu" = (
@@ -38493,19 +38501,10 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
 "huw" = (
-/obj/structure/bed/chair/sofa/brown/left,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/random/toy/plushie,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "huC" = (
 /obj/structure/bookcase,
 /obj/item/book/ritual/cruciform,
@@ -39597,10 +39596,17 @@
 	name = "Dormitory 1"
 	})
 "hHU" = (
-/obj/structure/table/woodentable,
-/obj/machinery/reagentgrinder/portable,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "hHX" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -40019,10 +40025,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "hMs" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "hMw" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -40122,15 +40130,9 @@
 	name = "\improper Outdoors - Pad"
 	})
 "hNx" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/tool/multitool,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "hNF" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/cable/green{
@@ -40490,12 +40492,13 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "hQO" = (
-/obj/structure/catwalk,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
+/obj/structure/closet/secure_closet/reinforced/preacher,
+/obj/item/device/taperecorder,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/item/clothing/mask/gas/germanmask,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "hQP" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -40663,11 +40666,16 @@
 /turf/unsimulated/mineral,
 /area/colony)
 "hSz" = (
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "hSA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -40940,12 +40948,18 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
 "hVD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "hVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -41860,22 +41874,9 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ifo" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/material/kitchen/rollingpin,
-/obj/machinery/light_switch{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/loading/white,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "ifw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/security{
@@ -42326,12 +42327,10 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
 "ikj" = (
-/obj/machinery/light_switch{
-	pixel_y = 30
-	},
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "ikn" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -43455,14 +43454,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "ivC" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "ivM" = (
 /obj/machinery/holoposter{
 	pixel_y = 30
@@ -43915,15 +43912,12 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "iAo" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "iAq" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -44584,14 +44578,12 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "iGZ" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "iHa" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/unsimulated/wall/jungle,
@@ -45053,6 +45045,23 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"iKX" = (
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
+	},
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "iKZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/binary/pump{
@@ -45679,13 +45688,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "iRf" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/structure/invislight,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/catwalk,
+/obj/machinery/light,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "iRh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -46565,11 +46575,19 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "iZz" = (
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "iZD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
@@ -47696,20 +47714,13 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "jkf" = (
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "jkj" = (
 /obj/structure/table/steel,
 /obj/random/material_resources,
@@ -47974,16 +47985,19 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jnw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "jny" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -48446,6 +48460,13 @@
 /obj/effect/floor_decal/industrial/arrows/white,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
+"jsb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "jsf" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -48547,11 +48568,15 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jsM" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/prime)
+/obj/machinery/atm{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "jsR" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/gloves{
@@ -48570,10 +48595,12 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "jte" = (
-/obj/machinery/light,
-/obj/machinery/vending/fortune,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "jtl" = (
 /obj/machinery/light_switch{
 	pixel_y = 30
@@ -48859,11 +48886,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
 "jwd" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "jwe" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
@@ -49996,15 +50022,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jHx" = (
-/obj/structure/multiz/stairs/enter{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "jHC" = (
 /obj/random/scrap/dense_weighted,
 /obj/structure/table/rack/shelf,
@@ -50024,12 +50044,12 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jHL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/sign/faction/neotheology{
+	pixel_x = 32
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "jHS" = (
 /obj/random/contraband/low_chance,
 /obj/effect/decal/cleanable/cobweb{
@@ -50634,6 +50654,15 @@
 /obj/machinery/camera/network/colony_underground,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/crew_quarters/pool)
+"jNP" = (
+/obj/machinery/light,
+/obj/machinery/light_switch{
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "jNU" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/junk/low_chance,
@@ -51242,11 +51271,12 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jTG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "jTH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/reinforced/polarized{
@@ -51521,20 +51551,9 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/barquarters)
 "jVP" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "jWc" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -51631,8 +51650,10 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jXd" = (
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/structure/table/woodentable,
+/obj/machinery/reagentgrinder/portable,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "jXf" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/under,
@@ -52159,12 +52180,15 @@
 	name = "\improper Clinic"
 	})
 "kbl" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 24
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "kbm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -53260,17 +53284,17 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "klX" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "kmc" = (
 /obj/structure/railing/grey{
@@ -53671,9 +53695,21 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "koL" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "koP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53712,12 +53748,8 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
 "kpf" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
@@ -53856,14 +53888,6 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"kqQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
 "kqX" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -54016,20 +54040,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"ksw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
 "ksx" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -54187,12 +54197,12 @@
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "ktR" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "ktS" = (
 /obj/structure/closet/crate,
 /obj/item/am_shielding_container,
@@ -54439,13 +54449,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "kwb" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/skyyard)
 "kwd" = (
 /obj/random/flora/jungle_tree,
 /obj/effect/decal/cleanable/dirt,
@@ -54614,10 +54622,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/hut_cell1)
 "kxQ" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "kxW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54637,24 +54651,11 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kyl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/machinery/camera/network/church{
+	dir = 5
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "kym" = (
 /mob/living/simple_animal/hostile/naniteswarm{
 	desc = "A swarm of disgusting mini locusts infested with disease and hatred.";
@@ -54663,17 +54664,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kyt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/bed/chair/comfy/brown,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "kyu" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -55184,17 +55177,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/construction)
-"kCV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
 "kCW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
@@ -55269,22 +55251,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kDY" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
-"kEe" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"kEe" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "kEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -55472,14 +55452,9 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "kFQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "kFU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -55676,16 +55651,6 @@
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/office)
-"kHx" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
-	},
-/obj/machinery/atm{
-	dir = 4;
-	pixel_x = 30
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
 "kHE" = (
 /obj/random/junk/low_chance,
 /obj/effect/floor_decal/spline/plain,
@@ -56007,13 +55972,8 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kLc" = (
-/obj/structure/bed/chair/sofa/brown/right,
-/obj/landmark/join/start/acolyte,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "kLm" = (
 /obj/structure/table/rack/shelf,
 /obj/random/lowkeyrandom,
@@ -56231,18 +56191,8 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kMZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "kNa" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -56394,10 +56344,14 @@
 /turf/simulated/open,
 /area/colony)
 "kOD" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/box/white,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/multiz/stairs/enter{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "kOJ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -56437,10 +56391,13 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
 "kPg" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
+/area/colony)
 "kPj" = (
 /obj/structure/sign/departmentold/security,
 /turf/simulated/wall/r_wall,
@@ -56822,15 +56779,16 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "kSK" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4;
-	name = "biomatter chute"
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/sink{
+	pixel_y = -22
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "kSR" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/table/rack/shelf,
@@ -57155,9 +57113,14 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "kVO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "kWa" = (
 /obj/structure/flora/big/bush2,
 /obj/effect/decal/cleanable/dirt,
@@ -57991,28 +57954,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ldw" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/engineering/atmos/storage)
 "ldz" = (
 /obj/structure/holohoop{
 	dir = 1
@@ -58268,18 +58212,23 @@
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "lfc" = (
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+/obj/machinery/door/airlock{
+	name = "Church";
+	req_access = list(27)
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "lfh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spider/spiderling,
@@ -58693,23 +58642,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ljQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/pros/foreman)
 "ljT" = (
 /obj/structure/table/standard,
 /obj/item/storage/briefcase/inflatable,
@@ -59083,15 +59020,35 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "lnV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/structure/railing/grey{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey,
+/obj/structure/sign/faction/derelict1{
+	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
+	name = "NOTICE: Dangerous Biohazard";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "lnW" = (
 /obj/item/clothing/suit/armor/platecarrier/ih,
 /obj/item/clothing/suit/armor/platecarrier/ih,
@@ -59130,6 +59087,9 @@
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
+	},
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
@@ -60134,6 +60094,12 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/command/teleporter)
+"lyG" = (
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/prime)
 "lyI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -61457,17 +61423,14 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/barbackroom)
 "lLw" = (
-/obj/effect/floor_decal/industrial/danger{
+/obj/structure/disposalpipe/segment{
 	dir = 1;
-	icon_state = "danger"
+	icon_state = "pipe-c"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/catwalk,
+/obj/random/scrap/dense_weighted/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "lLB" = (
 /obj/machinery/atmospherics/omni/mixer{
 	active_power_usage = 7500;
@@ -62010,12 +61973,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
-"lQf" = (
-/obj/item/tool/knife/neotritual,
-/obj/item/clothing/gloves/psionic_ring,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
 "lQg" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -62476,19 +62433,12 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "lUP" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "lUR" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -62601,9 +62551,23 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
 "lVU" = (
-/obj/structure/closet/coffin,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
+	},
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/hallway/surface/section1)
 "lVV" = (
 /obj/machinery/power/breakerbox{
 	RCon_tag = "AI Core Substation Bypass"
@@ -63177,15 +63141,7 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "mce" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
+/turf/simulated/wall/church_reinforced,
 /area/colony)
 "mcg" = (
 /obj/structure/bed/chair,
@@ -63362,9 +63318,10 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/quartermaster/office)
 "mdn" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "mdt" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 2;
@@ -63513,11 +63470,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "meA" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/random/junk/cigbutt,
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/atmos/storage)
 "meB" = (
@@ -63885,11 +63840,24 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "miP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "miQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -65592,15 +65560,28 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
 "mxN" = (
-/obj/machinery/conveyor_switch{
-	id = "disposals grinder"
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 2";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
 	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/floor_decal/industrial/danger,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "mxR" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -65877,18 +65858,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/engineering/foyer)
 "mBf" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "mBn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating/under,
@@ -65996,6 +65975,12 @@
 "mCq" = (
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
+"mCt" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mCv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -66593,14 +66578,12 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/construction)
 "mHf" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "mHh" = (
 /obj/landmark/join/start/cargo_tech,
 /obj/structure/disposalpipe/segment,
@@ -66975,12 +66958,11 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
 "mKY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mLl" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -67412,12 +67394,11 @@
 /turf/simulated/floor/beach/sand/drywater,
 /area/nadezhda/crew_quarters/pool)
 "mPy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "mPC" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -67582,13 +67563,16 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "mRi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "mRq" = (
 /obj/structure/table/bench/marble,
 /obj/machinery/alarm{
@@ -68021,9 +68005,15 @@
 	name = "\improper Outdoors - Pad"
 	})
 "mVl" = (
-/obj/structure/reagent_dispensers/biomatter/large,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "mVm" = (
 /obj/structure/closet,
@@ -68069,14 +68059,14 @@
 	name = "Residential District Substation"
 	})
 "mVE" = (
-/obj/structure/multiz/stairs/enter{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "mVH" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/generic,
@@ -68642,23 +68632,9 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ncd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/steel/golden,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/church_reinforced,
+/area/nadezhda/absolutism/bioreactor)
 "nch" = (
 /obj/random/furniture/pottedplant,
 /obj/item/device/radio/intercom{
@@ -69216,9 +69192,12 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "nib" = (
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "nic" = (
 /obj/structure/table/onestar,
 /obj/item/pen,
@@ -69620,11 +69599,17 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "nmo" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "nmp" = (
 /obj/item/reagent_containers/blood/AMinus,
 /obj/item/reagent_containers/blood/APlus,
@@ -69795,12 +69780,11 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/fo)
 "nol" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "nom" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -69918,16 +69902,13 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "npm" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "npp" = (
 /obj/structure/multiz/stairs/active/bottom,
 /obj/structure/window/reinforced{
@@ -70133,12 +70114,15 @@
 /turf/simulated/floor/plating/under,
 /area/asteroid/cave)
 "nrD" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/random/furniture/pottedplant,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/item/scrap_lump,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "nrI" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -70327,9 +70311,23 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ntC" = (
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "ntK" = (
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
@@ -70510,14 +70508,15 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nvB" = (
-/obj/structure/table/standard,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
 	},
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "nvD" = (
 /obj/structure/table/bar_special,
 /obj/machinery/floor_light,
@@ -70669,20 +70668,19 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "nxH" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/multiz/stairs/active{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/sign/levels/stairsdown{
+	pixel_y = -30;
+	pixel_x = 32
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "nxP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -71465,10 +71463,15 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "nFm" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/tool/multitool,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/storage)
 "nFp" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -71948,14 +71951,10 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nJR" = (
 /obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "nJX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -72671,15 +72670,10 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "nRM" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/reagent_dispensers/biomatter/large,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "nRO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -72804,14 +72798,21 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "nTE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "nTL" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -73627,24 +73628,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "oaI" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/standard,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/area/nadezhda/hallway/side/f2section1)
 "oaM" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -74538,6 +74529,22 @@
 /obj/item/device/radio/random_radio,
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/merchant)
+"oin" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "oiq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -74893,14 +74900,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"oma" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
 "omb" = (
 /obj/machinery/door/airlock/glass{
 	name = "Employee Lounge";
@@ -75008,12 +75007,12 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/main/stairwell)
 "omK" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_x = 28
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "omU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75298,20 +75297,9 @@
 /turf/simulated/mineral,
 /area/nadezhda/command/cbo)
 "oqc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "oqd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -76005,14 +75993,19 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
 "owI" = (
-/obj/structure/multiz/stairs/active/bottom{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "owK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/furniture/pottedplant,
@@ -77334,12 +77327,8 @@
 	},
 /area/nadezhda/pros/proelav)
 "oJb" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/sign/faction/neotheology{
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/meadow)
 "oJo" = (
 /obj/structure/table/marble,
@@ -77556,6 +77545,25 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"oLh" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "oLn" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -77707,10 +77715,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "oMM" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "oMS" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/junk/snappop,
@@ -77781,12 +77794,16 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
 "oNA" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "oNP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78291,27 +78308,19 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "oSN" = (
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/outside/meadow)
-"oSO" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
 	dir = 4;
-	icon_state = "pipe-c"
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "oST" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -78388,22 +78397,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "oTp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+	pixel_x = -32
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "oTv" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -78561,15 +78559,9 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
 "oVv" = (
-/obj/machinery/vending/theomat,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "oVO" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 6
@@ -79248,10 +79240,10 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "pes" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -79862,12 +79854,6 @@
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"pkB" = (
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/hallway/surface/section1)
 "pkC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81263,17 +81249,12 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/virology)
 "pyY" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/recycler,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/area/nadezhda/engineering/atmos/storage)
 "pzk" = (
 /obj/structure/nt_pedestal,
 /turf/simulated/floor/carpet/bcarpet,
@@ -81543,15 +81524,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "pBQ" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/colony)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "pBV" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -81620,6 +81598,20 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"pCt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "pCu" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -81678,17 +81670,9 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
 "pCL" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	dir = 4;
-	name = "Warrant Officer RC";
-	pixel_x = 30;
-	pixel_y = 0
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
 	},
-/obj/item/biosyphon,
-/obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
 "pCQ" = (
@@ -82634,16 +82618,12 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
 "pLt" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/computer/arcade,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_room)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "pLw" = (
 /obj/random/mob/croaker/low_chance,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -82841,13 +82821,19 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "pNu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/bed/chair/sofa/brown/left,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/random/toy/plushie,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "pNw" = (
 /turf/simulated/mineral,
 /area/nadezhda/outside/dcave)
@@ -83144,15 +83130,18 @@
 	})
 "pPU" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "pPW" = (
 /obj/machinery/vending/printomat,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -83972,10 +83961,12 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "pYx" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/item/device/radio/intercom{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "pYB" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -84129,23 +84120,10 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "pZI" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/disposaloutlet,
-/obj/machinery/conveyor/south{
-	id = "junk_to_bioreactor"
-	},
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0";
-	tag = "icon-railing0 (NORTH)"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "pZS" = (
 /mob/living/simple_animal/opossum{
 	desc = "The Nedezhda basketball team mascot. - Currently scavenging for rebounds";
@@ -84266,11 +84244,13 @@
 "qbh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -84700,10 +84680,11 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qfx" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/multiz/stairs/enter/bottom,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "qfC" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -84865,31 +84846,14 @@
 	name = "\improper Outdoors - Pad"
 	})
 "qgM" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 1";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/cyan{
+/obj/structure/cable/green{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qhd" = (
 /obj/structure/table/bar_special,
 /obj/machinery/chemical_dispenser/beer,
@@ -86278,18 +86242,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "qvn" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/chapel)
 "qvy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -86394,9 +86352,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "qwE" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/random/furniture/pottedplant,
+/obj/machinery/camera/network/church{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qwI" = (
 /obj/machinery/light{
 	dir = 8;
@@ -86617,11 +86584,10 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qyo" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
-	},
-/turf/simulated/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "qyq" = (
 /obj/structure/grille,
@@ -86755,12 +86721,9 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "qzx" = (
-/obj/machinery/camera/network/church{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "qzA" = (
 /obj/structure/table/bar_special,
 /obj/item/modular_computer/tablet/preset/custom_loadout/standard,
@@ -86982,15 +86945,16 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
 "qBq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "qBx" = (
 /obj/structure/table/standard,
 /obj/random/material/low_chance,
@@ -87003,15 +86967,21 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest)
 "qBQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
 "qBV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/rock5,
@@ -87063,19 +87033,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/command/cbo)
-"qCP" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
 "qCT" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -87103,22 +87060,10 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "qDa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "qDd" = (
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
@@ -87471,10 +87416,14 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "qGp" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "qGu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -87889,11 +87838,9 @@
 	name = "\improper Clinic"
 	})
 "qKJ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/open,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qKO" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt,
@@ -88795,14 +88742,23 @@
 	name = "Dormitory 3"
 	})
 "qTC" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
 "qTD" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 4;
@@ -88888,8 +88844,10 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/atmos/storage)
 "qUt" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/structure/invislight,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -88897,9 +88855,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "qUw" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -88946,16 +88906,10 @@
 	name = "Residential District Maintenance"
 	})
 "qUT" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/dogbed,
+/mob/living/simple_animal/corgi/Lisa,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/swo/quarters)
 "qUY" = (
 /obj/structure/mopbucket,
 /obj/effect/floor_decal/industrial/botright,
@@ -89184,19 +89138,11 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/crew_quarters/podrooms)
 "qWT" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
 	},
-/obj/structure/cable/green,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/hallway/surface/section1)
 "qWW" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/small/busha3,
@@ -89623,22 +89569,13 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "raN" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/bed/chair/sofa/brown/right,
+/obj/landmark/join/start/acolyte,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/vectorrooms)
 "raR" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
@@ -89682,10 +89619,8 @@
 	name = "Militia Commander RC";
 	pixel_x = 30
 	},
-/obj/structure/cyberplant{
-	emagged = 1;
-	name = "holodancer";
-	pixel_y = 12
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/smc/quarters)
@@ -89706,12 +89641,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rby" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/hallway/surface/section1)
 "rbA" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -89889,19 +89821,12 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "rcV" = (
-/obj/structure/mirror{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "rcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -90399,21 +90324,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rig" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/area/nadezhda/outside/meadow)
 "rip" = (
 /obj/machinery/door/firedoor,
 /obj/structure/door_assembly/door_assembly_maint_cargo,
@@ -90483,11 +90395,13 @@
 	name = "Dormitory 3"
 	})
 "riP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "riQ" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/powermonitor{
@@ -90594,8 +90508,20 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "rjV" = (
-/turf/simulated/wall/church_reinforced,
-/area/colony)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "rjY" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -90998,6 +90924,16 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/pros/prep)
+"roc" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "rod" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -91224,15 +91160,17 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/courtroom)
 "rqj" = (
-/obj/structure/multiz/stairs/active/bottom{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/obj/structure/catwalk,
+/obj/structure/railing{
+	anchored = 1;
 	dir = 4;
-	pixel_x = 0
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "rqk" = (
 /obj/machinery/power/wall_obelisk{
 	pixel_x = 32
@@ -91242,13 +91180,18 @@
 	name = "Dormitory 1"
 	})
 "rqm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "rqp" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -91364,12 +91307,15 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rrx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 5
+/obj/machinery/conveyor_switch{
+	id = "disposals grinder"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/floor_decal/industrial/danger,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "rrB" = (
 /obj/structure/table/steel,
 /obj/random/mob/spiders,
@@ -91922,11 +91868,10 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/pros/prep)
 "rwF" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "rwG" = (
 /obj/machinery/camera/network/colony_transition{
@@ -92337,18 +92282,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/orangecorner,
 /area/eris/crew_quarters/plasma_tag)
-"rAl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
 "rAq" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/table/rack/shelf,
@@ -92809,11 +92742,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/command/courtroom)
 "rEA" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "rED" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/rock,
@@ -93005,14 +92943,13 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rGx" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "rGz" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -93121,12 +93058,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rHD" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/floor/rock/manmade/road,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "rHE" = (
 /obj/machinery/light{
 	dir = 1
@@ -95642,11 +95577,10 @@
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/meadow)
 "sfi" = (
-/obj/machinery/camera/network/church{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/multiz/stairs/enter/bottom,
+/obj/structure/invislight,
+/turf/simulated/floor/plating,
+/area/nadezhda/outside/meadow)
 "sfB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -96307,6 +96241,9 @@
 "slL" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
@@ -97110,21 +97047,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "suE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/area/nadezhda/absolutism/chapel)
 "suL" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -97441,9 +97367,12 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "sxY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/obj/item/scrap_lump,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "syb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -97639,26 +97568,11 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "sAo" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 2";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "sAN" = (
@@ -98013,11 +97927,10 @@
 /area/colony)
 "sFL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/wall_obelisk{
-	pixel_x = 1;
-	pixel_y = 24
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "sFQ" = (
 /turf/simulated/floor/reinforced,
@@ -98423,18 +98336,18 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/genetics)
 "sJX" = (
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "sKc" = (
 /obj/structure/table/woodentable,
 /obj/item/device/paicard{
@@ -98647,13 +98560,14 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/kitchen)
 "sMN" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair";
+	tag = "icon-wooden_chair (EAST)"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "sMT" = (
 /obj/structure/table/rack,
 /obj/item/storage/toolbox/electrical{
@@ -98789,15 +98703,13 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/gmaster)
 "sOa" = (
-/obj/structure/bed/chair/wood{
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
 	dir = 8;
-	icon_state = "wooden_chair"
+	pixel_x = 22
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "sOd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -98908,11 +98820,31 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "sPh" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 1";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "sPj" = (
 /obj/structure/flora/small/trailrocka3,
 /obj/effect/decal/cleanable/dirt,
@@ -99285,20 +99217,12 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "sSM" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/engineering/atmos/storage)
 "sSW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -99540,17 +99464,16 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sUM" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/carpet,
+/obj/item/storage/fancy/crayons,
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/crayons,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "sUN" = (
 /obj/structure/table/standard,
@@ -100041,16 +99964,20 @@
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sZu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "sZw" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
@@ -100275,10 +100202,17 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "tby" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "tbJ" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -100660,10 +100594,18 @@
 /turf/simulated/mineral,
 /area/nadezhda/outside/forest)
 "tgh" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "tgi" = (
@@ -101376,22 +101318,18 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "tmF" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/glass/urn/veteran{
+	pixel_x = 7
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+/obj/item/oddity/nt/pyramid{
+	pixel_x = -9
 	},
-/obj/item/scrap_lump,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "tmR" = (
 /obj/machinery/door/airlock/glass{
 	name = "Plasma Drome"
@@ -101527,15 +101465,14 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/main/stairwell)
 "toM" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "toN" = (
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -101585,10 +101522,22 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "tpj" = (
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/material/kitchen/rollingpin,
+/obj/machinery/light_switch{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "tpn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/bushc3,
@@ -102583,10 +102532,9 @@
 	name = "Dormitory 4"
 	})
 "tzn" = (
-/turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "tzo" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/rock,
@@ -102619,9 +102567,20 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tzJ" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/absolutism/bioreactor)
 "tzM" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/window/reinforced,
@@ -103172,6 +103131,16 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
+"tFC" = (
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "tFP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -103474,22 +103443,15 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
 "tJf" = (
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
+/obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "tJk" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -104185,15 +104147,10 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tPN" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "tPO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -105049,13 +105006,17 @@
 	name = "\improper Upper Research Hallway"
 	})
 "tZL" = (
-/obj/machinery/light/small,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "tZS" = (
 /obj/effect/floor_decal/industrial/arrows/white{
@@ -105065,18 +105026,14 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "tZT" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/mob/roaches/low_chance,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "tZW" = (
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -105216,13 +105173,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "uaN" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/engineering/atmos/storage)
 "uaO" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -105318,13 +105274,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "ucl" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/turf/simulated/floor/plating/under,
-/area/colony)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "ucn" = (
 /mob/living/simple_animal/hostile/snake,
 /turf/simulated/floor/asteroid/grass,
@@ -105339,8 +105294,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "ucs" = (
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/small/grassb1,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "ucx" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/stack/ore,
@@ -105695,11 +105651,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/cryo)
 "ugj" = (
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Office"
+/obj/machinery/camera/network/church{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "ugm" = (
 /obj/random/structures,
 /obj/effect/spider/stickyweb,
@@ -105710,27 +105666,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ugn" = (
-/obj/structure/cable/yellow{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/railing/grey{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey,
-/obj/structure/cable/yellow,
-/obj/machinery/light,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/vectorrooms)
 "ugx" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Permanent Holding";
@@ -105781,15 +105728,7 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/crew_quarters/kitchen_storage)
-"ugF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
 "ugI" = (
-/obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lamp/green,
 /obj/machinery/light{
 	dir = 4
@@ -105955,6 +105894,9 @@
 /obj/structure/noticeboard/lonestar_supply{
 	pixel_x = 32
 	},
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
+	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/merchant)
 "uiw" = (
@@ -106069,14 +106011,18 @@
 	name = "\improper Outdoors - Pad"
 	})
 "ujR" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/biomatter,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "ujT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -106638,9 +106584,27 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/crew_quarters/podrooms)
 "uqM" = (
-/obj/structure/table/woodentable,
-/obj/random/toy/plushie,
-/turf/simulated/floor/carpet,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "uqQ" = (
 /obj/structure/flora/big/rocks2,
@@ -106895,23 +106859,19 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "usX" = (
-/obj/machinery/door/airlock{
-	name = "Church";
-	req_access = list(27)
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/structure/sign/levels/stairsup{
+	pixel_x = 32;
+	pixel_y = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "utl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -108064,17 +108024,12 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "uCH" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "uCI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -108108,6 +108063,16 @@
 /obj/machinery/door/blast/regular,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"uDc" = (
+/obj/structure/multiz/stairs/enter{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "uDf" = (
 /obj/structure/sign/department/bar,
 /turf/simulated/wall,
@@ -108473,11 +108438,11 @@
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "uGA" = (
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = -32
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "uGD" = (
 /obj/landmark/machinery/input,
 /obj/machinery/conveyor/south{
@@ -109207,10 +109172,20 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "uOA" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "chudorm4";
+	name = "Church Dorm 2";
+	req_access = list(70)
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "uOB" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -109499,11 +109474,15 @@
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "uQx" = (
-/obj/structure/closet/secure_closet/personal/agrolyte,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = -32
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "uQC" = (
 /obj/structure/flora/ausbushes/pointybush,
@@ -109589,12 +109568,14 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "uRw" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/structure/multiz/stairs/active{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/absolutism/skyyard)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "uRx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -109873,15 +109854,14 @@
 	name = "\improper Upper Research Hallway"
 	})
 "uTQ" = (
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "uTS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -109968,10 +109948,12 @@
 	name = "\improper Outdoors - Pad"
 	})
 "uUU" = (
-/obj/structure/reagent_dispensers/biomatter,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "uUW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -110042,12 +110024,12 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
 "uVx" = (
-/obj/structure/railing,
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/structure/closet/secure_closet/personal/agrolyte,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = -32
 	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "uVy" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/robotics{
@@ -110403,16 +110385,8 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "uZv" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
@@ -110924,14 +110898,10 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
 "vfg" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/floor_decal/industrial/danger,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "vfj" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section2";
@@ -111652,11 +111622,13 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "vmm" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/wall_obelisk{
+	pixel_x = 1;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "vmq" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
@@ -112298,11 +112270,14 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/meeting_room)
 "vsx" = (
-/obj/structure/catwalk,
-/obj/structure/invislight,
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/outside/meadow)
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "vsy" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/structures,
@@ -112643,9 +112618,12 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "vvO" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/hallway/surface/section1)
 "vvS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame/vertical{
@@ -112806,11 +112784,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "vwJ" = (
-/obj/machinery/alarm{
-	pixel_y = 26
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "vwK" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 4
@@ -112888,14 +112870,23 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/cafeteria)
 "vxj" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	dir = 4;
+	name = "Warrant Officer RC";
+	pixel_x = 30;
+	pixel_y = 0
+	},
+/obj/item/biosyphon,
+/obj/structure/table/woodentable,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 1
 	},
-/obj/structure/dogbed,
-/mob/living/simple_animal/corgi/Lisa,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
 "vxo" = (
@@ -113208,9 +113199,13 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "vAx" = (
-/obj/machinery/biomatter_solidifier,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/random/toy/plushie_onlyfox,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "vAB" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -113367,10 +113362,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vCh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/catwalk,
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/structure/invislight,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -113378,9 +113371,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/vectorrooms)
 "vCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -113704,11 +113697,20 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical_blackshield)
 "vFR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "vFU" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -113775,13 +113777,17 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vGk" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/replenishing/chalice,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = -32
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "vGA" = (
 /obj/structure/sign/security/cells{
 	pixel_x = -32
@@ -114002,13 +114008,9 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vIL" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 1;
-	name = "trash chute"
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/meadow)
 "vJb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -114215,7 +114217,12 @@
 	name = "Residential District Maintenance"
 	})
 "vKM" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/camera/network/church{
+	dir = 8
+	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "vKR" = (
@@ -114378,9 +114385,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "vMo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment,
+/obj/random/scrap/dense_weighted/low_chance,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "vMr" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -114411,34 +114420,22 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "vMK" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
-"vMQ" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Prime's Office";
-	departmentType = 22;
-	name = "Prime's RC";
-	pixel_x = 30;
-	pixel_y = 0
-	},
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Prime's Office"
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood/wild3,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/prime)
+"vMQ" = (
+/obj/machinery/biomatter_solidifier,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/absolutism/bioreactor)
 "vMU" = (
 /obj/structure/disposalpipe/junction,
 /obj/structure/cable/yellow{
@@ -115431,23 +115428,19 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "vWA" = (
-/obj/structure/disposaloutlet{
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/area/nadezhda/absolutism/bioreactor)
 "vWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -115877,14 +115870,22 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "waf" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/item/scrap_lump,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "wak" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
@@ -115915,18 +115916,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "waT" = (
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Office"
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/absolutism/skyyard)
 "waY" = (
 /obj/structure/multiz/stairs/active/bottom,
 /obj/structure/window/reinforced{
@@ -115936,20 +115931,24 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/side/f2section1)
 "wbe" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/random/toy/plushie_onlyfox,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
-"wbm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/storage)
+"wbm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "wbo" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -116270,17 +116269,13 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "weh" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/glass/replenishing/chalice,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = -32
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/conveyor/south{
-	id = "junk_to_bioreactor"
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "wev" = (
 /obj/machinery/power/nt_obelisk,
 /obj/structure/sign/faction/neotheology_cross/gold{
@@ -116334,11 +116329,25 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
 "weP" = (
-/obj/machinery/light{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/random/scrap/dense_weighted/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "weT" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/effect/floor_decal/industrial/arrows/white,
@@ -116409,9 +116418,11 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "wfn" = (
-/obj/structure/flora/small/grassa5,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "wft" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/cafe,
@@ -116531,21 +116542,10 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/cafeteria)
 "wgN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/steel/golden,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "wgV" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -116789,19 +116789,13 @@
 /obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/mob/roaches/low_chance,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "wjI" = (
@@ -117407,16 +117401,10 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "wpu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/table/woodentable,
+/obj/random/toy/plushie,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "wpv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -118078,13 +118066,11 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
 "wuN" = (
-/obj/structure/bed/chair/wood{
-	dir = 4;
-	icon_state = "wooden_chair";
-	tag = "icon-wooden_chair (EAST)"
+/obj/machinery/camera/network/church{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "wuV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -118565,13 +118551,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
-"wzr" = (
-/obj/machinery/power/nt_obelisk,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
 "wzv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -120183,11 +120162,12 @@
 	name = "Dormitory 3"
 	})
 "wQW" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "wRb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -120275,11 +120255,11 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "wSl" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/prime)
 "wSn" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -120604,13 +120584,19 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/tcommsat/computer)
 "wVv" = (
-/obj/structure/table/woodentable,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/sink{
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "wVx" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,18"
@@ -120681,12 +120667,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "wWN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
+/obj/structure/table/woodentable,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "wWP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -120884,7 +120871,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
@@ -121581,9 +121568,19 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "xfb" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "xfc" = (
 /obj/machinery/conveyor/east{
 	dir = 1;
@@ -122010,9 +122007,23 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "xke" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "xki" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -122120,13 +122131,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xlL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light,
-/turf/simulated/floor/plating/under,
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "xlP" = (
 /obj/machinery/door/airlock/glass_security{
@@ -122330,24 +122337,20 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xmO" = (
-/obj/structure/cable/green{
-	d1 = 4;
+/obj/structure/cable/yellow{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "xmV" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/nightmare,
@@ -122403,14 +122406,20 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "xnv" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "xnw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -122674,6 +122683,18 @@
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"xpC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "xpF" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -122767,11 +122788,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xqJ" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "xqM" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -122842,16 +122862,15 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "xrs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
@@ -122873,17 +122892,24 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "xrD" = (
-/obj/effect/floor_decal/industrial/danger{
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 1;
-	icon_state = "danger"
+	icon_state = "pipe-c"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "xrF" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 6;
@@ -123324,12 +123350,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "xwB" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "xwH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/random/flora/jungle_tree,
@@ -123489,19 +123515,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xyC" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "xyJ" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/armory)
@@ -123728,25 +123746,17 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "xBq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/noticeboard/church{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/structure/catwalk,
-/obj/random/mob/roaches/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "xBr" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,3"
@@ -123955,19 +123965,9 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "xDf" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating/under,
-/area/colony)
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "xDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -124082,12 +124082,10 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xEe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/table/woodentable,
+/obj/item/device/lighting/toggleable/lantern/censer,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "xEk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/wood,
@@ -124754,12 +124752,27 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "xKz" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/structure/cable/yellow{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
 	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey,
+/obj/structure/cable/yellow,
+/obj/machinery/light,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "xKD" = (
 /obj/structure/grille,
 /turf/simulated/floor/asteroid/grass,
@@ -124796,6 +124809,18 @@
 /obj/random/mob/spiders/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"xKZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "xLd" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/small/busha1,
@@ -125022,16 +125047,11 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "xMy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/cyancorner,
+/area/nadezhda/hallway/surface/section1)
 "xMA" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -125675,11 +125695,10 @@
 /area/nadezhda/hallway/surface/section1)
 "xTb" = (
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 8;
+	icon_state = "pipe-s"
 	},
 /obj/structure/catwalk,
-/obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "xTe" = (
@@ -126869,20 +126888,17 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "yfE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/light/small,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "yfL" = (
 /obj/item/storage/briefcase/inflatable{
 	pixel_x = 3;
@@ -127282,12 +127298,17 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "yjK" = (
-/obj/structure/mopbucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/soap/deluxe,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "yjM" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -127442,18 +127463,18 @@
 /area/nadezhda/command/courtroom)
 "ylz" = (
 /obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/area/colony)
 "ylB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -134659,7 +134680,7 @@ uCp
 oGw
 oJI
 bhK
-bhK
+qUT
 oGw
 oGw
 oGw
@@ -193849,13 +193870,13 @@ vvL
 wAo
 xPH
 xPH
-pLt
-pBQ
-pBQ
-pBQ
-mce
-pBQ
-xDf
+efu
+kbl
+kbl
+kbl
+qBq
+kbl
+ylz
 xGi
 sFI
 sFI
@@ -194057,7 +194078,7 @@ xGi
 xGi
 xGi
 beK
-buS
+vFR
 beK
 sFI
 sFI
@@ -194259,7 +194280,7 @@ sFI
 sFI
 sFI
 beK
-ylz
+vWA
 beK
 sFI
 sFI
@@ -194461,7 +194482,7 @@ sFI
 sFI
 sFI
 beK
-sSM
+xnv
 beK
 sFI
 sFI
@@ -194663,7 +194684,7 @@ sFI
 sFI
 sFI
 beK
-ylz
+vWA
 beK
 sFI
 sFI
@@ -194865,7 +194886,7 @@ sFI
 beK
 beK
 beK
-oqc
+tzJ
 beK
 beK
 beK
@@ -195067,7 +195088,7 @@ sFI
 beK
 eWs
 mCq
-xrs
+pCt
 vgv
 tZa
 mUh
@@ -195269,7 +195290,7 @@ sFI
 beK
 hov
 uww
-kyt
+hHU
 naZ
 dMu
 xhZ
@@ -195471,7 +195492,7 @@ sFI
 beK
 uHt
 uww
-yfE
+fPE
 mxC
 wuq
 mBO
@@ -195672,9 +195693,9 @@ beK
 beK
 beK
 mCq
-ucs
-hpq
-cNE
+kMZ
+cDx
+riP
 gcr
 gzw
 vcq
@@ -195866,16 +195887,16 @@ jPJ
 iVn
 byG
 ult
+jnw
 bmx
-aED
-ucl
-ivC
-dBr
-vfg
-ivC
+kPg
+hkR
+jkf
+uTQ
+hkR
 bho
 xhZ
-fgM
+rEA
 mxC
 gcr
 tkm
@@ -196075,9 +196096,9 @@ beK
 beK
 beK
 beK
-uZv
-qvn
-wpu
+iZz
+xrs
+mVl
 mxC
 hCa
 tNb
@@ -196277,10 +196298,10 @@ sFI
 sFI
 sFI
 beK
-qgM
+sPh
 puT
-qUT
-gnT
+mRi
+rGx
 nvW
 hpm
 hpm
@@ -196479,16 +196500,16 @@ sFI
 sFI
 sFI
 beK
-sAo
+mxN
 rOL
-bPu
+xmO
 eyI
 ctG
 ctC
 wIe
 mCq
 naZ
-ugn
+xKz
 beK
 sFI
 ula
@@ -196683,7 +196704,7 @@ sFI
 beK
 oPl
 uUJ
-hVD
+cye
 aUn
 aUn
 qHo
@@ -196885,14 +196906,14 @@ sFI
 beK
 azM
 uUJ
-nTE
+cxF
 aUn
 aUn
 sDT
 qPy
 mCq
-cHs
-gHI
+toM
+fqE
 beK
 sFI
 sFI
@@ -197093,8 +197114,8 @@ usk
 jeg
 vcq
 mCq
-mHf
-dNI
+cTB
+lnV
 beK
 beK
 beK
@@ -197287,19 +197308,19 @@ sFI
 sFI
 sFI
 beK
-wzr
+fEH
 mCq
-xMy
+fgM
 xhZ
 mCq
 mCq
 mCq
 mCq
-mHf
-cox
-cox
-qTC
-owI
+cTB
+kFQ
+kFQ
+gSa
+vsx
 beK
 sFI
 sFI
@@ -197489,19 +197510,19 @@ sFI
 sFI
 beK
 beK
-ikj
-sxY
-kSK
-dCC
+gXz
+jHx
+dmD
+bal
 mCq
 mCq
 mCq
-cox
-mHf
-cox
-cox
-eIV
-rqj
+kFQ
+cTB
+kFQ
+kFQ
+usX
+nvB
 beK
 sFI
 sFI
@@ -197691,16 +197712,16 @@ sFI
 sFI
 beK
 hSC
-sxY
-kDY
+jHx
+xqJ
 bMK
-tJf
-lfc
+iKX
+sJX
 lti
 rCq
 dMu
-gnT
-hmj
+rGx
+jNP
 beK
 beK
 beK
@@ -197892,17 +197913,17 @@ uNP
 uNP
 uNP
 beK
-weh
+doA
 nSn
 nSn
 oYg
 nSn
-vIL
-xlL
+dBr
+iRf
 beK
 mCq
 rhf
-aFL
+uZv
 beK
 sFI
 sFI
@@ -198089,17 +198110,17 @@ vQv
 vQv
 uOb
 cSt
-aJN
-xEe
-qwE
-xfb
-cye
-uaN
-uaN
-uaN
-uaN
-uaN
-uaN
+fAA
+deL
+esz
+gdn
+ncd
+bPu
+bPu
+bPu
+bPu
+bPu
+bPu
 mAy
 beK
 lZC
@@ -198291,24 +198312,24 @@ uim
 uWe
 vIm
 cSt
-mxN
-vWA
-rEA
+rrx
+eIV
+mPy
 uNP
-rjV
-rjV
-rjV
-rjV
+mce
+mce
+mce
+mce
 beK
 beK
-ucs
-ucs
-ucs
+kMZ
+kMZ
+kMZ
 mCq
-sfi
+ugj
 mCq
-mVl
-mVl
+nRM
+nRM
 beK
 sFI
 sFI
@@ -198493,9 +198514,9 @@ dvQ
 uWK
 vIm
 pBF
-uOA
-nrD
-ktR
+bqh
+sxY
+iAo
 uNP
 sFI
 sFI
@@ -198503,14 +198524,14 @@ sFI
 sFI
 sFI
 beK
-ucs
-ucs
-ucs
-cTB
-vAx
+kMZ
+kMZ
+kMZ
+ifo
+vMQ
 vcq
-mVl
-mVl
+nRM
+nRM
 beK
 sFI
 gfQ
@@ -198695,9 +198716,9 @@ vQv
 vQv
 jkc
 cSt
-qfx
-xwB
-egd
+vfg
+uaN
+tZT
 uNP
 sFI
 sFI
@@ -198705,14 +198726,14 @@ sFI
 sFI
 sFI
 beK
-dnk
-dnk
-dnk
+xlL
+xlL
+xlL
 mCq
 mCq
 mCq
-uUU
-ujR
+hpq
+cox
 beK
 gfQ
 gfQ
@@ -198897,9 +198918,9 @@ vQv
 vQv
 jkc
 nmW
-wSl
-oNA
-xrD
+meA
+sSM
+tby
 uNP
 sFI
 sFI
@@ -198907,14 +198928,14 @@ sFI
 sFI
 sFI
 beK
-lVU
-lVU
-lVU
+fyb
+fyb
+fyb
 mCq
 mCq
-nFm
-nFm
-nFm
+pZI
+pZI
+pZI
 beK
 gfQ
 vNF
@@ -199099,9 +199120,9 @@ dvQ
 uWe
 vIm
 cSt
-epB
-xwB
-meA
+mHf
+uaN
+fBV
 uNP
 sFI
 sFI
@@ -199109,14 +199130,14 @@ sFI
 sFI
 sFI
 beK
-kqQ
-qGp
-qGp
+sAo
+kEe
+kEe
 mCq
-weP
-kOD
-kOD
-kOD
+gRP
+boU
+boU
+boU
 beK
 gfQ
 wHA
@@ -199301,9 +199322,9 @@ tKp
 tQX
 vIm
 cSt
-fyb
-nol
-lLw
+fPi
+pyY
+nmo
 uNP
 sFI
 sFI
@@ -199503,9 +199524,9 @@ vQv
 vQv
 jkc
 cSt
-fyb
-boU
-tmF
+fPi
+uGA
+waf
 uNP
 sFI
 sFI
@@ -199705,9 +199726,9 @@ vQv
 vQv
 vIm
 cSt
-aJN
-bwG
-koL
+fAA
+ldw
+tzn
 uNP
 sFI
 sFI
@@ -224560,7 +224581,7 @@ vrp
 vrp
 uEB
 leU
-wfn
+hmj
 vUJ
 xcy
 sbB
@@ -224985,7 +225006,7 @@ bjU
 vUJ
 vUJ
 vUJ
-hkR
+ucs
 vUJ
 vUJ
 vUJ
@@ -225170,7 +225191,7 @@ uEB
 pIy
 quu
 vUJ
-wfn
+hmj
 leU
 leU
 leU
@@ -225388,7 +225409,7 @@ vUJ
 vUJ
 vUJ
 vUJ
-tzJ
+oqc
 sbB
 sbB
 xcy
@@ -225778,7 +225799,7 @@ leU
 sbB
 pDw
 mkI
-nib
+xDf
 leU
 bjU
 xcy
@@ -226397,7 +226418,7 @@ sbB
 sbB
 mkI
 vUJ
-tby
+wgN
 bjU
 leU
 leU
@@ -226794,7 +226815,7 @@ mET
 vUJ
 vUJ
 sbB
-vvO
+vIL
 sbB
 sbB
 hvW
@@ -227376,7 +227397,7 @@ cjv
 fJv
 wBa
 pwm
-vwJ
+xMy
 uEV
 ciH
 gba
@@ -227797,7 +227818,7 @@ vTn
 nyS
 cKe
 jBi
-dzK
+yjK
 leR
 oHf
 oHf
@@ -227999,7 +228020,7 @@ gEY
 wrl
 oal
 cVR
-jXd
+kLc
 jaT
 hpV
 hpV
@@ -228201,7 +228222,7 @@ pwm
 pwm
 aot
 njl
-jXd
+kLc
 stq
 iVt
 aJG
@@ -228403,7 +228424,7 @@ pwm
 pwm
 aot
 ved
-jXd
+kLc
 stq
 iVt
 aJG
@@ -228605,7 +228626,7 @@ aug
 fMZ
 jeo
 puc
-jXd
+kLc
 gOa
 gaS
 gaS
@@ -228807,10 +228828,10 @@ stG
 wzY
 kCJ
 hYL
-jXd
+kLc
 tpO
-ntC
-ntC
+oJb
+oJb
 aot
 hLv
 hLv
@@ -229198,7 +229219,7 @@ epc
 moX
 xFe
 koI
-pkB
+qWT
 fKf
 wIm
 fKf
@@ -229239,8 +229260,8 @@ leU
 leU
 leU
 leU
-tzn
-tzn
+rHD
+rHD
 kfg
 aCl
 nfX
@@ -229407,9 +229428,9 @@ hcE
 kOW
 kOW
 kOW
-rwF
+ucl
 kOW
-rwF
+ucl
 kOW
 kOW
 kOW
@@ -229441,8 +229462,8 @@ leU
 leU
 leU
 leU
-tzn
-tzn
+rHD
+rHD
 hgC
 hgC
 hgC
@@ -229602,48 +229623,48 @@ epc
 rjh
 gSM
 kOW
-tpj
+suE
 dsj
-rrx
+kyl
 dsj
 ndM
 kOW
 aFx
 lpW
-iAo
+vwJ
 aFx
 lpW
-mKY
+hMs
 kOW
 bVb
 bVb
 kOW
 iUs
-fqE
+jHL
 dld
 dld
 pDI
-rGx
-rGx
-rGx
-rGx
-rGx
-rGx
-rGx
-rGx
-rGx
-rGx
-rGx
-eVP
-tzn
-tzn
-tzn
-tzn
-tzn
-tzn
-tzn
-tzn
-tzn
+cNE
+cNE
+cNE
+cNE
+cNE
+cNE
+cNE
+cNE
+cNE
+cNE
+cNE
+qfx
+rHD
+rHD
+rHD
+rHD
+rHD
+rHD
+rHD
+rHD
+rHD
 lxo
 aot
 hgC
@@ -229836,7 +229857,7 @@ bSp
 fCA
 nRc
 nRc
-toM
+tFC
 vUJ
 vUJ
 vUJ
@@ -230012,12 +230033,12 @@ dsj
 dsj
 mtA
 pQO
-kbl
+pYx
 fiW
 qHh
 fiW
 dsj
-aAw
+bZJ
 aFx
 aFx
 uYT
@@ -230026,7 +230047,7 @@ kOW
 iUs
 xDI
 dld
-fuZ
+mBf
 nRc
 nRc
 neA
@@ -230210,25 +230231,25 @@ pmt
 kOW
 cxA
 dsj
-ugF
+jsb
 dsj
 xOv
 kOW
-sFL
+vmm
 fiW
 qHh
 fiW
 dsj
-aAw
+bZJ
 wGn
 aFx
 dsj
 pQO
-rwF
+ucl
 iUs
 dld
 dld
-fuZ
+mBf
 nRc
 nRc
 neA
@@ -230408,15 +230429,15 @@ pwm
 pwm
 jZV
 qMM
-wgN
+qBQ
 kOW
 kOW
-fAA
-ccn
-jHL
+nib
+lUP
+sFL
 kOW
 kOW
-wbm
+jTG
 fiW
 qHh
 mcP
@@ -230426,11 +230447,11 @@ pVr
 pVr
 dsj
 pQO
-rwF
-ekD
+ucl
+jwd
 dld
 dld
-fuZ
+mBf
 nRc
 nRc
 sgF
@@ -230614,25 +230635,25 @@ mMj
 hcE
 rQU
 rrG
-cDx
+iGZ
 dsj
 bkH
-rby
+qvn
 aFx
 aFx
-ggs
+ktR
 aFx
 aFx
 aFx
-vMK
+kVO
 dsj
 dsj
 pQO
-rwF
-kPg
+ucl
+qDa
 dld
 dld
-fuZ
+mBf
 nRc
 nRc
 neA
@@ -230814,12 +230835,12 @@ jZV
 czp
 eJY
 kQv
-pPU
-mBf
+hSz
+ujR
 nur
+rwF
+rwF
 ddN
-ddN
-nmo
 bND
 ezK
 ePE
@@ -230830,11 +230851,11 @@ eks
 dsj
 dsj
 pQO
-rwF
+ucl
 cUi
 dld
 dld
-fuZ
+mBf
 nRc
 nRc
 neA
@@ -231017,8 +231038,8 @@ plK
 cvN
 vFt
 jjQ
-tPN
-fgb
+tJf
+ejM
 dsj
 cAW
 hcE
@@ -231032,11 +231053,11 @@ pVr
 dsj
 dsj
 pQO
-rwF
-hbi
+ucl
+tPN
 dld
 dld
-fuZ
+mBf
 nRc
 nRc
 wMt
@@ -231216,17 +231237,17 @@ bfy
 xjG
 sAh
 wXd
-ncd
+qTC
 kOW
 kOW
-rAl
-omK
-jHL
+xKZ
+pBQ
+sFL
 kOW
 kOW
-wbm
+jTG
 fiW
-fgb
+ejM
 fiW
 dsj
 aFx
@@ -231234,11 +231255,11 @@ pVr
 eUn
 dsj
 pQO
-rwF
+ucl
 ucY
 dld
 dld
-fuZ
+mBf
 nRc
 nRc
 neA
@@ -231420,27 +231441,27 @@ rIb
 qMM
 qrQ
 kOW
-jVP
-gRP
-gou
+rjV
+cUo
+rcV
 dsj
-jte
+bPm
 kOW
-sFL
+vmm
 fiW
 aQF
 fiW
 rrG
-aAw
+bZJ
 wGn
 aFx
 dsj
 pQO
-rwF
+ucl
 iUs
 dld
 dld
-fuZ
+mBf
 nRc
 nRc
 sgF
@@ -231622,8 +231643,8 @@ uHd
 qMM
 uPn
 pQO
-vKM
-gRP
+kyt
+cUo
 dsj
 dsj
 llg
@@ -231633,7 +231654,7 @@ fiW
 aQF
 fiW
 dsj
-aAw
+bZJ
 aFx
 aFx
 uYT
@@ -231642,7 +231663,7 @@ kOW
 iUs
 xDI
 dld
-fuZ
+mBf
 nRc
 nRc
 neA
@@ -231824,8 +231845,8 @@ she
 jlQ
 ebN
 pQO
-vKM
-gRP
+kyt
+cUo
 dsj
 dsj
 llg
@@ -231837,14 +231858,14 @@ fiW
 dsj
 aFx
 tVS
-aAw
+bZJ
 aFx
 kOW
 iUs
 iUs
 dld
 dld
-fuZ
+mBf
 nRc
 nRc
 neA
@@ -232026,24 +232047,24 @@ qMI
 pQa
 qmD
 kOW
-wVv
-raN
-xnv
-kHx
-nJR
+wWN
+eVP
+vKM
+jsM
+gHI
 kOW
-oMM
+ikj
 tVS
-lnV
+roc
 aFx
 tVS
-mKY
+hMs
 kOW
 bVb
 bVb
 kOW
 iUs
-oJb
+fxv
 dld
 dld
 mXo
@@ -232058,7 +232079,7 @@ lFw
 hbK
 nRc
 nRc
-qCP
+hVD
 vUJ
 vUJ
 eqh
@@ -232249,18 +232270,18 @@ wVU
 dld
 dld
 pDI
-uCH
-uCH
-uCH
-uCH
-uCH
-uCH
-uCH
-uCH
-uCH
-uCH
-uCH
-eVP
+rqj
+rqj
+rqj
+rqj
+rqj
+rqj
+rqj
+rqj
+rqj
+rqj
+rqj
+qfx
 vUJ
 vUJ
 vUJ
@@ -232396,9 +232417,9 @@ veZ
 cwr
 cwr
 cwr
-nvB
-nvB
-cFP
+oaI
+oaI
+czb
 ook
 tcp
 tcp
@@ -232435,31 +232456,31 @@ xGz
 wzU
 riw
 tZm
-uGA
+oTp
 yiO
 riw
-iGZ
-cRj
-waf
-mdn
-iRf
 aAy
-aAy
+dNo
+mVE
+fuZ
+hpc
+fsi
+fsi
 vXR
-hmk
+sfi
 dld
 dld
 dld
 vLi
 vLi
 qgJ
-sMN
-fBV
+hbi
+xyC
 oei
 qgJ
 tqr
-cUo
-vmm
+cZV
+nol
 qgJ
 vLi
 vLi
@@ -232598,10 +232619,10 @@ veZ
 veZ
 cwr
 cwr
-nvB
-nvB
-cFP
-nvB
+oaI
+oaI
+czb
+oaI
 tcp
 rva
 mNx
@@ -232640,13 +232661,13 @@ oQZ
 elF
 xzr
 riw
-mdn
+fuZ
 rYv
 rYv
 rYv
-iRf
-oSN
-oSN
+hpc
+rig
+rig
 vXR
 gzr
 dld
@@ -232800,10 +232821,10 @@ veZ
 veZ
 cwr
 cwr
-nvB
-nvB
-cFP
-nvB
+oaI
+oaI
+czb
+oaI
 tcp
 uCI
 sOt
@@ -232838,19 +232859,19 @@ uXK
 uXK
 oXE
 riw
-sJX
+tZL
 qox
 opN
 riw
 cNP
-vMo
+jVP
 jAU
 rYv
-iRf
-aAy
-aAy
+hpc
+fsi
+fsi
 vXR
-hmk
+sfi
 dld
 dld
 dld
@@ -233004,8 +233025,8 @@ cwr
 cwr
 nYl
 fCX
-cFP
-nvB
+czb
+oaI
 tcp
 fPz
 gPf
@@ -233040,20 +233061,20 @@ dFx
 bAk
 oXE
 riw
-kLc
-fPi
+raN
+oVv
 nlp
 riw
-ifo
-fkm
-hHU
-dNo
+tpj
+ivC
+jXd
+rqm
 riw
-vsx
+aJN
 kbv
 riw
 vMI
-czb
+qzx
 dld
 dld
 hvW
@@ -233206,7 +233227,7 @@ cwr
 cwr
 lPU
 fCX
-cFP
+czb
 ajp
 tcp
 rzR
@@ -233242,14 +233263,14 @@ nBw
 fLG
 oXE
 riw
-huw
-fCn
-sUM
+pNu
+hmk
+klX
 riw
 int
 vsl
-qBq
-kCV
+cfH
+aAw
 riw
 tTa
 tTa
@@ -233408,7 +233429,7 @@ cwr
 cwr
 rxq
 rxq
-cFP
+czb
 ajp
 cwr
 xdv
@@ -233445,19 +233466,19 @@ qWG
 riw
 riw
 riw
-klX
+ugn
 riw
 riw
 riw
 sGE
-gEc
+eMK
 riw
 riw
-fxv
-wWN
+qKJ
+uCH
 riw
 riw
-kxQ
+mdn
 dld
 dld
 mcG
@@ -233610,7 +233631,7 @@ cwr
 cwr
 rxq
 rxq
-cFP
+czb
 ajp
 cwr
 mcJ
@@ -233643,23 +233664,23 @@ mJT
 pwm
 pwm
 vvK
-mPy
+vvO
 riw
 riw
-nRM
+nrD
 vdu
 rMH
 juo
-cxF
-cxF
-sZu
-qzx
+aED
+aED
+kxQ
+wuN
 diT
 qQZ
 rOh
 rpa
 riw
-xKz
+wQW
 dld
 dld
 leU
@@ -233812,7 +233833,7 @@ cwr
 cwr
 fCX
 fCX
-cFP
+czb
 ajp
 cwr
 trx
@@ -233842,15 +233863,15 @@ tnR
 vaT
 vaT
 qZu
-kVO
-xke
+rby
+dzK
 bZF
-kVO
+rby
 riw
-kwb
+bfZ
 wFB
 qQZ
-wuN
+sMN
 orJ
 rOh
 rOh
@@ -233860,7 +233881,7 @@ riw
 mqQ
 rOh
 iWQ
-iRf
+hpc
 rjY
 dld
 dld
@@ -234049,7 +234070,7 @@ riw
 lDz
 riw
 riw
-gSa
+sUM
 wFB
 hAv
 mwt
@@ -234062,7 +234083,7 @@ rpa
 qQZ
 rOh
 iWQ
-iRf
+hpc
 fXR
 dld
 dld
@@ -234248,24 +234269,24 @@ nfq
 jMp
 riw
 grQ
-ldw
-rig
-usX
-cKd
-uTQ
+uqM
+nTE
+lfc
+oin
+oMM
 hAv
 mwt
-uqM
+wpu
 tuI
 rOh
 qWp
 cFR
-dXG
+hNx
 qQZ
 qQZ
 iWQ
-iRf
-czb
+hpc
+qzx
 dld
 dld
 mcG
@@ -234446,15 +234467,15 @@ lIg
 dVl
 vaT
 qkp
-oSO
-pyY
-qUt
+oLh
+egd
+vCh
 oKC
-ksw
-dBR
+ekD
+kSK
 riw
-tgh
-xyC
+pLt
+ggs
 hAv
 mwt
 mwt
@@ -234466,7 +234487,7 @@ rpa
 qQZ
 qQZ
 iWQ
-iRf
+hpc
 rjY
 dld
 dld
@@ -234648,27 +234669,27 @@ vaT
 vaT
 vaT
 qkp
-fPE
+miP
 pwm
 riw
 qza
-wQW
-rcV
+eSm
+wVv
 riw
 sPG
-deL
-kFQ
-qyo
-qyo
+pPU
+qgM
+uUU
+uUU
 rOh
 rOh
-tZL
+eMx
 riw
 riw
 mqQ
 rOh
 iWQ
-iRf
+hpc
 wVU
 dld
 dld
@@ -234850,20 +234871,20 @@ sfG
 imO
 lNu
 tPK
-fPE
+miP
 pwm
 riw
 riw
 riw
-asE
+xke
 riw
 riw
-bZJ
-nxH
-qWT
-kEe
-miP
-cxF
+qwE
+tgh
+oSN
+xpC
+qyo
+aED
 oBo
 qQZ
 diT
@@ -234871,7 +234892,7 @@ rOh
 qQZ
 rpa
 riw
-xKz
+wQW
 dld
 dld
 dIp
@@ -235052,12 +235073,12 @@ kRE
 gxW
 mfV
 lem
-gXz
+weP
 pwm
 riw
 lkJ
 vkU
-oma
+fkm
 riw
 riw
 riw
@@ -235066,14 +235087,14 @@ riw
 riw
 riw
 riw
-guj
+uOA
 riw
 riw
 qQZ
-hSz
+guj
 riw
 riw
-hMs
+dNI
 dld
 dld
 nAX
@@ -235254,20 +235275,20 @@ sfG
 imO
 bJC
 pEI
-gXz
+weP
 pwm
 riw
 riw
 riw
-npm
+oNA
 riw
-xqJ
+nJR
 sbj
 wFB
 jac
 riw
-xqJ
-wbe
+nJR
+vAx
 kZn
 xwO
 riw
@@ -235275,13 +235296,13 @@ tTa
 tTa
 riw
 quT
-czb
+qzx
 dld
 dld
 owa
 vUJ
 vhs
-rHD
+jte
 lOl
 hbO
 dft
@@ -235456,22 +235477,22 @@ uSX
 nnT
 vaT
 qkp
-gXz
+weP
 pwm
 riw
 lkJ
 vkU
-riP
+gnT
 riw
-bvz
-kpf
-qBQ
-efu
+dBR
+kDY
+dXG
+mKY
 riw
-bvz
-sOa
+dBR
+ccn
 rOh
-vFR
+wfn
 riw
 kbv
 kbv
@@ -235482,7 +235503,7 @@ dld
 dld
 kVt
 vUJ
-uVx
+gxd
 ooV
 jWc
 uOU
@@ -235658,27 +235679,27 @@ lLF
 xJm
 vaT
 qkp
-xBq
+bwG
 pwm
 riw
 riw
 riw
 riw
 riw
-iZz
-jwd
+kpf
+mCt
 qQZ
-vFR
+wfn
 riw
-iZz
+kpf
 qQZ
 qQZ
 qQZ
 riw
-aAy
-aAy
+fsi
+fsi
 vXR
-hmk
+sfi
 dld
 dld
 dld
@@ -235860,7 +235881,7 @@ wan
 wxz
 vaT
 pkv
-gXz
+weP
 pwm
 xGz
 xGz
@@ -235878,9 +235899,9 @@ gzV
 vtp
 riw
 qQO
-oSN
+rig
 vXR
-jkf
+sZu
 dld
 dld
 dld
@@ -236062,7 +236083,7 @@ dXg
 kLp
 vaT
 nvI
-gXz
+weP
 pwm
 xGz
 xGz
@@ -236079,13 +236100,13 @@ riw
 riw
 riw
 riw
-aAy
-aAy
+fsi
+fsi
 vXR
-hmk
-fEH
+sfi
+xwB
 dld
-mRi
+sOa
 dld
 jZI
 jZI
@@ -236264,7 +236285,7 @@ wIg
 uob
 gUg
 brN
-gXz
+weP
 pwm
 xGz
 xGz
@@ -236466,7 +236487,7 @@ fsM
 aom
 vaT
 soq
-gXz
+weP
 pwm
 xGz
 xGz
@@ -236477,7 +236498,7 @@ xGz
 xGz
 opH
 plZ
-jsM
+lyG
 opH
 ouv
 mmt
@@ -236668,7 +236689,7 @@ bqj
 vaT
 vaT
 soq
-xBq
+bwG
 pwm
 xGz
 xGz
@@ -236689,7 +236710,7 @@ spV
 spV
 uVK
 qrB
-uQx
+uVx
 lze
 ycP
 ycP
@@ -236870,14 +236891,14 @@ pwm
 pwm
 gTr
 fID
-fPE
+miP
 pwm
 xGz
 xGz
 opH
 hHX
-vGk
-cfH
+weh
+xEe
 yex
 opH
 opH
@@ -236888,8 +236909,8 @@ fpd
 opH
 opH
 mZy
-eMx
-eTj
+pes
+cFP
 spV
 spV
 spV
@@ -237072,7 +237093,7 @@ xGz
 pwm
 soq
 pwm
-oaI
+dnk
 pwm
 xGz
 xGz
@@ -237080,7 +237101,7 @@ opH
 opH
 sJb
 gMa
-sPh
+fCn
 opH
 phC
 gMa
@@ -237090,11 +237111,11 @@ gMa
 wtw
 opH
 mqs
-qbh
+uQx
 dEk
 vkI
 dEk
-kMZ
+qbh
 rnS
 xok
 gUk
@@ -237262,7 +237283,7 @@ cgQ
 uvj
 vSU
 lob
-fSf
+ljQ
 uVa
 wNG
 uvj
@@ -237274,7 +237295,7 @@ pwm
 pwm
 uIC
 pwm
-oaI
+dnk
 pwm
 xGz
 xGz
@@ -237283,15 +237304,15 @@ pzk
 gMa
 vqG
 gMa
-ugj
+wSl
 gMa
 gMa
 geA
 xgI
 vfv
 fqG
-waT
-suE
+vMK
+koL
 ezs
 lhz
 kAU
@@ -237475,8 +237496,8 @@ pwm
 pwm
 dkm
 vMU
-xTb
-gXz
+lLw
+weP
 pwm
 xGz
 xGz
@@ -237484,9 +237505,9 @@ opH
 opH
 sJb
 gMa
-sPh
+fCn
 opH
-gdn
+omK
 gMa
 pIr
 acB
@@ -237494,13 +237515,13 @@ eCm
 uBy
 opH
 nuM
-pes
+buS
 gkZ
 uVK
 uVK
 uVK
 spV
-hpc
+wbe
 lhz
 gWi
 rIc
@@ -237677,32 +237698,32 @@ seQ
 bVD
 wWa
 bXy
-rqm
-gXz
+xTb
+weP
 pwm
 xGz
 xGz
 opH
 hvz
-bPm
-lQf
-eSm
+tmF
+aFL
+hQO
 opH
 huC
-lUP
-vMQ
-eMK
-jnw
-cZV
+xfb
+epB
+gwj
+diH
+yfE
 opH
-hNx
+nFm
 spV
-yjK
+eTj
 uVK
-bal
-mVE
+uRw
+kOD
 spV
-fBw
+vGk
 gUk
 ewj
 gYP
@@ -237879,8 +237900,8 @@ pwm
 pwm
 soz
 pwm
-rqm
-fPE
+xTb
+miP
 pwm
 xGz
 xGz
@@ -237894,20 +237915,20 @@ opH
 opH
 opH
 opH
-ejM
-gxd
+cRj
+xBq
 opH
-pYx
-esz
-oVv
+huw
+qGp
+bAa
 uVK
-bfZ
-jHx
+nxH
+uDc
 spV
-kyl
+fBw
 gUk
 kHd
-doA
+owI
 sdN
 rEL
 rEL
@@ -238081,8 +238102,8 @@ veZ
 pwm
 rYq
 pwm
-rqm
-xmO
+xTb
+dtG
 xwU
 xwU
 xwU
@@ -238090,11 +238111,11 @@ xwU
 xwU
 xwU
 etH
-fsi
-fsi
-fsi
-tZT
+bvz
+bvz
+bvz
 wjD
+xrD
 opH
 opH
 opH
@@ -238109,7 +238130,7 @@ uVK
 uVK
 gUk
 kHd
-doA
+owI
 pdx
 utp
 oly
@@ -238283,31 +238304,31 @@ veZ
 pwm
 rsS
 pwm
-pNu
-ljQ
+npm
+ntC
 rQO
-vCh
+cKd
 rQO
 rQO
 rQO
-qDa
+qUt
 ctQ
-pZI
-qKJ
-qKJ
+lVU
+eit
+eit
 pwm
 mQc
-dtG
-fsi
-fsi
-fsi
-tZT
-fsi
-fsi
-fsi
-fsi
-fsi
-fsi
+dCC
+bvz
+bvz
+bvz
+wjD
+bvz
+bvz
+bvz
+bvz
+bvz
+bvz
 sRR
 fWi
 xrJ
@@ -238691,22 +238712,22 @@ aHk
 aHk
 hJp
 aHk
-dmD
+wbm
 hJp
-dmD
+wbm
 uVi
 hJp
-dmD
-dmD
-dmD
-eit
-dmD
-dmD
-eit
-dmD
-eit
+wbm
+wbm
+wbm
+vMo
+wbm
+wbm
+vMo
+wbm
+vMo
 bLR
-jTG
+kwb
 bLR
 bLR
 bLR
@@ -239514,7 +239535,7 @@ veZ
 veZ
 veZ
 vzY
-hQO
+gou
 vzY
 vzY
 vzY
@@ -239927,7 +239948,7 @@ vzY
 eip
 npq
 gUk
-oTp
+fgb
 pNT
 srq
 xAC
@@ -240725,7 +240746,7 @@ veZ
 veZ
 veZ
 hqC
-uRw
+waT
 bcG
 cxn
 kLt

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -1079,10 +1079,14 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/quartermaster/miningdock)
 "ajp" = (
-/obj/structure/table/bench/padded,
+/obj/structure/table/rack/shelf,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
+	},
+/area/nadezhda/hallway/side/f2section1)
 "ajA" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -1826,6 +1830,24 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"asE" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "asG" = (
 /obj/structure/scrap_cube,
 /obj/effect/decal/cleanable/dirt,
@@ -2503,10 +2525,8 @@
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "aAw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
-	},
-/turf/simulated/floor/carpet,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "aAy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2854,9 +2874,14 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "aED" = (
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "aEL" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -2972,18 +2997,11 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/detectives_office)
 "aFL" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "aFM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3373,9 +3391,8 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/prisoncells)
 "aJN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "aJP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5074,12 +5091,14 @@
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
 "bal" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/multiz/stairs/active{
+	dir = 1
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "bam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
@@ -5691,19 +5710,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bfZ" = (
-/obj/structure/bed/chair/sofa/brown/left,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+/obj/structure/multiz/stairs/active{
+	dir = 1
 	},
-/obj/random/toy/plushie,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/sign/levels/stairsdown{
+	pixel_y = -30;
+	pixel_x = 32
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "bgc" = (
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -6106,19 +6125,12 @@
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
 "bkH" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "bkM" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -6344,20 +6356,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bmx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "bmy" = (
 /obj/structure/railing{
 	dir = 1;
@@ -6613,7 +6624,10 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
 "boU" = (
-/turf/simulated/floor/tiled/dark/gray_perforated,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
 "boY" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
@@ -7207,12 +7221,20 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "buS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 5
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "buT" = (
 /obj/effect/window_lwall_spawn,
 /turf/simulated/floor/plating/under,
@@ -7281,17 +7303,12 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "bvz" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/woodentable,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "bvA" = (
 /obj/structure/railing{
 	dir = 4;
@@ -7421,10 +7438,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bwG" = (
-/obj/structure/table/woodentable,
-/obj/random/toy/plushie,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/engineering/atmos/storage)
 "bwJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -7984,20 +8000,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
-"bCT" = (
-/obj/structure/mirror{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
 "bCY" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/big/bush3,
@@ -9090,18 +9092,18 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "bPm" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/glass/urn/veteran{
+	pixel_x = 7
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/oddity/nt/pyramid{
+	pixel_x = -9
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "bPp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9120,14 +9122,20 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/quartermaster/disposaldrop)
 "bPu" = (
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "bPJ" = (
 /obj/structure/flora/small/busha1,
 /obj/random/flora/jungle_tree,
@@ -10090,14 +10098,18 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "bZJ" = (
-/obj/structure/table/standard,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+/obj/random/furniture/pottedplant,
+/obj/machinery/camera/network/church{
+	dir = 8
 	},
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "bZL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10396,14 +10408,11 @@
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/plasma_tag)
 "ccn" = (
-/obj/machinery/atmospherics/unary/vent_pump{
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/plating,
 /area/nadezhda/absolutism/chapel)
 "cco" = (
 /obj/machinery/light{
@@ -10634,20 +10643,10 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cfH" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/table/woodentable,
+/obj/item/device/lighting/toggleable/lantern/censer,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "cfK" = (
 /obj/machinery/camera/xray/security{
 	dir = 9
@@ -11501,22 +11500,9 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cox" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "coC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -12474,10 +12460,10 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "cxF" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/box/white,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "cxN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12534,10 +12520,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cye" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/church_reinforced,
+/area/nadezhda/absolutism/bioreactor)
 "cyf" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/pros/foreman)
@@ -12634,12 +12619,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
 "czb" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "czd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -13183,19 +13165,12 @@
 	name = "Dormitory 1"
 	})
 "cDx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "cDF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13406,22 +13381,22 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/command/bridgebar)
 "cFP" = (
-/obj/structure/closet/secure_closet/personal/agrolyte,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = -32
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/hallway/side/f2section1)
 "cFR" = (
-/obj/machinery/vending/theomat,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/vectorrooms)
 "cFV" = (
 /obj/random/scrap/sparse_weighted,
 /obj/effect/decal/cleanable/dirt,
@@ -13523,6 +13498,15 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
+"cHs" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "cHz" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/big/bush2,
@@ -13798,10 +13782,19 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/bridge)
 "cKd" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "cKe" = (
@@ -14102,15 +14095,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
-"cNj" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
 "cNl" = (
 /obj/structure/flora/small/trailrocka3,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -14156,8 +14140,12 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/surface/section1)
 "cNE" = (
-/obj/machinery/biomatter_solidifier,
-/turf/simulated/floor/tiled/dark/danger,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "cNF" = (
 /obj/structure/flora/ausbushes/sunnybush,
@@ -14415,18 +14403,12 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "cRj" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light_switch{
+	pixel_x = -20
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/machinery/smartfridge/kitchen/church,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "cRq" = (
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark/panels,
@@ -14639,11 +14621,9 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
 "cTB" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/floor_decal/industrial/loading/white,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "cTE" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = -32
@@ -14766,11 +14746,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "cUo" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "cUx" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 1
@@ -15210,11 +15190,17 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
 "cZV" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "dar" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/railing/grey{
@@ -15724,12 +15710,19 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "deL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "deM" = (
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/structure/table/standard,
@@ -16502,12 +16495,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
 "dnk" = (
-/obj/structure/table/woodentable,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "dnl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -16625,9 +16616,19 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "doA" = (
-/obj/structure/flora/small/grassb1,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "doD" = (
 /obj/structure/catwalk,
 /obj/random/cluster/roaches/low_chance,
@@ -17224,9 +17225,20 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
 "dtG" = (
-/obj/structure/closet/coffin,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "dup" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/rock,
@@ -17786,10 +17798,17 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dzK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "dzS" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "16,9"
@@ -17957,20 +17976,13 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "dBr" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/area/nadezhda/absolutism/bioreactor)
 "dBt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -17984,9 +17996,14 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "dBR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
 	},
+/obj/structure/sink{
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "dBU" = (
@@ -18113,16 +18130,13 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/bridgebar)
 "dCC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/power/eotp,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "dCH" = (
 /obj/machinery/light/small{
@@ -19140,20 +19154,17 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "dNo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "dNp" = (
 /obj/effect/floor_decal/border/techfloor{
@@ -19203,7 +19214,34 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "dNI" = (
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey,
+/obj/structure/sign/faction/derelict1{
+	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
+	name = "NOTICE: Dangerous Biohazard";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "dNK" = (
 /turf/simulated/shuttle/wall/mining{
@@ -20096,20 +20134,9 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "dXG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "dXJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -20908,11 +20935,11 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
 "efu" = (
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Office"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "efv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21017,25 +21044,14 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "egd" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/random/mob/roaches/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "egg" = (
 /obj/structure/table/rack/shelf,
 /obj/random/pack/cloth/low_chance,
@@ -21258,11 +21274,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "eit" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment,
+/obj/random/scrap/dense_weighted/low_chance,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "eix" = (
 /obj/structure/table/steel,
 /obj/machinery/microwave,
@@ -21354,10 +21370,17 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ejM" = (
-/obj/structure/reagent_dispensers/biomatter/large,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "ejZ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -21414,12 +21437,10 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "ekD" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "ekF" = (
 /obj/structure/table/rack/shelf,
 /obj/random/mecha_equipment/low_chance,
@@ -21872,15 +21893,12 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "epB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "epH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22170,11 +22188,14 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "esz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "esA" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -23628,13 +23649,19 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "eIV" = (
-/obj/structure/table/woodentable,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/sign/levels/stairsup{
+	pixel_x = 32;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "eIZ" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,22"
@@ -24074,9 +24101,14 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/crew_quarters/kitchen_storage)
 "eMx" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "eMB" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/extinguisher_cabinet{
@@ -24100,9 +24132,18 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory_blackshield)
 "eMK" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "eMS" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -24640,14 +24681,13 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/construction)
 "eSm" = (
-/obj/machinery/light/small,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/closet/secure_closet/reinforced/preacher,
+/obj/item/device/taperecorder,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/item/clothing/mask/gas/germanmask,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "eSv" = (
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/effect/floor_decal/border/techfloor{
@@ -24813,23 +24853,22 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/main/stairwell)
 "eTj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 32;
+	icon_state = "32-1"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/railing/grey{
+	dir = 1;
+	icon_state = "grey_railing0"
 	},
-/obj/machinery/light/small,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/steel/golden,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/catwalk,
+/turf/simulated/open,
+/area/nadezhda/absolutism/storage)
 "eTk" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -25109,19 +25148,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "eVP" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/multiz/stairs/enter/bottom,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "eVQ" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -26152,23 +26183,12 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "fgb" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/disposaloutlet,
-/obj/machinery/conveyor/south{
-	id = "junk_to_bioreactor"
-	},
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0";
-	tag = "icon-railing0 (NORTH)"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "fgf" = (
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/hallway/main/stairwell)
@@ -26258,11 +26278,16 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "fgM" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/prime)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "fgN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -26621,10 +26646,12 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fkm" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27252,18 +27279,12 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "fqE" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/structure/invislight,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/sign/faction/neotheology{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "fqF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -27445,10 +27466,16 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
 "fsi" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/open,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "fsk" = (
 /turf/simulated/floor/carpet,
@@ -27780,20 +27807,16 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "fuZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "chudorm4";
-	name = "Church Dorm 2";
-	req_access = list(70)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "fvc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -28010,19 +28033,9 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "fxv" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "fxy" = (
 /obj/machinery/door/airlock/maintenance_security{
 	req_access = list(1)
@@ -28089,16 +28102,10 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "fyb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "fyc" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
@@ -28339,8 +28346,12 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical)
 "fAA" = (
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "fAG" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/simulated/floor/bluegrid{
@@ -28382,16 +28393,14 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "fBw" = (
+/obj/machinery/camera/network/church{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -28484,15 +28493,11 @@
 	name = "Dormitory 3"
 	})
 "fBV" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "fBY" = (
 /obj/structure/multiz/stairs/active{
 	dir = 1
@@ -28531,14 +28536,15 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/cryo)
 "fCn" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "fCp" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -28613,11 +28619,10 @@
 	name = "\improper Blackshield - Firing Range"
 	})
 "fCX" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/hallway/side/f2section1)
 "fDb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4;
@@ -28874,14 +28879,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "fEH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
 	},
-/obj/structure/catwalk,
-/obj/machinery/light,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "fEJ" = (
 /obj/structure/catwalk,
 /obj/structure/grille,
@@ -29923,18 +29926,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fPi" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "fPo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -30033,11 +30027,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "fPE" = (
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = -32
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "fPG" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/camera/network/cev_eris,
@@ -31333,13 +31340,12 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/abandoned_solars/powered)
 "gdn" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/light_switch{
+	pixel_x = 28
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "gdr" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -31755,14 +31761,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ggs" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "ggt" = (
 /obj/machinery/power/nt_obelisk,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -32596,13 +32600,13 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "gnT" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/random/toy/plushie_onlyfox,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "gnW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -32643,15 +32647,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
 "gou" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4;
-	name = "biomatter chute"
-	},
-/obj/structure/disposalpipe/trunk{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "gow" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -33219,9 +33220,18 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "guj" = (
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "chudorm4";
+	name = "Church Dorm 2";
+	req_access = list(70)
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "gum" = (
@@ -33455,9 +33465,17 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "gxd" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
+	},
+/obj/structure/noticeboard/church{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "gxg" = (
 /obj/structure/closet/l3closet,
 /turf/simulated/floor/tiled/white,
@@ -34183,6 +34201,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/captain)
+"gEc" = (
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/vectorrooms)
 "gEm" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/tiled/dark/danger,
@@ -34535,19 +34565,19 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "gHI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
+/obj/machinery/camera/network/church{
+	dir = 1
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "gHJ" = (
 /obj/structure/flora/small/rock2,
 /turf/simulated/floor/asteroid/grass,
@@ -35463,13 +35493,6 @@
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
-"gPB" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/sign/faction/neotheology{
-	pixel_x = 32
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
 "gPD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -35661,12 +35684,16 @@
 	name = "Dormitory 2"
 	})
 "gSa" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/item/storage/fancy/crayons,
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/crayons,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "gSb" = (
 /obj/structure/catwalk,
@@ -36590,10 +36617,10 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/turret_protected/ai_upload)
 "hbi" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "hbk" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -37528,9 +37555,9 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "hkR" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/flora/small/grassb1,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "hkW" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -37674,29 +37701,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "hmj" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/material/kitchen/rollingpin,
+/obj/machinery/light,
 /obj/machinery/light_switch{
-	pixel_y = 30
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
-"hmk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
+"hmk" = (
+/obj/structure/multiz/stairs/enter/bottom,
+/obj/structure/invislight,
+/turf/simulated/floor/plating,
 /area/nadezhda/outside/meadow)
 "hmp" = (
 /obj/structure/cable/green{
@@ -37939,12 +37955,19 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "hpc" = (
-/obj/machinery/light_switch{
-	pixel_x = 28
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/bed/chair/comfy/black,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "hpe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -37965,23 +37988,17 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/absolutism/bioreactor)
 "hpq" = (
-/obj/structure/disposaloutlet{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/power/eotp,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "hpu" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/effect/decal/cleanable/dirt,
@@ -38476,24 +38493,19 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
 "huw" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/bed/chair/sofa/brown/left,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/random/toy/plushie,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "huC" = (
 /obj/structure/bookcase,
 /obj/item/book/ritual/cruciform,
@@ -39585,12 +39597,10 @@
 	name = "Dormitory 1"
 	})
 "hHU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/table/woodentable,
+/obj/machinery/reagentgrinder/portable,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "hHX" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -40009,22 +40019,10 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "hMs" = (
-/obj/structure/cable/yellow{
-	d1 = 32;
-	icon_state = "32-1"
-	},
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/catwalk,
-/turf/simulated/open,
-/area/nadezhda/absolutism/storage)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "hMw" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -40124,17 +40122,15 @@
 	name = "\improper Outdoors - Pad"
 	})
 "hNx" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/tool/multitool,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "hNF" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/cable/green{
@@ -40494,24 +40490,12 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "hQO" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/area/nadezhda/absolutism/skyyard)
 "hQP" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -40679,11 +40663,11 @@
 /turf/unsimulated/mineral,
 /area/colony)
 "hSz" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
+/obj/structure/sign/faction/neotheology_cross{
 	pixel_y = -32
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "hSA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -40956,25 +40940,12 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
 "hVD" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Prime's Office";
-	departmentType = 22;
-	name = "Prime's RC";
-	pixel_x = 30;
-	pixel_y = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Prime's Office"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "hVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -41889,12 +41860,22 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ifo" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/material/kitchen/rollingpin,
+/obj/machinery/light_switch{
+	pixel_y = 30
 	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "ifw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/security{
@@ -42345,11 +42326,12 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
 "ikj" = (
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = 32
+/obj/machinery/light_switch{
+	pixel_y = 30
 	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "ikn" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -43473,9 +43455,13 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "ivC" = (
-/obj/structure/reagent_dispensers/biomatter,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "ivM" = (
 /obj/machinery/holoposter{
@@ -43929,15 +43915,15 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "iAo" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/camera/network/church{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "iAq" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -44598,13 +44584,14 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "iGZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "iHa" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/unsimulated/wall/jungle,
@@ -46578,9 +46565,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "iZz" = (
-/obj/structure/flora/small/grassa5,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "iZD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
@@ -47707,15 +47696,20 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "jkf" = (
-/obj/machinery/conveyor_switch{
-	id = "disposals grinder"
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
 	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/floor_decal/industrial/danger,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "jkj" = (
 /obj/structure/table/steel,
 /obj/random/material_resources,
@@ -47980,23 +47974,16 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jnw" = (
-/obj/machinery/door/airlock{
-	name = "Church";
-	req_access = list(27)
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "jny" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -48560,15 +48547,11 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jsM" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/tool/multitool,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/prime)
 "jsR" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/gloves{
@@ -48587,28 +48570,10 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "jte" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 2";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/light,
+/obj/machinery/vending/fortune,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "jtl" = (
 /obj/machinery/light_switch{
 	pixel_y = 30
@@ -48894,13 +48859,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
 "jwd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "jwe" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
@@ -50033,12 +49996,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jHx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/multiz/stairs/enter{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "jHC" = (
 /obj/random/scrap/dense_weighted,
 /obj/structure/table/rack/shelf,
@@ -50058,8 +50024,12 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jHL" = (
-/turf/simulated/wall/church_reinforced,
-/area/colony)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "jHS" = (
 /obj/random/contraband/low_chance,
 /obj/effect/decal/cleanable/cobweb{
@@ -51272,14 +51242,11 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jTG" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/pistachios,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/skyyard)
 "jTH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/reinforced/polarized{
@@ -51554,8 +51521,19 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/barquarters)
 "jVP" = (
-/obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/carpet,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "jWc" = (
 /obj/structure/window/reinforced{
@@ -51653,12 +51631,7 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jXd" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/sign/faction/neotheology{
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
+/turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/meadow)
 "jXf" = (
 /obj/structure/table/rack/shelf,
@@ -52186,19 +52159,12 @@
 	name = "\improper Clinic"
 	})
 "kbl" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/device/radio/intercom{
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "kbm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -53297,9 +53263,15 @@
 /obj/machinery/door/unpowered/simple/wood/saloon{
 	name = "Church Foyer"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/vectorrooms)
 "kmc" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -53699,16 +53671,9 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "koL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "koP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53747,16 +53712,15 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
 "kpf" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "kpi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -53892,6 +53856,14 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"kqQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "kqX" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -54044,6 +54016,20 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"ksw" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "ksx" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -54201,11 +54187,12 @@
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "ktR" = (
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "ktS" = (
 /obj/structure/closet/crate,
 /obj/item/am_shielding_container,
@@ -54452,11 +54439,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "kwb" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "kwd" = (
 /obj/random/flora/jungle_tree,
@@ -54626,11 +54614,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/hut_cell1)
 "kxQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "kxW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54649,14 +54636,25 @@
 /turf/simulated/floor/asteroid/dirt/dark/plough,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kyl" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/industrial/warningred,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "kym" = (
 /mob/living/simple_animal/hostile/naniteswarm{
 	desc = "A swarm of disgusting mini locusts infested with disease and hatred.";
@@ -54665,11 +54663,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kyt" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "kyu" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -55180,6 +55184,17 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/construction)
+"kCV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "kCW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
@@ -55254,6 +55269,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kDY" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
+"kEe" = (
 /obj/machinery/light{
 	dir = 4
 	},
@@ -55265,18 +55285,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
-"kEe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
 "kEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -55464,14 +55472,13 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "kFQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "kFU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55669,6 +55676,16 @@
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/office)
+"kHx" = (
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/atm{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "kHE" = (
 /obj/random/junk/low_chance,
 /obj/effect/floor_decal/spline/plain,
@@ -55990,12 +56007,13 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kLc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
+/obj/structure/bed/chair/sofa/brown/right,
+/obj/landmark/join/start/acolyte,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "kLm" = (
 /obj/structure/table/rack/shelf,
 /obj/random/lowkeyrandom,
@@ -56213,15 +56231,18 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kMZ" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/atm{
-	dir = 4;
-	pixel_x = 30
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "kNa" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -56373,12 +56394,10 @@
 /turf/simulated/open,
 /area/colony)
 "kOD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/box/white,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "kOJ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -56418,22 +56437,10 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
 "kPg" = (
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "kPj" = (
 /obj/structure/sign/departmentold/security,
 /turf/simulated/wall/r_wall,
@@ -56815,16 +56822,15 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "kSK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/disposal/deliveryChute{
+	dir = 4;
+	name = "biomatter chute"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "kSR" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/table/rack/shelf,
@@ -57149,14 +57155,9 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "kVO" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/hallway/surface/section1)
 "kWa" = (
 /obj/structure/flora/big/bush2,
 /obj/effect/decal/cleanable/dirt,
@@ -57990,13 +57991,28 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ldw" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "ldz" = (
 /obj/structure/holohoop{
 	dir = 1
@@ -58252,10 +58268,18 @@
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "lfc" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "lfh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spider/spiderling,
@@ -58426,13 +58450,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -58676,10 +58693,23 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ljQ" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/obj/structure/invislight,
-/turf/simulated/floor/plating,
-/area/nadezhda/outside/meadow)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "ljT" = (
 /obj/structure/table/standard,
 /obj/item/storage/briefcase/inflatable,
@@ -59053,12 +59083,15 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "lnV" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/item/scrap_lump,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "lnW" = (
 /obj/item/clothing/suit/armor/platecarrier/ih,
 /obj/item/clothing/suit/armor/platecarrier/ih,
@@ -61424,18 +61457,17 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/barbackroom)
 "lLw" = (
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Office"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "lLB" = (
 /obj/machinery/atmospherics/omni/mixer{
 	active_power_usage = 7500;
@@ -61978,6 +62010,12 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
+"lQf" = (
+/obj/item/tool/knife/neotritual,
+/obj/item/clothing/gloves/psionic_ring,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "lQg" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -62438,14 +62476,19 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "lUP" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "lUR" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -62558,19 +62601,8 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
 "lVU" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/closet/coffin,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "lVV" = (
 /obj/machinery/power/breakerbox{
@@ -63145,9 +63177,16 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "mce" = (
-/obj/effect/floor_decal/industrial/loading/white,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "mcg" = (
 /obj/structure/bed/chair,
 /obj/structure/window/reinforced{
@@ -63249,9 +63288,7 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/crew_quarters/plasma_tag)
 "mcP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/table/bench/padded,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
@@ -63325,13 +63362,9 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/quartermaster/office)
 "mdn" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
-/area/colony)
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "mdt" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 2;
@@ -63480,27 +63513,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "meA" = (
-/obj/structure/cable/yellow{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
 	},
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey,
-/obj/structure/cable/yellow,
-/obj/machinery/light,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "meB" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 0;
@@ -63866,16 +63885,9 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "miP" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/camera/network/church{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "miQ" = (
@@ -65580,15 +65592,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
 "mxN" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
+/obj/machinery/conveyor_switch{
+	id = "disposals grinder"
 	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/floor_decal/industrial/danger,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "mxR" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -65865,11 +65877,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/engineering/foyer)
 "mBf" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "mBn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating/under,
@@ -66574,12 +66593,14 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/construction)
 "mHf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "mHh" = (
 /obj/landmark/join/start/cargo_tech,
 /obj/structure/disposalpipe/segment,
@@ -66954,17 +66975,12 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
 "mKY" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "mLl" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -67396,9 +67412,12 @@
 /turf/simulated/floor/beach/sand/drywater,
 /area/nadezhda/crew_quarters/pool)
 "mPy" = (
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/hallway/surface/section1)
 "mPC" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -67563,11 +67582,13 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "mRi" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "mRq" = (
 /obj/structure/table/bench/marble,
 /obj/machinery/alarm{
@@ -68000,11 +68021,10 @@
 	name = "\improper Outdoors - Pad"
 	})
 "mVl" = (
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/reagent_dispensers/biomatter/large,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "mVm" = (
 /obj/structure/closet,
 /turf/simulated/floor/tiled/white,
@@ -68049,12 +68069,14 @@
 	name = "Residential District Substation"
 	})
 "mVE" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
+/obj/structure/multiz/stairs/enter{
+	dir = 1
 	},
-/obj/machinery/smartfridge/kitchen/church,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "mVH" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/generic,
@@ -68620,17 +68642,23 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ncd" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/conveyor/south{
-	id = "junk_to_bioreactor"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/light/small,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
 "nch" = (
 /obj/random/furniture/pottedplant,
 /obj/item/device/radio/intercom{
@@ -69188,14 +69216,9 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "nib" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "nic" = (
 /obj/structure/table/onestar,
 /obj/item/pen,
@@ -69597,14 +69620,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "nmo" = (
-/obj/machinery/light,
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "nmp" = (
 /obj/item/reagent_containers/blood/AMinus,
 /obj/item/reagent_containers/blood/APlus,
@@ -69775,19 +69795,12 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/fo)
 "nol" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/recycler,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "nom" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -69905,9 +69918,15 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "npm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "npp" = (
 /obj/structure/multiz/stairs/active/bottom,
@@ -70114,14 +70133,12 @@
 /turf/simulated/floor/plating/under,
 /area/asteroid/cave)
 "nrD" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/obj/item/scrap_lump,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "nrI" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -70310,24 +70327,9 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ntC" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "ntK" = (
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
@@ -70387,16 +70389,13 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "nur" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "nuD" = (
@@ -70511,12 +70510,14 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nvB" = (
-/obj/machinery/camera/network/church{
-	dir = 4
-	},
+/obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
+	},
+/area/nadezhda/hallway/side/f2section1)
 "nvD" = (
 /obj/structure/table/bar_special,
 /obj/machinery/floor_light,
@@ -70668,15 +70669,20 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "nxH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "nxP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -71057,21 +71063,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
-"nBa" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "nBd" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -71474,17 +71465,10 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "nFm" = (
-/obj/machinery/camera/network/church{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "nFp" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -71963,15 +71947,15 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nJR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "nJX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -72687,9 +72671,15 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "nRM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/random/furniture/pottedplant,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "nRO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -72814,15 +72804,14 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "nTE" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "nTL" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -73638,7 +73627,22 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "oaI" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "oaM" = (
@@ -74889,6 +74893,14 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
+"oma" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "omb" = (
 /obj/machinery/door/airlock/glass{
 	name = "Employee Lounge";
@@ -74996,14 +75008,12 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/main/stairwell)
 "omK" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "omU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75288,22 +75298,20 @@
 /turf/simulated/mineral,
 /area/nadezhda/command/cbo)
 "oqc" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/item/scrap_lump,
-/obj/structure/cable/green{
+/obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/absolutism/bioreactor)
 "oqd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -75997,9 +76005,14 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
 "owI" = (
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "owK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/furniture/pottedplant,
@@ -77321,24 +77334,13 @@
 	},
 /area/nadezhda/pros/proelav)
 "oJb" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/sign/faction/neotheology{
+	pixel_x = -30;
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "oJo" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood/wild3,
@@ -77705,13 +77707,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "oMM" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/chapel)
 "oMS" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/junk/snappop,
@@ -77782,11 +77781,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
 "oNA" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "oNP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78291,13 +78291,27 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "oSN" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/replenishing/chalice,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = -32
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
+"oSO" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "oST" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -78374,13 +78388,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "oTp" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 1;
-	name = "trash chute"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "oTv" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -78538,10 +78561,15 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
 "oVv" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/machinery/vending/theomat,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "oVO" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 6
@@ -79834,6 +79862,12 @@
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"pkB" = (
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/hallway/surface/section1)
 "pkC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81229,10 +81263,17 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/virology)
 "pyY" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "pzk" = (
 /obj/structure/nt_pedestal,
 /turf/simulated/floor/carpet/bcarpet,
@@ -81502,18 +81543,15 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "pBQ" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/urn/veteran{
-	pixel_x = 7
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/oddity/nt/pyramid{
-	pixel_x = -9
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "pBV" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -82596,12 +82634,16 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
 "pLt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_room)
 "pLw" = (
 /obj/random/mob/croaker/low_chance,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -82799,11 +82841,13 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "pNu" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "pNw" = (
 /turf/simulated/mineral,
 /area/nadezhda/outside/dcave)
@@ -83099,12 +83143,16 @@
 	name = "\improper Upper Research Hallway"
 	})
 "pPU" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "pPW" = (
 /obj/machinery/vending/printomat,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -83924,19 +83972,10 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "pYx" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating/under,
-/area/colony)
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "pYB" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -84090,13 +84129,23 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "pZI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/wall_obelisk{
-	pixel_x = 1;
-	pixel_y = 24
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/disposaloutlet,
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
+	},
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/hallway/surface/section1)
 "pZS" = (
 /mob/living/simple_animal/opossum{
 	desc = "The Nedezhda basketball team mascot. - Currently scavenging for rebounds";
@@ -84217,13 +84266,11 @@
 "qbh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -84653,15 +84700,10 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qfx" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "qfC" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -84823,14 +84865,31 @@
 	name = "\improper Outdoors - Pad"
 	})
 "qgM" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 1";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "qhd" = (
 /obj/structure/table/bar_special,
 /obj/machinery/chemical_dispenser/beer,
@@ -86219,9 +86278,17 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "qvn" = (
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "qvy" = (
 /obj/machinery/light/small{
@@ -86327,10 +86394,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "qwE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "qwI" = (
 /obj/machinery/light{
 	dir = 8;
@@ -86551,14 +86617,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qyo" = (
-/obj/structure/multiz/stairs/active{
-	dir = 1
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "qyq" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
@@ -86691,12 +86755,12 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "qzx" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/machinery/camera/network/church{
+	dir = 4
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qzA" = (
 /obj/structure/table/bar_special,
 /obj/item/modular_computer/tablet/preset/custom_loadout/standard,
@@ -86918,14 +86982,15 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
 "qBq" = (
-/obj/structure/multiz/stairs/active/bottom{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "qBx" = (
 /obj/structure/table/standard,
 /obj/random/material/low_chance,
@@ -86938,17 +87003,15 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest)
 "qBQ" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qBV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/rock5,
@@ -87000,6 +87063,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/command/cbo)
+"qCP" = (
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "qCT" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -87027,13 +87103,22 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "qDa" = (
-/obj/structure/closet/secure_closet/reinforced/preacher,
-/obj/item/device/taperecorder,
-/obj/item/device/camera,
-/obj/item/device/camera_film,
-/obj/item/clothing/mask/gas/germanmask,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "qDd" = (
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
@@ -87386,16 +87471,10 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "qGp" = (
-/obj/structure/mirror{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "qGu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -87464,13 +87543,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qHh" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "qHk" = (
 /obj/structure/flora/small/grassb4,
 /obj/effect/decal/cleanable/dirt,
@@ -87811,15 +87889,11 @@
 	name = "\improper Clinic"
 	})
 "qKJ" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/turf/simulated/open,
+/area/nadezhda/hallway/surface/section1)
 "qKO" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt,
@@ -88721,12 +88795,14 @@
 	name = "Dormitory 3"
 	})
 "qTC" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "qTD" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 4;
@@ -88812,14 +88888,18 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/atmos/storage)
 "qUt" = (
-/obj/structure/multiz/stairs/enter{
-	dir = 1
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/structure/invislight,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/vectorrooms)
 "qUw" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -88866,17 +88946,16 @@
 	name = "Residential District Maintenance"
 	})
 "qUT" = (
-/obj/structure/bed/chair/sofa/black/right{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 32
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "qUY" = (
 /obj/structure/mopbucket,
 /obj/effect/floor_decal/industrial/botright,
@@ -89105,16 +89184,19 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/crew_quarters/podrooms)
 "qWT" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qWW" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/small/busha3,
@@ -89541,11 +89623,21 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "raN" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 24
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "raR" = (
 /obj/structure/table/woodentable,
@@ -89614,18 +89706,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rby" = (
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "rbA" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -89803,9 +89889,12 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "rcV" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/obj/structure/sink{
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -90311,23 +90400,20 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rig" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 2
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "rip" = (
 /obj/machinery/door/firedoor,
 /obj/structure/door_assembly/door_assembly_maint_cargo,
@@ -90397,12 +90483,11 @@
 	name = "Dormitory 3"
 	})
 "riP" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "riQ" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/powermonitor{
@@ -90509,12 +90594,8 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "rjV" = (
-/obj/machinery/power/nt_obelisk,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/wall/church_reinforced,
+/area/colony)
 "rjY" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -91143,11 +91224,15 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/courtroom)
 "rqj" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/outside/meadow)
+/area/nadezhda/absolutism/bioreactor)
 "rqk" = (
 /obj/machinery/power/wall_obelisk{
 	pixel_x = 32
@@ -91157,16 +91242,13 @@
 	name = "Dormitory 1"
 	})
 "rqm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "rqp" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -91282,9 +91364,12 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rrx" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 5
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "rrB" = (
 /obj/structure/table/steel,
 /obj/random/mob/spiders,
@@ -91837,20 +91922,12 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/pros/prep)
 "rwF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "rwG" = (
 /obj/machinery/camera/network/colony_transition{
 	dir = 8
@@ -91913,12 +91990,14 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "rxq" = (
+/obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/hallway/side/f2section1)
 "rxs" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/under,
@@ -92258,6 +92337,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/orangecorner,
 /area/eris/crew_quarters/plasma_tag)
+"rAl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "rAq" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/table/rack/shelf,
@@ -92718,20 +92809,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/command/courtroom)
 "rEA" = (
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
 	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "rED" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/rock,
@@ -92923,19 +93005,14 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rGx" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/structure/cable/green,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "rGz" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -93044,14 +93121,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rHD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "rHE" = (
 /obj/machinery/light{
 	dir = 1
@@ -93086,18 +93161,6 @@
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"rHW" = (
-/obj/structure/bed/chair/sofa/black/left{
-	dir = 8
-	},
-/obj/structure/noticeboard/church{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
 "rHX" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -95579,12 +95642,11 @@
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/meadow)
 "sfi" = (
-/obj/structure/catwalk,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/machinery/camera/network/church{
+	dir = 4
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "sfB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -97048,16 +97110,21 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "suE" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0";
-	tag = "icon-railing0 (NORTH)"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "suL" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -97375,13 +97442,8 @@
 /area/nadezhda/hallway/side/f2section1)
 "sxY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "syb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -97577,12 +97639,27 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "sAo" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 2";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
 	},
-/turf/simulated/floor/plating/under,
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "sAN" = (
 /obj/structure/cable/green,
@@ -97935,11 +98012,12 @@
 /turf/simulated/mineral,
 /area/colony)
 "sFL" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/wall_obelisk{
+	pixel_x = 1;
+	pixel_y = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "sFQ" = (
 /turf/simulated/floor/reinforced,
@@ -98345,9 +98423,18 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/genetics)
 "sJX" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "sKc" = (
 /obj/structure/table/woodentable,
 /obj/item/device/paicard{
@@ -98560,17 +98647,13 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/kitchen)
 "sMN" = (
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "sMT" = (
 /obj/structure/table/rack,
 /obj/item/storage/toolbox/electrical{
@@ -98706,12 +98789,15 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/gmaster)
 "sOa" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "sOd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -98822,23 +98908,11 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "sPh" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
+/obj/structure/sign/faction/neotheology_cross/gold{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "sPj" = (
 /obj/structure/flora/small/trailrocka3,
 /obj/effect/decal/cleanable/dirt,
@@ -99211,12 +99285,20 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "sSM" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "sSW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -99458,12 +99540,16 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sUM" = (
-/obj/structure/bed/chair/wood{
-	dir = 4;
-	icon_state = "wooden_chair";
-	tag = "icon-wooden_chair (EAST)"
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "sUN" = (
@@ -99955,35 +100041,16 @@
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sZu" = (
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/railing/grey{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey,
-/obj/structure/sign/faction/derelict1{
-	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
-	name = "NOTICE: Dangerous Biohazard";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "sZw" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
@@ -100208,19 +100275,10 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "tby" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/sign/levels/stairsup{
-	pixel_x = 32;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "tbJ" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -100602,15 +100660,12 @@
 /turf/simulated/mineral,
 /area/nadezhda/outside/forest)
 "tgh" = (
-/obj/structure/multiz/stairs/active/bottom{
+/obj/machinery/computer/arcade,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "tgi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -101321,17 +101376,22 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "tmF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/obj/structure/cable/cyan{
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/item/scrap_lump,
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "tmR" = (
 /obj/machinery/door/airlock/glass{
 	name = "Plasma Drome"
@@ -101467,10 +101527,15 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/main/stairwell)
 "toM" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "toN" = (
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -101520,31 +101585,10 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "tpj" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 1";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "tpn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/bushc3,
@@ -101693,18 +101737,6 @@
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/substation/bridge)
-"tra" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
 "trc" = (
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -102551,12 +102583,10 @@
 	name = "Dormitory 4"
 	})
 "tzn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/rock/manmade/road,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "tzo" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/rock,
@@ -102589,11 +102619,9 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tzJ" = (
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "tzM" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/window/reinforced,
@@ -103446,12 +103474,22 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
 "tJf" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
 	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/absolutism/skyyard)
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "tJk" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -103979,10 +104017,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"tOI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
 "tON" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -104151,17 +104185,15 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tPN" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "tPO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -104680,15 +104712,6 @@
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/cafeteria)
-"tWL" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
 "tWW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -105026,17 +105049,13 @@
 	name = "\improper Upper Research Hallway"
 	})
 "tZL" = (
-/obj/machinery/camera/network/church{
-	dir = 1
+/obj/machinery/light/small,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/tiled/cafe,
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "tZS" = (
 /obj/effect/floor_decal/industrial/arrows/white{
@@ -105046,18 +105065,18 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "tZT" = (
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/cable/yellow{
+/obj/structure/catwalk,
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/mob/roaches/low_chance,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "tZW" = (
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -105197,11 +105216,13 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "uaN" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
-/obj/structure/invislight,
-/obj/machinery/camera/network/church,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/outside/meadow)
+/area/nadezhda/absolutism/bioreactor)
 "uaO" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -105297,12 +105318,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "ucl" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/plating/under,
+/area/colony)
 "ucn" = (
 /mob/living/simple_animal/hostile/snake,
 /turf/simulated/floor/asteroid/grass,
@@ -105317,12 +105339,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "ucs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = 32
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "ucx" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/stack/ore,
@@ -105355,7 +105373,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ucY" = (
 /obj/structure/invislight,
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "udb" = (
@@ -105677,12 +105695,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/cryo)
 "ugj" = (
-/obj/machinery/light_switch{
-	pixel_y = 30
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
 	},
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/prime)
 "ugm" = (
 /obj/random/structures,
 /obj/effect/spider/stickyweb,
@@ -105693,11 +105710,27 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ugn" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/cable/yellow{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey,
+/obj/structure/cable/yellow,
+/obj/machinery/light,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "ugx" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Permanent Holding";
@@ -105748,6 +105781,13 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/crew_quarters/kitchen_storage)
+"ugF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "ugI" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lamp/green,
@@ -106029,13 +106069,14 @@
 	name = "\improper Outdoors - Pad"
 	})
 "ujR" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/biomatter,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "ujT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -106597,17 +106638,10 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/crew_quarters/podrooms)
 "uqM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/table/woodentable,
+/obj/random/toy/plushie,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "uqQ" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -106685,17 +106719,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
-"urt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
 "urA" = (
 /obj/random/cluster/spiders,
 /obj/effect/decal/cleanable/dirt,
@@ -106872,10 +106895,22 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "usX" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/machinery/door/airlock{
+	name = "Church";
+	req_access = list(27)
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "utl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -108029,13 +108064,17 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "uCH" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/catwalk,
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "uCI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -108434,11 +108473,11 @@
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "uGA" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = -32
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "uGD" = (
 /obj/landmark/machinery/input,
 /obj/machinery/conveyor/south{
@@ -108508,11 +108547,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
-"uHl" = (
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
 "uHq" = (
 /obj/machinery/light{
 	dir = 8;
@@ -109173,13 +109207,9 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "uOA" = (
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
+/obj/effect/floor_decal/industrial/danger,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/atmos/storage)
 "uOB" = (
 /obj/machinery/holoposter{
@@ -109469,14 +109499,11 @@
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "uQx" = (
-/obj/structure/multiz/stairs/enter{
-	dir = 1
+/obj/structure/closet/secure_closet/personal/agrolyte,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = -32
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
 "uQC" = (
 /obj/structure/flora/ausbushes/pointybush,
@@ -109562,10 +109589,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "uRw" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/absolutism/skyyard)
 "uRx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -109844,10 +109873,15 @@
 	name = "\improper Upper Research Hallway"
 	})
 "uTQ" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "uTS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -109934,12 +109968,10 @@
 	name = "\improper Outdoors - Pad"
 	})
 "uUU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/reagent_dispensers/biomatter,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "uUW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -110010,25 +110042,12 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
 "uVx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/railing,
+/obj/machinery/camera/network/church{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "uVy" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/robotics{
@@ -110384,21 +110403,19 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "uZv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "uZx" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/big/bush3,
@@ -110907,12 +110924,14 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
 "vfg" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "vfj" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section2";
@@ -111633,16 +111652,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "vmm" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_room)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "vmq" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
@@ -112284,9 +112298,11 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/meeting_room)
 "vsx" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/catwalk,
+/obj/structure/invislight,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/meadow)
 "vsy" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/structures,
@@ -112627,19 +112643,9 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "vvO" = (
-/obj/machinery/camera/network/church{
-	dir = 1
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/meadow)
 "vvS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame/vertical{
@@ -112800,19 +112806,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "vwJ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/cyancorner,
+/area/nadezhda/hallway/surface/section1)
 "vwK" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 4
@@ -113210,10 +113208,9 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "vAx" = (
-/obj/machinery/light,
-/obj/machinery/vending/fortune,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/biomatter_solidifier,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/absolutism/bioreactor)
 "vAB" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -113370,9 +113367,20 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vCh" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/church_reinforced,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "vCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -113696,20 +113704,11 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical_blackshield)
 "vFR" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "vFU" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -113777,8 +113776,12 @@
 	})
 "vGk" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/item/reagent_containers/glass/replenishing/chalice,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = -32
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "vGA" = (
 /obj/structure/sign/security/cells{
 	pixel_x = -32
@@ -113999,16 +114002,13 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vIL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/disposal/deliveryChute{
+	dir = 1;
+	name = "trash chute"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "vJb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -114215,14 +114215,9 @@
 	name = "Residential District Maintenance"
 	})
 "vKM" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/bed/chair/comfy/brown,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "vKR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -114383,11 +114378,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "vMo" = (
-/obj/structure/disposalpipe/segment,
-/obj/random/scrap/dense_weighted/low_chance,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "vMr" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -114418,25 +114411,34 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "vMK" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "vMQ" = (
-/obj/structure/mopbucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/soap/deluxe,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Prime's Office";
+	departmentType = 22;
+	name = "Prime's RC";
+	pixel_x = 30;
+	pixel_y = 0
+	},
+/obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Prime's Office"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "vMU" = (
 /obj/structure/disposalpipe/junction,
 /obj/structure/cable/yellow{
@@ -115429,20 +115431,23 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "vWA" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposaloutlet{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/engineering/atmos/storage)
 "vWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -115672,22 +115677,11 @@
 	name = "Dormitory 1"
 	})
 "vXR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "vYb" = (
 /obj/structure/closet/secure_closet/personal/doctor,
 /obj/item/clothing/glasses/hud/health,
@@ -115884,7 +115878,11 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "waf" = (
 /obj/structure/table/woodentable,
-/obj/machinery/reagentgrinder/portable,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "wak" = (
@@ -115917,14 +115915,18 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "waT" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/prime)
 "waY" = (
 /obj/structure/multiz/stairs/active/bottom,
 /obj/structure/window/reinforced{
@@ -115934,16 +115936,20 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/side/f2section1)
 "wbe" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/random/toy/plushie_onlyfox,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "wbm" = (
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "wbo" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -116264,14 +116270,17 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "weh" = (
-/obj/structure/table/rack/shelf,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+/obj/machinery/light{
+	dir = 1
 	},
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "wev" = (
 /obj/machinery/power/nt_obelisk,
 /obj/structure/sign/faction/neotheology_cross/gold{
@@ -116325,22 +116334,11 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
 "weP" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "weT" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/effect/floor_decal/industrial/arrows/white,
@@ -116411,13 +116409,9 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "wfn" = (
-/obj/structure/bed/chair/sofa/brown/right,
-/obj/landmark/join/start/acolyte,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/small/grassa5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "wft" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/cafe,
@@ -116537,14 +116531,21 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/cafeteria)
 "wgN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/light/small,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
 "wgV" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -116788,13 +116789,19 @@
 /obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/mob/roaches/low_chance,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "wjI" = (
@@ -117400,11 +117407,16 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "wpu" = (
-/obj/item/tool/knife/neotritual,
-/obj/item/clothing/gloves/psionic_ring,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "wpv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -118066,19 +118078,14 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
 "wuN" = (
-/obj/structure/multiz/stairs/active{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/obj/structure/bed/chair/wood{
 	dir = 4;
-	pixel_x = 0
+	icon_state = "wooden_chair";
+	tag = "icon-wooden_chair (EAST)"
 	},
-/obj/structure/sign/levels/stairsdown{
-	pixel_y = -30;
-	pixel_x = 32
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "wuV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
@@ -118435,16 +118442,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/surgery)
-"wyv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
 "wyw" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -118568,6 +118565,13 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
+"wzr" = (
+/obj/machinery/power/nt_obelisk,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "wzv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -120179,16 +120183,8 @@
 	name = "Dormitory 3"
 	})
 "wQW" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
@@ -120279,11 +120275,11 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "wSl" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "wSn" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -120608,23 +120604,13 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/tcommsat/computer)
 "wVv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/structure/table/woodentable,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "wVx" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,18"
@@ -120695,10 +120681,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "wWN" = (
-/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "wWP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -121593,21 +121581,9 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "xfb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/steel/golden,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/atmos/storage)
 "xfc" = (
 /obj/machinery/conveyor/east{
 	dir = 1;
@@ -122034,10 +122010,9 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "xke" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "xki" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -122145,15 +122120,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xlL" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/machinery/light,
 /turf/simulated/floor/plating/under,
-/area/colony)
+/area/nadezhda/absolutism/bioreactor)
 "xlP" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Post";
@@ -122361,10 +122335,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "xmV" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/nightmare,
@@ -122420,10 +122403,14 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "xnv" = (
-/turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/camera/network/church{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "xnw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -122780,8 +122767,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xqJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "xqM" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -122853,12 +122842,19 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "xrs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "xrx" = (
 /obj/landmark/machinery/input,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -122877,28 +122873,17 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "xrD" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "xrF" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 6;
@@ -123339,10 +123324,10 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "xwB" = (
-/obj/machinery/recycler,
 /obj/machinery/conveyor/east{
 	id = "disposals grinder"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
 "xwH" = (
@@ -123504,16 +123489,19 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xyC" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "xyJ" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/armory)
@@ -123740,17 +123728,25 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "xBq" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/storage/fancy/crayons,
-/obj/structure/table/woodentable,
-/obj/item/storage/fancy/crayons,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "xBr" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,3"
@@ -123959,14 +123955,19 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "xDf" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/biomatter,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating/under,
+/area/colony)
 "xDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -124081,16 +124082,12 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xEe" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/colony)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "xEk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/wood,
@@ -124757,15 +124754,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "xKz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "xKD" = (
 /obj/structure/grille,
 /turf/simulated/floor/asteroid/grass,
@@ -125028,7 +125022,14 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "xMy" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "xMA" = (
@@ -125331,12 +125332,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/crew_quarters/plasma_tag)
-"xPq" = (
-/obj/machinery/camera/network/church{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
 "xPw" = (
 /obj/machinery/vending/engivend,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -126874,9 +126869,20 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "yfE" = (
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "yfL" = (
 /obj/item/storage/briefcase/inflatable{
 	pixel_x = 3;
@@ -127276,10 +127282,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "yjK" = (
-/obj/structure/table/woodentable,
-/obj/item/device/lighting/toggleable/lantern/censer,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/mopbucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/soap/deluxe,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "yjM" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -127433,10 +127441,19 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
 "ylz" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "ylB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -193832,13 +193849,13 @@ vvL
 wAo
 xPH
 xPH
-vmm
-xlL
-xlL
-xlL
-xEe
-xlL
-pYx
+pLt
+pBQ
+pBQ
+pBQ
+mce
+pBQ
+xDf
 xGi
 sFI
 sFI
@@ -194040,7 +194057,7 @@ xGi
 xGi
 xGi
 beK
-cfH
+buS
 beK
 sFI
 sFI
@@ -194242,7 +194259,7 @@ sFI
 sFI
 sFI
 beK
-kbl
+ylz
 beK
 sFI
 sFI
@@ -194444,7 +194461,7 @@ sFI
 sFI
 sFI
 beK
-vWA
+sSM
 beK
 sFI
 sFI
@@ -194646,7 +194663,7 @@ sFI
 sFI
 sFI
 beK
-kbl
+ylz
 beK
 sFI
 sFI
@@ -194848,7 +194865,7 @@ sFI
 beK
 beK
 beK
-dXG
+oqc
 beK
 beK
 beK
@@ -195050,7 +195067,7 @@ sFI
 beK
 eWs
 mCq
-cDx
+xrs
 vgv
 tZa
 mUh
@@ -195252,7 +195269,7 @@ sFI
 beK
 hov
 uww
-tmF
+kyt
 naZ
 dMu
 xhZ
@@ -195454,7 +195471,7 @@ sFI
 beK
 uHt
 uww
-rwF
+yfE
 mxC
 wuq
 mBO
@@ -195655,9 +195672,9 @@ beK
 beK
 beK
 mCq
-dNI
-dCC
-uCH
+ucs
+hpq
+cNE
 gcr
 gzw
 vcq
@@ -195849,16 +195866,16 @@ jPJ
 iVn
 byG
 ult
-gHI
-uOA
-mdn
-fCn
-ldw
-cNj
-fCn
+bmx
+aED
+ucl
+ivC
+dBr
+vfg
+ivC
 bho
 xhZ
-fyb
+fgM
 mxC
 gcr
 tkm
@@ -196058,9 +196075,9 @@ beK
 beK
 beK
 beK
-bkH
-bPm
-rqm
+uZv
+qvn
+wpu
 mxC
 hCa
 tNb
@@ -196260,10 +196277,10 @@ sFI
 sFI
 sFI
 beK
-tpj
+qgM
 puT
-kpf
-oMM
+qUT
+gnT
 nvW
 hpm
 hpm
@@ -196462,16 +196479,16 @@ sFI
 sFI
 sFI
 beK
-jte
+sAo
 rOL
-lVU
+bPu
 eyI
 ctG
 ctC
 wIe
 mCq
 naZ
-meA
+ugn
 beK
 sFI
 ula
@@ -196666,7 +196683,7 @@ sFI
 beK
 oPl
 uUJ
-jHx
+hVD
 aUn
 aUn
 qHo
@@ -196868,14 +196885,14 @@ sFI
 beK
 azM
 uUJ
-rHD
+nTE
 aUn
 aUn
 sDT
 qPy
 mCq
-nib
-vvO
+cHs
+gHI
 beK
 sFI
 sFI
@@ -197076,8 +197093,8 @@ usk
 jeg
 vcq
 mCq
-vKM
-sZu
+mHf
+dNI
 beK
 beK
 beK
@@ -197270,19 +197287,19 @@ sFI
 sFI
 sFI
 beK
-rjV
+wzr
 mCq
-xyC
+xMy
 xhZ
 mCq
 mCq
 mCq
 mCq
-vKM
-xMy
-xMy
-nrD
-qBq
+mHf
+cox
+cox
+qTC
+owI
 beK
 sFI
 sFI
@@ -197472,19 +197489,19 @@ sFI
 sFI
 beK
 beK
-ugj
-nRM
-gou
-tWL
+ikj
+sxY
+kSK
+dCC
 mCq
 mCq
 mCq
-xMy
-vKM
-xMy
-xMy
-tby
-tgh
+cox
+mHf
+cox
+cox
+eIV
+rqj
 beK
 sFI
 sFI
@@ -197674,16 +197691,16 @@ sFI
 sFI
 beK
 hSC
-nRM
-wWN
+sxY
+kDY
 bMK
-kPg
-tZT
+tJf
+lfc
 lti
 rCq
 dMu
-oMM
-nmo
+gnT
+hmj
 beK
 beK
 beK
@@ -197875,17 +197892,17 @@ uNP
 uNP
 uNP
 beK
-ncd
+weh
 nSn
 nSn
 oYg
 nSn
-oTp
-fEH
+vIL
+xlL
 beK
 mCq
 rhf
-mBf
+aFL
 beK
 sFI
 sFI
@@ -198072,17 +198089,17 @@ vQv
 vQv
 uOb
 cSt
-boU
-mHf
-hkR
-eMK
-vCh
-sAo
-sAo
-sAo
-sAo
-sAo
-sAo
+aJN
+xEe
+qwE
+xfb
+cye
+uaN
+uaN
+uaN
+uaN
+uaN
+uaN
 mAy
 beK
 lZC
@@ -198274,24 +198291,24 @@ uim
 uWe
 vIm
 cSt
-jkf
-hpq
-kyt
+mxN
+vWA
+rEA
 uNP
-jHL
-jHL
-jHL
-jHL
+rjV
+rjV
+rjV
+rjV
 beK
 beK
-dNI
-dNI
-dNI
+ucs
+ucs
+ucs
 mCq
-xPq
+sfi
 mCq
-ejM
-ejM
+mVl
+mVl
 beK
 sFI
 sFI
@@ -198476,9 +198493,9 @@ dvQ
 uWK
 vIm
 pBF
-ylz
-lnV
-sOa
+uOA
+nrD
+ktR
 uNP
 sFI
 sFI
@@ -198486,14 +198503,14 @@ sFI
 sFI
 sFI
 beK
-dNI
-dNI
-dNI
-mce
-cNE
+ucs
+ucs
+ucs
+cTB
+vAx
 vcq
-ejM
-ejM
+mVl
+mVl
 beK
 sFI
 gfQ
@@ -198678,9 +198695,9 @@ vQv
 vQv
 jkc
 cSt
-hbi
-pPU
-jTG
+qfx
+xwB
+egd
 uNP
 sFI
 sFI
@@ -198688,14 +198705,14 @@ sFI
 sFI
 sFI
 beK
-qvn
-qvn
-qvn
+dnk
+dnk
+dnk
 mCq
 mCq
 mCq
-ivC
-xDf
+uUU
+ujR
 beK
 gfQ
 gfQ
@@ -198880,9 +198897,9 @@ vQv
 vQv
 jkc
 nmW
-cTB
-qzx
-qBQ
+wSl
+oNA
+xrD
 uNP
 sFI
 sFI
@@ -198890,14 +198907,14 @@ sFI
 sFI
 sFI
 beK
-dtG
-dtG
-dtG
+lVU
+lVU
+lVU
 mCq
 mCq
-toM
-toM
-toM
+nFm
+nFm
+nFm
 beK
 gfQ
 vNF
@@ -199082,9 +199099,9 @@ dvQ
 uWe
 vIm
 cSt
-qTC
-pPU
-ujR
+epB
+xwB
+meA
 uNP
 sFI
 sFI
@@ -199092,14 +199109,14 @@ sFI
 sFI
 sFI
 beK
-gdn
-pyY
-pyY
+kqQ
+qGp
+qGp
 mCq
-oNA
-cxF
-cxF
-cxF
+weP
+kOD
+kOD
+kOD
 beK
 gfQ
 wHA
@@ -199284,9 +199301,9 @@ tKp
 tQX
 vIm
 cSt
-uRw
-xwB
-tPN
+fyb
+nol
+lLw
 uNP
 sFI
 sFI
@@ -199486,9 +199503,9 @@ vQv
 vQv
 jkc
 cSt
-uRw
-mRi
-oqc
+fyb
+boU
+tmF
 uNP
 sFI
 sFI
@@ -199688,9 +199705,9 @@ vQv
 vQv
 vIm
 cSt
-boU
-owI
-sJX
+aJN
+bwG
+koL
 uNP
 sFI
 sFI
@@ -224543,7 +224560,7 @@ vrp
 vrp
 uEB
 leU
-iZz
+wfn
 vUJ
 xcy
 sbB
@@ -224968,7 +224985,7 @@ bjU
 vUJ
 vUJ
 vUJ
-doA
+hkR
 vUJ
 vUJ
 vUJ
@@ -225153,7 +225170,7 @@ uEB
 pIy
 quu
 vUJ
-iZz
+wfn
 leU
 leU
 leU
@@ -225371,7 +225388,7 @@ vUJ
 vUJ
 vUJ
 vUJ
-gxd
+tzJ
 sbB
 sbB
 xcy
@@ -225761,7 +225778,7 @@ leU
 sbB
 pDw
 mkI
-aED
+nib
 leU
 bjU
 xcy
@@ -226380,7 +226397,7 @@ sbB
 sbB
 mkI
 vUJ
-cye
+tby
 bjU
 leU
 leU
@@ -226777,7 +226794,7 @@ mET
 vUJ
 vUJ
 sbB
-rrx
+vvO
 sbB
 sbB
 hvW
@@ -227359,7 +227376,7 @@ cjv
 fJv
 wBa
 pwm
-tzJ
+vwJ
 uEV
 ciH
 gba
@@ -227780,7 +227797,7 @@ vTn
 nyS
 cKe
 jBi
-sMN
+dzK
 leR
 oHf
 oHf
@@ -227982,7 +227999,7 @@ gEY
 wrl
 oal
 cVR
-fAA
+jXd
 jaT
 hpV
 hpV
@@ -228184,7 +228201,7 @@ pwm
 pwm
 aot
 njl
-fAA
+jXd
 stq
 iVt
 aJG
@@ -228386,7 +228403,7 @@ pwm
 pwm
 aot
 ved
-fAA
+jXd
 stq
 iVt
 aJG
@@ -228588,7 +228605,7 @@ aug
 fMZ
 jeo
 puc
-fAA
+jXd
 gOa
 gaS
 gaS
@@ -228790,10 +228807,10 @@ stG
 wzY
 kCJ
 hYL
-fAA
+jXd
 tpO
-mPy
-mPy
+ntC
+ntC
 aot
 hLv
 hLv
@@ -229181,7 +229198,7 @@ epc
 moX
 xFe
 koI
-ikj
+pkB
 fKf
 wIm
 fKf
@@ -229222,8 +229239,8 @@ leU
 leU
 leU
 leU
-xnv
-xnv
+tzn
+tzn
 kfg
 aCl
 nfX
@@ -229390,9 +229407,9 @@ hcE
 kOW
 kOW
 kOW
-ucl
+rwF
 kOW
-ucl
+rwF
 kOW
 kOW
 kOW
@@ -229424,8 +229441,8 @@ leU
 leU
 leU
 leU
-xnv
-xnv
+tzn
+tzn
 hgC
 hgC
 hgC
@@ -229585,48 +229602,48 @@ epc
 rjh
 gSM
 kOW
-uHl
+tpj
 dsj
-buS
+rrx
 dsj
 ndM
 kOW
 aFx
 lpW
-ccn
+iAo
 aFx
 lpW
-deL
+mKY
 kOW
 bVb
 bVb
 kOW
 iUs
-gPB
+fqE
 dld
 dld
 pDI
-waT
-waT
-waT
-waT
-waT
-waT
-waT
-waT
-waT
-waT
-waT
-uGA
-xnv
-xnv
-xnv
-xnv
-xnv
-xnv
-xnv
-xnv
-xnv
+rGx
+rGx
+rGx
+rGx
+rGx
+rGx
+rGx
+rGx
+rGx
+rGx
+rGx
+eVP
+tzn
+tzn
+tzn
+tzn
+tzn
+tzn
+tzn
+tzn
+tzn
 lxo
 aot
 hgC
@@ -229795,7 +229812,7 @@ pci
 pQO
 aFx
 fiW
-mcP
+qHh
 fiW
 dsj
 aFx
@@ -229819,7 +229836,7 @@ bSp
 fCA
 nRc
 nRc
-qKJ
+toM
 vUJ
 vUJ
 vUJ
@@ -229995,12 +230012,12 @@ dsj
 dsj
 mtA
 pQO
-raN
+kbl
 fiW
-mcP
+qHh
 fiW
 dsj
-qwE
+aAw
 aFx
 aFx
 uYT
@@ -230009,7 +230026,7 @@ kOW
 iUs
 xDI
 dld
-suE
+fuZ
 nRc
 nRc
 neA
@@ -230193,25 +230210,25 @@ pmt
 kOW
 cxA
 dsj
-rxq
+ugF
 dsj
 xOv
 kOW
-pZI
+sFL
 fiW
-mcP
+qHh
 fiW
 dsj
-qwE
+aAw
 wGn
 aFx
 dsj
 pQO
-ucl
+rwF
 iUs
 dld
 dld
-suE
+fuZ
 nRc
 nRc
 neA
@@ -230391,29 +230408,29 @@ pwm
 pwm
 jZV
 qMM
-xfb
+wgN
 kOW
 kOW
-uUU
-vfg
-aAw
+fAA
+ccn
+jHL
 kOW
 kOW
-pLt
+wbm
 fiW
+qHh
 mcP
-ajp
 dsj
 aFx
 pVr
 pVr
 dsj
 pQO
-ucl
-uTQ
+rwF
+ekD
 dld
 dld
-suE
+fuZ
 nRc
 nRc
 sgF
@@ -230597,25 +230614,25 @@ mMj
 hcE
 rQU
 rrG
-sSM
+cDx
 dsj
-xrs
-klX
+bkH
+rby
 aFx
 aFx
-hHU
+ggs
 aFx
 aFx
 aFx
-kVO
+vMK
 dsj
 dsj
 pQO
-ucl
-fkm
+rwF
+kPg
 dld
 dld
-suE
+fuZ
 nRc
 nRc
 neA
@@ -230797,12 +230814,12 @@ jZV
 czp
 eJY
 kQv
-vIL
+pPU
+mBf
 nur
-wyv
 ddN
 ddN
-fCX
+nmo
 bND
 ezK
 ePE
@@ -230813,11 +230830,11 @@ eks
 dsj
 dsj
 pQO
-ucl
+rwF
 cUi
 dld
 dld
-suE
+fuZ
 nRc
 nRc
 neA
@@ -231000,8 +231017,8 @@ plK
 cvN
 vFt
 jjQ
-xmO
-bal
+tPN
+fgb
 dsj
 cAW
 hcE
@@ -231015,11 +231032,11 @@ pVr
 dsj
 dsj
 pQO
-ucl
-ucY
+rwF
+hbi
 dld
 dld
-suE
+fuZ
 nRc
 nRc
 wMt
@@ -231199,17 +231216,17 @@ bfy
 xjG
 sAh
 wXd
-eTj
+ncd
 kOW
 kOW
-kEe
-sFL
-aAw
+rAl
+omK
+jHL
 kOW
 kOW
-pLt
+wbm
 fiW
-bal
+fgb
 fiW
 dsj
 aFx
@@ -231217,11 +231234,11 @@ pVr
 eUn
 dsj
 pQO
-ucl
-oVv
+rwF
+ucY
 dld
 dld
-suE
+fuZ
 nRc
 nRc
 neA
@@ -231403,27 +231420,27 @@ rIb
 qMM
 qrQ
 kOW
-vFR
+jVP
 gRP
-tzn
+gou
 dsj
-vAx
+jte
 kOW
-pZI
+sFL
 fiW
 aQF
 fiW
 rrG
-qwE
+aAw
 wGn
 aFx
 dsj
 pQO
-ucl
+rwF
 iUs
 dld
 dld
-suE
+fuZ
 nRc
 nRc
 sgF
@@ -231605,7 +231622,7 @@ uHd
 qMM
 uPn
 pQO
-jVP
+vKM
 gRP
 dsj
 dsj
@@ -231616,7 +231633,7 @@ fiW
 aQF
 fiW
 dsj
-qwE
+aAw
 aFx
 aFx
 uYT
@@ -231625,7 +231642,7 @@ kOW
 iUs
 xDI
 dld
-suE
+fuZ
 nRc
 nRc
 neA
@@ -231807,7 +231824,7 @@ she
 jlQ
 ebN
 pQO
-jVP
+vKM
 gRP
 dsj
 dsj
@@ -231820,14 +231837,14 @@ fiW
 dsj
 aFx
 tVS
-qwE
+aAw
 aFx
 kOW
 iUs
 iUs
 dld
 dld
-suE
+fuZ
 nRc
 nRc
 neA
@@ -232009,24 +232026,24 @@ qMI
 pQa
 qmD
 kOW
-eIV
-weP
-kyl
-kMZ
-mxN
+wVv
+raN
+xnv
+kHx
+nJR
 kOW
-xke
+oMM
 tVS
-nxH
+lnV
 aFx
 tVS
-deL
+mKY
 kOW
 bVb
 bVb
 kOW
 iUs
-jXd
+oJb
 dld
 dld
 mXo
@@ -232041,7 +232058,7 @@ lFw
 hbK
 nRc
 nRc
-fPi
+qCP
 vUJ
 vUJ
 eqh
@@ -232232,18 +232249,18 @@ wVU
 dld
 dld
 pDI
-mKY
-mKY
-mKY
-mKY
-mKY
-mKY
-mKY
-mKY
-mKY
-mKY
-mKY
-uGA
+uCH
+uCH
+uCH
+uCH
+uCH
+uCH
+uCH
+uCH
+uCH
+uCH
+uCH
+eVP
 vUJ
 vUJ
 vUJ
@@ -232379,9 +232396,9 @@ veZ
 cwr
 cwr
 cwr
-bZJ
-bZJ
-iAo
+nvB
+nvB
+cFP
 ook
 tcp
 tcp
@@ -232418,31 +232435,31 @@ xGz
 wzU
 riw
 tZm
-fPE
+uGA
 yiO
 riw
-ggs
-mVE
-qgM
-vGk
+iGZ
+cRj
+waf
+mdn
 iRf
 aAy
 aAy
-rqj
-ljQ
+vXR
+hmk
 dld
 dld
 dld
 vLi
 vLi
 qgJ
-wbe
-mVl
+sMN
+fBV
 oei
 qgJ
 tqr
-pNu
-ugn
+cUo
+vmm
 qgJ
 vLi
 vLi
@@ -232581,10 +232598,10 @@ veZ
 veZ
 cwr
 cwr
-bZJ
-bZJ
-iAo
-bZJ
+nvB
+nvB
+cFP
+nvB
 tcp
 rva
 mNx
@@ -232623,14 +232640,14 @@ oQZ
 elF
 xzr
 riw
-vGk
+mdn
 rYv
 rYv
 rYv
 iRf
-wbm
-wbm
-rqj
+oSN
+oSN
+vXR
 gzr
 dld
 dld
@@ -232783,10 +232800,10 @@ veZ
 veZ
 cwr
 cwr
-bZJ
-bZJ
-iAo
-bZJ
+nvB
+nvB
+cFP
+nvB
 tcp
 uCI
 sOt
@@ -232821,19 +232838,19 @@ uXK
 uXK
 oXE
 riw
-rby
+sJX
 qox
 opN
 riw
 cNP
-xqJ
+vMo
 jAU
 rYv
 iRf
 aAy
 aAy
-rqj
-ljQ
+vXR
+hmk
 dld
 dld
 dld
@@ -232986,9 +233003,9 @@ veZ
 cwr
 cwr
 nYl
-dzK
-iAo
-bZJ
+fCX
+cFP
+nvB
 tcp
 fPz
 gPf
@@ -233023,20 +233040,20 @@ dFx
 bAk
 oXE
 riw
-wfn
-tOI
+kLc
+fPi
 nlp
 riw
-hmj
-czb
-waf
-tZL
+ifo
+fkm
+hHU
+dNo
 riw
-uaN
+vsx
 kbv
 riw
 vMI
-eMx
+czb
 dld
 dld
 hvW
@@ -233188,9 +233205,9 @@ veZ
 cwr
 cwr
 lPU
-dzK
-iAo
-weh
+fCX
+cFP
+ajp
 tcp
 rzR
 lmJ
@@ -233225,14 +233242,14 @@ nBw
 fLG
 oXE
 riw
-bfZ
-nJR
-aFL
+huw
+fCn
+sUM
 riw
 int
 vsl
-kFQ
-koL
+qBq
+kCV
 riw
 tTa
 tTa
@@ -233389,10 +233406,10 @@ wLD
 veZ
 cwr
 cwr
-omK
-omK
-iAo
-weh
+rxq
+rxq
+cFP
+ajp
 cwr
 xdv
 xdv
@@ -233428,19 +233445,19 @@ qWG
 riw
 riw
 riw
-vMK
+klX
 riw
 riw
 riw
 sGE
-hNx
+gEc
 riw
 riw
-yfE
-kOD
+fxv
+wWN
 riw
 riw
-vAX
+kxQ
 dld
 dld
 mcG
@@ -233591,10 +233608,10 @@ veZ
 veZ
 cwr
 cwr
-omK
-omK
-iAo
-weh
+rxq
+rxq
+cFP
+ajp
 cwr
 mcJ
 lVF
@@ -233626,23 +233643,23 @@ mJT
 pwm
 pwm
 vvK
-kLc
+mPy
 riw
 riw
-qfx
+nRM
 vdu
 rMH
 juo
-npm
-npm
-kSK
-nvB
+cxF
+cxF
+sZu
+qzx
 diT
 qQZ
 rOh
 rpa
 riw
-riP
+xKz
 dld
 dld
 leU
@@ -233793,10 +233810,10 @@ veZ
 veZ
 cwr
 cwr
-dzK
-dzK
-iAo
-weh
+fCX
+fCX
+cFP
+ajp
 cwr
 trx
 wyH
@@ -233825,15 +233842,15 @@ tnR
 vaT
 vaT
 qZu
-aJN
-oaI
+kVO
+xke
 bZF
-aJN
+kVO
 riw
-qHh
+kwb
 wFB
 qQZ
-sUM
+wuN
 orJ
 rOh
 rOh
@@ -233995,10 +234012,10 @@ veZ
 veZ
 cwr
 qau
-dzK
-dzK
+fCX
+fCX
 gCx
-weh
+ajp
 cwr
 leh
 hKm
@@ -234032,7 +234049,7 @@ riw
 lDz
 riw
 riw
-xBq
+gSa
 wFB
 hAv
 mwt
@@ -234040,7 +234057,7 @@ mwt
 cVH
 qQZ
 jzE
-ekD
+cFR
 rpa
 qQZ
 rOh
@@ -234231,24 +234248,24 @@ nfq
 jMp
 riw
 grQ
-xrD
-uZv
-jnw
-dNo
-epB
+ldw
+rig
+usX
+cKd
+uTQ
 hAv
 mwt
-bwG
+uqM
 tuI
 rOh
 qWp
-ekD
-vsx
+cFR
+dXG
 qQZ
 qQZ
 iWQ
 iRf
-eMx
+czb
 dld
 dld
 mcG
@@ -234429,22 +234446,22 @@ lIg
 dVl
 vaT
 qkp
-huw
-tra
-fqE
+oSO
+pyY
+qUt
 oKC
-wQW
-qGp
+ksw
+dBR
 riw
-cKd
-vwJ
+tgh
+xyC
 hAv
 mwt
 mwt
 tuI
 rOh
 dFc
-ekD
+cFR
 rpa
 qQZ
 qQZ
@@ -234631,21 +234648,21 @@ vaT
 vaT
 vaT
 qkp
-rig
+fPE
 pwm
 riw
 qza
-usX
-bCT
+wQW
+rcV
 riw
 sPG
-eVP
-bPu
-kwb
-kwb
+deL
+kFQ
+qyo
+qyo
 rOh
 rOh
-eSm
+tZL
 riw
 riw
 mqQ
@@ -234833,20 +234850,20 @@ sfG
 imO
 lNu
 tPK
-rig
+fPE
 pwm
 riw
 riw
 riw
-sPh
+asE
 riw
 riw
+bZJ
+nxH
+qWT
+kEe
 miP
-nBa
-rGx
-kDY
-esz
-npm
+cxF
 oBo
 qQZ
 diT
@@ -234854,7 +234871,7 @@ rOh
 qQZ
 rpa
 riw
-riP
+xKz
 dld
 dld
 dIp
@@ -235040,7 +235057,7 @@ pwm
 riw
 lkJ
 vkU
-gSa
+oma
 riw
 riw
 riw
@@ -235049,14 +235066,14 @@ riw
 riw
 riw
 riw
-fuZ
-riw
-riw
-qQZ
 guj
 riw
 riw
-rjY
+qQZ
+hSz
+riw
+riw
+hMs
 dld
 dld
 nAX
@@ -235242,15 +235259,15 @@ pwm
 riw
 riw
 riw
-rcV
+npm
 riw
-wSl
+xqJ
 sbj
 wFB
 jac
 riw
-wSl
-gnT
+xqJ
+wbe
 kZn
 xwO
 riw
@@ -235258,13 +235275,13 @@ tTa
 tTa
 riw
 quT
-eMx
+czb
 dld
 dld
 owa
 vUJ
 vhs
-ifo
+rHD
 lOl
 hbO
 dft
@@ -235444,17 +235461,17 @@ pwm
 riw
 lkJ
 vkU
-dBR
+riP
 riw
-dnk
-fBV
-xKz
-kxQ
+bvz
+kpf
+qBQ
+efu
 riw
-dnk
-nTE
+bvz
+sOa
 rOh
-eit
+vFR
 riw
 kbv
 kbv
@@ -235465,7 +235482,7 @@ dld
 dld
 kVt
 vUJ
-vhs
+uVx
 ooV
 jWc
 uOU
@@ -235641,27 +235658,27 @@ lLF
 xJm
 vaT
 qkp
-egd
+xBq
 pwm
 riw
 riw
 riw
 riw
 riw
-ktR
-cZV
+iZz
+jwd
 qQZ
-eit
+vFR
 riw
-ktR
+iZz
 qQZ
 qQZ
 qQZ
 riw
 aAy
 aAy
-rqj
-ljQ
+vXR
+hmk
 dld
 dld
 dld
@@ -235861,9 +235878,9 @@ gzV
 vtp
 riw
 qQO
-wbm
-rqj
-rEA
+oSN
+vXR
+jkf
 dld
 dld
 dld
@@ -236064,11 +236081,11 @@ riw
 riw
 aAy
 aAy
-rqj
-ljQ
-ucs
-dld
+vXR
 hmk
+fEH
+dld
+mRi
 dld
 jZI
 jZI
@@ -236460,7 +236477,7 @@ xGz
 xGz
 opH
 plZ
-fgM
+jsM
 opH
 ouv
 mmt
@@ -236651,7 +236668,7 @@ bqj
 vaT
 vaT
 soq
-egd
+xBq
 pwm
 xGz
 xGz
@@ -236672,7 +236689,7 @@ spV
 spV
 uVK
 qrB
-cFP
+uQx
 lze
 ycP
 ycP
@@ -236853,14 +236870,14 @@ pwm
 pwm
 gTr
 fID
-rig
+fPE
 pwm
 xGz
 xGz
 opH
 hHX
-oSN
-yjK
+vGk
+cfH
 yex
 opH
 opH
@@ -236871,8 +236888,8 @@ fpd
 opH
 opH
 mZy
-sxY
-hMs
+eMx
+eTj
 spV
 spV
 spV
@@ -237055,7 +237072,7 @@ xGz
 pwm
 soq
 pwm
-oJb
+oaI
 pwm
 xGz
 xGz
@@ -237063,7 +237080,7 @@ opH
 opH
 sJb
 gMa
-hSz
+sPh
 opH
 phC
 gMa
@@ -237073,11 +237090,11 @@ gMa
 wtw
 opH
 mqs
-urt
+qbh
 dEk
 vkI
 dEk
-qbh
+kMZ
 rnS
 xok
 gUk
@@ -237257,7 +237274,7 @@ pwm
 pwm
 uIC
 pwm
-oJb
+oaI
 pwm
 xGz
 xGz
@@ -237266,17 +237283,17 @@ pzk
 gMa
 vqG
 gMa
-efu
+ugj
 gMa
 gMa
 geA
 xgI
 vfv
 fqG
-lLw
-lhz
+waT
+suE
 ezs
-wgN
+lhz
 kAU
 mLR
 oeV
@@ -237467,9 +237484,9 @@ opH
 opH
 sJb
 gMa
-hSz
+sPh
 opH
-hpc
+gdn
 gMa
 pIr
 acB
@@ -237483,8 +237500,8 @@ uVK
 uVK
 uVK
 spV
-fBw
-wgN
+hpc
+lhz
 gWi
 rIc
 sdN
@@ -237660,32 +237677,32 @@ seQ
 bVD
 wWa
 bXy
-iGZ
+rqm
 gXz
 pwm
 xGz
 xGz
 opH
 hvz
-pBQ
-wpu
-qDa
+bPm
+lQf
+eSm
 opH
 huC
-fxv
-hVD
-cRj
-qWT
-uqM
-opH
-jsM
-spV
+lUP
 vMQ
-uVK
-qyo
-qUt
+eMK
+jnw
+cZV
+opH
+hNx
 spV
-nFm
+yjK
+uVK
+bal
+mVE
+spV
+fBw
 gUk
 ewj
 gYP
@@ -237862,8 +237879,8 @@ pwm
 pwm
 soz
 pwm
-iGZ
-rig
+rqm
+fPE
 pwm
 xGz
 xGz
@@ -237877,20 +237894,20 @@ opH
 opH
 opH
 opH
-qUT
-rHW
+ejM
+gxd
 opH
-lfc
-lUP
-cFR
+pYx
+esz
+oVv
 uVK
-wuN
-uQx
+bfZ
+jHx
 spV
-uVx
+kyl
 gUk
 kHd
-nol
+doA
 sdN
 rEL
 rEL
@@ -238064,8 +238081,8 @@ veZ
 pwm
 rYq
 pwm
-iGZ
-hQO
+rqm
+xmO
 xwU
 xwU
 xwU
@@ -238073,11 +238090,11 @@ xwU
 xwU
 xwU
 etH
-bvz
-bvz
-bvz
+fsi
+fsi
+fsi
+tZT
 wjD
-ntC
 opH
 opH
 opH
@@ -238092,7 +238109,7 @@ uVK
 uVK
 gUk
 kHd
-nol
+doA
 pdx
 utp
 oly
@@ -238266,31 +238283,31 @@ veZ
 pwm
 rsS
 pwm
-jwd
-wVv
+pNu
+ljQ
 rQO
-bmx
+vCh
 rQO
 rQO
 rQO
-cox
+qDa
 ctQ
-fgb
-fsi
-fsi
+pZI
+qKJ
+qKJ
 pwm
 mQc
-dBr
-bvz
-bvz
-bvz
-wjD
-bvz
-bvz
-bvz
-bvz
-bvz
-bvz
+dtG
+fsi
+fsi
+fsi
+tZT
+fsi
+fsi
+fsi
+fsi
+fsi
+fsi
 sRR
 fWi
 xrJ
@@ -238682,14 +238699,14 @@ hJp
 dmD
 dmD
 dmD
-vMo
+eit
 dmD
 dmD
-vMo
+eit
 dmD
-vMo
+eit
 bLR
-cUo
+jTG
 bLR
 bLR
 bLR
@@ -239497,7 +239514,7 @@ veZ
 veZ
 veZ
 vzY
-sfi
+hQO
 vzY
 vzY
 vzY
@@ -239910,7 +239927,7 @@ vzY
 eip
 npq
 gUk
-vXR
+oTp
 pNT
 srq
 xAC
@@ -240708,7 +240725,7 @@ veZ
 veZ
 veZ
 hqC
-tJf
+uRw
 bcG
 cxn
 kLt

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -1079,21 +1079,14 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/quartermaster/miningdock)
 "ajp" = (
+/obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/area/nadezhda/hallway/side/f2section1)
 "ajA" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -2513,23 +2506,20 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "aAw" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/cable/green,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable,
+/obj/machinery/reagentgrinder/portable,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "aAy" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/outside/meadow)
+/obj/machinery/camera/network/church{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "aAN" = (
 /obj/structure/table/rack/shelf,
 /obj/random/junk/low_chance,
@@ -2872,9 +2862,13 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "aED" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "aEL" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -2990,20 +2984,20 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/detectives_office)
 "aFL" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 32
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/light/small,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "aFM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3393,24 +3387,12 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/prisoncells)
 "aJN" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/area/nadezhda/engineering/atmos/storage)
 "aJP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -4236,10 +4218,10 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/eris/crew_quarters/plasma_tag)
 "aQF" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "aQH" = (
@@ -5109,22 +5091,15 @@
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
 "bal" = (
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "bam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
@@ -5736,11 +5711,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bfZ" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
+	},
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/hallway/surface/section1)
 "bgc" = (
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -6143,16 +6130,16 @@
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
 "bkH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "bkM" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -6378,15 +6365,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bmx" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/hallway/side/f2section1)
 "bmy" = (
 /obj/structure/railing{
 	dir = 1;
@@ -6642,12 +6624,20 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
 "boU" = (
-/obj/structure/table/woodentable,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "boY" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "WO"
@@ -7240,13 +7230,20 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "buS" = (
-/obj/structure/table/woodentable,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "buT" = (
 /obj/effect/window_lwall_spawn,
 /turf/simulated/floor/plating/under,
@@ -7455,15 +7452,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bwG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "bwJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -9115,15 +9105,10 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "bPm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "bPp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9142,10 +9127,10 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/quartermaster/disposaldrop)
 "bPu" = (
-/obj/structure/table/bench/padded,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "bPJ" = (
 /obj/structure/flora/small/busha1,
 /obj/random/flora/jungle_tree,
@@ -10108,15 +10093,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "bZJ" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/hallway/surface/section1)
 "bZL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10415,12 +10394,13 @@
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/plasma_tag)
 "ccn" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "cco" = (
 /obj/machinery/light{
 	dir = 1;
@@ -10650,12 +10630,21 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cfH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "cfK" = (
 /obj/machinery/camera/xray/security{
 	dir = 9
@@ -11509,9 +11498,11 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cox" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/multiz/stairs/enter/bottom,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "coC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -12469,19 +12460,12 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "cxF" = (
-/obj/structure/multiz/stairs/active{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/sign/levels/stairsdown{
-	pixel_y = -30;
-	pixel_x = 32
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "cxN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12538,12 +12522,15 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cye" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "cyf" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/pros/foreman)
@@ -12640,15 +12627,20 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
 "czb" = (
-/obj/structure/cable/green{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "czd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -13195,17 +13187,22 @@
 	name = "Dormitory 1"
 	})
 "cDx" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/item/scrap_lump,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "cDF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13416,16 +13413,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/command/bridgebar)
 "cFP" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/skyyard)
 "cFR" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/blast/regular/open{
@@ -13809,10 +13801,12 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/bridge)
 "cKd" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "cKe" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -14156,10 +14150,9 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/surface/section1)
 "cNE" = (
-/obj/structure/table/woodentable,
-/obj/item/device/lighting/toggleable/lantern/censer,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "cNF" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/unsimulated/wall/jungle,
@@ -14416,9 +14409,35 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "cRj" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey,
+/obj/structure/sign/faction/derelict1{
+	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
+	name = "NOTICE: Dangerous Biohazard";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "cRq" = (
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark/panels,
@@ -14631,8 +14650,9 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
 "cTB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/structure/reagent_dispensers/biomatter,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "cTE" = (
 /obj/structure/closet/wall_mounted/emcloset{
@@ -14756,9 +14776,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "cUo" = (
-/obj/effect/floor_decal/industrial/loading/white,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "cUx" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 1
@@ -15198,10 +15223,14 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
 "cZV" = (
-/turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/multiz/stairs/enter{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "dar" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/railing/grey{
@@ -15556,10 +15585,10 @@
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
 "ddN" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/plating,
 /area/nadezhda/absolutism/chapel)
 "ddR" = (
 /obj/structure/ore_box,
@@ -15711,31 +15740,8 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "deL" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 1";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "deM" = (
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/structure/table/standard,
@@ -16417,16 +16423,10 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "dmD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/table/bench/padded,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "dmG" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/camera/network/medbay{
@@ -16514,17 +16514,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
 "dnk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/small/grassb1,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "dnl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -16642,14 +16634,16 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "doA" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "doD" = (
 /obj/structure/catwalk,
 /obj/random/cluster/roaches/low_chance,
@@ -17246,13 +17240,7 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
 "dtG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "dup" = (
 /obj/structure/flora/big/rocks3,
@@ -17813,10 +17801,16 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dzK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_room)
 "dzS" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "16,9"
@@ -17984,10 +17978,16 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "dBr" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/obj/structure/invislight,
-/turf/simulated/floor/plating,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "dBt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -18001,11 +18001,13 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "dBR" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "dBU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18130,13 +18132,14 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/bridgebar)
 "dCC" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/turf/simulated/floor/tiled/cafe,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "dCH" = (
 /obj/machinery/light/small{
@@ -18275,16 +18278,14 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dEk" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "dEo" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -19154,19 +19155,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "dNo" = (
-/obj/structure/mirror{
-	pixel_x = 0;
-	pixel_y = -28
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/cyancorner,
+/area/nadezhda/hallway/surface/section1)
 "dNp" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 1
@@ -19215,14 +19208,9 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "dNI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "dNK" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,18"
@@ -20114,8 +20102,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "dXG" = (
-/turf/simulated/wall/church_reinforced,
-/area/colony)
+/obj/machinery/computer/arcade,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "dXJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -20914,9 +20906,22 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
 "efu" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/area/nadezhda/absolutism/chapel)
 "efv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21021,16 +21026,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "egd" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
 	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/colony)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "egg" = (
 /obj/structure/table/rack/shelf,
 /obj/random/pack/cloth/low_chance,
@@ -21253,12 +21253,19 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "eit" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "eix" = (
 /obj/structure/table/steel,
 /obj/machinery/microwave,
@@ -21350,14 +21357,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ejM" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/light,
+/obj/machinery/light_switch{
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "ejZ" = (
@@ -21416,11 +21421,9 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "ekD" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/meadow)
 "ekF" = (
 /obj/structure/table/rack/shelf,
 /obj/random/mecha_equipment/low_chance,
@@ -21873,9 +21876,20 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "epB" = (
-/obj/machinery/camera/network/church{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Church";
+	req_access = list(27)
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
@@ -22168,8 +22182,9 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "esz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "esA" = (
 /obj/machinery/power/apc{
@@ -23624,11 +23639,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "eIV" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "eIZ" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,22"
@@ -24068,8 +24081,15 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/crew_quarters/kitchen_storage)
 "eMx" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
+	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "eMB" = (
@@ -24095,11 +24115,27 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory_blackshield)
 "eMK" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey,
+/obj/structure/cable/yellow,
+/obj/machinery/light,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "eMS" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -24637,20 +24673,10 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/construction)
 "eSm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "eSv" = (
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/effect/floor_decal/border/techfloor{
@@ -24816,13 +24842,11 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/main/stairwell)
 "eTj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/wall_obelisk{
-	pixel_x = 1;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "eTk" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -25102,10 +25126,22 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "eVP" = (
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "eVQ" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -26136,27 +26172,14 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "fgb" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 2";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
 	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
 	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/bioreactor)
 "fgf" = (
 /turf/simulated/floor/carpet/purcarpet,
@@ -26247,9 +26270,12 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "fgM" = (
-/obj/structure/closet/coffin,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/item/device/radio/intercom{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "fgN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -26608,12 +26634,11 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fkm" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27241,18 +27266,15 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "fqE" = (
-/obj/structure/bed/chair/sofa/brown/left,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
 	},
-/obj/random/toy/plushie,
-/obj/effect/floor_decal/industrial/warningred{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/carpet,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "fqF" = (
 /obj/machinery/light/small{
@@ -27435,9 +27457,9 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
 "fsi" = (
-/obj/structure/closet/custodial,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "fsk" = (
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm4{
@@ -27768,7 +27790,15 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "fuZ" = (
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "fvc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -27986,20 +28016,11 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "fxv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "chudorm4";
-	name = "Church Dorm 2";
-	req_access = list(70)
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "fxy" = (
 /obj/machinery/door/airlock/maintenance_security{
 	req_access = list(1)
@@ -28066,14 +28087,12 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "fyb" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "fyc" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
@@ -28314,11 +28333,14 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical)
 "fAA" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "fAG" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/simulated/floor/bluegrid{
@@ -28360,14 +28382,16 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "fBw" = (
-/obj/machinery/camera/network/church{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -28460,10 +28484,11 @@
 	name = "Dormitory 3"
 	})
 "fBV" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "fBY" = (
 /obj/structure/multiz/stairs/active{
 	dir = 1
@@ -28502,17 +28527,15 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/cryo)
 "fCn" = (
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/hallway/side/f2section1)
 "fCp" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -28587,23 +28610,9 @@
 	name = "\improper Blackshield - Firing Range"
 	})
 "fCX" = (
-/obj/machinery/door/airlock{
-	name = "Church";
-	req_access = list(27)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "fDb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4;
@@ -28860,13 +28869,18 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "fEH" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "fEJ" = (
 /obj/structure/catwalk,
@@ -29909,12 +29923,19 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fPi" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "fPo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -30013,19 +30034,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "fPE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/atmos/storage)
 "fPG" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/camera/network/cev_eris,
@@ -31738,9 +31749,18 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ggs" = (
-/obj/structure/table/woodentable,
-/obj/random/toy/plushie,
-/turf/simulated/floor/carpet,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "ggt" = (
 /obj/machinery/power/nt_obelisk,
@@ -32575,10 +32595,17 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "gnT" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "gnW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -32619,9 +32646,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
 "gou" = (
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "gow" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -33189,9 +33217,18 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "guj" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "chudorm4";
+	name = "Church Dorm 2";
+	req_access = list(70)
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "gum" = (
@@ -33425,8 +33462,21 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "gxd" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/church_reinforced,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
+	},
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "gxg" = (
 /obj/structure/closet/l3closet,
@@ -34505,18 +34555,17 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "gHI" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "gHJ" = (
 /obj/structure/flora/small/rock2,
@@ -35589,9 +35638,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "gRQ" = (
 /obj/random/material/low_chance,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -35624,11 +35683,22 @@
 	name = "Dormitory 2"
 	})
 "gSa" = (
-/obj/item/tool/knife/neotritual,
-/obj/item/clothing/gloves/psionic_ring,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "gSb" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -36190,25 +36260,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "gXz" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/random/scrap/dense_weighted/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "gXB" = (
 /obj/structure/sink/kitchen{
 	name = "utility sink";
@@ -36551,17 +36608,14 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/turret_protected/ai_upload)
 "hbi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/biomatter,
 /obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+	pixel_y = -32
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "hbk" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -37496,12 +37550,15 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "hkR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/multiz/stairs/enter{
+	dir = 1
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "hkW" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -37652,19 +37709,13 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "hmk" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/bioreactor)
 "hmp" = (
 /obj/structure/cable/green{
@@ -37907,14 +37958,19 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "hpc" = (
-/obj/structure/multiz/stairs/active/bottom{
-	dir = 1
+/obj/structure/bed/chair/sofa/brown/left,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/random/toy/plushie,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "hpe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -37935,16 +37991,19 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/absolutism/bioreactor)
 "hpq" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "hpu" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/effect/decal/cleanable/dirt,
@@ -38439,19 +38498,11 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
 "huw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "huC" = (
 /obj/structure/bookcase,
 /obj/item/book/ritual/cruciform,
@@ -39543,10 +39594,19 @@
 	name = "Dormitory 1"
 	})
 "hHU" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating/under,
+/area/colony)
 "hHX" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -39965,13 +40025,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "hMs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "hMw" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -40071,16 +40130,11 @@
 	name = "\improper Outdoors - Pad"
 	})
 "hNx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/prime)
 "hNF" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/cable/green{
@@ -40440,20 +40494,10 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "hQO" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/table/woodentable,
+/obj/item/device/lighting/toggleable/lantern/censer,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "hQP" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -40621,8 +40665,18 @@
 /turf/unsimulated/mineral,
 /area/colony)
 "hSz" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/cafe,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "hSA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40896,12 +40950,10 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
 "hVD" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "hVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -41816,13 +41868,13 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ifo" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "ifw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/security{
@@ -42273,16 +42325,11 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
 "ikj" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0";
-	tag = "icon-railing0 (NORTH)"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "ikn" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -43406,19 +43453,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "ivC" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/item/scrap_lump,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "ivM" = (
 /obj/machinery/holoposter{
 	pixel_y = 30
@@ -43871,15 +43911,12 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "iAo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "iAq" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -44540,13 +44577,17 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "iGZ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/plating/under,
-/area/colony)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/storage/fancy/crayons,
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/crayons,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "iHa" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/unsimulated/wall/jungle,
@@ -45634,18 +45675,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "iRf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "iRh" = (
 /obj/structure/cable/green{
@@ -46248,15 +46283,15 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "iWQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "iWS" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -46532,15 +46567,17 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "iZz" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/vectorrooms)
 "iZD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
@@ -47667,11 +47704,17 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "jkf" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/power/eotp,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "jkj" = (
 /obj/structure/table/steel,
 /obj/random/material_resources,
@@ -47936,11 +47979,17 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jnw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "jny" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -48504,25 +48553,17 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jsM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/noticeboard/church{
+	pixel_x = 32
 	},
-/obj/effect/floor_decal/industrial/warningred,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "jsR" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/gloves{
@@ -48541,23 +48582,15 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "jte" = (
-/obj/structure/disposaloutlet{
+/obj/machinery/vending/theomat,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
 	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "jtl" = (
 /obj/machinery/light_switch{
 	pixel_y = 30
@@ -48843,9 +48876,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
 "jwd" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/atmos/storage)
+/obj/item/tool/knife/neotritual,
+/obj/item/clothing/gloves/psionic_ring,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "jwe" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
@@ -49978,16 +50013,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jHx" = (
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "jHC" = (
 /obj/random/scrap/dense_weighted,
 /obj/structure/table/rack/shelf,
@@ -50007,18 +50043,9 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jHL" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/church_reinforced,
+/area/nadezhda/absolutism/bioreactor)
 "jHS" = (
 /obj/random/contraband/low_chance,
 /obj/effect/decal/cleanable/cobweb{
@@ -51231,22 +51258,19 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jTG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "jTH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/reinforced/polarized{
@@ -51521,10 +51545,14 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/barquarters)
 "jVP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "jWc" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -51621,12 +51649,13 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jXd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "jXf" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/under,
@@ -52153,14 +52182,20 @@
 	name = "\improper Clinic"
 	})
 "kbl" = (
-/obj/machinery/light,
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -28
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "kbm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -53256,13 +53291,12 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "klX" = (
-/obj/structure/bed/chair/sofa/brown/right,
-/obj/landmark/join/start/acolyte,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "kmc" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -53663,15 +53697,9 @@
 /area/nadezhda/hallway/surface/section1)
 "koL" = (
 /obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/item/reagent_containers/glass/replenishing/chalice,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "koP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53710,17 +53738,12 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
 "kpf" = (
-/obj/structure/bed/chair/sofa/black/left{
-	dir = 8
+/obj/machinery/light_switch{
+	pixel_x = -20
 	},
-/obj/structure/noticeboard/church{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/smartfridge/kitchen/church,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "kpi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -54165,18 +54188,9 @@
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "ktR" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/loading/white,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "ktS" = (
 /obj/structure/closet/crate,
 /obj/item/am_shielding_container,
@@ -54423,22 +54437,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "kwb" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/material/kitchen/rollingpin,
-/obj/machinery/light_switch{
-	pixel_y = 30
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "kwd" = (
 /obj/random/flora/jungle_tree,
 /obj/effect/decal/cleanable/dirt,
@@ -54607,27 +54611,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/hut_cell1)
 "kxQ" = (
-/obj/structure/cable/yellow{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
+/obj/structure/catwalk,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey,
-/obj/structure/cable/yellow,
-/obj/machinery/light,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/skyyard)
 "kxW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54646,11 +54635,14 @@
 /turf/simulated/floor/asteroid/dirt/dark/plough,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kyl" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "kym" = (
 /mob/living/simple_animal/hostile/naniteswarm{
 	desc = "A swarm of disgusting mini locusts infested with disease and hatred.";
@@ -54659,15 +54651,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kyt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/absolutism/bioreactor)
 "kyu" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -55252,38 +55249,26 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kDY" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
+/obj/random/furniture/pottedplant,
+/obj/machinery/camera/network/church{
+	dir = 8
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "kEe" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Prime's Office";
-	departmentType = 22;
-	name = "Prime's RC";
-	pixel_x = 30;
+/obj/structure/window/reinforced{
+	dir = 1;
 	pixel_y = 0
 	},
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Prime's Office"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "kEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -55471,15 +55456,13 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "kFQ" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "kFU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -55997,13 +55980,19 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kLc" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/multiz/stairs/active{
+	dir = 1
 	},
-/obj/random/toy/plushie_onlyfox,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/sign/levels/stairsdown{
+	pixel_y = -30;
+	pixel_x = 32
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "kLm" = (
 /obj/structure/table/rack/shelf,
 /obj/random/lowkeyrandom,
@@ -56221,12 +56210,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kMZ" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 24
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "kNa" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -56378,10 +56366,14 @@
 /turf/simulated/open,
 /area/colony)
 "kOD" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/box/white,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "kOJ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -56420,20 +56412,6 @@
 /obj/random/booze,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
-"kPg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos/storage)
 "kPj" = (
 /obj/structure/sign/departmentold/security,
 /turf/simulated/wall/r_wall,
@@ -56815,9 +56793,18 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "kSK" = (
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "kSR" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/table/rack/shelf,
@@ -57142,12 +57129,8 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "kVO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/turf/simulated/wall/church_reinforced,
+/area/colony)
 "kWa" = (
 /obj/structure/flora/big/bush2,
 /obj/effect/decal/cleanable/dirt,
@@ -57981,9 +57964,22 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ldw" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/material/kitchen/rollingpin,
+/obj/machinery/light_switch{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "ldz" = (
 /obj/structure/holohoop{
 	dir = 1
@@ -58239,10 +58235,16 @@
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "lfc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "lfh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spider/spiderling,
@@ -58408,18 +58410,14 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/crew_quarters/cafeteria)
 "lhz" = (
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Office"
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "lhH" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -58660,17 +58658,14 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ljQ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9;
+	pixel_y = 0
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "ljT" = (
@@ -58794,14 +58789,11 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "llg" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "llh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -59049,28 +59041,14 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "lnV" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/camera/network/church{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "lnW" = (
 /obj/item/clothing/suit/armor/platecarrier/ih,
 /obj/item/clothing/suit/armor/platecarrier/ih,
@@ -61436,19 +61414,13 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/barbackroom)
 "lLw" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
+/obj/structure/bed/chair/sofa/brown/right,
+/obj/landmark/join/start/acolyte,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/sign/levels/stairsup{
-	pixel_x = 32;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "lLB" = (
 /obj/machinery/atmospherics/omni/mixer{
 	active_power_usage = 7500;
@@ -62451,19 +62423,15 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "lUP" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating/under,
-/area/colony)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "lUR" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -62576,10 +62544,9 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
 "lVU" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "lVV" = (
 /obj/machinery/power/breakerbox{
 	RCon_tag = "AI Core Substation Bypass"
@@ -63153,24 +63120,20 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "mce" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "mcg" = (
 /obj/structure/bed/chair,
 /obj/structure/window/reinforced{
@@ -63272,11 +63235,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/crew_quarters/plasma_tag)
 "mcP" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "mcQ" = (
 /obj/machinery/door/blast/shutters{
@@ -63348,10 +63311,20 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/quartermaster/office)
 "mdn" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "mdt" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 2;
@@ -63500,24 +63473,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "meA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/woodentable,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "meB" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 0;
@@ -63883,12 +63844,11 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "miP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 5
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = -32
 	},
 /turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/vectorrooms)
 "miQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -65145,10 +65105,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
 "mtA" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "mtG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -65588,15 +65548,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
 "mxN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "mxR" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -65873,13 +65827,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/engineering/foyer)
 "mBf" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "mBn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating/under,
@@ -66584,16 +66534,12 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/construction)
 "mHf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "mHh" = (
 /obj/landmark/join/start/cargo_tech,
 /obj/structure/disposalpipe/segment,
@@ -66968,17 +66914,9 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
 "mKY" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/bed/chair/comfy/brown,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "mLl" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -66998,20 +66936,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "mLR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "mLS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -67413,14 +67343,16 @@
 /turf/simulated/floor/beach/sand/drywater,
 /area/nadezhda/crew_quarters/pool)
 "mPy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/obj/structure/catwalk,
-/obj/machinery/light,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/sink{
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "mPC" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -67585,12 +67517,12 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "mRi" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/machinery/camera/network/church{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mRq" = (
 /obj/structure/table/bench/marble,
 /obj/machinery/alarm{
@@ -68023,16 +67955,13 @@
 	name = "\improper Outdoors - Pad"
 	})
 "mVl" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mVm" = (
 /obj/structure/closet,
 /turf/simulated/floor/tiled/white,
@@ -68077,10 +68006,11 @@
 	name = "Residential District Substation"
 	})
 "mVE" = (
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "mVH" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/generic,
@@ -68643,12 +68573,14 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ncd" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "nch" = (
 /obj/random/furniture/pottedplant,
 /obj/item/device/radio/intercom{
@@ -69206,8 +69138,11 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "nib" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/outside/meadow)
+/area/nadezhda/absolutism/vectorrooms)
 "nic" = (
 /obj/structure/table/onestar,
 /obj/item/pen,
@@ -69609,9 +69544,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "nmo" = (
-/obj/machinery/light,
-/obj/machinery/vending/fortune,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/atm{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "nmp" = (
 /obj/item/reagent_containers/blood/AMinus,
@@ -69783,19 +69723,12 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/fo)
 "nol" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "nom" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -69913,17 +69846,18 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "npm" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/obj/structure/sink{
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "npp" = (
 /obj/structure/multiz/stairs/active/bottom,
@@ -70130,12 +70064,19 @@
 /turf/simulated/floor/plating/under,
 /area/asteroid/cave)
 "nrD" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/sign/levels/stairsup{
+	pixel_x = 32;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "nrI" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -70324,15 +70265,15 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ntC" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/colony)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "ntK" = (
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
@@ -70516,12 +70457,22 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nvB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 32;
+	icon_state = "32-1"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/catwalk,
+/turf/simulated/open,
+/area/nadezhda/absolutism/storage)
 "nvD" = (
 /obj/structure/table/bar_special,
 /obj/machinery/floor_light,
@@ -70673,8 +70624,11 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "nxH" = (
-/obj/machinery/biomatter_solidifier,
-/turf/simulated/floor/tiled/dark/danger,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "nxP" = (
 /obj/structure/cable/green{
@@ -71458,14 +71412,17 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "nFm" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "nFp" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -71944,15 +71901,28 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nJR" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4;
-	name = "biomatter chute"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "nJX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -72668,12 +72638,17 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "nRM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "nRO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -72798,12 +72773,12 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "nTE" = (
-/obj/structure/mopbucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/soap/deluxe,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "nTL" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -73619,12 +73594,19 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "oaI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "oaM" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -74980,14 +74962,8 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/main/stairwell)
 "omK" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
-	},
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "omU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75269,23 +75245,14 @@
 /turf/simulated/mineral,
 /area/nadezhda/command/cbo)
 "oqc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair";
+	tag = "icon-wooden_chair (EAST)"
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "oqd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -75979,15 +75946,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
 "owI" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
-	},
-/obj/machinery/atm{
-	dir = 4;
-	pixel_x = 30
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "owK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/furniture/pottedplant,
@@ -77309,15 +77271,9 @@
 	},
 /area/nadezhda/pros/proelav)
 "oJb" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/closet/coffin,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "oJo" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood/wild3,
@@ -77684,12 +77640,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "oMM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "oMS" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/junk/snappop,
@@ -77760,25 +77716,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
 "oNA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/random/mob/roaches/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "oNP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78283,14 +78226,12 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "oSN" = (
-/obj/machinery/light/small,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "oST" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -78367,13 +78308,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "oTp" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "oTv" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -78531,18 +78470,23 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
 "oVv" = (
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+/obj/structure/disposaloutlet{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "oVO" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 6
@@ -79221,10 +79165,10 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "pes" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -81230,11 +81174,9 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/virology)
 "pyY" = (
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/engineering/atmos/storage)
 "pzk" = (
 /obj/structure/nt_pedestal,
 /turf/simulated/floor/carpet/bcarpet,
@@ -81504,10 +81446,8 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "pBQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "pBV" = (
 /obj/structure/cable/green{
@@ -82591,10 +82531,24 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
 "pLt" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "pLw" = (
 /obj/random/mob/croaker/low_chance,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -82792,20 +82746,10 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "pNu" = (
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "pNw" = (
 /turf/simulated/mineral,
 /area/nadezhda/outside/dcave)
@@ -83101,19 +83045,14 @@
 	name = "\improper Upper Research Hallway"
 	})
 "pPU" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/multiz/stairs/active{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "pPW" = (
 /obj/machinery/vending/printomat,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -83933,14 +83872,13 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "pYx" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/table/woodentable,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "pYB" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -84094,12 +84032,21 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "pZI" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "pZS" = (
 /mob/living/simple_animal/opossum{
 	desc = "The Nedezhda basketball team mascot. - Currently scavenging for rebounds";
@@ -84656,8 +84603,13 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qfx" = (
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "qfC" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -84819,21 +84771,14 @@
 	name = "\improper Outdoors - Pad"
 	})
 "qgM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "qhd" = (
 /obj/structure/table/bar_special,
 /obj/machinery/chemical_dispenser/beer,
@@ -86181,9 +86126,12 @@
 /turf/simulated/wall/r_wall,
 /area/colony)
 "quT" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/meadow)
 "quV" = (
 /obj/structure/bed/chair/wood,
@@ -86219,9 +86167,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "qvn" = (
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "qvy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -86326,11 +86278,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "qwE" = (
-/obj/machinery/alarm{
-	pixel_y = 26
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "qwI" = (
 /obj/machinery/light{
 	dir = 8;
@@ -86551,11 +86504,10 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qyo" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "qyq" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
@@ -86688,12 +86640,14 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "qzx" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
 	},
-/obj/item/scrap_lump,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "qzA" = (
 /obj/structure/table/bar_special,
 /obj/item/modular_computer/tablet/preset/custom_loadout/standard,
@@ -86915,18 +86869,10 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
 "qBq" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/mob/roaches/low_chance,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "qBx" = (
 /obj/structure/table/standard,
 /obj/random/material/low_chance,
@@ -86939,12 +86885,20 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest)
 "qBQ" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/tool/multitool,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "qBV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/rock5,
@@ -87023,12 +86977,9 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "qDa" = (
-/obj/structure/catwalk,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
+/obj/structure/flora/small/grassa5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "qDd" = (
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
@@ -87381,14 +87332,15 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "qGp" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
+/obj/random/furniture/pottedplant,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qGu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -87457,12 +87409,15 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qHh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "qHk" = (
 /obj/structure/flora/small/grassb4,
 /obj/effect/decal/cleanable/dirt,
@@ -87803,12 +87758,18 @@
 	name = "\improper Clinic"
 	})
 "qKJ" = (
-/obj/structure/closet/secure_closet/personal/agrolyte,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = -32
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/structure/invislight,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/vectorrooms)
 "qKO" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt,
@@ -88710,22 +88671,17 @@
 	name = "Dormitory 3"
 	})
 "qTC" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/item/scrap_lump,
-/obj/structure/cable/green{
+/obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "qTD" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 4;
@@ -88811,34 +88767,8 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/atmos/storage)
 "qUt" = (
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey,
-/obj/structure/sign/faction/derelict1{
-	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
-	name = "NOTICE: Dangerous Biohazard";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/under,
+/obj/machinery/biomatter_solidifier,
+/turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/absolutism/bioreactor)
 "qUw" = (
 /obj/structure/cable/green{
@@ -88886,15 +88816,19 @@
 	name = "Residential District Maintenance"
 	})
 "qUT" = (
-/obj/structure/multiz/stairs/enter{
-	dir = 1
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "qUY" = (
 /obj/structure/mopbucket,
 /obj/effect/floor_decal/industrial/botright,
@@ -89123,12 +89057,16 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/crew_quarters/podrooms)
 "qWT" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/smartfridge/kitchen/church,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "qWW" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/small/busha3,
@@ -89555,11 +89493,12 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "raN" = (
-/obj/machinery/light{
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "raR" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
@@ -89627,14 +89566,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rby" = (
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/structure/cable/yellow{
+/obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/area/colony)
 "rbA" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -89812,10 +89753,11 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "rcV" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/hallway/surface/section1)
 "rcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -90313,11 +90255,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rig" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
+/obj/machinery/door/holy{
+	name = "Church"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/absolutism/storage)
 "rip" = (
 /obj/machinery/door/firedoor,
 /obj/structure/door_assembly/door_assembly_maint_cargo,
@@ -90387,13 +90332,10 @@
 	name = "Dormitory 3"
 	})
 "riP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "riQ" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/powermonitor{
@@ -90500,10 +90442,15 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "rjV" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "rjY" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood,
@@ -91147,19 +91094,10 @@
 	})
 "rqm" = (
 /obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/bioreactor)
 "rqp" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -91275,13 +91213,9 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rrx" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "rrB" = (
 /obj/structure/table/steel,
 /obj/random/mob/spiders,
@@ -91834,22 +91768,12 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/pros/prep)
 "rwF" = (
-/obj/structure/cable/yellow{
-	d1 = 32;
-	icon_state = "32-1"
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/catwalk,
-/turf/simulated/open,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "rwG" = (
 /obj/machinery/camera/network/colony_transition{
 	dir = 8
@@ -91912,12 +91836,15 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "rxq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "rxs" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/under,
@@ -92717,17 +92644,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/command/courtroom)
 "rEA" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/rock/manmade/road,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "rED" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/rock,
@@ -92919,12 +92839,10 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rGx" = (
+/obj/effect/floor_decal/industrial/danger,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "rGz" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -93033,11 +92951,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rHD" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/multiz/stairs/enter/bottom,
+/obj/structure/invislight,
+/turf/simulated/floor/plating,
+/area/nadezhda/outside/meadow)
 "rHE" = (
 /obj/machinery/light{
 	dir = 1
@@ -95393,14 +95310,18 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "sdY" = (
-/obj/machinery/door/holy{
-	name = "Church"
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "sec" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
@@ -95552,6 +95473,18 @@
 /obj/effect/floor_decal/industrial/road/curvebig3,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/meadow)
+"sfi" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "sfB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -97015,16 +96948,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "suE" = (
-/obj/structure/mirror{
-	pixel_x = 0;
-	pixel_y = -28
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/sink{
-	pixel_y = -22
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "suL" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -97341,9 +97274,25 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "sxY" = (
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "syb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -97541,18 +97490,22 @@
 "sAo" = (
 /obj/structure/cable/green{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "sAN" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -97904,9 +97857,10 @@
 /turf/simulated/mineral,
 /area/colony)
 "sFL" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/table/woodentable,
+/obj/random/toy/plushie,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "sFQ" = (
 /turf/simulated/floor/reinforced,
 /area/nadezhda/hallway/surface/section1)
@@ -98526,12 +98480,11 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/kitchen)
 "sMN" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "sMT" = (
 /obj/structure/table/rack,
 /obj/item/storage/toolbox/electrical{
@@ -98668,13 +98621,11 @@
 /area/nadezhda/command/gmaster)
 "sOa" = (
 /obj/structure/table/standard,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
-	},
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/recharger,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/tool/multitool,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "sOd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -98785,15 +98736,10 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "sPh" = (
-/obj/machinery/conveyor_switch{
-	id = "disposals grinder"
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/floor_decal/industrial/danger,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "sPj" = (
 /obj/structure/flora/small/trailrocka3,
 /obj/effect/decal/cleanable/dirt,
@@ -99166,14 +99112,20 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "sSM" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/pistachios,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "sSW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -99415,12 +99367,16 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sUM" = (
-/obj/structure/bed/chair/wood{
-	dir = 4;
-	icon_state = "wooden_chair";
-	tag = "icon-wooden_chair (EAST)"
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "sUN" = (
@@ -99912,9 +99868,8 @@
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sZu" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "sZw" = (
 /obj/effect/floor_decal/spline/fancy,
@@ -100140,24 +100095,10 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "tby" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/reagent_dispensers/biomatter/large,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "tbJ" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -101255,15 +101196,10 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "tmF" = (
-/obj/machinery/vending/theomat,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "tmR" = (
 /obj/machinery/door/airlock/glass{
 	name = "Plasma Drome"
@@ -101399,15 +101335,23 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/main/stairwell)
 "toM" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 10
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "toN" = (
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -101457,12 +101401,14 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "tpj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "tpn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/bushc3,
@@ -102457,12 +102403,10 @@
 	name = "Dormitory 4"
 	})
 "tzn" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/camera/network/church{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "tzo" = (
 /obj/structure/flora/small/trailrockb2,
@@ -102496,12 +102440,11 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tzJ" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/open,
+/area/nadezhda/hallway/surface/section1)
 "tzM" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/window/reinforced,
@@ -103355,19 +103298,15 @@
 /area/eris/crew_quarters/plasma_tag)
 "tJf" = (
 /obj/structure/disposalpipe/segment{
-	dir = 2
+	dir = 4
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "tJk" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -104063,10 +104002,17 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tPN" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "tPO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -104922,13 +104868,14 @@
 	name = "\improper Upper Research Hallway"
 	})
 "tZL" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/closet/crate/trashcart,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/hallway/side/f2section1)
 "tZS" = (
 /obj/effect/floor_decal/industrial/arrows/white{
 	dir = 1
@@ -104937,14 +104884,28 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "tZT" = (
-/obj/structure/multiz/stairs/enter{
-	dir = 1
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 2";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "tZW" = (
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -105084,15 +105045,28 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "uaN" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 1";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
 	},
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
@@ -105191,17 +105165,24 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "ucl" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "ucn" = (
 /mob/living/simple_animal/hostile/snake,
 /turf/simulated/floor/asteroid/grass,
@@ -105216,10 +105197,16 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "ucs" = (
-/obj/structure/reagent_dispensers/biomatter/large,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "ucx" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/stack/ore,
@@ -105252,7 +105239,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ucY" = (
 /obj/structure/invislight,
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "udb" = (
@@ -105574,11 +105561,16 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/cryo)
 "ugj" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "ugm" = (
 /obj/random/structures,
 /obj/effect/spider/stickyweb,
@@ -105589,20 +105581,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ugn" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "ugx" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Permanent Holding";
@@ -106504,17 +106494,9 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/crew_quarters/podrooms)
 "uqM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "uqQ" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -106768,11 +106750,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "usX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "utl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -107925,9 +107907,13 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "uCH" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
+/area/colony)
 "uCI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -108326,9 +108312,15 @@
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "uGA" = (
-/obj/structure/flora/small/grassa5,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/machinery/disposal/deliveryChute{
+	dir = 4;
+	name = "biomatter chute"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "uGD" = (
 /obj/landmark/machinery/input,
 /obj/machinery/conveyor/south{
@@ -109059,11 +109051,13 @@
 /area/nadezhda/engineering/atmos/storage)
 "uOA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "uOB" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -109352,8 +109346,20 @@
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "uQx" = (
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "uQC" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -109726,13 +109732,8 @@
 	name = "\improper Upper Research Hallway"
 	})
 "uTQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "uTS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -109820,17 +109821,14 @@
 	name = "\improper Outdoors - Pad"
 	})
 "uUU" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/item/storage/fancy/crayons,
-/obj/structure/table/woodentable,
-/obj/item/storage/fancy/crayons,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/catwalk,
+/obj/machinery/light,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "uUW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -109901,12 +109899,25 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
 "uVx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Prime's Office";
+	departmentType = 22;
+	name = "Prime's RC";
+	pixel_x = 30;
+	pixel_y = 0
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Prime's Office"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "uVy" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/robotics{
@@ -110225,21 +110236,14 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
 "uYT" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "uZc" = (
 /obj/structure/flora/small/bushc1,
@@ -110269,13 +110273,12 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "uZv" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/chapel)
 "uZx" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/big/bush3,
@@ -110784,10 +110787,19 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
 "vfg" = (
-/obj/structure/reagent_dispensers/biomatter,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "vfj" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section2";
@@ -111508,18 +111520,14 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "vmm" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "vmq" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
@@ -112161,18 +112169,11 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/meeting_room)
 "vsx" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/structure/invislight,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "vsy" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/structures,
@@ -112513,13 +112514,23 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "vvO" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
 "vvS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame/vertical{
@@ -113084,20 +113095,12 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "vAx" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/closet/secure_closet/personal/agrolyte,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = -32
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "vAB" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -113254,21 +113257,16 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vCh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/steel/golden,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "vCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -113592,15 +113590,12 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical_blackshield)
 "vFR" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "vFU" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -113667,20 +113662,11 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vGk" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "vGA" = (
 /obj/structure/sign/security/cells{
@@ -113899,11 +113885,12 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vIL" = (
-/obj/machinery/camera/network/church{
-	dir = 4
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "vJb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -114110,11 +114097,13 @@
 	name = "Residential District Maintenance"
 	})
 "vKM" = (
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Office"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/wall_obelisk{
+	pixel_x = 1;
+	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "vKR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -114307,24 +114296,32 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "vMK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/cyan{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
+"vMQ" = (
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/power/eotp,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
-"vMQ" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 1;
-	name = "trash chute"
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "vMU" = (
 /obj/structure/disposalpipe/junction,
@@ -115318,9 +115315,13 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "vWA" = (
-/obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/random/toy/plushie_onlyfox,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "vWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -115550,17 +115551,12 @@
 	name = "Dormitory 1"
 	})
 "vXR" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/recycler,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/conveyor/south{
-	id = "junk_to_bioreactor"
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "vYb" = (
 /obj/structure/closet/secure_closet/personal/doctor,
 /obj/item/clothing/glasses/hud/health,
@@ -115756,12 +115752,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "waf" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "wak" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
@@ -115792,9 +115788,21 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "waT" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
 "waY" = (
 /obj/structure/multiz/stairs/active/bottom,
 /obj/structure/window/reinforced{
@@ -115804,25 +115812,19 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/side/f2section1)
 "wbe" = (
-/obj/structure/closet/secure_closet/reinforced/preacher,
-/obj/item/device/taperecorder,
-/obj/item/device/camera,
-/obj/item/device/camera_film,
-/obj/item/clothing/mask/gas/germanmask,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
-"wbm" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
+/obj/machinery/light/small,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"wbm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "wbo" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -116204,22 +116206,24 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
 "weP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/steel/golden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/random/scrap/dense_weighted/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "weT" = (
 /obj/machinery/door/firedoor/multi_tile,
@@ -116291,9 +116295,12 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "wfn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/mopbucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/soap/deluxe,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "wft" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/cafe,
@@ -116413,14 +116420,13 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/cafeteria)
 "wgN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/disposal/deliveryChute{
+	dir = 1;
+	name = "trash chute"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "wgV" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -116664,19 +116670,13 @@
 /obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/mob/roaches/low_chance,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "wjI" = (
@@ -117282,16 +117282,13 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "wpu" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_room)
+/obj/structure/closet/secure_closet/reinforced/preacher,
+/obj/item/device/taperecorder,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/item/clothing/mask/gas/germanmask,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "wpv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -120048,12 +120045,10 @@
 	name = "Dormitory 3"
 	})
 "wQW" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "wRb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -120141,10 +120136,20 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "wSl" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = -32
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "wSn" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -120470,11 +120475,14 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/tcommsat/computer)
 "wVv" = (
-/obj/structure/catwalk,
-/obj/structure/invislight,
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "wVx" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,18"
@@ -120545,11 +120553,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "wWN" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/box/white,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "wWP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -121444,11 +121451,14 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "xfb" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "xfc" = (
 /obj/machinery/conveyor/east{
 	dir = 1;
@@ -121875,22 +121885,18 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "xke" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/vectorrooms)
 "xki" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -121998,10 +122004,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xlL" = (
-/obj/structure/table/woodentable,
-/obj/machinery/reagentgrinder/portable,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/catwalk,
+/obj/structure/invislight,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/meadow)
 "xlP" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Post";
@@ -122204,9 +122211,12 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xmO" = (
-/obj/structure/flora/small/grassb1,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "xmV" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/nightmare,
@@ -122262,19 +122272,11 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "xnv" = (
-/obj/machinery/light{
+/obj/effect/floor_decal/industrial/danger{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "xnw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -122631,18 +122633,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xqJ" = (
-/obj/machinery/camera/network/church{
-	dir = 1
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "xqM" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -122713,14 +122712,17 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "xrs" = (
-/obj/structure/multiz/stairs/active{
-	dir = 1
+/obj/structure/catwalk,
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "xrx" = (
 /obj/landmark/machinery/input,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -122739,13 +122741,9 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "xrD" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "xrF" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 6;
@@ -123186,14 +123184,10 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "xwB" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/biomatter,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/floor_decal/industrial/danger,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "xwH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/random/flora/jungle_tree,
@@ -123353,14 +123347,25 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xyC" = (
-/obj/structure/bed/chair/sofa/black/right{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "xyJ" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/armory)
@@ -123587,16 +123592,24 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "xBq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "xBr" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,3"
@@ -123805,14 +123818,14 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "xDf" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "xDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -123928,20 +123941,11 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xEe" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/engineering/atmos/storage)
 "xEk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/wood,
@@ -124608,23 +124612,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "xKz" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/conveyor_switch{
+	id = "disposals grinder"
 	},
-/obj/structure/disposaloutlet,
-/obj/machinery/conveyor/south{
-	id = "junk_to_bioreactor"
-	},
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0";
-	tag = "icon-railing0 (NORTH)"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/floor_decal/industrial/danger,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "xKD" = (
 /obj/structure/grille,
 /turf/simulated/floor/asteroid/grass,
@@ -124887,10 +124883,12 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "xMy" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/replenishing/chalice,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "xMA" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -126481,11 +126479,9 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "ycP" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/open,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/closet/custodial,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "ycR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -126730,13 +126726,15 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "yfE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "yfL" = (
 /obj/item/storage/briefcase/inflatable{
 	pixel_x = 3;
@@ -127136,15 +127134,18 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "yjK" = (
-/obj/structure/multiz/stairs/active/bottom{
-	dir = 1
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/prime)
 "yjM" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -127298,11 +127299,10 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
 "ylz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/light,
+/obj/machinery/vending/fortune,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "ylB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -193698,13 +193698,13 @@ vvL
 wAo
 xPH
 xPH
-wpu
-ntC
-ntC
-ntC
-egd
-ntC
-lUP
+dzK
+qHh
+qHh
+qHh
+rby
+qHh
+hHU
 xGi
 sFI
 sFI
@@ -193906,7 +193906,7 @@ xGi
 xGi
 xGi
 beK
-vAx
+buS
 beK
 sFI
 sFI
@@ -194108,7 +194108,7 @@ sFI
 sFI
 sFI
 beK
-gHI
+qUT
 beK
 sFI
 sFI
@@ -194310,7 +194310,7 @@ sFI
 sFI
 sFI
 beK
-xEe
+uQx
 beK
 sFI
 sFI
@@ -194512,7 +194512,7 @@ sFI
 sFI
 sFI
 beK
-gHI
+qUT
 beK
 sFI
 sFI
@@ -194714,7 +194714,7 @@ sFI
 beK
 beK
 beK
-mLR
+kyt
 beK
 beK
 beK
@@ -194916,7 +194916,7 @@ sFI
 beK
 eWs
 mCq
-iRf
+fEH
 vgv
 tZa
 mUh
@@ -195118,7 +195118,7 @@ sFI
 beK
 hov
 uww
-dnk
+qTC
 naZ
 dMu
 xhZ
@@ -195320,7 +195320,7 @@ sFI
 beK
 uHt
 uww
-eSm
+czb
 mxC
 wuq
 mBO
@@ -195521,9 +195521,9 @@ beK
 beK
 beK
 mCq
-fuZ
-vMK
-tZL
+dtG
+jkf
+kFQ
 gcr
 gzw
 vcq
@@ -195715,16 +195715,16 @@ jPJ
 iVn
 byG
 ult
-kPg
-rby
-iGZ
-nFm
-ifo
-fEH
-nFm
+jTG
+fAA
+uCH
+vmm
+iRf
+dEk
+vmm
 bho
 xhZ
-mHf
+doA
 mxC
 gcr
 tkm
@@ -195924,9 +195924,9 @@ beK
 beK
 beK
 beK
-xnv
-uaN
-hpq
+eit
+vMQ
+suE
 mxC
 hCa
 tNb
@@ -196126,10 +196126,10 @@ sFI
 sFI
 sFI
 beK
-deL
+uaN
 puT
-ejM
-uZv
+fuZ
+qfx
 nvW
 hpm
 hpm
@@ -196328,16 +196328,16 @@ sFI
 sFI
 sFI
 beK
-fgb
+tZT
 rOL
-hmk
+qBQ
 eyI
 ctG
 ctC
 wIe
 mCq
 naZ
-kxQ
+eMK
 beK
 sFI
 ula
@@ -196532,7 +196532,7 @@ sFI
 beK
 oPl
 uUJ
-oMM
+nxH
 aUn
 aUn
 qHo
@@ -196734,7 +196734,7 @@ sFI
 beK
 azM
 uUJ
-dtG
+kyl
 aUn
 aUn
 sDT
@@ -196942,8 +196942,8 @@ usk
 jeg
 vcq
 mCq
-fyb
-qUt
+qgM
+cRj
 beK
 beK
 beK
@@ -197138,17 +197138,17 @@ sFI
 beK
 tgh
 mCq
-hNx
+tJf
 xhZ
 mCq
 mCq
 mCq
 mCq
-fyb
-esz
-esz
-qGp
-hpc
+qgM
+sZu
+sZu
+hmk
+ncd
 beK
 sFI
 sFI
@@ -197339,18 +197339,18 @@ sFI
 beK
 beK
 sJX
-cTB
-nJR
-xDf
+uqM
+uGA
+wVv
 mCq
 mCq
 mCq
-esz
-fyb
-esz
-esz
-lLw
-yjK
+sZu
+qgM
+sZu
+sZu
+nrD
+fgb
 beK
 sFI
 sFI
@@ -197540,16 +197540,16 @@ sFI
 sFI
 beK
 hSC
-cTB
-eMx
+uqM
+tmF
 bMK
-bal
-oVv
+gxd
+gHI
 lti
 rCq
 dMu
-uZv
-kbl
+qfx
+ejM
 beK
 beK
 beK
@@ -197741,13 +197741,13 @@ uNP
 uNP
 uNP
 beK
-vXR
+eMx
 nSn
 nSn
 oYg
 nSn
-vMQ
-mPy
+wgN
+uUU
 beK
 mCq
 rhf
@@ -197938,17 +197938,17 @@ vQv
 vQv
 uOb
 cSt
-qfx
-rxq
-ldw
-jwd
-gxd
-oTp
-oTp
-oTp
-oTp
-oTp
-oTp
+bwG
+mLR
+rrx
+fPE
+jHL
+jXd
+jXd
+jXd
+jXd
+jXd
+jXd
 mAy
 beK
 lZC
@@ -198140,24 +198140,24 @@ uim
 uWe
 vIm
 cSt
-sPh
-jte
-rig
+xKz
+oVv
+xnv
 uNP
-dXG
-dXG
-dXG
-dXG
+kVO
+kVO
+kVO
+kVO
 beK
 beK
-fuZ
-fuZ
-fuZ
+dtG
+dtG
+dtG
 mCq
-vIL
+tzn
 mCq
-ucs
-ucs
+tby
+tby
 beK
 sFI
 sFI
@@ -198342,9 +198342,9 @@ dvQ
 uWK
 vIm
 pBF
-hHU
-qzx
-mRi
+xwB
+ivC
+nol
 uNP
 sFI
 sFI
@@ -198352,14 +198352,14 @@ sFI
 sFI
 sFI
 beK
-fuZ
-fuZ
-fuZ
-cUo
-nxH
+dtG
+dtG
+dtG
+ktR
+qUt
 vcq
-ucs
-ucs
+tby
+tby
 beK
 sFI
 gfQ
@@ -198544,9 +198544,9 @@ vQv
 vQv
 jkc
 cSt
-rjV
-wQW
-sSM
+rGx
+aJN
+xfb
 uNP
 sFI
 sFI
@@ -198554,14 +198554,14 @@ sFI
 sFI
 sFI
 beK
-eVP
-eVP
-eVP
+hVD
+hVD
+hVD
 mCq
 mCq
 mCq
-vfg
-xwB
+cTB
+hbi
 beK
 gfQ
 gfQ
@@ -198746,9 +198746,9 @@ vQv
 vQv
 jkc
 nmW
-rHD
-fkm
-rEA
+mVE
+cKd
+tPN
 uNP
 sFI
 sFI
@@ -198756,14 +198756,14 @@ sFI
 sFI
 sFI
 beK
-fgM
-fgM
-fgM
+oJb
+oJb
+oJb
 mCq
 mCq
-lVU
-lVU
-lVU
+esz
+esz
+esz
 beK
 gfQ
 vNF
@@ -198948,9 +198948,9 @@ dvQ
 uWe
 vIm
 cSt
-waf
-wQW
-vvO
+fyb
+aJN
+kEe
 uNP
 sFI
 sFI
@@ -198958,14 +198958,14 @@ sFI
 sFI
 sFI
 beK
-tzn
-sZu
-sZu
+aED
+bPm
+bPm
 mCq
-raN
-kOD
-kOD
-kOD
+rqm
+wWN
+wWN
+wWN
 beK
 gfQ
 wHA
@@ -199150,9 +199150,9 @@ tKp
 tQX
 vIm
 cSt
-gnT
-fPi
-ucl
+qyo
+vXR
+nRM
 uNP
 sFI
 sFI
@@ -199352,9 +199352,9 @@ vQv
 vQv
 jkc
 cSt
-gnT
-eIV
-qTC
+qyo
+xEe
+cDx
 uNP
 sFI
 sFI
@@ -199554,9 +199554,9 @@ vQv
 vQv
 vIm
 cSt
-qfx
-qvn
-sFL
+bwG
+pyY
+mxN
 uNP
 sFI
 sFI
@@ -224409,7 +224409,7 @@ vrp
 vrp
 uEB
 leU
-uGA
+qDa
 vUJ
 xcy
 sbB
@@ -224834,7 +224834,7 @@ bjU
 vUJ
 vUJ
 vUJ
-xmO
+dnk
 vUJ
 vUJ
 vUJ
@@ -225019,7 +225019,7 @@ uEB
 pIy
 quu
 vUJ
-uGA
+qDa
 leU
 leU
 leU
@@ -225237,7 +225237,7 @@ vUJ
 vUJ
 vUJ
 vUJ
-cRj
+mBf
 sbB
 sbB
 xcy
@@ -225627,7 +225627,7 @@ leU
 sbB
 pDw
 mkI
-kSK
+dNI
 leU
 bjU
 xcy
@@ -226246,7 +226246,7 @@ sbB
 sbB
 mkI
 vUJ
-pLt
+bPu
 bjU
 leU
 leU
@@ -226643,7 +226643,7 @@ mET
 vUJ
 vUJ
 sbB
-uCH
+ekD
 sbB
 sbB
 hvW
@@ -227225,7 +227225,7 @@ cjv
 fJv
 wBa
 pwm
-qwE
+dNo
 uEV
 ciH
 gba
@@ -227646,7 +227646,7 @@ vTn
 nyS
 cKe
 jBi
-fCn
+jHx
 leR
 oHf
 oHf
@@ -227848,7 +227848,7 @@ gEY
 wrl
 oal
 cVR
-uQx
+omK
 jaT
 hpV
 hpV
@@ -228050,7 +228050,7 @@ pwm
 pwm
 aot
 njl
-uQx
+omK
 stq
 iVt
 aJG
@@ -228252,7 +228252,7 @@ pwm
 pwm
 aot
 ved
-uQx
+omK
 stq
 iVt
 aJG
@@ -228454,7 +228454,7 @@ aug
 fMZ
 jeo
 puc
-uQx
+omK
 gOa
 gaS
 gaS
@@ -228656,10 +228656,10 @@ stG
 wzY
 kCJ
 hYL
-uQx
+omK
 tpO
-sxY
-sxY
+cNE
+cNE
 aot
 hLv
 hLv
@@ -229047,7 +229047,7 @@ epc
 moX
 xFe
 koI
-ugj
+rcV
 fKf
 wIm
 fKf
@@ -229088,8 +229088,8 @@ leU
 leU
 leU
 leU
-cZV
-cZV
+rEA
+rEA
 kfg
 aCl
 nfX
@@ -229256,9 +229256,9 @@ hcE
 kOW
 kOW
 kOW
-mcP
+rwF
 kOW
-mcP
+rwF
 kOW
 kOW
 kOW
@@ -229290,8 +229290,8 @@ leU
 leU
 leU
 leU
-cZV
-cZV
+rEA
+rEA
 hgC
 hgC
 hgC
@@ -229451,18 +229451,18 @@ epc
 rjh
 gSM
 kOW
-mVE
+wQW
 dsj
-miP
+iAo
 dsj
 ndM
 kOW
 aFx
 lpW
-bmx
+aAy
 aFx
 lpW
-nRM
+hMs
 kOW
 bVb
 bVb
@@ -229472,27 +229472,27 @@ wVU
 dld
 dld
 pDI
-pYx
-pYx
-pYx
-pYx
-pYx
-pYx
-pYx
-pYx
-pYx
-pYx
-pYx
-kyl
-cZV
-cZV
-cZV
-cZV
-cZV
-cZV
-cZV
-cZV
-cZV
+jVP
+jVP
+jVP
+jVP
+jVP
+jVP
+jVP
+jVP
+jVP
+jVP
+jVP
+cox
+rEA
+rEA
+rEA
+rEA
+rEA
+rEA
+rEA
+rEA
+rEA
 lxo
 aot
 hgC
@@ -229661,7 +229661,7 @@ pci
 pQO
 aFx
 fiW
-qHh
+mcP
 fiW
 dsj
 aFx
@@ -229685,7 +229685,7 @@ bSp
 fCA
 nRc
 nRc
-kFQ
+yfE
 vUJ
 vUJ
 vUJ
@@ -229859,23 +229859,23 @@ qFY
 dsj
 dsj
 dsj
-xfb
+mtA
 pQO
-kMZ
+fgM
 fiW
-qHh
+mcP
 fiW
 dsj
-lfc
+eSm
 aFx
 aFx
-kyt
+uYT
 kOW
 kOW
 iUs
 dld
 dld
-ikj
+vCh
 nRc
 nRc
 neA
@@ -230059,25 +230059,25 @@ pmt
 kOW
 cxA
 dsj
-eit
+xMy
 dsj
 xOv
 kOW
-eTj
+vKM
 fiW
-qHh
+mcP
 fiW
 dsj
-lfc
+eSm
 wGn
 aFx
 dsj
 pQO
-mcP
+rwF
 iUs
 dld
 dld
-ikj
+vCh
 nRc
 nRc
 neA
@@ -230257,29 +230257,29 @@ pwm
 pwm
 jZV
 qMM
-vCh
+waT
 kOW
 kOW
-uOA
-ccn
-uVx
+nTE
+raN
+oMM
 kOW
 kOW
-rGx
+uZv
 fiW
-qHh
-bPu
+mcP
+dmD
 dsj
 aFx
 pVr
 pVr
 dsj
 pQO
-mcP
-fBV
+rwF
+owI
 dld
 dld
-ikj
+vCh
 nRc
 nRc
 sgF
@@ -230463,13 +230463,13 @@ mMj
 hcE
 rQU
 rrG
-cye
+oSN
 dsj
-oaI
-ncd
+mHf
+oNA
 aFx
 aFx
-tpj
+cxF
 aFx
 aFx
 aFx
@@ -230477,11 +230477,11 @@ xDI
 dsj
 dsj
 pQO
-mcP
-cKd
+rwF
+gou
 dld
 dld
-ikj
+vCh
 nRc
 nRc
 neA
@@ -230663,12 +230663,12 @@ jZV
 czp
 eJY
 kQv
-jHx
+ucs
 nur
-bPm
+iWQ
+fxv
+fxv
 ddN
-ddN
-jkf
 bND
 ezK
 ePE
@@ -230679,11 +230679,11 @@ eks
 dsj
 dsj
 pQO
-mcP
+rwF
 cUi
 dld
 dld
-ikj
+vCh
 nRc
 nRc
 neA
@@ -230867,9 +230867,9 @@ cvN
 vFt
 jjQ
 cAW
-aQF
+xmO
 dsj
-hkR
+kwb
 hcE
 aFx
 aFx
@@ -230881,11 +230881,11 @@ pVr
 dsj
 dsj
 pQO
-mcP
-ucY
+rwF
+sPh
 dld
 dld
-ikj
+vCh
 nRc
 nRc
 wMt
@@ -231065,17 +231065,17 @@ bfy
 xjG
 sAh
 wXd
-weP
+vvO
 kOW
 kOW
-hbi
-nrD
-uVx
+jnw
+klX
+oMM
 kOW
 kOW
-rGx
+uZv
 fiW
-aQF
+xmO
 fiW
 dsj
 aFx
@@ -231083,11 +231083,11 @@ pVr
 eUn
 dsj
 pQO
-mcP
-quT
+rwF
+ucY
 dld
 dld
-ikj
+vCh
 nRc
 nRc
 neA
@@ -231269,27 +231269,27 @@ rIb
 qMM
 qrQ
 kOW
-rqm
-gRP
-nvB
+boU
+cUo
+gXz
 dsj
-nmo
+ylz
 kOW
-eTj
+vKM
 fiW
-cfH
+aQF
 fiW
 rrG
-lfc
+eSm
 wGn
 aFx
 dsj
 pQO
-mcP
+rwF
 iUs
 dld
 dld
-ikj
+vCh
 nRc
 nRc
 sgF
@@ -231471,27 +231471,27 @@ uHd
 qMM
 uPn
 pQO
-vWA
-gRP
+mKY
+cUo
 dsj
 dsj
-mtA
+llg
 pQO
 aFx
 fiW
-cfH
+aQF
 fiW
 dsj
-lfc
+eSm
 aFx
 aFx
-kyt
+uYT
 kOW
 kOW
 iUs
 dld
 dld
-ikj
+vCh
 nRc
 nRc
 neA
@@ -231673,11 +231673,11 @@ she
 jlQ
 ebN
 pQO
-vWA
-gRP
+mKY
+cUo
 dsj
 dsj
-mtA
+llg
 pQO
 aFx
 fiW
@@ -231686,14 +231686,14 @@ fiW
 dsj
 aFx
 tVS
-lfc
+eSm
 aFx
 kOW
 iUs
 iUs
 dld
 dld
-ikj
+vCh
 nRc
 nRc
 neA
@@ -231875,18 +231875,18 @@ qMI
 pQa
 qmD
 kOW
-buS
-uYT
-doA
-owI
-vFR
+pYx
+efu
+lnV
+nmo
+xqJ
 kOW
-tPN
+pNu
 tVS
-iZz
+ntC
 aFx
 tVS
-nRM
+hMs
 kOW
 bVb
 bVb
@@ -231907,7 +231907,7 @@ lFw
 hbK
 nRc
 nRc
-kDY
+kSK
 vUJ
 vUJ
 eqh
@@ -232098,18 +232098,18 @@ wVU
 dld
 dld
 pDI
-cDx
-cDx
-cDx
-cDx
-cDx
-cDx
-cDx
-cDx
-cDx
-cDx
-cDx
-kyl
+xrs
+xrs
+xrs
+xrs
+xrs
+xrs
+xrs
+xrs
+xrs
+xrs
+xrs
+cox
 vUJ
 vUJ
 vUJ
@@ -232245,9 +232245,9 @@ veZ
 cwr
 cwr
 cwr
-sOa
-sOa
-czb
+ajp
+ajp
+fCn
 ook
 tcp
 tcp
@@ -232284,31 +232284,31 @@ xGz
 wzU
 riw
 tZm
-wSl
+miP
 yiO
 riw
-dCC
-qWT
-hSz
-hSz
+xDf
+kpf
+pBQ
+pBQ
 vwJ
-aAy
-aAy
+fsi
+fsi
 rqj
-dBr
+rHD
 dld
 dld
 dld
 vLi
 vLi
 qgJ
-xrD
-pyY
+ifo
+vsx
 oei
 qgJ
 tqr
-dBR
-qyo
+fkm
+sMN
 qgJ
 vLi
 vLi
@@ -232447,10 +232447,10 @@ veZ
 veZ
 cwr
 cwr
-sOa
-sOa
-czb
-sOa
+ajp
+ajp
+fCn
+ajp
 tcp
 rva
 mNx
@@ -232489,13 +232489,13 @@ oQZ
 elF
 xzr
 riw
-hSz
+pBQ
 rYv
 rYv
 rYv
 vwJ
-nib
-nib
+deL
+deL
 rqj
 gzr
 dld
@@ -232649,10 +232649,10 @@ veZ
 veZ
 cwr
 cwr
-sOa
-sOa
-czb
-sOa
+ajp
+ajp
+fCn
+ajp
 tcp
 uCI
 sOt
@@ -232687,19 +232687,19 @@ uXK
 uXK
 oXE
 riw
-koL
+bkH
 qox
 opN
 riw
 cNP
-cox
+uTQ
 jAU
 rYv
 vwJ
-aAy
-aAy
+fsi
+fsi
 rqj
-dBr
+rHD
 dld
 dld
 dld
@@ -232852,9 +232852,9 @@ veZ
 cwr
 cwr
 nYl
-dzK
-czb
-sOa
+bmx
+fCn
+ajp
 tcp
 fPz
 gPf
@@ -232889,16 +232889,16 @@ dFx
 bAk
 oXE
 riw
-klX
-efu
+lLw
+lVU
 nlp
 riw
-kwb
-pZI
-xlL
-xqJ
+ldw
+vFR
+aAw
+ugn
 riw
-wVv
+xlL
 kbv
 riw
 vMI
@@ -233054,8 +233054,8 @@ veZ
 cwr
 cwr
 lPU
-dzK
-czb
+bmx
+fCn
 weh
 tcp
 rzR
@@ -233091,14 +233091,14 @@ nBw
 fLG
 oXE
 riw
-fqE
-mxN
-ktR
+hpc
+lUP
+sUM
 riw
 int
 vsl
-bwG
-dmD
+rxq
+ugj
 riw
 tTa
 tTa
@@ -233255,9 +233255,9 @@ wLD
 veZ
 cwr
 cwr
-omK
-omK
-czb
+tZL
+tZL
+fCn
 weh
 cwr
 xdv
@@ -233294,16 +233294,16 @@ qWG
 riw
 riw
 riw
-jHL
+xke
 riw
 riw
 riw
 sGE
-wbm
+iZz
 riw
 riw
-gou
-jXd
+xrD
+vGk
 riw
 riw
 vAX
@@ -233457,9 +233457,9 @@ veZ
 veZ
 cwr
 cwr
-omK
-omK
-czb
+tZL
+tZL
+fCn
 weh
 cwr
 mcJ
@@ -233492,17 +233492,17 @@ mJT
 pwm
 pwm
 vvK
-aED
+bZJ
 riw
 riw
-oJb
+qGp
 vdu
 rMH
 juo
-jVP
-jVP
-xBq
-epB
+riP
+riP
+ljQ
+mRi
 diT
 qQZ
 rOh
@@ -233659,9 +233659,9 @@ veZ
 veZ
 cwr
 cwr
-dzK
-dzK
-czb
+bmx
+bmx
+fCn
 weh
 cwr
 trx
@@ -233691,15 +233691,15 @@ tnR
 vaT
 vaT
 qZu
-aED
-wfn
+bZJ
+fCX
 bZF
-aED
+bZJ
 riw
-mBf
+mVl
 wFB
 qQZ
-sUM
+oqc
 orJ
 rOh
 rOh
@@ -233861,8 +233861,8 @@ veZ
 veZ
 cwr
 qau
-dzK
-dzK
+bmx
+bmx
 gCx
 weh
 cwr
@@ -233898,7 +233898,7 @@ riw
 lDz
 riw
 riw
-uUU
+iGZ
 wFB
 hAv
 mwt
@@ -234097,19 +234097,19 @@ nfq
 jMp
 riw
 grQ
-lnV
-vGk
-fCX
-qgM
-iWQ
+nJR
+wSl
+epB
+cfH
+bal
 hAv
 mwt
-ggs
+sFL
 tuI
 rOh
 qWp
 cFR
-waT
+eIV
 qQZ
 qQZ
 rjY
@@ -234295,15 +234295,15 @@ lIg
 dVl
 vaT
 qkp
-aJN
-uqM
-vsx
+sAo
+sfi
+qKJ
 oKC
-fPE
-suE
+oaI
+mPy
 riw
-hVD
-ljQ
+dXG
+hSz
 hAv
 mwt
 mwt
@@ -234497,21 +234497,21 @@ vaT
 vaT
 vaT
 qkp
-tby
+pLt
 pwm
 riw
 qza
-fAA
-dNo
+nib
+npm
 riw
 sPG
-ivC
-uTQ
-sMN
-sMN
+vfg
+tpj
+waf
+waf
 rOh
 rOh
-oSN
+wbe
 riw
 riw
 mqQ
@@ -234699,20 +234699,20 @@ sfG
 imO
 lNu
 tPK
-tby
+pLt
 pwm
 riw
 riw
 riw
-aFL
+mdn
 riw
 riw
-npm
-sAo
-aAw
-mKY
-pBQ
-jVP
+kDY
+kbl
+ggs
+gnT
+eTj
+riP
 oBo
 qQZ
 diT
@@ -234901,12 +234901,12 @@ kRE
 gxW
 mfV
 lem
-gXz
+weP
 pwm
 riw
 lkJ
 vkU
-rrx
+dBR
 riw
 riw
 riw
@@ -234915,11 +234915,11 @@ riw
 riw
 riw
 riw
-fxv
+guj
 riw
 riw
 qQZ
-guj
+oTp
 riw
 riw
 vMI
@@ -235103,20 +235103,20 @@ sfG
 imO
 bJC
 pEI
-gXz
+weP
 pwm
 riw
 riw
 riw
-cFP
+fqE
 riw
-bfZ
+usX
 sbj
 wFB
 jac
 riw
-bfZ
-kLc
+usX
+vWA
 kZn
 xwO
 riw
@@ -235130,7 +235130,7 @@ dld
 owa
 vUJ
 vhs
-tzJ
+vIL
 lOl
 hbO
 dft
@@ -235305,22 +235305,22 @@ uSX
 nnT
 vaT
 qkp
-gXz
+weP
 pwm
 riw
 lkJ
 vkU
-ekD
+kMZ
 riw
-boU
-toM
-iAo
-ylz
+meA
+dCC
+rjV
+huw
 riw
-boU
-bZJ
+meA
+cye
 rOh
-jnw
+fBV
 riw
 kbv
 kbv
@@ -235507,27 +235507,27 @@ lLF
 xJm
 vaT
 qkp
-oNA
+xyC
 pwm
 riw
 riw
 riw
 riw
 riw
-wWN
-eMK
+egd
+ikj
 qQZ
-jnw
+fBV
 riw
-wWN
+egd
 qQZ
 qQZ
 qQZ
 riw
-aAy
-aAy
+fsi
+fsi
 rqj
-dBr
+rHD
 dld
 dld
 dld
@@ -235709,7 +235709,7 @@ wan
 wxz
 vaT
 pkv
-gXz
+weP
 pwm
 xGz
 xGz
@@ -235727,9 +235727,9 @@ gzV
 vtp
 riw
 qQO
-nib
+deL
 rqj
-pNu
+mce
 dld
 dld
 dld
@@ -235911,7 +235911,7 @@ dXg
 kLp
 vaT
 nvI
-gXz
+weP
 pwm
 xGz
 xGz
@@ -235928,13 +235928,13 @@ riw
 riw
 riw
 riw
-aAy
-aAy
+fsi
+fsi
 rqj
-dBr
-kVO
+rHD
+qwE
 dld
-yfE
+quT
 dld
 jZI
 jZI
@@ -236113,7 +236113,7 @@ wIg
 uob
 gUg
 brN
-gXz
+weP
 pwm
 xGz
 xGz
@@ -236315,7 +236315,7 @@ fsM
 aom
 vaT
 soq
-gXz
+weP
 pwm
 xGz
 xGz
@@ -236332,8 +236332,8 @@ ouv
 mmt
 opH
 opH
-sdY
-sdY
+rig
+rig
 uVK
 uVK
 uVK
@@ -236517,7 +236517,7 @@ bqj
 vaT
 vaT
 soq
-oNA
+xyC
 pwm
 xGz
 xGz
@@ -236538,10 +236538,10 @@ spV
 spV
 uVK
 qrB
-qKJ
+vAx
 lze
-fsi
-fsi
+ycP
+ycP
 gUk
 itH
 jje
@@ -236719,14 +236719,14 @@ pwm
 pwm
 gTr
 fID
-tby
+pLt
 pwm
 xGz
 xGz
 opH
 hHX
-xMy
-cNE
+koL
+hQO
 yex
 opH
 opH
@@ -236737,8 +236737,8 @@ fpd
 opH
 opH
 mZy
-dNI
-rwF
+pes
+nvB
 spV
 spV
 spV
@@ -236921,7 +236921,7 @@ xGz
 pwm
 soq
 pwm
-mce
+xBq
 pwm
 xGz
 xGz
@@ -236939,10 +236939,10 @@ gMa
 wtw
 opH
 mqs
-bkH
-dEk
+dBr
+qWT
 vkI
-dEk
+qWT
 qbh
 rnS
 xok
@@ -237123,7 +237123,7 @@ pwm
 pwm
 uIC
 pwm
-mce
+xBq
 pwm
 xGz
 xGz
@@ -237132,23 +237132,23 @@ pzk
 gMa
 vqG
 gMa
-vKM
+hNx
 gMa
 gMa
 geA
 xgI
 vfv
 fqG
-lhz
-ajp
+yjK
+pZI
 ezs
-wgN
+lhz
 kAU
-wgN
+lhz
 oeV
 msx
 wSh
-dEk
+qWT
 qwK
 gJe
 pdt
@@ -237325,7 +237325,7 @@ pwm
 dkm
 vMU
 xTb
-gXz
+weP
 pwm
 xGz
 xGz
@@ -237343,14 +237343,14 @@ eCm
 uBy
 opH
 nuM
-pes
+uOA
 gkZ
 uVK
 uVK
 uVK
 spV
-huw
-wgN
+fBw
+lhz
 gWi
 rIc
 sdN
@@ -237526,32 +237526,32 @@ seQ
 bVD
 wWa
 bXy
-hMs
-gXz
+ccn
+weP
 pwm
 xGz
 xGz
 opH
 hvz
 ujR
-gSa
-wbe
+jwd
+wpu
 opH
 uRw
-pPU
-kEe
-vmm
-mVl
-ugn
+fPi
+uVx
+sdY
+lfc
+aFL
 opH
-qBQ
+sOa
 spV
-nTE
+wfn
 uVK
-xrs
-tZT
+pPU
+cZV
 spV
-fBw
+nFm
 gUk
 ewj
 gYP
@@ -237728,8 +237728,8 @@ pwm
 pwm
 soz
 pwm
-hMs
-tby
+ccn
+pLt
 pwm
 xGz
 xGz
@@ -237743,20 +237743,20 @@ opH
 opH
 opH
 opH
-xyC
-kpf
-opH
-rcV
-llg
-tmF
-uVK
-cxF
-qUT
-spV
+kOD
 jsM
+opH
+qBq
+qzx
+jte
+uVK
+kLc
+hkR
+spV
+sxY
 gUk
 kHd
-nol
+hpq
 sdN
 rEL
 rEL
@@ -237930,8 +237930,8 @@ veZ
 pwm
 rYq
 pwm
-hMs
-meA
+ccn
+gRP
 xwU
 xwU
 xwU
@@ -237942,8 +237942,8 @@ etH
 bvz
 bvz
 bvz
-qBq
 wjD
+ucl
 opH
 opH
 opH
@@ -237958,7 +237958,7 @@ uVK
 uVK
 gUk
 kHd
-nol
+hpq
 pdx
 utp
 oly
@@ -238132,25 +238132,25 @@ veZ
 pwm
 rsS
 pwm
-riP
-oqc
+qvn
+toM
 rQO
-tJf
+sSM
 rQO
 rQO
 rQO
-xke
+eVP
 ctQ
-xKz
-ycP
-ycP
+bfZ
+tzJ
+tzJ
 pwm
 mQc
-hQO
+vMK
 bvz
 bvz
 bvz
-qBq
+wjD
 bvz
 bvz
 bvz
@@ -238540,22 +238540,22 @@ aHk
 aHk
 hJp
 aHk
-mdn
+wbm
 hJp
-mdn
+wbm
 uVi
 hJp
-mdn
-mdn
-mdn
+wbm
+wbm
+wbm
 vMo
-mdn
-mdn
+wbm
+wbm
 vMo
-mdn
+wbm
 vMo
 bLR
-usX
+cFP
 bLR
 bLR
 bLR
@@ -239363,7 +239363,7 @@ veZ
 veZ
 veZ
 vzY
-qDa
+kxQ
 vzY
 vzY
 vzY
@@ -239776,7 +239776,7 @@ vzY
 eip
 npq
 gUk
-jTG
+gSa
 pNT
 srq
 xAC

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -2506,25 +2506,31 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "aAw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/cable/yellow{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey,
+/obj/structure/cable/yellow,
+/obj/machinery/light,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "aAy" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "aAN" = (
 /obj/structure/table/rack/shelf,
 /obj/random/junk/low_chance,
@@ -2867,8 +2873,9 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "aED" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "aEL" = (
@@ -2986,11 +2993,11 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/detectives_office)
 "aFL" = (
-/obj/item/tool/knife/neotritual,
-/obj/item/clothing/gloves/psionic_ring,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "aFM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3380,11 +3387,13 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/prisoncells)
 "aJN" = (
-/obj/structure/catwalk,
-/obj/structure/invislight,
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/wall_obelisk{
+	pixel_x = 1;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "aJP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5083,14 +5092,9 @@
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
 "bal" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "bam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
@@ -5702,13 +5706,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bfZ" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/reagent_dispensers/biomatter/large,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "bgc" = (
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -6111,12 +6112,20 @@
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
 "bkH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "bkM" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -6342,14 +6351,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bmx" = (
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/hallway/side/f2section1)
 "bmy" = (
 /obj/structure/railing{
 	dir = 1;
@@ -6605,10 +6610,15 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
 "boU" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/box/white,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "boY" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "WO"
@@ -6731,11 +6741,6 @@
 /obj/machinery/door/unpowered/simple/wood/saloon,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/cafeteria)
-"bqh" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
 "bqj" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -7097,6 +7102,12 @@
 /obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/cryo)
+"btO" = (
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = -32
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "btP" = (
 /obj/structure/sign/department/drones,
 /turf/simulated/wall/r_wall,
@@ -7206,14 +7217,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "buS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/catwalk,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/skyyard)
 "buT" = (
 /obj/effect/window_lwall_spawn,
 /turf/simulated/floor/plating/under,
@@ -7422,25 +7431,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bwG" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/railing,
+/obj/machinery/camera/network/church{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/random/mob/roaches/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "bwJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -7746,16 +7742,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
-"bAa" = (
-/obj/machinery/vending/theomat,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
 "bAb" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/asteroid/dirt,
@@ -8218,6 +8204,13 @@
 /area/nadezhda/rnd/docking{
 	name = "\improper Upper Research Hallway"
 	})
+"bFp" = (
+/obj/machinery/camera/network/church{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "bFx" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -9102,10 +9095,13 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "bPm" = (
-/obj/machinery/light,
-/obj/machinery/vending/fortune,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/bed/chair/sofa/brown/right,
+/obj/landmark/join/start/acolyte,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "bPp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -9124,13 +9120,16 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/quartermaster/disposaldrop)
 "bPu" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/area/colony)
 "bPJ" = (
 /obj/structure/flora/small/busha1,
 /obj/random/flora/jungle_tree,
@@ -10093,10 +10092,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "bZJ" = (
+/obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
+	},
+/area/nadezhda/hallway/side/f2section1)
 "bZL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10395,15 +10398,18 @@
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/plasma_tag)
 "ccn" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/glass/urn/veteran{
+	pixel_x = 7
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/item/oddity/nt/pyramid{
+	pixel_x = -9
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "cco" = (
 /obj/machinery/light{
 	dir = 1;
@@ -10633,15 +10639,12 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cfH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "cfK" = (
 /obj/machinery/camera/xray/security{
 	dir = 9
@@ -11495,14 +11498,15 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cox" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/biomatter,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/random/furniture/pottedplant,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "coC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -12460,14 +12464,19 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "cxF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "cxN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12524,12 +12533,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cye" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/chapel)
 "cyf" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/pros/foreman)
@@ -12626,15 +12634,15 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
 "czb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/tool/multitool,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "czd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -13178,16 +13186,19 @@
 	name = "Dormitory 1"
 	})
 "cDx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/power/eotp,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "cDF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13399,22 +13410,23 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/command/bridgebar)
 "cFP" = (
-/obj/structure/cable/yellow{
-	d1 = 32;
-	icon_state = "32-1"
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+/obj/structure/disposaloutlet,
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
 	},
-/obj/structure/railing/grey{
+/obj/structure/railing{
 	dir = 1;
-	icon_state = "grey_railing0"
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
-/obj/structure/catwalk,
-/turf/simulated/open,
-/area/nadezhda/absolutism/storage)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/hallway/surface/section1)
 "cFR" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/blast/regular/open{
@@ -13798,20 +13810,12 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/bridge)
 "cKd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "cKe" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -14155,14 +14159,23 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/surface/section1)
 "cNE" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "cNF" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/unsimulated/wall/jungle,
@@ -14419,17 +14432,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "cRj" = (
-/obj/structure/bed/chair/sofa/black/right{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 32
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/meadow)
 "cRq" = (
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark/panels,
@@ -14642,13 +14647,8 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
 "cTB" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/church_reinforced,
 /area/nadezhda/absolutism/bioreactor)
 "cTE" = (
 /obj/structure/closet/wall_mounted/emcloset{
@@ -14772,14 +14772,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "cUo" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/rock/manmade/road,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "cUx" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 1
@@ -15219,11 +15215,13 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
 "cZV" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "dar" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/railing/grey{
@@ -15578,10 +15576,10 @@
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
 "ddN" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "ddR" = (
 /obj/structure/ore_box,
@@ -15733,12 +15731,16 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "deL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "deM" = (
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/structure/table/standard,
@@ -16086,17 +16088,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
-"diH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
 "diQ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16431,15 +16422,24 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "dmD" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4;
-	name = "biomatter chute"
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "dmG" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/camera/network/medbay{
@@ -16527,24 +16527,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
 "dnk" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "dnl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -16662,17 +16648,15 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "doA" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/machinery/conveyor/south{
-	id = "junk_to_bioreactor"
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "doD" = (
 /obj/structure/catwalk,
 /obj/random/cluster/roaches/low_chance,
@@ -17269,24 +17253,12 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
 "dtG" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "dup" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/rock,
@@ -17846,9 +17818,10 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dzK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "dzS" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "16,9"
@@ -18016,13 +17989,10 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "dBr" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 1;
-	name = "trash chute"
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "dBt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -18036,11 +18006,15 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "dBR" = (
-/obj/structure/table/woodentable,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "dBU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18166,20 +18140,12 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/bridgebar)
 "dCC" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "dCH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -18317,16 +18283,9 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dEk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/bed/chair/comfy/brown,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "dEo" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -19196,11 +19155,16 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "dNo" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/smartfridge/kitchen/church,
-/turf/simulated/floor/tiled/cafe,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/storage/fancy/crayons,
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/crayons,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "dNp" = (
 /obj/effect/floor_decal/border/techfloor{
@@ -19250,10 +19214,31 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "dNI" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 1";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "dNK" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,18"
@@ -20145,13 +20130,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "dXG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/light/small,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
+/obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "dXJ" = (
@@ -20952,16 +20936,11 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
 "efu" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/invislight,
+/obj/machinery/camera/network/church,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_room)
+/area/nadezhda/outside/meadow)
 "efv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21066,17 +21045,12 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "egd" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "egg" = (
 /obj/structure/table/rack/shelf,
 /obj/random/pack/cloth/low_chance,
@@ -21299,11 +21273,13 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "eit" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/table/woodentable,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/turf/simulated/open,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "eix" = (
 /obj/structure/table/steel,
 /obj/machinery/microwave,
@@ -21395,12 +21371,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ejM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_x = -20
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/smartfridge/kitchen/church,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "ejZ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -21457,19 +21433,11 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "ekD" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/item/tool/knife/neotritual,
+/obj/item/clothing/gloves/psionic_ring,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "ekF" = (
 /obj/structure/table/rack/shelf,
 /obj/random/mecha_equipment/low_chance,
@@ -21922,25 +21890,19 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "epB" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Prime's Office";
-	departmentType = 22;
-	name = "Prime's RC";
-	pixel_x = 30;
-	pixel_y = 0
-	},
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Prime's Office"
-	},
-/obj/structure/cable/green{
+/obj/structure/cable/cyan{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating/under,
+/area/colony)
 "epH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22230,9 +22192,19 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "esz" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "esA" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -22701,6 +22673,13 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid,
 /area/nadezhda/rnd/xenobiology/ameridian)
+"exB" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "exD" = (
 /obj/structure/sign/warning/hazard_coldloop,
 /turf/simulated/wall/r_wall,
@@ -23686,23 +23665,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "eIV" = (
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
+/obj/random/furniture/pottedplant,
+/obj/machinery/camera/network/church{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "eIZ" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,22"
@@ -24142,12 +24116,14 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/crew_quarters/kitchen_storage)
 "eMx" = (
-/obj/machinery/light/small,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/warningred,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "eMB" = (
@@ -24173,17 +24149,8 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory_blackshield)
 "eMK" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "eMS" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -24724,7 +24691,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "eSv" = (
 /obj/effect/floor_decal/corner_techfloor_grid,
@@ -24891,12 +24858,28 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/main/stairwell)
 "eTj" = (
-/obj/structure/mopbucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/soap/deluxe,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "eTk" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -25176,19 +25159,12 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "eVP" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
@@ -26222,22 +26198,12 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "fgb" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "fgf" = (
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/hallway/main/stairwell)
@@ -26327,15 +26293,19 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "fgM" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
+/obj/structure/cable/cyan{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/bioreactor)
 "fgN" = (
 /obj/structure/cable/green{
@@ -26695,13 +26665,24 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fkm" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27329,19 +27310,20 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "fqE" = (
-/obj/machinery/camera/network/church{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock{
+	id_tag = "chudorm4";
+	name = "Church Dorm 2";
+	req_access = list(70)
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "fqF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -27501,6 +27483,16 @@
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/nadezhda/engineering/construction)
+"frF" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 4;
+	name = "biomatter chute"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "frI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27523,9 +27515,11 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
 "fsi" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/outside/meadow)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/nadezhda/hallway/surface/section1)
 "fsk" = (
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm4{
@@ -27856,9 +27850,11 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "fuZ" = (
-/obj/structure/table/woodentable,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/area/nadezhda/command/prime)
 "fvc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -28075,13 +28071,14 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "fxv" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/sign/faction/neotheology{
-	pixel_x = -30;
-	pixel_y = 0
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "fxy" = (
 /obj/machinery/door/airlock/maintenance_security{
 	req_access = list(1)
@@ -28148,9 +28145,14 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "fyb" = (
-/obj/structure/closet/coffin,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "fyc" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
@@ -28391,8 +28393,14 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical)
 "fAA" = (
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/multiz/stairs/active{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "fAG" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/simulated/floor/bluegrid{
@@ -28542,13 +28550,12 @@
 	name = "Dormitory 3"
 	})
 "fBV" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "fBY" = (
 /obj/structure/multiz/stairs/active{
 	dir = 1
@@ -28587,8 +28594,16 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/cryo)
 "fCn" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
@@ -28666,10 +28681,15 @@
 	name = "\improper Blackshield - Firing Range"
 	})
 "fCX" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/camera/network/church{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "fDb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4;
@@ -28926,11 +28946,13 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "fEH" = (
-/obj/machinery/power/nt_obelisk,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "fEJ" = (
 /obj/structure/catwalk,
@@ -29976,10 +29998,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fPi" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/hallway/surface/section1)
 "fPo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -30078,20 +30101,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "fPE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "fPG" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/camera/network/cev_eris,
@@ -31387,9 +31401,18 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/abandoned_solars/powered)
 "gdn" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "gdr" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -31805,19 +31828,15 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ggs" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "ggt" = (
 /obj/machinery/power/nt_obelisk,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -32168,6 +32187,16 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"gjo" = (
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/atm{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "gjp" = (
 /obj/effect/floor_decal/industrial/box/white,
 /obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_smallarms,
@@ -32651,11 +32680,11 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "gnT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "gnW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -32696,12 +32725,14 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
 "gou" = (
-/obj/structure/catwalk,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "gow" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -33444,19 +33475,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
 /area/colony)
-"gwj" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
 "gwv" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -33518,12 +33536,10 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "gxd" = (
-/obj/structure/railing,
-/obj/machinery/camera/network/church{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/table/woodentable,
+/obj/item/device/lighting/toggleable/lantern/censer,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "gxg" = (
 /obj/structure/closet/l3closet,
 /turf/simulated/floor/tiled/white,
@@ -34601,15 +34617,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "gHI" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/bioreactor)
 "gHJ" = (
 /obj/structure/flora/small/rock2,
 /turf/simulated/floor/asteroid/grass,
@@ -35676,11 +35686,14 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "gRP" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "gRQ" = (
 /obj/random/material/low_chance,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -35713,14 +35726,11 @@
 	name = "Dormitory 2"
 	})
 "gSa" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "gSb" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -36282,12 +36292,25 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "gXz" = (
-/obj/machinery/light_switch{
-	pixel_y = 30
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/random/scrap/dense_weighted/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "gXB" = (
 /obj/structure/sink/kitchen{
 	name = "utility sink";
@@ -36630,13 +36653,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/turret_protected/ai_upload)
 "hbi" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/closet/coffin,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "hbk" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -37571,14 +37590,8 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "hkR" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "hkW" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -37722,19 +37735,27 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "hmj" = (
-/obj/structure/flora/small/grassa5,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
-"hmk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
+"hmk" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "hmp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -38003,10 +38024,12 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/absolutism/bioreactor)
 "hpq" = (
-/obj/structure/reagent_dispensers/biomatter,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "hpu" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/effect/decal/cleanable/dirt,
@@ -38501,10 +38524,15 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
 "huw" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/conveyor_switch{
+	id = "disposals grinder"
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/floor_decal/industrial/danger,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "huC" = (
 /obj/structure/bookcase,
 /obj/item/book/ritual/cruciform,
@@ -39596,17 +39624,17 @@
 	name = "Dormitory 1"
 	})
 "hHU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "hHX" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -40025,12 +40053,21 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "hMs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "hMw" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -40130,9 +40167,14 @@
 	name = "\improper Outdoors - Pad"
 	})
 "hNx" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "hNF" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/cable/green{
@@ -40492,13 +40534,19 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "hQO" = (
-/obj/structure/closet/secure_closet/reinforced/preacher,
-/obj/item/device/taperecorder,
-/obj/item/device/camera,
-/obj/item/device/camera_film,
-/obj/item/clothing/mask/gas/germanmask,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "hQP" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -40666,16 +40714,8 @@
 /turf/unsimulated/mineral,
 /area/colony)
 "hSz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "hSA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -40948,18 +40988,18 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
 "hVD" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "hVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -41874,9 +41914,9 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ifo" = (
-/obj/effect/floor_decal/industrial/loading/white,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/small/grassa5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "ifw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/security{
@@ -42327,10 +42367,12 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
 "ikj" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "ikn" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -43454,12 +43496,19 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "ivC" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "ivM" = (
 /obj/machinery/holoposter{
 	pixel_y = 30
@@ -43912,12 +43961,9 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "iAo" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "iAq" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -44225,6 +44271,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"iDQ" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/absolutism/skyyard)
 "iDR" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/chemistry)
@@ -44578,12 +44631,14 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "iGZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "iHa" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/unsimulated/wall/jungle,
@@ -45045,23 +45100,6 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"iKX" = (
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
 "iKZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/binary/pump{
@@ -45688,14 +45726,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "iRf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/multiz/stairs/enter/bottom,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "iRh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -46297,9 +46332,11 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "iWQ" = (
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/skyyard)
 "iWS" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -46575,19 +46612,25 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "iZz" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Prime's Office";
+	departmentType = 22;
+	name = "Prime's RC";
+	pixel_x = 30;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 10
+/obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Prime's Office"
 	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "iZD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
@@ -47714,13 +47757,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "jkf" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/engineering/atmos/storage)
 "jkj" = (
 /obj/structure/table/steel,
 /obj/random/material_resources,
@@ -47847,6 +47888,17 @@
 "jlB" = (
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"jlE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "jlJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -47986,18 +48038,18 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jnw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "jny" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -48460,13 +48512,6 @@
 /obj/effect/floor_decal/industrial/arrows/white,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
-"jsb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
 "jsf" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -48568,15 +48613,17 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jsM" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atm{
-	dir = 4;
-	pixel_x = 30
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "jsR" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/gloves{
@@ -48595,12 +48642,13 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "jte" = (
-/obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	pixel_y = 0
 	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "jtl" = (
 /obj/machinery/light_switch{
 	pixel_y = 30
@@ -48886,10 +48934,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
 "jwd" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/machinery/light_switch{
+	pixel_x = 28
+	},
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "jwe" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
@@ -50022,9 +50072,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jHx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/multiz/stairs/enter{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "jHC" = (
 /obj/random/scrap/dense_weighted,
 /obj/structure/table/rack/shelf,
@@ -50044,12 +50100,11 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jHL" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/sign/faction/neotheology{
-	pixel_x = 32
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "jHS" = (
 /obj/random/contraband/low_chance,
 /obj/effect/decal/cleanable/cobweb{
@@ -50654,15 +50709,6 @@
 /obj/machinery/camera/network/colony_underground,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/crew_quarters/pool)
-"jNP" = (
-/obj/machinery/light,
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
 "jNU" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/junk/low_chance,
@@ -51271,12 +51317,17 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jTG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "jTH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/reinforced/polarized{
@@ -51551,9 +51602,13 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/barquarters)
 "jVP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "jWc" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -51650,10 +51705,12 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jXd" = (
-/obj/structure/table/woodentable,
-/obj/machinery/reagentgrinder/portable,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "jXf" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/under,
@@ -52180,15 +52237,15 @@
 	name = "\improper Clinic"
 	})
 "kbl" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/colony)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "kbm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -53284,18 +53341,21 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "klX" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
+/obj/machinery/light/small,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
 "kmc" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -53695,21 +53755,22 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "koL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "koP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53748,11 +53809,15 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
 "kpf" = (
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/hallway/side/f2section1)
 "kpi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -54197,12 +54262,13 @@
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "ktR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "ktS" = (
 /obj/structure/closet/crate,
 /obj/item/am_shielding_container,
@@ -54449,11 +54515,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "kwb" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "kwd" = (
 /obj/random/flora/jungle_tree,
 /obj/effect/decal/cleanable/dirt,
@@ -54473,6 +54540,12 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/eris/crew_quarters/plasma_tag)
+"kwk" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "kwo" = (
 /obj/structure/ore_box,
 /obj/effect/floor_decal/industrial/danger,
@@ -54622,16 +54695,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/hut_cell1)
 "kxQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/closet/secure_closet/reinforced/preacher,
+/obj/item/device/taperecorder,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/item/clothing/mask/gas/germanmask,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "kxW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54650,12 +54720,9 @@
 /turf/simulated/floor/asteroid/dirt/dark/plough,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kyl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 5
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "kym" = (
 /mob/living/simple_animal/hostile/naniteswarm{
 	desc = "A swarm of disgusting mini locusts infested with disease and hatred.";
@@ -54664,9 +54731,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kyt" = (
-/obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "kyu" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -55251,20 +55318,23 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kDY" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "kEe" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "kEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -55452,9 +55522,18 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "kFQ" = (
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/vectorrooms)
 "kFU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -55972,8 +56051,10 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kLc" = (
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "kLm" = (
 /obj/structure/table/rack/shelf,
 /obj/random/lowkeyrandom,
@@ -56191,8 +56272,25 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kMZ" = (
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "kNa" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -56344,14 +56442,14 @@
 /turf/simulated/open,
 /area/colony)
 "kOD" = (
-/obj/structure/multiz/stairs/enter{
-	dir = 1
+/obj/machinery/light,
+/obj/machinery/light_switch{
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "kOJ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -56391,13 +56489,9 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
 "kPg" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
-/area/colony)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "kPj" = (
 /obj/structure/sign/departmentold/security,
 /turf/simulated/wall/r_wall,
@@ -56779,16 +56873,9 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "kSK" = (
-/obj/structure/mirror{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/biomatter_solidifier,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/absolutism/bioreactor)
 "kSR" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/table/rack/shelf,
@@ -57113,14 +57200,24 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "kVO" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "kWa" = (
 /obj/structure/flora/big/bush2,
 /obj/effect/decal/cleanable/dirt,
@@ -57954,9 +58051,14 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ldw" = (
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "ldz" = (
 /obj/structure/holohoop{
 	dir = 1
@@ -58212,23 +58314,17 @@
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "lfc" = (
-/obj/machinery/door/airlock{
-	name = "Church";
-	req_access = list(27)
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "lfh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spider/spiderling,
@@ -58620,6 +58716,13 @@
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/panic_room)
+"lju" = (
+/obj/structure/mopbucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/soap/deluxe,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "ljw" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -58642,11 +58745,22 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ljQ" = (
-/obj/structure/bed/chair/sofa/black/left{
-	dir = 8
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/pros/foreman)
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/item/scrap_lump,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "ljT" = (
 /obj/structure/table/standard,
 /obj/item/storage/briefcase/inflatable,
@@ -58768,11 +58882,23 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "llg" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
+/obj/structure/disposaloutlet{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "llh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -59020,34 +59146,12 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "lnV" = (
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+/obj/machinery/disposal/deliveryChute{
+	dir = 1;
+	name = "trash chute"
 	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey,
-/obj/structure/sign/faction/derelict1{
-	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
-	name = "NOTICE: Dangerous Biohazard";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/under,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "lnW" = (
 /obj/item/clothing/suit/armor/platecarrier/ih,
@@ -60094,12 +60198,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/command/teleporter)
-"lyG" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/prime)
 "lyI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -61423,14 +61521,9 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/barbackroom)
 "lLw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/catwalk,
-/obj/random/scrap/dense_weighted/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "lLB" = (
 /obj/machinery/atmospherics/omni/mixer{
 	active_power_usage = 7500;
@@ -62433,12 +62526,24 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "lUP" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "lUR" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -62551,23 +62656,21 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
 "lVU" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposaloutlet,
-/obj/machinery/conveyor/south{
-	id = "junk_to_bioreactor"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0";
-	tag = "icon-railing0 (NORTH)"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "lVV" = (
 /obj/machinery/power/breakerbox{
 	RCon_tag = "AI Core Substation Bypass"
@@ -63133,6 +63236,20 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/cafeteria)
+"mbU" = (
+/obj/structure/multiz/stairs/active{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/sign/levels/stairsdown{
+	pixel_y = -30;
+	pixel_x = 32
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "mca" = (
 /obj/machinery/camera/network/command{
 	dir = 1
@@ -63141,8 +63258,11 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "mce" = (
-/turf/simulated/wall/church_reinforced,
-/area/colony)
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/prime)
 "mcg" = (
 /obj/structure/bed/chair,
 /obj/structure/window/reinforced{
@@ -63318,10 +63438,15 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/quartermaster/office)
 "mdn" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "mdt" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 2;
@@ -63470,11 +63595,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "meA" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "meB" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 0;
@@ -63840,24 +63970,9 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "miP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "miQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -65117,10 +65232,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
 "mtA" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "mtG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -65560,28 +65675,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
 "mxN" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 2";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "mxR" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -65975,12 +66071,6 @@
 "mCq" = (
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
-"mCt" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "mCv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -66578,12 +66668,10 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/construction)
 "mHf" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/table/woodentable,
+/obj/machinery/reagentgrinder/portable,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "mHh" = (
 /obj/landmark/join/start/cargo_tech,
 /obj/structure/disposalpipe/segment,
@@ -66958,11 +67046,9 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
 "mKY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "mLl" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -67394,11 +67480,14 @@
 /turf/simulated/floor/beach/sand/drywater,
 /area/nadezhda/crew_quarters/pool)
 "mPy" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "mPC" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -67563,16 +67652,15 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "mRi" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mRq" = (
 /obj/structure/table/bench/marble,
 /obj/machinery/alarm{
@@ -68005,16 +68093,12 @@
 	name = "\improper Outdoors - Pad"
 	})
 "mVl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mVm" = (
 /obj/structure/closet,
 /turf/simulated/floor/tiled/white,
@@ -68059,14 +68143,13 @@
 	name = "Residential District Substation"
 	})
 "mVE" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
+/area/colony)
 "mVH" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/generic,
@@ -68632,9 +68715,11 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ncd" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/church_reinforced,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "nch" = (
 /obj/random/furniture/pottedplant,
 /obj/item/device/radio/intercom{
@@ -69040,6 +69125,20 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
+"ngA" = (
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/sign/levels/stairsup{
+	pixel_x = 32;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "ngE" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 1;
@@ -69192,12 +69291,10 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "nib" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/dogbed,
+/mob/living/simple_animal/corgi/Lisa,
+/turf/simulated/floor/wood,
+/area/nadezhda/command/swo/quarters)
 "nic" = (
 /obj/structure/table/onestar,
 /obj/item/pen,
@@ -69599,17 +69696,20 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "nmo" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "nmp" = (
 /obj/item/reagent_containers/blood/AMinus,
 /obj/item/reagent_containers/blood/APlus,
@@ -69780,11 +69880,11 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/fo)
 "nol" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "nom" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -69902,13 +70002,22 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "npm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "npp" = (
 /obj/structure/multiz/stairs/active/bottom,
 /obj/structure/window/reinforced{
@@ -70114,14 +70223,17 @@
 /turf/simulated/floor/plating/under,
 /area/asteroid/cave)
 "nrD" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "nrI" = (
 /obj/structure/window/reinforced,
@@ -70311,23 +70423,16 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ntC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 4
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "ntK" = (
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
@@ -70387,13 +70492,16 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "nur" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "nuD" = (
@@ -70508,14 +70616,19 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nvB" = (
-/obj/structure/multiz/stairs/active/bottom{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "nvD" = (
 /obj/structure/table/bar_special,
@@ -70668,19 +70781,10 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "nxH" = (
-/obj/structure/multiz/stairs/active{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/sign/levels/stairsdown{
-	pixel_y = -30;
-	pixel_x = 32
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "nxP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -71463,15 +71567,20 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "nFm" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/tool/multitool,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "nFp" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -71950,11 +72059,19 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nJR" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "nJX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -72670,8 +72787,11 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "nRM" = (
-/obj/structure/reagent_dispensers/biomatter/large,
-/obj/effect/floor_decal/industrial/hatch,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "nRO" = (
@@ -72798,20 +72918,13 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "nTE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "nTL" = (
 /obj/effect/overlay/water,
@@ -73628,14 +73741,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "oaI" = (
-/obj/structure/table/standard,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+/obj/structure/multiz/stairs/enter{
+	dir = 1
 	},
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "oaM" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -74529,22 +74642,6 @@
 /obj/item/device/radio/random_radio,
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/merchant)
-"oin" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "oiq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -75007,12 +75104,14 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/main/stairwell)
 "omK" = (
-/obj/machinery/light_switch{
-	pixel_x = 28
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
 	},
-/obj/structure/bed/chair/comfy/black,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "omU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75049,6 +75148,14 @@
 /obj/effect/window_lwall_spawn,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/campground)
+"onz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "onD" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/railing{
@@ -75297,9 +75404,12 @@
 /turf/simulated/mineral,
 /area/nadezhda/command/cbo)
 "oqc" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "oqd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -75993,19 +76103,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
 "owI" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/structure/flora/small/grassb1,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "owK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/furniture/pottedplant,
@@ -77327,9 +77427,19 @@
 	},
 /area/nadezhda/pros/proelav)
 "oJb" = (
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "oJo" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood/wild3,
@@ -77545,25 +77655,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"oLh" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
 "oLn" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -77715,15 +77806,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "oMM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/pros/foreman)
 "oMS" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/junk/snappop,
@@ -77794,16 +77881,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
 "oNA" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/camera/network/church{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "oNP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78308,18 +78390,18 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "oSN" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "oST" = (
 /obj/effect/decal/cleanable/dirt,
@@ -78397,11 +78479,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "oTp" = (
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = -32
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/prime)
 "oTv" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -78559,9 +78648,13 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
 "oVv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/glass/replenishing/chalice,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = -32
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "oVO" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 6
@@ -79240,10 +79333,10 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "pes" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -81249,12 +81342,10 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/virology)
 "pyY" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "pzk" = (
 /obj/structure/nt_pedestal,
 /turf/simulated/floor/carpet/bcarpet,
@@ -81524,12 +81615,14 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "pBQ" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/catwalk,
+/obj/machinery/light,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "pBV" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -81598,20 +81691,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"pCt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
 "pCu" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -82618,12 +82697,13 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
 "pLt" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "pLw" = (
 /obj/random/mob/croaker/low_chance,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -82821,19 +82901,20 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "pNu" = (
-/obj/structure/bed/chair/sofa/brown/left,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/random/toy/plushie,
-/obj/effect/floor_decal/industrial/warningred{
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "pNw" = (
 /turf/simulated/mineral,
 /area/nadezhda/outside/dcave)
@@ -83129,17 +83210,21 @@
 	name = "\improper Upper Research Hallway"
 	})
 "pPU" = (
+/obj/machinery/door/airlock{
+	name = "Church";
+	req_access = list(27)
+	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "pPW" = (
@@ -83961,12 +84046,12 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "pYx" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 24
+/obj/structure/table/woodentable,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "pYB" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -84120,10 +84205,11 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "pZI" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "pZS" = (
 /mob/living/simple_animal/opossum{
 	desc = "The Nedezhda basketball team mascot. - Currently scavenging for rebounds";
@@ -84244,13 +84330,11 @@
 "qbh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -84680,11 +84764,10 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qfx" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/table/woodentable,
+/obj/random/toy/plushie,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "qfC" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -84846,14 +84929,14 @@
 	name = "\improper Outdoors - Pad"
 	})
 "qgM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "qhd" = (
 /obj/structure/table/bar_special,
 /obj/machinery/chemical_dispenser/beer,
@@ -85278,6 +85361,19 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
+"qlF" = (
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "qlN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/trailrockb5,
@@ -85672,6 +85768,7 @@
 	dir = 5
 	},
 /obj/item/computer_hardware/hard_drive/portable/design/cargo,
+/obj/item/device/lighting/toggleable/lamp/green,
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/merchant)
 "qpG" = (
@@ -86242,12 +86339,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "qvn" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "qvy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -86352,17 +86453,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "qwE" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/obj/structure/sink{
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "qwI" = (
 /obj/machinery/light{
@@ -86584,11 +86686,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qyo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "qyq" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
@@ -86721,9 +86824,12 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "qzx" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "qzA" = (
 /obj/structure/table/bar_special,
 /obj/item/modular_computer/tablet/preset/custom_loadout/standard,
@@ -86945,16 +87051,22 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
 "qBq" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
 	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/colony)
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "qBx" = (
 /obj/structure/table/standard,
 /obj/random/material/low_chance,
@@ -86967,21 +87079,13 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest)
 "qBQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/sign/faction/neotheology{
+	pixel_x = -30;
+	pixel_y = 0
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/steel/golden,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "qBV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/rock5,
@@ -87060,10 +87164,17 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "qDa" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/catwalk,
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "qDd" = (
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
@@ -87416,14 +87527,9 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "qGp" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "qGu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -87838,9 +87944,12 @@
 	name = "\improper Clinic"
 	})
 "qKJ" = (
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/closet/secure_closet/personal/agrolyte,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "qKO" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt,
@@ -88742,23 +88851,35 @@
 	name = "Dormitory 3"
 	})
 "qTC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/railing/grey{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
 	},
-/obj/machinery/light/small,
-/obj/structure/sign/faction/neotheology_cross{
+/obj/structure/railing/grey,
+/obj/structure/sign/faction/derelict1{
+	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
+	name = "NOTICE: Dangerous Biohazard";
+	pixel_x = 0;
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/steel/golden,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "qTD" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 4;
@@ -88844,22 +88965,18 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/atmos/storage)
 "qUt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "qUw" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -88906,10 +89023,12 @@
 	name = "Residential District Maintenance"
 	})
 "qUT" = (
-/obj/structure/dogbed,
-/mob/living/simple_animal/corgi/Lisa,
-/turf/simulated/floor/wood,
-/area/nadezhda/command/swo/quarters)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 5
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "qUY" = (
 /obj/structure/mopbucket,
 /obj/effect/floor_decal/industrial/botright,
@@ -89138,11 +89257,16 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/crew_quarters/podrooms)
 "qWT" = (
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "qWW" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/small/busha3,
@@ -89569,13 +89693,12 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "raN" = (
-/obj/structure/bed/chair/sofa/brown/right,
-/obj/landmark/join/start/acolyte,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/recycler,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "raR" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
@@ -89641,9 +89764,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rby" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/camera/network/church{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "rbA" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -89821,12 +89949,10 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "rcV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/industrial/danger,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "rcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -90324,8 +90450,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rig" = (
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/outside/meadow)
+/obj/machinery/door/holy{
+	name = "Church"
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/absolutism/storage)
 "rip" = (
 /obj/machinery/door/firedoor,
 /obj/structure/door_assembly/door_assembly_maint_cargo,
@@ -90395,13 +90527,12 @@
 	name = "Dormitory 3"
 	})
 "riP" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/device/radio/intercom{
+	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "riQ" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/powermonitor{
@@ -90508,24 +90639,16 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "rjV" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/power/nt_obelisk,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
 	},
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "rjY" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "rjZ" = (
 /obj/item/modular_computer/console/preset/command{
 	dir = 4;
@@ -90924,16 +91047,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/pros/prep)
-"roc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
 "rod" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -91160,17 +91273,15 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/courtroom)
 "rqj" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "rqk" = (
 /obj/machinery/power/wall_obelisk{
 	pixel_x = 32
@@ -91180,18 +91291,11 @@
 	name = "Dormitory 1"
 	})
 "rqm" = (
-/obj/machinery/camera/network/church{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "rqp" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -91307,15 +91411,18 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rrx" = (
-/obj/machinery/conveyor_switch{
-	id = "disposals grinder"
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/floor_decal/industrial/danger,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "rrB" = (
 /obj/structure/table/steel,
 /obj/random/mob/spiders,
@@ -91868,11 +91975,13 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/pros/prep)
 "rwF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "rwG" = (
 /obj/machinery/camera/network/colony_transition{
 	dir = 8
@@ -92742,15 +92851,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/command/courtroom)
 "rEA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "rED" = (
 /obj/structure/flora/big/rocks2,
@@ -92943,12 +93048,7 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rGx" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "rGz" = (
 /obj/structure/cable/cyan{
@@ -93058,10 +93158,19 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rHD" = (
-/turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/bed/chair/sofa/brown/left,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/random/toy/plushie,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "rHE" = (
 /obj/machinery/light{
 	dir = 1
@@ -95417,14 +95526,12 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "sdY" = (
-/obj/machinery/door/holy{
-	name = "Church"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "sec" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
@@ -95577,10 +95684,9 @@
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/meadow)
 "sfi" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/obj/structure/invislight,
-/turf/simulated/floor/plating,
-/area/nadezhda/outside/meadow)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/atmos/storage)
 "sfB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -96675,6 +96781,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"sqt" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "sqv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -97047,10 +97161,22 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "suE" = (
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "suL" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -97367,12 +97493,10 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "sxY" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/obj/item/scrap_lump,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "syb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -97568,13 +97692,16 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "sAo" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/sink{
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "sAN" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -97927,11 +98054,17 @@
 /area/colony)
 "sFL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "sFQ" = (
 /turf/simulated/floor/reinforced,
 /area/nadezhda/hallway/surface/section1)
@@ -98336,17 +98469,10 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/genetics)
 "sJX" = (
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "sKc" = (
 /obj/structure/table/woodentable,
@@ -98560,14 +98686,11 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/kitchen)
 "sMN" = (
-/obj/structure/bed/chair/wood{
-	dir = 4;
-	icon_state = "wooden_chair";
-	tag = "icon-wooden_chair (EAST)"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "sMT" = (
 /obj/structure/table/rack,
 /obj/item/storage/toolbox/electrical{
@@ -98704,12 +98827,11 @@
 /area/nadezhda/command/gmaster)
 "sOa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "sOd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -98820,31 +98942,15 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "sPh" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 1";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/cyan{
+/obj/structure/cable/green{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "sPj" = (
 /obj/structure/flora/small/trailrocka3,
 /obj/effect/decal/cleanable/dirt,
@@ -99217,12 +99323,24 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "sSM" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/area/nadezhda/hallway/surface/section1)
 "sSW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -99464,16 +99582,13 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sUM" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair";
+	tag = "icon-wooden_chair (EAST)"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/storage/fancy/crayons,
-/obj/structure/table/woodentable,
-/obj/item/storage/fancy/crayons,
-/turf/simulated/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "sUN" = (
 /obj/structure/table/standard,
@@ -99964,20 +100079,16 @@
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sZu" = (
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "sZw" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
@@ -100202,17 +100313,10 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "tby" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/reagent_dispensers/biomatter,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "tbJ" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -100594,20 +100698,12 @@
 /turf/simulated/mineral,
 /area/nadezhda/outside/forest)
 "tgh" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/item/scrap_lump,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "tgi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -101318,18 +101414,10 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "tmF" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/urn/veteran{
-	pixel_x = 7
-	},
-/obj/item/oddity/nt/pyramid{
-	pixel_x = -9
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "tmR" = (
 /obj/machinery/door/airlock/glass{
 	name = "Plasma Drome"
@@ -101465,14 +101553,10 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/main/stairwell)
 "toM" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
+/obj/machinery/light,
+/obj/machinery/vending/fortune,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/chapel)
 "toN" = (
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -101522,22 +101606,14 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "tpj" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/material/kitchen/rollingpin,
-/obj/machinery/light_switch{
-	pixel_y = 30
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "tpn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/bushc3,
@@ -102532,9 +102608,28 @@
 	name = "Dormitory 4"
 	})
 "tzn" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 2";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "tzo" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/rock,
@@ -102567,19 +102662,9 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tzJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "tzM" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -103131,16 +103216,6 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
-"tFC" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
 "tFP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -103443,14 +103518,9 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
 "tJf" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "tJk" = (
 /obj/random/structures/low_chance,
@@ -104147,10 +104217,17 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tPN" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "tPO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -105006,17 +105083,20 @@
 	name = "\improper Upper Research Hallway"
 	})
 "tZL" = (
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
-/turf/simulated/floor/carpet,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "tZS" = (
 /obj/effect/floor_decal/industrial/arrows/white{
@@ -105026,14 +105106,9 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "tZT" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/pistachios,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "tZW" = (
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -105173,12 +105248,17 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "uaN" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/noticeboard/church{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "uaO" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -105294,9 +105374,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "ucs" = (
-/obj/structure/flora/small/grassb1,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "ucx" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/stack/ore,
@@ -105329,7 +105411,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ucY" = (
 /obj/structure/invislight,
-/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "udb" = (
@@ -105651,11 +105733,15 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/cryo)
 "ugj" = (
-/obj/machinery/camera/network/church{
-	dir = 4
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "ugm" = (
 /obj/random/structures,
 /obj/effect/spider/stickyweb,
@@ -105666,18 +105752,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ugn" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/hallway/surface/section1)
 "ugx" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Permanent Holding";
@@ -105729,12 +105806,14 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/crew_quarters/kitchen_storage)
 "ugI" = (
-/obj/item/device/lighting/toggleable/lamp/green,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/item/contraband/poster/placed/generic/lizard{
 	pixel_x = 32
+	},
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/merchant)
@@ -106011,17 +106090,9 @@
 	name = "\improper Outdoors - Pad"
 	})
 "ujR" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "ujT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -106584,28 +106655,12 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/crew_quarters/podrooms)
 "uqM" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "uqQ" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -106859,19 +106914,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "usX" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/sign/faction/neotheology{
+	pixel_x = 32
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/sign/levels/stairsup{
-	pixel_x = 32;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "utl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -108024,12 +108072,11 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "uCH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/cyancorner,
+/area/nadezhda/hallway/surface/section1)
 "uCI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -108063,16 +108110,6 @@
 /obj/machinery/door/blast/regular,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"uDc" = (
-/obj/structure/multiz/stairs/enter{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
 "uDf" = (
 /obj/structure/sign/department/bar,
 /turf/simulated/wall,
@@ -108438,11 +108475,18 @@
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "uGA" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "uGD" = (
 /obj/landmark/machinery/input,
 /obj/machinery/conveyor/south{
@@ -109172,20 +109216,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "uOA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "chudorm4";
-	name = "Church Dorm 2";
-	req_access = list(70)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "uOB" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -109477,11 +109512,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "uQC" = (
@@ -109568,14 +109601,17 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "uRw" = (
-/obj/structure/multiz/stairs/active{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
 	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "uRx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -109854,14 +109890,12 @@
 	name = "\improper Upper Research Hallway"
 	})
 "uTQ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "uTS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -109948,12 +109982,19 @@
 	name = "\improper Outdoors - Pad"
 	})
 "uUU" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "uUW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -110002,7 +110043,6 @@
 "uVi" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
-/obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "uVp" = (
@@ -110024,12 +110064,17 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
 "uVx" = (
-/obj/structure/closet/secure_closet/personal/agrolyte,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = -32
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "uVy" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/robotics{
@@ -110385,11 +110430,17 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "uZv" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/camera/network/church{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/storage)
 "uZx" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/big/bush3,
@@ -110898,10 +110949,9 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
 "vfg" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "vfj" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section2";
@@ -111623,11 +111673,10 @@
 /area/nadezhda/outside/forest)
 "vmm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/wall_obelisk{
-	pixel_x = 1;
-	pixel_y = 24
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "vmq" = (
 /obj/structure/table/standard,
@@ -112270,14 +112319,17 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/meeting_room)
 "vsx" = (
-/obj/structure/multiz/stairs/active/bottom{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/industrial/warningwhite{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "vsy" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/structures,
@@ -112618,12 +112670,14 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "vvO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "vvS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame/vertical{
@@ -112784,15 +112838,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "vwJ" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "vwK" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 4
@@ -113199,13 +113251,22 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "vAx" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable/yellow{
+	d1 = 32;
+	icon_state = "32-1"
 	},
-/obj/random/toy/plushie_onlyfox,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/catwalk,
+/turf/simulated/open,
+/area/nadezhda/absolutism/storage)
 "vAB" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -113362,18 +113423,13 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vCh" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/structure/invislight,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "vCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -113697,20 +113753,20 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical_blackshield)
 "vFR" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "vFU" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -113777,17 +113833,15 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vGk" = (
-/obj/machinery/camera/network/church{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "vGA" = (
 /obj/structure/sign/security/cells{
 	pixel_x = -32
@@ -114008,8 +114062,11 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vIL" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "vJb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -114217,14 +114274,10 @@
 	name = "Residential District Maintenance"
 	})
 "vKM" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
-	},
-/obj/machinery/camera/network/church{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "vKR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -114420,22 +114473,22 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "vMK" = (
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Office"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/prime)
-"vMQ" = (
-/obj/machinery/biomatter_solidifier,
-/turf/simulated/floor/tiled/dark/danger,
+/obj/machinery/power/eotp,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
+"vMQ" = (
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "vMU" = (
 /obj/structure/disposalpipe/junction,
 /obj/structure/cable/yellow{
@@ -115428,19 +115481,10 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "vWA" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "vWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -115870,22 +115914,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "waf" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/item/scrap_lump,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "wak" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
@@ -115916,12 +115952,16 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "waT" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/absolutism/skyyard)
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_room)
 "waY" = (
 /obj/structure/multiz/stairs/active/bottom,
 /obj/structure/window/reinforced{
@@ -115931,24 +115971,20 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/side/f2section1)
 "wbe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "wbm" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "wbo" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -116269,13 +116305,20 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "weh" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/replenishing/chalice,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = -32
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "wev" = (
 /obj/machinery/power/nt_obelisk,
 /obj/structure/sign/faction/neotheology_cross/gold{
@@ -116329,25 +116372,22 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
 "weP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/material/kitchen/rollingpin,
+/obj/machinery/light_switch{
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/random/scrap/dense_weighted/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "weT" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/effect/floor_decal/industrial/arrows/white,
@@ -116418,9 +116458,11 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "wfn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
+/obj/random/toy/plushie_onlyfox,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "wft" = (
@@ -116542,10 +116584,20 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/cafeteria)
 "wgN" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "wgV" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -116834,6 +116886,18 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"wkx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "wkz" = (
 /turf/unsimulated/mask,
 /area/mine/gulag)
@@ -117401,10 +117465,14 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "wpu" = (
-/obj/structure/table/woodentable,
-/obj/random/toy/plushie,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "wpv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -118066,12 +118134,19 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
 "wuN" = (
-/obj/machinery/camera/network/church{
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "wuV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
@@ -120162,12 +120237,9 @@
 	name = "Dormitory 3"
 	})
 "wQW" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/effect/floor_decal/industrial/loading/white,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "wRb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -120255,11 +120327,12 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "wSl" = (
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Office"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/hallway/surface/section1)
 "wSn" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -120584,19 +120657,10 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/tcommsat/computer)
 "wVv" = (
-/obj/structure/mirror{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/box/white,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "wVx" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,18"
@@ -120667,13 +120731,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "wWN" = (
-/obj/structure/table/woodentable,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/light_switch{
+	pixel_y = 30
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "wWP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -121568,19 +121631,10 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "xfb" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "xfc" = (
 /obj/machinery/conveyor/east{
 	dir = 1;
@@ -122007,23 +122061,9 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "xke" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/engineering/atmos/storage)
 "xki" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -122131,10 +122171,15 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xlL" = (
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/theomat,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/storage)
 "xlP" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Post";
@@ -122159,6 +122204,13 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"xlU" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "xlW" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -122337,20 +122389,18 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xmO" = (
-/obj/structure/cable/yellow{
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/structure/invislight,
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/vectorrooms)
 "xmV" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/nightmare,
@@ -122406,20 +122456,10 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "xnv" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "xnw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -122683,18 +122723,6 @@
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"xpC" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
 "xpF" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -122788,10 +122816,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xqJ" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/wall/church_reinforced,
+/area/colony)
 "xqM" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -122862,18 +122888,10 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "xrs" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/multiz/stairs/enter/bottom,
+/obj/structure/invislight,
+/turf/simulated/floor/plating,
+/area/nadezhda/outside/meadow)
 "xrx" = (
 /obj/landmark/machinery/input,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -122892,24 +122910,14 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "xrD" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "xrF" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 6;
@@ -123350,12 +123358,15 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "xwB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_x = 32
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
 	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "xwH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/random/flora/jungle_tree,
@@ -123515,11 +123526,16 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xyC" = (
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "xyJ" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/armory)
@@ -123746,17 +123762,9 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "xBq" = (
-/obj/structure/bed/chair/sofa/black/left{
-	dir = 8
-	},
-/obj/structure/noticeboard/church{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "xBr" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,3"
@@ -123965,9 +123973,17 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "xDf" = (
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/vectorrooms)
 "xDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -124082,10 +124098,23 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xEe" = (
-/obj/structure/table/woodentable,
-/obj/item/device/lighting/toggleable/lantern/censer,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "xEk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/wood,
@@ -124752,26 +124781,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "xKz" = (
-/obj/structure/cable/yellow{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
+/obj/machinery/camera/network/church{
 	dir = 1
 	},
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/structure/railing/grey,
-/obj/structure/cable/yellow,
-/obj/machinery/light,
-/turf/simulated/floor/plating/under,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "xKD" = (
 /obj/structure/grille,
@@ -124809,18 +124830,6 @@
 /obj/random/mob/spiders/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"xKZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/faction/neotheology_cross{
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
 "xLd" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/small/busha1,
@@ -125047,11 +125056,15 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "xMy" = (
-/obj/machinery/alarm{
-	pixel_y = 26
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "xMA" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -125666,6 +125679,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/merchant)
+"xSQ" = (
+/obj/machinery/computer/arcade,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "xSS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -125695,10 +125715,11 @@
 /area/nadezhda/hallway/surface/section1)
 "xTb" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /obj/structure/catwalk,
+/obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "xTe" = (
@@ -126888,17 +126909,10 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "yfE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "yfL" = (
 /obj/item/storage/briefcase/inflatable{
 	pixel_x = 3;
@@ -127298,17 +127312,14 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "yjK" = (
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 8
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/biomatter,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "yjM" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -127462,19 +127473,11 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
 "ylz" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating/under,
-/area/colony)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "ylB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -134680,7 +134683,7 @@ uCp
 oGw
 oJI
 bhK
-qUT
+nib
 oGw
 oGw
 oGw
@@ -193870,13 +193873,13 @@ vvL
 wAo
 xPH
 xPH
-efu
-kbl
-kbl
-kbl
-qBq
-kbl
-ylz
+waT
+ugj
+ugj
+ugj
+bPu
+ugj
+epB
 xGi
 sFI
 sFI
@@ -194078,7 +194081,7 @@ xGi
 xGi
 xGi
 beK
-vFR
+nmo
 beK
 sFI
 sFI
@@ -194280,7 +194283,7 @@ sFI
 sFI
 sFI
 beK
-vWA
+wuN
 beK
 sFI
 sFI
@@ -194482,7 +194485,7 @@ sFI
 sFI
 sFI
 beK
-xnv
+cDx
 beK
 sFI
 sFI
@@ -194684,7 +194687,7 @@ sFI
 sFI
 sFI
 beK
-vWA
+wuN
 beK
 sFI
 sFI
@@ -194886,7 +194889,7 @@ sFI
 beK
 beK
 beK
-tzJ
+fgM
 beK
 beK
 beK
@@ -195088,7 +195091,7 @@ sFI
 beK
 eWs
 mCq
-pCt
+nJR
 vgv
 tZa
 mUh
@@ -195290,7 +195293,7 @@ sFI
 beK
 hov
 uww
-hHU
+wkx
 naZ
 dMu
 xhZ
@@ -195492,7 +195495,7 @@ sFI
 beK
 uHt
 uww
-fPE
+nvB
 mxC
 wuq
 mBO
@@ -195693,9 +195696,9 @@ beK
 beK
 beK
 mCq
-kMZ
-cDx
-riP
+rGx
+vMK
+vwJ
 gcr
 gzw
 vcq
@@ -195887,16 +195890,16 @@ jPJ
 iVn
 byG
 ult
-jnw
-bmx
-kPg
-hkR
-jkf
-uTQ
-hkR
+oJb
+hNx
+mVE
+fEH
+sqt
+ldw
+fEH
 bho
 xhZ
-rEA
+qvn
 mxC
 gcr
 tkm
@@ -196096,9 +196099,9 @@ beK
 beK
 beK
 beK
-iZz
-xrs
-mVl
+ivC
+hVD
+xyC
 mxC
 hCa
 tNb
@@ -196298,10 +196301,10 @@ sFI
 sFI
 sFI
 beK
-sPh
+dNI
 puT
-mRi
-rGx
+ntC
+rwF
 nvW
 hpm
 hpm
@@ -196500,16 +196503,16 @@ sFI
 sFI
 sFI
 beK
-mxN
+tzn
 rOL
-xmO
+pNu
 eyI
 ctG
 ctC
 wIe
 mCq
 naZ
-xKz
+aAw
 beK
 sFI
 ula
@@ -196704,7 +196707,7 @@ sFI
 beK
 oPl
 uUJ
-cye
+rEA
 aUn
 aUn
 qHo
@@ -196906,14 +196909,14 @@ sFI
 beK
 azM
 uUJ
-cxF
+gou
 aUn
 aUn
 sDT
 qPy
 mCq
-toM
-fqE
+iGZ
+xKz
 beK
 sFI
 sFI
@@ -197114,8 +197117,8 @@ usk
 jeg
 vcq
 mCq
-cTB
-lnV
+wpu
+qTC
 beK
 beK
 beK
@@ -197308,19 +197311,19 @@ sFI
 sFI
 sFI
 beK
-fEH
+rjV
 mCq
-fgM
+sZu
 xhZ
 mCq
 mCq
 mCq
 mCq
-cTB
-kFQ
-kFQ
-gSa
-vsx
+wpu
+gHI
+gHI
+qgM
+xrD
 beK
 sFI
 sFI
@@ -197510,19 +197513,19 @@ sFI
 sFI
 beK
 beK
-gXz
-jHx
-dmD
-bal
+wWN
+kPg
+frF
+vvO
 mCq
 mCq
 mCq
-kFQ
-cTB
-kFQ
-kFQ
-usX
-nvB
+gHI
+wpu
+gHI
+gHI
+ngA
+xMy
 beK
 sFI
 sFI
@@ -197712,16 +197715,16 @@ sFI
 sFI
 beK
 hSC
-jHx
-xqJ
+kPg
+tzJ
 bMK
-iKX
-sJX
+npm
+qUt
 lti
 rCq
 dMu
-rGx
-jNP
+rwF
+kOD
 beK
 beK
 beK
@@ -197913,17 +197916,17 @@ uNP
 uNP
 uNP
 beK
-doA
+uVx
 nSn
 nSn
 oYg
 nSn
-dBr
-iRf
+lnV
+pBQ
 beK
 mCq
 rhf
-uZv
+sJX
 beK
 sFI
 sFI
@@ -198110,17 +198113,17 @@ vQv
 vQv
 uOb
 cSt
-fAA
-deL
-esz
-gdn
-ncd
-bPu
-bPu
-bPu
-bPu
-bPu
-bPu
+eMK
+qzx
+mKY
+sfi
+cTB
+cZV
+cZV
+cZV
+cZV
+cZV
+cZV
 mAy
 beK
 lZC
@@ -198312,24 +198315,24 @@ uim
 uWe
 vIm
 cSt
-rrx
-eIV
-mPy
+huw
+llg
+sMN
 uNP
-mce
-mce
-mce
-mce
+xqJ
+xqJ
+xqJ
+xqJ
 beK
 beK
-kMZ
-kMZ
-kMZ
+rGx
+rGx
+rGx
 mCq
-ugj
+oNA
 mCq
-nRM
-nRM
+bfZ
+bfZ
 beK
 sFI
 sFI
@@ -198514,9 +198517,9 @@ dvQ
 uWK
 vIm
 pBF
-bqh
-sxY
-iAo
+rcV
+tgh
+cfH
 uNP
 sFI
 sFI
@@ -198524,14 +198527,14 @@ sFI
 sFI
 sFI
 beK
-kMZ
-kMZ
-kMZ
-ifo
-vMQ
+rGx
+rGx
+rGx
+wQW
+kSK
 vcq
-nRM
-nRM
+bfZ
+bfZ
 beK
 sFI
 gfQ
@@ -198716,9 +198719,9 @@ vQv
 vQv
 jkc
 cSt
-vfg
-uaN
-tZT
+vWA
+qyo
+tpj
 uNP
 sFI
 sFI
@@ -198726,14 +198729,14 @@ sFI
 sFI
 sFI
 beK
-xlL
-xlL
-xlL
+dnk
+dnk
+dnk
 mCq
 mCq
 mCq
-hpq
-cox
+tby
+yjK
 beK
 gfQ
 gfQ
@@ -198918,9 +198921,9 @@ vQv
 vQv
 jkc
 nmW
-meA
-sSM
-tby
+aFL
+exB
+tPN
 uNP
 sFI
 sFI
@@ -198928,14 +198931,14 @@ sFI
 sFI
 sFI
 beK
-fyb
-fyb
-fyb
+hbi
+hbi
+hbi
 mCq
 mCq
-pZI
-pZI
-pZI
+kLc
+kLc
+kLc
 beK
 gfQ
 vNF
@@ -199120,9 +199123,9 @@ dvQ
 uWe
 vIm
 cSt
-mHf
-uaN
-fBV
+hpq
+qyo
+jte
 uNP
 sFI
 sFI
@@ -199130,14 +199133,14 @@ sFI
 sFI
 sFI
 beK
-sAo
-kEe
-kEe
+nRM
+vKM
+vKM
 mCq
-gRP
-boU
-boU
-boU
+gnT
+wVv
+wVv
+wVv
 beK
 gfQ
 wHA
@@ -199322,9 +199325,9 @@ tKp
 tQX
 vIm
 cSt
-fPi
-pyY
-nmo
+dzK
+raN
+jTG
 uNP
 sFI
 sFI
@@ -199524,9 +199527,9 @@ vQv
 vQv
 jkc
 cSt
-fPi
-uGA
-waf
+dzK
+jkf
+ljQ
 uNP
 sFI
 sFI
@@ -199726,9 +199729,9 @@ vQv
 vQv
 vIm
 cSt
-fAA
-ldw
-tzn
+eMK
+xke
+mxN
 uNP
 sFI
 sFI
@@ -224581,7 +224584,7 @@ vrp
 vrp
 uEB
 leU
-hmj
+ifo
 vUJ
 xcy
 sbB
@@ -225006,7 +225009,7 @@ bjU
 vUJ
 vUJ
 vUJ
-ucs
+owI
 vUJ
 vUJ
 vUJ
@@ -225191,7 +225194,7 @@ uEB
 pIy
 quu
 vUJ
-hmj
+ifo
 leU
 leU
 leU
@@ -225409,7 +225412,7 @@ vUJ
 vUJ
 vUJ
 vUJ
-oqc
+kyt
 sbB
 sbB
 xcy
@@ -225799,7 +225802,7 @@ leU
 sbB
 pDw
 mkI
-xDf
+bal
 leU
 bjU
 xcy
@@ -226418,7 +226421,7 @@ sbB
 sbB
 mkI
 vUJ
-wgN
+xnv
 bjU
 leU
 leU
@@ -226815,7 +226818,7 @@ mET
 vUJ
 vUJ
 sbB
-vIL
+cRj
 sbB
 sbB
 hvW
@@ -227397,7 +227400,7 @@ cjv
 fJv
 wBa
 pwm
-xMy
+uCH
 uEV
 ciH
 gba
@@ -227818,7 +227821,7 @@ vTn
 nyS
 cKe
 jBi
-yjK
+vsx
 leR
 oHf
 oHf
@@ -228020,7 +228023,7 @@ gEY
 wrl
 oal
 cVR
-kLc
+hkR
 jaT
 hpV
 hpV
@@ -228222,7 +228225,7 @@ pwm
 pwm
 aot
 njl
-kLc
+hkR
 stq
 iVt
 aJG
@@ -228424,7 +228427,7 @@ pwm
 pwm
 aot
 ved
-kLc
+hkR
 stq
 iVt
 aJG
@@ -228626,7 +228629,7 @@ aug
 fMZ
 jeo
 puc
-kLc
+hkR
 gOa
 gaS
 gaS
@@ -228828,10 +228831,10 @@ stG
 wzY
 kCJ
 hYL
-kLc
+hkR
 tpO
-oJb
-oJb
+qGp
+qGp
 aot
 hLv
 hLv
@@ -229219,7 +229222,7 @@ epc
 moX
 xFe
 koI
-qWT
+fPi
 fKf
 wIm
 fKf
@@ -229260,8 +229263,8 @@ leU
 leU
 leU
 leU
-rHD
-rHD
+cUo
+cUo
 kfg
 aCl
 nfX
@@ -229462,8 +229465,8 @@ leU
 leU
 leU
 leU
-rHD
-rHD
+cUo
+cUo
 hgC
 hgC
 hgC
@@ -229623,48 +229626,48 @@ epc
 rjh
 gSM
 kOW
-suE
+ujR
 dsj
-kyl
+qUT
 dsj
 ndM
 kOW
 aFx
 lpW
-vwJ
+xwB
 aFx
 lpW
-hMs
+sOa
 kOW
 bVb
 bVb
 kOW
 iUs
-jHL
+usX
 dld
 dld
 pDI
-cNE
-cNE
-cNE
-cNE
-cNE
-cNE
-cNE
-cNE
-cNE
-cNE
-cNE
-qfx
-rHD
-rHD
-rHD
-rHD
-rHD
-rHD
-rHD
-rHD
-rHD
+mPy
+mPy
+mPy
+mPy
+mPy
+mPy
+mPy
+mPy
+mPy
+mPy
+mPy
+iRf
+cUo
+cUo
+cUo
+cUo
+cUo
+cUo
+cUo
+cUo
+cUo
 lxo
 aot
 hgC
@@ -229857,7 +229860,7 @@ bSp
 fCA
 nRc
 nRc
-tFC
+mdn
 vUJ
 vUJ
 vUJ
@@ -230031,14 +230034,14 @@ qFY
 dsj
 dsj
 dsj
-mtA
+cye
 pQO
-pYx
+riP
 fiW
 qHh
 fiW
 dsj
-bZJ
+tJf
 aFx
 aFx
 uYT
@@ -230231,16 +230234,16 @@ pmt
 kOW
 cxA
 dsj
-jsb
+vmm
 dsj
 xOv
 kOW
-vmm
+aJN
 fiW
 qHh
 fiW
 dsj
-bZJ
+tJf
 wGn
 aFx
 dsj
@@ -230429,15 +230432,15 @@ pwm
 pwm
 jZV
 qMM
-qBQ
+klX
 kOW
 kOW
-nib
-lUP
-sFL
+jXd
+kwb
+uTQ
 kOW
 kOW
-jTG
+dCC
 fiW
 qHh
 mcP
@@ -230448,7 +230451,7 @@ pVr
 dsj
 pQO
 ucl
-jwd
+dBr
 dld
 dld
 mBf
@@ -230635,22 +230638,22 @@ mMj
 hcE
 rQU
 rrG
-iGZ
+uqM
 dsj
-bkH
-qvn
+cKd
+egd
 aFx
 aFx
-ktR
+fgb
 aFx
 aFx
 aFx
-kVO
+omK
 dsj
 dsj
 pQO
 ucl
-qDa
+nxH
 dld
 dld
 mBf
@@ -230835,12 +230838,12 @@ jZV
 czp
 eJY
 kQv
-hSz
-ujR
+deL
 nur
-rwF
-rwF
+eVP
 ddN
+ddN
+rqm
 bND
 ezK
 ePE
@@ -231038,8 +231041,8 @@ plK
 cvN
 vFt
 jjQ
-tJf
-ejM
+rqj
+sdY
 dsj
 cAW
 hcE
@@ -231054,7 +231057,7 @@ dsj
 dsj
 pQO
 ucl
-tPN
+ucY
 dld
 dld
 mBf
@@ -231237,17 +231240,17 @@ bfy
 xjG
 sAh
 wXd
-qTC
+hmj
 kOW
 kOW
-xKZ
-pBQ
-sFL
+hHU
+fBV
+uTQ
 kOW
 kOW
-jTG
+dCC
 fiW
-ejM
+sdY
 fiW
 dsj
 aFx
@@ -231256,7 +231259,7 @@ eUn
 dsj
 pQO
 ucl
-ucY
+yfE
 dld
 dld
 mBf
@@ -231441,18 +231444,18 @@ rIb
 qMM
 qrQ
 kOW
-rjV
-cUo
-rcV
+wgN
+gRP
+dtG
 dsj
-bPm
+toM
 kOW
-vmm
+aJN
 fiW
 aQF
 fiW
 rrG
-bZJ
+tJf
 wGn
 aFx
 dsj
@@ -231643,18 +231646,18 @@ uHd
 qMM
 uPn
 pQO
-kyt
-cUo
+dEk
+gRP
 dsj
 dsj
-llg
+mtA
 pQO
 aFx
 fiW
 aQF
 fiW
 dsj
-bZJ
+tJf
 aFx
 aFx
 uYT
@@ -231845,11 +231848,11 @@ she
 jlQ
 ebN
 pQO
-kyt
-cUo
+dEk
+gRP
 dsj
 dsj
-llg
+mtA
 pQO
 aFx
 fiW
@@ -231858,7 +231861,7 @@ fiW
 dsj
 aFx
 tVS
-bZJ
+tJf
 aFx
 kOW
 iUs
@@ -232047,24 +232050,24 @@ qMI
 pQa
 qmD
 kOW
-wWN
-eVP
-vKM
-jsM
-gHI
+eit
+qBq
+rby
+gjo
+ggs
 kOW
-ikj
+pyY
 tVS
-roc
+fCX
 aFx
 tVS
-hMs
+sOa
 kOW
 bVb
 bVb
 kOW
 iUs
-fxv
+qBQ
 dld
 dld
 mXo
@@ -232079,7 +232082,7 @@ lFw
 hbK
 nRc
 nRc
-hVD
+qlF
 vUJ
 vUJ
 eqh
@@ -232270,18 +232273,18 @@ wVU
 dld
 dld
 pDI
-rqj
-rqj
-rqj
-rqj
-rqj
-rqj
-rqj
-rqj
-rqj
-rqj
-rqj
-qfx
+qDa
+qDa
+qDa
+qDa
+qDa
+qDa
+qDa
+qDa
+qDa
+qDa
+qDa
+iRf
 vUJ
 vUJ
 vUJ
@@ -232417,9 +232420,9 @@ veZ
 cwr
 cwr
 cwr
-oaI
-oaI
-czb
+bZJ
+bZJ
+kpf
 ook
 tcp
 tcp
@@ -232456,31 +232459,31 @@ xGz
 wzU
 riw
 tZm
-oTp
+btO
 yiO
 riw
-aAy
-dNo
-mVE
-fuZ
+nTE
+ejM
+waf
+kyl
 hpc
-fsi
-fsi
+aAy
+aAy
 vXR
-sfi
+xrs
 dld
 dld
 dld
 vLi
 vLi
 qgJ
-hbi
-xyC
+vCh
+uOA
 oei
 qgJ
 tqr
-cZV
-nol
+kDY
+fPE
 qgJ
 vLi
 vLi
@@ -232619,10 +232622,10 @@ veZ
 veZ
 cwr
 cwr
-oaI
-oaI
-czb
-oaI
+bZJ
+bZJ
+kpf
+bZJ
 tcp
 rva
 mNx
@@ -232661,13 +232664,13 @@ oQZ
 elF
 xzr
 riw
-fuZ
+kyl
 rYv
 rYv
 rYv
 hpc
-rig
-rig
+hSz
+hSz
 vXR
 gzr
 dld
@@ -232821,10 +232824,10 @@ veZ
 veZ
 cwr
 cwr
-oaI
-oaI
-czb
-oaI
+bZJ
+bZJ
+kpf
+bZJ
 tcp
 uCI
 sOt
@@ -232859,19 +232862,19 @@ uXK
 uXK
 oXE
 riw
-tZL
+nrD
 qox
 opN
 riw
 cNP
-jVP
+tZT
 jAU
 rYv
 hpc
-fsi
-fsi
+aAy
+aAy
 vXR
-sfi
+xrs
 dld
 dld
 dld
@@ -233024,9 +233027,9 @@ veZ
 cwr
 cwr
 nYl
-fCX
-czb
-oaI
+bmx
+kpf
+bZJ
 tcp
 fPz
 gPf
@@ -233061,20 +233064,20 @@ dFx
 bAk
 oXE
 riw
-raN
-oVv
+bPm
+lLw
 nlp
 riw
-tpj
-ivC
-jXd
-rqm
+weP
+xlU
+mHf
+uGA
 riw
-aJN
+efu
 kbv
 riw
 vMI
-qzx
+iAo
 dld
 dld
 hvW
@@ -233226,8 +233229,8 @@ veZ
 cwr
 cwr
 lPU
-fCX
-czb
+bmx
+kpf
 ajp
 tcp
 rzR
@@ -233263,14 +233266,14 @@ nBw
 fLG
 oXE
 riw
-pNu
-hmk
-klX
+rHD
+vGk
+gdn
 riw
 int
 vsl
-cfH
-aAw
+doA
+jlE
 riw
 tTa
 tTa
@@ -233429,7 +233432,7 @@ cwr
 cwr
 rxq
 rxq
-czb
+kpf
 ajp
 cwr
 xdv
@@ -233466,19 +233469,19 @@ qWG
 riw
 riw
 riw
-ugn
+kFQ
 riw
 riw
 riw
 sGE
-eMK
+xDf
 riw
 riw
-qKJ
-uCH
+xBq
+mVl
 riw
 riw
-mdn
+sxY
 dld
 dld
 mcG
@@ -233631,7 +233634,7 @@ cwr
 cwr
 rxq
 rxq
-czb
+kpf
 ajp
 cwr
 mcJ
@@ -233664,23 +233667,23 @@ mJT
 pwm
 pwm
 vvK
-vvO
+wSl
 riw
 riw
-nrD
+cox
 vdu
 rMH
 juo
-aED
-aED
-kxQ
-wuN
+tmF
+tmF
+eMx
+bFp
 diT
 qQZ
 rOh
 rpa
 riw
-wQW
+vIL
 dld
 dld
 leU
@@ -233831,9 +233834,9 @@ veZ
 veZ
 cwr
 cwr
-fCX
-fCX
-czb
+bmx
+bmx
+kpf
 ajp
 cwr
 trx
@@ -233863,15 +233866,15 @@ tnR
 vaT
 vaT
 qZu
-rby
-dzK
+ugn
+hmk
 bZF
-rby
+ugn
 riw
-bfZ
+wbe
 wFB
 qQZ
-sMN
+sUM
 orJ
 rOh
 rOh
@@ -233880,9 +233883,9 @@ riw
 riw
 mqQ
 rOh
-iWQ
-hpc
 rjY
+hpc
+vfg
 dld
 dld
 ljw
@@ -234033,8 +234036,8 @@ veZ
 veZ
 cwr
 qau
-fCX
-fCX
+bmx
+bmx
 gCx
 ajp
 cwr
@@ -234070,7 +234073,7 @@ riw
 lDz
 riw
 riw
-sUM
+dNo
 wFB
 hAv
 mwt
@@ -234082,7 +234085,7 @@ cFR
 rpa
 qQZ
 rOh
-iWQ
+rjY
 hpc
 fXR
 dld
@@ -234269,24 +234272,24 @@ nfq
 jMp
 riw
 grQ
-uqM
-nTE
-lfc
-oin
-oMM
+eTj
+tZL
+pPU
+hMs
+sPh
 hAv
 mwt
-wpu
+qfx
 tuI
 rOh
 qWp
 cFR
-hNx
+miP
 qQZ
 qQZ
-iWQ
+rjY
 hpc
-qzx
+iAo
 dld
 dld
 mcG
@@ -234467,15 +234470,15 @@ lIg
 dVl
 vaT
 qkp
-oLh
-egd
-vCh
+fkm
+jsM
+xmO
 oKC
-ekD
-kSK
+oSN
+sAo
 riw
-pLt
-ggs
+xSQ
+cxF
 hAv
 mwt
 mwt
@@ -234486,9 +234489,9 @@ cFR
 rpa
 qQZ
 qQZ
-iWQ
-hpc
 rjY
+hpc
+vfg
 dld
 dld
 pIy
@@ -234669,26 +234672,26 @@ vaT
 vaT
 vaT
 qkp
-miP
+lUP
 pwm
 riw
 qza
-eSm
-wVv
+ylz
+qwE
 riw
 sPG
-pPU
-qgM
-uUU
-uUU
+esz
+fxv
+wbm
+wbm
 rOh
 rOh
-eMx
+dXG
 riw
 riw
 mqQ
 rOh
-iWQ
+rjY
 hpc
 wVU
 dld
@@ -234871,20 +234874,20 @@ sfG
 imO
 lNu
 tPK
-miP
+lUP
 pwm
 riw
 riw
 riw
-xke
+cNE
 riw
 riw
-qwE
-tgh
-oSN
-xpC
-qyo
-aED
+eIV
+bkH
+hQO
+uRw
+gSa
+tmF
 oBo
 qQZ
 diT
@@ -234892,7 +234895,7 @@ rOh
 qQZ
 rpa
 riw
-wQW
+vIL
 dld
 dld
 dIp
@@ -235073,12 +235076,12 @@ kRE
 gxW
 mfV
 lem
-weP
+gXz
 pwm
 riw
 lkJ
 vkU
-fkm
+ktR
 riw
 riw
 riw
@@ -235087,14 +235090,14 @@ riw
 riw
 riw
 riw
-uOA
+fqE
 riw
 riw
 qQZ
 guj
 riw
 riw
-dNI
+xfb
 dld
 dld
 nAX
@@ -235275,20 +235278,20 @@ sfG
 imO
 bJC
 pEI
-weP
+gXz
 pwm
 riw
 riw
 riw
-oNA
+dBR
 riw
-nJR
+pZI
 sbj
 wFB
 jac
 riw
-nJR
-vAx
+pZI
+wfn
 kZn
 xwO
 riw
@@ -235296,13 +235299,13 @@ tTa
 tTa
 riw
 quT
-qzx
+iAo
 dld
 dld
 owa
 vUJ
 vhs
-jte
+oqc
 lOl
 hbO
 dft
@@ -235477,22 +235480,22 @@ uSX
 nnT
 vaT
 qkp
-weP
+gXz
 pwm
 riw
 lkJ
 vkU
-gnT
+kwk
 riw
-dBR
-kDY
-dXG
-mKY
+pYx
+boU
+mRi
+aED
 riw
-dBR
-ccn
+pYx
+kbl
 rOh
-wfn
+ncd
 riw
 kbv
 kbv
@@ -235503,7 +235506,7 @@ dld
 dld
 kVt
 vUJ
-gxd
+bwG
 ooV
 jWc
 uOU
@@ -235679,27 +235682,27 @@ lLF
 xJm
 vaT
 qkp
-bwG
+kMZ
 pwm
 riw
 riw
 riw
 riw
 riw
-kpf
-mCt
+nol
+eSm
 qQZ
-wfn
+ncd
 riw
-kpf
+nol
 qQZ
 qQZ
 qQZ
 riw
-fsi
-fsi
+aAy
+aAy
 vXR
-sfi
+xrs
 dld
 dld
 dld
@@ -235881,7 +235884,7 @@ wan
 wxz
 vaT
 pkv
-weP
+gXz
 pwm
 xGz
 xGz
@@ -235899,9 +235902,9 @@ gzV
 vtp
 riw
 qQO
-rig
+hSz
 vXR
-sZu
+vFR
 dld
 dld
 dld
@@ -236083,7 +236086,7 @@ dXg
 kLp
 vaT
 nvI
-weP
+gXz
 pwm
 xGz
 xGz
@@ -236100,13 +236103,13 @@ riw
 riw
 riw
 riw
-fsi
-fsi
+aAy
+aAy
 vXR
-sfi
-xwB
+xrs
+ikj
 dld
-sOa
+pLt
 dld
 jZI
 jZI
@@ -236285,7 +236288,7 @@ wIg
 uob
 gUg
 brN
-weP
+gXz
 pwm
 xGz
 xGz
@@ -236487,7 +236490,7 @@ fsM
 aom
 vaT
 soq
-weP
+gXz
 pwm
 xGz
 xGz
@@ -236498,14 +236501,14 @@ xGz
 xGz
 opH
 plZ
-lyG
+fuZ
 opH
 ouv
 mmt
 opH
 opH
-sdY
-sdY
+rig
+rig
 uVK
 uVK
 uVK
@@ -236689,7 +236692,7 @@ bqj
 vaT
 vaT
 soq
-bwG
+kMZ
 pwm
 xGz
 xGz
@@ -236710,7 +236713,7 @@ spV
 spV
 uVK
 qrB
-uVx
+qKJ
 lze
 ycP
 ycP
@@ -236891,14 +236894,14 @@ pwm
 pwm
 gTr
 fID
-miP
+lUP
 pwm
 xGz
 xGz
 opH
 hHX
-weh
-xEe
+oVv
+gxd
 yex
 opH
 opH
@@ -236909,8 +236912,8 @@ fpd
 opH
 opH
 mZy
-pes
-cFP
+uQx
+vAx
 spV
 spV
 spV
@@ -237093,7 +237096,7 @@ xGz
 pwm
 soq
 pwm
-dnk
+dmD
 pwm
 xGz
 xGz
@@ -237101,7 +237104,7 @@ opH
 opH
 sJb
 gMa
-fCn
+ucs
 opH
 phC
 gMa
@@ -237111,11 +237114,11 @@ gMa
 wtw
 opH
 mqs
-uQx
-dEk
-vkI
-dEk
 qbh
+qWT
+vkI
+qWT
+sFL
 rnS
 xok
 gUk
@@ -237283,7 +237286,7 @@ cgQ
 uvj
 vSU
 lob
-ljQ
+oMM
 uVa
 wNG
 uvj
@@ -237295,7 +237298,7 @@ pwm
 pwm
 uIC
 pwm
-dnk
+dmD
 pwm
 xGz
 xGz
@@ -237304,15 +237307,15 @@ pzk
 gMa
 vqG
 gMa
-wSl
+mce
 gMa
 gMa
 geA
 xgI
 vfv
 fqG
-vMK
-koL
+oTp
+lVU
 ezs
 lhz
 kAU
@@ -237320,7 +237323,7 @@ mLR
 oeV
 msx
 wSh
-dEk
+qWT
 qwK
 gJe
 pdt
@@ -237496,8 +237499,8 @@ pwm
 pwm
 dkm
 vMU
-lLw
-weP
+xTb
+gXz
 pwm
 xGz
 xGz
@@ -237505,9 +237508,9 @@ opH
 opH
 sJb
 gMa
-fCn
+ucs
 opH
-omK
+jwd
 gMa
 pIr
 acB
@@ -237515,13 +237518,13 @@ eCm
 uBy
 opH
 nuM
-buS
+pes
 gkZ
 uVK
 uVK
 uVK
 spV
-wbe
+jnw
 lhz
 gWi
 rIc
@@ -237698,32 +237701,32 @@ seQ
 bVD
 wWa
 bXy
-xTb
-weP
+jVP
+gXz
 pwm
 xGz
 xGz
 opH
 hvz
-tmF
-aFL
-hQO
+ccn
+ekD
+kxQ
 opH
 huC
-xfb
-epB
-gwj
-diH
-yfE
+fCn
+iZz
+rrx
+meA
+kEe
 opH
-nFm
+czb
 spV
-eTj
+lju
 uVK
-uRw
-kOD
+fAA
+oaI
 spV
-vGk
+uZv
 gUk
 ewj
 gYP
@@ -237900,8 +237903,8 @@ pwm
 pwm
 soz
 pwm
-xTb
-miP
+jVP
+lUP
 pwm
 xGz
 xGz
@@ -237915,20 +237918,20 @@ opH
 opH
 opH
 opH
-cRj
-xBq
+lfc
+uaN
 opH
-huw
-qGp
-bAa
+vMQ
+fyb
+xlL
 uVK
-nxH
-uDc
+mbU
+jHx
 spV
 fBw
 gUk
 kHd
-owI
+uUU
 sdN
 rEL
 rEL
@@ -238102,8 +238105,8 @@ veZ
 pwm
 rYq
 pwm
-xTb
-dtG
+jVP
+sSM
 xwU
 xwU
 xwU
@@ -238115,7 +238118,7 @@ bvz
 bvz
 bvz
 wjD
-xrD
+kVO
 opH
 opH
 opH
@@ -238130,7 +238133,7 @@ uVK
 uVK
 gUk
 kHd
-owI
+uUU
 pdx
 utp
 oly
@@ -238304,21 +238307,21 @@ veZ
 pwm
 rsS
 pwm
-npm
-ntC
+onz
+xEe
 rQO
-cKd
+nFm
 rQO
 rQO
 rQO
-qUt
+suE
 ctQ
-lVU
-eit
-eit
+cFP
+fsi
+fsi
 pwm
 mQc
-dCC
+weh
 bvz
 bvz
 bvz
@@ -238712,22 +238715,22 @@ aHk
 aHk
 hJp
 aHk
-wbm
-hJp
-wbm
 uVi
 hJp
-wbm
-wbm
-wbm
+uVi
+jHL
+hJp
+uVi
+uVi
+uVi
 vMo
-wbm
-wbm
+uVi
+uVi
 vMo
-wbm
+uVi
 vMo
 bLR
-kwb
+iWQ
 bLR
 bLR
 bLR
@@ -239535,7 +239538,7 @@ veZ
 veZ
 veZ
 vzY
-gou
+buS
 vzY
 vzY
 vzY
@@ -239948,7 +239951,7 @@ vzY
 eip
 npq
 gUk
-fgb
+koL
 pNT
 srq
 xAC
@@ -240746,7 +240749,7 @@ veZ
 veZ
 veZ
 hqC
-waT
+iDQ
 bcG
 cxn
 kLt

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -1079,14 +1079,10 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/quartermaster/miningdock)
 "ajp" = (
-/obj/structure/table/standard,
+/obj/structure/table/bench/padded,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
-	},
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "ajA" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -2506,20 +2502,16 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "aAw" = (
-/obj/structure/table/woodentable,
-/obj/machinery/reagentgrinder/portable,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
-"aAy" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 5
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"aAy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "aAN" = (
 /obj/structure/table/rack/shelf,
 /obj/random/junk/low_chance,
@@ -2862,13 +2854,9 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "aED" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "aEL" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -2984,20 +2972,18 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/detectives_office)
 "aFL" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "aFM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3387,12 +3373,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/prisoncells)
 "aJN" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/hallway/surface/section1)
 "aJP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5091,15 +5074,12 @@
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
 "bal" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "bam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
@@ -5711,23 +5691,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bfZ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/bed/chair/sofa/brown/left,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
 	},
-/obj/structure/disposaloutlet,
-/obj/machinery/conveyor/south{
-	id = "junk_to_bioreactor"
+/obj/random/toy/plushie,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
 	},
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0";
-	tag = "icon-railing0 (NORTH)"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "bgc" = (
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -6130,16 +6106,19 @@
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
 "bkH" = (
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "bkM" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -6365,10 +6344,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bmx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "bmy" = (
 /obj/structure/railing{
 	dir = 1;
@@ -6624,20 +6613,8 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
 "boU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "boY" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "WO"
@@ -7230,20 +7207,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "buS" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 5
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "buT" = (
 /obj/effect/window_lwall_spawn,
 /turf/simulated/floor/plating/under,
@@ -7452,8 +7421,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bwG" = (
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/table/woodentable,
+/obj/random/toy/plushie,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "bwJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -8013,6 +7984,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
+"bCT" = (
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/obj/structure/sink{
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "bCY" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/big/bush3,
@@ -9105,9 +9090,17 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "bPm" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "bPp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9127,10 +9120,14 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/quartermaster/disposaldrop)
 "bPu" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "bPJ" = (
 /obj/structure/flora/small/busha1,
 /obj/random/flora/jungle_tree,
@@ -9465,7 +9462,7 @@
 /obj/machinery/camera/network/colony_surface{
 	dir = 8
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
+/obj/structure/sign/faction/neotheology_cross{
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/steel,
@@ -10093,9 +10090,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "bZJ" = (
+/obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
+	},
+/area/nadezhda/hallway/side/f2section1)
 "bZL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10394,13 +10396,15 @@
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/plasma_tag)
 "ccn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "cco" = (
 /obj/machinery/light{
 	dir = 1;
@@ -10630,21 +10634,20 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cfH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "cfK" = (
 /obj/machinery/camera/xray/security{
 	dir = 9
@@ -11498,11 +11501,22 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cox" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "coC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -12460,12 +12474,10 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "cxF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/box/white,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "cxN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12522,15 +12534,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cye" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "cyf" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/pros/foreman)
@@ -12627,20 +12634,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
 "czb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "czd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -12865,13 +12864,10 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
 "cAW" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "cBa" = (
@@ -13187,22 +13183,19 @@
 	name = "Dormitory 1"
 	})
 "cDx" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/item/scrap_lump,
-/obj/structure/cable/green{
+/obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "cDF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13413,18 +13406,22 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/command/bridgebar)
 "cFP" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
-"cFR" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/closet/secure_closet/personal/agrolyte,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = -32
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
+"cFR" = (
+/obj/machinery/vending/theomat,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "cFV" = (
 /obj/random/scrap/sparse_weighted,
 /obj/effect/decal/cleanable/dirt,
@@ -13801,12 +13798,12 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/bridge)
 "cKd" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/machinery/computer/arcade,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "cKe" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -14105,6 +14102,15 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"cNj" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "cNl" = (
 /obj/structure/flora/small/trailrocka3,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -14150,9 +14156,9 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/surface/section1)
 "cNE" = (
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/machinery/biomatter_solidifier,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/absolutism/bioreactor)
 "cNF" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/unsimulated/wall/jungle,
@@ -14409,35 +14415,18 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "cRj" = (
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey,
-/obj/structure/sign/faction/derelict1{
-	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
-	name = "NOTICE: Dangerous Biohazard";
-	pixel_x = 0;
-	pixel_y = -32
-	},
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
 /obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "cRq" = (
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark/panels,
@@ -14650,10 +14639,11 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
 "cTB" = (
-/obj/structure/reagent_dispensers/biomatter,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "cTE" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = -32
@@ -14776,14 +14766,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "cUo" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/skyyard)
 "cUx" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 1
@@ -15223,14 +15210,11 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
 "cZV" = (
-/obj/structure/multiz/stairs/enter{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "dar" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/railing/grey{
@@ -15585,10 +15569,10 @@
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
 "ddN" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "ddR" = (
 /obj/structure/ore_box,
@@ -15740,8 +15724,12 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "deL" = (
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "deM" = (
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/structure/table/standard,
@@ -16423,10 +16411,10 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "dmD" = (
-/obj/structure/table/bench/padded,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "dmG" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/camera/network/medbay{
@@ -16514,9 +16502,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
 "dnk" = (
-/obj/structure/flora/small/grassb1,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/table/woodentable,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "dnl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -16634,16 +16625,9 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "doA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/small/grassb1,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "doD" = (
 /obj/structure/catwalk,
 /obj/random/cluster/roaches/low_chance,
@@ -17240,6 +17224,7 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
 "dtG" = (
+/obj/structure/closet/coffin,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "dup" = (
@@ -17801,16 +17786,10 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dzK" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_room)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/hallway/side/f2section1)
 "dzS" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "16,9"
@@ -17978,16 +17957,20 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "dBr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "dBt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -18001,11 +17984,9 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "dBR" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "dBU" = (
@@ -18132,15 +18113,17 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/bridgebar)
 "dCC" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/power/eotp,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "dCH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -18278,14 +18261,16 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dEk" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "dEo" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -19155,11 +19140,21 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "dNo" = (
-/obj/machinery/alarm{
-	pixel_y = 26
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "dNp" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 1
@@ -19208,9 +19203,8 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "dNI" = (
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "dNK" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,18"
@@ -20102,12 +20096,20 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "dXG" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/absolutism/bioreactor)
 "dXJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -20906,22 +20908,11 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
 "efu" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/prime)
 "efv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21026,11 +21017,25 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "egd" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "egg" = (
 /obj/structure/table/rack/shelf,
 /obj/random/pack/cloth/low_chance,
@@ -21253,19 +21258,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "eit" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "eix" = (
 /obj/structure/table/steel,
 /obj/machinery/microwave,
@@ -21357,13 +21354,9 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ejM" = (
-/obj/machinery/light,
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/reagent_dispensers/biomatter/large,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "ejZ" = (
 /obj/machinery/alarm{
@@ -21421,9 +21414,12 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "ekD" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/meadow)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/vectorrooms)
 "ekF" = (
 /obj/structure/table/rack/shelf,
 /obj/random/mecha_equipment/low_chance,
@@ -21876,21 +21872,13 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "epB" = (
-/obj/machinery/door/airlock{
-	name = "Church";
-	req_access = list(27)
-	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "epH" = (
@@ -22182,10 +22170,11 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "esz" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "esA" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -23639,9 +23628,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "eIV" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/table/woodentable,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "eIZ" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,22"
@@ -24081,17 +24074,9 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/crew_quarters/kitchen_storage)
 "eMx" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/conveyor/south{
-	id = "junk_to_bioreactor"
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "eMB" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/extinguisher_cabinet{
@@ -24115,27 +24100,9 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory_blackshield)
 "eMK" = (
-/obj/structure/cable/yellow{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey,
-/obj/structure/cable/yellow,
-/obj/machinery/light,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/atmos/storage)
 "eMS" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -24673,10 +24640,14 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/construction)
 "eSm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/light/small,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "eSv" = (
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/effect/floor_decal/border/techfloor{
@@ -24842,11 +24813,23 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/main/stairwell)
 "eTj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
 "eTk" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -25126,22 +25109,19 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "eVP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/catwalk,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "eVQ" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -26172,15 +26152,23 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "fgb" = (
-/obj/structure/multiz/stairs/active/bottom{
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+/obj/structure/disposaloutlet,
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/hallway/surface/section1)
 "fgf" = (
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/hallway/main/stairwell)
@@ -26270,12 +26258,11 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "fgM" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 24
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/command/prime)
 "fgN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -26634,11 +26621,10 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fkm" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27266,15 +27252,17 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "fqE" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/structure/invislight,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
 /area/nadezhda/absolutism/vectorrooms)
 "fqF" = (
 /obj/machinery/light/small{
@@ -27457,9 +27445,11 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
 "fsi" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/outside/meadow)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/nadezhda/hallway/surface/section1)
 "fsk" = (
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm4{
@@ -27790,16 +27780,20 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "fuZ" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/door/airlock{
+	id_tag = "chudorm4";
+	name = "Church Dorm 2";
+	req_access = list(70)
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "fvc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -28016,11 +28010,19 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "fxv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "fxy" = (
 /obj/machinery/door/airlock/maintenance_security{
 	req_access = list(1)
@@ -28087,12 +28089,16 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "fyb" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "fyc" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
@@ -28333,14 +28339,8 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical)
 "fAA" = (
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "fAG" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/simulated/floor/bluegrid{
@@ -28484,8 +28484,12 @@
 	name = "Dormitory 3"
 	})
 "fBV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
@@ -28527,15 +28531,14 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/cryo)
 "fCn" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "fCp" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -28610,9 +28613,11 @@
 	name = "\improper Blackshield - Firing Range"
 	})
 "fCX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "fDb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4;
@@ -28869,18 +28874,13 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "fEH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/catwalk,
+/obj/machinery/light,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "fEJ" = (
 /obj/structure/catwalk,
@@ -29923,19 +29923,18 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fPi" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	anchored = 1;
 	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "fPo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -30034,9 +30033,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "fPE" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = -32
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "fPG" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/camera/network/cev_eris,
@@ -31332,8 +31333,13 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/abandoned_solars/powered)
 "gdn" = (
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/command/prime)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "gdr" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -31749,18 +31755,13 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ggs" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
 	},
-/obj/structure/cable/green,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "ggt" = (
 /obj/machinery/power/nt_obelisk,
@@ -32595,15 +32596,11 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "gnT" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/random/toy/plushie_onlyfox,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "gnW" = (
@@ -32646,10 +32643,15 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
 "gou" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/machinery/disposal/deliveryChute{
+	dir = 4;
+	name = "biomatter chute"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "gow" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -33217,18 +33219,9 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "guj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "chudorm4";
-	name = "Church Dorm 2";
-	req_access = list(70)
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "gum" = (
@@ -33462,22 +33455,9 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "gxd" = (
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "gxg" = (
 /obj/structure/closet/l3closet,
 /turf/simulated/floor/tiled/white,
@@ -34555,18 +34535,19 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "gHI" = (
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "gHJ" = (
 /obj/structure/flora/small/rock2,
 /turf/simulated/floor/asteroid/grass,
@@ -35482,6 +35463,13 @@
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
+"gPB" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/sign/faction/neotheology{
+	pixel_x = 32
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "gPD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -35638,19 +35626,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "gRQ" = (
 /obj/random/material/low_chance,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -35683,22 +35661,13 @@
 	name = "Dormitory 2"
 	})
 "gSa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "gSb" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -36260,12 +36229,25 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "gXz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/random/scrap/dense_weighted/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "gXB" = (
 /obj/structure/sink/kitchen{
 	name = "utility sink";
@@ -36608,14 +36590,10 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/turret_protected/ai_upload)
 "hbi" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/biomatter,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "hbk" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -37550,15 +37528,9 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "hkR" = (
-/obj/structure/multiz/stairs/enter{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "hkW" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -37702,21 +37674,30 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "hmj" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/camera/network/church{
-	dir = 1
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/material/kitchen/rollingpin,
+/obj/machinery/light_switch{
+	pixel_y = 30
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "hmk" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "hmp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -37958,19 +37939,12 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "hpc" = (
-/obj/structure/bed/chair/sofa/brown/left,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
+/obj/machinery/light_switch{
+	pixel_x = 28
 	},
-/obj/random/toy/plushie,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "hpe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -37991,19 +37965,23 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/absolutism/bioreactor)
 "hpq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposaloutlet{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "hpu" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/effect/decal/cleanable/dirt,
@@ -38498,11 +38476,24 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
 "huw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "huC" = (
 /obj/structure/bookcase,
 /obj/item/book/ritual/cruciform,
@@ -39594,19 +39585,12 @@
 	name = "Dormitory 1"
 	})
 "hHU" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating/under,
-/area/colony)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "hHX" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -40025,12 +40009,22 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "hMs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/structure/cable/yellow{
+	d1 = 32;
+	icon_state = "32-1"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/catwalk,
+/turf/simulated/open,
+/area/nadezhda/absolutism/storage)
 "hMw" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -40130,11 +40124,17 @@
 	name = "\improper Outdoors - Pad"
 	})
 "hNx" = (
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Office"
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/vectorrooms)
 "hNF" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/cable/green{
@@ -40494,10 +40494,24 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "hQO" = (
-/obj/structure/table/woodentable,
-/obj/item/device/lighting/toggleable/lantern/censer,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "hQP" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -40665,19 +40679,11 @@
 /turf/unsimulated/mineral,
 /area/colony)
 "hSz" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "hSA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -40950,10 +40956,25 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
 "hVD" = (
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Prime's Office";
+	departmentType = 22;
+	name = "Prime's RC";
+	pixel_x = 30;
+	pixel_y = 0
+	},
+/obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Prime's Office"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "hVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -41868,13 +41889,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ifo" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "ifw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/security{
@@ -42325,11 +42345,11 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
 "ikj" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/hallway/surface/section1)
 "ikn" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -43453,12 +43473,10 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "ivC" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/obj/item/scrap_lump,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/reagent_dispensers/biomatter,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "ivM" = (
 /obj/machinery/holoposter{
 	pixel_y = 30
@@ -43911,12 +43929,15 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "iAo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/hallway/side/f2section1)
 "iAq" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -44577,17 +44598,13 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "iGZ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-s"
 	},
-/obj/item/storage/fancy/crayons,
-/obj/structure/table/woodentable,
-/obj/item/storage/fancy/crayons,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "iHa" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/unsimulated/wall/jungle,
@@ -45675,13 +45692,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "iRf" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/structure/invislight,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/vectorrooms)
 "iRh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -46283,15 +46300,9 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "iWQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "iWS" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -46567,17 +46578,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "iZz" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/small/grassa5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "iZD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
@@ -47579,8 +47582,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -47704,17 +47707,15 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "jkf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/conveyor_switch{
+	id = "disposals grinder"
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/power/eotp,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/floor_decal/industrial/danger,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "jkj" = (
 /obj/structure/table/steel,
 /obj/random/material_resources,
@@ -47979,17 +47980,23 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jnw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock{
+	name = "Church";
+	req_access = list(27)
+	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "jny" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -48553,17 +48560,15 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jsM" = (
-/obj/structure/bed/chair/sofa/black/left{
-	dir = 8
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/tool/multitool,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
-/obj/structure/noticeboard/church{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "jsR" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/gloves{
@@ -48582,15 +48587,28 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "jte" = (
-/obj/machinery/vending/theomat,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 2";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/area/nadezhda/absolutism/bioreactor)
 "jtl" = (
 /obj/machinery/light_switch{
 	pixel_y = 30
@@ -48703,11 +48721,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = -32
+	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "jup" = (
@@ -48876,11 +48894,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
 "jwd" = (
-/obj/item/tool/knife/neotritual,
-/obj/item/clothing/gloves/psionic_ring,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "jwe" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
@@ -50013,17 +50033,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jHx" = (
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "jHC" = (
 /obj/random/scrap/dense_weighted,
 /obj/structure/table/rack/shelf,
@@ -50043,9 +50058,8 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jHL" = (
-/obj/structure/disposalpipe/segment,
 /turf/simulated/wall/church_reinforced,
-/area/nadezhda/absolutism/bioreactor)
+/area/colony)
 "jHS" = (
 /obj/random/contraband/low_chance,
 /obj/effect/decal/cleanable/cobweb{
@@ -51258,18 +51272,13 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jTG" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/atmos/storage)
 "jTH" = (
 /obj/machinery/door/firedoor,
@@ -51545,14 +51554,9 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/barquarters)
 "jVP" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/bed/chair/comfy/brown,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "jWc" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -51649,13 +51653,13 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jXd" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/sign/faction/neotheology{
+	pixel_x = -30;
+	pixel_y = 0
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "jXf" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/under,
@@ -52182,20 +52186,19 @@
 	name = "\improper Clinic"
 	})
 "kbl" = (
-/obj/structure/cable/green{
-	d1 = 2;
+/obj/structure/cable/cyan{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "kbm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -53291,11 +53294,11 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "klX" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "kmc" = (
 /obj/structure/railing/grey{
@@ -53696,10 +53699,16 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "koL" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/replenishing/chalice,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "koP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53738,12 +53747,16 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
 "kpf" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/smartfridge/kitchen/church,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "kpi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -54188,9 +54201,11 @@
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "ktR" = (
-/obj/effect/floor_decal/industrial/loading/white,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "ktS" = (
 /obj/structure/closet/crate,
 /obj/item/am_shielding_container,
@@ -54437,12 +54452,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "kwb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
 /turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/vectorrooms)
 "kwd" = (
 /obj/random/flora/jungle_tree,
 /obj/effect/decal/cleanable/dirt,
@@ -54611,12 +54626,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/hut_cell1)
 "kxQ" = (
-/obj/structure/catwalk,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "kxW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54635,14 +54649,14 @@
 /turf/simulated/floor/asteroid/dirt/dark/plough,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kyl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/camera/network/church{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "kym" = (
 /mob/living/simple_animal/hostile/naniteswarm{
 	desc = "A swarm of disgusting mini locusts infested with disease and hatred.";
@@ -54651,20 +54665,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kyt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "kyu" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -55249,26 +55254,29 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kDY" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "kEe" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "kEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -55456,13 +55464,15 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "kFQ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "kFU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -55980,19 +55990,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kLc" = (
-/obj/structure/multiz/stairs/active{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/sign/levels/stairsdown{
-	pixel_y = -30;
-	pixel_x = 32
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/hallway/surface/section1)
 "kLm" = (
 /obj/structure/table/rack/shelf,
 /obj/random/lowkeyrandom,
@@ -56210,11 +56213,15 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kMZ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
+/obj/structure/bed/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atm{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "kNa" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -56366,14 +56373,12 @@
 /turf/simulated/open,
 /area/colony)
 "kOD" = (
-/obj/structure/bed/chair/sofa/black/right{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "kOJ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -56412,6 +56417,23 @@
 /obj/random/booze,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
+"kPg" = (
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
+	},
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "kPj" = (
 /obj/structure/sign/departmentold/security,
 /turf/simulated/wall/r_wall,
@@ -56793,18 +56815,16 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "kSK" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "kSR" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/table/rack/shelf,
@@ -57129,8 +57149,14 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "kVO" = (
-/turf/simulated/wall/church_reinforced,
-/area/colony)
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "kWa" = (
 /obj/structure/flora/big/bush2,
 /obj/effect/decal/cleanable/dirt,
@@ -57964,22 +57990,13 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ldw" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/material/kitchen/rollingpin,
-/obj/machinery/light_switch{
-	pixel_y = 30
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "ldz" = (
 /obj/structure/holohoop{
 	dir = 1
@@ -58235,16 +58252,10 @@
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "lfc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "lfh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spider/spiderling,
@@ -58415,6 +58426,13 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -58658,16 +58676,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ljQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/multiz/stairs/enter/bottom,
+/obj/structure/invislight,
+/turf/simulated/floor/plating,
+/area/nadezhda/outside/meadow)
 "ljT" = (
 /obj/structure/table/standard,
 /obj/item/storage/briefcase/inflatable,
@@ -59041,14 +59053,12 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "lnV" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/machinery/camera/network/church{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/item/scrap_lump,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "lnW" = (
 /obj/item/clothing/suit/armor/platecarrier/ih,
 /obj/item/clothing/suit/armor/platecarrier/ih,
@@ -61414,13 +61424,18 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/barbackroom)
 "lLw" = (
-/obj/structure/bed/chair/sofa/brown/right,
-/obj/landmark/join/start/acolyte,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/prime)
 "lLB" = (
 /obj/machinery/atmospherics/omni/mixer{
 	active_power_usage = 7500;
@@ -62423,15 +62438,14 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "lUP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "lUR" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -62544,9 +62558,20 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
 "lVU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "lVV" = (
 /obj/machinery/power/breakerbox{
 	RCon_tag = "AI Core Substation Bypass"
@@ -63120,20 +63145,9 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "mce" = (
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/effect/floor_decal/industrial/loading/white,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "mcg" = (
 /obj/structure/bed/chair,
 /obj/structure/window/reinforced{
@@ -63311,20 +63325,13 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/quartermaster/office)
 "mdn" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 32
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/colony)
 "mdt" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 2;
@@ -63473,12 +63480,27 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "meA" = (
-/obj/structure/table/woodentable,
-/obj/machinery/light{
+/obj/structure/cable/yellow{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey,
+/obj/structure/cable/yellow,
+/obj/machinery/light,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "meB" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 0;
@@ -63844,10 +63866,17 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "miP" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = -32
+/obj/random/furniture/pottedplant,
+/obj/machinery/camera/network/church{
+	dir = 8
 	},
-/turf/simulated/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "miQ" = (
 /obj/machinery/light,
@@ -64819,6 +64848,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "mqS" = (
@@ -65548,9 +65580,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
 "mxN" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "mxR" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -65827,9 +65865,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/engineering/foyer)
 "mBf" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "mBn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating/under,
@@ -66534,12 +66574,12 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/construction)
 "mHf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "mHh" = (
 /obj/landmark/join/start/cargo_tech,
 /obj/structure/disposalpipe/segment,
@@ -66914,9 +66954,17 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
 "mKY" = (
-/obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/catwalk,
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "mLl" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -66936,12 +66984,17 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "mLR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "mLS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -67343,16 +67396,9 @@
 /turf/simulated/floor/beach/sand/drywater,
 /area/nadezhda/crew_quarters/pool)
 "mPy" = (
-/obj/structure/mirror{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "mPC" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -67517,12 +67563,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "mRi" = (
-/obj/machinery/camera/network/church{
-	dir = 4
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "mRq" = (
 /obj/structure/table/bench/marble,
 /obj/machinery/alarm{
@@ -67955,13 +68000,11 @@
 	name = "\improper Outdoors - Pad"
 	})
 "mVl" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "mVm" = (
 /obj/structure/closet,
 /turf/simulated/floor/tiled/white,
@@ -68006,11 +68049,12 @@
 	name = "Residential District Substation"
 	})
 "mVE" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/light_switch{
+	pixel_x = -20
+	},
+/obj/machinery/smartfridge/kitchen/church,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "mVH" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/generic,
@@ -68362,6 +68406,9 @@
 	dir = 1;
 	light_color = "#0892d0"
 	},
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "mZB" = (
@@ -68573,13 +68620,16 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ncd" = (
-/obj/structure/multiz/stairs/active/bottom{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "nch" = (
 /obj/random/furniture/pottedplant,
@@ -69138,11 +69188,14 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "nib" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "nic" = (
 /obj/structure/table/onestar,
 /obj/item/pen,
@@ -69544,15 +69597,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "nmo" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
+/obj/machinery/light,
+/obj/machinery/light_switch{
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/obj/machinery/atm{
-	dir = 4;
-	pixel_x = 30
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "nmp" = (
 /obj/item/reagent_containers/blood/AMinus,
 /obj/item/reagent_containers/blood/APlus,
@@ -69723,12 +69775,19 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/fo)
 "nol" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "nom" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -69846,18 +69905,9 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "npm" = (
-/obj/structure/mirror{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/structure/sink{
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "npp" = (
 /obj/structure/multiz/stairs/active/bottom,
@@ -70068,12 +70118,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
-	},
-/obj/structure/sign/levels/stairsup{
-	pixel_x = 32;
-	pixel_y = -28
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/bioreactor)
@@ -70265,15 +70310,24 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ntC" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "ntK" = (
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
@@ -70457,22 +70511,12 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nvB" = (
-/obj/structure/cable/yellow{
-	d1 = 32;
-	icon_state = "32-1"
+/obj/machinery/camera/network/church{
+	dir = 4
 	},
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
-	},
-/obj/structure/catwalk,
-/turf/simulated/open,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "nvD" = (
 /obj/structure/table/bar_special,
 /obj/machinery/floor_light,
@@ -70624,12 +70668,15 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "nxH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/chapel)
 "nxP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -71010,6 +71057,21 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
+"nBa" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "nBd" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -71901,27 +71963,14 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nJR" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "nJX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -72638,17 +72687,9 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "nRM" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "nRO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -72773,12 +72814,15 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "nTE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "nTL" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -73594,19 +73638,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "oaI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "oaM" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -74962,8 +74996,14 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/main/stairwell)
 "omK" = (
-/turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/meadow)
+/obj/structure/closet/crate/trashcart,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
+	},
+/area/nadezhda/hallway/side/f2section1)
 "omU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75211,6 +75251,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
 	},
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "opO" = (
@@ -75245,14 +75288,22 @@
 /turf/simulated/mineral,
 /area/nadezhda/command/cbo)
 "oqc" = (
-/obj/structure/bed/chair/wood{
-	dir = 4;
-	icon_state = "wooden_chair";
-	tag = "icon-wooden_chair (EAST)"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/item/scrap_lump,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "oqd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -75946,10 +75997,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
 "owI" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/engineering/atmos/storage)
 "owK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/furniture/pottedplant,
@@ -77271,9 +77321,24 @@
 	},
 /area/nadezhda/pros/proelav)
 "oJb" = (
-/obj/structure/closet/coffin,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "oJo" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood/wild3,
@@ -77640,12 +77705,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "oMM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "oMS" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/junk/snappop,
@@ -77716,12 +77782,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
 "oNA" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/bioreactor)
 "oNP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78226,12 +78291,13 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "oSN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/glass/replenishing/chalice,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = -32
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "oST" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -78308,11 +78374,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "oTp" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/disposal/deliveryChute{
+	dir = 1;
+	name = "trash chute"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "oTv" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -78470,23 +78538,10 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
 "oVv" = (
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "oVO" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 6
@@ -79165,10 +79220,10 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "pes" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -81174,9 +81229,10 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/virology)
 "pyY" = (
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "pzk" = (
 /obj/structure/nt_pedestal,
 /turf/simulated/floor/carpet/bcarpet,
@@ -81447,8 +81503,17 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "pBQ" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/item/reagent_containers/glass/urn/veteran{
+	pixel_x = 7
+	},
+/obj/item/oddity/nt/pyramid{
+	pixel_x = -9
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "pBV" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -82531,24 +82596,12 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
 "pLt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "pLw" = (
 /obj/random/mob/croaker/low_chance,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -82746,10 +82799,11 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "pNu" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "pNw" = (
 /turf/simulated/mineral,
 /area/nadezhda/outside/dcave)
@@ -83045,14 +83099,12 @@
 	name = "\improper Upper Research Hallway"
 	})
 "pPU" = (
-/obj/structure/multiz/stairs/active{
-	dir = 1
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "pPW" = (
 /obj/machinery/vending/printomat,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -83872,13 +83924,19 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "pYx" = (
-/obj/structure/table/woodentable,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating/under,
+/area/colony)
 "pYB" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -84033,20 +84091,12 @@
 /area/colony)
 "pZI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/machinery/power/wall_obelisk{
+	pixel_x = 1;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/area/nadezhda/absolutism/chapel)
 "pZS" = (
 /mob/living/simple_animal/opossum{
 	desc = "The Nedezhda basketball team mascot. - Currently scavenging for rebounds";
@@ -84603,13 +84653,15 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qfx" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/random/furniture/pottedplant,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qfC" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -84771,14 +84823,14 @@
 	name = "\improper Outdoors - Pad"
 	})
 "qgM" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "qhd" = (
 /obj/structure/table/bar_special,
 /obj/machinery/chemical_dispenser/beer,
@@ -86126,12 +86178,12 @@
 /turf/simulated/wall/r_wall,
 /area/colony)
 "quT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/sign/faction/neotheology{
+	pixel_x = -30;
+	pixel_y = 0
 	},
-/turf/simulated/floor/asteroid/dirt/dust,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "quV" = (
 /obj/structure/bed/chair/wood,
@@ -86167,13 +86219,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "qvn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "qvy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -86279,11 +86328,9 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "qwE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "qwI" = (
 /obj/machinery/light{
 	dir = 8;
@@ -86504,10 +86551,14 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qyo" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/multiz/stairs/active{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "qyq" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
@@ -86640,14 +86691,12 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "qzx" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "qzA" = (
 /obj/structure/table/bar_special,
 /obj/item/modular_computer/tablet/preset/custom_loadout/standard,
@@ -86869,10 +86918,14 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
 "qBq" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "qBx" = (
 /obj/structure/table/standard,
 /obj/random/material/low_chance,
@@ -86885,20 +86938,17 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest)
 "qBQ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "qBV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/rock5,
@@ -86977,9 +87027,13 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "qDa" = (
-/obj/structure/flora/small/grassa5,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/closet/secure_closet/reinforced/preacher,
+/obj/item/device/taperecorder,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/item/clothing/mask/gas/germanmask,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "qDd" = (
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
@@ -87332,14 +87386,15 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "qGp" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/sink{
+	pixel_y = -22
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "qGu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -87409,15 +87464,13 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qHh" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/colony)
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qHk" = (
 /obj/structure/flora/small/grassb4,
 /obj/effect/decal/cleanable/dirt,
@@ -87758,18 +87811,15 @@
 	name = "\improper Clinic"
 	})
 "qKJ" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/structure/invislight,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "qKO" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt,
@@ -88671,17 +88721,12 @@
 	name = "Dormitory 3"
 	})
 "qTC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "qTD" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 4;
@@ -88767,9 +88812,14 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/atmos/storage)
 "qUt" = (
-/obj/machinery/biomatter_solidifier,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/multiz/stairs/enter{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "qUw" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -88816,19 +88866,17 @@
 	name = "Residential District Maintenance"
 	})
 "qUT" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_x = 32
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "qUY" = (
 /obj/structure/mopbucket,
 /obj/effect/floor_decal/industrial/botright,
@@ -89057,16 +89105,16 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/crew_quarters/podrooms)
 "qWT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "qWW" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/small/busha3,
@@ -89493,11 +89541,11 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "raN" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/item/device/radio/intercom{
+	pixel_y = 24
 	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "raR" = (
 /obj/structure/table/woodentable,
@@ -89566,16 +89614,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rby" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/under,
-/area/colony)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/wineglass,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "rbA" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -89753,11 +89803,16 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "rcV" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
 	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "rcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -90255,14 +90310,24 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rig" = (
-/obj/machinery/door/holy{
-	name = "Church"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "rip" = (
 /obj/machinery/door/firedoor,
 /obj/structure/door_assembly/door_assembly_maint_cargo,
@@ -90332,10 +90397,12 @@
 	name = "Dormitory 3"
 	})
 "riP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "riQ" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/powermonitor{
@@ -90442,19 +90509,16 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "rjV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/power/nt_obelisk,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "rjY" = (
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "rjZ" = (
 /obj/item/modular_computer/console/preset/command{
 	dir = 4;
@@ -91093,8 +91157,13 @@
 	name = "Dormitory 1"
 	})
 "rqm" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
@@ -91213,9 +91282,9 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rrx" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/meadow)
 "rrB" = (
 /obj/structure/table/steel,
 /obj/random/mob/spiders,
@@ -91768,12 +91837,20 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/pros/prep)
 "rwF" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "rwG" = (
 /obj/machinery/camera/network/colony_transition{
 	dir = 8
@@ -91836,15 +91913,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "rxq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "rxs" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/under,
@@ -92644,10 +92718,20 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/command/courtroom)
 "rEA" = (
-/turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
+	},
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "rED" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/rock,
@@ -92839,10 +92923,19 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rGx" = (
-/obj/effect/floor_decal/industrial/danger,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "rGz" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -92951,10 +93044,14 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rHD" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/obj/structure/invislight,
-/turf/simulated/floor/plating,
-/area/nadezhda/outside/meadow)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "rHE" = (
 /obj/machinery/light{
 	dir = 1
@@ -92989,6 +93086,18 @@
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"rHW" = (
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
+	},
+/obj/structure/noticeboard/church{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "rHX" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -95310,18 +95419,14 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "sdY" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/holy{
+	name = "Church"
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = 32
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/absolutism/storage)
 "sec" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
@@ -95474,17 +95579,12 @@
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/meadow)
 "sfi" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/area/nadezhda/absolutism/skyyard)
 "sfB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -96948,16 +97048,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "suE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "suL" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -97275,21 +97375,10 @@
 /area/nadezhda/hallway/side/f2section1)
 "sxY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -97488,24 +97577,13 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "sAo" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/area/nadezhda/absolutism/bioreactor)
 "sAN" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -97857,10 +97935,12 @@
 /turf/simulated/mineral,
 /area/colony)
 "sFL" = (
-/obj/structure/table/woodentable,
-/obj/random/toy/plushie,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "sFQ" = (
 /turf/simulated/floor/reinforced,
 /area/nadezhda/hallway/surface/section1)
@@ -98164,6 +98244,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
 "sJh" = (
@@ -98262,12 +98345,9 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/genetics)
 "sJX" = (
-/obj/machinery/light_switch{
-	pixel_y = 30
-	},
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "sKc" = (
 /obj/structure/table/woodentable,
 /obj/item/device/paicard{
@@ -98480,11 +98560,17 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/kitchen)
 "sMN" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "sMT" = (
 /obj/structure/table/rack,
 /obj/item/storage/toolbox/electrical{
@@ -98620,12 +98706,12 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/gmaster)
 "sOa" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/tool/multitool,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "sOd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -98736,10 +98822,23 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "sPh" = (
-/obj/structure/invislight,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/meadow)
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "sPj" = (
 /obj/structure/flora/small/trailrocka3,
 /obj/effect/decal/cleanable/dirt,
@@ -99112,20 +99211,12 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "sSM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/mob/roaches/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "sSW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -99367,16 +99458,12 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sUM" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair";
+	tag = "icon-wooden_chair (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "sUN" = (
@@ -99868,8 +99955,34 @@
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sZu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey,
+/obj/structure/sign/faction/derelict1{
+	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
+	name = "NOTICE: Dangerous Biohazard";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "sZw" = (
 /obj/effect/floor_decal/spline/fancy,
@@ -100095,9 +100208,18 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "tby" = (
-/obj/structure/reagent_dispensers/biomatter/large,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/sign/levels/stairsup{
+	pixel_x = 32;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/bioreactor)
 "tbJ" = (
 /obj/structure/closet/wall_mounted/firecloset{
@@ -100480,11 +100602,14 @@
 /turf/simulated/mineral,
 /area/nadezhda/outside/forest)
 "tgh" = (
-/obj/machinery/power/nt_obelisk,
-/obj/machinery/power/wall_obelisk{
-	pixel_y = 22
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/bioreactor)
 "tgi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -101196,9 +101321,16 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "tmF" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "tmR" = (
 /obj/machinery/door/airlock/glass{
@@ -101335,23 +101467,10 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/main/stairwell)
 "toM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "toN" = (
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -101401,14 +101520,31 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "tpj" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 1";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "tpn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/bushc3,
@@ -101557,6 +101693,18 @@
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/substation/bridge)
+"tra" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "trc" = (
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -102403,11 +102551,12 @@
 	name = "Dormitory 4"
 	})
 "tzn" = (
-/obj/machinery/camera/network/church{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "tzo" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/rock,
@@ -102440,10 +102589,10 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tzJ" = (
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
-/turf/simulated/open,
+/turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/hallway/surface/section1)
 "tzM" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -103297,16 +103446,12 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
 "tJf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/absolutism/skyyard)
 "tJk" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -103834,6 +103979,10 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"tOI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "tON" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -104006,11 +104155,11 @@
 	dir = 1;
 	icon_state = "danger"
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	pixel_y = 0
 	},
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/atmos/storage)
 "tPO" = (
@@ -104531,6 +104680,15 @@
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/cafeteria)
+"tWL" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "tWW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -104868,14 +105026,18 @@
 	name = "\improper Upper Research Hallway"
 	})
 "tZL" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "tZS" = (
 /obj/effect/floor_decal/industrial/arrows/white{
 	dir = 1
@@ -104884,27 +105046,17 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "tZT" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 2";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
 	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "tZW" = (
 /obj/structure/closet/cabinet,
@@ -105045,31 +105197,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "uaN" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 1";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/catwalk,
+/obj/structure/invislight,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/meadow)
 "uaO" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -105165,24 +105297,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "ucl" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "ucn" = (
 /mob/living/simple_animal/hostile/snake,
 /turf/simulated/floor/asteroid/grass,
@@ -105197,16 +105317,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "ucs" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_x = 32
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "ucx" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/stack/ore,
@@ -105239,7 +105355,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ucY" = (
 /obj/structure/invislight,
-/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "udb" = (
@@ -105561,16 +105677,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/cryo)
 "ugj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/light_switch{
+	pixel_y = 30
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "ugm" = (
 /obj/random/structures,
 /obj/effect/spider/stickyweb,
@@ -105581,18 +105693,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ugn" = (
-/obj/machinery/camera/network/church{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "ugx" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Permanent Holding";
@@ -105924,15 +106029,13 @@
 	name = "\improper Outdoors - Pad"
 	})
 "ujR" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/urn/veteran{
-	pixel_x = 7
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
 	},
-/obj/item/oddity/nt/pyramid{
-	pixel_x = -9
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "ujT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -106494,9 +106597,17 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/crew_quarters/podrooms)
 "uqM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "uqQ" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -106574,6 +106685,17 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
+"urt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "urA" = (
 /obj/random/cluster/spiders,
 /obj/effect/decal/cleanable/dirt,
@@ -106750,10 +106872,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "usX" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "utl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -107908,12 +108030,12 @@
 /area/nadezhda/command/cbo)
 "uCH" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/under,
-/area/colony)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "uCI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -108312,15 +108434,11 @@
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "uGA" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4;
-	name = "biomatter chute"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/multiz/stairs/enter/bottom,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "uGD" = (
 /obj/landmark/machinery/input,
 /obj/machinery/conveyor/south{
@@ -108390,6 +108508,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
+"uHl" = (
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "uHq" = (
 /obj/machinery/light{
 	dir = 8;
@@ -109050,14 +109173,14 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "uOA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "uOB" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -109346,20 +109469,15 @@
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "uQx" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/multiz/stairs/enter{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "uQC" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -109444,16 +109562,10 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "uRw" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/machinery/light_switch{
-	pixel_x = 28
-	},
-/obj/structure/bed/chair/comfy/black,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "uRx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -109732,9 +109844,10 @@
 	name = "\improper Upper Research Hallway"
 	})
 "uTQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "uTS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -109821,14 +109934,12 @@
 	name = "\improper Outdoors - Pad"
 	})
 "uUU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
-/obj/structure/catwalk,
-/obj/machinery/light,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "uUW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -109899,25 +110010,25 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
 "uVx" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Prime's Office";
-	departmentType = 22;
-	name = "Prime's RC";
-	pixel_x = 30;
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
 	pixel_y = 0
 	},
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Prime's Office"
-	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/effect/floor_decal/industrial/warningred,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "uVy" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/robotics{
@@ -110273,12 +110384,21 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "uZv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "uZx" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/big/bush3,
@@ -110787,19 +110907,12 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
 "vfg" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "vfj" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section2";
@@ -111520,14 +111633,16 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "vmm" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/engineering/engine_room)
 "vmq" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
@@ -112169,11 +112284,9 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/meeting_room)
 "vsx" = (
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "vsy" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/structures,
@@ -112514,23 +112627,19 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "vvO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/steel/golden,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "vvS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame/vertical{
@@ -112691,12 +112800,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "vwJ" = (
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/obj/structure/invislight,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "vwK" = (
 /obj/effect/decal/cleanable/cobweb{
@@ -113095,12 +113210,10 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "vAx" = (
-/obj/structure/closet/secure_closet/personal/agrolyte,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/light,
+/obj/machinery/vending/fortune,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "vAB" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -113257,16 +113370,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vCh" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0";
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/church_reinforced,
+/area/nadezhda/absolutism/bioreactor)
 "vCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -113590,12 +113696,20 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical_blackshield)
 "vFR" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "vFU" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -113662,11 +113776,8 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vGk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
-	},
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "vGA" = (
 /obj/structure/sign/security/cells{
@@ -113876,6 +113987,9 @@
 /area/nadezhda/engineering/atmos/storage)
 "vIw" = (
 /obj/structure/flora/ausbushes/brflowers,
+/obj/structure/sign/faction/neotheology{
+	pixel_x = 32
+	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "vIF" = (
@@ -113885,12 +113999,16 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vIL" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "vJb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -114097,13 +114215,14 @@
 	name = "Residential District Maintenance"
 	})
 "vKM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/wall_obelisk{
-	pixel_x = 1;
-	pixel_y = 24
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/bioreactor)
 "vKR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -114293,36 +114412,31 @@
 /area/nadezhda/security/armory_blackshield)
 "vMI" = (
 /obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/meadow)
 "vMK" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
-"vMQ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/absolutism/vectorrooms)
+"vMQ" = (
+/obj/structure/mopbucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/soap/deluxe,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "vMU" = (
 /obj/structure/disposalpipe/junction,
 /obj/structure/cable/yellow{
@@ -115315,13 +115429,20 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "vWA" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/random/toy/plushie_onlyfox,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "vWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -115551,12 +115672,22 @@
 	name = "Dormitory 1"
 	})
 "vXR" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "vYb" = (
 /obj/structure/closet/secure_closet/personal/doctor,
 /obj/item/clothing/glasses/hud/health,
@@ -115752,11 +115883,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "waf" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
-	},
-/turf/simulated/floor/carpet,
+/obj/structure/table/woodentable,
+/obj/machinery/reagentgrinder/portable,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "wak" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -115788,21 +115917,14 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "waT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/steel/golden,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "waY" = (
 /obj/structure/multiz/stairs/active/bottom,
 /obj/structure/window/reinforced{
@@ -115812,19 +115934,16 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/side/f2section1)
 "wbe" = (
-/obj/machinery/light/small,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "wbm" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "wbo" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -116206,25 +116325,22 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
 "weP" = (
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
 /obj/structure/cable/green{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/random/scrap/dense_weighted/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "weT" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/effect/floor_decal/industrial/arrows/white,
@@ -116295,12 +116411,13 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "wfn" = (
-/obj/structure/mopbucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/soap/deluxe,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/bed/chair/sofa/brown/right,
+/obj/landmark/join/start/acolyte,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "wft" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/cafe,
@@ -116420,13 +116537,14 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/cafeteria)
 "wgN" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 1;
-	name = "trash chute"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "wgV" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -117282,11 +117400,9 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "wpu" = (
-/obj/structure/closet/secure_closet/reinforced/preacher,
-/obj/item/device/taperecorder,
-/obj/item/device/camera,
-/obj/item/device/camera_film,
-/obj/item/clothing/mask/gas/germanmask,
+/obj/item/tool/knife/neotritual,
+/obj/item/clothing/gloves/psionic_ring,
+/obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
 "wpv" = (
@@ -117950,11 +118066,19 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
 "wuN" = (
-/obj/machinery/door/holy{
-	name = "Church"
+/obj/structure/multiz/stairs/active{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/sign/levels/stairsdown{
+	pixel_y = -30;
+	pixel_x = 32
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "wuV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
@@ -118311,6 +118435,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/surgery)
+"wyv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "wyw" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -120045,10 +120179,19 @@
 	name = "Dormitory 3"
 	})
 "wQW" = (
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "wRb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -120136,20 +120279,10 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "wSl" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "wSn" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -120475,14 +120608,23 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/tcommsat/computer)
 "wVv" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "wVx" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,18"
@@ -120553,9 +120695,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "wWN" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/box/white,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "wWP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -121451,14 +121593,21 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "xfb" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/pistachios,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
 "xfc" = (
 /obj/machinery/conveyor/east{
 	dir = 1;
@@ -121885,18 +122034,10 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "xke" = (
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/vectorrooms)
+/area/nadezhda/absolutism/chapel)
 "xki" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -122004,11 +122145,15 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xlL" = (
-/obj/structure/catwalk,
-/obj/structure/invislight,
-/obj/machinery/camera/network/church,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/outside/meadow)
+/area/colony)
 "xlP" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Post";
@@ -122211,10 +122356,13 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xmO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "xmV" = (
@@ -122272,11 +122420,10 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "xnv" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/turf/simulated/floor/rock/manmade/road,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "xnw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -122633,15 +122780,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xqJ" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "xqM" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -122712,17 +122853,12 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "xrs" = (
-/obj/structure/catwalk,
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "xrx" = (
 /obj/landmark/machinery/input,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -122741,8 +122877,27 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "xrD" = (
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/wood,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "xrF" = (
 /obj/effect/floor_decal/spline/wood{
@@ -123184,9 +123339,11 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "xwB" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
+/obj/machinery/recycler,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
 "xwH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -123347,25 +123504,16 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xyC" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/random/mob/roaches/low_chance,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 4
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "xyJ" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/armory)
@@ -123592,24 +123740,17 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "xBq" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 4
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/item/storage/fancy/crayons,
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/crayons,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "xBr" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,3"
@@ -123818,14 +123959,14 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "xDf" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/biomatter,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "xDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -123901,14 +124042,13 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "xDI" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross{
+	pixel_y = 30
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "xDL" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
@@ -123941,11 +124081,16 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xEe" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos/storage)
+/area/colony)
 "xEk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/wood,
@@ -124612,15 +124757,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "xKz" = (
-/obj/machinery/conveyor_switch{
-	id = "disposals grinder"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/floor_decal/industrial/danger,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "xKD" = (
 /obj/structure/grille,
 /turf/simulated/floor/asteroid/grass,
@@ -124884,11 +125029,8 @@
 /area/nadezhda/security/armory_blackshield)
 "xMy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "xMA" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -125189,6 +125331,12 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/crew_quarters/plasma_tag)
+"xPq" = (
+/obj/machinery/camera/network/church{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "xPw" = (
 /obj/machinery/vending/engivend,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -126726,15 +126874,9 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "yfE" = (
-/obj/structure/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "yfL" = (
 /obj/item/storage/briefcase/inflatable{
 	pixel_x = 3;
@@ -127134,17 +127276,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "yjK" = (
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Office"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel/gray_perforated,
+/obj/structure/table/woodentable,
+/obj/item/device/lighting/toggleable/lantern/censer,
+/turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
 "yjM" = (
 /obj/structure/cable/cyan{
@@ -127299,10 +127433,10 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
 "ylz" = (
-/obj/machinery/light,
-/obj/machinery/vending/fortune,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/industrial/danger,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "ylB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -193698,13 +193832,13 @@ vvL
 wAo
 xPH
 xPH
-dzK
-qHh
-qHh
-qHh
-rby
-qHh
-hHU
+vmm
+xlL
+xlL
+xlL
+xEe
+xlL
+pYx
 xGi
 sFI
 sFI
@@ -193906,7 +194040,7 @@ xGi
 xGi
 xGi
 beK
-buS
+cfH
 beK
 sFI
 sFI
@@ -194108,7 +194242,7 @@ sFI
 sFI
 sFI
 beK
-qUT
+kbl
 beK
 sFI
 sFI
@@ -194310,7 +194444,7 @@ sFI
 sFI
 sFI
 beK
-uQx
+vWA
 beK
 sFI
 sFI
@@ -194512,7 +194646,7 @@ sFI
 sFI
 sFI
 beK
-qUT
+kbl
 beK
 sFI
 sFI
@@ -194714,7 +194848,7 @@ sFI
 beK
 beK
 beK
-kyt
+dXG
 beK
 beK
 beK
@@ -194916,7 +195050,7 @@ sFI
 beK
 eWs
 mCq
-fEH
+cDx
 vgv
 tZa
 mUh
@@ -195118,7 +195252,7 @@ sFI
 beK
 hov
 uww
-qTC
+tmF
 naZ
 dMu
 xhZ
@@ -195320,7 +195454,7 @@ sFI
 beK
 uHt
 uww
-czb
+rwF
 mxC
 wuq
 mBO
@@ -195521,9 +195655,9 @@ beK
 beK
 beK
 mCq
-dtG
-jkf
-kFQ
+dNI
+dCC
+uCH
 gcr
 gzw
 vcq
@@ -195715,16 +195849,16 @@ jPJ
 iVn
 byG
 ult
-jTG
-fAA
-uCH
-vmm
-iRf
-dEk
-vmm
+gHI
+uOA
+mdn
+fCn
+ldw
+cNj
+fCn
 bho
 xhZ
-doA
+fyb
 mxC
 gcr
 tkm
@@ -195924,9 +196058,9 @@ beK
 beK
 beK
 beK
-eit
-vMQ
-suE
+bkH
+bPm
+rqm
 mxC
 hCa
 tNb
@@ -196126,10 +196260,10 @@ sFI
 sFI
 sFI
 beK
-uaN
+tpj
 puT
-fuZ
-qfx
+kpf
+oMM
 nvW
 hpm
 hpm
@@ -196328,16 +196462,16 @@ sFI
 sFI
 sFI
 beK
-tZT
+jte
 rOL
-qBQ
+lVU
 eyI
 ctG
 ctC
 wIe
 mCq
 naZ
-eMK
+meA
 beK
 sFI
 ula
@@ -196532,14 +196666,14 @@ sFI
 beK
 oPl
 uUJ
-nxH
+jHx
 aUn
 aUn
 qHo
 jTL
 mCq
 mxC
-hmj
+uPd
 beK
 sFI
 sFI
@@ -196734,14 +196868,14 @@ sFI
 beK
 azM
 uUJ
-kyl
+rHD
 aUn
 aUn
 sDT
 qPy
 mCq
-mxC
-uPd
+nib
+vvO
 beK
 sFI
 sFI
@@ -196942,8 +197076,8 @@ usk
 jeg
 vcq
 mCq
-qgM
-cRj
+vKM
+sZu
 beK
 beK
 beK
@@ -197136,19 +197270,19 @@ sFI
 sFI
 sFI
 beK
-tgh
+rjV
 mCq
-tJf
+xyC
 xhZ
 mCq
 mCq
 mCq
 mCq
-qgM
-sZu
-sZu
-hmk
-ncd
+vKM
+xMy
+xMy
+nrD
+qBq
 beK
 sFI
 sFI
@@ -197338,19 +197472,19 @@ sFI
 sFI
 beK
 beK
-sJX
-uqM
-uGA
-wVv
+ugj
+nRM
+gou
+tWL
 mCq
 mCq
 mCq
-sZu
-qgM
-sZu
-sZu
-nrD
-fgb
+xMy
+vKM
+xMy
+xMy
+tby
+tgh
 beK
 sFI
 sFI
@@ -197540,16 +197674,16 @@ sFI
 sFI
 beK
 hSC
-uqM
-tmF
+nRM
+wWN
 bMK
-gxd
-gHI
+kPg
+tZT
 lti
 rCq
 dMu
-qfx
-ejM
+oMM
+nmo
 beK
 beK
 beK
@@ -197741,17 +197875,17 @@ uNP
 uNP
 uNP
 beK
-eMx
+ncd
 nSn
 nSn
 oYg
 nSn
-wgN
-uUU
+oTp
+fEH
 beK
 mCq
 rhf
-mCq
+mBf
 beK
 sFI
 sFI
@@ -197938,22 +198072,22 @@ vQv
 vQv
 uOb
 cSt
-bwG
-mLR
-rrx
-fPE
-jHL
-jXd
-jXd
-jXd
-jXd
-jXd
-jXd
+boU
+mHf
+hkR
+eMK
+vCh
+sAo
+sAo
+sAo
+sAo
+sAo
+sAo
 mAy
 beK
 lZC
 beK
-wuN
+lZC
 beK
 beK
 beK
@@ -198140,24 +198274,24 @@ uim
 uWe
 vIm
 cSt
-xKz
-oVv
-xnv
+jkf
+hpq
+kyt
 uNP
-kVO
-kVO
-kVO
-kVO
+jHL
+jHL
+jHL
+jHL
 beK
 beK
-dtG
-dtG
-dtG
+dNI
+dNI
+dNI
 mCq
-tzn
+xPq
 mCq
-tby
-tby
+ejM
+ejM
 beK
 sFI
 sFI
@@ -198342,9 +198476,9 @@ dvQ
 uWK
 vIm
 pBF
-xwB
-ivC
-nol
+ylz
+lnV
+sOa
 uNP
 sFI
 sFI
@@ -198352,14 +198486,14 @@ sFI
 sFI
 sFI
 beK
-dtG
-dtG
-dtG
-ktR
-qUt
+dNI
+dNI
+dNI
+mce
+cNE
 vcq
-tby
-tby
+ejM
+ejM
 beK
 sFI
 gfQ
@@ -198544,9 +198678,9 @@ vQv
 vQv
 jkc
 cSt
-rGx
-aJN
-xfb
+hbi
+pPU
+jTG
 uNP
 sFI
 sFI
@@ -198554,14 +198688,14 @@ sFI
 sFI
 sFI
 beK
-hVD
-hVD
-hVD
+qvn
+qvn
+qvn
 mCq
 mCq
 mCq
-cTB
-hbi
+ivC
+xDf
 beK
 gfQ
 gfQ
@@ -198746,9 +198880,9 @@ vQv
 vQv
 jkc
 nmW
-mVE
-cKd
-tPN
+cTB
+qzx
+qBQ
 uNP
 sFI
 sFI
@@ -198756,14 +198890,14 @@ sFI
 sFI
 sFI
 beK
-oJb
-oJb
-oJb
+dtG
+dtG
+dtG
 mCq
 mCq
-esz
-esz
-esz
+toM
+toM
+toM
 beK
 gfQ
 vNF
@@ -198948,9 +199082,9 @@ dvQ
 uWe
 vIm
 cSt
-fyb
-aJN
-kEe
+qTC
+pPU
+ujR
 uNP
 sFI
 sFI
@@ -198958,14 +199092,14 @@ sFI
 sFI
 sFI
 beK
-aED
-bPm
-bPm
+gdn
+pyY
+pyY
 mCq
-rqm
-wWN
-wWN
-wWN
+oNA
+cxF
+cxF
+cxF
 beK
 gfQ
 wHA
@@ -199150,9 +199284,9 @@ tKp
 tQX
 vIm
 cSt
-qyo
-vXR
-nRM
+uRw
+xwB
+tPN
 uNP
 sFI
 sFI
@@ -199352,9 +199486,9 @@ vQv
 vQv
 jkc
 cSt
-qyo
-xEe
-cDx
+uRw
+mRi
+oqc
 uNP
 sFI
 sFI
@@ -199554,9 +199688,9 @@ vQv
 vQv
 vIm
 cSt
-bwG
-pyY
-mxN
+boU
+owI
+sJX
 uNP
 sFI
 sFI
@@ -224409,7 +224543,7 @@ vrp
 vrp
 uEB
 leU
-qDa
+iZz
 vUJ
 xcy
 sbB
@@ -224834,7 +224968,7 @@ bjU
 vUJ
 vUJ
 vUJ
-dnk
+doA
 vUJ
 vUJ
 vUJ
@@ -225019,7 +225153,7 @@ uEB
 pIy
 quu
 vUJ
-qDa
+iZz
 leU
 leU
 leU
@@ -225237,7 +225371,7 @@ vUJ
 vUJ
 vUJ
 vUJ
-mBf
+gxd
 sbB
 sbB
 xcy
@@ -225627,7 +225761,7 @@ leU
 sbB
 pDw
 mkI
-dNI
+aED
 leU
 bjU
 xcy
@@ -226246,7 +226380,7 @@ sbB
 sbB
 mkI
 vUJ
-bPu
+cye
 bjU
 leU
 leU
@@ -226643,7 +226777,7 @@ mET
 vUJ
 vUJ
 sbB
-ekD
+rrx
 sbB
 sbB
 hvW
@@ -227225,7 +227359,7 @@ cjv
 fJv
 wBa
 pwm
-dNo
+tzJ
 uEV
 ciH
 gba
@@ -227646,7 +227780,7 @@ vTn
 nyS
 cKe
 jBi
-jHx
+sMN
 leR
 oHf
 oHf
@@ -227848,7 +227982,7 @@ gEY
 wrl
 oal
 cVR
-omK
+fAA
 jaT
 hpV
 hpV
@@ -228050,7 +228184,7 @@ pwm
 pwm
 aot
 njl
-omK
+fAA
 stq
 iVt
 aJG
@@ -228252,7 +228386,7 @@ pwm
 pwm
 aot
 ved
-omK
+fAA
 stq
 iVt
 aJG
@@ -228454,7 +228588,7 @@ aug
 fMZ
 jeo
 puc
-omK
+fAA
 gOa
 gaS
 gaS
@@ -228656,10 +228790,10 @@ stG
 wzY
 kCJ
 hYL
-omK
+fAA
 tpO
-cNE
-cNE
+mPy
+mPy
 aot
 hLv
 hLv
@@ -229047,7 +229181,7 @@ epc
 moX
 xFe
 koI
-rcV
+ikj
 fKf
 wIm
 fKf
@@ -229088,8 +229222,8 @@ leU
 leU
 leU
 leU
-rEA
-rEA
+xnv
+xnv
 kfg
 aCl
 nfX
@@ -229256,9 +229390,9 @@ hcE
 kOW
 kOW
 kOW
-rwF
+ucl
 kOW
-rwF
+ucl
 kOW
 kOW
 kOW
@@ -229290,8 +229424,8 @@ leU
 leU
 leU
 leU
-rEA
-rEA
+xnv
+xnv
 hgC
 hgC
 hgC
@@ -229451,48 +229585,48 @@ epc
 rjh
 gSM
 kOW
-wQW
+uHl
 dsj
-iAo
+buS
 dsj
 ndM
 kOW
 aFx
 lpW
-aAy
+ccn
 aFx
 lpW
-hMs
+deL
 kOW
 bVb
 bVb
 kOW
 iUs
-wVU
+gPB
 dld
 dld
 pDI
-jVP
-jVP
-jVP
-jVP
-jVP
-jVP
-jVP
-jVP
-jVP
-jVP
-jVP
-cox
-rEA
-rEA
-rEA
-rEA
-rEA
-rEA
-rEA
-rEA
-rEA
+waT
+waT
+waT
+waT
+waT
+waT
+waT
+waT
+waT
+waT
+waT
+uGA
+xnv
+xnv
+xnv
+xnv
+xnv
+xnv
+xnv
+xnv
+xnv
 lxo
 aot
 hgC
@@ -229685,7 +229819,7 @@ bSp
 fCA
 nRc
 nRc
-yfE
+qKJ
 vUJ
 vUJ
 vUJ
@@ -229861,21 +229995,21 @@ dsj
 dsj
 mtA
 pQO
-fgM
+raN
 fiW
 mcP
 fiW
 dsj
-eSm
+qwE
 aFx
 aFx
 uYT
 kOW
 kOW
 iUs
+xDI
 dld
-dld
-vCh
+suE
 nRc
 nRc
 neA
@@ -230059,25 +230193,25 @@ pmt
 kOW
 cxA
 dsj
-xMy
+rxq
 dsj
 xOv
 kOW
-vKM
+pZI
 fiW
 mcP
 fiW
 dsj
-eSm
+qwE
 wGn
 aFx
 dsj
 pQO
-rwF
+ucl
 iUs
 dld
 dld
-vCh
+suE
 nRc
 nRc
 neA
@@ -230257,29 +230391,29 @@ pwm
 pwm
 jZV
 qMM
-waT
+xfb
 kOW
 kOW
-nTE
-raN
-oMM
+uUU
+vfg
+aAw
 kOW
 kOW
-uZv
+pLt
 fiW
 mcP
-dmD
+ajp
 dsj
 aFx
 pVr
 pVr
 dsj
 pQO
-rwF
-owI
+ucl
+uTQ
 dld
 dld
-vCh
+suE
 nRc
 nRc
 sgF
@@ -230463,25 +230597,25 @@ mMj
 hcE
 rQU
 rrG
-oSN
+sSM
 dsj
-mHf
-oNA
+xrs
+klX
 aFx
 aFx
-cxF
+hHU
 aFx
 aFx
 aFx
-xDI
+kVO
 dsj
 dsj
 pQO
-rwF
-gou
+ucl
+fkm
 dld
 dld
-vCh
+suE
 nRc
 nRc
 neA
@@ -230663,12 +230797,12 @@ jZV
 czp
 eJY
 kQv
-ucs
+vIL
 nur
-iWQ
-fxv
-fxv
+wyv
 ddN
+ddN
+fCX
 bND
 ezK
 ePE
@@ -230679,11 +230813,11 @@ eks
 dsj
 dsj
 pQO
-rwF
+ucl
 cUi
 dld
 dld
-vCh
+suE
 nRc
 nRc
 neA
@@ -230866,10 +231000,10 @@ plK
 cvN
 vFt
 jjQ
-cAW
 xmO
+bal
 dsj
-kwb
+cAW
 hcE
 aFx
 aFx
@@ -230881,11 +231015,11 @@ pVr
 dsj
 dsj
 pQO
-rwF
-sPh
+ucl
+ucY
 dld
 dld
-vCh
+suE
 nRc
 nRc
 wMt
@@ -231065,17 +231199,17 @@ bfy
 xjG
 sAh
 wXd
-vvO
+eTj
 kOW
 kOW
-jnw
-klX
-oMM
+kEe
+sFL
+aAw
 kOW
 kOW
-uZv
+pLt
 fiW
-xmO
+bal
 fiW
 dsj
 aFx
@@ -231083,11 +231217,11 @@ pVr
 eUn
 dsj
 pQO
-rwF
-ucY
+ucl
+oVv
 dld
 dld
-vCh
+suE
 nRc
 nRc
 neA
@@ -231269,27 +231403,27 @@ rIb
 qMM
 qrQ
 kOW
-boU
-cUo
-gXz
+vFR
+gRP
+tzn
 dsj
-ylz
+vAx
 kOW
-vKM
+pZI
 fiW
 aQF
 fiW
 rrG
-eSm
+qwE
 wGn
 aFx
 dsj
 pQO
-rwF
+ucl
 iUs
 dld
 dld
-vCh
+suE
 nRc
 nRc
 sgF
@@ -231471,8 +231605,8 @@ uHd
 qMM
 uPn
 pQO
-mKY
-cUo
+jVP
+gRP
 dsj
 dsj
 llg
@@ -231482,16 +231616,16 @@ fiW
 aQF
 fiW
 dsj
-eSm
+qwE
 aFx
 aFx
 uYT
 kOW
 kOW
 iUs
+xDI
 dld
-dld
-vCh
+suE
 nRc
 nRc
 neA
@@ -231673,8 +231807,8 @@ she
 jlQ
 ebN
 pQO
-mKY
-cUo
+jVP
+gRP
 dsj
 dsj
 llg
@@ -231686,14 +231820,14 @@ fiW
 dsj
 aFx
 tVS
-eSm
+qwE
 aFx
 kOW
 iUs
 iUs
 dld
 dld
-vCh
+suE
 nRc
 nRc
 neA
@@ -231875,24 +232009,24 @@ qMI
 pQa
 qmD
 kOW
-pYx
-efu
-lnV
-nmo
-xqJ
+eIV
+weP
+kyl
+kMZ
+mxN
 kOW
-pNu
+xke
 tVS
-ntC
+nxH
 aFx
 tVS
-hMs
+deL
 kOW
 bVb
 bVb
 kOW
 iUs
-vAX
+jXd
 dld
 dld
 mXo
@@ -231907,7 +232041,7 @@ lFw
 hbK
 nRc
 nRc
-kSK
+fPi
 vUJ
 vUJ
 eqh
@@ -232098,18 +232232,18 @@ wVU
 dld
 dld
 pDI
-xrs
-xrs
-xrs
-xrs
-xrs
-xrs
-xrs
-xrs
-xrs
-xrs
-xrs
-cox
+mKY
+mKY
+mKY
+mKY
+mKY
+mKY
+mKY
+mKY
+mKY
+mKY
+mKY
+uGA
 vUJ
 vUJ
 vUJ
@@ -232245,9 +232379,9 @@ veZ
 cwr
 cwr
 cwr
-ajp
-ajp
-fCn
+bZJ
+bZJ
+iAo
 ook
 tcp
 tcp
@@ -232284,31 +232418,31 @@ xGz
 wzU
 riw
 tZm
-miP
+fPE
 yiO
 riw
-xDf
-kpf
-pBQ
-pBQ
-vwJ
-fsi
-fsi
+ggs
+mVE
+qgM
+vGk
+iRf
+aAy
+aAy
 rqj
-rHD
+ljQ
 dld
 dld
 dld
 vLi
 vLi
 qgJ
-ifo
-vsx
+wbe
+mVl
 oei
 qgJ
 tqr
-fkm
-sMN
+pNu
+ugn
 qgJ
 vLi
 vLi
@@ -232447,10 +232581,10 @@ veZ
 veZ
 cwr
 cwr
-ajp
-ajp
-fCn
-ajp
+bZJ
+bZJ
+iAo
+bZJ
 tcp
 rva
 mNx
@@ -232489,13 +232623,13 @@ oQZ
 elF
 xzr
 riw
-pBQ
+vGk
 rYv
 rYv
 rYv
-vwJ
-deL
-deL
+iRf
+wbm
+wbm
 rqj
 gzr
 dld
@@ -232649,10 +232783,10 @@ veZ
 veZ
 cwr
 cwr
-ajp
-ajp
-fCn
-ajp
+bZJ
+bZJ
+iAo
+bZJ
 tcp
 uCI
 sOt
@@ -232687,19 +232821,19 @@ uXK
 uXK
 oXE
 riw
-bkH
+rby
 qox
 opN
 riw
 cNP
-uTQ
+xqJ
 jAU
 rYv
-vwJ
-fsi
-fsi
+iRf
+aAy
+aAy
 rqj
-rHD
+ljQ
 dld
 dld
 dld
@@ -232852,9 +232986,9 @@ veZ
 cwr
 cwr
 nYl
-bmx
-fCn
-ajp
+dzK
+iAo
+bZJ
 tcp
 fPz
 gPf
@@ -232889,20 +233023,20 @@ dFx
 bAk
 oXE
 riw
-lLw
-lVU
+wfn
+tOI
 nlp
 riw
-ldw
-vFR
-aAw
-ugn
+hmj
+czb
+waf
+tZL
 riw
-xlL
+uaN
 kbv
 riw
 vMI
-vIw
+eMx
 dld
 dld
 hvW
@@ -233054,8 +233188,8 @@ veZ
 cwr
 cwr
 lPU
-bmx
-fCn
+dzK
+iAo
 weh
 tcp
 rzR
@@ -233091,14 +233225,14 @@ nBw
 fLG
 oXE
 riw
-hpc
-lUP
-sUM
+bfZ
+nJR
+aFL
 riw
 int
 vsl
-rxq
-ugj
+kFQ
+koL
 riw
 tTa
 tTa
@@ -233255,9 +233389,9 @@ wLD
 veZ
 cwr
 cwr
-tZL
-tZL
-fCn
+omK
+omK
+iAo
 weh
 cwr
 xdv
@@ -233294,16 +233428,16 @@ qWG
 riw
 riw
 riw
-xke
+vMK
 riw
 riw
 riw
 sGE
-iZz
+hNx
 riw
 riw
-xrD
-vGk
+yfE
+kOD
 riw
 riw
 vAX
@@ -233457,9 +233591,9 @@ veZ
 veZ
 cwr
 cwr
-tZL
-tZL
-fCn
+omK
+omK
+iAo
 weh
 cwr
 mcJ
@@ -233492,23 +233626,23 @@ mJT
 pwm
 pwm
 vvK
-bZJ
+kLc
 riw
 riw
-qGp
+qfx
 vdu
 rMH
 juo
-riP
-riP
-ljQ
-mRi
+npm
+npm
+kSK
+nvB
 diT
 qQZ
 rOh
 rpa
 riw
-fXR
+riP
 dld
 dld
 leU
@@ -233659,9 +233793,9 @@ veZ
 veZ
 cwr
 cwr
-bmx
-bmx
-fCn
+dzK
+dzK
+iAo
 weh
 cwr
 trx
@@ -233691,15 +233825,15 @@ tnR
 vaT
 vaT
 qZu
-bZJ
-fCX
+aJN
+oaI
 bZF
-bZJ
+aJN
 riw
-mVl
+qHh
 wFB
 qQZ
-oqc
+sUM
 orJ
 rOh
 rOh
@@ -233708,9 +233842,9 @@ riw
 riw
 mqQ
 rOh
+iWQ
+iRf
 rjY
-vwJ
-vMI
 dld
 dld
 ljw
@@ -233861,8 +233995,8 @@ veZ
 veZ
 cwr
 qau
-bmx
-bmx
+dzK
+dzK
 gCx
 weh
 cwr
@@ -233898,7 +234032,7 @@ riw
 lDz
 riw
 riw
-iGZ
+xBq
 wFB
 hAv
 mwt
@@ -233906,12 +234040,12 @@ mwt
 cVH
 qQZ
 jzE
-cFR
+ekD
 rpa
 qQZ
 rOh
-rjY
-vwJ
+iWQ
+iRf
 fXR
 dld
 dld
@@ -234097,24 +234231,24 @@ nfq
 jMp
 riw
 grQ
-nJR
-wSl
+xrD
+uZv
+jnw
+dNo
 epB
-cfH
-bal
 hAv
 mwt
-sFL
+bwG
 tuI
 rOh
 qWp
-cFR
-eIV
+ekD
+vsx
 qQZ
 qQZ
-rjY
-vwJ
-vIw
+iWQ
+iRf
+eMx
 dld
 dld
 mcG
@@ -234295,28 +234429,28 @@ lIg
 dVl
 vaT
 qkp
-sAo
-sfi
-qKJ
+huw
+tra
+fqE
 oKC
-oaI
-mPy
+wQW
+qGp
 riw
-dXG
-hSz
+cKd
+vwJ
 hAv
 mwt
 mwt
 tuI
 rOh
 dFc
-cFR
+ekD
 rpa
 qQZ
 qQZ
+iWQ
+iRf
 rjY
-vwJ
-vMI
 dld
 dld
 pIy
@@ -234497,27 +234631,27 @@ vaT
 vaT
 vaT
 qkp
-pLt
+rig
 pwm
 riw
 qza
-nib
-npm
+usX
+bCT
 riw
 sPG
-vfg
-tpj
-waf
-waf
+eVP
+bPu
+kwb
+kwb
 rOh
 rOh
-wbe
+eSm
 riw
 riw
 mqQ
 rOh
-rjY
-vwJ
+iWQ
+iRf
 wVU
 dld
 dld
@@ -234699,20 +234833,20 @@ sfG
 imO
 lNu
 tPK
-pLt
+rig
 pwm
 riw
 riw
 riw
-mdn
+sPh
 riw
 riw
+miP
+nBa
+rGx
 kDY
-kbl
-ggs
-gnT
-eTj
-riP
+esz
+npm
 oBo
 qQZ
 diT
@@ -234720,7 +234854,7 @@ rOh
 qQZ
 rpa
 riw
-fXR
+riP
 dld
 dld
 dIp
@@ -234901,12 +235035,12 @@ kRE
 gxW
 mfV
 lem
-weP
+gXz
 pwm
 riw
 lkJ
 vkU
-dBR
+gSa
 riw
 riw
 riw
@@ -234915,14 +235049,14 @@ riw
 riw
 riw
 riw
-guj
+fuZ
 riw
 riw
 qQZ
-oTp
+guj
 riw
 riw
-vMI
+rjY
 dld
 dld
 nAX
@@ -235103,34 +235237,34 @@ sfG
 imO
 bJC
 pEI
-weP
+gXz
 pwm
 riw
 riw
 riw
-fqE
+rcV
 riw
-usX
+wSl
 sbj
 wFB
 jac
 riw
-usX
-vWA
+wSl
+gnT
 kZn
 xwO
 riw
 tTa
 tTa
 riw
-wVU
-vIw
+quT
+eMx
 dld
 dld
 owa
 vUJ
 vhs
-vIL
+ifo
 lOl
 hbO
 dft
@@ -235305,22 +235439,22 @@ uSX
 nnT
 vaT
 qkp
-weP
+gXz
 pwm
 riw
 lkJ
 vkU
-kMZ
+dBR
 riw
-meA
-dCC
-rjV
-huw
-riw
-meA
-cye
-rOh
+dnk
 fBV
+xKz
+kxQ
+riw
+dnk
+nTE
+rOh
+eit
 riw
 kbv
 kbv
@@ -235507,27 +235641,27 @@ lLF
 xJm
 vaT
 qkp
-xyC
+egd
 pwm
 riw
 riw
 riw
 riw
 riw
-egd
-ikj
+ktR
+cZV
 qQZ
-fBV
+eit
 riw
-egd
+ktR
 qQZ
 qQZ
 qQZ
 riw
-fsi
-fsi
+aAy
+aAy
 rqj
-rHD
+ljQ
 dld
 dld
 dld
@@ -235709,7 +235843,7 @@ wan
 wxz
 vaT
 pkv
-weP
+gXz
 pwm
 xGz
 xGz
@@ -235727,9 +235861,9 @@ gzV
 vtp
 riw
 qQO
-deL
+wbm
 rqj
-mce
+rEA
 dld
 dld
 dld
@@ -235911,7 +236045,7 @@ dXg
 kLp
 vaT
 nvI
-weP
+gXz
 pwm
 xGz
 xGz
@@ -235928,13 +236062,13 @@ riw
 riw
 riw
 riw
-fsi
-fsi
+aAy
+aAy
 rqj
-rHD
-qwE
+ljQ
+ucs
 dld
-quT
+hmk
 dld
 jZI
 jZI
@@ -236113,7 +236247,7 @@ wIg
 uob
 gUg
 brN
-weP
+gXz
 pwm
 xGz
 xGz
@@ -236315,7 +236449,7 @@ fsM
 aom
 vaT
 soq
-weP
+gXz
 pwm
 xGz
 xGz
@@ -236326,14 +236460,14 @@ xGz
 xGz
 opH
 plZ
-gdn
+fgM
 opH
 ouv
 mmt
 opH
 opH
-rig
-rig
+sdY
+sdY
 uVK
 uVK
 uVK
@@ -236517,7 +236651,7 @@ bqj
 vaT
 vaT
 soq
-xyC
+egd
 pwm
 xGz
 xGz
@@ -236538,7 +236672,7 @@ spV
 spV
 uVK
 qrB
-vAx
+cFP
 lze
 ycP
 ycP
@@ -236719,14 +236853,14 @@ pwm
 pwm
 gTr
 fID
-pLt
+rig
 pwm
 xGz
 xGz
 opH
 hHX
-koL
-hQO
+oSN
+yjK
 yex
 opH
 opH
@@ -236737,8 +236871,8 @@ fpd
 opH
 opH
 mZy
-pes
-nvB
+sxY
+hMs
 spV
 spV
 spV
@@ -236921,7 +237055,7 @@ xGz
 pwm
 soq
 pwm
-xBq
+oJb
 pwm
 xGz
 xGz
@@ -236929,7 +237063,7 @@ opH
 opH
 sJb
 gMa
-gMa
+hSz
 opH
 phC
 gMa
@@ -236939,10 +237073,10 @@ gMa
 wtw
 opH
 mqs
-dBr
-qWT
+urt
+dEk
 vkI
-qWT
+dEk
 qbh
 rnS
 xok
@@ -237123,7 +237257,7 @@ pwm
 pwm
 uIC
 pwm
-xBq
+oJb
 pwm
 xGz
 xGz
@@ -237132,23 +237266,23 @@ pzk
 gMa
 vqG
 gMa
-hNx
+efu
 gMa
 gMa
 geA
 xgI
 vfv
 fqG
-yjK
-pZI
+lLw
+lhz
 ezs
-lhz
+wgN
 kAU
-lhz
+mLR
 oeV
 msx
 wSh
-qWT
+dEk
 qwK
 gJe
 pdt
@@ -237325,7 +237459,7 @@ pwm
 dkm
 vMU
 xTb
-weP
+gXz
 pwm
 xGz
 xGz
@@ -237333,9 +237467,9 @@ opH
 opH
 sJb
 gMa
-gMa
+hSz
 opH
-huC
+hpc
 gMa
 pIr
 acB
@@ -237343,14 +237477,14 @@ eCm
 uBy
 opH
 nuM
-uOA
+pes
 gkZ
 uVK
 uVK
 uVK
 spV
 fBw
-lhz
+wgN
 gWi
 rIc
 sdN
@@ -237526,30 +237660,30 @@ seQ
 bVD
 wWa
 bXy
-ccn
-weP
+iGZ
+gXz
 pwm
 xGz
 xGz
 opH
 hvz
-ujR
-jwd
+pBQ
 wpu
+qDa
 opH
-uRw
-fPi
-uVx
-sdY
-lfc
-aFL
+huC
+fxv
+hVD
+cRj
+qWT
+uqM
 opH
-sOa
+jsM
 spV
-wfn
+vMQ
 uVK
-pPU
-cZV
+qyo
+qUt
 spV
 nFm
 gUk
@@ -237728,8 +237862,8 @@ pwm
 pwm
 soz
 pwm
-ccn
-pLt
+iGZ
+rig
 pwm
 xGz
 xGz
@@ -237743,20 +237877,20 @@ opH
 opH
 opH
 opH
-kOD
-jsM
+qUT
+rHW
 opH
-qBq
-qzx
-jte
+lfc
+lUP
+cFR
 uVK
-kLc
-hkR
+wuN
+uQx
 spV
-sxY
+uVx
 gUk
 kHd
-hpq
+nol
 sdN
 rEL
 rEL
@@ -237930,8 +238064,8 @@ veZ
 pwm
 rYq
 pwm
-ccn
-gRP
+iGZ
+hQO
 xwU
 xwU
 xwU
@@ -237943,7 +238077,7 @@ bvz
 bvz
 bvz
 wjD
-ucl
+ntC
 opH
 opH
 opH
@@ -237958,7 +238092,7 @@ uVK
 uVK
 gUk
 kHd
-hpq
+nol
 pdx
 utp
 oly
@@ -238132,21 +238266,21 @@ veZ
 pwm
 rsS
 pwm
-qvn
-toM
+jwd
+wVv
 rQO
-sSM
+bmx
 rQO
 rQO
 rQO
-eVP
+cox
 ctQ
-bfZ
-tzJ
-tzJ
+fgb
+fsi
+fsi
 pwm
 mQc
-vMK
+dBr
 bvz
 bvz
 bvz
@@ -238540,22 +238674,22 @@ aHk
 aHk
 hJp
 aHk
-wbm
+dmD
 hJp
-wbm
+dmD
 uVi
 hJp
-wbm
-wbm
-wbm
+dmD
+dmD
+dmD
 vMo
-wbm
-wbm
+dmD
+dmD
 vMo
-wbm
+dmD
 vMo
 bLR
-cFP
+cUo
 bLR
 bLR
 bLR
@@ -239363,7 +239497,7 @@ veZ
 veZ
 veZ
 vzY
-kxQ
+sfi
 vzY
 vzY
 vzY
@@ -239776,7 +239910,7 @@ vzY
 eip
 npq
 gUk
-gSa
+vXR
 pNT
 srq
 xAC
@@ -240574,7 +240708,7 @@ veZ
 veZ
 veZ
 hqC
-gEm
+tJf
 bcG
 cxn
 kLt

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -401,13 +401,12 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/dcave)
 "acB" = (
-/obj/structure/table/standard,
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/stamp/pr,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "acE" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -875,8 +874,13 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "ahn" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/tiled/cafe,
+/obj/machinery/light/small,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "aho" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1075,12 +1079,21 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/quartermaster/miningdock)
 "ajp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "ajA" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -2500,13 +2513,23 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "aAw" = (
-/obj/structure/sign/faction/neotheology_cross/gold,
-/turf/simulated/wall/church_reinforced,
-/area/nadezhda/absolutism/storage)
-"aAy" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"aAy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "aAN" = (
 /obj/structure/table/rack/shelf,
 /obj/random/junk/low_chance,
@@ -2777,7 +2800,6 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "aDO" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -2850,12 +2872,9 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
 "aED" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/hallway/surface/section1)
 "aEL" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -2971,26 +2990,20 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/detectives_office)
 "aFL" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "aFM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3380,30 +3393,24 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/prisoncells)
 "aJN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -34
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "aJP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -4229,10 +4236,9 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/eris/crew_quarters/plasma_tag)
 "aQF" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
@@ -5103,23 +5109,22 @@
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
 "bal" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "bam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
@@ -5731,17 +5736,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bfZ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/security/maingate{
-	name = "\improper Outdoors - Pad"
-	})
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "bgc" = (
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -6144,14 +6143,16 @@
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
 "bkH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/catwalk,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "bkM" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -6377,9 +6378,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/meeting_room)
 "bmx" = (
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "bmy" = (
 /obj/structure/railing{
 	dir = 1;
@@ -6635,11 +6642,12 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
 "boU" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/table/woodentable,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "boY" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "WO"
@@ -7232,18 +7240,13 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "buS" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/woodentable,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "buT" = (
 /obj/effect/window_lwall_spawn,
 /turf/simulated/floor/plating/under,
@@ -7312,11 +7315,17 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "bvz" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "bvA" = (
 /obj/structure/railing{
 	dir = 4;
@@ -7446,10 +7455,15 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bwG" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/invislight,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/meadow)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "bwJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -8964,13 +8978,10 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "bND" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "bNE" = (
 /obj/structure/closet/secure_closet/freezer,
@@ -9104,20 +9115,14 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "bPm" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "bPp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9137,16 +9142,10 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/quartermaster/disposaldrop)
 "bPu" = (
-/obj/structure/closet/secure_closet/reinforced/preacher,
-/obj/item/device/taperecorder,
-/obj/item/device/camera,
-/obj/item/device/camera_film,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/clothing/mask/gas/germanmask,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/table/bench/padded,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "bPJ" = (
 /obj/structure/flora/small/busha1,
 /obj/random/flora/jungle_tree,
@@ -9481,6 +9480,9 @@
 /obj/machinery/camera/network/colony_surface{
 	dir = 8
 	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
 "bSS" = (
@@ -9706,7 +9708,6 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/cafeteria)
 "bVD" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -9877,13 +9878,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/psych)
 "bXy" = (
-/obj/structure/disposalpipe/segment,
-/obj/random/mob/roaches/low_chance,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "bXz" = (
@@ -10104,27 +10104,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "bZJ" = (
-/obj/structure/disposaloutlet{
-	dir = 4
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "bZL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10423,12 +10415,12 @@
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/plasma_tag)
 "ccn" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "cco" = (
 /obj/machinery/light{
 	dir = 1;
@@ -10659,13 +10651,11 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cfH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "cfK" = (
 /obj/machinery/camera/xray/security{
 	dir = 9
@@ -11519,10 +11509,9 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cox" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "coC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -12087,10 +12076,24 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/crematorium)
 "ctQ" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "ctU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -12313,18 +12316,16 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/bridge)
 "cvN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "cvO" = (
@@ -12468,8 +12469,19 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "cxF" = (
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/multiz/stairs/active{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/sign/levels/stairsdown{
+	pixel_y = -30;
+	pixel_x = 32
+	},
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "cxN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12526,11 +12538,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cye" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "cyf" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/pros/foreman)
@@ -12627,12 +12640,13 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
 "czb" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "czd" = (
@@ -12651,11 +12665,10 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/eris/crew_quarters/plasma_tag)
 "czp" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "czs" = (
@@ -12860,9 +12873,14 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
 "cAW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "cBa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13177,22 +13195,17 @@
 	name = "Dormitory 1"
 	})
 "cDx" = (
-/obj/machinery/conveyor_switch{
-	id = "disposals grinder"
+/obj/structure/catwalk,
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
-/obj/effect/decal/cleanable/generic,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "cDF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13403,31 +13416,22 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/command/bridgebar)
 "cFP" = (
-/obj/effect/floor_decal/industrial/danger{
+/obj/machinery/alarm{
 	dir = 1;
-	icon_state = "danger"
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/item/scrap_lump,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
-"cFR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
+"cFR" = (
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/plating,
 /area/nadezhda/absolutism/vectorrooms)
 "cFV" = (
 /obj/random/scrap/sparse_weighted,
@@ -13805,14 +13809,10 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/bridge)
 "cKd" = (
-/obj/structure/bed/chair/sofa/black/left{
-	dir = 8
-	},
-/obj/structure/noticeboard/church{
-	pixel_x = 32
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "cKe" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -14156,11 +14156,10 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/surface/section1)
 "cNE" = (
-/obj/machinery/light/floor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/table/woodentable,
+/obj/item/device/lighting/toggleable/lantern/censer,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "cNF" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/unsimulated/wall/jungle,
@@ -14417,12 +14416,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
 "cRj" = (
-/obj/structure/table/woodentable,
-/obj/machinery/camera/network/church{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "cRq" = (
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark/panels,
@@ -14635,15 +14631,9 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
 "cTB" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 8
-	},
-/obj/structure/railing,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/outside/meadow)
+/area/nadezhda/absolutism/bioreactor)
 "cTE" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = -32
@@ -14756,36 +14746,19 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "cUi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "cUk" = (
 /obj/structure/catwalk,
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "cUo" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/industrial/loading/white,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "cUx" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 1
@@ -14898,13 +14871,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/turbolift/ElevatorOne/surface)
 "cVH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock{
-	name = "Church";
-	req_access = list(27)
+/obj/structure/bed/chair/wood{
+	dir = 1;
+	icon_state = "wooden_chair";
+	tag = "icon-wooden_chair (NORTH)"
 	},
-/turf/simulated/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "cVI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15225,12 +15198,10 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
 "cZV" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/rock/manmade/road,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "dar" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/railing/grey{
@@ -15585,13 +15556,10 @@
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
 "ddN" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "ddR" = (
 /obj/structure/ore_box,
@@ -15743,8 +15711,30 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "deL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 1";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "deM" = (
 /obj/item/grenade/chem_grenade/metalfoam,
@@ -16100,15 +16090,11 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barquarters)
 "diT" = (
-/obj/structure/table/woodentable,
-/obj/random/toy/mecha,
-/obj/machinery/light_switch{
-	pixel_x = -20
+/obj/machinery/door/airlock{
+	name = "Church";
+	req_access = list(27)
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "dja" = (
@@ -16237,7 +16223,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/random/scrap/dense_weighted/low_chance,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "dku" = (
@@ -16431,9 +16417,16 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "dmD" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "dmG" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/camera/network/medbay{
@@ -16521,12 +16514,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
 "dnk" = (
-/obj/structure/table/woodentable,
-/obj/machinery/alarm{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/bioreactor)
 "dnl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -16644,13 +16642,13 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "doA" = (
-/obj/structure/table/woodentable,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
-	pixel_y = -30
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/camera/network/church{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "doD" = (
 /obj/structure/catwalk,
@@ -17248,10 +17246,14 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
 "dtG" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/bioreactor)
 "dup" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/rock,
@@ -17811,10 +17813,9 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dzK" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
-/turf/simulated/floor/plating/under,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "dzS" = (
 /obj/structure/shuttle_part/mining{
@@ -17983,13 +17984,10 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "dBr" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/church_reinforced,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/structure/multiz/stairs/enter/bottom,
+/obj/structure/invislight,
+/turf/simulated/floor/plating,
+/area/nadezhda/outside/meadow)
 "dBt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -18003,11 +18001,11 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "dBR" = (
-/obj/structure/table/marble,
-/obj/item/tool/knife/neotritual,
-/obj/item/clothing/gloves/psionic_ring,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "dBU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18132,21 +18130,13 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/bridgebar)
 "dCC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/church_reinforced,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "dCH" = (
 /obj/machinery/light/small{
@@ -18285,15 +18275,14 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dEk" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "dEo" = (
@@ -18509,10 +18498,6 @@
 /area/nadezhda/command/meeting_room)
 "dGa" = (
 /obj/random/scrap/dense_weighted/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -18798,7 +18783,6 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/cbo)
 "dJU" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -19170,22 +19154,19 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "dNo" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/sink{
+	pixel_y = -22
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "dNp" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 1
@@ -19234,9 +19215,14 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "dNI" = (
-/obj/structure/bed/chair/comfy/brown,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/storage)
 "dNK" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,18"
@@ -20128,19 +20114,8 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "dXG" = (
-/obj/machinery/power/nt_obelisk,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/machinery/camera/network/church{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/wall/church_reinforced,
+/area/colony)
 "dXJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -20939,16 +20914,9 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
 "efu" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "efv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21053,19 +21021,16 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "egd" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "egg" = (
 /obj/structure/table/rack/shelf,
 /obj/random/pack/cloth/low_chance,
@@ -21288,11 +21253,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "eit" = (
-/obj/structure/disposalpipe/segment,
-/obj/random/scrap/dense_weighted/low_chance,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/skyyard)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "eix" = (
 /obj/structure/table/steel,
 /obj/machinery/microwave,
@@ -21384,19 +21350,16 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ejM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Great Hall"
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/bioreactor)
 "ejZ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -21432,27 +21395,15 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "ekp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "eks" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/optable/altar,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "eku" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -21465,20 +21416,10 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "ekD" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
 "ekF" = (
 /obj/structure/table/rack/shelf,
@@ -21932,13 +21873,12 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "epB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/camera/network/church{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "epH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22228,24 +22168,9 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "esz" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "esA" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
@@ -22375,9 +22300,21 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/eris/crew_quarters/plasma_tag)
 "etH" = (
-/obj/structure/closet/coffin,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "etI" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/engineering/engine_room)
@@ -22836,13 +22773,16 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ezs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -22875,16 +22815,13 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
 "ezK" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/floor,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "ezO" = (
 /obj/machinery/button/remote/blast_door{
@@ -23073,11 +23010,14 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "eCm" = (
-/obj/machinery/light_switch{
-	pixel_x = 28
+/obj/structure/bed/chair/office/dark{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "eCr" = (
 /obj/structure/table/woodentable,
 /obj/item/device/camera,
@@ -23684,26 +23624,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "eIV" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/vectorrooms)
+/area/nadezhda/engineering/atmos/storage)
 "eIZ" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,22"
@@ -23835,10 +23760,6 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/pool)
 "eJY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23849,6 +23770,12 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
@@ -24141,18 +24068,10 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/crew_quarters/kitchen_storage)
 "eMx" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
-	},
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "eMB" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/extinguisher_cabinet{
@@ -24176,11 +24095,11 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory_blackshield)
 "eMK" = (
-/obj/machinery/camera/network/church{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "eMS" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -24313,17 +24232,12 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "eOD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "eOI" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
@@ -24401,19 +24315,16 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
 "ePE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "ePF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24726,12 +24637,20 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/construction)
 "eSm" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "eSv" = (
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/effect/floor_decal/border/techfloor{
@@ -24897,18 +24816,13 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/main/stairwell)
 "eTj" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/wall_obelisk{
+	pixel_x = 1;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/area/nadezhda/absolutism/chapel)
 "eTk" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -25188,14 +25102,10 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "eVP" = (
-/obj/structure/bed/chair/sofa/black/right{
-	dir = 8
-	},
-/obj/machinery/camera/network/church{
-	dir = 8
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "eVQ" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -26035,6 +25945,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/external,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "fec" = (
@@ -26223,11 +26136,28 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "fgb" = (
-/obj/structure/table/woodentable,
-/obj/machinery/light,
-/obj/item/storage/firstaid/regular,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Bioreactor - Main - 2";
+	capacity = 5e+006;
+	charge = 5e+006;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 5e+006;
+	input_level_max = 5e+006;
+	output_attempt = 1;
+	output_level = 5e+006;
+	output_level_max = 5e+006
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "fgf" = (
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/hallway/main/stairwell)
@@ -26317,12 +26247,9 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
 "fgM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/holy/preacher{
-	name = "Bathroom"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/closet/coffin,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "fgN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -26681,11 +26608,12 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fkm" = (
-/obj/machinery/camera/network/church{
-	dir = 1
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "fkv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26757,9 +26685,6 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/smc/quarters)
 "flk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27119,14 +27044,12 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/atmos)
 "fpd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "fpf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
@@ -27318,12 +27241,19 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "fqE" = (
-/obj/structure/table/bench/padded,
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/structure/bed/chair/sofa/brown/left,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/random/toy/plushie,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/area/nadezhda/absolutism/vectorrooms)
 "fqF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -27332,22 +27262,17 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "fqG" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "fqI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27510,7 +27435,8 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
 "fsi" = (
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/closet/custodial,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
 "fsk" = (
 /turf/simulated/floor/carpet,
@@ -27842,23 +27768,8 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "fuZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "fvc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -28075,11 +27986,19 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "fxv" = (
-/obj/structure/railing,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "chudorm4";
+	name = "Church Dorm 2";
+	req_access = list(70)
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "fxy" = (
 /obj/machinery/door/airlock/maintenance_security{
@@ -28147,12 +28066,14 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "fyb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "fyc" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
@@ -28393,22 +28314,11 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical)
 "fAA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/area/nadezhda/absolutism/vectorrooms)
 "fAG" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/simulated/floor/bluegrid{
@@ -28450,16 +28360,10 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "fBw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -28556,17 +28460,10 @@
 	name = "Dormitory 3"
 	})
 "fBV" = (
-/obj/structure/table/woodentable,
-/obj/random/toy/plushie_onlyfox,
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "fBY" = (
 /obj/structure/multiz/stairs/active{
 	dir = 1
@@ -28605,21 +28502,17 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/cryo)
 "fCn" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/generic,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "fCp" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -28694,12 +28587,23 @@
 	name = "\improper Blackshield - Firing Range"
 	})
 "fCX" = (
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/machinery/door/airlock{
+	name = "Church";
+	req_access = list(27)
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "fDb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4;
@@ -28956,14 +28860,14 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "fEH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/vectorrooms)
+/area/nadezhda/absolutism/bioreactor)
 "fEJ" = (
 /obj/structure/catwalk,
 /obj/structure/grille,
@@ -29388,18 +29292,6 @@
 "fIJ" = (
 /obj/machinery/conveyor/north{
 	id = "scrapbeaconCon"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -30017,11 +29909,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "fPi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/recycler,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "fPo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -30120,17 +30013,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "fPE" = (
-/obj/machinery/optable/altar,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "fPG" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/camera/network/cev_eris,
@@ -30655,7 +30550,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel/gray_perforated,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "fWo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30939,9 +30840,6 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "fZb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -31840,9 +31738,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ggs" = (
-/obj/structure/filingcabinet,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/table/woodentable,
+/obj/random/toy/plushie,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "ggt" = (
 /obj/machinery/power/nt_obelisk,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -32335,8 +32234,28 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/merchant)
 "gkZ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 1;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/obj/structure/cable/green{
+	d1 = 32;
+	d2 = 2;
+	icon_state = "32-1"
+	},
+/turf/simulated/open,
 /area/nadezhda/absolutism/storage)
 "gle" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32656,13 +32575,10 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "gnT" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "gnW" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -32703,16 +32619,8 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
 "gou" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
-/turf/simulated/floor/carpet,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "gow" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33021,6 +32929,9 @@
 "grg" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/catwalk,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "grj" = (
@@ -33279,10 +33190,7 @@
 /area/nadezhda/medical/genetics)
 "guj" = (
 /obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	pixel_y = -32
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
@@ -33517,15 +33425,8 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "gxd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/church_reinforced,
 /area/nadezhda/absolutism/bioreactor)
 "gxg" = (
 /obj/structure/closet/l3closet,
@@ -33725,11 +33626,21 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/pros/prep)
 "gzr" = (
-/obj/machinery/camera/network/church{
-	dir = 4
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "gzw" = (
 /obj/machinery/multistructure/biogenerator_part/console,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -34105,6 +34016,8 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "gCz" = (
@@ -34592,12 +34505,18 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "gHI" = (
-/obj/structure/cable/green{
+/obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "gHJ" = (
 /obj/structure/flora/small/rock2,
@@ -34772,6 +34691,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "gJu" = (
@@ -34908,6 +34833,9 @@
 /area/nadezhda/hallway/surface/section1)
 "gKn" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "gKI" = (
@@ -35656,8 +35584,13 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "gRP" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "gRQ" = (
 /obj/random/material/low_chance,
@@ -35691,13 +35624,11 @@
 	name = "Dormitory 2"
 	})
 "gSa" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/obj/structure/invislight,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/nadezhda/outside/meadow)
+/obj/item/tool/knife/neotritual,
+/obj/item/clothing/gloves/psionic_ring,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "gSb" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -35807,6 +35738,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "gTt" = (
@@ -35962,13 +35894,6 @@
 	convdir = -1;
 	id = "churchgardenCon"
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/moebius/nuclear;
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
-/obj/structure/cable/green,
 /obj/machinery/camera/network/church,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -36072,14 +35997,21 @@
 /turf/simulated/floor/plating/under,
 /area/mine/gulag)
 "gWi" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/holy{
+	name = "Church"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "gWl" = (
 /obj/machinery/light/small{
@@ -36258,18 +36190,25 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "gXz" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/disposaloutlet,
-/obj/machinery/conveyor/south{
-	id = "junk_to_bioreactor"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/catwalk,
+/obj/random/scrap/dense_weighted/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "gXB" = (
 /obj/structure/sink/kitchen{
 	name = "utility sink";
@@ -36458,6 +36397,17 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "gYZ" = (
@@ -36601,10 +36551,17 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/turret_protected/ai_upload)
 "hbi" = (
-/obj/structure/reagent_dispensers/biomatter,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "hbk" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -37539,20 +37496,12 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "hkR" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "hkW" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -37703,14 +37652,20 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "hmk" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/table/woodentable,
-/obj/item/device/lighting/toggleable/lantern/censer,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "hmp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -37952,10 +37907,14 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "hpc" = (
-/obj/structure/bed/chair/sofa/brown/right,
-/obj/landmark/join/start/acolyte,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "hpe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -37976,12 +37935,16 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/absolutism/bioreactor)
 "hpq" = (
-/obj/structure/closet,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "hpu" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/effect/decal/cleanable/dirt,
@@ -38476,15 +38439,19 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
 "huw" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "huC" = (
 /obj/structure/bookcase,
 /obj/item/book/ritual/cruciform,
@@ -39576,10 +39543,10 @@
 	name = "Dormitory 1"
 	})
 "hHU" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/light/small,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/danger,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "hHX" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -39998,9 +39965,13 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "hMs" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/tiled/white/cargo,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "hMw" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -40100,13 +40071,15 @@
 	name = "\improper Outdoors - Pad"
 	})
 "hNx" = (
-/obj/machinery/light,
-/obj/machinery/disposal/deliveryChute{
-	dir = 1;
-	name = "trash chute"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "hNF" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -40467,12 +40440,20 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "hQO" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "hQP" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -40640,16 +40621,9 @@
 /turf/unsimulated/mineral,
 /area/colony)
 "hSz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/holy{
-	name = "Church"
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "hSA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -40922,17 +40896,11 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/rnd/xenobiology)
 "hVD" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+/obj/machinery/computer/arcade,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "hVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -41396,9 +41364,6 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/command/bridgebar)
 "ial" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -41851,10 +41816,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ifo" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "ifw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41906,6 +41873,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
@@ -42303,29 +42273,16 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
 "ikj" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "ikn" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -43351,6 +43308,9 @@
 /area/nadezhda/quartermaster/hangarsupply)
 "ivb" = (
 /obj/machinery/door/airlock/external,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
 "ivc" = (
@@ -43446,9 +43406,19 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "ivC" = (
-/obj/structure/invislight,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "ivM" = (
 /obj/machinery/holoposter{
 	pixel_y = 30
@@ -43868,6 +43838,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/skyyard)
 "izW" = (
@@ -43898,22 +43871,15 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "iAo" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 1;
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
 	pixel_y = 0
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "iAq" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -44574,9 +44540,13 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "iGZ" = (
-/obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
+/area/colony)
 "iHa" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/unsimulated/wall/jungle,
@@ -45664,20 +45634,19 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "iRf" = (
-/obj/structure/bed/chair/sofa/brown/left,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/random/toy/plushie,
-/obj/effect/floor_decal/industrial/warningred{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "iRh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -46279,10 +46248,13 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "iWQ" = (
-/obj/random/furniture/pottedplant,
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "iWS" = (
@@ -46560,14 +46532,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "iZz" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "iZD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
@@ -47569,6 +47542,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "jji" = (
@@ -47661,18 +47637,12 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jjQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "jkb" = (
 /obj/machinery/camera/network/cargo{
@@ -47697,9 +47667,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "jkf" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "jkj" = (
 /obj/structure/table/steel,
 /obj/random/material_resources,
@@ -47964,9 +47936,8 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jnw" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
@@ -48533,18 +48504,25 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jsM" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/door/airlock{
-	name = "Church";
-	req_access = list(27)
+/obj/effect/floor_decal/industrial/warningred,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "jsR" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/gloves{
@@ -48563,15 +48541,23 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "jte" = (
-/obj/random/furniture/pottedplant,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/disposaloutlet{
+	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = -28
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "jtl" = (
 /obj/machinery/light_switch{
 	pixel_y = 30
@@ -48681,23 +48667,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "juo" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = -32
 	},
-/obj/effect/floor_decal/industrial/warningred,
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
-	},
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "jup" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -48865,12 +48843,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
 "jwd" = (
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/atmos/storage)
 "jwe" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
@@ -49217,12 +49192,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jzE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/structure/table/woodentable,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "jzH" = (
@@ -50007,10 +49978,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jHx" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/invislight,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "jHC" = (
 /obj/random/scrap/dense_weighted,
 /obj/structure/table/rack/shelf,
@@ -50030,9 +50007,18 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jHL" = (
-/obj/structure/railing,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/vectorrooms)
 "jHS" = (
 /obj/random/contraband/low_chance,
 /obj/effect/decal/cleanable/cobweb{
@@ -51245,19 +51231,22 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jTG" = (
-/obj/structure/closet/wall_mounted/firecloset{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/box/red/corners,
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "jTH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/reinforced/polarized{
@@ -51532,12 +51521,10 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/barquarters)
 "jVP" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "jWc" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -51634,8 +51621,12 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jXd" = (
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "jXf" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/under,
@@ -51979,12 +51970,8 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jZI" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/turf/simulated/floor/plating,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/wall/wood_barrel,
+/area/nadezhda/outside/meadow)
 "jZK" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/glass/urn,
@@ -52166,12 +52153,14 @@
 	name = "\improper Clinic"
 	})
 "kbl" = (
-/obj/structure/closet,
-/obj/machinery/camera/network/church{
-	dir = 5
+/obj/machinery/light,
+/obj/machinery/light_switch{
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "kbm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -53267,12 +53256,13 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "klX" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/bed/chair/sofa/brown/right,
+/obj/landmark/join/start/acolyte,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "kmc" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -53672,24 +53662,15 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "koL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "koP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -53729,19 +53710,17 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
 "kpf" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/pistachios,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/noticeboard/church{
+	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "kpi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -53808,7 +53787,6 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "kpT" = (
-/obj/structure/disposalpipe/segment,
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/structure/cable/yellow{
@@ -54187,13 +54165,18 @@
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "ktR" = (
-/obj/machinery/light{
+/obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "ktS" = (
 /obj/structure/closet/crate,
 /obj/item/am_shielding_container,
@@ -54240,6 +54223,9 @@
 "kup" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/window_lwall_spawn/reinforced,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/skyyard)
 "kut" = (
@@ -54437,11 +54423,21 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "kwb" = (
-/obj/machinery/door/airlock{
-	name = "Church";
-	req_access = list(27)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/material/kitchen/rollingpin,
+/obj/machinery/light_switch{
+	pixel_y = 30
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "kwd" = (
 /obj/random/flora/jungle_tree,
@@ -54611,11 +54607,27 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/hut_cell1)
 "kxQ" = (
-/obj/structure/table/woodentable,
-/obj/item/storage/fancy/crayons,
-/obj/item/storage/fancy/crayons,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/yellow{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey,
+/obj/structure/cable/yellow,
+/obj/machinery/light,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "kxW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -54634,11 +54646,11 @@
 /turf/simulated/floor/asteroid/dirt/dark/plough,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kyl" = (
-/obj/machinery/power/wall_obelisk{
-	pixel_y = -42
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/multiz/stairs/enter/bottom,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "kym" = (
 /mob/living/simple_animal/hostile/naniteswarm{
 	desc = "A swarm of disgusting mini locusts infested with disease and hatred.";
@@ -54647,8 +54659,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kyt" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 1
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
@@ -54927,17 +54943,15 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "kAU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/holy{
-	name = "Church"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "kAX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55238,23 +55252,38 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kDY" = (
-/obj/machinery/camera/network/church{
-	dir = 5
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "kEe" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 1
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Prime's Office";
+	departmentType = 22;
+	name = "Prime's RC";
+	pixel_x = 30;
+	pixel_y = 0
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Prime's Office"
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "kEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -55442,16 +55471,15 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "kFQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warningred{
+/obj/structure/catwalk,
+/obj/structure/railing,
+/obj/structure/railing{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "kFU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -55814,20 +55842,7 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "kJN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "kKa" = (
@@ -55982,18 +55997,13 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kLc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/random/toy/plushie_onlyfox,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "kLm" = (
 /obj/structure/table/rack/shelf,
 /obj/random/lowkeyrandom,
@@ -56146,12 +56156,19 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
 "kMD" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "kME" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/material/low_chance,
@@ -56204,18 +56221,12 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kMZ" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/item/device/radio/intercom{
+	pixel_y = 24
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "kNa" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -56367,18 +56378,10 @@
 /turf/simulated/open,
 /area/colony)
 "kOD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/box/white,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "kOJ" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -56418,12 +56421,19 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
 "kPg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Armory"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos/storage)
 "kPj" = (
 /obj/structure/sign/departmentold/security,
 /turf/simulated/wall/r_wall,
@@ -56512,15 +56522,15 @@
 	name = "\improper Upper Research Hallway"
 	})
 "kQv" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
 /area/nadezhda/absolutism/chapel)
 "kQx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -56805,11 +56815,9 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "kSK" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 6
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "kSR" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/table/rack/shelf,
@@ -57080,31 +57088,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/ameridian)
 "kVt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
 "kVy" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -57154,10 +57142,12 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "kVO" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/railing,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "kWa" = (
 /obj/structure/flora/big/bush2,
 /obj/effect/decal/cleanable/dirt,
@@ -57555,9 +57545,14 @@
 	name = "Dormitory 2"
 	})
 "kZn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "kZG" = (
@@ -57986,17 +57981,9 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ldw" = (
-/obj/machinery/disposal,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "ldz" = (
 /obj/structure/holohoop{
 	dir = 1
@@ -58252,12 +58239,8 @@
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "lfc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/simple/wood/saloon{
-	name = "Church Foyer"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "lfh" = (
@@ -58425,15 +58408,18 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/crew_quarters/cafeteria)
 "lhz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
+	},
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/prime)
 "lhH" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -58674,15 +58660,19 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ljQ" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/cable/green,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "ljT" = (
 /obj/structure/table/standard,
 /obj/item/storage/briefcase/inflatable,
@@ -58804,13 +58794,14 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "llg" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
 	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/storage)
 "llh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -59058,14 +59049,28 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "lnV" = (
-/obj/machinery/light/floor{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "lnW" = (
 /obj/item/clothing/suit/armor/platecarrier/ih,
 /obj/item/clothing/suit/armor/platecarrier/ih,
@@ -59621,16 +59626,8 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
 "lsD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/light/floor,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "lsS" = (
@@ -59758,6 +59755,9 @@
 "luo" = (
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/maintenance_interior,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/skyyard)
 "luq" = (
@@ -59863,6 +59863,7 @@
 /area/nadezhda/command/cbo)
 "lvZ" = (
 /obj/machinery/camera/network/colony_surface,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "lwb" = (
@@ -59993,8 +59994,10 @@
 /obj/machinery/camera/network/cev_eris{
 	dir = 1
 	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/rock/manmade/road,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "lxq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
@@ -60036,9 +60039,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/security/prisoncells)
 "lxG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -60189,11 +60189,8 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/robotics)
 "lze" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/closet/secure_closet/personal/agrolyte,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
 "lzf" = (
 /obj/structure/flora/small/busha1,
@@ -60705,24 +60702,26 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/cafeteria)
 "lDz" = (
+/obj/machinery/door/airlock{
+	name = "Church";
+	req_access = list(27)
+	},
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "lDA" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/stack/ore/glass,
@@ -61437,11 +61436,19 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/barbackroom)
 "lLw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/sign/levels/stairsup{
+	pixel_x = 32;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "lLB" = (
 /obj/machinery/atmospherics/omni/mixer{
 	active_power_usage = 7500;
@@ -61948,12 +61955,9 @@
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload)
 "lPU" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/window/reinforced,
-/obj/machinery/power/wall_obelisk{
-	pixel_y = 22
-	},
+/obj/machinery/camera/network/colony_surface,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "lPY" = (
@@ -62447,13 +62451,19 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "lUP" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
-/area/nadezhda/outside/meadow)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating/under,
+/area/colony)
 "lUR" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -62566,12 +62576,10 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
 "lVU" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "lVV" = (
 /obj/machinery/power/breakerbox{
 	RCon_tag = "AI Core Substation Bypass"
@@ -63145,15 +63153,24 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
 "mce" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/vending/theomat,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "mcg" = (
 /obj/structure/bed/chair,
 /obj/structure/window/reinforced{
@@ -63255,7 +63272,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/crew_quarters/plasma_tag)
 "mcP" = (
-/turf/simulated/floor/carpet,
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/plating,
 /area/nadezhda/absolutism/chapel)
 "mcQ" = (
 /obj/machinery/door/blast/shutters{
@@ -63328,8 +63349,9 @@
 /area/nadezhda/quartermaster/office)
 "mdn" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "mdt" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 2;
@@ -63479,27 +63501,23 @@
 /area/turret_protected/ai)
 "meA" = (
 /obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 2";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "meB" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 0;
@@ -63865,13 +63883,12 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "miP" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/church{
+	dir = 5
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "miQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -64376,9 +64393,6 @@
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "mmG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/side/f2section1)
@@ -64803,12 +64817,12 @@
 	},
 /area/turbolift/ElevatorOne/surface)
 "mqs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -64842,13 +64856,10 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "mqQ" = (
-/obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "mqS" = (
 /obj/effect/floor_decal/industrial/warningred/full,
@@ -65023,16 +65034,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "msx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -65133,8 +65145,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
 "mtA" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/dirt/dark,
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "mtG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -65574,28 +65588,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
 "mxN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "mxR" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -65872,22 +65873,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/engineering/foyer)
 "mBf" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mBn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating/under,
@@ -66222,10 +66214,6 @@
 /area/nadezhda/security/triage_blackshield)
 "mDT" = (
 /obj/effect/decal/cleanable/rubble,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
@@ -66596,10 +66584,16 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/construction)
 "mHf" = (
-/obj/structure/table/woodentable,
-/obj/machinery/recharger,
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "mHh" = (
 /obj/landmark/join/start/cargo_tech,
 /obj/structure/disposalpipe/segment,
@@ -66974,18 +66968,17 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
 "mKY" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/random/junk/cigbutt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "mLl" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -67005,19 +66998,20 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "mLR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light_switch{
-	pixel_x = 28
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/absolutism/bioreactor)
 "mLS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -67419,11 +67413,14 @@
 /turf/simulated/floor/beach/sand/drywater,
 /area/nadezhda/crew_quarters/pool)
 "mPy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/catwalk,
+/obj/machinery/light,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "mPC" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -67486,14 +67483,24 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/bridgebar)
 "mQc" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/biomatter,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = -32
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "mQf" = (
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -67578,13 +67585,12 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
 "mRi" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "mRq" = (
 /obj/structure/table/bench/marble,
 /obj/machinery/alarm{
@@ -68017,9 +68023,16 @@
 	name = "\improper Outdoors - Pad"
 	})
 "mVl" = (
-/obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "mVm" = (
 /obj/structure/closet,
 /turf/simulated/floor/tiled/white,
@@ -68064,23 +68077,10 @@
 	name = "Residential District Substation"
 	})
 "mVE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/table/woodentable,
+/obj/structure/reagent_dispensers/cahorsbarrel,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "mVH" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/generic,
@@ -68205,23 +68205,22 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "mXo" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "mXJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -68428,11 +68427,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/colony)
 "mZy" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 8
+	dir = 1;
+	light_color = "#0892d0"
 	},
-/obj/structure/closet/acolyte,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "mZB" = (
 /obj/structure/table/woodentable,
@@ -68643,15 +68643,11 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ncd" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
 	},
-/turf/simulated/floor/carpet,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "nch" = (
 /obj/random/furniture/pottedplant,
@@ -69210,15 +69206,8 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "nib" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 2
-	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/turf/simulated/floor/plating,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "nic" = (
 /obj/structure/table/onestar,
 /obj/item/pen,
@@ -69563,10 +69552,13 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "nlp" = (
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "nlr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -69617,19 +69609,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "nmo" = (
-/obj/machinery/button/remote/airlock{
-	id = "chudorm4";
-	name = "Door Bolt Control";
-	pixel_x = -28;
-	pixel_y = 0;
-	specialfunctions = 4
-	},
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/light,
+/obj/machinery/vending/fortune,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "nmp" = (
 /obj/item/reagent_containers/blood/AMinus,
 /obj/item/reagent_containers/blood/APlus,
@@ -69680,6 +69663,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "nmX" = (
@@ -69799,18 +69783,19 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/fo)
 "nol" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "nom" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -69928,20 +69913,18 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/podrooms)
 "npm" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/random/furniture/pottedplant,
+/obj/machinery/camera/network/church{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "npp" = (
 /obj/structure/multiz/stairs/active/bottom,
 /obj/structure/window/reinforced{
@@ -70147,22 +70130,12 @@
 /turf/simulated/floor/plating/under,
 /area/asteroid/cave)
 "nrD" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/chapel)
 "nrI" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -70351,14 +70324,15 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ntC" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
+/obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "ntK" = (
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
@@ -70418,14 +70392,17 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "nur" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "nuD" = (
 /obj/machinery/light,
@@ -70465,12 +70442,8 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "nuM" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/structure/closet/acolyte,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/machinery/power/nt_obelisk,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
 "nvc" = (
 /turf/simulated/shuttle/wall/mining{
@@ -70543,10 +70516,12 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nvB" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "nvD" = (
 /obj/structure/table/bar_special,
 /obj/machinery/floor_light,
@@ -70698,10 +70673,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "nxH" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/machinery/biomatter_solidifier,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/absolutism/bioreactor)
 "nxP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -71484,10 +71458,14 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "nFm" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/railing,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "nFp" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -71966,21 +71944,14 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nJR" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/disposal/deliveryChute{
+	dir = 4;
+	name = "biomatter chute"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "nJX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -72697,13 +72668,12 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "nRM" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/hallway/surface/section1)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "nRO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -72828,11 +72798,12 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "nTE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/mopbucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/soap/deluxe,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "nTL" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -73159,9 +73130,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "nWF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/side/f2section1)
 "nWL" = (
@@ -73309,12 +73277,23 @@
 /turf/simulated/open,
 /area/colony)
 "nYl" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/warningred{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
+/obj/effect/floor_decal/industrial/box/red/corners{
+	dir = 1;
+	icon_state = "box_corners_red"
+	},
+/obj/effect/floor_decal/industrial/box/red/corners,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
+	},
 /area/nadezhda/hallway/side/f2section1)
 "nYn" = (
 /obj/structure/flora/small/busha1,
@@ -73640,10 +73619,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "oaI" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/machinery/camera/network/colony_surface,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "oaM" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -74015,13 +73996,11 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "oei" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/camera/network/church{
-	dir = 5
-	},
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/meadow)
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "oep" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -74134,14 +74113,13 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/lakeside)
 "oeV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -74541,10 +74519,6 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/merchant)
 "oiq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -75006,11 +74980,13 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/main/stairwell)
 "omK" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
-	},
+/obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
+	},
 /area/nadezhda/hallway/side/f2section1)
 "omU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75114,10 +75090,8 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
 "ook" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/side/f2section1)
@@ -75192,6 +75166,9 @@
 	dir = 4;
 	pixel_x = 0
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "ooW" = (
@@ -75250,10 +75227,15 @@
 /turf/simulated/wall/church_reinforced,
 /area/nadezhda/command/prime)
 "opN" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "opO" = (
 /obj/effect/overlay/water,
@@ -75287,10 +75269,23 @@
 /turf/simulated/mineral,
 /area/nadezhda/command/cbo)
 "oqc" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/invislight,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/meadow)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "oqd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -75918,26 +75913,10 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
 "owa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
 "owe" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood,
@@ -76000,9 +75979,15 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
 "owI" = (
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/atm{
+	dir = 4;
+	pixel_x = 30
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "owK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/furniture/pottedplant,
@@ -76497,12 +76482,13 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/captain/quarters)
 "oBo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "oBq" = (
@@ -77323,20 +77309,15 @@
 	},
 /area/nadezhda/pros/proelav)
 "oJb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/random/furniture/pottedplant,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "oJo" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood/wild3,
@@ -77437,25 +77418,17 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/command/cro)
 "oKC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/random/furniture/pottedplant,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/holy{
-	name = "Church"
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/cargo,
+/area/nadezhda/absolutism/vectorrooms)
 "oKG" = (
 /obj/random/pouch/low_chance,
 /obj/random/toolbox,
@@ -77711,10 +77684,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "oMM" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/railing,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "oMS" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/junk/snappop,
@@ -77785,12 +77760,25 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
 "oNA" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "oNP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78295,11 +78283,14 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "oSN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/light/small,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "oST" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -78376,12 +78367,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "oTp" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/vectorrooms)
+/area/nadezhda/absolutism/bioreactor)
 "oTv" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -78539,17 +78531,18 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
 "oVv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "oVO" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 6
@@ -79227,8 +79220,13 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "pes" = (
-/obj/structure/closet/acolyte,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "pev" = (
 /obj/effect/decal/cleanable/dirt,
@@ -80013,9 +80011,6 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "pmt" = (
-/obj/structure/sign/faction/neotheology{
-	pixel_y = -30
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -80024,6 +80019,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology{
+	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
@@ -81232,26 +81230,15 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/virology)
 "pyY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "pzk" = (
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/nt_pedestal,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "pzm" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -81517,11 +81504,11 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "pBQ" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "pBV" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -81797,29 +81784,13 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/crematorium)
 "pDI" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "pDY" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -82291,19 +82262,9 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
 "pIr" = (
-/obj/structure/table/standard,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/obj/item/tool/multitool,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "pIs" = (
 /obj/machinery/light{
 	dir = 1
@@ -82630,11 +82591,10 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
 "pLt" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "pLw" = (
 /obj/random/mob/croaker/low_chance,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -82832,15 +82792,20 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "pNu" = (
-/obj/structure/sign/faction/neotheology{
-	pixel_y = -30
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "pNw" = (
 /turf/simulated/mineral,
 /area/nadezhda/outside/dcave)
@@ -83136,31 +83101,19 @@
 	name = "\improper Upper Research Hallway"
 	})
 "pPU" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Bioreactor - Main - 1";
-	capacity = 5e+006;
-	charge = 5e+006;
-	cur_coils = 4;
-	input_attempt = 1;
-	input_level = 5e+006;
-	input_level_max = 5e+006;
-	output_attempt = 1;
-	output_level = 5e+006;
-	output_level_max = 5e+006
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
 	},
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "pPW" = (
 /obj/machinery/vending/printomat,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -83980,15 +83933,14 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "pYx" = (
-/obj/machinery/computer/guestpass{
-	pixel_x = -32
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/camera/network/church{
-	dir = 5
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "pYB" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -84142,15 +84094,12 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "pZI" = (
-/obj/structure/table/woodentable,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "pZS" = (
 /mob/living/simple_animal/opossum{
 	desc = "The Nedezhda basketball team mascot. - Currently scavenging for rebounds";
@@ -84216,6 +84165,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "qay" = (
@@ -84268,12 +84218,16 @@
 	name = "\improper Outdoors - Pad"
 	})
 "qbh" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "qbj" = (
@@ -84702,16 +84656,8 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qfx" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "qfC" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -84867,31 +84813,27 @@
 	name = "Dormitory 3"
 	})
 "qgJ" = (
-/obj/structure/multiz/stairs/enter/bottom,
-/obj/structure/invislight,
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/nadezhda/outside/meadow)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "qgM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "qhd" = (
 /obj/structure/table/bar_special,
 /obj/machinery/chemical_dispenser/beer,
@@ -85915,9 +85857,6 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/sleeper)
 "qrQ" = (
-/obj/structure/sign/faction/neotheology{
-	pixel_y = -30
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -85928,6 +85867,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology{
+	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
@@ -86239,11 +86181,10 @@
 /turf/simulated/wall/r_wall,
 /area/colony)
 "quT" = (
-/obj/machinery/newscaster{
-	pixel_y = -34
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "quV" = (
 /obj/structure/bed/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -86278,11 +86219,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "qvn" = (
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/effect/floor_decal/industrial/box/red,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/engineering/atmos/storage)
 "qvy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -86387,10 +86326,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "qwE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/road/straight4,
-/turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/outside/meadow)
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/dark/cyancorner,
+/area/nadezhda/hallway/surface/section1)
 "qwI" = (
 /obj/machinery/light{
 	dir = 8;
@@ -86402,10 +86342,9 @@
 	name = "Dormitory 3"
 	})
 "qwK" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
+/obj/machinery/door/holy{
+	name = "Church"
 	},
-/obj/machinery/door/airlock/external,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -86414,7 +86353,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "qwM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -86607,18 +86551,11 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qyo" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "qyq" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
@@ -86751,24 +86688,12 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "qzx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/item/scrap_lump,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "qzA" = (
 /obj/structure/table/bar_special,
 /obj/item/modular_computer/tablet/preset/custom_loadout/standard,
@@ -86990,13 +86915,18 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
 "qBq" = (
+/obj/structure/catwalk,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/mob/roaches/low_chance,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "qBx" = (
 /obj/structure/table/standard,
 /obj/random/material/low_chance,
@@ -87009,9 +86939,12 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/forest)
 "qBQ" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/tool/multitool,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "qBV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/rock5,
@@ -87090,11 +87023,12 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "qDa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/catwalk,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/skyyard)
 "qDd" = (
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
@@ -87447,21 +87381,14 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "qGp" = (
-/obj/machinery/light{
+/obj/structure/multiz/stairs/enter/bottom{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "qGu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -87530,15 +87457,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qHh" = (
-/obj/structure/table/woodentable,
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "qHk" = (
 /obj/structure/flora/small/grassb4,
@@ -87880,11 +87803,12 @@
 	name = "\improper Clinic"
 	})
 "qKJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/closet/secure_closet/personal/agrolyte,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "qKO" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt,
@@ -87957,9 +87881,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "qLy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -88488,9 +88409,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "qQO" = (
-/obj/structure/closet/custodial,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/camera/network/church,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "qQP" = (
 /obj/structure/catwalk,
 /obj/random/scrap/dense_weighted/low_chance,
@@ -88786,19 +88710,22 @@
 	name = "Dormitory 3"
 	})
 "qTC" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
 	pixel_y = 0
 	},
+/obj/item/scrap_lump,
 /obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "qTD" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 4;
@@ -88884,14 +88811,35 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/atmos/storage)
 "qUt" = (
-/obj/structure/railing,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+/obj/structure/railing/grey{
+	dir = 8;
+	icon_state = "grey_railing0"
 	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/meadow)
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey,
+/obj/structure/sign/faction/derelict1{
+	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
+	name = "NOTICE: Dangerous Biohazard";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "qUw" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -88938,17 +88886,15 @@
 	name = "Residential District Maintenance"
 	})
 "qUT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/multiz/stairs/enter{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "qUY" = (
 /obj/structure/mopbucket,
 /obj/effect/floor_decal/industrial/botright,
@@ -88968,9 +88914,6 @@
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/cafeteria)
 "qVe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -89110,13 +89053,8 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "qWp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
+/obj/machinery/power/nt_obelisk,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "qWs" = (
 /obj/machinery/door/firedoor,
@@ -89169,6 +89107,7 @@
 /area/nadezhda/quartermaster/hangarsupply)
 "qWG" = (
 /obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/hallway/surface/section1)
 "qWI" = (
@@ -89184,15 +89123,12 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/crew_quarters/podrooms)
 "qWT" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light_switch{
+	pixel_x = -20
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/smartfridge/kitchen/church,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "qWW" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/small/busha3,
@@ -89619,15 +89555,11 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "raN" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/turf/simulated/floor/plating,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "raR" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
@@ -89695,12 +89627,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rby" = (
-/obj/structure/closet/acolyte,
-/obj/machinery/camera/network/church{
-	dir = 5
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "rbA" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -89878,21 +89812,10 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "rcV" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/storage)
 "rcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -90390,14 +90313,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rig" = (
-/obj/structure/mopbucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/structure/noticeboard/church{
-	pixel_x = 32
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "rip" = (
 /obj/machinery/door/firedoor,
 /obj/structure/door_assembly/door_assembly_maint_cargo,
@@ -90467,13 +90387,13 @@
 	name = "Dormitory 3"
 	})
 "riP" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/vending/fortune,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "riQ" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/powermonitor{
@@ -90580,14 +90500,12 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "rjV" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "rjY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "rjZ" = (
@@ -90836,17 +90754,18 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "rmB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "rmH" = (
@@ -90949,14 +90868,17 @@
 	name = "Dormitory 2"
 	})
 "rnS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/obj/structure/cable/green{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -91037,9 +90959,6 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rou" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -91213,13 +91132,11 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/courtroom)
 "rqj" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/meadow)
 "rqk" = (
 /obj/machinery/power/wall_obelisk{
 	pixel_x = 32
@@ -91229,12 +91146,20 @@
 	name = "Dormitory 1"
 	})
 "rqm" = (
-/obj/machinery/computer/guestpass{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/hologram/holopad,
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/area/nadezhda/absolutism/chapel)
 "rqp" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -91350,30 +91275,13 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "rrx" = (
-/obj/structure/bed/chair,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "rrB" = (
 /obj/structure/table/steel,
 /obj/random/mob/spiders,
@@ -91382,10 +91290,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rrG" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "rrM" = (
 /obj/structure/table/reinforced,
@@ -91598,9 +91505,6 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "rtn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -91930,8 +91834,22 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/pros/prep)
 "rwF" = (
-/turf/simulated/wall/r_wall,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/cable/yellow{
+	d1 = 32;
+	icon_state = "32-1"
+	},
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/railing/grey{
+	dir = 1;
+	icon_state = "grey_railing0"
+	},
+/obj/structure/catwalk,
+/turf/simulated/open,
+/area/nadezhda/absolutism/storage)
 "rwG" = (
 /obj/machinery/camera/network/colony_transition{
 	dir = 8
@@ -91994,12 +91912,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "rxq" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "rxs" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/under,
@@ -92799,11 +92717,17 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/command/courtroom)
 "rEA" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "rED" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/rock,
@@ -92995,10 +92919,12 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rGx" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/window_lwall_spawn/smartspawn/church,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "rGz" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -93107,23 +93033,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rHD" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Prime's Office";
-	departmentType = 22;
-	name = "Prime's RC";
-	pixel_x = 30;
-	pixel_y = 0
-	},
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Prime's Office"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "rHE" = (
 /obj/machinery/light{
 	dir = 1
@@ -93178,6 +93092,17 @@
 /area/nadezhda/hallway/surface/section1)
 "rIc" = (
 /obj/structure/invislight,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "rIf" = (
@@ -93580,8 +93505,12 @@
 	name = "Interrogation"
 	})
 "rMH" = (
+/obj/machinery/light_switch{
+	pixel_x = -20
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "rMK" = (
 /obj/structure/multiz/stairs/enter/bottom,
@@ -94015,16 +93944,19 @@
 	name = "Dormitory 4"
 	})
 "rQO" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "rQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -94046,11 +93978,12 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
 "rQU" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/golden,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "rRe" = (
 /obj/random/spider_trap_burrowing/low_chance,
@@ -94810,9 +94743,6 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/bridgebar)
 "rXX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -95171,9 +95101,10 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/pros/prep)
 "sbj" = (
-/obj/machinery/power/eotp,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/table/woodentable,
+/obj/random/toy/mecha,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "sbq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild5,
@@ -95462,11 +95393,13 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "sdY" = (
-/obj/machinery/light_switch{
-	pixel_x = 28
+/obj/machinery/door/holy{
+	name = "Church"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/storage)
 "sec" = (
 /obj/structure/table/rack,
@@ -95584,7 +95517,6 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "seQ" = (
-/obj/structure/disposalpipe/segment,
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -95620,16 +95552,6 @@
 /obj/effect/floor_decal/industrial/road/curvebig3,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/meadow)
-"sfi" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
-	},
-/obj/machinery/atm{
-	dir = 4;
-	pixel_x = 30
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
 "sfB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
@@ -96988,6 +96910,10 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
+	},
 /turf/simulated/floor/wood,
 /area/nadezhda/hallway/surface/section1)
 "stB" = (
@@ -97089,25 +97015,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "suE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/sink{
+	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/power/wall_obelisk{
-	pixel_y = -42
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "suL" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -97420,16 +97337,13 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/captain/quarters)
 "sxR" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/hallway/side/f2section1)
 "sxY" = (
-/obj/machinery/newscaster{
-	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "syb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -97626,21 +97540,19 @@
 /area/nadezhda/hallway/surface/section1)
 "sAo" = (
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "sAN" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -97992,11 +97904,9 @@
 /turf/simulated/mineral,
 /area/colony)
 "sFL" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "sFQ" = (
 /turf/simulated/floor/reinforced,
 /area/nadezhda/hallway/surface/section1)
@@ -98012,11 +97922,6 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "sFY" = (
-/obj/random/scrap/dense_weighted/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -98057,12 +97962,8 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
 "sGE" = (
-/obj/structure/table/woodentable,
-/obj/structure/noticeboard{
-	pixel_y = 28
-	},
-/obj/machinery/reagentgrinder/portable,
-/turf/simulated/floor/tiled/cafe,
+/obj/structure/low_wall/church,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/vectorrooms)
 "sGF" = (
 /obj/structure/flora/small/bushc1,
@@ -98306,13 +98207,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "sJb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "sJh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -98627,23 +98526,12 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/kitchen)
 "sMN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/vectorrooms)
 "sMT" = (
 /obj/structure/table/rack,
 /obj/item/storage/toolbox/electrical{
@@ -98779,11 +98667,13 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/gmaster)
 "sOa" = (
-/obj/machinery/conveyor/east{
-	id = "disposals grinder"
+/obj/structure/table/standard,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
 	},
-/obj/item/scrap_lump,
-/turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/side/f2section1)
 "sOd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -98895,12 +98785,15 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "sPh" = (
-/obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_y = -34
+/obj/machinery/conveyor_switch{
+	id = "disposals grinder"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/floor_decal/industrial/danger,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "sPj" = (
 /obj/structure/flora/small/trailrocka3,
 /obj/effect/decal/cleanable/dirt,
@@ -99182,27 +99075,20 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/engine_room)
 "sRR" = (
-/obj/effect/floor_decal/industrial/caution{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/structure/catwalk,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "sRV" = (
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/electrical,
@@ -99280,16 +99166,14 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "sSM" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 0;
-	pixel_y = 32
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "sSW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -99531,7 +99415,13 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sUM" = (
-/turf/simulated/floor/tiled/white,
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair";
+	tag = "icon-wooden_chair (EAST)"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "sUN" = (
 /obj/structure/table/standard,
@@ -100022,16 +99912,8 @@
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sZu" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "sZw" = (
@@ -100258,11 +100140,24 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "tby" = (
-/obj/machinery/light/floor{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-s"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "tbJ" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -101360,10 +101255,13 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
 "tmF" = (
+/obj/machinery/vending/theomat,
 /obj/machinery/light{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/power/nt_obelisk,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/storage)
 "tmR" = (
@@ -101501,14 +101399,15 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/main/stairwell)
 "toM" = (
-/obj/machinery/light/floor{
-	dir = 8
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
 	},
-/obj/machinery/camera/network/church{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "toN" = (
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -101558,13 +101457,12 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
 "tpj" = (
-/obj/effect/floor_decal/industrial/road/curvebig1,
-/obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/outside/meadow)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "tpn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/bushc3,
@@ -101647,11 +101545,11 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/podrooms)
 "tqr" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/meadow)
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "tqy" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -102248,9 +102146,6 @@
 /area/nadezhda/command/captain/quarters)
 "twn" = (
 /obj/random/scrap/dense_weighted/low_chance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -102562,12 +102457,13 @@
 	name = "Dormitory 4"
 	})
 "tzn" = (
-/obj/structure/table/woodentable,
-/obj/machinery/camera/network/church{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "tzo" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/rock,
@@ -102600,13 +102496,12 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tzJ" = (
-/obj/structure/table/standard,
-/obj/structure/sign/faction/neotheology_cross/gold{
-	pixel_y = 32
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/item/soap/deluxe,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "tzM" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/window/reinforced,
@@ -103459,8 +103354,17 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
 "tJf" = (
-/obj/structure/disposalpipe/segment,
-/obj/random/scrap/dense_weighted/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
@@ -103520,6 +103424,9 @@
 	icon_state = "pipe-s"
 	},
 /obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/crematorium)
 "tJK" = (
@@ -104156,11 +104063,9 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tPN" = (
-/obj/structure/table/bench/padded,
-/obj/machinery/camera/network/church{
-	dir = 5
-	},
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "tPO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -104423,13 +104328,11 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
 "tTa" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/vectorrooms)
 "tTl" = (
 /obj/random/boxes,
@@ -105019,13 +104922,13 @@
 	name = "\improper Upper Research Hallway"
 	})
 "tZL" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
-/obj/machinery/alarm{
-	pixel_y = 24
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "tZS" = (
 /obj/effect/floor_decal/industrial/arrows/white{
 	dir = 1
@@ -105034,16 +104937,14 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "tZT" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/multiz/stairs/enter{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/reinforced,
+/area/nadezhda/absolutism/storage)
 "tZW" = (
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -105183,14 +105084,18 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "uaN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "uaO" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -105286,18 +105191,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "ucl" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1;
+	icon_state = "danger"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "ucn" = (
 /mob/living/simple_animal/hostile/snake,
 /turf/simulated/floor/asteroid/grass,
@@ -105312,23 +105216,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "ucs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/reagent_dispensers/biomatter/large,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "ucx" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/stack/ore,
@@ -105360,14 +105251,10 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ucY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/structure/invislight,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "udb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -105687,13 +105574,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/cryo)
 "ugj" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
 	},
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/replenishing/chalice,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/hallway/surface/section1)
 "ugm" = (
 /obj/random/structures,
 /obj/effect/spider/stickyweb,
@@ -105704,12 +105589,20 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ugn" = (
-/obj/machinery/light,
-/obj/machinery/power/wall_obelisk{
-	pixel_y = -42
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "ugx" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Permanent Holding";
@@ -106112,7 +106005,6 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ukS" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -106612,19 +106504,17 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/crew_quarters/podrooms)
 "uqM" = (
-/obj/machinery/button/remote/airlock{
-	id = "chudorm3";
-	name = "Door Bolt Control";
-	pixel_x = -28;
-	pixel_y = 0;
-	specialfunctions = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "uqQ" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -106878,25 +106768,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "usX" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/material/kitchen/rollingpin,
-/obj/machinery/light_switch{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/skyyard)
 "utl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -107931,19 +107807,24 @@
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "uBy" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+/obj/machinery/camera/network/church{
+	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "uBz" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -108044,16 +107925,9 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
 "uCH" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
-	},
-/obj/item/stamp/pr,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/meadow)
 "uCI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -108452,11 +108326,9 @@
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "uGA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/flora/small/grassa5,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "uGD" = (
 /obj/landmark/machinery/input,
 /obj/machinery/conveyor/south{
@@ -109186,8 +109058,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "uOA" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/turf/simulated/floor/tiled/dark/golden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "uOB" = (
 /obj/machinery/holoposter{
@@ -109477,18 +109352,8 @@
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "uQx" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/meadow)
 "uQC" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -109861,12 +109726,14 @@
 	name = "\improper Upper Research Hallway"
 	})
 "uTQ" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "uTS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -109953,16 +109820,17 @@
 	name = "\improper Outdoors - Pad"
 	})
 "uUU" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/item/storage/fancy/crayons,
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/crayons,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "uUW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -110010,10 +109878,10 @@
 /area/nadezhda/security/hut_cell1)
 "uVi" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/box/white,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/catwalk,
+/obj/random/mob/roaches/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "uVp" = (
 /obj/structure/toilet,
 /obj/effect/decal/cleanable/filth,
@@ -110033,9 +109901,12 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
 "uVx" = (
-/obj/structure/closet/secure_closet/personal/agrolyte,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/absolutism/chapel)
 "uVy" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/robotics{
@@ -110354,10 +110225,21 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
 "uYT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
+/obj/structure/bed/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/cell/large/high;
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "uZc" = (
 /obj/structure/flora/small/bushc1,
@@ -110387,9 +110269,13 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "uZv" = (
-/obj/effect/floor_decal/industrial/road/curvebig2,
-/turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/outside/meadow)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "uZx" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/big/bush3,
@@ -110795,8 +110681,14 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/crew_quarters/hydroponics)
 "vdu" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "vdy" = (
 /obj/structure/disposalpipe/segment{
@@ -110892,18 +110784,9 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
 "vfg" = (
-/obj/structure/sign/faction/derelict1{
-	desc = "ATTENTION: The biogenerator is a dangerous device. All members of the church must wear there vests and coats to protect from the biohazards. Failure to do so will result in a swift death due to toxins and a new cruciform will need to be implanted. Do not use the biogenerator without protection.";
-	name = "NOTICE: Dangerous Biohazard";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/reagent_dispensers/biomatter,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "vfj" = (
 /obj/machinery/button/remote/blast_door{
@@ -110928,19 +110811,11 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "vfv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 6
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "vfw" = (
 /obj/machinery/camera/network/research{
 	dir = 8
@@ -111471,16 +111346,17 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
 "vkI" = (
-/obj/structure/cable/green{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/holy{
-	name = "Church"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
+/turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "vkK" = (
 /obj/machinery/light,
@@ -111633,10 +111509,17 @@
 /area/nadezhda/outside/forest)
 "vmm" = (
 /obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/recharger,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "vmq" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
@@ -112114,10 +111997,6 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "vqy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -112241,8 +112120,10 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vsl" = (
-/obj/machinery/smartfridge/kitchen/church,
-/obj/machinery/camera/network/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
 "vsm" = (
@@ -112280,12 +112161,18 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/meeting_room)
 "vsx" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/structure/invislight,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/absolutism/chapel)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/nadezhda/absolutism/vectorrooms)
 "vsy" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/structures,
@@ -112618,14 +112505,21 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "vvO" = (
-/obj/structure/closet/crate/trashcart,
-/obj/structure/closet/crate/trashcart,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/pros/prep)
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "vvS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame/vertical{
@@ -112786,9 +112680,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "vwJ" = (
-/obj/structure/table/woodentable,
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/carpet,
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/structure/invislight,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/plating,
 /area/nadezhda/absolutism/vectorrooms)
 "vwK" = (
 /obj/effect/decal/cleanable/cobweb{
@@ -113187,16 +113084,19 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "vAx" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
+/obj/structure/cable/cyan{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
 "vAB" = (
 /obj/structure/window/reinforced{
@@ -113354,13 +113254,21 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vCh" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
 "vCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -113630,8 +113538,10 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vFt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
@@ -113682,11 +113592,15 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical_blackshield)
 "vFR" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/invislight,
-/obj/machinery/camera/network/church,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/meadow)
+/obj/structure/table/woodentable,
+/obj/machinery/recharger,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "vFU" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -113753,13 +113667,21 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vGk" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/deliveryChute{
-	dir = 4;
-	name = "biomatter chute"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/vectorrooms)
 "vGA" = (
 /obj/structure/sign/security/cells{
 	pixel_x = -32
@@ -113967,12 +113889,9 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "vIw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
 "vIF" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -113980,23 +113899,11 @@
 	name = "\improper Outdoors - Pad"
 	})
 "vIL" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/camera/network/church{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/invislight,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/bioreactor)
 "vJb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -114203,14 +114110,11 @@
 	name = "Residential District Maintenance"
 	})
 "vKM" = (
-/obj/structure/sign/faction/neotheology{
-	pixel_y = -30
+/obj/machinery/door/holy/preacher{
+	name = "Chapel Office"
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/command/prime)
 "vKR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -114372,9 +114276,10 @@
 /area/nadezhda/outside/forest)
 "vMo" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/biomatter_solidifier,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/absolutism/storage)
+/obj/random/scrap/dense_weighted/low_chance,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "vMr" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -114398,47 +114303,37 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "vMI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/meadow)
+"vMK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/nadezhda/absolutism/vectorrooms)
-"vMK" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos/storage)
+/obj/machinery/power/eotp,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "vMQ" = (
-/obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+/obj/machinery/disposal/deliveryChute{
+	dir = 1;
+	name = "trash chute"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "vMU" = (
 /obj/structure/disposalpipe/junction,
-/obj/random/scrap/dense_weighted/low_chance,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "vMV" = (
@@ -115423,15 +115318,9 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "vWA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/power/nt_obelisk,
+/obj/structure/bed/chair/comfy/brown,
 /turf/simulated/floor/carpet,
-/area/nadezhda/absolutism/vectorrooms)
+/area/nadezhda/absolutism/chapel)
 "vWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -115661,10 +115550,17 @@
 	name = "Dormitory 1"
 	})
 "vXR" = (
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/absolutism/bioreactor)
 "vYb" = (
 /obj/structure/closet/secure_closet/personal/doctor,
 /obj/item/clothing/glasses/hud/health,
@@ -115860,18 +115756,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "waf" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/window/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/scrap_lump,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/engineering/atmos/storage)
 "wak" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
@@ -115902,21 +115792,9 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "waT" = (
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
-	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "waY" = (
 /obj/structure/multiz/stairs/active/bottom,
 /obj/structure/window/reinforced{
@@ -115926,17 +115804,25 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/side/f2section1)
 "wbe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/closet/secure_closet/reinforced/preacher,
+/obj/item/device/taperecorder,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/item/clothing/mask/gas/germanmask,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
+"wbm" = (
+/obj/machinery/door/unpowered/simple/wood/saloon{
+	name = "Church Foyer"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/chapel)
-"wbm" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/industrial/loading/white,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/area/nadezhda/absolutism/vectorrooms)
 "wbo" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -116257,14 +116143,13 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "weh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/rack/shelf,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/monofloor{
+	dir = 4;
+	icon_state = "monofloor"
 	},
-/obj/structure/catwalk,
-/obj/structure/closet/crate/trashcart{
-	old_lock_odds = -20
-	},
-/turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/side/f2section1)
 "wev" = (
 /obj/machinery/power/nt_obelisk,
@@ -116319,13 +116204,23 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
 "weP" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/wall/church_reinforced,
-/area/nadezhda/absolutism/bioreactor)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/steel/golden,
+/area/nadezhda/hallway/surface/section1)
 "weT" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/effect/floor_decal/industrial/arrows/white,
@@ -116396,22 +116291,9 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "wfn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/church_reinforced,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "wft" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/cafe,
@@ -116531,10 +116413,12 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/cafeteria)
 "wgN" = (
-/obj/machinery/door/blast/regular/open{
-	id = "Colony Lockdown"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "wgV" = (
@@ -116777,10 +116661,24 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/shuttle/surface_transport_lz)
 "wjD" = (
-/obj/structure/reagent_dispensers/biomatter/large,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "wjI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -117384,14 +117282,16 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "wpu" = (
-/obj/machinery/door/holy{
-	name = "Church"
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
-	},
-/area/nadezhda/absolutism/vectorrooms)
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_room)
 "wpv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -117899,22 +117799,9 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "wtw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "wtC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 6;
@@ -118654,16 +118541,21 @@
 "wAo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -119243,10 +119135,13 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/rbreakroom)
 "wFB" = (
-/obj/structure/noticeboard/church{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "wFO" = (
 /obj/landmark/join/start/clubmanager,
@@ -119510,10 +119405,8 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
 "wIm" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/obj/structure/sign/faction/neotheology{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
@@ -120155,12 +120048,12 @@
 	name = "Dormitory 3"
 	})
 "wQW" = (
-/obj/effect/floor_decal/industrial/danger,
-/obj/structure/window/reinforced,
+/obj/machinery/conveyor/east{
+	id = "disposals grinder"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/scrap_lump,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos/storage)
 "wRb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -120232,37 +120125,26 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
 "wSh" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
 "wSl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "chudorm3";
-	name = "Church Dorm 1";
-	req_access = list(70)
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "wSn" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -120588,26 +120470,11 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/tcommsat/computer)
 "wVv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/holy/preacher{
-	name = "Prime's Quarters"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/prime)
+/obj/structure/catwalk,
+/obj/structure/invislight,
+/obj/machinery/camera/network/church,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/meadow)
 "wVx" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,18"
@@ -120627,13 +120494,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/random/scrap/dense_weighted/low_chance,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "wWc" = (
@@ -120679,13 +120545,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "wWN" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = 32
 	},
-/obj/structure/closet/acolyte,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "wWP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -121580,9 +121444,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "xfb" = (
-/obj/structure/invislight,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/dark/golden,
+/area/nadezhda/absolutism/chapel)
 "xfc" = (
 /obj/machinery/conveyor/east{
 	dir = 1;
@@ -121716,14 +121582,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xgI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/table/woodentable,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/prime)
 "xgP" = (
 /obj/random/gun_combat,
 /turf/simulated/floor/asteroid/dirt,
@@ -122013,10 +121875,22 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "xke" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/floor_decal/industrial/box/red,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/hallway/surface/section1)
 "xki" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -122124,16 +121998,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xlL" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/meadow)
+/obj/structure/table/woodentable,
+/obj/machinery/reagentgrinder/portable,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "xlP" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Post";
@@ -122336,19 +122204,9 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xmO" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/holy/preacher{
-	name = "Chapel Office"
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/command/prime)
+/obj/structure/flora/small/grassb1,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "xmV" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/nightmare,
@@ -122404,17 +122262,18 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "xnv" = (
-/obj/machinery/light,
-/obj/machinery/light_switch{
-	pixel_x = 0;
-	pixel_y = -28
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "xnw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -122489,22 +122348,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xok" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -122641,6 +122486,9 @@
 "xpb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/machinery/door/blast/regular/open{
+	id = "Colony Lockdown"
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "xpc" = (
@@ -122783,18 +122631,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xqJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/camera/network/church{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
 	},
-/obj/machinery/door/holy{
-	name = "Church"
-	},
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/absolutism/vectorrooms)
 "xqM" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -122865,12 +122713,13 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "xrs" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+/obj/structure/multiz/stairs/active{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
 /area/nadezhda/absolutism/storage)
 "xrx" = (
 /obj/landmark/machinery/input,
@@ -122886,18 +122735,17 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "xrD" = (
-/obj/structure/nt_pedestal,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/command/prime)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate{
+	name = "\improper Outdoors - Pad"
+	})
 "xrF" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 6;
@@ -123338,9 +123186,14 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "xwB" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/biomatter,
+/obj/structure/sign/faction/neotheology_cross/gold{
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/absolutism/bioreactor)
 "xwH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/random/flora/jungle_tree,
@@ -123361,8 +123214,9 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/miningdock)
 "xwO" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
+/obj/random/furniture/pottedplant,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
@@ -123499,21 +123353,13 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xyC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/wood/wild3,
+/turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
 "xyJ" = (
 /turf/simulated/wall/r_wall,
@@ -123691,9 +123537,6 @@
 	name = "\improper Upper Research Hallway"
 	})
 "xAO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -123744,14 +123587,16 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
 "xBq" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/meadow)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "xBr" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,3"
@@ -123960,10 +123805,13 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "xDf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/golden,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "xDh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -124040,7 +123888,13 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "xDI" = (
-/turf/simulated/floor/tiled/dark/golden,
+/obj/structure/sink{
+	density = 1;
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
+	icon_state = "BaptismFont_Water";
+	name = "Water Fountain"
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
 "xDL" = (
 /obj/effect/decal/cleanable/rubble,
@@ -124074,9 +123928,20 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xEe" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/absolutism/bioreactor)
 "xEk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/wood,
@@ -124743,11 +124608,23 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
 "xKz" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 5
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/obj/structure/disposaloutlet,
+/obj/machinery/conveyor/south{
+	id = "junk_to_bioreactor"
+	},
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/nadezhda/hallway/surface/section1)
 "xKD" = (
 /obj/structure/grille,
 /turf/simulated/floor/asteroid/grass,
@@ -125010,11 +124887,10 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "xMy" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/outside/meadow)
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/glass/replenishing/chalice,
+/turf/simulated/floor/carpet/bcarpet,
+/area/nadezhda/command/prime)
 "xMA" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -125330,9 +125206,15 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/genetics)
 "xPH" = (
-/obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "xPK" = (
@@ -125651,10 +125533,14 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "xTb" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/window_lwall_spawn/smartspawn/church,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/catwalk,
+/obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/absolutism/bioreactor)
+/area/nadezhda/hallway/surface/section1)
 "xTe" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/techmaint,
@@ -126595,23 +126481,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "ycP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/absolutism/storage)
+/turf/simulated/open,
+/area/nadezhda/hallway/surface/section1)
 "ycR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -126856,16 +126730,13 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "yfE" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/absolutism/vectorrooms)
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/meadow)
 "yfL" = (
 /obj/item/storage/briefcase/inflatable{
 	pixel_x = 3;
@@ -127265,9 +127136,15 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "yjK" = (
-/obj/structure/invislight,
-/turf/simulated/wall/church_reinforced,
-/area/nadezhda/outside/meadow)
+/obj/structure/multiz/stairs/active/bottom{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/absolutism/bioreactor)
 "yjM" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -127421,19 +127298,11 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
 "ylz" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/absolutism/bioreactor)
+/turf/simulated/floor/wood,
+/area/nadezhda/absolutism/vectorrooms)
 "ylB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -193628,13 +193497,13 @@ wyB
 vqX
 qSA
 eyR
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+xGi
+xGi
+xGi
+xGi
+xGi
+xGi
+xGi
 sFI
 sFI
 sFI
@@ -193827,16 +193696,16 @@ eyR
 uFC
 vvL
 wAo
-qSA
 xPH
-eyR
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+xPH
+wpu
+ntC
+ntC
+ntC
+egd
+ntC
+lUP
+xGi
 sFI
 sFI
 sFI
@@ -194032,13 +193901,13 @@ wDz
 xrz
 eyR
 eyR
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+xGi
+xGi
+xGi
+xGi
+beK
+vAx
+beK
 sFI
 sFI
 sFI
@@ -194238,9 +194107,9 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
+beK
+gHI
+beK
 sFI
 sFI
 sFI
@@ -194440,9 +194309,9 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
+beK
+xEe
+beK
 sFI
 sFI
 sFI
@@ -194642,9 +194511,9 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
+beK
+gHI
+beK
 sFI
 sFI
 sFI
@@ -194842,18 +194711,18 @@ eyR
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+beK
+beK
+mLR
+beK
+beK
+beK
+beK
+beK
+beK
+beK
+beK
 sFI
 sFI
 ula
@@ -195044,18 +194913,18 @@ eyR
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+eWs
+mCq
+iRf
+vgv
+tZa
+mUh
+mCq
+bME
+eoh
+qIF
+beK
 sFI
 sFI
 ula
@@ -195246,18 +195115,18 @@ eyR
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+hov
+uww
+dnk
+naZ
+dMu
+xhZ
+nbK
+rKo
+bRX
+flu
+beK
 sFI
 sFI
 ula
@@ -195448,18 +195317,18 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+uHt
+uww
+eSm
+mxC
+wuq
+mBO
+afV
+mCq
+iDu
+qIF
+beK
 sFI
 ula
 ula
@@ -195646,22 +195515,22 @@ tiM
 ult
 wFu
 uNP
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+xGi
+xGi
+beK
+beK
+beK
+mCq
+fuZ
+vMK
+tZL
+gcr
+gzw
+vcq
+mCq
+mCq
+kFi
+beK
 sFI
 ula
 uma
@@ -195846,24 +195715,24 @@ jPJ
 iVn
 byG
 ult
-uYr
-uNP
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+kPg
+rby
+iGZ
+nFm
+ifo
+fEH
+nFm
+bho
+xhZ
+mHf
+mxC
+gcr
+tkm
+vcq
+mCq
+pDr
+uUh
+beK
 sFI
 ula
 ssK
@@ -196050,22 +195919,22 @@ uQF
 vHx
 wGk
 uNP
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+xGi
+beK
+beK
+beK
+beK
+xnv
+uaN
+hpq
+mxC
+hCa
+tNb
+tNb
+daZ
+jNI
+uUh
+beK
 sFI
 ula
 guh
@@ -196256,18 +196125,18 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+deL
+puT
+ejM
+uZv
+nvW
+hpm
+hpm
+mCq
+lHE
+uUh
+beK
 sFI
 ula
 hdW
@@ -196458,18 +196327,18 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+fgb
+rOL
+hmk
+eyI
+ctG
+ctC
+wIe
+mCq
+naZ
+kxQ
+beK
 sFI
 ula
 ula
@@ -196660,18 +196529,18 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+oPl
+uUJ
+oMM
+aUn
+aUn
+qHo
+jTL
+mCq
+mxC
+hmj
+beK
 sFI
 sFI
 sFI
@@ -196862,18 +196731,18 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+azM
+uUJ
+dtG
+aUn
+aUn
+sDT
+qPy
+mCq
+mxC
+uPd
+beK
 sFI
 sFI
 sFI
@@ -197064,21 +196933,21 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+cuT
+dYM
+tFp
+cKx
+usk
+jeg
+vcq
+mCq
+fyb
+qUt
+beK
+beK
+beK
+beK
 sFI
 sFI
 sFI
@@ -197266,21 +197135,21 @@ sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+tgh
+mCq
+hNx
+xhZ
+mCq
+mCq
+mCq
+mCq
+fyb
+esz
+esz
+qGp
+hpc
+beK
 sFI
 sFI
 sFI
@@ -197467,22 +197336,22 @@ uNP
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+beK
+sJX
+cTB
+nJR
+xDf
+mCq
+mCq
+mCq
+esz
+fyb
+esz
+esz
+lLw
+yjK
+beK
 sFI
 sFI
 sFI
@@ -197669,22 +197538,22 @@ uNP
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+hSC
+cTB
+eMx
+bMK
+bal
+oVv
+lti
+rCq
+dMu
+uZv
+kbl
+beK
+beK
+beK
+beK
 sFI
 sFI
 sFI
@@ -197868,22 +197737,22 @@ vQv
 jkc
 cSt
 uNP
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+uNP
+uNP
+uNP
+beK
+vXR
+nSn
+nSn
+oYg
+nSn
+vMQ
+mPy
+beK
+mCq
+rhf
+mCq
+beK
 sFI
 sFI
 sFI
@@ -198069,25 +197938,25 @@ vQv
 vQv
 uOb
 cSt
-uNP
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+qfx
+rxq
+ldw
+jwd
+gxd
+oTp
+oTp
+oTp
+oTp
+oTp
+oTp
+mAy
+beK
+lZC
+beK
+wuN
+beK
+beK
+beK
 sFI
 sFI
 sFI
@@ -198271,25 +198140,25 @@ uim
 uWe
 vIm
 cSt
+sPh
+jte
+rig
 uNP
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+dXG
+dXG
+dXG
+dXG
+beK
+beK
+fuZ
+fuZ
+fuZ
+mCq
+vIL
+mCq
+ucs
+ucs
+beK
 sFI
 sFI
 sFI
@@ -198471,27 +198340,27 @@ epg
 tKp
 dvQ
 uWK
-vMK
+vIm
 pBF
+hHU
+qzx
+mRi
 uNP
 sFI
 sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+fuZ
+fuZ
+fuZ
+cUo
+nxH
+vcq
+ucs
+ucs
+beK
 sFI
 gfQ
 gfQ
@@ -198675,25 +198544,25 @@ vQv
 vQv
 jkc
 cSt
+rjV
+wQW
+sSM
 uNP
 sFI
 sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+eVP
+eVP
+eVP
+mCq
+mCq
+mCq
+vfg
+xwB
+beK
 gfQ
 gfQ
 xGX
@@ -198877,25 +198746,25 @@ vQv
 vQv
 jkc
 nmW
+rHD
+fkm
+rEA
 uNP
 sFI
 sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+fgM
+fgM
+fgM
+mCq
+mCq
+lVU
+lVU
+lVU
+beK
 gfQ
 vNF
 wHA
@@ -199078,26 +198947,26 @@ tKp
 dvQ
 uWe
 vIm
-nja
+cSt
+waf
+wQW
+vvO
 uNP
 sFI
 sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+tzn
+sZu
+sZu
+mCq
+raN
+kOD
+kOD
+kOD
+beK
 gfQ
 wHA
 lgp
@@ -199281,25 +199150,25 @@ tKp
 tQX
 vIm
 cSt
+gnT
+fPi
+ucl
 uNP
 sFI
 sFI
 sFI
 sFI
 sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
-sFI
+beK
+beK
+beK
+beK
+beK
+beK
+beK
+beK
+beK
+beK
 gfQ
 kKh
 raF
@@ -199483,10 +199352,10 @@ vQv
 vQv
 jkc
 cSt
+gnT
+eIV
+qTC
 uNP
-sFI
-sFI
-sFI
 sFI
 sFI
 sFI
@@ -199685,10 +199554,10 @@ vQv
 vQv
 vIm
 cSt
+qfx
+qvn
+sFL
 uNP
-sFI
-sFI
-sFI
 sFI
 sFI
 sFI
@@ -199888,9 +199757,9 @@ uWe
 uOb
 hSq
 uNP
-sFI
-sFI
-sFI
+uNP
+uNP
+uNP
 sFI
 sFI
 sFI
@@ -224338,7 +224207,7 @@ vrp
 uEB
 pIy
 hvW
-vmU
+pmO
 sbB
 hvW
 sbB
@@ -224540,8 +224409,8 @@ vrp
 vrp
 uEB
 leU
-quu
-sbB
+uGA
+vUJ
 xcy
 sbB
 sbB
@@ -224560,16 +224429,16 @@ sbB
 sbB
 hvW
 leU
-tEB
-leU
-leU
+cJT
+sbB
+sbB
 fvM
 hvW
 akm
 jzd
 tSB
-pMI
 hvW
+kqO
 leU
 sbB
 wOE
@@ -224743,8 +224612,8 @@ vrp
 uEB
 vmU
 leU
-hvW
-sbB
+mET
+vUJ
 sbB
 quu
 kqO
@@ -224752,25 +224621,25 @@ hvW
 leU
 fXP
 pIy
+kqO
+hvW
 leU
-vUJ
-fxz
-fxz
-fxz
-fxz
-fxz
-fxz
-fxz
-fxz
-fxz
-fxz
-fxz
-vUJ
+fXP
+pIy
+leU
+fXP
+kqO
+xcy
 sbB
-leU
+sbB
+sbB
+sbB
 iuk
 sbB
-sbB
+vUJ
+vUJ
+vUJ
+vUJ
 sbB
 sbB
 xHt
@@ -224946,32 +224815,32 @@ uEB
 uEB
 uEB
 leU
-leU
-sbB
+vUJ
+vUJ
 wOE
 sFd
 leU
 leU
 hvW
 leU
+sFd
+leU
+sbB
+hvW
+leU
 vYJ
-vhs
-nRc
-nRc
-nRc
-nRc
-nRc
-nRc
-nRc
-nRc
-nRc
-nRc
-eNd
-xBq
-sbB
-sbB
-sbB
-sbB
+xcy
+bjU
+vUJ
+vUJ
+vUJ
+xmO
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
 pTs
 xzG
 lfJ
@@ -225150,28 +225019,28 @@ uEB
 pIy
 quu
 vUJ
-yaD
+uGA
 leU
 leU
 leU
 leU
 hvW
 sbB
-vhs
-nRc
-nRc
-nRc
-nRc
-nRc
-nRc
-nRc
-nRc
-nRc
-nRc
-eNd
-huw
-hvW
+sbB
 leU
+leU
+hvW
+sbB
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+sbB
 sbB
 hvW
 akm
@@ -225358,22 +225227,22 @@ leU
 leU
 hvW
 wtf
+sbB
+leU
+leU
+hvW
+wtf
+sbB
 vUJ
-vhs
-nRc
-nRc
-uUP
-bSp
-tNT
-bSp
-tNT
-bSp
-fCA
-nRc
-eNd
-pBQ
-leU
-leU
+vUJ
+vUJ
+vUJ
+cRj
+sbB
+sbB
+xcy
+sbB
+hvW
 hpB
 ilm
 hvW
@@ -225554,27 +225423,27 @@ uEB
 uEB
 uEB
 sbB
-xcy
+neH
 vUJ
+vUJ
+hvW
+hvW
+xcy
+leU
 leU
 leU
 hvW
 xcy
-mET
-vhs
-nRc
-nRc
-neA
-kAD
-lpo
-obU
-dux
-nyk
-uwg
-nRc
-eNd
-jVP
+vUJ
+vUJ
+vUJ
+sbB
+sbB
+hvW
+pIy
+pIy
 leU
+pIy
 leU
 hvW
 hvW
@@ -225758,24 +225627,24 @@ leU
 sbB
 pDw
 mkI
-vUJ
-mET
+kSK
+leU
 bjU
 xcy
+leU
+hvW
+xcy
+bjU
+mET
 vUJ
-rhl
-nRc
-nRc
-neA
-oBL
-oFp
-wnB
-hGv
-tuC
-uwg
-nRc
-eNd
-pBQ
+vUJ
+sbB
+iuk
+leU
+leU
+hvW
+leU
+leU
 pIy
 leU
 leU
@@ -225964,21 +225833,21 @@ vUJ
 mET
 mET
 vUJ
+pIy
 vUJ
-rhl
-nRc
-nRc
-sgF
-qNk
-eVh
-cgB
-dCV
-hkY
-xpM
-nRc
-eNd
-pBQ
+vUJ
+vUJ
+vUJ
+vUJ
+sbB
+sbB
+sbB
 leU
+hvW
+wtf
+leU
+hvW
+lHB
 leU
 leU
 leU
@@ -226166,20 +226035,20 @@ ilm
 qAh
 vUJ
 vUJ
+pmO
 vUJ
-nFm
-nRc
-nRc
-neA
-rhd
-ddz
-dbo
-ikD
-ngo
-uwg
-nRc
-eNd
-pBQ
+vUJ
+vUJ
+sbB
+leU
+iuk
+vUJ
+leU
+leU
+hvW
+xcy
+pIy
+leU
 leU
 leU
 leU
@@ -226364,24 +226233,24 @@ leU
 sbB
 sbB
 quu
-hvW
-kuB
+leU
+leU
 leU
 vUJ
-xcy
-nFm
-nRc
-nRc
-neA
-kgk
-mgz
-fFY
-huv
-joZ
-uwg
-nRc
-eNd
-pBQ
+vUJ
+vUJ
+vUJ
+vUJ
+sbB
+sbB
+sbB
+mkI
+vUJ
+pLt
+bjU
+leU
+leU
+leU
 leU
 hvW
 pIy
@@ -226566,25 +226435,25 @@ sbB
 yaD
 sbB
 quu
-quu
+leU
 hvW
 vUJ
 vUJ
-vkl
-nFm
-nRc
-nRc
-wMt
-xyZ
-mgz
-dbo
-nYz
-hvX
-qxV
-nRc
-eNd
-pBQ
-pIy
+vUJ
+vUJ
+vUJ
+iuk
+iuk
+sbB
+sbB
+leU
+leU
+leU
+mET
+leU
+hvW
+leU
+hvW
 leU
 leU
 leU
@@ -226769,23 +226638,23 @@ sbB
 yaD
 jKZ
 pIy
-sbB
+leU
 mET
 vUJ
+vUJ
+sbB
+uCH
+sbB
+sbB
 hvW
-rhl
-nRc
-nRc
-neA
-rhd
-mgz
-dbo
-qlC
-ngo
-uwg
-nRc
-eNd
-pBQ
+mET
+vmU
+leU
+hvW
+leU
+leU
+leU
+pIy
 leU
 leU
 xcy
@@ -226975,19 +226844,19 @@ mET
 vUJ
 sbB
 leU
-rhl
-nRc
-nRc
-sgF
-cuM
-jPL
-dbo
-jPL
-tOc
-xpM
-nRc
-eNd
-pBQ
+iuk
+kuB
+quu
+pMI
+kuB
+kuB
+quu
+pIy
+leU
+leU
+hvW
+xcy
+vUJ
 hvW
 leU
 mET
@@ -227174,26 +227043,26 @@ sbB
 qKO
 vUJ
 vUJ
-mET
-hvW
+vUJ
 sbB
-rhl
-nRc
-nRc
-neA
-bQZ
-har
-rGF
-gBV
-wjC
-uwg
-nRc
-eNd
-pBQ
+sbB
+sbB
+hvW
+quu
+quu
+hvW
+hvW
+quu
+quu
+hvW
+pIy
+leU
+vkl
+vUJ
 leU
 pIy
 vUJ
-hvW
+kqO
 hvW
 vhs
 eON
@@ -227356,7 +227225,7 @@ cjv
 fJv
 wBa
 pwm
-uEV
+qwE
 uEV
 ciH
 gba
@@ -227378,20 +227247,20 @@ vUJ
 pmO
 sbB
 leU
+jKZ
+pIy
+leU
+jKZ
+pIy
+leU
+leU
+jKZ
+pIy
 sbB
-rhl
-nRc
-nRc
-neA
-wXW
-iqI
-pWh
-acG
-xRC
-uwg
-nRc
-eNd
-xlL
+mET
+vUJ
+hvW
+vUJ
 leU
 leU
 vUJ
@@ -227579,21 +227448,21 @@ vUJ
 fxz
 atk
 atk
+fxz
+atk
+fxz
+atk
+fxz
+atk
+fxz
 atk
 atk
-qUt
-nRc
-nRc
-gWK
-lFw
-rcd
-rcd
-rcd
-lFw
-hbK
-nRc
-nRc
-lUP
+fxz
+fxz
+atk
+atk
+atk
+atk
 jQP
 eMk
 fxz
@@ -227777,24 +227646,24 @@ vTn
 nyS
 cKe
 jBi
+fCn
 leR
-kEe
 oHf
 oHf
 oHf
 oHf
 oHf
-bfZ
-bfZ
-bfZ
-bfZ
-bfZ
-bfZ
-bfZ
-bfZ
-bfZ
-bfZ
-bfZ
+oHf
+oHf
+oHf
+oHf
+oHf
+oHf
+oHf
+oHf
+oHf
+oHf
+oHf
 oHf
 oHf
 oHf
@@ -227979,8 +227848,8 @@ gEY
 wrl
 oal
 cVR
+uQx
 jaT
-tpj
 hpV
 hpV
 hpV
@@ -227989,11 +227858,11 @@ hpV
 hpV
 hpV
 hpV
-xMy
-xMy
-xMy
-xMy
-xMy
+hpV
+hpV
+hpV
+hpV
+hpV
 hpV
 hpV
 hpV
@@ -228181,8 +228050,8 @@ pwm
 pwm
 aot
 njl
+uQx
 stq
-qwE
 iVt
 aJG
 iVt
@@ -228383,8 +228252,8 @@ pwm
 pwm
 aot
 ved
+uQx
 stq
-qwE
 iVt
 aJG
 aJG
@@ -228585,8 +228454,8 @@ aug
 fMZ
 jeo
 puc
+uQx
 gOa
-uZv
 gaS
 gaS
 dEY
@@ -228787,10 +228656,10 @@ stG
 wzY
 kCJ
 hYL
+uQx
 tpO
-hZa
-hZa
-ssA
+sxY
+sxY
 aot
 hLv
 hLv
@@ -228988,11 +228857,11 @@ tdw
 fKf
 pwm
 aot
-cTB
+hZa
 mpT
-eON
-sMV
-sbB
+mpT
+hZa
+ssA
 aot
 pfU
 dmc
@@ -229178,7 +229047,7 @@ epc
 moX
 xFe
 koI
-wsf
+ugj
 fKf
 wIm
 fKf
@@ -229194,8 +229063,8 @@ tdv
 eON
 eON
 sMV
-sbB
-sbB
+gyc
+vAX
 dld
 dld
 adr
@@ -229219,8 +229088,8 @@ leU
 leU
 leU
 leU
-vUJ
-vUJ
+cZV
+cZV
 kfg
 aCl
 nfX
@@ -229379,40 +229248,40 @@ poE
 epc
 rID
 bEX
-rwF
-rwF
-rwF
-rwF
-rwF
-rwF
-rwF
-rwF
-rwF
-rwF
-rwF
-rwF
-aot
-aot
-eON
+kOW
+kOW
+hcE
+kOW
+hcE
+kOW
+kOW
+kOW
+mcP
+kOW
+mcP
+kOW
+kOW
+kOW
+kbv
 kbv
 fgm
-sbB
-sbB
+wVU
+fXR
+dld
+dld
 vUJ
 vUJ
-xfb
-iUs
-iUs
-iUs
-iUs
-iUs
-iUs
-iUs
-iUs
-fXR
-vAX
-fXR
-vAX
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
+vUJ
 vUJ
 vUJ
 gRK
@@ -229421,8 +229290,8 @@ leU
 leU
 leU
 leU
-vUJ
-vUJ
+cZV
+cZV
 hgC
 hgC
 hgC
@@ -229582,48 +229451,48 @@ epc
 rjh
 gSM
 kOW
+mVE
+dsj
+miP
+dsj
+ndM
 kOW
+aFx
+lpW
+bmx
+aFx
+lpW
+nRM
 kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-iUs
-iUs
-klX
-nib
-iUs
-iUs
-iUs
-iUs
 bVb
-opH
-opH
-opH
-opH
-opH
-opH
-opH
+bVb
+kOW
 iUs
 wVU
-gyc
-wVU
-gyc
-vUJ
-vUJ
-vUJ
-gRK
-leU
-leU
-leU
-sbB
-vUJ
+dld
+dld
+pDI
+pYx
+pYx
+pYx
+pYx
+pYx
+pYx
+pYx
+pYx
+pYx
+pYx
+pYx
+kyl
+cZV
+cZV
+cZV
+cZV
+cZV
+cZV
+cZV
+cZV
+cZV
 lxo
 aot
 hgC
@@ -229783,48 +229652,48 @@ poE
 epc
 rID
 mMj
-tPN
 pQO
-uTQ
-iGZ
-mVl
-vsx
-pQO
-pQO
-cRj
-qHh
-dtG
+xtm
+dsj
+dsj
+dsj
 pci
+pQO
+aFx
+fiW
+qHh
+fiW
+dsj
+aFx
+lpW
+aFx
+aFx
 kOW
 iUs
 iUs
-klX
-nib
-iUs
-iUs
-iUs
-iUs
+dld
+dld
 kMD
-opH
-jyK
-ckV
-opH
-jCL
-ylF
-opH
-iUs
-iUs
-iUs
-iUs
-iUs
+nRc
+nRc
+uUP
+bSp
+tNT
+bSp
+tNT
+bSp
+fCA
+nRc
+nRc
+kFQ
+vUJ
+vUJ
+vUJ
 sbB
-vUJ
-vUJ
-vUJ
-vUJ
-vUJ
-vUJ
-vUJ
+leU
+leU
+leU
+gRK
 vUJ
 vUJ
 vUJ
@@ -229985,41 +229854,41 @@ poE
 epc
 wXd
 mqc
+pQO
+qFY
+dsj
+dsj
+dsj
+xfb
+pQO
+kMZ
 fiW
-pQO
-gRP
-mtA
-gRP
-mtA
-pQO
-pQO
-xtm
-mcP
-mcP
-doA
-kOW
-xDI
-cNE
+qHh
+fiW
+dsj
+lfc
+aFx
+aFx
 kyt
-xDI
-toM
-xDI
-xDI
-lpW
-vCh
-opH
-plZ
-gdn
-opH
-ouv
-mmt
-opH
-opH
-opH
-opH
-opH
+kOW
+kOW
 iUs
-iUs
+dld
+dld
+ikj
+nRc
+nRc
+neA
+kAD
+lpo
+obU
+dux
+nyk
+uwg
+nRc
+nRc
+eNd
+vUJ
 vUJ
 vUJ
 sbB
@@ -230188,40 +230057,40 @@ epc
 wXd
 pmt
 kOW
+cxA
+dsj
+eit
+dsj
+xOv
 kOW
-pQO
-pQO
-pQO
-pQO
-kOW
-kOW
-qFY
-mcP
-mcP
-ndM
-kOW
-boU
+eTj
 fiW
-lLw
+qHh
 fiW
-mcP
-xDI
+dsj
+lfc
+wGn
 aFx
-xDI
+dsj
+pQO
 mcP
-opH
-lje
-oRV
-opH
-geE
-kab
-opH
-opH
-xrD
-kDY
-opH
-opH
 iUs
+dld
+dld
+ikj
+nRc
+nRc
+neA
+oBL
+oFp
+wnB
+hGv
+tuC
+uwg
+nRc
+nRc
+eNd
+vUJ
 vUJ
 vUJ
 gRK
@@ -230388,42 +230257,42 @@ pwm
 pwm
 jZV
 qMM
-mqc
-wGn
-kOW
-fiW
-fiW
-fiW
-fiW
+vCh
 kOW
 kOW
-cxA
-mcP
-mcP
-xOv
+uOA
+ccn
+uVx
 kOW
-rjV
+kOW
+rGx
 fiW
-lLw
-fiW
-mcP
-aFx
-wGn
-xDI
-mcP
-opH
-opH
-fgM
-opH
-opH
-kPg
-opH
-opH
+qHh
 bPu
-cxF
-hvz
-opH
-iUs
+dsj
+aFx
+pVr
+pVr
+dsj
+pQO
+mcP
+fBV
+dld
+dld
+ikj
+nRc
+nRc
+sgF
+qNk
+eVh
+cgB
+dCV
+hkY
+xpM
+nRc
+nRc
+eNd
+vUJ
 vUJ
 eqh
 eqh
@@ -230591,41 +230460,41 @@ xjG
 rIb
 wXd
 mMj
-xDI
-rQU
-aFx
-aFx
-xDI
-aFx
-aFx
 hcE
+rQU
+rrG
+cye
+dsj
+oaI
+ncd
 aFx
 aFx
-qKJ
-vKM
-kOW
+tpj
+aFx
+aFx
+aFx
 xDI
-fiW
-lLw
-fiW
+dsj
+dsj
+pQO
 mcP
-aFx
-pVr
-pVr
-kyl
-opH
-phC
-gMa
-pyY
-ldw
-rEA
-vMQ
-ljQ
-cxF
-cxF
-vqG
-opH
-iUs
+cKd
+dld
+dld
+ikj
+nRc
+nRc
+neA
+rhd
+ddz
+dbo
+ikD
+ngo
+uwg
+nRc
+nRc
+eNd
+vUJ
 vUJ
 eqh
 eqf
@@ -230794,41 +230663,41 @@ jZV
 czp
 eJY
 kQv
+jHx
 nur
-nur
-nur
+bPm
 ddN
 ddN
-ddN
+jkf
 bND
 ezK
 ePE
 lsD
-bPm
-ejM
+aFx
+aFx
 eks
-eks
-bal
-ucl
-ucl
+dsj
+dsj
+pQO
+mcP
 cUi
-fPE
-ncd
-aFL
-opH
-huC
-gMa
-uGA
-xyC
-oVv
-gnT
-cxF
-cxF
-cxF
-dBR
-opH
-iUs
-owI
+dld
+dld
+ikj
+nRc
+nRc
+neA
+kgk
+mgz
+fFY
+huv
+joZ
+uwg
+nRc
+nRc
+eNd
+vUJ
+vUJ
 eqh
 eqf
 oZA
@@ -230998,38 +230867,38 @@ cvN
 vFt
 jjQ
 cAW
-cAW
-cAW
-cAW
-vFt
-lfc
-vFt
-ekp
-wbe
-pNu
-kOW
-xDI
-fiW
-iIr
-fiW
+aQF
 dsj
-ucY
+hkR
+hcE
+aFx
+aFx
+ekp
+aFx
+aFx
+aFx
 pVr
-eUn
-suE
-opH
-uRw
-geA
-gMa
-qgM
-eVP
-cKd
-cxF
-cxF
-cxF
-ujR
-opH
-iUs
+dsj
+dsj
+pQO
+mcP
+ucY
+dld
+dld
+ikj
+nRc
+nRc
+wMt
+xyZ
+mgz
+dbo
+nYz
+hvX
+qxV
+nRc
+nRc
+eNd
+vUJ
 vUJ
 eqh
 eqf
@@ -231196,42 +231065,42 @@ bfy
 xjG
 sAh
 wXd
-uPn
-wGn
-kOW
-fiW
-fiW
-fiW
-fiW
+weP
 kOW
 kOW
-ktR
+hbi
+nrD
+uVx
+kOW
+kOW
+rGx
+fiW
 aQF
-mcP
-riP
-kOW
-xDI
 fiW
-iIr
-fiW
+dsj
+aFx
+pVr
+eUn
+dsj
+pQO
 mcP
-ucY
-wGn
-xDI
-mBf
-opH
-opH
-opH
-opH
-wVv
-opH
-opH
-hHX
-ugj
-hmk
-yex
-opH
-iUs
+quT
+dld
+dld
+ikj
+nRc
+nRc
+neA
+rhd
+mgz
+dbo
+qlC
+ngo
+uwg
+nRc
+nRc
+eNd
+vUJ
 vUJ
 eqh
 eqf
@@ -231400,40 +231269,40 @@ rIb
 qMM
 qrQ
 kOW
+rqm
+gRP
+nvB
+dsj
+nmo
 kOW
-pQO
-pQO
-pQO
-pQO
-kOW
-kOW
-dNI
-aQF
-mcP
+eTj
+fiW
+cfH
+fiW
 rrG
-kOW
-boU
-fiW
-iIr
-fiW
+lfc
+wGn
+aFx
+dsj
+pQO
 mcP
-ucY
-aFx
-aFx
-mBf
-opH
-jte
-pYx
-qGp
-qzx
-kSK
-opH
-opH
-opH
-opH
-opH
-opH
 iUs
+dld
+dld
+ikj
+nRc
+nRc
+sgF
+cuM
+jPL
+dbo
+jPL
+tOc
+xpM
+nRc
+nRc
+eNd
+vUJ
 vUJ
 eqh
 eqf
@@ -231601,41 +231470,41 @@ xjG
 uHd
 qMM
 uPn
+pQO
+vWA
+gRP
+dsj
+dsj
+mtA
+pQO
+aFx
 fiW
-pQO
-gRP
-mtA
-gRP
-mtA
-pQO
-pQO
-dNI
-aQF
-mcP
-rrG
+cfH
+fiW
+dsj
+lfc
+aFx
+aFx
+kyt
 kOW
-uOA
-tby
-uYT
-xDI
-lnV
-egd
-xDI
-tVS
+kOW
+iUs
+dld
+dld
 ikj
-xmO
-kLc
-kOD
-rrx
-pZI
-cye
-opH
-iUs
-iUs
-iUs
-iUs
-iUs
-iUs
+nRc
+nRc
+neA
+bQZ
+har
+rGF
+gBV
+wjC
+uwg
+nRc
+nRc
+eNd
+vUJ
 vUJ
 eqh
 eqf
@@ -231803,41 +231672,41 @@ qUD
 she
 jlQ
 ebN
-fqE
 pQO
-cUo
-iGZ
-mVl
-llg
+vWA
+gRP
+dsj
+dsj
+mtA
 pQO
-pQO
-tzn
-dNo
-sfi
-dnk
+aFx
+fiW
+iIr
+fiW
+dsj
+aFx
+tVS
+lfc
+aFx
 kOW
-kOW
-kOW
-klX
-nib
-kOW
-kOW
-kOW
-kOW
-fuZ
-opH
-rHD
-kMZ
-qTC
-uCH
-ggs
-opH
 iUs
-wVU
-gyc
-wVU
-gyc
-nAX
+iUs
+dld
+dld
+ikj
+nRc
+nRc
+neA
+wXW
+iqI
+pWh
+acG
+xRC
+uwg
+nRc
+nRc
+eNd
+vUJ
 vUJ
 eqh
 eqf
@@ -232006,40 +231875,40 @@ qMI
 pQa
 qmD
 kOW
+buS
+uYT
+doA
+owI
+vFR
 kOW
+tPN
+tVS
+iZz
+aFx
+tVS
+nRM
 kOW
+bVb
+bVb
 kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-kOW
-klX
-nib
-kOW
-kOW
-kOW
-kOW
-mXo
-opH
-opH
-opH
-opH
-opH
-opH
-opH
 iUs
-fXR
 vAX
-fXR
-vAX
-tyn
+dld
+dld
+mXo
+nRc
+nRc
+gWK
+lFw
+rcd
+rcd
+rcd
+lFw
+hbK
+nRc
+nRc
+kDY
+vUJ
 vUJ
 eqh
 eqh
@@ -232207,41 +232076,41 @@ edi
 qMd
 soH
 mTk
-pwm
-xGz
-xGz
-wzU
-wzU
-wzU
-wzU
-wzU
-wzU
-riw
-mHf
-gou
-tZm
-sxY
-uQx
-mRi
-nol
-jsM
-yfE
-qyo
-ntC
+kOW
+kOW
+kOW
+kOW
+kOW
+kOW
+kOW
+kOW
+kOW
+kOW
+kOW
+kOW
+kOW
+kOW
+kbv
+kbv
+kOW
+fXR
+wVU
+dld
+dld
 pDI
-iUs
-iUs
-iUs
-iUs
-iUs
-iUs
-iUs
-iUs
-nAX
-nAX
-tyn
-leU
-hvW
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
+cDx
+kyl
+vUJ
 vUJ
 vUJ
 sbB
@@ -232376,8 +232245,8 @@ veZ
 cwr
 cwr
 cwr
-jTG
-aED
+sOa
+sOa
 czb
 ook
 tcp
@@ -232413,36 +232282,36 @@ pwm
 xGz
 xGz
 wzU
-wzU
-wzU
-wzU
-wzU
-wzU
 riw
-elF
-qox
-qox
-qQZ
-rOh
-qQZ
+tZm
+wSl
+yiO
+riw
+dCC
+qWT
+hSz
+hSz
+vwJ
+aAy
+aAy
 rqj
-riw
-riw
-riw
-riw
-mVE
-pLt
+dBr
+dld
+dld
+dld
+vLi
+vLi
 qgJ
-vUJ
-nAX
+xrD
+pyY
 oei
-tyn
+qgJ
 tqr
-vUJ
-vUJ
-vUJ
-vUJ
-vUJ
+dBR
+qyo
+qgJ
+vLi
+vLi
 vUJ
 vUJ
 sbB
@@ -232578,10 +232447,10 @@ veZ
 veZ
 cwr
 cwr
-oaI
-bZJ
-cDx
-ajp
+sOa
+sOa
+czb
+sOa
 tcp
 rva
 mNx
@@ -232616,40 +232485,40 @@ pwm
 pwm
 oXE
 riw
-riw
-riw
-riw
-riw
-riw
 oQZ
-qox
-qox
-qQZ
-rOh
-qQZ
-qQZ
-gzr
-ccn
-cZV
+elF
+xzr
 riw
-koL
-fxv
-jHx
+hSz
+rYv
+rYv
+rYv
+vwJ
+nib
+nib
+rqj
+gzr
+dld
+dld
+dld
+dld
+dld
+dld
+ljw
+dIp
 vUJ
 vUJ
 vUJ
-vUJ
-nAX
-vUJ
-vUJ
-hvW
-pIy
-fXP
-blv
-vUJ
-xaf
-hvW
 leU
+hvW
+dld
+vUJ
+vUJ
+dld
+vUJ
+mcG
+dIp
+hvW
 leU
 leU
 leU
@@ -232780,10 +232649,10 @@ veZ
 veZ
 cwr
 cwr
-nvB
 sOa
-eMx
-ajp
+sOa
+czb
+sOa
 tcp
 uCI
 sOt
@@ -232818,25 +232687,25 @@ uXK
 uXK
 oXE
 riw
-lkJ
-vkU
+koL
+qox
 opN
-hMs
 riw
 cNP
+cox
+jAU
 rYv
-qQZ
-rOh
-qQZ
+vwJ
 aAy
-qQZ
-qQZ
-rOh
-rOh
-kwb
-mVE
-pLt
-gSa
+aAy
+rqj
+dBr
+dld
+dld
+dld
+dld
+dld
+dld
 vUJ
 vUJ
 vUJ
@@ -232844,14 +232713,14 @@ vUJ
 vUJ
 vUJ
 vUJ
-eqh
-eqh
-gCF
-gCF
-gCF
-gCF
-eqh
-eqh
+dld
+dld
+dld
+dld
+vUJ
+xaf
+hvW
+leU
 uvO
 leU
 hvW
@@ -232983,9 +232852,9 @@ veZ
 cwr
 cwr
 nYl
-omK
-kpf
-ajp
+dzK
+czb
+sOa
 tcp
 fPz
 gPf
@@ -233020,24 +232889,24 @@ dFx
 bAk
 oXE
 riw
-riw
-riw
+klX
+efu
 nlp
-ugn
 riw
-int
-rYv
-qox
-orJ
-orJ
-qox
-qQZ
+kwb
+pZI
+xlL
+xqJ
+riw
+wVv
+kbv
+riw
 vMI
-rOh
-fgb
-riw
-dCC
-yjK
+vIw
+dld
+dld
+hvW
+dld
 vUJ
 vUJ
 leU
@@ -233047,12 +232916,12 @@ hvW
 iXU
 vUJ
 eqh
-eqf
-eqf
-eqf
-eqf
-eqf
-eqf
+eqh
+gCF
+gCF
+gCF
+gCF
+eqh
 eqh
 mcG
 hvW
@@ -233185,9 +233054,9 @@ veZ
 cwr
 cwr
 lPU
-fCX
-fCn
-ajp
+dzK
+czb
+weh
 tcp
 rzR
 lmJ
@@ -233222,24 +233091,24 @@ nBw
 fLG
 oXE
 riw
-lkJ
-vkU
-sUM
-eSm
+fqE
+mxN
+ktR
 riw
+int
 vsl
-rYv
-hAv
-mwt
-mwt
-tuI
-qQZ
+bwG
+dmD
+riw
+tTa
+tTa
+riw
 vIw
-qQZ
-kxQ
-oTp
-eIV
-oqc
+wVU
+dld
+dld
+leU
+nMm
 vUJ
 dIp
 leU
@@ -233248,14 +233117,14 @@ eqh
 leU
 hvW
 vUJ
-ddH
+eqh
 eqf
 eqf
 eqf
 eqf
 eqf
 eqf
-ouI
+eqh
 hvW
 jZE
 leU
@@ -233386,10 +233255,10 @@ wLD
 veZ
 cwr
 cwr
-wQW
 omK
-mKY
-ajp
+omK
+czb
+weh
 cwr
 xdv
 xdv
@@ -233422,26 +233291,26 @@ luu
 pwm
 pOS
 qWG
-oXE
 riw
 riw
 riw
-sSM
-fkm
+jHL
+riw
+riw
 riw
 sGE
-rYv
-hAv
-mwt
-mwt
-tuI
-rOh
-qDa
-qQZ
-dFc
-oTp
-eIV
-ivC
+wbm
+riw
+riw
+gou
+jXd
+riw
+riw
+vAX
+dld
+dld
+mcG
+uvO
 vUJ
 leU
 eqh
@@ -233588,9 +233457,9 @@ veZ
 veZ
 cwr
 cwr
-tZL
-rxq
-iAo
+omK
+omK
+czb
 weh
 cwr
 mcJ
@@ -233623,27 +233492,27 @@ mJT
 pwm
 pwm
 vvK
-bAk
-oXE
+aED
 riw
-qza
+riw
+oJb
 vdu
 rMH
 juo
-riw
-jAU
-rYv
-hAv
-mwt
-mwt
-tuI
+jVP
+jVP
+xBq
+epB
+diT
 qQZ
-qDa
 rOh
 rpa
-oTp
-eIV
-ivC
+riw
+fXR
+dld
+dld
+leU
+dIp
 vUJ
 hvW
 eqh
@@ -233790,9 +233659,9 @@ veZ
 veZ
 cwr
 cwr
-nxH
 dzK
-cFP
+dzK
+czb
 weh
 cwr
 trx
@@ -233822,30 +233691,30 @@ tnR
 vaT
 vaT
 qZu
-bAk
-dkg
+aED
+wfn
 bZF
-bAk
+aED
 riw
-riw
-grQ
+mBf
+wFB
+qQZ
 sUM
-sUM
-mPy
-riw
-usX
+orJ
+rOh
+rOh
 ahn
-uaN
+riw
+riw
 mqQ
-mqQ
-vWA
+rOh
 rjY
-fyb
-rjY
-rjY
-fEH
-nrD
-ivC
+vwJ
+vMI
+dld
+dld
+ljw
+nMm
 vUJ
 leU
 eqh
@@ -233992,8 +233861,8 @@ veZ
 veZ
 cwr
 qau
-sxR
-bmx
+dzK
+dzK
 gCx
 weh
 cwr
@@ -234001,7 +233870,7 @@ leh
 hKm
 xjZ
 bkk
-vvO
+bkk
 tCJ
 jQr
 hBf
@@ -234024,30 +233893,30 @@ vaT
 ycD
 hJp
 ylB
-bAk
-esz
+riw
+riw
 lDz
-bAk
-wpu
-sUM
+riw
+riw
+uUU
 wFB
-hVD
-waf
-rcV
+hAv
+mwt
+mwt
 cVH
-rjY
+qQZ
 jzE
 cFR
+rpa
 qQZ
-qQZ
-qWp
-qQZ
+rOh
+rjY
 vwJ
-qox
-qox
-oTp
-eIV
-ivC
+fXR
+dld
+dld
+ljw
+dIp
 vUJ
 mcG
 eqh
@@ -234226,30 +234095,30 @@ vaT
 aca
 nfq
 jMp
-nRM
-buS
-pwm
-pwm
 riw
-riw
-riw
-riw
-riw
-riw
-riw
-sPG
+grQ
+lnV
+vGk
+fCX
+qgM
+iWQ
+hAv
+mwt
+ggs
+tuI
+rOh
 qWp
+cFR
+waT
 qQZ
 qQZ
-qQZ
-qWp
-qQZ
-hpc
-qox
-yiO
-oTp
-eIV
-bwG
+rjY
+vwJ
+vIw
+dld
+dld
+mcG
+leU
 vUJ
 leU
 tEB
@@ -234258,14 +234127,14 @@ leU
 nAX
 uvO
 vUJ
-eqh
+ddH
 eqf
 eqf
 eqf
 eqf
 eqf
 eqf
-eqh
+ouI
 leU
 gjW
 leU
@@ -234426,32 +234295,32 @@ lIg
 dVl
 vaT
 qkp
-beK
-beK
-beK
+aJN
+uqM
+vsx
 oKC
-beK
-beK
+fPE
+suE
 riw
-riw
-riw
-riw
-riw
-riw
-riw
-sPG
-qWp
-ekD
-jnw
-miP
-qWp
-iWQ
-iRf
-qox
-xzr
-gUk
-wfn
-vFR
+hVD
+ljQ
+hAv
+mwt
+mwt
+tuI
+rOh
+dFc
+cFR
+rpa
+qQZ
+qQZ
+rjY
+vwJ
+vMI
+dld
+dld
+pIy
+hvW
 vUJ
 ebB
 ebB
@@ -234461,12 +234330,12 @@ lDX
 wLt
 vUJ
 eqh
-eqh
-fYi
-fYi
-fYi
-fYi
-eqh
+eqf
+eqf
+eqf
+eqf
+eqf
+eqf
 eqh
 leU
 hhn
@@ -234628,32 +234497,32 @@ vaT
 vaT
 vaT
 qkp
-beK
-eWs
-mCq
-nJR
-vgv
-tZa
-mUh
-mCq
-bME
-eoh
-qIF
-beK
+tby
+pwm
+riw
+qza
+fAA
+dNo
+riw
+sPG
+ivC
+uTQ
+sMN
+sMN
+rOh
+rOh
+oSN
 riw
 riw
-olA
-riw
-riw
-riw
-wSl
-riw
-riw
-riw
-gUk
-gUk
-wfn
-hvW
+mqQ
+rOh
+rjY
+vwJ
+wVU
+dld
+dld
+nMm
+mcG
 vhs
 rIN
 bdi
@@ -234662,14 +234531,14 @@ fUW
 sCV
 hlG
 vUJ
-vgK
-leU
-nAX
-vgK
-sbB
-hvW
-hvW
-hvW
+eqh
+eqh
+fYi
+fYi
+fYi
+fYi
+eqh
+eqh
 hvW
 nMm
 hhn
@@ -234830,32 +234699,32 @@ sfG
 imO
 lNu
 tPK
-beK
-hov
-uww
-oJb
-naZ
-dMu
-xhZ
-nbK
-rKo
-bRX
-flu
-beK
+tby
+pwm
 riw
 riw
+riw
+aFL
+riw
+riw
+npm
+sAo
+aAw
+mKY
+pBQ
+jVP
 oBo
-nmo
+qQZ
 diT
+rOh
+qQZ
+rpa
 riw
-oBo
-uqM
-fBV
-riw
-gUk
-kVO
-fAA
-vUJ
+fXR
+dld
+dld
+dIp
+mcG
 vhs
 sXL
 frU
@@ -235032,32 +234901,32 @@ kRE
 gxW
 mfV
 lem
-beK
-uHt
-uww
-sAo
-mxC
-wuq
-mBO
-afV
-mCq
-iDu
-qIF
-beK
+gXz
+pwm
+riw
+lkJ
+vkU
+rrx
 riw
 riw
-guj
+riw
+olA
+riw
+riw
+riw
+riw
+fxv
+riw
+riw
 qQZ
-hHU
-riw
 guj
-jac
-qQZ
-gzV
-gUk
-oMM
-vIL
-vUJ
+riw
+riw
+vMI
+dld
+dld
+nAX
+leU
 vhs
 ueI
 jpj
@@ -235234,34 +235103,34 @@ sfG
 imO
 bJC
 pEI
-beK
-ifo
-qBQ
-hkR
-mxC
-gcr
-gzw
-vcq
-sbj
-mCq
-kFi
-beK
+gXz
+pwm
 riw
-gzV
+riw
+riw
+cFP
+riw
+bfZ
+sbj
+wFB
+jac
+riw
+bfZ
+kLc
 kZn
 xwO
-quT
 riw
 tTa
-xwO
-quT
+tTa
 riw
-gUk
-gUk
+wVU
+vIw
+dld
+dld
 owa
-gUk
-gUk
-wak
+vUJ
+vhs
+tzJ
 lOl
 hbO
 dft
@@ -235435,34 +235304,34 @@ nnT
 uSX
 nnT
 vaT
-mxN
-weP
-bho
-xhZ
-tZT
-mxC
-gcr
-tkm
-vcq
-mCq
-pDr
-uUh
-beK
+qkp
+gXz
+pwm
 riw
+lkJ
+vkU
+ekD
 riw
-mjw
-gzV
-vtp
+boU
+toM
+iAo
+ylz
 riw
-mjw
-gzV
-vtp
+boU
+bZJ
+rOh
+jnw
 riw
-uVK
-uVK
+kbv
+kbv
+riw
+vMI
+vAX
+dld
+dld
 kVt
-gUk
-gUk
+vUJ
+vhs
 ooV
 jWc
 uOU
@@ -235638,32 +235507,32 @@ lLF
 xJm
 vaT
 qkp
-beK
-ylz
-sZu
-efu
-mxC
-hCa
-tNb
-tNb
-daZ
-jNI
-uUh
-beK
+oNA
+pwm
 riw
 riw
 riw
 riw
 riw
+wWN
+eMK
+qQZ
+jnw
 riw
+wWN
+qQZ
+qQZ
+qQZ
 riw
-riw
-riw
-riw
-kbl
-kFQ
-sMN
-jZI
+aAy
+aAy
+rqj
+dBr
+dld
+dld
+dld
+dld
+vUJ
 jZI
 pLd
 lBL
@@ -235840,32 +235709,32 @@ wan
 wxz
 vaT
 pkv
-beK
-pPU
-puT
-nTE
-mxC
-mCq
-nvW
-hpm
-hpm
-lHE
-uUh
-beK
-uVK
-uVK
-uVK
-uVx
-dXG
+gXz
+pwm
+xGz
+xGz
+xGz
+xGz
+riw
+mjw
+gzV
+gzV
+vtp
+riw
+mjw
+gzV
+gzV
+vtp
+riw
 qQO
-uVK
-uVK
-uVK
-uVK
-hpq
-spV
-kJN
-jZI
+nib
+rqj
+pNu
+dld
+dld
+dld
+dld
+vUJ
 jZI
 tRt
 khb
@@ -236042,31 +235911,31 @@ dXg
 kLp
 vaT
 nvI
-beK
-meA
-rOL
-qfx
-vAx
-eyI
-ctG
-ctC
-wIe
-mCq
-sPh
-beK
-uVx
-xrs
-fsi
-fsi
-xwB
-fsi
-fsi
-vXR
-uVK
-uVK
-xEe
-fsi
-kJN
+gXz
+pwm
+xGz
+xGz
+xGz
+xGz
+riw
+riw
+riw
+riw
+riw
+riw
+riw
+riw
+riw
+riw
+riw
+aAy
+aAy
+rqj
+dBr
+kVO
+dld
+yfE
+dld
 jZI
 jZI
 kTZ
@@ -236244,32 +236113,32 @@ wIg
 uob
 gUg
 brN
-beK
-oPl
-uUJ
-deL
-xDf
-aUn
-aUn
-qHo
-jTL
-mCq
-hmj
-beK
-mce
-jkf
-fPi
-fsi
-lVU
-fsi
-fsi
-qvn
-uVK
-uVK
-xEe
-fsi
-ucs
-gUk
+gXz
+pwm
+xGz
+xGz
+xGz
+xGz
+xGz
+xGz
+xGz
+opH
+jyK
+ckV
+opH
+jCL
+ylF
+opH
+opH
+kbv
+kbv
+iUs
+iUs
+iUs
+iUs
+iUs
+iUs
+iUs
 gUk
 gMH
 khb
@@ -236446,33 +236315,33 @@ fsM
 aom
 vaT
 soq
-beK
-azM
-uUJ
-oSN
-xDf
-aUn
-aUn
-sDT
-qPy
-mCq
-uPd
-beK
-qQO
-epB
-cfH
-hQO
-uVK
-rig
+gXz
+pwm
+xGz
+xGz
+xGz
+xGz
+xGz
+xGz
+xGz
+opH
+plZ
+gdn
+opH
+ouv
+mmt
+opH
+opH
 sdY
-vXR
+sdY
 uVK
 uVK
-vmm
-fsi
-aJN
-dBr
-dBr
+uVK
+uVK
+uVK
+uVK
+gUk
+gUk
 gUU
 iyP
 gCt
@@ -236648,31 +236517,31 @@ bqj
 vaT
 vaT
 soq
-beK
-cuT
-dYM
-dMu
-tFp
-cKx
-usk
-jeg
-vcq
-mCq
-vfg
-beK
+oNA
+pwm
+xGz
+xGz
+opH
+opH
+opH
+opH
+opH
+opH
+lje
+oRV
+opH
+geE
+kab
+opH
+opH
+spV
+spV
 uVK
-uVK
-xqJ
-uVK
-uVK
-uVK
-uVK
-uVK
-uVK
-uVK
+qrB
+qKJ
 lze
 fsi
-ycP
+fsi
 gUk
 itH
 jje
@@ -236850,33 +236719,33 @@ pwm
 pwm
 gTr
 fID
-beK
-tgh
-mCq
-mCq
-gxd
-mCq
-mCq
-mCq
-mCq
-mCq
-gHI
-beK
-tzJ
-iZz
+tby
+pwm
+xGz
+xGz
+opH
+hHX
+xMy
+cNE
+yex
+opH
+opH
 fpd
-uUU
-rby
+opH
+opH
+fpd
+opH
+opH
 mZy
-pes
-qrB
-uVK
-uVK
-fsi
-fsi
+dNI
+rwF
+spV
+spV
+spV
+spV
 kJN
-jZI
-raN
+gUk
+ewj
 mmm
 xjb
 gCt
@@ -237051,34 +236920,34 @@ xGz
 xGz
 pwm
 soq
-beK
-beK
-sJX
-vcq
-vGk
-qUT
-mCq
-mCq
-mCq
-mCq
-mCq
-qBq
-hSz
+pwm
+mce
+pwm
+xGz
+xGz
+opH
+opH
+sJb
+gMa
+gMa
+opH
+phC
+gMa
 eOD
-qbh
-npm
+gMa
+gMa
 wtw
-qbh
+opH
 mqs
-qbh
-qWT
+bkH
+dEk
 vkI
-qWT
+dEk
 qbh
 rnS
 xok
-jZI
-raN
+gUk
+ewj
 mmm
 khb
 mUK
@@ -237253,29 +237122,29 @@ pwm
 pwm
 pwm
 uIC
-beK
-hSC
-vcq
-jHL
-bMK
-waT
+pwm
+mce
+pwm
+xGz
+xGz
+opH
 pzk
-lti
-rCq
-dMu
-dMu
-xnv
-weP
-eTj
+gMa
+vqG
+gMa
+vKM
+gMa
+gMa
+geA
 xgI
 vfv
 fqG
 lhz
-lhz
+ajp
 ezs
-lhz
+wgN
 kAU
-mLR
+wgN
 oeV
 msx
 wSh
@@ -237457,30 +237326,30 @@ dkm
 vMU
 xTb
 gXz
-nSn
-nSn
-oYg
-nSn
-hNx
+pwm
+xGz
+xGz
+opH
+opH
 sJb
-beK
-mCq
-rhf
-mCq
-beK
+gMa
+gMa
+opH
+huC
+gMa
 pIr
 acB
 eCm
 uBy
-wWN
+opH
 nuM
 pes
 gkZ
 uVK
 uVK
-tmF
-sFL
-fBw
+uVK
+spV
+huw
 wgN
 gWi
 rIc
@@ -237639,7 +237508,7 @@ aDO
 ukS
 ukS
 aDO
-lbX
+nju
 mDT
 nju
 yjy
@@ -237657,31 +237526,31 @@ seQ
 bVD
 wWa
 bXy
-xTb
-cox
-cox
-cox
-cox
-cox
-cox
-mAy
-beK
-lZC
-beK
-wuN
-beK
+hMs
+gXz
+pwm
+xGz
+xGz
+opH
+hvz
+ujR
+gSa
+wbe
+opH
+uRw
+pPU
+kEe
+vmm
+mVl
+ugn
+opH
+qBQ
+spV
+nTE
 uVK
-uVK
-uVK
-uVK
-uVK
-uVK
-uVK
-uVK
-uVK
-uVK
-uVK
-rqm
+xrs
+tZT
+spV
 fBw
 gUk
 ewj
@@ -237859,35 +237728,35 @@ pwm
 pwm
 soz
 pwm
-cVx
-cVx
-cVx
-cVx
-cVx
+hMs
+tby
+pwm
+xGz
+xGz
+opH
+opH
+opH
+opH
+opH
+opH
+opH
+opH
+opH
+opH
+xyC
+kpf
+opH
+rcV
+llg
+tmF
 uVK
-jXd
-jXd
-eMK
-fsi
-fsi
-fsi
-wjD
-wjD
-uVK
-veZ
-veZ
-veZ
-veZ
-veZ
-veZ
-veZ
-veZ
-uVK
-jwd
-fBw
+cxF
+qUT
+spV
+jsM
 gUk
 kHd
-khb
+nol
 sdN
 rEL
 rEL
@@ -238061,35 +237930,35 @@ veZ
 pwm
 rYq
 pwm
-veZ
-wLD
-veZ
-veZ
-veZ
-uVK
+hMs
+meA
+xwU
+xwU
+xwU
+xwU
+xwU
+xwU
 etH
-etH
-etH
-fsi
-fsi
-fsi
+bvz
+bvz
+bvz
+qBq
 wjD
-wjD
+opH
+opH
+opH
+opH
 uVK
-veZ
-veZ
-veZ
-veZ
-veZ
-wLD
-veZ
-veZ
 uVK
-fsi
-fBw
+uVK
+uVK
+uVK
+uVK
+uVK
+uVK
 gUk
 kHd
-khb
+nol
 pdx
 utp
 oly
@@ -238263,30 +238132,30 @@ veZ
 pwm
 rsS
 pwm
-veZ
-veZ
-veZ
-veZ
-veZ
-uVK
+riP
+oqc
 rQO
+tJf
+rQO
+rQO
+rQO
+xke
 ctQ
-ctQ
-fsi
-fsi
-fsi
-hbi
+xKz
+ycP
+ycP
+pwm
 mQc
-uVK
-veZ
-veZ
-veZ
-wLD
-wLD
-veZ
-veZ
-veZ
-uVK
+hQO
+bvz
+bvz
+bvz
+qBq
+bvz
+bvz
+bvz
+bvz
+bvz
 bvz
 sRR
 fWi
@@ -238470,19 +238339,19 @@ pwm
 pwm
 pwm
 pwm
-uVK
-xke
-xke
-xke
-fsi
-fsi
-fsi
-fsi
-xKz
-uVK
-vzY
-vzY
-vzY
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
 vzY
 vzY
 vzY
@@ -238671,22 +238540,22 @@ aHk
 aHk
 hJp
 aHk
-tJf
-rGx
+mdn
+hJp
+mdn
 uVi
-uVi
-uVi
-dmD
-oNA
-wbm
+hJp
+mdn
+mdn
+mdn
 vMo
 mdn
-rGx
-eit
+mdn
+vMo
+mdn
+vMo
 bLR
-eit
-bLR
-bLR
+usX
 bLR
 bLR
 bLR
@@ -238874,19 +238743,19 @@ pwm
 pwm
 pwm
 pwm
-uVK
-uVK
-uVK
-uVK
-uVK
-aAw
-uVK
-uVK
-uVK
-uVK
-vzY
-vzY
-vzY
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
+pwm
 vzY
 bci
 bci
@@ -239494,7 +239363,7 @@ veZ
 veZ
 veZ
 vzY
-bci
+qDa
 vzY
 vzY
 vzY
@@ -239702,7 +239571,7 @@ bci
 bci
 lYa
 bci
-bkH
+eip
 npq
 gUk
 rcO
@@ -239907,7 +239776,7 @@ vzY
 eip
 npq
 gUk
-rcO
+jTG
 pNT
 srq
 xAC


### PR DESCRIPTION
Massively reworks the church map to be better trade mark
Moves the church/guild """recycler""" (aka the thing that eats every item ever and gives nothing but refined scrap) into the guilds atmos storage
Removes 1 doble stacked trash cart in scavs
turns the old recycler room that into a table/shelf/trashcart storge room
Fixes the missing landing zone in the river forest
Added more sofa's

Testing: Tested every wire line that I remember to, ever pipe I remember to and the new stairs to make sure it all works
Performance: less wall oblistics but not sure if its good or bad in net