### PR TITLE
Sheet Snatchers Offers!! Wow!!

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/rigprovider.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/rigprovider.dm
@@ -38,5 +38,6 @@
 	)
 	offer_types = list(
 		// TODO: offers
-		/obj/item/rig/merc = offer_data("crimson hardsuit control module", 10000, 1)		// base price: 6282 (incl. components)
+		/obj/item/rig/merc = offer_data("crimson hardsuit control module", 10000, 1), 	 	// base price: 6282 (incl. components)
+		/obj/item/storage/bag/sheetsnatcher/guild = offer_data("advanced sheet snatcher", 400, 2)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/trash_refine.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/trash_refine.dm
@@ -59,7 +59,8 @@
 	offer_types = list(
 		/obj/structure/scrap_cube = offer_data("compressed scrap cube", 80, 3),
 		/obj/item/reagent_containers/food/snacks/baconburger = offer_data("bacon burger", 150, 5),
-		/obj/item/reagent_containers/food/snacks/blt = offer_data("blt sandwich", 180, 12)
+		/obj/item/reagent_containers/food/snacks/blt = offer_data("blt sandwich", 180, 12),
+		/obj/item/storage/bag/sheetsnatcher = offer_data("sheet snatcher", 300, 4)
 	)
 //imo way better place of doing the whole list to be in same file as the ship - Trilby
 /obj/random/scrap


### PR DESCRIPTION
Makes Lancer station offer 300 credits for up to 4 sheet snatchers at a time, considering Solnishko buys many more knives at a time, for 150 each, this seems more than fair considering the effort  and materials involved. Also ain't no one cooking food for trade offers chief.

Also makes Boris station offer 400 credits for up to 2  guild made advanced sheet snatchers at a time.  Having literally only one, extremely niche and rare to obtain offer as the only offer for a station is a really bad idea. Might not make the most sense for this station, but I'll consider replacing it with something more fitting. Eventually. But it works for now.


...Also it's been awhile since I've made a PR so yell at me if I fucked it up somehow.

And, tested to make sure it works and compiles 

![image](https://user-images.githubusercontent.com/47806118/201452726-c8acb6a0-d7ff-4351-8786-71f2b95b66ff.png)

![image](https://user-images.githubusercontent.com/47806118/201452729-4f4c0063-7042-47c9-a37a-23629de59467.png)
