### PR TITLE
Ranger Loadout & Fixes

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disk/marshal.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/marshal.dm
@@ -125,6 +125,8 @@
 		/datum/design/autolathe/ammo/kurtz_ammobox_rubber = 0,
 		/datum/design/autolathe/ammo/kurtz_ammobox = 0,
 		/datum/design/autolathe/ammo/kurtz_ammobox_practice = 0,
+		/datum/design/autolathe/ammo/mag_10x24 = 0,
+		/datum/design/autolathe/ammo/box_10x24_small = 1,
 		/datum/design/autolathe/ammo/lrifle_ammobox = 1,
 		/datum/design/autolathe/ammo/lrifle_ammobox_lethal = 1,
 		/datum/design/autolathe/ammo/lrifle_ammobox_rubber = 0,
@@ -181,7 +183,7 @@
 
 	license = 12
 	designs = list(
-		/datum/design/autolathe/gun/thompson = 4,
+		/datum/design/autolathe/gun/freedom = 4,
 		/datum/design/autolathe/ammo/smg_magnum_40 = 2,
 		/datum/design/autolathe/ammo/smg_magnum_40_rubber = 1,
 		/datum/design/autolathe/ammo/smg_magnum_40_lethal = 3,

--- a/code/game/objects/items/weapons/storage/marshal_kits.dm
+++ b/code/game/objects/items/weapons/storage/marshal_kits.dm
@@ -94,13 +94,13 @@
 
 //Ranger kits
 /obj/item/storage/box/m_kit/armstrong
-	name = "Armstrong Kit"
-	desc = "The standard Marshal box kit containing a Armstrong lever action rifle, a repeating rifle chambered in 10mm Magnum."
+	name = "Custer Kit"
+	desc = "The standard Marshal box kit containing a Custer lever action rifle, a variant of the famous Armstrong repeating rifle chambered in 8.6mm."
 
 	populate_contents()
-		new /obj/item/gun/projectile/boltgun/lever(src)
-		new /obj/item/ammo_magazine/ammobox/magnum_40(src)
-		new /obj/item/ammo_magazine/ammobox/magnum_40/rubber(src)
+		new /obj/item/gun/projectile/boltgun/lever/custer(src)
+		new /obj/item/ammo_magazine/ammobox/heavy_rifle_408_small(src)
+		new /obj/item/ammo_magazine/ammobox/heavy_rifle_408_small/rubber(src)
 
 /obj/item/storage/box/m_kit/specop
 	name = "Spec-Op Caseless SMG Kit"


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Replaces the Armstrong rifle in the Ranger's loadout with the 8.6mm Custer lever action. The reason being that the Spec-Op and the E-shotgun vastly surpassed the 10mms damage. This should balance it as the 8.6mm Custer is strong but sports a high recoil and is bolt-action, being slower firing than either other option but hard-hitting. Also fixes two issues; one being the Freedom SMG disk printed the wrong gun and the fact there was no ability to print 10x24 caseless for Rangers who used the spec-op.
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
add: Custer rifle has replaced the Armstrong for Rangers.
add: Adds the ability for the Marshal 'Shoot Out' disk to print 10x24 mags and ammo for the Spec-Op
fix: Fixed the issue with the Freedom SMG disk printing Thompsons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
