### PR TITLE
recoil and new gunmod

### DIFF
--- a/code/__DEFINES/weapons.dm
+++ b/code/__DEFINES/weapons.dm
@@ -83,7 +83,7 @@
 
 // recoil
 
-#define MAX_ACCURACY_OFFSET  30 //It's both how big gun recoil can build up, and how hard you can miss
+#define MAX_ACCURACY_OFFSET  50 //It's both how big gun recoil can build up, and how hard you can miss
 #define RECOIL_REDUCTION_TIME 1 SECOND
 
 // _recoil_buildup, _brace_penalty, _one_hand_penalty

--- a/code/datums/uplink/stealth and camouflage items.dm
+++ b/code/datums/uplink/stealth and camouflage items.dm
@@ -35,11 +35,6 @@
 	item_cost = 8
 	path = /obj/item/device/chameleon
 
-/datum/uplink_item/item/stealth_items/dna_trigger
-	name = "SI \"DNA lock\" trigger"
-	item_cost = 2 //low do to like being really really unuseful
-	path = /obj/item/gun_upgrade/trigger/dnalock
-
 /datum/uplink_item/item/stealth_items/tool_dampener
 	name = "Tool Upgrade: Aural Dampener"
 	item_cost = 1

--- a/code/datums/uplink/stealthy and inconspicuous weapons.dm
+++ b/code/datums/uplink/stealthy and inconspicuous weapons.dm
@@ -35,6 +35,23 @@
 	item_cost = 2
 	path = /obj/item/gun_upgrade/mechanism/glass_widow
 	antag_roles = ROLES_UPLINK_BASE
