### PR TITLE
Synthetic Church Healing - No More Self-Synth Healing

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -89,6 +89,9 @@
 		else
 			to_chat(H, SPAN_WARNING("You manage to cast the litany at a cost. The physical body consumes itself..."))
 			H.vessel.remove_reagent("blood",blood_cost)
+	if(H.species?.reagent_tag == IS_SYNTHETIC)
+		to_chat(H, SPAN_WARNING("You fail to cast the litany due to your non-organic body..."))
+		return FALSE
 	to_chat(H, "<span class='info'>A sensation of relief bathes you, washing away your pain.</span>")
 	H.reagents.add_reagent("laudanum", 10)
 	H.adjustBruteLoss(-20)
@@ -139,6 +142,8 @@
 			user.vessel.remove_reagent("blood",blood_cost)
 	if (do_after(user, 40, H, TRUE))
 		T = get_turf(user)
+		if (H.species?.reagent_tag == IS_SYNTHETIC)
+			to_chat(user, SPAN_DANGER("[H] is synthetic, healing them has no effect!"))
 		if (!(T.Adjacent(get_turf(H))))
 			to_chat(user, SPAN_DANGER("[H] is beyond your reach.."))
 			return
@@ -192,9 +197,7 @@
 
 /datum/ritual/cruciform/priest/heal_heathen/proc/heal_other(mob/living/carbon/human/participant)
 		to_chat(participant, "<span class='info'>A sensation of relief bathes you, washing away your some of your pain.</span>")
-		participant.reagents.add_reagent("laudanum", 5)
-		participant.adjustBruteLoss(-15)
-		participant.adjustFireLoss(-15)
+		participant.reagents.add_reagent("laudanum", 5, "meralyne", 5, "kelotane", 5)
 		participant.adjustToxLoss(-15)
 		participant.adjustOxyLoss(-30)
 		participant.adjustBrainLoss(-5)

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -197,7 +197,7 @@
 
 /datum/ritual/cruciform/priest/heal_heathen/proc/heal_other(mob/living/carbon/human/participant)
 		to_chat(participant, "<span class='info'>A sensation of relief bathes you, washing away your some of your pain.</span>")
-		participant.reagents.add_reagent("laudanum", 5, "meralyne", 5, "kelotane", 5)
+		participant.reagents.add_reagent("laudanum", 5, "bicaridine", 5, "kelotane", 5)
 		participant.adjustToxLoss(-15)
 		participant.adjustOxyLoss(-30)
 		participant.adjustBrainLoss(-5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simple change. Makes it so FBPs can no longer be healed by church litanies nor heal themselves via church litanies.
Note: The new way the Heathen healing prayer works is that it gives healing chems, doing roughly the same healing as prior. Only risk is OD but brute-healing chem used is uncommon. Thus hard to OD on ever really.

Done in accordance as asked by lore-head.
![image](https://user-images.githubusercontent.com/47883419/187679451-afd681ed-4cb3-4a4f-9f59-f3e16693318d.png)

Reasons given:
- Church healing is strong since it's full-on brute/burn damage removal.
- Self healing is very cheap power-wise and strong for the previous reason.
- Lore wise it doesn't seem to make sense cruciform can heal synthetic beings.

## Changelog
:cl:
balance: FBPs no longer get free hard-heals or self heals as requested.
/:cl: