### PR TITLE
Xenoarch Expiditions

### DIFF
--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(xenoarch)
 			continue
 
 		digsite_spawning_turfs.Add(M)
-		var/digsite = get_random_digsite_type()
+		var/digsite = get_random_digsite_type(M.z)
 		var/target_digsite_size = rand(digsite_size_lower, digsite_size_upper)
 		var/list/processed_turfs = list()
 		var/list/turfs_to_process = list(M)

--- a/code/modules/research/xenoarchaeology/finds/finds_defines.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_defines.dm
@@ -125,8 +125,14 @@
 	return "plasma"
 
 //see /turf/simulated/mineral/New() in code/modules/mining/mine_turfs.dm
-/proc/get_random_digsite_type()
-	return pick(100;DIGSITE_GARDEN,95;DIGSITE_ANIMAL,90;DIGSITE_HOUSE,85;DIGSITE_TECHNICAL,80;DIGSITE_TEMPLE,75;DIGSITE_WAR)
+/proc/get_random_digsite_type(Z)
+	switch (Z)
+		if (2, 3, 4) return DIGSITE_HOUSE // all colony besides mines
+		if (8, 9) return DIGSITE_TECHNICAL //deep jungle
+		if (10) return DIGSITE_TEMPLE // swamp
+		if (15, 16) return pick(50;DIGSITE_GARDEN, 50;DIGSITE_ANIMAL) // hunter field
+		if (17, 18, 19, 20, 21) return DIGSITE_WAR // scrap haven
+		else return pick(100;DIGSITE_GARDEN,95;DIGSITE_ANIMAL,90;DIGSITE_HOUSE,85;DIGSITE_TECHNICAL,80;DIGSITE_TEMPLE,75;DIGSITE_WAR)
 
 /proc/get_random_find_type(var/digsite)
 


### PR DESCRIPTION
Alters digsite spawning to be based on z level. This means mines and any map not specifically set will use the current normal way of spawning.
Maps like colony will use the HOUSE set of finds. While hunter fields will use GARDEN and ANIMAL. There are others of course but I don't want to spoil it.

Tested and code has comments for those who like to browse thru it.