### PR TITLE
Lodge wiring and soap

### DIFF
--- a/maps/_HunterLodge/map/_Hunting_Lodge.dmm
+++ b/maps/_HunterLodge/map/_Hunting_Lodge.dmm
@@ -265,10 +265,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
-"bl" = (
-/obj/machinery/power/solar,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/outside/forest/hunting_lodge)
 "bn" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/cafe,
@@ -2604,6 +2600,7 @@
 	dir = 4;
 	icon_state = "term"
 	},
+/obj/structure/cable,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/forest/hunting_lodge)
 "vA" = (
@@ -3998,6 +3995,7 @@
 /obj/item/storage/bag/produce,
 /obj/item/storage/bag/produce,
 /obj/item/storage/bag/produce,
+/obj/item/soap/hunters,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "On" = (
@@ -6263,7 +6261,7 @@ ct
 pw
 pw
 dv
-bl
+dT
 BO
 RE
 CO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds two wires to the Lodge's solar array, one under a panel that was missing a connection, the other underneath the SMES' terminal since currently it can only output, not input, so this lets it act as a proper battery.

Adds a bar of soap in the Barn for blood since it used to have one already inside the old farm shack.

Testing:
Compiled and ran it on a local server, panel now moved along with all the others and the SMES when given a surplus of energy, charged instead of staying at 20% or depleting.

The solar array has a fair amount of vestigial wiring leading to nowhere still, but unless that's deemed problematic by the dev team I'm not messing with it, since it's doing nothing.

First time using StrongDMM so let me know if there's been any sort of change that's not the above two, or any mistake.

## Changelog
:cl:
add: Added a bar of soap for the Lodge barn
fix: Fixed the Lodge's solar array and SMES
/:cl:
