### PR TITLE
Emotes now use gender, not sex

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -552,7 +552,6 @@
 			m_type = 1
 
 		if("shake")
-			message = "[identifying_gender]"
 			message = "shakes [identifying_gender == "male" ? "his" : identifying_gender == "female" ? "her" : "their"] head."
 			m_type = 1
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -195,7 +195,7 @@
 
 		if ("choke")
 			if(miming)
-				message = "clutches [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] throat desperately!"
+				message = "clutches [identifying_gender == "male" ? "his" : identifying_gender == "female" ? "her" : "their"] throat desperately!"
 				m_type = 1
 			else
 				if (!muzzled)
@@ -223,14 +223,14 @@
 
 		if ("flap")
 			if (!src.restrained())
-				message = "flaps [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] wings."
+				message = "flaps [identifying_gender == "male" ? "his" : identifying_gender == "female" ? "her" : "their"] wings."
 				m_type = 2
 				if(miming)
 					m_type = 1
 
 		if ("aflap")
 			if (!src.restrained())
-				message = "flaps [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] wings ANGRILY!"
+				message = "flaps [identifying_gender == "male" ? "his" : identifying_gender == "female" ? "her" : "their"] wings ANGRILY!"
 				m_type = 2
 				if(miming)
 					m_type = 1
@@ -276,7 +276,7 @@
 
 		if ("cough")
 			if(miming)
-				message = "takes [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] curled up fist to their mouth, mimicking a cough!"
+				message = "takes [identifying_gender == "male" ? "his" : identifying_gender == "female" ? "her" : "their"] curled up fist to their mouth, mimicking a cough!"
 				m_type = 1
 			else
 				if (!muzzled)
@@ -425,7 +425,7 @@
 					message = "cries."
 					m_type = 2
 				else
-					message = "makes a weak, whimpering noise. [get_visible_gender() == MALE ? "He" : get_visible_gender() == FEMALE ? "She" : "They"] [get_visible_gender() == NEUTER ? "frown" : "frowns"]."
+					message = "makes a weak, whimpering noise. [identifying_gender == "male" ? "He" : identifying_gender == "female" ? "She" : "They"] [get_gender() == NEUTER ? "frown" : "frowns"]."
 					m_type = 2
 
 		if ("sigh")
@@ -552,7 +552,8 @@
 			m_type = 1
 
 		if("shake")
-			message = "shakes [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] head."
+			message = "[identifying_gender]"
+			message = "shakes [identifying_gender == "male" ? "his" : identifying_gender == "female" ? "her" : "their"] head."
 			m_type = 1
 
 		if ("shrug")
@@ -676,7 +677,7 @@
 				if (M)
 					message = "hugs [M]."
 				else
-					message = "hugs [get_visible_gender() == MALE ? "himself" : get_visible_gender() == FEMALE ? "herself" : "themselves"]."
+					message = "hugs [identifying_gender == "male" ? "himself" : identifying_gender == "female" ? "herself" : "themselves"]."
 
 		if ("handshake")
 			m_type = 1
@@ -694,7 +695,7 @@
 					if (M.canmove && !M.r_hand && !M.restrained())
 						message = "shakes hands with [M]."
 					else
-						message = "holds out [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] hand to [M] to shake."
+						message = "holds out [identifying_gender == "male" ? "his" : identifying_gender == "female" ? "her" : "their"] hand to [M] to shake."
 
 		if("dap")
 			m_type = 1
@@ -708,7 +709,7 @@
 				if (M)
 					message = "gives daps to [M]."
 				else
-					message = "sadly can't find anybody to give daps to, and daps [get_visible_gender() == MALE ? "himself" : get_visible_gender() == FEMALE ? "herself" : "themselves"]. Shameful."
+					message = "sadly can't find anybody to give daps to, and daps [identifying_gender == "male" ? "himselves" : identifying_gender == "female" ? "her" : "themselves"]. Shameful."
 
 		if ("scream")
 			if (miming)
@@ -976,4 +977,4 @@
 	if(suppress_communication)
 		return FALSE
 
-	pose =  sanitize(input(usr, "This is [src]. [get_visible_gender() == MALE ? "He" : get_visible_gender() == FEMALE ? "She" : "They"] [get_visible_gender() == NEUTER ? "are" : "is"]...", "Pose", null)  as text)
+	pose =  sanitize(input(usr, "This is [src]. [identifying_gender == "male" ? "He" : identifying_gender == "female" ? "She" : "They"] [get_gender() == NEUTER ? "are" : "is"]...", "Pose", null)  as text)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
Alters all * emotes (i.e. *shake, *dap) to use pronouns based on the character's gender, rather than biological sex. 
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fix: emotes are consistent with a character's pronouns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
