### PR TITLE
Aberrant Organs - tweaks and balancing

### DIFF
--- a/code/modules/aberrants/organs/_defines.dm
+++ b/code/modules/aberrants/organs/_defines.dm
@@ -14,7 +14,7 @@
 		OP_HEART		= list(100,   2,   0,   0,   10,  10,  list("he", "ar", "t"), list()),\
 		OP_LUNGS		= list(100,   2,   50,	10,  10,  0,   list("l", "un", "gs"), list()),\
 		OP_LIVER		= list(100,   1,   25,	5,   5,   7,   list("l", "iv", "er"), list()),\
-		OP_KIDNEYS		= list(50,    1,   7.5, 1.5, 2,   2.5, list("k", "idn", "ey"), list()),\
+		OP_KIDNEYS		= list(100,   2,   15,  3,   4,   5, list("k", "idn", "ey"), list()),\
 		OP_APPENDIX		= list(100,   0,   0,	0,   0,   0,   list("app", "end", "ix"), list()),\
 		OP_STOMACH		= list(100,   1,   25,	5,   0,   5,   list("st", "om", "ach"), list()),\
 		OP_BONE			= list(100,   1,   0,	0,   0,   0,   list("b", "on", "e"), list()),\

--- a/code/modules/aberrants/organs/holders.dm
+++ b/code/modules/aberrants/organs/holders.dm
@@ -57,11 +57,6 @@
 		details_unlocked = TRUE
 
 	if(using_sci_goggles || details_unlocked)
-		var/organs = ""
-		for(var/organ in organ_efficiency)
-			organs += organ + " ([organ_efficiency[organ]]), "
-		organs = copytext(organs, 1, length(organs) - 1)
-
 		var/function_info
 		var/input_info
 		var/process_info
@@ -85,12 +80,8 @@
 						output_info + (output_info && secondary_info ? "\n" : null) +\
 						secondary_info
 
-		if(item_upgrades.len)
-			to_chat(user, SPAN_NOTICE("Organoid grafts present ([item_upgrades.len]/[max_upgrades]). Use a laser cutting tool to remove."))
 		if(aberrant_cooldown_time > 0)
 			to_chat(user, SPAN_NOTICE("Average organ process duration: [aberrant_cooldown_time / (1 SECOND)] seconds"))
-
-		to_chat(user, SPAN_NOTICE("Organ tissues present (efficiency): <span style='color:pink'>[organs ? organs : "none"]</span>"))
 
 		if(function_info)
 			to_chat(user, SPAN_NOTICE(function_info))

--- a/code/modules/aberrants/organs/internal/dependent.dm
+++ b/code/modules/aberrants/organs/internal/dependent.dm
@@ -10,7 +10,7 @@
 	should_process_have_organ_stats = FALSE
 	output_pool = ALL_STANDARD_ORGAN_EFFICIENCIES
 	output_info = list(1)
-	special_info = list(STAT_ROB, 3)
+	special_info = list(STAT_ROB, 10)
 
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/wifebeater
@@ -19,7 +19,7 @@
 		/datum/reagent/ethanol/beer, /datum/reagent/ethanol/ale, /datum/reagent/ethanol/mead
 	)
 	input_mode = CHEM_INGEST
