### PR TITLE
Wake the fuck up, Samurai. We have a city to var/fire_stack

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -266,3 +266,5 @@
 /obj/proc/multiply_projectile_agony(newmult)
 
 /obj/proc/multiply_pve_damage(newmult)
+
+/obj/proc/add_fire_stacks(newmult)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -41,6 +41,7 @@
 	var/move_delay = 1
 	var/fire_sound = 'sound/weapons/Gunshot.ogg'
 	var/modded_sound = FALSE
+	var/fire_stacks = 0 //Should we apply fire stacks on hit?
 
 	var/fire_sound_text = "gunshot"
 	var/rigged = FALSE
@@ -453,6 +454,9 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 			projectile.multiply_pve_damage(multiply_pve_damage)
 
 		projectile.multiply_pve_damage(proj_pve_damage_multiplier)
+
+		if(fire_stacks)
+			projectile.add_fire_stacks(fire_stacks)
 
 		if(muzzle_flash)
 			set_light(muzzle_flash)

--- a/code/modules/projectiles/guns/projectile/pistol/silver_eye.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/silver_eye.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/projectile/silvereye
 	name = "\"Silver-Eye\" heavy pistol"
-	desc = "A silver plated Basilisk heavy pistol, customized with specialized counterweights to assist with recoil handling. Gifted to the Foreman by Over-Boss Jeremiah Hogg in exchange for their wrangling of the prospector team. Uses 12mm rounds."
+	desc = "A silver plated Basilisk heavy pistol, customized with specialized counterweights to assist with recoil handling. Gifted to the Foreman by Over-Boss Jeremiah Hogg in exchange for their wrangling of the prospector team. This model is capable of literally atomising its rounds to fire a short-range blast of fire. Shiny, powerful and barely legal - just like all the best loot. Uses 12mm rounds."
 	icon = 'icons/obj/guns/projectile/silvereye.dmi'
 	icon_state = "silvereye"
 	item_state = "silvereye"
@@ -16,6 +16,12 @@
 	init_recoil = HANDGUN_RECOIL(1.1)
 	penetration_multiplier = 1
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_CALIBRE_12MM)
+
+	init_firemodes = list(
+		list(mode_name = "semiauto",  mode_desc = "Fire as fast as you can pull the trigger", burst=1, fire_delay=0.2, fire_stacks=0, move_delay=null, icon="semi"),
+		list(mode_name="fire blast", mode_desc="Consumes one round to fire a burst of flame.", burst=1, fire_delay=0.2, fire_stacks=3, penetration_multiplier = 0.5, damage_multiplier = 0.9, icon="kill") //Worse than Kurtz incendiary.
+		)
+
 	reload_sound 	= 'sound/weapons/guns/interact/reload_silver.ogg'
 	fire_sound = 'sound/weapons/guns/fire/fire_silver.ogg'
 	serial_type = "NM"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -188,7 +188,7 @@
 	added_damage_laser_pve  = initial(added_damage_laser_pve) * newmult
 
 /obj/item/projectile/add_fire_stacks(newmult)
-	fire_stacks = newmult
+	fire_stacks = initial(fire_stacks) + newmult
 
 // bullet/pellets redefines this
 /obj/item/projectile/proc/adjust_damages(var/list/newdamages)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -79,6 +79,7 @@
 	var/agony = 0
 	var/embed = 0 // whether or not the projectile can embed itself in the mob
 	var/knockback = 0
+	var/fire_stacks = 0 //Whether to apply fire stacks
 
 	var/shrapnel_type //Do we have a special thing to embed in the target? If this is null, it will embed a generic 'shrapnel' item.
 
@@ -186,6 +187,9 @@
 	added_damage_bullet_pve = initial(added_damage_bullet_pve) * newmult
 	added_damage_laser_pve  = initial(added_damage_laser_pve) * newmult
 
+/obj/item/projectile/add_fire_stacks(newmult)
+	fire_stacks = newmult
+
 // bullet/pellets redefines this
 /obj/item/projectile/proc/adjust_damages(var/list/newdamages)
 	if(!newdamages.len)
@@ -203,6 +207,10 @@
 		return FALSE
 	var/mob/living/L = target
 	if (!testing)
+		if(fire_stacks && iscarbon(L))
+			L.adjust_fire_stacks(fire_stacks)
+			L.IgniteMob()
+			src.visible_message(SPAN_WARNING("\The [src] sets [target] on fire!"))
 		L.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy)
 	return TRUE
 

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -696,16 +696,9 @@
 /obj/item/projectile/bullet/shotgun/incendiary
 	//This is the best ammo for pvp in a shotgun, beating the stunshell with its pain and cooks anyone in any armor!
 	damage_types = list(BURN = 22.5) //We deal most of are damage with fire stacks
-	var/fire_stacks = 4 //40 pain a fire proc through ALL armor!
+	fire_stacks = 4 //40 pain a fire proc through ALL armor!
 	recoil = 38
 	added_damage_laser_pve = 22.5
-
-/obj/item/projectile/bullet/shotgun/incendiary/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(iscarbon(target) && !testing)
-		var/mob/living/carbon/M = target
-		M.adjust_fire_stacks(fire_stacks)
-		M.IgniteMob()
 
 /obj/item/projectile/bullet/shotgun/scrap
 	damage_types = list(BRUTE = 27)
