### PR TITLE
guns and robo fixes

### DIFF
--- a/code/datums/outfits/jobs/off_colony.dm
+++ b/code/datums/outfits/jobs/off_colony.dm
@@ -51,5 +51,5 @@
 	l_ear = /obj/item/tool/knife/shiv // Let's see if this frees up backpack content space.
 	id_type = FALSE
 	pda_type = FALSE
-	backpack_contents = list(/obj/item/storage/firstaid/outsider = 1, /obj/item/reagent_containers/food/drinks/flask/lithium = 1)
+	backpack_contents = list(/obj/item/storage/hcases/ammo/scrap/outsider = 1)
 

--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -10,7 +10,9 @@
 		/datum/job/cmo,
 		/datum/job/chief_engineer,
 		/datum/job/smc,
-		/datum/job/outsider
+		/datum/job/outsider,
+		/datum/job/cyborg, //To stop people auto dropping these
+		/datum/job/ai
 		)
 	allowed_depts = CHURCH
 	allow_modifications = TRUE
@@ -43,7 +45,9 @@
 		/datum/job/merchant,
 		/datum/job/rd,
 		/datum/job/smc,
-		/datum/job/swo
+		/datum/job/swo,
+		/datum/job/cyborg, //To stop people auto dropping these
+		/datum/job/ai
 	) // The way to restrict this to one job could be done cleaner but this way easier so fuck it. -Kaz
 	allow_modifications = FALSE
 	restricted_depts = SECURITY | PROSPECTORS | ENGINEERING | SCIENCE | CHURCH | INDEPENDENT | CIVILIAN | LSS
@@ -73,7 +77,9 @@
 		/datum/job/merchant,
 		/datum/job/rd,
 		/datum/job/smc,
-		/datum/job/swo
+		/datum/job/swo,
+		/datum/job/cyborg, //To stop people auto dropping these
+		/datum/job/ai
 		)
 	allow_modifications = TRUE
 	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_AGSYNTH)
@@ -85,7 +91,9 @@
 	particular design is an opifex original and one of the best that can be found in the galaxy."
 	implant_organ_type = "opifex nanogate"
 	restricted_jobs = list(
-		/datum/job/outsider // Nanogates are only available to colonist or allies.
+		/datum/job/outsider, // Nanogates are only available to colonist or allies.
+		/datum/job/cyborg, //To stop people auto dropping these
+		/datum/job/ai
 		)
 	allow_modifications = TRUE
 	restricted_to_species = list(FORM_OPIFEX) // Opifex get their own fancy nanogate

--- a/code/game/objects/items/weapons/storage/hardcases.dm
+++ b/code/game/objects/items/weapons/storage/hardcases.dm
@@ -268,6 +268,19 @@ obj/item/storage/hcases/attackby(obj/item/W, mob/user)
 	desc = "A lacquer coated ammo can. Can hold ammo magazines, boxes, and bullets. Alt+click to open and close."
 	max_storage_space = DEFAULT_SMALL_STORAGE * 1.3 //a better fancy box
 
+/obj/item/storage/hcases/ammo/scrap/outsider
+	exspand_when_spawned = FALSE //No exspanding cheats
+
+/obj/item/storage/hcases/ammo/scrap/outsider/populate_contents()
+	new /obj/random/gun_handmade/willspawn(src)
+	new /obj/item/device/lighting/toggleable/flashlight(src)
+	new /obj/item/cell/small/high(src)
+	new /obj/item/cell/medium/high(src)
+	new /obj/item/ammo_kit(src)
+	new /obj/item/storage/firstaid/outsider(src)
+	new /obj/item/reagent_containers/food/drinks/flask/lithium(src)
+
+
 //////////////////////////////////////////Cards//////////////////////////////////////////
 
 /obj/item/storage/hcases/cardcarp
@@ -389,7 +402,6 @@ obj/item/storage/hcases/attackby(obj/item/W, mob/user)
 	new /obj/item/modular_computer/tablet/moebius/preset(src)
 	new /obj/item/gun/projectile/clarissa/moebius/preloaded_cbo(src)
 	new /obj/item/gun_upgrade/trigger/dnalock(src)
-	new /obj/item/gun_upgrade/muzzle/silencer(src)
 
 /obj/item/storage/hcases/med/medical_job_trama
 	exspand_when_spawned = FALSE //No exspanding cheats

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -42,7 +42,6 @@
 
 /datum/component/item_upgrade/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_IATTACK, .proc/attempt_install)
-	RegisterSignal(parent, COMSIG_ATTACKBY, .proc/attempt_install)
 	RegisterSignal(parent, COMSIG_EXAMINE, .proc/on_examine)
 	RegisterSignal(parent, COMSIG_REMOVE, .proc/uninstall)
 

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -199,6 +199,33 @@
 	spawn_nothing_percentage = 80
 
 
+/obj/random/gun_handmade
+	name = "random handmade gun weapon"
+	icon_state = "gun-black"
+	spawn_nothing_percentage = 30
+
+/obj/random/gun_handmade/item_to_spawn()
+	return pickweight(list(/obj/item/gun/projectile/handmade_pistol = 1,\
+				/obj/item/gun/projectile/handmade_pistol/magnum = 1,\
+				/obj/item/gun/projectile/handmade_pistol/shotgun = 1,\
+				/obj/item/gun/projectile/handmade_pistol/anti_material = 1,\
+				/obj/item/gun/projectile/revolver/handmade = 1,\
+				/obj/item/gun/projectile/boltgun/handmade = 1,\
+				/obj/item/gun/projectile/shotgun/slidebarrel = 1,\
+				/obj/item/gun/energy/laser/makeshift = 1,\
+				/obj/item/gun/energy/lasersmg = 0.5,\
+				/obj/item/gun/energy/lasersmg/alt = 0.5,))
+
+/obj/random/gun_handmade/willspawn
+	name = "will spawn random handmade gun weapon"
+	spawn_nothing_percentage = 0
+	icon_state = "gun-black-hight"
+
+/obj/random/gun_handmade/low_chance
+	name = "low chance random handmade gun weapon"
+	icon_state = "gun-black-low"
+	spawn_nothing_percentage = 80
+
 /obj/random/gun_shotgun
 	name = "random shotgun"
 	icon_state = "gun-red"
@@ -283,6 +310,7 @@
 /obj/random/dungeon_gun_mods
 	name = "random gun mod"
 	icon_state = "gun-red"
+
 /obj/random/dungeon_gun_mods/item_to_spawn()
 	return pickweight(list(/obj/item/gun_upgrade/muzzle/silencer = 1,
 				/obj/item/gun_upgrade/muzzle/pain_maker = 0.3,
@@ -293,6 +321,8 @@
 				/obj/item/gun_upgrade/barrel/excruciator = 1,
 				/obj/item/gun_upgrade/trigger/dangerzone = 1,
 				/obj/item/gun_upgrade/trigger/cop_block = 0.5,
+				/obj/item/gun_upgrade/magwell/auto_eject = 0.5,
+				/obj/item/gun_upgrade/magwell/auto_eject/no_removal = 0.5,
 				/obj/item/gun_upgrade/mechanism/overshooter = 1,
 				/obj/item/gun_upgrade/mechanism/weintraub = 1,
 				/obj/item/gun_upgrade/mechanism/reverse_loader = 0.5,
@@ -309,11 +339,14 @@
 				/obj/item/gun_upgrade/mechanism/greyson_master_catalyst = 0.01))
 
 /obj/random/dungeon_gun_mods/low_chance
-	name = "low chance random gun  mod"
+	name = "low chance random gun mod"
 	icon_state = "gun-red-low"
 	spawn_nothing_percentage = 80
 
 /obj/random/dungeon_gun_mods/voidwolf
+	name = "random voidwolf good only gun mod"
+	icon_state = "gun-red-low"
+	spawn_nothing_percentage = 0
 
 /obj/random/dungeon_gun_mods/voidwolf/item_to_spawn()
 	return pickweight(list( // i hate pickweight but fine

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -629,7 +629,7 @@
 /obj/item/storage/bag/robotic/proc/add_to_storage(obj/item/target_item as obj)
 
 	if(max_w_class < target_item.w_class)
-		to_chat(usr, SPAN_NOTICE("[src] can not fit inside."))
+		to_chat(usr, SPAN_NOTICE("[target_item] can not fit inside."))
 		return FALSE
 
 

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -627,17 +627,18 @@
 	return TRUE
 
 /obj/item/storage/bag/robotic/proc/add_to_storage(obj/item/target_item as obj)
+
+	if(max_w_class < target_item.w_class)
+		to_chat(usr, SPAN_NOTICE("[src] can not fit inside."))
+		return FALSE
+
+
 	if(used_storage_space < max_storage_space)
 		var/transfer //Used to track how much was transferred between stacks.
 		var/overfill_amount //Used to track just how much the bag would get filled over it's capacity.
 		if(istype(target_item, /obj/item/stack) && is_type_in_list(target_item, can_hold) || can_hold.len == 0 && !is_type_in_list(target_item, cant_hold))
 		//Checking if the item is a stack since they are processed differently, and if the item is allowed.
 			var/obj/item/stack/S = target_item
-
-			if(max_w_class < target_item.w_class)
-				to_chat(usr, SPAN_NOTICE("[src] can not fit inside."))
-				return FALSE
-
 			if(is_type_in_list(S, contents)) //Checking if the bag contains item's type to avoid needless looping.
 				for(var/obj/item/stack/current_stack in contents)
 					if(current_stack.amount < current_stack.max_amount)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -633,6 +633,11 @@
 		if(istype(target_item, /obj/item/stack) && is_type_in_list(target_item, can_hold) || can_hold.len == 0 && !is_type_in_list(target_item, cant_hold))
 		//Checking if the item is a stack since they are processed differently, and if the item is allowed.
 			var/obj/item/stack/S = target_item
+
+			if(max_w_class < target_item.w_class)
+				to_chat(usr, SPAN_NOTICE("[src] can not fit inside."))
+				return FALSE
+
 			if(is_type_in_list(S, contents)) //Checking if the bag contains item's type to avoid needless looping.
 				for(var/obj/item/stack/current_stack in contents)
 					if(current_stack.amount < current_stack.max_amount)
@@ -775,7 +780,7 @@
 	w_class = ITEM_SIZE_BULKY
 	max_storage_space = DEFAULT_BULKY_STORAGE * 2
 	max_w_class = ITEM_SIZE_SMALL
-	can_hold = list()
+	can_hold = list(/obj/item) //hacky fix maybe to let them pick up items
 	cant_hold = list(/obj/item/disk/nuclear)
 
 /obj/item/storage/bag/robotic/trash/autoload(mob/user as mob)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -286,6 +286,8 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/form_printer(src)
 	src.modules += new /obj/item/gripper/paperwork(src)
 	src.modules += new /obj/item/device/gps(src)
+	src.modules += new /obj/item/gripper/ammo(src)
+	src.modules += new /obj/item/gun/projectile/clarissa/moebius/auto_eject(src)
 	src.emag += new /obj/item/melee/energy/sword(src)
 
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
@@ -384,6 +386,8 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/form_printer(src)
 	src.modules += new /obj/item/gripper/paperwork(src)
 	src.modules += new /obj/item/device/gps(src)
+	src.modules += new /obj/item/gripper/ammo(src)
+	src.modules += new /obj/item/gun/projectile/clarissa/moebius/auto_eject(src)
 	src.emag += new /obj/item/reagent_containers/spray/acid(src)
 
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
@@ -722,7 +726,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/scanner/price(src)
 	src.modules += new /obj/item/gripper/service(src)
 	src.modules += new /obj/item/soap/deluxe(src)
-	src.modules += new /obj/item/storage/bag/robotic/trash/(src)
+	src.modules += new /obj/item/storage/bag/robotic/trash(src)
 	src.modules += new /obj/item/mop(src)
 	src.modules += new /obj/item/device/lightreplacer(src)
 	src.modules += new /obj/item/reagent_containers/glass/bucket(src) // a hydroponist's bucket
@@ -734,6 +738,8 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/pen/robopen(src)
 	src.modules += new /obj/item/form_printer(src)
 	src.modules += new /obj/item/gripper/paperwork(src)
+	src.modules += new /obj/item/gripper/ammo(src)
+	src.modules += new /obj/item/gun/projectile/automatic/c20r/sci(src)
 	src.emag += new /obj/item/reagent_containers/spray/lube(src)
 
 	if(R.icon_state == "mekajani")
@@ -975,6 +981,8 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/gripper/paperwork(src)
 	src.modules += new /obj/item/storage/part_replacer(src)
 	src.modules += new /obj/item/gripper/upgrade(src)
+	src.modules += new /obj/item/gripper/ammo(src)
+	src.modules += new /obj/item/gun/projectile/clarissa/moebius/auto_eject(src)
 	src.modules += new /obj/item/device/gps(src)
 	src.emag += new /obj/item/tool/pickaxe/onestar/cyborg(src)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -504,6 +504,8 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/pen/robopen(src)
 	src.modules += new /obj/item/form_printer(src)
 	src.modules += new /obj/item/gripper/paperwork(src)
+	src.modules += new /obj/item/gripper/ammo(src)
+	src.modules += new /obj/item/gun/projectile/clarissa/moebius/auto_eject(src)
 	src.emag += new /obj/item/tool/baton/robot(src)
 
 	var/datum/matter_synth/metal = new /datum/matter_synth/metal(80000)

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -731,7 +731,25 @@
 	GUN_UPGRADE_AUTOEJECT = TRUE)
 	I.req_gun_tags = list(GUN_MAGWELL)
 	I.gun_loc_tag = GUN_MAGWELL
-	I.prefix = "auto dropped"
+	I.prefix = "auto dropping"
+
+//Fancy verson
+/obj/item/gun_upgrade/magwell/auto_eject/no_removal
+	name = "SI \"Faller\" Magwell Clearer"
+	desc = "A rather oddly designed magwell clearing device that when added to guns that have an auto-eject magwell prevent it, if it dosn't prevent an auto-eject it will force the magwel itself out! When force-ejecting a mag, will play a beeping sound.\
+	Unlike the other versons on the market this was once added will not be removable as it replaces key components to be as seemless as possable."
+	can_remove = FALSE
+	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_PLASTEEL = 1, MATERIAL_GLASS = 2, MATERIAL_SILVER = 1, MATERIAL_GOLD = 1)
+
+/obj/item/gun_upgrade/magwell/auto_eject/no_removal/New()
+	..()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.weapon_upgrades = list(
+	GUN_UPGRADE_AUTOEJECT = TRUE)
+	I.req_gun_tags = list(GUN_MAGWELL)
+	I.gun_loc_tag = GUN_MAGWELL
+	I.prefix = "intrigated dropping"
+
 
 //Underbarrel aka bipods
 

