### PR TITLE
Nv coverted guild goggles

### DIFF
--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -448,6 +448,22 @@
 
 
 //Wearables =========================
+/datum/craft_recipe/guild/nv_guild
+	name = "Converted NV Goggles"
+	result = /obj/item/clothing/glasses/powered/night/guild/crafted
+	icon_state = "clothing"
+	steps = list(
+		list(/obj/item/clothing/glasses/powered/meson, 1, "time" = 30),
+		list(CRAFT_MATERIAL, 2, MATERIAL_RGLASS),
+		list(QUALITY_WELDING, 40, "time"= 60),
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTEEL, "time" = 30),
+		list(QUALITY_BOLT_TURNING, 40, "time" = 40),
+		list(CRAFT_MATERIAL, 1, MATERIAL_URANIUM, "time" = 20),
+		list(QUALITY_WIRE_CUTTING, 40, 30),
+		list(/obj/item/stack/cable_coil, 2, "time" = 20),
+		list(QUALITY_SCREW_DRIVING, 40, "time" = 60),
+	)
+
 /datum/craft_recipe/guild/technosuit
 	name = "'Mark V' environmental protection suit"
 	result = /obj/item/clothing/suit/armor/vest/technomancersuit

--- a/code/modules/clothing/glasses/powered.dm
+++ b/code/modules/clothing/glasses/powered.dm
@@ -10,10 +10,11 @@
 	var/tick_cost = 1
 	cell = null
 	suitable_cell = /obj/item/cell/small
+	var/spawn_with_cell = TRUE
 
 /obj/item/clothing/glasses/powered/Initialize()
 	. = ..()
-	if(!cell && suitable_cell)
+	if(!cell && suitable_cell && spawn_with_cell)
 		cell = new /obj/item/cell/small(src)
 
 /obj/item/clothing/glasses/powered/Process()
@@ -93,4 +94,16 @@
 	. = ..()
 	screenOverlay = global_hud.nvg
 
+/obj/item/clothing/glasses/powered/night/guild
+	name = "converted vision goggles"
+	desc = "Converted from boring mesons these refined Guild designs sports the benefits form the mesons power saving making these last 10% longer then other NV goggles on the market!"
+	darkness_view = 7
+	see_invisible = SEE_INVISIBLE_NOLIGHTING
+	origin_tech = list(TECH_MAGNET = 3)
+	price_tag = 350
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_GLASS = 1, MATERIAL_PLASTIC = 2, MATERIAL_URANIUM = 1)
+	tick_cost = 0.4 //10% more so you have a reason to go to the guild and get these
 
+
+/obj/item/clothing/glasses/powered/night/guild/crafted
+	spawn_with_cell = FALSE

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/fs_weapon_factory.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/fs_weapon_factory.dm
@@ -86,5 +86,6 @@
 		/obj/item/gun_upgrade/muzzle/silencer = offer_data("silencer", 150, 6),
 		/obj/item/gun_upgrade/barrel/bore = offer_data("bored barrel", 750, 2),
 		/obj/item/gun_upgrade/barrel/forged = offer_data("forged barrel", 750, 4),
-		/obj/item/gun_upgrade/magwell/auto_eject = offer_data("H&S \"Dropper\" Magwell Braker", 450, 5)
+		/obj/item/gun_upgrade/magwell/auto_eject = offer_data("H&S \"Dropper\" Magwell Braker", 450, 5),
+		/obj/item/clothing/glasses/powered/night/guild  = offer_data("Converted NV Goggles", 1000, 1)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon2.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon2.dm
@@ -61,5 +61,6 @@
 	offer_types = list(
 		/obj/item/stack/telecrystal = offer_data("telecrystal x50", 100000, 1),
 		/obj/item/device/radio/uplink = offer_data("Radio Uplink", 10000, 1),
-		/obj/item/card/emag = offer_data("Cryptographic Sequencer", 5000, 1)
+		/obj/item/card/emag = offer_data("Cryptographic Sequencer", 5000, 1),
+		/obj/item/clothing/glasses/powered/night/guild  = offer_data("Converted NV Goggles", 1200, 3)
 	)


### PR DESCRIPTION
Guild can now covert mesons into NV goggles, these NV goggles to incentivize them being made and used have 10% better charge whatever

Also added 2 new cargo deals to want said goggles so guild has a product to trade thats also worth any amount of credits that doesnt cost an arm and a leg

Testing: Made sure it complied, spawned a normal measons checked its cell that it spawned with
spawned crafted, made sure no cell, made sure adding a cell worked

Performance, technically less