### PR TITLE
Hotfixes and Lodge improvement

### DIFF
--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -326,16 +326,21 @@
 /datum/perk/nightcrawler
 	name = "Nightcrawler"
 	desc = "Having lived in a light-deprived enviroment for most of your life has honed your vision more than the average person.\nYour accelerated dark adaptation has also made you more photosensitive to sudden bright lights and flashes."
+	var/init_sight
+	var/init_flash
+	var/obj/screen/lightOverlay = null
 	//icon_state = "night" // https://game-icons.net/1x1/lorc/night-sky.html
 
 /datum/perk/nightcrawler/assign(mob/living/carbon/human/H)
 	..()
-	holder.additional_darksight += 1
+	init_sight = holder.additional_darksight
+	init_flash = holder.flash_mod
+	holder.additional_darksight = 8
 	holder.flash_mod += 2
 
 /datum/perk/nightcrawler/remove()
-	holder.additional_darksight -= 1
-	holder.flash_mod -= 2
+	holder.additional_darksight = init_sight
+	holder.flash_mod = init_flash
 	..()
 
 /datum/perk/fast_fingers

--- a/code/game/jobs/job/offcolony.dm
+++ b/code/game/jobs/job/offcolony.dm
@@ -27,9 +27,9 @@
 		STAT_COG = 0
 	)
 	playtimerequired = 1200
-	description = "You are not apart of the colony, at least currently, having decided to take a shift with the local lodge hunters either temporarily or permanently. As the hunt \
-	master your job is to lead your fledgling hunters on expeditions and generally work towards keeping them alive while thriving in your lodge. You are not nearly as well \
-	equipped as the colony is, but special training by the lodge has given you the ability to live off the land."
+	description = "You are not part of the colony, at least currently, having decided to take a shift with the local Lodge Hunters either temporarily or permanently. As the Hunt \
+	Master your job is to lead your fledgling hunters on expeditions and generally work towards keeping them alive while thriving in your lodge. You are not nearly as well \
+	equipped as the colony is, but special training by the Lodge has given you the ability to live off the land."
 
 	duties = "Keep your hunters alive, ensuring they don't get killed by the various dangerous fauna.<br>\
 		Ensure all of your hunters are equipped and working properly in teams.<br>\
@@ -69,9 +69,9 @@
 		STAT_COG = 0
 	)
 
-	description = "You are not apart of the colony, at least currently, having decided to take a shift with the local lodge hunters either temporarily or permanently. As a lodge hunter \
-	your primary work is both as an animal rancher and big game hunter. Expeditions should be prepared for using whatever you can craft and make with your fellow hunters. Good lodge members \
-	work as a team under the direction of the hunt master or if present the lodge matriarch. An expert lodge hunter reads the lodge codex for the do's and dont's."
+	description = "You are not part of the colony, at least currently, having decided to take a shift with the local lodge hunters either temporarily or permanently. As a Lodge Hunter \
+	your primary work is both as an animal rancher and big game hunter. Expeditions should be prepared for using whatever you can craft and make with your fellow hunters. Good Lodge members \
+	work as a team under the direction of the Hunt Master or if present the Lodge Matriarch. An expert Lodge Hunter reads the Lodge codex for the do's and dont's."
 
 	duties = "Care for, feed, and raise your various animals to harvest supplies and food.<br>\
 		Work with your fellow hunters to ensure you can take down dangerous fauna.<br>\
@@ -108,10 +108,10 @@
 		STAT_COG = 10
 	)
 
-	description = "You are not apart of the colony, at least currently, having decided to take a shift with the local lodge hunters either temporarily or permanently. As a lodge herbalist \
-	your primary work is both as gardener and field medic for the lodge. Expeditions should be prepared for using whatever you can craft and make with your fellow hunters. Good lodge members \
-	work as a team under the direction of the hunt master or if present the lodge matriarch. An expert lodge hunter reads the lodge codex for the do's and dont's. While hunters are more combat \
-	focused, your purpose as an herbalist is to attend to the medical needs of your lodge, but additional skills as a crafter, gardener, and chemist are quite handy!"
+	description = "You are not part of the colony, at least currently, having decided to take a shift with the local Lodge Hunters either temporarily or permanently. As a Lodge Herbalist \
+	your primary work is both as gardener and field medic for the lodge. Expeditions should be prepared for using whatever you can craft and make with your fellow hunters. Good Lodge members \
+	work as a team under the direction of the Hunt Master or if present the Lodge Matriarch. While hunters are more combat focused, your purpose as an herbalist is to attend to the medical needs of your lodge, \
+	but additional skills as a crafter, gardener, and chemist are quite handy!"
 
 	duties = "Grow plants and harvest them for their medical reagents using your primitive chem lab.<br>\
 		Work as a medic for your lodge, keeping people alive and patching them up.<br>\

--- a/code/game/objects/items/weapons/storage/hardcases.dm
+++ b/code/game/objects/items/weapons/storage/hardcases.dm
@@ -409,7 +409,7 @@ obj/item/storage/hcases/attackby(obj/item/W, mob/user)
 /obj/item/storage/hcases/med/medical_job_trama/populate_contents()
 	new /obj/item/gearbox/traumatizedteam(src)
 	new /obj/item/gunbox/traumatizedteam(src) // Moved the weapon selection to here
-	new /obj/item/cell/medium/moebius/high // Returning their high capacity cell from Sprocket removal
+	new /obj/item/cell/medium/moebius/high(src) // Returning their high capacity cell from Sprocket removal
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/storage/firstaid/soteria/large(src)
 	new /obj/item/gun/energy/sst/formatbound/preloaded(src)

--- a/code/modules/clothing/glasses/misc.dm
+++ b/code/modules/clothing/glasses/misc.dm
@@ -69,7 +69,7 @@
 	desc = "An eyepatch worn to cover a single eye, with a built-in heads-up display for combat and security information."
 	icon_state = "secpatch"
 	item_state = "secpatch"
-	flash_protection = FLASH_PROTECTION_MODERATE // They cover just one eye!
+	flash_protection = FLASH_PROTECTION_MINOR // They cover just one eye!
 
 /obj/item/clothing/glasses/eyepatch/secpatch/process_hud(var/mob/M)
 	process_sec_hud(M, 1)
@@ -197,6 +197,7 @@
 	item_state = "blindfold"
 	tint = TINT_BLIND
 	obscuration = HEAVY_OBSCURATION
+	flash_protection = FLASH_PROTECTION_MAJOR // You are literally blind wearing these.
 
 /obj/item/clothing/glasses/blindfold/tape
 	name = "length of tape"

--- a/code/modules/genetics/mutations/cat_eyes.dm
+++ b/code/modules/genetics/mutations/cat_eyes.dm
@@ -11,10 +11,9 @@
 /datum/genetics/mutation/cat_eyes/onPlayerImplant()
 	if(!..())
 		return
-	if(ishuman(container.holder))
-		var/mob/living/carbon/human/human_holder = container.holder
-		human_holder.flash_mod += 2
-		human_holder.additional_darksight += 1
+	var/mob/living/carbon/human/human_holder = container.holder
+	human_holder.flash_mod += 2
+	human_holder.additional_darksight += 1
 
 /datum/genetics/mutation/cat_eyes/onPlayerRemove()
 	if(!..())

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1250,7 +1250,7 @@
 		return
 	if(XRAY in mutations)
 		sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
-	if(unnatural_mutations.getMutation("MUTATION_CAT_EYES", TRUE) || stats.getPerk(PERK_NIGHTCRAWLER))
+	if(unnatural_mutations.getMutation("MUTATION_CAT_EYES", TRUE))
 		see_invisible = SEE_INVISIBLE_NOLIGHTING
 	if(CE_DARKSIGHT in chem_effects)//TODO: Move this to where it belongs, doesn't work without being right here for now. -Kaz/k5.
 		see_invisible = min(see_invisible, chem_effects[CE_DARKSIGHT])

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -486,7 +486,7 @@
 	off_icon = "portgen2"
 	on_icon = "portgen2_1"
 	sheet_path = /obj/item/stack/material/tritium