--- a/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
@@ -65,7 +65,13 @@
 	price_tag = 200
 	serial_type = "SI"
 
+/obj/item/gun/projectile/clarissa/moebius/auto_eject
+	initialized_upgrades = list(/obj/item/gun_upgrade/magwell/auto_eject/no_removal
+								)
+
 /obj/item/gun/projectile/clarissa/moebius/preloaded_cbo
+	initialized_upgrades = list(/obj/item/gun_upgrade/muzzle/silencer
+								)
 
 /obj/item/gun/projectile/clarissa/moebius/preloaded_cbo/New()
 	. = ..()

--- a/code/modules/research/designs/weapon.dm
+++ b/code/modules/research/designs/weapon.dm
@@ -363,6 +363,9 @@
 	name = "Soteria \"DNA lock\" Finger Imprinter Trigger"
 	build_path = /obj/item/gun_upgrade/trigger/dnalock
 
+/datum/design/research/item/weapon/weapon_upgrade/auto_eject_no_removal
+	name = "Soteria \"Faller\" Magwell Clearer"
+	build_path = /obj/item/gun_upgrade/magwell/auto_eject/no_removal
 
 /*
 /datum/design/research/item/weapon/weapon_upgrade/isotope_diffuser

--- a/code/modules/research/nodes/combat.dm
+++ b/code/modules/research/nodes/combat.dm
@@ -28,7 +28,8 @@
 	required_tech_levels = list()
 	cost = 375
 
-	unlocks_designs = list(/datum/design/research/item/flash)
+	unlocks_designs = list(/datum/design/research/item/flash,
+						   /datum/design/research/item/weapon/weapon_upgrade/auto_eject_no_removal)
 
 
 


### PR DESCRIPTION
## About The Pull Request
New gun mod for SI the Faller - like the dropper but once added cant be removed dosnt skrink the gun nor slow its fire rate, mostly for borg guns

All borg models (other then drones) now have a gun, a 9mm minium malpractice

Outsiders now will always have a medium and small cell as well as a random makeshift weapon with an ammo kit for crafting ammo aid them in the harder spawns or worst rng cases / soft locks
Outsiders now always get a flashlight as well

Fixes a few bugs with some intractions with installing mods
Fixes cyborg trashbag not able to store items

CBO gun now spawns with its silencer attached (not the DNA lock as that could lead to issues)

You can no longer by core-implanted and selete AI or Robot as they auto-drop and such the implants making it an admin saddo issue

## Changelog
:cl:
/:cl:

Testing: Spawned in as an outsider made sure my gun worked and such
Spawned a borg and tested its trashbagging to made sure it cant hold everything ever
Performance: idk