### PR TITLE
Measons +1 view

### DIFF
--- a/code/modules/clothing/glasses/powered.dm
+++ b/code/modules/clothing/glasses/powered.dm
@@ -70,6 +70,7 @@
 	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	price_tag = 250
+	darkness_view = 1
 
 	tick_cost = 0.1
 


### PR DESCRIPTION
Measons now get +1 darkview so you can see around you 1 more tile with them

Testing: Actually none, legit 0
Performance: No real change

Why is this made?
Requested by Jack Torrs