### PR TITLE
stat runtime fix: negative robust stat should not make you a god in grabs

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -188,6 +188,9 @@ Turf and target are seperate in case you want to teleport some distance from a t
 /proc/sign(x)
 	return x!=0?x/abs(x):0
 
+/proc/spow(x,y)
+	return (sign(x) * (abs(x) ** y))
+
 /proc/getline(atom/M, atom/N)//Ultra-Fast Bresenham Line-Drawing Algorithm
 	var/px=M.x		//starting x
 	var/py=M.y

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -69,7 +69,7 @@
 			if(GRAB_PASSIVE)
 				qdel(G)
 			if(GRAB_AGGRESSIVE)
-				if(prob(max(60 + ((stats?.getStat(STAT_ROB)) - G.assailant?.stats.getStat(STAT_ROB) ** 0.8), 1))) // same scaling as cooldown increase and if you manage to be THAT BAD, 1% for luck
+				if(prob(max(60 + ((stats?.getStat(STAT_ROB)) - spow(G.assailant?.stats.getStat(STAT_ROB), 0.8)), 1))) // same scaling as cooldown increase and if you manage to be THAT BAD, 1% for luck
 					visible_message("<span class='warning'>[src] has broken free of [G.assailant]'s grip!</span>")
 					qdel(G)
 			if(GRAB_NECK)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -273,14 +273,14 @@
 	var/warmup_increase
 	if(assailant_stat > 0)
 		// Positive ROB decreases warmup, but not linearly
-		warmup_increase = -(assailant_stat ** 0.8)
+		warmup_increase = -spow(assailant_stat, 0.8)
 	else
 		// Negative ROB is a flat warmup increase
 		warmup_increase = abs(assailant_stat)
 	if(affecting_stat > 0)
-		warmup_increase += affecting_stat ** 0.8
+		warmup_increase += spow(affecting_stat, 0.8)
 	else
-		warmup_increase += affecting_stat ** 0.6
+		warmup_increase += spow(affecting_stat, 0.6)
 
 	var/total_warmup = max(0, UPGRADE_WARMUP + round(warmup_increase))
 


### PR DESCRIPTION
Changes pow operations used to perform roots to preserve the sign of the first parameter.

This introduces `/proc/spow(x,y)` as a helper to solve this issue.

It should be used instead of `(x ** y)`.

Fixes the following runtime exceptions;
```
[23:40:51] Runtime in mob_grab.dm,283: illegal: pow(-3.000000,0.600000)
   proc name: s click (/obj/item/grab/proc/s_click)
[23:45:01] Runtime in resist.dm,72: illegal: pow(-3.000000,0.800000)
   proc name: resist grab (/mob/living/proc/resist_grab)
```
