### PR TITLE
RnD Anti-cheating

### DIFF
--- a/code/modules/modular_computers/file_system/binary/research.dm
+++ b/code/modules/modular_computers/file_system/binary/research.dm
@@ -19,6 +19,9 @@
 	filetype = "RDAT"
 	size = 1 		// Scales with the amount of research points
 	var/research_id	// ID of a generated file, so you can't feed a single file into an R&D console indefinitely
+	clone_able = FALSE
+	copy_cat = TRUE //Were unable to be imported or exported hardware wise, as were already pre-downloaded somehow onto a disk.
+
 
 /datum/computer_file/binary/research_points/New(size = 1)
 	..()

--- a/code/modules/modular_computers/file_system/programs/research/passive_pointes.dm
+++ b/code/modules/modular_computers/file_system/programs/research/passive_pointes.dm
@@ -31,13 +31,18 @@
 		return
 	var/obj/item/computer_hardware/processor_unit/CPU = computer.processor_unit
 	var/obj/item/computer_hardware/hard_drive/HD = computer.hard_drive
+	var/obj/item/computer_hardware/hard_drive/portable/PD = computer.portable_drive
 
 	if(!istype(CPU) || !CPU.check_functionality() || !istype(HD))
 		message = "A fatal hardware error has been detected."
 		return
 
-	if(HD.used_capacity >= HD.max_capacity)
-		message = "Storage hard drive capacity error, clear space."
+	if(!istype(PD) || !PD.check_functionality())
+		message = "!!ERROR!! No Portal Data Disk! Please Insert Data Disk."
+		return
+
+	if(PD.used_capacity >= PD.max_capacity)
+		message = "Storage Data Disk capacity error, clear space."
 		return
 
 	progress += get_speed()
@@ -49,7 +54,7 @@
 		playsound(computer.loc, 'sound/machines/ping.ogg', 50, 1 -3)
 		message = "Successfully collected data points and saved metadata results."
 		var/datum/computer_file/binary/research_points/RP = new(target_progress/1000) // 1 Size = 1000 points.
-		HD.store_file(RP)
+		PD.store_file(RP)
 
 /datum/computer_file/program/point_miner/proc/reset()
 	running = FALSE

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -98,6 +98,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	. = ..()
 	files = new /datum/research(src) //Setup the research data holder.
 	SyncRDevices()
+	sync_tech() //To stop cheaters
 
 /obj/machinery/computer/rdconsole/Destroy()
 	files = null

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -186,7 +186,8 @@ Procs:
 /datum/research/proc/can_load_file(datum/computer_file/file)
 	if(istype(file, /datum/computer_file/binary/research_points))
 		var/datum/computer_file/binary/research_points/research_points_file = file
-		return !(research_points_file.research_id in known_research_file_ids)
+		if(research_points_file.size >= 1)
+			return TRUE //!(research_points_file.research_id in known_research_file_ids) Soj edit we now just kill the file
 
 	return FALSE
 
@@ -196,8 +197,10 @@ Procs:
 
 	if(istype(file, /datum/computer_file/binary/research_points))
 		var/datum/computer_file/binary/research_points/research_points_file = file
-		known_research_file_ids += research_points_file.research_id
+		known_research_file_ids += research_points_file.research_id //Used for admins/logs still
 		adjust_research_points(research_points_file.size * 1000)
+		file.size = 0 //Just in case
+		file.holder.recalculate_size()
 		return TRUE
 
 	return FALSE


### PR DESCRIPTION
## About The Pull Request
Adds in 2 robust anti-cheat messers and fixes a rare but real issue regarding same numbered data

When data is uploaded into rnd now it sets its size to 0 
Data now cant be copyed or exported
Data from the dataminer now only gets placed onto a disk

When a rnd console is made it now auto-syncs 

## Changelog
:cl:
fix: Data for RnD is much more robust in anticheats, as well as more fair if same numbers are rng roled. Also Data disks when uploaded to a console now sets their size to 0.
balance: RnD console now auto-sync when made as an anti-cheat
/:cl:

Testing: Robust testing of the bare minium to make sure it all works, made sure the console still works as well as the point miner
Performance: Not much changed