+
+/datum/uplink_item/item/stealthy_weapons/silencer
+	name = "Silencer"
+	item_cost = 1
+	path = /obj/item/gun_upgrade/muzzle/silencer
+
+/datum/uplink_item/item/stealthy_weapons/pain_maker
+	name = "SA \"PainMaker\" muzzle"
+	item_cost = 2
+	path = /obj/item/gun_upgrade/muzzle/pain_maker
+
+/datum/uplink_item/item/stealthy_weapons/dna_trigger
+	name = "SI \"DNA lock\" trigger"
+	item_cost = 2 //low do to like being really really unuseful
+	path = /obj/item/gun_upgrade/trigger/dnalock
+
+
 /*
 //Remove Lens from premisis -Hex
 /datum/uplink_item/item/stealthy_weapons/eye_banger

--- a/code/game/objects/items/weapons/tools/mods/_defines.dm
+++ b/code/game/objects/items/weapons/tools/mods/_defines.dm
@@ -58,7 +58,7 @@
 #define GUN_UPGRADE_MELEE_DAMAGE "melee_damage"
 #define GUN_UPGRADE_PVE_PROJ_MULT_DAMAGE "pve_proj_mult_damage"
 //Int additive
-#define GUN_UPGRADE_DAMAGEMOD_PLUS "damage_plus"
+#define GUN_UPGRADE_PAIN_MULT "pain_damage_plus"
 #define GUN_UPGRADE_MAGUP "magazine_addition"
 
 #define GUN_UPGRADE_DAMAGE_BRUTE "brute_damage"

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -387,8 +387,8 @@
 /datum/component/item_upgrade/proc/apply_values_gun(var/obj/item/gun/G)
 	if(weapon_upgrades[GUN_UPGRADE_DAMAGE_MULT])
 		G.damage_multiplier *= weapon_upgrades[GUN_UPGRADE_DAMAGE_MULT]
-	if(weapon_upgrades[GUN_UPGRADE_DAMAGEMOD_PLUS])
-		G.damage_multiplier += weapon_upgrades[GUN_UPGRADE_DAMAGEMOD_PLUS]
+	if(weapon_upgrades[GUN_UPGRADE_PAIN_MULT])
+		G.proj_agony_multiplier += weapon_upgrades[GUN_UPGRADE_PAIN_MULT]
 	if(weapon_upgrades[GUN_UPGRADE_PEN_MULT])
 		G.penetration_multiplier *= weapon_upgrades[GUN_UPGRADE_PEN_MULT]
 	if(weapon_upgrades[GUN_UPGRADE_PIERC_MULT])
@@ -573,6 +573,13 @@
 				to_chat(user, SPAN_NOTICE("Increases projectile damage by [amount*100]%"))
 			else
 				to_chat(user, SPAN_WARNING("Decreases projectile damage by [abs(amount*100)]%"))
+
+		if(weapon_upgrades[GUN_UPGRADE_PAIN_MULT])
+			var/amount = weapon_upgrades[GUN_UPGRADE_PAIN_MULT]-1
+			if(amount > 0)
+				to_chat(user, SPAN_NOTICE("Increases projectile agony damage by [amount*100]%"))
+			else
+				to_chat(user, SPAN_WARNING("Decreases projectile agony damage by [abs(amount*100)]%"))
 
 		if(weapon_upgrades[GUN_UPGRADE_PVE_PROJ_MULT_DAMAGE])
 			var/amount = weapon_upgrades[GUN_UPGRADE_PVE_PROJ_MULT_DAMAGE]-1

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -284,6 +284,7 @@
 	icon_state = "gun-red"
 /obj/random/dungeon_gun_mods/item_to_spawn()
 	return pickweight(list(/obj/item/gun_upgrade/muzzle/silencer = 1,
+				/obj/item/gun_upgrade/muzzle/pain_maker = 0.3,
 				/obj/item/gun_upgrade/barrel/forged = 1,
 				/obj/item/gun_upgrade/barrel/mag_accel = 1,
 				/obj/item/gun_upgrade/barrel/overheat = 1,

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -18,16 +18,17 @@
 /obj/item/organ/internal/kidney/left/cindarite
 	name = "cindarite kidney"
 	icon_state = "kidney_left_cindar"
-	desc = "A dense set of tightly packed kidneys that work twice as better than a standard kidney.\
+	desc = "A dense set of tightly packed kidneys that work four times better than a standard kidney.\
 	Likely worth more on the black market."
-	price_tag = 2000
-	organ_efficiency = list(OP_KIDNEYS = 100)
+	price_tag = 1000
+	organ_efficiency = list(OP_KIDNEYS = 200)
 
 /obj/item/organ/internal/kidney/right/cindarite
 	icon_state = "kidney_right_cindar"
 	desc = "A dense set of tightly packed kidneys that work twice as better than a standard kidney.\
 	Likely worth more on the black market."
 	price_tag = 1000 //The right kidney should be worth as much as the left one.
+	organ_efficiency = list(OP_KIDNEYS = 200)
 
 /obj/item/organ/internal/kidney/prosthetic
 	name = "prosthetic kidneys"
@@ -47,7 +48,7 @@
 	icon_state = "kidney_left"
 	desc = "A dense set of Artisinal kidneys. Works twice as well as a common peasant's kidney.\
 	Likely worth more on the black market."
-	price_tag = 1000
+	price_tag = 700
 	organ_efficiency = list(OP_KIDNEYS = 150)
 
 /obj/item/organ/internal/kidney/right/exalt
@@ -55,5 +56,5 @@
 	icon_state = "kidney_right"
 	desc = "A dense set of Artisinal kidneys. Works twice as well as a common peasant's kidney.\
 	Likely worth more on the black market."
-	price_tag = 1000
+	price_tag = 700
 	organ_efficiency = list(OP_KIDNEYS = 150)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -962,6 +962,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	data["multiply_pve_damage"] = proj_pve_damage_multiplier
 	data["pierce_multiplier"] = pierce_multiplier
 	data["penetration_multiplier"] = penetration_multiplier
+	data["proj_agony_multiplier"] = proj_agony_multiplier
 
 	data["fire_delay"] = fire_delay //time between shot, in ms
 	data["burst"] = burst //How many shots are fired per click

--- a/code/modules/projectiles/gun_hud_actions.dm
+++ b/code/modules/projectiles/gun_hud_actions.dm
@@ -60,7 +60,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "weapon_stats.tmpl", name, 700, 550, state = state)
+		ui = new(user, src, ui_key, "weapon_stats.tmpl", name, 800, 600, state = state)
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -41,7 +41,7 @@
 	I.weapon_upgrades = list(
 		UPGRADE_BULK = 2,
 		GUN_UPGRADE_STEPDELAY_MULT = 1.5,
-		GUN_UPGRADE_DAMAGE_MULT = 0.8,
+		GUN_UPGRADE_DAMAGE_MULT = 0.5,
 		GUN_UPGRADE_PEN_MULT = 0.5,
 		GUN_UPGRADE_PIERC_MULT = -3, //This does a LOT lowering range, as well as most guns being unable to wall bang with it
 		GUN_UPGRADE_OFFSET = 11,

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -10,7 +10,7 @@
 //Silences the weapon, reduces damage multiplier slightly, Legacy port.
 /obj/item/gun_upgrade/muzzle/silencer
 	name = "Silencer"
-	desc = "A threaded silencer that can be attached to the muzzle of certain guns. Vastly reduces noise, but impedes muzzle velocity."
+	desc = "A threaded silencer that can be attached to the muzzle of certain guns. Vastly reduces noise."
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 1)
 	icon_state = "silencer"
 	price_tag = 100
@@ -25,6 +25,32 @@
 	I.gun_loc_tag = GUN_MUZZLE
 	I.req_gun_tags = list(GUN_SILENCABLE)
 	I.prefix = "silenced"
+
+/obj/item/gun_upgrade/muzzle/pain_maker
+	name = "SA \"PainMaker\" muzzle"
+	desc = "A threaded barrel that can be attached to the muzzle of most projectile guns. \
+	Using some creative barreling allows the bullet to spin and fracture on impact as it comes making the projectile hard to control but much more painful. \
+	Typically used when taking a hostages or kidnapping."
+	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 1)
+	icon_state = "silencer"
+	price_tag = 100
+
+/obj/item/gun_upgrade/muzzle/pain_maker/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.weapon_upgrades = list(
+		UPGRADE_BULK = 2,
+		GUN_UPGRADE_STEPDELAY_MULT = 1.5,
+		GUN_UPGRADE_DAMAGE_MULT = 0.8,
+		GUN_UPGRADE_PEN_MULT = 0.5,
+		GUN_UPGRADE_OFFSET = 11,
+		GUN_UPGRADE_RECOIL = 1.5,
+		GUN_UPGRADE_PAIN_MULT = 2
+		)
+	I.gun_loc_tag = GUN_MUZZLE
+	I.req_gun_tags = list(GUN_PROJECTILE)
+	I.prefix = "LTL"
+
 
 //Decreases fire delay. Acquired through loot spawns or guild crafting
 /obj/item/gun_upgrade/barrel/forged

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -29,7 +29,7 @@
 /obj/item/gun_upgrade/muzzle/pain_maker
 	name = "SA \"PainMaker\" muzzle"
 	desc = "A threaded barrel that can be attached to the muzzle of most projectile guns. \
-	Using some creative barreling allows the bullet to spin and fracture on impact as it comes making the projectile hard to control but much more painful. \
+	Threaded barrel device made of a coil sensor and heater. As bullets pass the device they are slowed down and heated up by the coil, causing them to deform when hitting a target and imparting all their painful energy. \
 	Typically used when taking a hostages or kidnapping."
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 1)
 	icon_state = "silencer"
@@ -43,6 +43,7 @@
 		GUN_UPGRADE_STEPDELAY_MULT = 1.5,
 		GUN_UPGRADE_DAMAGE_MULT = 0.8,
 		GUN_UPGRADE_PEN_MULT = 0.5,
+		GUN_UPGRADE_PIERC_MULT = -3, //This does a LOT lowering range, as well as most guns being unable to wall bang with it
 		GUN_UPGRADE_OFFSET = 11,
 		GUN_UPGRADE_RECOIL = 1.5,
 		GUN_UPGRADE_PAIN_MULT = 2

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
@@ -48,14 +48,14 @@
 		),
 		"Syndicate Gun Mods" = list(
 			/obj/item/gun_upgrade/barrel/gauss,
-			//obj/item/gun_upgrade/mechanism/glass_widow,
+			/obj/item/gun_upgrade/muzzle/pain_maker, //Clearly so you can get those
 			/obj/item/gun_upgrade/scope/killer
 		)
 	)
 	offer_types = list(
 		/obj/item/organ/internal/kidney = offer_data("kidney", 800, 2),
-		/obj/item/organ/internal/liver/big = offer_data("liver", 1200, 1),
-		/obj/item/organ/internal/heart/huge = offer_data("heart", 2000, 1),
+		/obj/item/organ/internal/liver/big = offer_data("big liver", 1200, 1),
+		/obj/item/organ/internal/heart/huge = offer_data("six-chambered heart", 2000, 1),
 		/obj/item/organ/internal/lungs/long = offer_data("long lungs", 1650, 1),
 		/obj/item/organ/internal/nerve/sensitive_nerve  = offer_data("sensitive nerve", 2650, 1),
 		/obj/item/organ/internal/blood_vessel/extensive   = offer_data("extensive blood vessels", 2650, 1)

--- a/nano/templates/weapon_stats.tmpl
+++ b/nano/templates/weapon_stats.tmpl
@@ -2,7 +2,7 @@
 	<h3>Specifications:</h3>
 	<div class="statusDisplay" style="overflow: auto;">
 		<h4>Weapon details:</h4>
-		
+
 		{{if data.damage_multiplier != 1}}
 			<div class="itemLabel">
 				Projectile damage multiplier:
@@ -20,7 +20,7 @@
 				 {{:data.multiply_pve_damage}}x
 			</div>
 		{{/if}}
-		
+
 		{{if data.pierce_multiplier != 0}}
 			<div class="itemLabel">
 				Projectile walls penetration:
@@ -29,7 +29,7 @@
 				{{:data.pierce_multiplier}} walls
 			</div>
 		{{/if}}
-		
+
 		{{if data.penetration_multiplier != 1}}
 			<div class="itemLabel">
 				Projectile AP multiplier: 
@@ -38,14 +38,23 @@
 				{{:data.penetration_multiplier}}x
 			</div>
 		{{/if}}
-		
+
+		{{if data.proj_agony_multiplier != 1}}
+			<div class="itemLabel">
+				Projectile Agony multiplier: 
+			</div>
+			<div class="itemContent">
+				{{:data.proj_agony_multiplier}}x
+			</div>
+		{{/if}}
+
 		<div class="itemLabel">
 			Fire delay: 
 		</div>
 			<div class="itemContent">
 				{{:data.fire_delay}} ms
 			</div>
-		
+
 		{{if data.burst > 1}}
 			<div class="itemLabel">
 				Rounds per burst: 
@@ -147,7 +156,7 @@
 				<div class="itemContent">
 					{{:data.projectile_name}}
 				</div>
-			
+
 			<div class="itemLabel">
 				PvP damage:
 			</div>
@@ -220,7 +229,7 @@
 								<div class="itemContent">
 									{{:value.burst}}
 								</div>
-							
+
 						{{/if}}
 						{{if value.fire_delay}}
 							<div class="itemLabel">


### PR DESCRIPTION
Recoil maxium has been raised to 50 from 30 meaning it can build up more

Red is current:
Yellow is the inbettewn:
Green is now:
![image](https://user-images.githubusercontent.com/30435998/191614559-d096c735-1f94-45a5-80f8-7ed39d5fdf67.png)

New gunmod - Pain-maker massively reduces a guns damage, AP and increase recoil offset and paindamage for when you dont want to snipe from 5000 years away and still take down someone

Fixes some bad numbers with kidneys
Fixes some bad trade names from organs
Makes the gun ui slightly bigger by default to prevent a UI scaling issue

Testing: shoot a gun a lot with the mod and without the mod to see recoil changes to make sure they were not storm trooper levels
Performance: no real change 