### PR TITLE
xenoarch guns fix

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -345,23 +345,10 @@
 				new_gun.desc = "This is an antique energy weapon, Wonder how it shoots."
 				new_gun.serial_type = "INDEX"
 				new_gun.serial_shown = FALSE
-
 				new_gun.cell.charge = new_gun.cell.maxcharge
-				/*5% chance to explode when first fired
-				//10% chance to have an unchargeable cell
-				//15% chance to gain a random amount of starting energy, otherwise start with an empty cell
-				if(prob(5))
-					new_gun.cell.rigged = TRUE
-				if(prob(10))
-					new_gun.cell.maxcharge = 0
-				if(prob(15))
-					new_gun.cell.charge = rand(0, new_gun.cell.maxcharge)
-				else
-					new_gun.cell.charge = 0
-				*/
-			new_item.price_tag = rand(950,2500)
-
+				new_item.price_tag = rand(950,2500)
 			item_type = "gun"
+
 		if(27)
 			//projectile guns
 			var/spawn_type = pick(\
@@ -376,28 +363,6 @@
 				new_gun.serial_type = "INDEX"
 				new_gun.serial_shown = FALSE
 				new_gun.price_tag = rand(950,2500)
-			/*33% chance to be able to reload the gun with human ammunition
-			if(prob(66))
-				new_gun.caliber = "999"
-
-			//33% chance to fill it with a random amount of bullets
-			new_gun.max_shells = rand(1,12)
-			if(prob(33))
-			*/
-				var/num_bullets = rand(1,new_gun.max_shells)
-				if(num_bullets < new_gun.loaded.len)
-					new_gun.loaded.Cut()
-					for(var/i = 1, i <= num_bullets, i++)
-						var/A = new_gun.ammo_type
-						new_gun.loaded += new A(new_gun)
-				else
-					for(var/obj/item/I in new_gun)
-						if(new_gun.loaded.len > num_bullets)
-							if(I in new_gun.loaded)
-								new_gun.loaded.Remove(I)
-								I.loc = null
-						else
-							break
 			item_type = "gun"
 
 		if(28)

--- a/code/modules/research/xenoarchaeology/finds/finds_eguns.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_eguns.dm
@@ -1,12 +1,12 @@
 //snowflake guns for xenoarch because you can't override the update_icon() proc inside the giant mess that is find creation
-
 //energy guns
 /obj/item/gun/energy/cog/xenoarch
 	name = "Fossilised Gun"
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	item_state_slots = null
 	icon_contained = FALSE
-	charge_cost = 100
+	charge_cost = 200
+	self_recharge = TRUE
 	projectile_type = /obj/item/projectile/beam/tesla/shotgun // thats right. Its a shotgun cog.
 
 /obj/item/gun/energy/cog/xenoarch/refresh_upgrades()
@@ -20,6 +20,7 @@
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	item_state_slots = null
 	icon_contained = FALSE
+	self_recharge = TRUE
 
 /obj/item/gun/energy/xray/xenoarch/refresh_upgrades()
 	return
@@ -67,8 +68,7 @@
 /obj/item/gun/projectile/boltgun/heavysniper/xenoarch
 	name = "Fossilized Gun"
 	icon = 'icons/obj/xenoarchaeology.dmi'
-	caliber = 999
-	damage_multiplier = 1.8 //It only gets one shot and can't be reloaded. Don't miss.
+	damage_multiplier = 1.5
 
 /obj/item/gun/projectile/boltgun/heavysniper/xenoarch/refresh_upgrades()
 	return


### PR DESCRIPTION
removes the xenoarch guns ammo problems.
Makes them overall better considering you can't just buy or make them and have to instead rely on RNG