### PR TITLE
Stops slime speed up being stackable to -0.2

### DIFF
--- a/code/modules/mob/living/carbon/slime/items.dm
+++ b/code/modules/mob/living/carbon/slime/items.dm
@@ -110,7 +110,7 @@
 
 /obj/item/slime_potion/slimes_speed/attackby(var/obj/item/clothing/C, mob/user as mob)
 	..()
-	if(C.slowdown < -0.1)//If target isn't already zooming
+	if(C.slowdown < 0)//If target isn't already zooming
 		to_chat(user, SPAN_WARNING("The tonic cant speed up this cloathing any more!"))
 		return ..()
 


### PR DESCRIPTION
REALLY small edit of preventing -0.2 speed ups via red slimes capping at -0.1

Performance: none
Testing: none