### PR TITLE
Xenoarch weapons pass

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -335,19 +335,19 @@
 		if(26)
 			//energy gun
 			var/spawn_type = pick(\
-			/obj/item/gun/energy/laser/practice/xenoarch,\
-			/obj/item/gun/energy/laser/xenoarch,\
+			/obj/item/gun/energy/cog/xenoarch,\
 			/obj/item/gun/energy/xray/xenoarch,\
 			/obj/item/gun/energy/captain/xenoarch)
 			if(spawn_type)
 				var/obj/item/gun/energy/new_gun = new spawn_type(src.loc)
 				new_item = new_gun
 				new_gun.icon_state = "egun[rand(1,6)]"
-				new_gun.desc = "This is an antique energy weapon, you're not sure if it will fire or not."
+				new_gun.desc = "This is an antique energy weapon, Wonder how it shoots."
 				new_gun.serial_type = "INDEX"
 				new_gun.serial_shown = FALSE
 
-				//5% chance to explode when first fired
+				new_gun.cell.charge = new_gun.cell.maxcharge
+				/*5% chance to explode when first fired
 				//10% chance to have an unchargeable cell
 				//15% chance to gain a random amount of starting energy, otherwise start with an empty cell
 				if(prob(5))
@@ -358,25 +358,32 @@
 					new_gun.cell.charge = rand(0, new_gun.cell.maxcharge)
 				else
 					new_gun.cell.charge = 0
+				*/
 			new_item.price_tag = rand(950,2500)
 
 			item_type = "gun"
 		if(27)
-			//revolver
-			var/obj/item/gun/projectile/new_gun = new /obj/item/gun/projectile/revolver/xenoarch(src.loc)
-			new_item = new_gun
-			new_gun.icon_state = "gun[rand(1,4)]"
-			new_gun.icon = 'icons/obj/xenoarchaeology.dmi'
-			new_gun.serial_type = "INDEX"
-			new_gun.serial_shown = FALSE
-			new_gun.price_tag = rand(950,2500)
-			//33% chance to be able to reload the gun with human ammunition
+			//projectile guns
+			var/spawn_type = pick(\
+			/obj/item/gun/projectile/revolver/xenoarch,\
+			/obj/item/gun/projectile/revolver/sixshot/xenoarch,\
+			/obj/item/gun/projectile/boltgun/heavysniper/xenoarch)
+			if(spawn_type)
+				var/obj/item/gun/projectile/new_gun = new spawn_type(src.loc)
+				new_item = new_gun
+				new_gun.icon_state = "gun[rand(1,4)]"
+				new_gun.desc = "This is a antique firearm. Cleaned and ready to use."
+				new_gun.serial_type = "INDEX"
+				new_gun.serial_shown = FALSE
+				new_gun.price_tag = rand(950,2500)
+			/*33% chance to be able to reload the gun with human ammunition
 			if(prob(66))
 				new_gun.caliber = "999"
 
 			//33% chance to fill it with a random amount of bullets
 			new_gun.max_shells = rand(1,12)
 			if(prob(33))
+			*/
 				var/num_bullets = rand(1,new_gun.max_shells)
 				if(num_bullets < new_gun.loaded.len)
 					new_gun.loaded.Cut()
@@ -391,13 +398,8 @@
 								I.loc = null
 						else
 							break
-			else
-				for(var/obj/item/I in new_gun)
-					if(I in new_gun.loaded)
-						new_gun.loaded.Remove(I)
-						I.loc = null
-
 			item_type = "gun"
+
 		if(28)
 			//completely unknown alien device
 			if(prob(50))

--- a/code/modules/research/xenoarchaeology/finds/finds_eguns.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_eguns.dm
@@ -1,23 +1,18 @@
 //snowflake guns for xenoarch because you can't override the update_icon() proc inside the giant mess that is find creation
-/obj/item/gun/energy/laser/xenoarch
+
+//energy guns
+/obj/item/gun/energy/cog/xenoarch
 	name = "Fossilised Gun"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	item_state_slots = null
 	icon_contained = FALSE
+	charge_cost = 100
+	projectile_type = /obj/item/projectile/beam/tesla/shotgun // thats right. Its a shotgun cog.
 
-/obj/item/gun/energy/laser/xenoarch/refresh_upgrades()
+/obj/item/gun/energy/cog/xenoarch/refresh_upgrades()
 	return
 
-/obj/item/gun/energy/laser/xenoarch/update_icon()
-	return
-
-/obj/item/gun/energy/laser/practice/xenoarch
-	name = "Fossilised Gun"
-	icon = 'icons/obj/xenoarchaeology.dmi'
-	item_state_slots = null
-	icon_contained = FALSE
-
-/obj/item/gun/energy/laser/practice/xenoarch/update_icon()
+/obj/item/gun/energy/cog/xenoarch/update_icon()
 	return
 
 /obj/item/gun/energy/xray/xenoarch
@@ -44,11 +39,39 @@
 /obj/item/gun/energy/captain/xenoarch/update_icon()
 	return
 
+//physical projectiles
 /obj/item/gun/projectile/revolver/xenoarch
 	name = "Fossilised Gun"
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	max_shells = 12
 
 /obj/item/gun/projectile/revolver/xenoarch/refresh_upgrades()
 	return
 
 /obj/item/gun/projectile/revolver/xenoarch/update_icon()
+	return
+
+/obj/item/gun/projectile/revolver/sixshot/xenoarch
+	name = "Fossilized Gun"
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	max_shells = 4
+	damage_multiplier = 1.2
+	saw_off = FALSE
+
+/obj/item/gun/projectile/revolver/sixshot/xenoarch/refresh_upgrades()
+	return
+
+/obj/item/gun/projectile/revolver/sixshot/xenoarch/update_icon()
+	return
+
+/obj/item/gun/projectile/boltgun/heavysniper/xenoarch
+	name = "Fossilized Gun"
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	caliber = 999
+	damage_multiplier = 1.8 //It only gets one shot and can't be reloaded. Don't miss.
+
+/obj/item/gun/projectile/boltgun/heavysniper/xenoarch/refresh_upgrades()
+	return
+
+/obj/item/gun/projectile/boltgun/heavysniper/xenoarch/update_icon()
 	return


### PR DESCRIPTION
Removes chance for weapon to explode and not be reloadable. Changes out two of the weaker weapons for 3 modified weapons using different gimmiks. Adds more rounds to the revolver styled weapon. Basically making the xenoarch guns partially worth the effort of finding.

Testing on this is barely done due to how finds are spawned in game. Its exceptionally hard to test. I can't just spawn the guns in to work with them. But overall shouldn't actually break anything. And no runtimes were firing on my server.