### PR TITLE
Moo Moo revolution

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -133,6 +133,10 @@
 	udder.my_atom = null
 
 	. = ..()
+/mob/living/simple_animal/cow/visible_emote(emote_see)
+	..()
+	if(prob(10))
+		playsound(loc, 'sound/voice/moo1.ogg', 50, 1, -1) //Credit to Minecraft for the sound effect!
 
 /mob/living/simple_animal/cow/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	var/obj/item/reagent_containers/G = O


### PR DESCRIPTION
Makes cows have a 10% chance to play the moo sound when they make a verbal emote (Mooing, moo's hauntingly)

Though this has brought my attention to the fact that cows, and maybe other simple animals don't do their noise emotes anymore. Will test if it's something in this PR specifically or if it's something that was broken at some point previously.

The cows will still moo, but won't show the emote of them mooing (Which already exists, but doesn't have a sound associated with it)

(PS, after saving the logs from a round and CTRL-Fing it, it seems chickens and cows, at the least, don't show their audible emotes. While this PR doesn't break it, I'll try looking into it to see if I can source out what's preventing them from showing.
They might even just be disabled for one reason or another, haven't seen a chicken go BWAK BWAAK BWAAK in chat in any time in recent memory.)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
add: Cows mooing (in 3d)
/:cl:

