### PR TITLE
Job Alternative Names Updates

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -46,7 +46,7 @@
 	spawn_positions = 2
 	supervisors = "the Chief Executive Officer"
 	difficulty = "Easy."
-	alt_titles = list("Culinary Artist","Cook")
+	alt_titles = list("Culinary Artist","Cook", "Line Chef", "Head Chef")
 	selection_color = "#dddddd"
 	health_modifier = -10
 	access = list(access_hydroponics, access_bar, access_kitchen)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -46,7 +46,7 @@
 	spawn_positions = 2
 	supervisors = "the Chief Executive Officer"
 	difficulty = "Easy."
-	alt_titles = list("Culinary Artist","Cook", "Line Chef", "Head Chef")
+	alt_titles = list("Culinary Artist","Cook", "Line Chef")
 	selection_color = "#dddddd"
 	health_modifier = -10
 	access = list(access_hydroponics, access_bar, access_kitchen)

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -76,7 +76,7 @@
 	selection_color = "#d5c88f"
 	wage = WAGE_PROFESSIONAL
 	outfit_type = /decl/hierarchy/outfit/job/engineering/engineer
-	alt_titles = list("Guild Trainee","Guild Electrician", "Guild Tinkerer", "Guild Pipefitter")
+	alt_titles = list("Guild Trainee","Guild Electrician", "Guild Mechanical Engineer")
 	noob_name = "Guild Trainee"
 	access = list(
 		access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -69,7 +69,7 @@ Counsel the council on directing the colony towards profitable opportunities."
 	spawn_positions = 4
 	supervisors = "the Chief Executive Officer"
 	difficulty = "Easy."
-	alt_titles = list("Cargo Specialist", "Lonestar Sales Technician", "Lonestar Salesclerk")
+	alt_titles = list("Cargo Specialist", "Lonestar Sales Technician", "Lonestar Retail Assistant")
 	selection_color = "#c3b9a6"
 	wage = WAGE_LABOUR_DUMB
 	department_account_access = TRUE
@@ -123,7 +123,7 @@ Avoid the deeper tunnels unless otherwise instructed, however - this domain is h
 	spawn_positions = 4
 	supervisors = "the Chief Executive Officer"
 	difficulty = "Easy."
-	alt_titles = list("Lonestar Drill Technician","Lonestar Digger","Mining Specialist","Junior Lonestar Miner","Ameridian Gatherer")
+	alt_titles = list("Lonestar Drill Technician", "Junior Lonestar Miner")
 	selection_color = "#c3b9a6"
 	wage = WAGE_LABOUR_HAZARD //The miners union is stubborn
 	health_modifier = 5

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -110,7 +110,7 @@
 	join_tag = /datum/job/doctor
 
 /datum/job/recovery_team
-	title = "Emergency Medical Technician"
+	title = "Soteria 'Lifeline' Technician"
 	flag = RECOVERYTEAM
 	department = DEPARTMENT_MEDICAL
 	department_flag = MEDICAL
@@ -121,7 +121,6 @@
 	difficulty = "Ungratifying."
 	selection_color = "#a8b69a"
 	wage = WAGE_PROFESSIONAL
-	alt_titles = list("Soteria Paramedic", "Soteria Internal Security Office")
 	outfit_type = /decl/hierarchy/outfit/job/medical/recovery_team
 	disallow_species = list(FORM_AGSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -110,7 +110,7 @@
 	join_tag = /datum/job/doctor
 
 /datum/job/recovery_team
-	title = "Soteria Client Recovery Specialist"
+	title = "Emergency Medical Technician"
 	flag = RECOVERYTEAM
 	department = DEPARTMENT_MEDICAL
 	department_flag = MEDICAL
@@ -121,7 +121,7 @@
 	difficulty = "Ungratifying."
 	selection_color = "#a8b69a"
 	wage = WAGE_PROFESSIONAL
-	alt_titles = list("Soteria Emergency Medical Technician")
+	alt_titles = list("Soteria Paramedic", "Soteria Internal Security Office")
 	outfit_type = /decl/hierarchy/outfit/job/medical/recovery_team
 	disallow_species = list(FORM_AGSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 

--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -66,7 +66,7 @@
 	supervisors = "the Foreman"
 	difficulty = "Medium."
 	noob_name = "Rookie Salvager"
-	alt_titles = list("Rookie Salvager","Scrapper","Sapper","Junk Technician","Sawbones")
+	alt_titles = list("Sawbones", "Rookie Salvager")
 	alt_perks = list("Sawbones"=list(/datum/perk/medicalexpertise, /datum/perk/stalker), "Junk Technician"=list(/datum/perk/junkborn, /datum/perk/robotics_expert))
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR
@@ -115,8 +115,8 @@
 	spawn_positions = 2
 	supervisors = "the Foreman"
 	difficulty = "Medium."
-	noob_name = "Greenhorn Prospector"
-	alt_titles = list("Greenhorn Prospector","Enforcer","Frontiersmen","Triggerman")
+	noob_name = "Rookie Prospector"
+	alt_titles = list("Rookie Prospector", "Hired Muscle")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_DUMB
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -119,7 +119,7 @@
 	supervisors = "the Chief Research Overseer"
 	difficulty = "Medium."
 	noob_name = "Soteria Roboticist Trainee"
-	alt_titles = list("Soteria Roboticist Trainee","Soteria Roboticist Fabricator", "Soteria Cyberneticist", "Soteria Mechanist", "Soteria Biomechanical Engineer")
+	alt_titles = list("Soteria Roboticist Trainee", "Soteria Cyberneticist", "Soteria Mechanist", "Soteria Biomechanical Engineer")
 	selection_color = "#bdb1bb"
 	wage = WAGE_PROFESSIONAL
 	department_account_access = TRUE

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -246,8 +246,8 @@
 	spawn_positions = 2
 	supervisors = "the Warrant Officer"
 	difficulty = "Hard."
-	noob_name = "Gumshoe"
-	alt_titles = list("Gumshoe","Detective","Forensics Specialist")
+	noob_name = "Junior Ranger"
+	alt_titles = list("Junior Ranger","Detective","Forensics Specialist")
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
 	playtimerequired = 1200
@@ -295,7 +295,7 @@
 
 
 /datum/job/medspec
-	title = "Corpsman"
+	title = "Combat Medic"
 	flag = MEDSPEC
 	department = DEPARTMENT_SECURITY
 	department_flag = SECURITY
@@ -305,7 +305,7 @@
 	supervisors = "the Blackshield Commander"
 	difficulty = "Hard."
 	noob_name = "Corpsman Recruit"
-	alt_titles = list("Corpsman Recruit","Combat Medic","Combat Surgeon")
+	alt_titles = list("Medic Cadet")
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
 	health_modifier = 5
@@ -361,7 +361,7 @@
 	supervisors = "the Blackshield Commander"
 	difficulty = "Hard."
 	noob_name = "Blackshield Cadet"
-	alt_titles = list("Blackshield Cadet","Blackshield Militiamen")
+	alt_titles = list("Blackshield Cadet", "Blackshield Heavy Trooper", "Blackshield Designated Marksman", "Blackshield Recon Specialist")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
 	health_modifier = 10
@@ -414,7 +414,7 @@
 	supervisors = "the Warrant Officer"
 	difficulty = "Hard."
 	noob_name = "Field Training Marshal"
-	alt_titles = list("Field Training Marshal","Marshal Civil Servant")
+	alt_titles = list("Junior Marshal Office")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
 	health_modifier = 10

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -305,7 +305,7 @@
 	supervisors = "the Blackshield Commander"
 	difficulty = "Hard."
 	noob_name = "Corpsman Cadet"
-	alt_titles = list("Medical Cadet", "Combat Medic")
+	alt_titles = list("Corpsman Cadet", "Combat Medic")
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
 	health_modifier = 5

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -304,7 +304,7 @@
 	spawn_positions = 2
 	supervisors = "the Blackshield Commander"
 	difficulty = "Hard."
-	noob_name = "Medical Cadet"
+	noob_name = "Corpsman Cadet"
 	alt_titles = list("Medical Cadet", "Combat Medic")
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -295,7 +295,7 @@
 
 
 /datum/job/medspec
-	title = "Combat Medic"
+	title = "Corpsman"
 	flag = MEDSPEC
 	department = DEPARTMENT_SECURITY
 	department_flag = SECURITY
@@ -305,7 +305,7 @@
 	supervisors = "the Blackshield Commander"
 	difficulty = "Hard."
 	noob_name = "Medical Cadet"
-	alt_titles = list("Medical Cadet")
+	alt_titles = list("Medical Cadet", "Combat Medic")
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
 	health_modifier = 5

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -413,7 +413,7 @@
 	spawn_positions = 4
 	supervisors = "the Warrant Officer"
 	difficulty = "Hard."
-	noob_name = "Field Training Marshal"
+	noob_name = "Junior Marshal Officer"
 	alt_titles = list("Junior Marshal Officer")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -361,7 +361,7 @@
 	supervisors = "the Blackshield Commander"
 	difficulty = "Hard."
 	noob_name = "Blackshield Cadet"
-	alt_titles = list("Blackshield Cadet", "Blackshield Heavy Trooper", "Blackshield Designated Marksman", "Blackshield Recon Specialist")
+	alt_titles = list("Blackshield Cadet")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
 	health_modifier = 10

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -414,7 +414,7 @@
 	supervisors = "the Warrant Officer"
 	difficulty = "Hard."
 	noob_name = "Field Training Marshal"
-	alt_titles = list("Junior Marshal Office")
+	alt_titles = list("Junior Marshal Officer")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
 	health_modifier = 10

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -304,8 +304,8 @@
 	spawn_positions = 2
 	supervisors = "the Blackshield Commander"
 	difficulty = "Hard."
-	noob_name = "Corpsman Recruit"
-	alt_titles = list("Medic Cadet")
+	noob_name = "Medical Cadet"
+	alt_titles = list("Medical Cadet")
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
 	health_modifier = 5


### PR DESCRIPTION
A simple PR that's entire purpose is to fix alternative job names basically being nicknames and inconsistencies that just cause confusion. Prospector having a job called "enforcer" for example is a good example of it. Also changing corpsman to field medic, seeing as the blackshield are not a navy so them using a navy term for their medic has always been confusing, might require some other name changes to match, I'll see how it goes.