-	special_info = list(STAT_ROB, 3)		// specfic organs will have better buffs
+	special_info = list(STAT_ROB, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/wifebeater/New()
 	..()
@@ -38,17 +38,17 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/wifebeater/liver
 	name = "wifebeater's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_ROB, 6)
+	special_info = list(STAT_ROB, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/wifebeater/stomach
 	name = "wifebeater's stomach"
 	output_pool = list(OP_STOMACH)
-	special_info = list(STAT_ROB, 6)
+	special_info = list(STAT_ROB, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/wifebeater/kidney
 	name = "wifebeater's kidney"
 	output_pool = list(OP_KIDNEYS)
-	special_info = list(STAT_ROB, 6)
+	special_info = list(STAT_ROB, 10)
 
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/functional_alcoholic
@@ -58,7 +58,7 @@
 		/datum/reagent/ethanol/vodka, /datum/reagent/ethanol/whiskey, /datum/reagent/ethanol/wine
 	)
 	input_mode = CHEM_INGEST
-	special_info = list(STAT_MEC, 3)
+	special_info = list(STAT_MEC, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/functional_alcoholic/New()
 	..()
@@ -77,17 +77,17 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/functional_alcoholic/liver
 	name = "functional alcoholic's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_MEC, 6)
+	special_info = list(STAT_MEC, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/functional_alcoholic/stomach
 	name = "functional alcoholic's stomach"
 	output_pool = list(OP_STOMACH)
-	special_info = list(STAT_MEC, 6)
+	special_info = list(STAT_MEC, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/functional_alcoholic/kidney
 	name = "functional alcoholic's kidney"
 	output_pool = list(OP_KIDNEYS)
-	special_info = list(STAT_MEC, 6)
+	special_info = list(STAT_MEC, 10)
 
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/classy
@@ -96,7 +96,7 @@
 		/datum/reagent/ethanol/martini, /datum/reagent/ethanol/coffee/b52, /datum/reagent/ethanol/black_russian, /datum/reagent/ethanol/gintonic
 	)
 	input_mode = CHEM_INGEST
-	special_info = list(STAT_COG, 3)
+	special_info = list(STAT_COG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/classy/New()
 	..()
@@ -115,17 +115,17 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/classy/liver
 	name = "aristocrat's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_COG, 6)
+	special_info = list(STAT_COG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/classy/stomach
 	name = "aristocrat's stomach"
 	output_pool = list(OP_STOMACH)
-	special_info = list(STAT_COG, 6)
+	special_info = list(STAT_COG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/classy/kidney
 	name = "aristocrat's kidney"
 	output_pool = list(OP_KIDNEYS)
-	special_info = list(STAT_COG, 6)
+	special_info = list(STAT_COG, 10)
 
 	
 /obj/item/organ/internal/scaffold/aberrant/dependent/exmercenary
@@ -134,7 +134,7 @@
 		/datum/reagent/stim/bouncer, /datum/reagent/stim/steady, /datum/reagent/stim/violence
 	)
 	input_mode = CHEM_BLOOD
-	special_info = list(STAT_VIG, 3)
+	special_info = list(STAT_VIG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/exmercenary/New()
 	..()
@@ -153,17 +153,17 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/exmercenary/blood_vessel
 	name = "ex-mercenary's blood vessel"
 	output_pool = list(OP_BLOOD_VESSEL)
-	special_info = list(STAT_VIG, 3)
+	special_info = list(STAT_VIG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/exmercenary/liver
 	name = "ex-mercenary's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_VIG, 6)
+	special_info = list(STAT_VIG, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/exmercenary/muscle
 	name = "ex-mercenary's muscle"
 	output_pool = list(OP_MUSCLE)
-	special_info = list(STAT_VIG, 3)
+	special_info = list(STAT_VIG, 10)
 
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/mobster
@@ -172,7 +172,7 @@
 		/datum/reagent/drug/space_drugs, /datum/reagent/drug/psilocybin
 	)
 	input_mode = CHEM_BLOOD
-	special_info = list(STAT_TGH, 3)
+	special_info = list(STAT_TGH, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/mobster/New()
 	..()
@@ -191,17 +191,17 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/mobster/blood_vessel
 	name = "mobster's blood vessel"
 	output_pool = list(OP_BLOOD_VESSEL)
-	special_info = list(STAT_TGH, 3)
+	special_info = list(STAT_TGH, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/mobster/liver
 	name = "mobster's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_TGH, 6)
+	special_info = list(STAT_TGH, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/mobster/muscle
 	name = "mobster's muscle"
 	output_pool = list(OP_MUSCLE)
-	special_info = list(STAT_TGH, 3)
+	special_info = list(STAT_TGH, 10)
 
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/chemist
@@ -210,7 +210,7 @@
 		/datum/reagent/stim/pro_surgeon, /datum/reagent/medicine/aminazine, /datum/reagent/medicine/citalopram
 	)
 	input_mode = CHEM_BLOOD
-	special_info = list(STAT_BIO, 3)
+	special_info = list(STAT_BIO, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/chemist/New()
 	..()
@@ -229,16 +229,16 @@
 /obj/item/organ/internal/scaffold/aberrant/dependent/chemist/blood_vessel
 	name = "chemist's blood vessel"
 	output_pool = list(OP_BLOOD_VESSEL)
-	special_info = list(STAT_BIO, 3)
+	special_info = list(STAT_BIO, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/chemist/liver
 	name = "chemist's liver"
 	output_pool = list(OP_LIVER)
-	special_info = list(STAT_BIO, 6)
+	special_info = list(STAT_BIO, 10)
 
 /obj/item/organ/internal/scaffold/aberrant/dependent/chemist/kidney
 	name = "chemist's kidney"
 	output_pool = list(OP_KIDNEYS)
-	special_info = list(STAT_BIO, 6)
+	special_info = list(STAT_BIO, 10)
 
 // Soj uses Viv (NSA stat, "addict") and Anatomy (health stat, "bodybuilder")

--- a/code/modules/aberrants/organs/internal/simple.dm
+++ b/code/modules/aberrants/organs/internal/simple.dm
@@ -5,7 +5,7 @@
 	process_mod_path = /obj/item/modification/organ/internal/process/boost
 	output_mod_path = /obj/item/modification/organ/internal/output/chemical_effects
 	specific_input_type_pool = list(/datum/reagent/toxin)	// Should let these scrub ANY toxin
-	output_pool = TYPE_1_HORMONES
+	output_pool = TYPE_2_HORMONES
 	output_info = list(NOT_USED)
 
 /obj/item/organ/internal/scaffold/aberrant/scrub_toxin/New()
@@ -48,7 +48,7 @@
 									/datum/reagent/toxin/amatoxin, /datum/reagent/toxin/carpotoxin, /datum/reagent/toxin/fertilizer)
 	input_mode = CHEM_INGEST
 	output_pool = list(/datum/reagent/organic/nutriment)
-	output_info = list(VERY_LOW_OUTPUT)
+	output_info = list(LOW_OUTPUT)
 
 /obj/item/organ/internal/scaffold/aberrant/gastric/New()
 	..()
@@ -72,7 +72,7 @@
 	output_mod_path = /obj/item/modification/organ/internal/output/chemical_effects
 	specific_input_type_pool = ALL_DAMAGE_TYPES
 	input_mode = NOT_USED
-	output_pool = TYPE_1_HORMONES
+	output_pool = TYPE_2_HORMONES
 	output_info = list(NOT_USED)
 
 /obj/item/organ/internal/scaffold/aberrant/damage_response/New()

--- a/code/modules/aberrants/organs/internal/teratoma.dm
+++ b/code/modules/aberrants/organs/internal/teratoma.dm
@@ -8,7 +8,7 @@
 	ruined_description_info = "Useless organ tissue. Recycle this in a regurgitator."
 	ruined_color = "#696969"
 	icon_state = "teratoma"
-	price_tag = 200
+	price_tag = 100
 
 	max_upgrades = 1
 	use_generated_name = FALSE
@@ -94,7 +94,7 @@
 				output_pool = ALL_STATS_FOR_LEVEL_UP
 			if(!output_info?.len)
 				for(var/i in 1 to req_num_outputs)
-					output_info += 3
+					output_info += MID_OUTPUT
 
 		if(/obj/item/modification/organ/internal/output/damaging_insight_gain)
 			if(!output_pool?.len)

--- a/code/modules/aberrants/organs/mods/0_mods.dm
+++ b/code/modules/aberrants/organs/mods/0_mods.dm
@@ -8,7 +8,7 @@
 	icon_state = "organoid"
 	desc = "Functional tissue of one or more organs in graftable form."
 	spawn_tags = SPAWN_TAG_ORGAN_MOD
-	price_tag = 200
+	price_tag = 25
 
 /obj/item/modification/organ/internal/New(loc, generate_organ_stats = FALSE, predefined_modifier = null)
 	..()
@@ -46,6 +46,9 @@
 			O.blood_req_mod 				+= round(organ_stats[4] * modifier * (1 + (1 * is_parasitic)), 0.01)
 			O.nutriment_req_mod 			+= round(organ_stats[5] * modifier * (1 + (1 * is_parasitic)), 0.01)
 			O.oxygen_req_mod 				+= round(organ_stats[6] * modifier * (1 + (1 * is_parasitic)), 0.01)
+
+			if(predefined_modifier)
+				break
 
 			probability = probability / 8
 

--- a/code/modules/aberrants/organs/mods/4_special.dm
+++ b/code/modules/aberrants/organs/mods/4_special.dm
@@ -113,7 +113,7 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_MEC
-	S.boost = 3
+	S.boost = 10
 	..()
 
 /obj/item/modification/organ/internal/special/on_cooldown/stat_boost/cognition
@@ -121,7 +121,7 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_COG
-	S.boost = 3
+	S.boost = 10
 	..()
 
 /obj/item/modification/organ/internal/special/on_cooldown/stat_boost/biology
@@ -129,7 +129,7 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_BIO
-	S.boost = 3
+	S.boost = 10
 	..()
 
 /obj/item/modification/organ/internal/special/on_cooldown/stat_boost/robustness
@@ -137,7 +137,7 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_ROB
-	S.boost = 3
+	S.boost = 10
 	..()
 
 /obj/item/modification/organ/internal/special/on_cooldown/stat_boost/toughness
@@ -145,7 +145,7 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_TGH
-	S.boost = 3
+	S.boost = 10
 	..()
 
 /obj/item/modification/organ/internal/special/on_cooldown/stat_boost/vigilance_5
@@ -153,5 +153,5 @@
 	var/datum/component/modification/organ/on_cooldown/stat_boost/S = AddComponent(/datum/component/modification/organ/on_cooldown/stat_boost)
 
 	S.stat = STAT_VIG
-	S.boost = 3
+	S.boost = 10
 	..()

--- a/code/modules/aberrants/organs/mods/5_upgrades.dm
+++ b/code/modules/aberrants/organs/mods/5_upgrades.dm
@@ -119,17 +119,14 @@
 	desc = "A graftable membrane for organ tissues. Contains functional tissue from one or more organs."
 	description_info = "Adds/increases organ efficiencies. Size, blood, oxygen, and nutrition requirements are based on the added efficiencies."
 	icon_state = "membrane"
-	var/organ_eff_mod = 0.1
+	var/organ_eff_mod = 0.2
 
 /obj/item/modification/organ/internal/parenchymal/New(loc, generate_organ_stats = TRUE, predefined_modifier = organ_eff_mod)
-	var/datum/component/modification/organ/M = AddComponent(/datum/component/modification/organ)
+	var/datum/component/modification/organ/parenchymal/M = AddComponent(/datum/component/modification/organ/parenchymal)
 
-	M.apply_to_types = list(/obj/item/organ/internal)
-	M.examine_msg = "Can be attached to internal organs."
-	M.examine_difficulty = STAT_LEVEL_BASIC
 	M.prefix = "multi-functional"
 	..()
 
 /obj/item/modification/organ/internal/parenchymal/large
 	name = "parenchymal membrane"
-	organ_eff_mod = 0.2
+	organ_eff_mod = 0.4

--- a/code/modules/aberrants/organs/mods/component/_component.dm
+++ b/code/modules/aberrants/organs/mods/component/_component.dm
@@ -96,6 +96,13 @@
 		for(var/organ in holder.organ_efficiency)
 			holder.organ_efficiency[organ] = round(holder.organ_efficiency[organ] * (1 + organ_efficiency_multiplier), 1)
 
+	if(holder.owner && istype(holder.owner, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = holder.owner
+		for(var/process in organ_efficiency_mod)
+			if(!islist(H.internal_organs_by_efficiency[process]))
+				H.internal_organs_by_efficiency[process] = list()
+			H.internal_organs_by_efficiency[process] |= holder
+
 	if(specific_organ_size_multiplier)
 		holder.specific_organ_size *= 1 - round(specific_organ_size_multiplier, 0.01)
 	if(max_blood_storage_multiplier)

--- a/code/modules/aberrants/organs/mods/component/_component.dm
+++ b/code/modules/aberrants/organs/mods/component/_component.dm
@@ -1,7 +1,7 @@
 /datum/component/modification/organ
 	install_time = WORKTIME_FAST
 	//install_tool_quality = null
-	install_difficulty = FAILCHANCE_HARD
+	install_difficulty = FAILCHANCE_NORMAL
 	install_stat = STAT_BIO
 	install_sound = 'sound/effects/squelch1.ogg'
 
@@ -13,7 +13,7 @@
 
 	removal_time = WORKTIME_SLOW
 	removal_tool_quality = QUALITY_LASER_CUTTING
-	removal_difficulty = FAILCHANCE_VERY_HARD
+	removal_difficulty = FAILCHANCE_HARD
 	removal_stat = STAT_BIO
 
 	bypass_perk = PERK_ADVANCED_MEDICAL

--- a/code/modules/aberrants/organs/mods/component/upgrades.dm
+++ b/code/modules/aberrants/organs/mods/component/upgrades.dm
@@ -42,11 +42,11 @@
 	if(oxygen_req_multiplier)
 		function_info += "[oxygen_req_multiplier >= 0 ? "Decreases" : "Increases"] oxygen requirement by [abs(oxygen_req_multiplier) * 100]%\n"
 	if(min_bruised_damage_multiplier)
-		function_info += "[min_bruised_damage_multiplier >= 0 ? "Decreases" : "Increases"] bruised threshold by [abs(min_bruised_damage_multiplier) * 100]%\n"
+		function_info += "[min_bruised_damage_multiplier >= 0 ? "Increases" : "Decreases"] bruised threshold by [abs(min_bruised_damage_multiplier) * 100]%\n"
 	if(min_broken_damage_multiplier)
-		function_info += "[min_broken_damage_multiplier >= 0 ? "Decreases" : "Increases"] broken threshold by [abs(min_broken_damage_multiplier) * 100]%\n"
+		function_info += "[min_broken_damage_multiplier >= 0 ? "Increases" : "Decreases"] broken threshold by [abs(min_broken_damage_multiplier) * 100]%\n"
 	if(max_damage_multiplier)
-		function_info += "[max_damage_multiplier >= 0 ? "Decreases" : "Increases"] maximum health by [abs(max_damage_multiplier) * 100]%\n"
+		function_info += "[max_damage_multiplier >= 0 ? "Increases" : "Decreases"] maximum health by [abs(max_damage_multiplier) * 100]%\n"
 
 	if(specific_organ_size_mod)
 		function_info += "[specific_organ_size_mod >= 0 ? "Increases" : "Decreases"] size by [abs(specific_organ_size_mod)]\n"
@@ -61,11 +61,11 @@
 	if(max_upgrade_mod)
 		function_info += "[max_upgrade_mod >= 0 ? "Increases" : "Decreases"] maximum upgrades by [abs(max_upgrade_mod)]\n"
 	if(min_bruised_damage_mod)
-		function_info += "[min_bruised_damage_mod >= 0 ? "Decreases" : "Increases"] bruised threshold by [abs(min_bruised_damage_mod)]\n"
+		function_info += "[min_bruised_damage_mod >= 0 ? "Increases" : "Decreases"] bruised threshold by [abs(min_bruised_damage_mod)]\n"
 	if(min_broken_damage_mod)
-		function_info += "[min_broken_damage_mod >= 0 ? "Decreases" : "Increases"] broken threshold by [abs(min_broken_damage_mod)]\n"
+		function_info += "[min_broken_damage_mod >= 0 ? "Increases" : "Decreases"] broken threshold by [abs(min_broken_damage_mod)]\n"
 	if(max_damage_mod)
-		function_info += "[max_damage_mod >= 0 ? "Decreases" : "Increases"] maximum health by [abs(max_damage_mod)]\n"
+		function_info += "[max_damage_mod >= 0 ? "Increases" : "Decreases"] maximum health by [abs(max_damage_mod)]\n"
 
 	if(scanner_hidden)
 		function_info += "Hides the organ from scanners\n"
@@ -74,3 +74,40 @@
 	function_info += "</i>"
 
 	return function_info
+
+/datum/component/modification/organ/parenchymal
+	apply_to_types = list(/obj/item/organ/internal)
+	examine_msg = "Can be attached to internal organs."
+	examine_difficulty = STAT_LEVEL_BASIC
+	adjustable = TRUE
+
+/datum/component/modification/organ/parenchymal/modify(obj/item/I, mob/living/user)
+	specific_organ_size_mod = 0
+	max_blood_storage_mod = 0
+	blood_req_mod = 0
+	nutriment_req_mod = 0
+	oxygen_req_mod = 0
+
+	var/list/possibilities = ALL_STANDARD_ORGAN_EFFICIENCIES
+
+	for(var/organ in organ_efficiency_mod)
+		if(organ_efficiency_mod.len > 1)
+			for(var/organ_eff in possibilities)
+				if(organ != organ_eff && organ_efficiency_mod.Find(organ_eff))
+					possibilities.Remove(organ_eff)
+
+		var/decision = input("Choose an organ type (current: [organ])","Adjusting Organoid") as null|anything in possibilities
+		if(!decision)
+			decision = organ
+
+		var/list/organ_stats = ALL_ORGAN_STATS[decision]
+		var/modifier = round(organ_efficiency_mod[organ] / 100, 0.01)
+
+		organ_efficiency_mod.Remove(organ)
+		organ_efficiency_mod.Add(decision)
+		organ_efficiency_mod[decision] 	= round(organ_stats[1] * modifier, 1)
+		specific_organ_size_mod 		+= round(organ_stats[2] * modifier, 0.01)
+		max_blood_storage_mod			+= round(organ_stats[3] * modifier, 1)
+		blood_req_mod 					+= round(organ_stats[4] * modifier, 0.01)
+		nutriment_req_mod 				+= round(organ_stats[5] * modifier, 0.01)
+		oxygen_req_mod 					+= round(organ_stats[6] * modifier, 0.01)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -106,7 +106,16 @@
 	if(user.stats?.getStat(STAT_BIO) > STAT_LEVEL_BASIC)
 		to_chat(user, SPAN_NOTICE("Organ size: [specific_organ_size]"))
 	if(user.stats?.getStat(STAT_BIO) > STAT_LEVEL_EXPERT)
+		var/organs
+		for(var/organ in organ_efficiency)
+			organs += organ + " ([organ_efficiency[organ]]), "
+		organs = copytext(organs, 1, length(organs) - 1)
+
 		to_chat(user, SPAN_NOTICE("Requirements: <span style='color:red'>[blood_req]</span>/<span style='color:blue'>[oxygen_req]</span>/<span style='color:orange'>[nutriment_req]</span>"))
+		to_chat(user, SPAN_NOTICE("Organ tissues present (efficiency): <span style='color:pink'>[organs ? organs : "none"]</span>"))
+
+		if(item_upgrades.len)
+			to_chat(user, SPAN_NOTICE("Organ grafts present ([item_upgrades.len]/[max_upgrades]). Use a laser cutting tool to remove."))
 
 /obj/item/organ/internal/is_usable()
 	return ..() && !is_broken()

--- a/code/modules/organs/internal/bones.dm
+++ b/code/modules/organs/internal/bones.dm
@@ -87,6 +87,34 @@ obj/item/organ/internal/bone/add_initial_transforms()
 		name = "reinforced [name]"
 		icon_state = "reinforced_[icon_state]"
 
+/obj/item/organ/internal/bone/refresh_upgrades()
+	name = initial(name)
+	color = initial(color)
+	max_upgrades = initial(max_upgrades)
+	prefixes = list()
+	min_bruised_damage = initial(min_bruised_damage)
+	min_broken_damage = initial(min_broken_damage)
+	max_damage = initial(max_damage)
+	owner_verbs = initial(owner_verbs)
+	organ_efficiency = initial_organ_efficiency.Copy()
+	scanner_hidden = initial(scanner_hidden)
+	unique_tag = initial(unique_tag)
+	specific_organ_size = initial(specific_organ_size)
+	max_blood_storage = initial(max_blood_storage)
+	current_blood = initial(current_blood)
+	blood_req = initial(blood_req)
+	nutriment_req = initial(nutriment_req)
+	oxygen_req = initial(oxygen_req)
+
+	if(reinforced)
+		reinforced = FALSE
+		reinforce()
+
+	LEGACY_SEND_SIGNAL(src, COMSIG_APPVAL, src)
+
+	for(var/prefix in prefixes)
+		name = "[prefix] [name]"
+
 /obj/item/organ/internal/bone/chest
 	name = "ribcage"
 	icon_state = "ribcage"

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -1493,7 +1493,7 @@
 #include "code\modules\aberrants\organs\mods\component\output.dm"
 #include "code\modules\aberrants\organs\mods\component\process.dm"
 #include "code\modules\aberrants\organs\mods\component\special.dm"
-#include "code\modules\aberrants\organs\mods\component\stromal.dm"
+#include "code\modules\aberrants\organs\mods\component\upgrades.dm"
 #include "code\modules\aberrants\organs\reagents\hormones.dm"
 #include "code\modules\acting\acting_items.dm"
 #include "code\modules\admin\admin.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bugfixes and changes made based on feedback.

## Changelog
:cl:
balance: Organ mod installation, adjustment, and removal are easier without a perk
balance: Intracrinal organoids increase a given stat by 5, intracrinal membranes increase it by 10
balance: Parenchymal mods can be adjusted
balance: Parenchymal membranes have doubled base efficiency, but only one organ type
balance: Organ mod price tag reduced to 25
balance: Vendor aberrant organs tweaked to have type 2 hormones and 2u reagent output
tweak: Internal organs show efficiencies and mods at 40 BIO
fix: Kidney efficiency mods are no longer halved
fix: Fixed an issue where organs with new efficiencies weren't being added correctly when modded during surgery
fix: Fixes bone bracing buff being overwritten by mods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