-	sheet_name = "Tritium Fuel Sheets"
+	sheet_name = "Tritium Sheets"
 
 	//I don't think tritium has any other use, so we might as well make this rewarding for players
 	//max safe power output (power level = 8) is 200 kW and lasts for 1 hour - 3 or 4 of these could power the station
@@ -505,12 +505,12 @@
 
 /obj/machinery/power/port_gen/pacman/camp
 	name = "C.A.M.P.E.R.P.A.C.M.A.N portable generator"
-	desc = "This pacman got its named form its low power rating of burning wood as fuel, tends to be used well people go out camping. Rated for 20 kW maximum safe output!"
+	desc = "This power generator got its name from its low power rating through burning wood as fuel. It tends to be used while people go out camping. Rated for 20 kW maximum safe output!"
 	icon_state = "portgen3"
 	off_icon = "portgen3"
 	on_icon = "portgen3_1"
 	sheet_path = /obj/item/stack/material/wood
-	sheet_name = "Wood Planks Fuel Sheets"
+	sheet_name = "Wooden Planks"
 
 	//Wood is everyware here, this is is rather weak
 	power_gen = 12000 //watts
@@ -525,12 +525,12 @@
 
 /obj/machinery/power/port_gen/pacman/miss
 	name = "M.I.S.S.P.A.C.M.A.N portable generator"
-	desc = "Using a girls best friend. Rated for 200 kW maximum safe output!"
+	desc = "Using a girl's best friend. Rated for 200 kW maximum safe output!"
 	icon_state = "portgen2"
 	off_icon = "portgen2"
 	on_icon = "portgen2_1"
 	sheet_path = /obj/item/stack/material/diamond
-	sheet_name = "Diamond Sheet Fuel Sheets"
+	sheet_name = "Diamond Sheets"
 
 	//diamonds are just as common as any other mat*
 	power_gen = 22500 //watts

--- a/code/modules/projectiles/guns/projectile/automatic/solmarine.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/solmarine.dm
@@ -93,9 +93,9 @@
 
 /obj/item/gun/projectile/automatic/omnirifle/omnicarbine/solmarine/shotgunless_sawn
 	name = "sawn down \"Saturnian\" carbine"
-	desc = "An ancient that predates mass autolathen printing rifle found commonly in the Sol Federation's oldest military stockpiles. Reliable but heavily dated. \
-		 Unlike other old stock this one was always intented to be a 6.5mm.\
-		 Someone butchered this thing beyond recognition! At least it fits in a holster."
+	desc = "An ancient design that predates mass autolathe-printed rifles found commonly in the Sol Federation's oldest military stockpiles. Reliable but heavily dated. \
+		 Unlike other old stocks this one was always intented to be a 6.5mm.\
+		 Someone butchered this thing beyond recognition! At least it fits in a holster now."
 	icon = 'icons/obj/guns/projectile/sawnoff/solmarine.dmi'
 	matter = list(MATERIAL_IRON = 10, MATERIAL_PLASTIC = 8)
 	init_recoil = CARBINE_RECOIL(1.2)
@@ -112,7 +112,7 @@
 
 /obj/item/gun/projectile/automatic/omnirifle/omnicarbine/solmarine/shotgunless
 	name = "\"Saturnian\" carbine"
-	desc = "An ancient that predates mass autolathen printing rifle found commonly in the Sol Federation's oldest military stockpiles. Reliable but heavily dated. \
+	desc = "An ancient design that predates mass autolathe-printed rifles found commonly in the Sol Federation's oldest military stockpiles. Reliable but heavily dated. \
 		 Unlike other old stock this one was always intented to be a 6.5mm."
 	icon = 'icons/obj/guns/projectile/martian.dmi'
 	icon_state = "service"

--- a/code/modules/tips_and_tricks/jobs.dm
+++ b/code/modules/tips_and_tricks/jobs.dm
@@ -320,7 +320,7 @@
 
 /tipsAndTricks/jobs/best_dagger_ever
     jobs_list = list(/datum/job/chaplain, /datum/job/acolyte)
-    tipText = "The absolutism ritual knife can be thrown, this is useful for embeding the knife into someones back. If thrown into someone that is also apart of the Absolutism, it is less likely to embed."
+    tipText = "The absolutism ritual knife can be thrown, this is useful for embedding the knife into someone's back. If thrown into someone that is also a follower of Absolutism, it is less likely to embed."
 
 /tipsAndTricks/jobs/skyfall_timer
     jobs_list = list(/datum/job/chaplain, /datum/job/acolyte)
@@ -328,7 +328,7 @@
 
 /tipsAndTricks/jobs/plants_n_meat
     jobs_list = list(/datum/job/chaplain, /datum/job/acolyte)
-    tipText = "If your ever in need of biomatter, you can always buy or trade for plants and meat with Hunters or Gardener."
+    tipText = "If you're ever in need of biomatter, you can always buy or trade for plants and meat with Hunters or Gardener."
 
 /tipsAndTricks/jobs/cleaning_carbine
     jobs_list = list(/datum/job/chaplain, /datum/job/acolyte)

--- a/maps/_HunterLodge/map/_Hunting_Lodge.dmm
+++ b/maps/_HunterLodge/map/_Hunting_Lodge.dmm
@@ -41,6 +41,7 @@
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid,
 /obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/o2,
 /obj/random/firstaid,
 /obj/random/firstaid,
 /turf/simulated/floor/tiled/white,
