### PR TITLE
More beacon fiddling, part TWO!! WOW! !EGHGHG!!! 

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -14,6 +14,7 @@
 	var/datum/genetics/genetics_holder/unnatural_mutations = new() //GMO in your MEAT
 	var/source_mob
 	var/source_name
+	price_tag = 20 //Partially to make it not dirt-cheap to buy from the beacon. Plus it's useful as biomatter, so it's worth something.
 
 //For initializing genetics information for meat, so it's easy to call.
 /obj/item/reagent_containers/food/snacks/meat/proc/initialize_genetics(mob/living/meat_source)

--- a/code/modules/trade/datums/trade_stations_presets/1-common/ghost_kitchen.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/ghost_kitchen.dm
@@ -276,6 +276,7 @@
 		/obj/item/reagent_containers/glass/rag = offer_data("Rag", 40, 5),
 		/obj/item/reagent_containers/spray = offer_data("Spray Bottle", 40, 10),
 		/obj/item/mop = offer_data("Mop", 150, 2),
-		/obj/item/reagent_containers/food/snacks/grown = offer_data("spare grown food", 10, 120)
+		/obj/item/reagent_containers/food/snacks/grown = offer_data("spare grown food", 10, 120),
+		/obj/item/tray = offer_data("dinner tray", 125, 5)
 	)
 

