### PR TITLE
fix runtimes in nanogate prk removal

### DIFF
--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -25,8 +25,8 @@
 	holder.brute_mod_perk += 0.10
 
 /datum/perk/nanite_muscle/remove()
-	..()
 	holder.brute_mod_perk -= 0.10
+	..()
 
 /datum/perk/nanite_armor
 	name = "Nanite Skin-Weave"
@@ -40,9 +40,9 @@
 	holder.health += 40
 
 /datum/perk/nanite_armor/remove()
-	..()
 	holder.maxHealth -= 40
 	holder.health -= 40
+	..()
 
 /datum/perk/nanite_chem
 	name = "Nanite Chemicals"


### PR DESCRIPTION
Fixes these runtimes; `..()` should be called _after_ messing with holder in both cases.

See other perk overloads of `remove()` for reference.

```
[22:56:03] Runtime in nanogate.dm,29: Cannot read null.brute_mod_perk
   proc name: remove (/datum/perk/nanite_muscle/remove)
   src: Nanofiber Muscle Therapy (/datum/perk/nanite_muscle)
   call stack:
   Nanofiber Muscle Therapy (/datum/perk/nanite_muscle): remove()
   /datum/stat_holder (/datum/stat_holder): removePerk(/datum/perk/nanite_muscle (/datum/perk/nanite_muscle))
...
[22:56:03] Runtime in nanogate.dm,44: Cannot read null.maxHealth
   proc name: remove (/datum/perk/nanite_armor/remove)
   src: Nanite Skin-Weave (/datum/perk/nanite_armor)
   call stack:
   Nanite Skin-Weave (/datum/perk/nanite_armor): remove()
   /datum/stat_holder (/datum/stat_holder): removePerk(/datum/perk/nanite_armor (/datum/perk/nanite_armor))
```