@@ -129,8 +130,11 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "aB" = (
-/turf/simulated/wall/wood_barrel,
-/area/nadezhda/outside/forest/hunting_lodge)
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/outside/forest/hunting_lodge_dark)
 "aC" = (
 /obj/structure/multiz/stairs/active{
 	dir = 2
@@ -199,6 +203,7 @@
 	pixel_y = -28
 	},
 /obj/machinery/light,
+/obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "aY" = (
@@ -307,6 +312,7 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "bt" = (
 /obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/curtain/open,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "bu" = (
@@ -886,11 +892,13 @@
 "et" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/structure/window/reinforced,
-/obj/machinery/power/port_gen/pacman/camp,
 /obj/effect/floor_decal/industrial/box,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/power/port_gen/pacman/camp{
+	anchored = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -1212,6 +1220,12 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -1681,6 +1695,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "jv" = (
@@ -1748,6 +1765,7 @@
 /obj/item/device/lighting/toggleable/lantern,
 /obj/item/device/lighting/toggleable/lantern,
 /obj/item/device/lighting/toggleable/lantern,
+/obj/item/staff/broom,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "jR" = (
@@ -1906,6 +1924,8 @@
 	dir = 4;
 	light_color = "#0892d0"
 	},
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/cookingoil,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "ms" = (
@@ -1968,11 +1988,9 @@
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "nG" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/multiz/ladder,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "nI" = (
 /obj/structure/closet/crate/bin,
@@ -2336,6 +2354,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
 	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "st" = (
@@ -2521,6 +2542,8 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "uX" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/bag/chemistry,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "va" = (
@@ -2536,9 +2559,19 @@
 /obj/item/honey_frame,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
+"vf" = (
+/obj/structure/multiz/ladder/up{
+	pixel_y = 10
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/outside/forest/hunting_lodge_dark)
 "vp" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -2615,7 +2648,7 @@
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
 /obj/item/stack/cable_coil/random,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "wq" = (
 /obj/random/furniture/pottedplant,
@@ -2674,6 +2707,11 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/cryopod/robot,
 /turf/simulated/floor/wood/wild5,
+/area/nadezhda/outside/forest/hunting_lodge_dark)
+"xc" = (
+/obj/structure/table/marble,
+/obj/item/material/kitchen/rollingpin,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "xf" = (
 /obj/machinery/light{
@@ -2758,7 +2796,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "yK" = (
 /obj/effect/floor_decal/spline/fancy{
@@ -2825,8 +2863,11 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/forest/hunting_lodge)
 "zr" = (
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/sign/departmentold/medical1{
+	desc = "A sign labelling the medical wing of the Hunters Lodge. You'll probably get treatment here.";
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "zs" = (
 /obj/effect/floor_decal/spline/fancy/corner{
@@ -2964,9 +3005,12 @@
 /area/nadezhda/outside/forest/hunting_lodge)
 "Bv" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 28
+	pixel_y = 32
 	},
-/turf/simulated/floor/wood/wild1,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "BB" = (
 /obj/effect/floor_decal/spline/fancy{
@@ -3015,7 +3059,7 @@
 "Cj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "Cm" = (
 /obj/effect/floor_decal/spline/fancy/corner{
@@ -3172,9 +3216,14 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "Ds" = (
-/obj/structure/table/woodentable,
-/obj/item/staff/broom,
-/turf/simulated/floor/wood/wild1,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "Dw" = (
 /obj/structure/extinguisher_cabinet{
@@ -3237,6 +3286,10 @@
 "Eu" = (
 /mob/living/carbon/superior_animal/lodge/clucker,
 /turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest/hunting_lodge_dark)
+"Ev" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "Ez" = (
 /obj/structure/multiz/stairs/enter/bottom{
@@ -3301,6 +3354,10 @@
 /obj/structure/table/rack/shelf,
 /obj/item/device/defib_kit/loaded,
 /obj/item/cell/large/moebius/high,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "Fy" = (
@@ -3337,6 +3394,12 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest/hunting_lodge)
+"FZ" = (
+/obj/structure/closet/wall_mounted{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/outside/forest/hunting_lodge_dark)
 "Gc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3724,7 +3787,10 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "MG" = (
 /obj/structure/reagent_dispensers/fueltank/huge,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "MK" = (
 /obj/effect/floor_decal/industrial/danger,
@@ -4032,6 +4098,15 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/forest/hunting_lodge)
+"QX" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/outside/forest/hunting_lodge_dark)
 "QZ" = (
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -4277,6 +4352,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
 	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "Vn" = (
@@ -4404,6 +4482,9 @@
 /obj/structure/reagent_dispensers/meadkeg,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -4779,9 +4860,9 @@ Aw
 Aw
 Aw
 Aw
-Aw
-Aw
-Aw
+RE
+RE
+RE
 Aw
 Aw
 Aw
@@ -4839,7 +4920,7 @@ RE
 pc
 jl
 Rn
-QO
+Ds
 Rn
 fO
 pc
@@ -4858,16 +4939,16 @@ RE
 RE
 RE
 RE
+vf
 RE
 RE
 RE
 RE
 RE
 RE
-AA
-ay
-aB
-BO
+RE
+RE
+RE
 RE
 Eo
 aN
@@ -4935,8 +5016,8 @@ RE
 av
 gg
 jO
-Ds
 LN
+gg
 va
 gg
 gg
@@ -5095,7 +5176,7 @@ jj
 jj
 iv
 jj
-jj
+zr
 jj
 db
 fJ
@@ -5248,11 +5329,11 @@ zF
 ah
 jR
 Fr
-nG
 hM
 hM
 hM
 hM
+Ev
 WQ
 bo
 nV
@@ -5640,7 +5721,7 @@ RE
 WQ
 vp
 dm
-hM
+FZ
 aZ
 LO
 WQ
@@ -7946,10 +8027,10 @@ WQ
 iX
 bq
 UY
-bn
+xc
 bq
 bq
-zr
+jv
 jj
 ur
 Rz
@@ -8027,7 +8108,7 @@ bn
 bX
 bq
 bq
-zr
+jv
 jj
 ur
 Rz
@@ -8115,7 +8196,7 @@ jj
 jj
 rQ
 WQ
-Cb
+Bv
 Cb
 wC
 gg
@@ -8270,7 +8351,7 @@ jj
 iv
 jj
 jj
-Bv
+gg
 Ae
 Cb
 Cb
@@ -9071,8 +9152,8 @@ RE
 bc
 UL
 uX
+nG
 wq
-jj
 fE
 Rz
 ur
@@ -9149,7 +9230,7 @@ mO
 jj
 jj
 jj
-jj
+aB
 jj
 ur
 Rz
@@ -9364,7 +9445,7 @@ jH
 ub
 MO
 jH
-jH
+ar
 jH
 MO
 ub
@@ -9578,7 +9659,7 @@ WQ
 jj
 jj
 jj
-jj
+ss
 cu
 jj
 xS
@@ -10206,7 +10287,7 @@ WQ
 WQ
 WQ
 WQ
-jj
+QX
 jj
 jj
 hq

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -1550,6 +1550,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"aoQ" = (
+/obj/item/toy/plushie/fumo/necochaos,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/crew_quarters/kitchen)
 "aoW" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt,
@@ -82828,8 +82832,12 @@
 "pBW" = (
 /obj/structure/catwalk,
 /obj/structure/table/rack/shelf,
-/obj/item/device/lighting,
-/obj/item/device/lighting,
+/obj/item/device/lighting/toggleable/flashlight{
+	pixel_x = -2
+	},
+/obj/item/device/lighting/toggleable/flashlight{
+	pixel_x = -2
+	},
 /turf/simulated/floor/plating/under,
 /area/mine/gulag)
 "pBY" = (
@@ -143380,7 +143388,7 @@ wLd
 bwh
 cud
 mXT
-mXT
+aoQ
 mXT
 cud
 wSq


### PR DESCRIPTION
## About The Pull Request
- Nightcrawler perk does no longer give perfect nightvision, now works **closer** to its intended luminosity. TODO: Apply a nightvision-like white overlay to make things easier to see without being literally free NVG
- Fixed medium cell not spawning for lifeline techs
- Typo fixes on the Saturnian
- Fixes Sec patch hud giving more flash protection than intended
- Blindfolds and tape blindfolds now offer maximum welding protection (as they should) since you're literally blind wearing them
- Replaces "items" in Blackshield mines with proper flashlights, adds a hidden easter egg somewhere else

## Lodge changes:
<details> <summary> Adds a bottle of oil and universal enzyme, and a rolling pin to the kitchen</summary>

![image](https://user-images.githubusercontent.com/1294508/199902098-f9fdc3a9-87e5-4493-8b1e-89fedba6914f.png)


</details>
<details> <summary> Adds a ladder for ease of travel between medical and hydroponics, as well as a chem bag to stock their own fridge with</summary>

![image](https://user-images.githubusercontent.com/1294508/199901502-1cb591b3-2592-40c9-a106-3e79e080b871.png)
![image](https://user-images.githubusercontent.com/1294508/199901675-2490569f-7ca1-4b02-a7a1-fb0147f3ffd6.png)


</details>
<details><summary>Minor touchup to Lodge medical, adding an O2 kit as well</summary>

![image](https://user-images.githubusercontent.com/1294508/199902887-eb13fc6f-32a8-49a1-942d-c46aabf1e8ec.png)


</details>

- OSHA compliant extinguishers
- CAMP pacman starts bolted down now
- Minor typo fixes

## Changelog
:cl:
balance: Nightcrawler no longer gives perfeced nightvision, instead increases vision range in the darkness. TODO: Add a light-ish overlay (as well for the Kriotol chem) for less darkness and more visibility
balance: Sec eyepatch HUDs now give half its flash protection values as intended (they cover just one eye)
tweak: Blindfolds and tape blindfolds now give maximum welding protection as you're literally blind using them
fix: Fixes medium cell not spawning in trauma team hardcase
mapfix: Replaces "item"s on Blackshield mining with actual flashlights
fix: Fixes cat eyes mutation not properly giving its night vision range bonus and flash penalty
map: Minor tweaks around the Lodge (oil and enzyme in kitchen, OSHA extinguishers, chem bag, easy access ladder between medical and hydroponics, curtains in surgery, O2 kit in the racks)
spellcheck: fixed a few typos
map: 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
