### PR TITLE
Marshal Bowman Headsets Unique

### DIFF
--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -1,6 +1,6 @@
 /decl/hierarchy/outfit/job/security
 	hierarchy_type = /decl/hierarchy/outfit/job/security
-	l_ear = /obj/item/device/radio/headset/headset_sec
+	l_ear = /obj/item/device/radio/headset/headset_sec/bowman
 	gloves = /obj/item/clothing/gloves/thick
 	shoes = /obj/item/clothing/shoes/jackboots
 	id_type = /obj/item/card/id/sec
@@ -13,7 +13,7 @@
 
 /decl/hierarchy/outfit/job/security/swo
 	name = OUTFIT_JOB_NAME("Marshal - Warrant Officer")
-	l_ear = /obj/item/device/radio/headset/heads/hos
+	l_ear = /obj/item/device/radio/headset/heads/hos/bowman
 	uniform = /obj/item/clothing/under/rank/ih_commander
 	suit = /obj/item/clothing/suit/armor/hos
 	l_pocket = /obj/item/device/flash

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -82,7 +82,7 @@
 	adhoc_fallback = TRUE
 	ks2type = /obj/item/device/encryptionkey/headset_mar
 
-/obj/item/device/radio/headset/headset_sec/bowman
+/obj/item/device/radio/headset/headset_sec/bowman		//Wearing a Marshal bowman aids against flashbangs. Same stats otherwise.
 	name = "marshal bowman headset"
 	desc = "This headset is a premium quality headset made for only true operators! Ignore.. the ten credit price tag and the rattling noise it makes when you shake it."
 	icon_state = "sec_headset_bowman"
@@ -191,7 +191,7 @@
 	adhoc_fallback = TRUE
 	ks2type = /obj/item/device/encryptionkey/heads/hos
 
-/obj/item/device/radio/headset/heads/hos/bowman
+/obj/item/device/radio/headset/heads/hos/bowman		//Wearing a Marshal bowman aids against flashbangs. Same stats otherwise.
 	name = "warrant officer bowman headset"
 	desc = "The headset of the men who lock away your worthless lives, in a comfortable bowman style.\nThis has a small symbol denoting its built in back-up transmitter."
 	icon_state = "wo_headset_bowman"

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -62,8 +62,12 @@
 		if(ishuman(M))
 			if(istype(M:l_ear, /obj/item/clothing/ears/earmuffs) || istype(M:r_ear, /obj/item/clothing/ears/earmuffs))
 				ear_safety += 2
-			if(HULK in M.mutations)
-				ear_safety += 1
+			if(istype(M:l_ear, /obj/item/device/radio/headset/headset_sec/bowman) || istype(M:r_ear, /obj/item/device/radio/headset/headset_sec/bowman))
+				ear_safety += 2
+			if(istype(M:l_ear, /obj/item/device/radio/headset/heads/hos/bowman) || istype(M:r_ear, /obj/item/device/radio/headset/heads/hos/bowman))
+				ear_safety += 2
+//			if(HULK in M.mutations)
+//				ear_safety += 1
 			if(istype(M:head, /obj/item/clothing/head/helmet))
 				ear_safety += 1
 			if(M.stats.getPerk(PERK_EAR_OF_QUICKSILVER))

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -85,7 +85,7 @@
 	new /obj/item/oddity/code_book(src)
 	new /obj/item/clothing/head/helmet/warrant_officer(src)
 	new /obj/item/storage/sheath/judgement/filled(src)
-	new /obj/item/device/radio/headset/heads/hos/bowman(src)
+	new /obj/item/device/radio/headset/heads/hos(src)
 
 /obj/structure/closet/secure_closet/warden
 	name = "supply specialist's locker"
@@ -149,7 +149,7 @@
 	new /obj/item/voucher/marshal/secondary(src)
 	new /obj/item/voucher/marshal/armor(src)
 	new /obj/item/storage/backpack/satchel/ironhammer(src)
-	new /obj/item/device/radio/headset/headset_sec/bowman(src)
+	new /obj/item/device/radio/headset/headset_sec(src)
 	new /obj/item/storage/belt/security(src)
 	new /obj/item/gun_upgrade/trigger/dnalock(src)
 	new /obj/item/clothing/suit/storage/vest/ironhammer(src)
@@ -186,7 +186,7 @@
 	new /obj/item/gun_upgrade/trigger/dnalock(src)
 	new /obj/item/clothing/shoes/reinforced(src)
 	new /obj/item/storage/box/evidence(src)
-	new /obj/item/device/radio/headset/headset_sec/bowman(src)
+	new /obj/item/device/radio/headset/headset_sec(src)
 	new /obj/item/storage/belt/security(src)
 	new /obj/item/device/holowarrant(src)
 	new /obj/item/clothing/accessory/holster/waist(src)

--- a/code/modules/clothing/glasses/misc.dm
+++ b/code/modules/clothing/glasses/misc.dm
@@ -151,8 +151,8 @@
 	desc = "A rather large pair of sunglasses."
 	icon_state = "bigsunglasses"
 	item_state = "bigsunglasses"
-	flash_protection = FLASH_PROTECTION_MODERATE
-	darkness_view = -3
+	flash_protection = FLASH_PROTECTION_MINOR
+	darkness_view = -1
 	obscuration = MEDIUM_OBSCURATION
 
 /obj/item/clothing/glasses/sunglasses/helltaker // Part of the whole Helltaker dude drip. - Seb
@@ -160,8 +160,8 @@
 	desc = "A stylish pair of small, circular sunglasses that keeps your eyes surprisingly well hidden."
 	icon_state = "hellgoggles"
 	item_state = "hellgoggles"
-	flash_protection = FLASH_PROTECTION_MODERATE
-	darkness_view = -3
+	flash_protection = FLASH_PROTECTION_MINOR
+	darkness_view = -1
 	obscuration = MEDIUM_OBSCURATION
 
 /obj/item/clothing/glasses/aviator


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Adds in ear protection akin to that of ear muffs for the Marshal bowman headsets. Reason for this being that otherwise Marshals can flashbang themselves. This should now add +2 protection, and another +1 can be stacked with it if a helmet is worn along with the headset. Also - PR makes it so large shades are no longer welding-goggles despite being sunglasses.
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
tweak: Makes Marshal bowman headsets flashbang proof. (Mostly)
tweak: Makes large sunglasses no longer equal to better welding goggles. Why did they do this in the first place?
balance: Swapped out regular spawn Sec headset with a Bowman so Marshals start with flashbang protection. Backup headset in locker changed from bowmans to regular headsets, providing no flashbang protection. (Just swapped the locker headset of current with the spawn headset)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