--- a/code/modules/trade/datums/trade_stations_presets/1-common/nt_cruisers.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/nt_cruisers.dm
@@ -148,7 +148,8 @@
 	offer_types = list(
 		/obj/item/clothing/suit/space/void/NTvoid = offer_data("angel voidsuit", 1250, 15),
 		/obj/item/clothing/shoes/hermes_shoes = offer_data("hermes shoes", 420, 10),
-		/obj/item/reagent_containers/food/snacks/grown = offer_data("spare grown food", 10, 120)
+		/obj/item/reagent_containers/food/snacks/grown = offer_data("spare grown food", 10, 120),
+		/obj/item/reagent_containers/food/snacks/meat = offer_data("meat", 80, 20) //Buys it for less than Dionis/McRonalds, but is willing to buy more of it.
 	)
 
 /obj/item/reagent_containers/food/drinks/cans/cahors/cargo

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/casino.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/casino.dm
@@ -29,12 +29,15 @@
 		)
 	)
 	hidden_inventory = list(
+		"Premium Assorted Goods" = list(
 			/obj/item/storage/deferred/disks = custom_good_amount_range(list(2, 4)),
 			/obj/item/storage/deferred/rig = custom_good_amount_range(list(2, 4)),
 			/obj/item/storage/deferred/tools = custom_good_amount_range(list(2, 4)),
 			/obj/item/gem //THE BIG TICKET ITEM
+		)
 	)
 	offer_types = list(
 		/obj/item/oddity/common/coin = offer_data("strange coin", 800, 1),
-		/obj/item/oddity/common/old_money = offer_data("old money", 800, 1)
+		/obj/item/oddity/common/old_money = offer_data("old money", 800, 1),
+		/obj/item/storage/box = offer_data("cardboard box", 75, 5) // SUPPOSED to be a rebate for the boxes they sell. But, they use a special, non-box based storage method. For now, it's just a non-RNG method of getting favor for this station besides spending money on loot-boxes you may or may not need.
 	)

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/rigprovider.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/rigprovider.dm
@@ -38,5 +38,6 @@
 	)
 	offer_types = list(
 		// TODO: offers
-		/obj/item/rig/merc = offer_data("crimson hardsuit control module", 10000, 1)		// base price: 6282 (incl. components)
+		/obj/item/rig/merc = offer_data("crimson hardsuit control module", 10000, 1), 	 	// base price: 6282 (incl. components)
+		/obj/item/storage/bag/sheetsnatcher/guild = offer_data("advanced sheet snatcher", 400, 2)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/trash_refine.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/trash_refine.dm
@@ -58,8 +58,8 @@
 	// TODO: offers
 	offer_types = list(
 		/obj/structure/scrap_cube = offer_data("compressed scrap cube", 80, 3),
-		/obj/item/reagent_containers/food/snacks/baconburger = offer_data("bacon burger", 150, 5),
-		/obj/item/reagent_containers/food/snacks/blt = offer_data("blt sandwich", 180, 12),
+		/obj/item/reagent_containers/food/snacks/baconburger = offer_data("bacon burger", 500, 4),
+		/obj/item/reagent_containers/food/snacks/blt = offer_data("blt sandwich", 500, 4),
 		/obj/item/storage/bag/sheetsnatcher = offer_data("sheet snatcher", 300, 4)
 	)
 //imo way better place of doing the whole list to be in same file as the ship - Trilby

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/trash_refine.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/trash_refine.dm
@@ -59,7 +59,8 @@
 	offer_types = list(
 		/obj/structure/scrap_cube = offer_data("compressed scrap cube", 80, 3),
 		/obj/item/reagent_containers/food/snacks/baconburger = offer_data("bacon burger", 150, 5),
-		/obj/item/reagent_containers/food/snacks/blt = offer_data("blt sandwich", 180, 12)
+		/obj/item/reagent_containers/food/snacks/blt = offer_data("blt sandwich", 180, 12),
+		/obj/item/storage/bag/sheetsnatcher = offer_data("sheet snatcher", 300, 4)
 	)
 //imo way better place of doing the whole list to be in same file as the ship - Trilby
 /obj/random/scrap

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/bluespace_tech.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/bluespace_tech.dm
@@ -30,5 +30,5 @@
 	offer_types = list(
 		/obj/item/bluespace_crystal = offer_data("bluespace crystal", 2000, 10),
 		/obj/item/device/mmi/digital/posibrain = offer_data("positronic brain", 750, 3),
-		/obj/item/reagent_containers/food/snacks/csandwich = offer_data("sandwich", 150, 1)
+		/obj/item/reagent_containers/food/snacks/csandwich = offer_data("sandwich", 400, 1)
 	)


### PR DESCRIPTION
Woops! Guess I gotta found out how to make it so the old commits go away before starting a new PR, but for now, it looks like nothing outside of the latest commit will be changed via doing this. So for now, hehehaw.


Makes the religion stations buy meat, not as much per slab as Dionis does (given it's a tier one, roundstart station), but they can buy more at a time based on RNG.

Gives meat and all of it's sub-types a base price of 20 credits (hopefully)

Ghost-kitchen, AKA the VERY under utilized chef station now buys dinner trays. Slightly cheaper than knives. But I may change this to be more profitable than knives, albeit very restricted in number sold at a time, given it's one steel PLUS a tool-step. (Though honestly, I think I'm gonna tone back kitchen knife sales to 100, at LEAST, here soon.)

BUG FIX!!! Casino station no longer has an unlisted secret inventory, it now correctly displays, and gives a name to the extra tab. TODO! Make rigsuits more expensive overall, because you're paying a premium for a usually inferior rigsuit. (And voidsuits suits on that note). Oh and make it so the gems are properly sold for a million credits instead of twenty or two hundred million credits.

Casino station now buys cardboard boxes. For the meantime, it's plain cardboard boxes, while it's supposed to be a rebate, the boxes used for the Casino sales are a special subtype that include a LOT of non-box special objects. It works as an alternate favor method for now.

Brings a few more kitchen dishes up to closer par with roach-meat burgers. Vermouth pays FIVE HUNDRED credits for certain types of roach burgers roundstart. Bacon is a somewhat limited resource, and a pain to cook, so it should a LEAST be closer to roach meat. Effected stations by this are the trash refining station and the bluespace station.

![image](https://user-images.githubusercontent.com/47806118/201503502-bb8ff628-6cd1-43b8-9ce8-c2b2e822d792.png)
![image](https://user-images.githubusercontent.com/47806118/201503505-5e506101-bb80-4f17-8791-72912c695666.png)
![image](https://user-images.githubusercontent.com/47806118/201503511-d93570bc-aa01-4634-a925-1c7d135db9c0.png)
![image](https://user-images.githubusercontent.com/47806118/201503517-a5c537da-e2c7-41ea-b4d3-7f1acb0d18b6.png)
![image](https://user-images.githubusercontent.com/47806118/201503520-a42f4632-e3b5-48e4-95f8-3d7de8dd7980.png)
