### PR TITLE
Ripley buff

### DIFF
--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -761,6 +761,37 @@
 		list(CRAFT_MATERIAL, 2, MATERIAL_SILVER)
 	)
 
+/datum/craft_recipe/guild/safety_clamp
+	name = "Hydraulic clamp overclock: KILL CLAMP"
+	result = /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
+	steps = list(
+		list(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp, 1, "time" = 60),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 40),
+		list(/obj/item/tool_upgrade/productivity/motor, 1, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(/obj/item/tool_upgrade/augment/hydraulic, 1, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(CRAFT_MATERIAL, 6, MATERIAL_PLASTEEL),
+		list(QUALITY_WELDING, 30, "time" = 40),
+		list(/obj/item/tool_upgrade/augment/spikes, 1, "time" = 60)
+	)
+
+/datum/craft_recipe/guild/tesla_energy_relay
+	name = "Mech energy relay"
+	result = /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
+	steps = list(
+		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL, "time" = 30),
+		list(QUALITY_WELDING, 45, "time" = 40),
+		list(QUALITY_BOLT_TURNING, 40, 70),
+		list(/obj/item/computer_hardware/tesla_link, 2, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 40, 70),
+		list(/obj/item/stack/cable_coil, 15, "time" = 90),
+		list(QUALITY_WIRE_CUTTING, 25, "time" = 90),
+		list(/obj/item/stock_parts/capacitor/guild, 1, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD)
+	)
+
 /datum/craft_recipe/guild/guild_bin
 	name = "Hand Cast Matter Bin"
 	result = /obj/item/stock_parts/matter_bin/handmade

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1020,28 +1020,41 @@
 		if(!cargo_holder) return
 		if(isobj(target))
 			var/obj/O = target
-			if(!O.anchored)
-				if(cargo_holder.cargo.len < cargo_holder.cargo_capacity)
-					chassis.occupant_message("You lift [target] and start to load it into cargo compartment.")
-					chassis.visible_message("[chassis] lifts [target] and starts to load it into cargo compartment.")
-					set_ready_state(0)
-					chassis.use_power(energy_drain)
-					O.anchored = 1
-					var/T = chassis.loc
-					if(do_after_cooldown(target))
-						if(T == chassis.loc && src == chassis.selected)
-							cargo_holder.cargo += O
-							O.loc = chassis
-							O.anchored = 0
-							chassis.occupant_message(SPAN_NOTICE("[target] succesfully loaded."))
-							chassis.log_message("Loaded [O]. Cargo compartment capacity: [cargo_holder.cargo_capacity - cargo_holder.cargo.len]")
-						else
-							chassis.occupant_message(SPAN_WARNING("You must hold still while handling objects."))
-							O.anchored = initial(O.anchored)
+			if(O.buckled_mob)
+				return
+			if(istype(target, /obj/structure/scrap))
+				occupant_message(SPAN_NOTICE("\The [chassis] begins compressing \the [O] with \the [src]."))
+				if(do_after_cooldown(O))
+					if(istype(O, /obj/structure/scrap))
+						var/obj/structure/scrap/S = O
+						S.make_cube()
+						occupant_message(SPAN_NOTICE("\The [chassis] compresses \the [O] into a cube with \the [src]."))
+				return
+			if(O.anchored && !istype(O, /obj/structure/salvageable))
+				occupant_message(SPAN_WARNING("[target] is firmly secured."))
+				return
+			if(cargo_holder.cargo.len >= cargo_holder.cargo_capacity)
+				occupant_message(SPAN_WARNING("Not enough room in cargo compartment."))
+				return
+
+
+			occupant_message("You lift [target] and start to load it into cargo compartment.")
+			playsound(src,'sound/mecha/hydraulic.ogg',100,1)
+			chassis.visible_message("[chassis] lifts [target] and starts to load it into cargo compartment.")
+			set_ready_state(0)
+			chassis.use_power(energy_drain)
+			O.anchored = 1
+			var/T = chassis.loc
+			if(do_after_cooldown(target))
+				if(T == chassis.loc && src == chassis.selected)
+					cargo_holder.cargo += O
+					O.loc = chassis
+					O.anchored = 0
+					occupant_message(SPAN_NOTICE("[target] succesfully loaded."))
+					log_message("Loaded [O]. Cargo compartment capacity: [cargo_holder.cargo_capacity - cargo_holder.cargo.len]")
 				else
-					chassis.occupant_message(SPAN_WARNING("Not enough room in cargo compartment."))
-			else
-				chassis.occupant_message(SPAN_WARNING("[target] is firmly secured."))
+					occupant_message(SPAN_WARNING("You must hold still while handling objects."))
+					O.anchored = initial(O.anchored)
 
 		else if(isliving(target))
 			var/mob/living/M = target

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -4,11 +4,12 @@
 	icon_state = "ripley"
 	initial_icon = "ripley"
 	step_in = 2
+	step_energy_drain = 6
 	max_temperature = 20000
 	price_tag = 5000
 	health = 500
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley
-	cargo_capacity = 10
+	cargo_capacity = 25
 	max_equip = 6
 
 /obj/mecha/working/ripley/Destroy()
@@ -26,6 +27,7 @@
 	name = "APLU \"Firefighter\""
 	icon_state = "firefighter"
 	initial_icon = "firefighter"
+	step_energy_drain = 8
 	max_temperature = 65000
 	price_tag = 6500
 	health = 550

--- a/code/game/objects/structures/burrows.dm
+++ b/code/game/objects/structures/burrows.dm
@@ -716,6 +716,8 @@ percentage is a value in the range 0..1 that determines what portion of this mob
 			qdel(src)
 		else
 			collapse()
+			if(severity >= 2)
+				qdel(src)
 
 /obj/structure/burrow/preventsTurfInteractions()
 	if(isRevealed)

--- a/code/game/objects/structures/burrows.dm
+++ b/code/game/objects/structures/burrows.dm
@@ -716,7 +716,7 @@ percentage is a value in the range 0..1 that determines what portion of this mob
 			qdel(src)
 		else
 			collapse()
-			if(severity >= 2)
+			if(severity <= 2)
 				qdel(src)
 
 /obj/structure/burrow/preventsTurfInteractions()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Ripley mech has been quite a disappointment for both mining and guild. While this PR is not addressing the issues for mining it does address those in the interest of guild. A common issues that mechs in maints is poor energy, overall slower progression and more tedium that especially shows when fighting armies of roaches. With the extra storage the ripley has much more of an incentive to be used over the rig suits cargo clamp and the decreased energy draw giving it more range. The tesla link would both reward the guild of turning on power in maints and help with tedious walking back and forth. Drills being able to seal burrows makes it also the ultimate maints clean up tool and the kill clamp recipe just to give the mech much needed offense that isn't relying too much on rng.

Tested: Yes, both the burrow drilling and the crafting. The extra storage too.

## Changelog
add: Guild KILL CLAMP recipy
add: Guild Mech Equipment Tesla link
tweak: Burrows now fully seal if exposed to devastating and strong explosions
balance: Ripleys can now hold 25 cargo items from 10
balance: Ripleys consume less power when walking
refactor: Updated Kill clamp code to latest cargo clamp code, allowing it to cube trash.