### PR TITLE
Fixes Explosive Makeshift AK

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -214,6 +214,7 @@
 	w_class = ITEM_SIZE_HUGE
 	init_recoil = RIFLE_RECOIL(0.7)
 	mag_well = MAG_WELL_RIFLE
+	excelsior = FALSE
 
 	origin_tech = list(TECH_COMBAT = 2)	//bad copies don't give good science
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_WOOD = 10)


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Makeshift AK was pulling from the Excelsior one and caused people to blow the fuck up when using it sometimes. It's been fixed.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fixes: Oversight on my end making makeshift AKs explode 40% of the time if the user was not Excelsior. Or - 99% shoot self.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
