### PR TITLE
Kitchen Freezer Area Fix

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -6902,11 +6902,6 @@
 /obj/machinery/door/airlock/freezer{
 	req_access = list(28)
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/kitchen)
 "brl" = (
@@ -29219,11 +29214,6 @@
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/kitchen)
 "fGA" = (
@@ -32169,11 +32159,6 @@
 /obj/effect/floor_decal/industrial/box/red/corners{
 	dir = 4;
 	icon_state = "box_corners_red"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/kitchen)
@@ -46055,14 +46040,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"iTq" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/crew_quarters/kitchen)
 "iTr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -93550,11 +93527,6 @@
 "rJx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -94608,11 +94580,6 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/structure/noticeboard/lonestar_service{
 	pixel_y = -31
@@ -98451,15 +98418,6 @@
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/server)
 "sIi" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	name = "fridge"
 	},
@@ -112928,14 +112886,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
-"vwf" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/crew_quarters/kitchen)
 "vwj" = (
 /obj/item/toy/plushie/fumo/arcueid,
 /obj/structure/barricade{
@@ -142665,7 +142615,7 @@ jps
 kwg
 cud
 sIi
-iTq
+rgG
 rTF
 cud
 vxM
@@ -143474,7 +143424,7 @@ cud
 cud
 egs
 uTx
-vwf
+dma
 smm
 jdf
 xQa

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -3518,7 +3518,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "aKG" = (
 /obj/item/remains/deer,
 /turf/simulated/floor/asteroid/grass,
@@ -6908,7 +6908,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "brl" = (
 /obj/machinery/microwave/burnbarrel,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -11391,7 +11391,7 @@
 "cmR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "cmV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -11969,7 +11969,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "csY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -14338,7 +14338,7 @@
 "cOK" = (
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "cOR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -24183,7 +24183,7 @@
 /obj/item/reagent_containers/food/snacks/chocolatebar,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "eMx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -29055,7 +29055,7 @@
 	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "fER" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/sliceable/bread,
@@ -29225,7 +29225,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "fGA" = (
 /obj/machinery/camera/network/medbay{
 	dir = 1
@@ -32176,7 +32176,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "ghX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/cluster/termite_no_despawn/lower_chance,
@@ -46062,7 +46062,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "iTr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -58063,7 +58063,7 @@
 /obj/item/reagent_containers/food/drinks/milk,
 /obj/item/storage/fancy/egg_box,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "lcf" = (
 /obj/machinery/shower{
 	dir = 1
@@ -68516,7 +68516,7 @@
 /area/nadezhda/engineering/construction)
 "mXT" = (
 /turf/simulated/mineral,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "mXY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/decal/cleanable/dirt,
@@ -90514,7 +90514,7 @@
 /area/nadezhda/rnd/server)
 "rgG" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "rgK" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/workshop)
@@ -94618,7 +94618,7 @@
 	pixel_y = -31
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "rTG" = (
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -98466,7 +98466,7 @@
 /obj/item/reagent_containers/food/drinks/milk,
 /obj/item/storage/fancy/egg_box,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "sIn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holoposter{
@@ -106013,7 +106013,7 @@
 "ugE" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "ugI" = (
 /obj/machinery/light{
 	dir = 4
@@ -112027,9 +112027,6 @@
 	opacity = 0
 	},
 /area/nadezhda/rnd/docking)
-"vnv" = (
-/turf/simulated/wall,
-/area/eris/crew_quarters/kitchen_storage)
 "vnB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -119920,7 +119917,7 @@
 "wIV" = (
 /obj/structure/sign/department/bar,
 /turf/simulated/wall,
-/area/eris/crew_quarters/kitchen_storage)
+/area/nadezhda/crew_quarters/kitchen)
 "wIZ" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -141253,10 +141250,10 @@ cwr
 cyr
 jTz
 wIV
-vnv
+cud
 cmR
-vnv
-vnv
+cud
+cud
 utm
 rIG
 jdf
@@ -141454,11 +141451,11 @@ wcv
 cwr
 efY
 ptB
-vnv
+cud
 mXT
 mXT
 mXT
-vnv
+cud
 iof
 fNh
 jdf
@@ -141656,11 +141653,11 @@ wcv
 cwr
 wLd
 bwh
-vnv
+cud
 mXT
 mXT
 mXT
-vnv
+cud
 wSq
 gAA
 qoC
@@ -141858,11 +141855,11 @@ wcv
 cwr
 cyr
 bwh
-vnv
+cud
 mXT
 mXT
 mXT
-vnv
+cud
 pLL
 jdf
 jdf
@@ -142060,11 +142057,11 @@ wcv
 cwr
 dqF
 mFH
-vnv
-vnv
-vnv
-vnv
-vnv
+cud
+cud
+cud
+cud
+cud
 rDw
 bgK
 iHQ
@@ -142262,11 +142259,11 @@ wcv
 cwr
 jps
 bwh
-vnv
+cud
 fEL
 rgG
 cOK
-vnv
+cud
 jdf
 pHC
 fNh
@@ -142464,11 +142461,11 @@ wcv
 cwr
 jps
 bwh
-vnv
+cud
 lce
 rgG
 eMt
-vnv
+cud
 jPv
 cev
 xZn
@@ -142666,11 +142663,11 @@ wcv
 cwr
 jps
 kwg
-vnv
+cud
 sIi
 iTq
 rTF
-vnv
+cud
 vxM
 sZz
 mhb
@@ -142868,11 +142865,11 @@ bwh
 jVE
 efY
 qRb
-vnv
+cud
 ugE
 rgG
 ghW
-vnv
+cud
 xxL
 cfS
 efv
@@ -143070,11 +143067,11 @@ wXS
 cdl
 vws
 jVE
-vnv
+cud
 aKD
 csW
 fGw
-vnv
+cud
 rPe
 eqF
 xoD
@@ -143272,11 +143269,11 @@ gUG
 gIO
 bev
 wow
-vnv
-vnv
-vnv
+cud
+cud
+cud
 brf
-vnv
+cud
 iNL
 nqB
 efv


### PR DESCRIPTION
The kitchen freezer area was using /area/eris/crew_quarters/kitchen_storage and led to space tiles when something destroyed the baseplate.
Replaced the area with /area/nadezhda/crew_quarters/kitchen and removed the double APC inside the freezer room.