### PR TITLE
By Pink-Chink

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -52,6 +52,7 @@ var/global/list/image/splatter_cache=list()
 	..(ignore=TRUE)
 
 /obj/effect/decal/cleanable/blood/Destroy()
+	QDEL_NULL(weak_reference)
 	return ..()
 
 /obj/effect/decal/cleanable/blood/New()

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -22,12 +22,11 @@
 		flick(anim, animation)
 		addtimer(CALLBACK(src, .proc/check_delete, animation), 15)
 	else
-		STOP_PROCESSING(SSmobs, src) //were dead, and have no possable way to revive
+		qdel(src)
 
 /mob/proc/check_delete(var/atom/movable/overlay/animation)
 	if(animation)	qdel(animation)
 	if(src)			qdel(src)
-	STOP_PROCESSING(SSmobs, src) //were dead, and have no possable way to revive
 
 
 //This is the proc for turning a mob into ash. Mostly a copy of gib code (above).
@@ -59,7 +58,7 @@
 		flick(anim, animation)
 		addtimer(CALLBACK(src, .proc/check_delete, animation), 15)
 	else
-		STOP_PROCESSING(SSmobs, src) //were dead, and have no possable way to revive
+		qdel(src)
 
 /mob/proc/death(gibbed,deathmessage="seizes up and falls limp...",show_dead_message = "You have died.")
 	if(stat == DEAD)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -27,7 +27,7 @@
 	touching.my_atom = null
 
 	metabolism_effects.parent = null
-
+	reagents = null
 	QDEL_NULL(ingested)
 	QDEL_NULL(touching)
 	QDEL_NULL(reagents) //TODO: test deleting QDEL_NULL(reagents) since QDEL_NULL(bloodstr) might be all we need

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -79,7 +79,6 @@
 
 	QDEL_NULL(sanity)
 	QDEL_NULL(vessel)
-
 	worn_underwear.Cut()
 	return ..()
 

--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -48,12 +48,14 @@
 
 	target_mob = null
 
-	friends.Cut()
+	LAZYCLEARLIST(objectsInView)
+	LAZYCLEARLIST(friends)
 
 	UnregisterSignal(src, COMSIG_ATTACKED)
 
 	lastarea = null
 
+	known_languages = null
 	. = ..()
 
 /mob/living/carbon/superior_animal/u_equip(obj/item/W as obj)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -913,6 +913,9 @@ default behaviour is:
 
 	learnt_tasks = null
 
+	if(registered_z)
+		SSmobs.mob_living_by_zlevel[registered_z] -= src	// STOP_PROCESSING() doesn't remove the mob from this list
+
 	update_z(null)
 
 	destroy_HUD() //this should fix the harddel on humans

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -11,6 +11,7 @@
 	QDEL_NULL(parallax)
 	transform = null
 	QDEL_NULL(transform)
+	QDEL_NULL(shadow)
 	if(client)
 		for(var/atom/movable/AM in client.screen)
 			qdel(AM)

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -66,6 +66,7 @@
 	reagent_list = null
 	if(my_atom && my_atom.reagents == src)
 		my_atom.reagents = null
+	my_atom = null
 
 /* Internal procs */
 

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -11,6 +11,11 @@
 	if(istype(parent_mob))
 		parent = parent_mob
 
+/datum/reagents/metabolism/Destroy()
+	parent = null
+	return ..()
+
+
 /datum/reagents/metabolism/proc/metabolize()
 	expose_temperature(parent.bodytemperature, 0.25)
 
@@ -47,6 +52,13 @@
 	var/addiction_tick = 1
 	/// The final chance for an addiction to manifest is multiplied by this value before being passed to prob.
 	var/addiction_chance_multiplier = 1
+
+/datum/metabolism_effects/Destroy()
+	parent = null
+	withdrawal_list.Cut()
+	active_withdrawals.Cut()
+	addiction_list.Cut()
+	return ..()
 
 //Must be called WHENEVER you modify nsa_bonus, nsa_chem_bonus, nsa_mult, or when you change nerve efficiency.
 //calc_nerves: Activates nerve efficiency recalculation, so its not recalculated every time.

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -99,6 +99,13 @@
 	handle_level()
 	LEGACY_SEND_SIGNAL(owner, COMSIG_HUMAN_SANITY, level)
 
+/datum/sanity/Destroy()
+	UnregisterSignal(owner, COMSIG_MOB_LIFE)
+	UnregisterSignal(owner, COMSIG_HUMAN_SAY)
+	owner = null
+	QDEL_LIST(breakdowns)
+	return ..()
+
 /datum/sanity/proc/give_insight(value)
 	var/new_value = value
 	if(value > 0)


### PR DESCRIPTION
fix: Added Destroy() logic to metabolism and metabolism effects
fix: Cleaned up logic for qdels in reagent holders
fix: Cleaned up logic for metabolism qdels in carbon mobs
fix: Living mobs remove themselves from mob_living_by_zlevel in SSmob
