### PR TITLE
You can teleport out of the wasonce

### DIFF
--- a/code/modules/genetics/creatures/wasonce.dm
+++ b/code/modules/genetics/creatures/wasonce.dm
@@ -141,12 +141,17 @@ Has ability of every roach.
 
 /mob/living/carbon/superior_animal/psi_monster/wasonce/Life()
 
+	if(captives.len)
+		for(var/mob/living/carbon/human/captive in captives)
+			if(captive.loc != src)
+				captives.Remove(captive)
 
 	if(captives.len && prob(15) && real_mutator)
 		var/fail_mutation_path = pick(injector.getFailList())
 		var/datum/genetics/mutation/injecting_mutation = new fail_mutation_path()
 		injector.addMutation(injecting_mutation)
 		for(var/mob/living/carbon/human/captive in captives)
+
 			if(captive.species.reagent_tag == IS_SYNTHETIC && (captive.getBruteLoss() < 300))
 				to_chat(captive, SPAN_DANGER(pick("The immense strength of the creature is crushing. Wasn't... Flesh supposed to be weak?")))
 				captive.adjustBruteLossByPart(15, pick(captive.organs))


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
Teleporting (like using the psionic teleport) while within a crimson jelly no longer pushes more mutations into you once freed.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
