### PR TITLE
Makes coolant cool

### DIFF
--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -509,7 +509,7 @@
 	var/reagent_property_divisor = volume_in_liters * reagent_property_coeff
 	var/temperature_change = removed_heat / reagent_property_divisor	// K
 
-	O.reagents.chem_temp -= temperature_change
+	O.reagents.chem_temp = max(O.reagents.chem_temp - temperature_change, 2.7)
 	O.reagents.handle_reactions()
 
 // Not even close to how refrigerant is used IRL, but it's just a game.

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -510,6 +510,7 @@
 	var/temperature_change = removed_heat / reagent_property_divisor	// K
 
 	O.reagents.chem_temp -= temperature_change
+	O.reagents.handle_reactions()
 
 // Not even close to how refrigerant is used IRL, but it's just a game.
 /datum/reagent/other/coolant/refrigerant

--- a/code/modules/reagents/recipes/recipes.dm
+++ b/code/modules/reagents/recipes/recipes.dm
@@ -336,7 +336,11 @@
 	result = "coolant"
 	required_reagents = list("tungsten" = 1, "acetone" = 1, "water" = 1)
 	result_amount = 3
-	log_is_important = 1
+
+/datum/chemical_reaction/refrigerant
+	result = "refrigerant"
+	required_reagents = list("carbon" = 1, "acetone" = 1, "water" = 1)
+	result_amount = 3
 
 /datum/chemical_reaction/rezadone
 	result = "rezadone"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Will be used in a future PR.

Allows coolant to cool reagent containers when sprayed. Adds a refrigerant subtype that is better at cooling. Also, this makes them both somewhat toxic. Coolant will cool a container by about 5.5 K per 5 unit squirt and refrigerant will cool it by about 38 K. Disables admin logs for coolant since it doesn't cool the air anymore.

## Changelog
:cl:
tweak: Allows coolant to cool reagent containers
add: Added refrigerant as a coolant subtype
code: Commented out unused coolant proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