@@ -772,15 +765,8 @@
 	embed = FALSE
 	can_ricochet = FALSE
 	knockback = 0
-	var/fire_stacks = 4
+	fire_stacks = 4
 	recoil = 17
-
-/obj/item/projectile/bullet/kurtz_50/incendiary/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(iscarbon(target) && !testing)
-		var/mob/living/carbon/M = target
-		M.adjust_fire_stacks(fire_stacks)
-		M.IgniteMob()
 
 /obj/item/projectile/bullet/heavy_rifle_408/railgun
 	can_ricochet = FALSE
@@ -797,15 +783,15 @@
 	can_ricochet = FALSE
 	knockback = 0
 	recoil = 18
-	var/fire_stacks = 4
-
+	fire_stacks = 4
+/*
 /obj/item/projectile/bullet/lrifle/incendiary/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(iscarbon(target) && !testing)
 		var/mob/living/carbon/M = target
 		M.adjust_fire_stacks(fire_stacks)
 		M.IgniteMob()
-
+*/
 //Gauss rifle
 /obj/item/projectile/bullet/gauss
 	name = "gauss"
@@ -884,7 +870,7 @@
 	damage_types = list(BRUTE = 15)
 	agony = 5
 	knockback = 1
-	var/fire_stacks = 2
+	fire_stacks = 2
 	armor_penetration = 10
 	nocap_structures = TRUE
 	check_armour = ARMOR_BOMB
@@ -893,15 +879,6 @@
 	step_delay = 0.9
 	recoil = 25
 	added_damage_bullet_pve = 15
-
-/obj/item/projectile/bullet/shotgun/payload/on_impact(atom/target)
-	if (!testing)
-		explosion(target, 0, 0, 3)
-		if(iscarbon(target))
-			var/mob/living/carbon/M = target
-			M.adjust_fire_stacks(fire_stacks)
-			M.IgniteMob()
-	return TRUE
 
 //Miscellaneous
 /obj/item/projectile/bullet/blank

--- a/code/modules/projectiles/projectile/plasma_aoe.dm
+++ b/code/modules/projectiles/projectile/plasma_aoe.dm
@@ -9,7 +9,7 @@
 	var/heat_damage = 0 // FALSE or 0 to disable
 	var/emp_strength = 0 // Divides the effects by this amount, FALSE or 0 to disable
 
-	var/fire_stacks = FALSE
+	fire_stacks = FALSE
 	recoil = 30
 
 /obj/item/projectile/plasma/aoe/on_hit(atom/target)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -265,15 +265,7 @@
 	damage_types = list(BURN = 16)
 	check_armour = ARMOR_MELEE
 	kill_count = 3
-	var/fire_stacks = 3
-
-/obj/item/projectile/flamer_lob/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if (!testing)
-		if(isliving(target))
-			var/mob/living/M = target
-			M.adjust_fire_stacks(fire_stacks)
-			M.IgniteMob()
+	fire_stacks = 3
 
 /obj/item/projectile/flamer_lob/Move(atom/A)
 	..()
@@ -298,7 +290,7 @@
 	luminosity_power = 1
 	luminosity_color = COLOR_LIGHTING_RED_MACHINERY //Makes it not as blindingly red
 	luminosity_ttl = 1
-	var/fire_stacks = 1
+	fire_stacks = 1
 	var/flash_range = 1
 	var/light_duration = 1800
 	var/brightness = 10
@@ -317,16 +309,6 @@
 			luminosity_color = chaose_number
 
 	..()
-
-/obj/item/projectile/bullet/flare/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if (!testing)
-		if(iscarbon(target))
-			var/mob/living/carbon/M = target
-			playsound(src, 'sound/effects/Custom_flare.ogg', 100, 1)
-			M.adjust_fire_stacks(fire_stacks)
-			M.IgniteMob()
-			src.visible_message(SPAN_WARNING("\The [src] sets [target] on fire!"))
 
 /obj/item/projectile/bullet/flare/on_impact(var/atom/A)
 	var/turf/T = flash_range? src.loc : get_turf(A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Totally reworks incendiary projectiles. Rather than having a specially defined on_hit proc for every single projectile that inflicts fire stacks, every projectile has a fire_stacks var set to 0 by default, and will inflict stacks if that var _isn't_ 0. In addition, every gun has a fire_stacks variable that gets added to the fire_stacks of the projectile (if it's more than 0).
**In other words: any ammo type or firearm can be made incendiary by simply setting the fire_stacks var.**

This _also_ adds a new firemode to the Silver-Eye, the Foreman's unique heavy pistol. It's pretty clearly based on the Malorian Arms 3516 of Cyberpunk, so this firemode is intended to replicate the unique ability of the gun in that game - to shoot a short-range fire blast. The new firemode for the Silver-Eye shoots a low-penetration, reduced-damage projectile that inflicts 3 fire stacks. **These numbers are subject to tuning!** I deliberately erred on the weaker side with this.
<hr>
</details>

## Changelog
:cl:
tweak: the Foreman's Silver-Eye pistol now has an incendiary alt-fire
refactor: reworked incendiary projectiles to not require a special proc for every single one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
