### PR TITLE
Caliber Damages & Recoil

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -13,8 +13,8 @@
 	step_delay = 0.65
 	can_ricochet = TRUE
 
-	affective_damage_range = 2
-	affective_ap_range = 2
+	affective_damage_range = 3
+	affective_ap_range = 3
 	recoil = 3
 	added_damage_bullet_pve = 4
 
@@ -129,13 +129,13 @@
 
 	affective_damage_range = 3
 	affective_ap_range = 3
-	recoil = 4
+	recoil = 5
 	added_damage_bullet_pve = 9
 
 /obj/item/projectile/bullet/magnum_40/practice
 	name = "practice bullet"
 	damage_types = list(BRUTE = 2)
-	agony = 3
+	agony = 4
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
@@ -152,7 +152,7 @@
 	nocap_structures = TRUE //Door breaching
 	affective_damage_range = 4
 	affective_ap_range = 4
-	recoil = 6
+	recoil = 7
 	added_damage_bullet_pve = 7
 
 /obj/item/projectile/bullet/magnum_40/rubber
@@ -164,7 +164,7 @@
 	embed = FALSE
 	sharp = FALSE
 	step_delay = 0.5
-	recoil = 2
+	recoil = 4
 	added_damage_bullet_pve = 2
 
 /obj/item/projectile/bullet/magnum_40/rubber/pepperball
@@ -213,7 +213,7 @@
 	embed = TRUE
 	sharp = TRUE
 	step_delay = 0.5
-	recoil = 2
+	recoil = 5
 	added_damage_bullet_pve = 21
 
 /obj/item/projectile/bullet/magnum_40/scrap
@@ -221,7 +221,7 @@
 	armor_penetration = 5
 	affective_damage_range = 1
 	affective_ap_range = 1
-	recoil = 1
+	recoil = 4
 	added_damage_bullet_pve = 7
 
 /obj/item/projectile/bullet/magnum_40/biomatter
@@ -235,7 +235,7 @@
 	sharp = FALSE
 	step_delay = 0.65
 	check_armour = ARMOR_BIO
-	recoil = 2
+	recoil = 4
 	added_damage_bullet_pve = 10
 
 /// 12mm Heavy Pistol ///
@@ -248,7 +248,7 @@
 	step_delay = 0.65
 	affective_damage_range = 3
 	affective_ap_range = 3
-	recoil = 7
+	recoil = 8
 	added_damage_bullet_pve = 9.5
 
 /obj/item/projectile/bullet/kurtz_50/rubber
@@ -260,7 +260,7 @@
 	armor_penetration = 0
 	can_ricochet = TRUE
 	step_delay = 0.75
-	recoil = 5
+	recoil = 6
 	added_damage_bullet_pve = 3
 
 /obj/item/projectile/bullet/kurtz_50/practice
@@ -283,7 +283,7 @@
 	penetrating = 0
 	can_ricochet = FALSE
 	step_delay = 0.8
-	recoil = 6
+	recoil = 10
 	added_damage_bullet_pve = 25
 
 /obj/item/projectile/bullet/kurtz_50/hv
@@ -296,7 +296,7 @@
 	affective_damage_range = 4
 	affective_ap_range = 4
 	nocap_structures = TRUE //We can breach doors rather well
-	recoil = 10
+	recoil = 12
 	added_damage_bullet_pve = 10
 
 
@@ -314,7 +314,7 @@
 	step_delay = 0.3
 	affective_damage_range = 7
 	affective_ap_range = 7
-	recoil = 2
+	recoil = 3
 	added_damage_bullet_pve = 8
 
 /obj/item/projectile/bullet/light_rifle_257/practice
@@ -326,7 +326,7 @@
 	sharp = FALSE
 	can_ricochet = FALSE
 	step_delay = 0.5
-	recoil = 1
+	recoil = 2
 	added_damage_bullet_pve = 2
 
 /obj/item/projectile/bullet/light_rifle_257/hv
@@ -337,7 +337,7 @@
 	affective_damage_range = 8 //Can snipe
 	affective_ap_range = 8
 	nocap_structures = TRUE //RATARATARAT down a door
-	recoil = 4
+	recoil = 5
 	added_damage_bullet_pve = 7
 
 /obj/item/projectile/bullet/light_rifle_257/rubber
@@ -351,7 +351,7 @@
 	sharp = FALSE
 	can_ricochet = TRUE
 	step_delay = 0.9
-	recoil = 1
+	recoil = 2
 	added_damage_bullet_pve = 3
 
 /obj/item/projectile/bullet/light_rifle_257/lethal
@@ -365,7 +365,7 @@
 	embed = TRUE
 	sharp = TRUE
 	step_delay = 0.6
-	recoil = 1
+	recoil = 4
 	added_damage_bullet_pve = 15
 
 /obj/item/projectile/bullet/light_rifle_257/scrap
@@ -373,7 +373,7 @@
 	armor_penetration = 7
 	affective_damage_range = 4
 	affective_ap_range = 4
-	recoil = 1
+	recoil = 4
 	added_damage_bullet_pve = 6
 
 /obj/item/projectile/bullet/light_rifle_257/nomuzzle
@@ -471,15 +471,15 @@
 
 /obj/item/projectile/bullet/heavy_rifle_408
 	icon_state = "bullet_heavy"
-	damage_types = list(BRUTE = 17)
-	armor_penetration = 30
+	damage_types = list(BRUTE = 20)
+	armor_penetration = 25
 	penetrating = 2
 	can_ricochet = TRUE
 	step_delay = 0.3
 	affective_damage_range = 8
 	affective_ap_range = 8
-	recoil = 10
-	added_damage_bullet_pve = 11
+	recoil = 12
+	added_damage_bullet_pve = 12
 
 /obj/item/projectile/bullet/heavy_rifle_408/rubber
 	name = "rubber bullet"
@@ -509,20 +509,20 @@
 
 /obj/item/projectile/bullet/heavy_rifle_408/hv
 	name = "sabot penetrator"
-	damage_types = list(BRUTE = 15)
-	armor_penetration = 48
+	damage_types = list(BRUTE = 16)
+	armor_penetration = 46
 	penetrating = 3
 	hitscan = TRUE
 	affective_damage_range = 9 //Sniping cal
 	affective_ap_range = 9
 	nocap_structures = TRUE //anit-wall/door
-	recoil = 14
+	recoil = 16
 	added_damage_bullet_pve = 9
 
 /obj/item/projectile/bullet/heavy_rifle_408/lethal
 	name = "hollow-point bullet"
-	damage_types = list(BRUTE = 17.5)
-	agony = 12
+	damage_types = list(BRUTE = 25)
+	agony = 14
 	post_penetration_dammult = 2
 	armor_penetration = 0 //Half of normal
 	penetrating = 0
@@ -530,15 +530,15 @@
 	embed = TRUE
 	sharp = TRUE
 	step_delay = 0.5
-	recoil = 8
+	recoil = 10
 	added_damage_bullet_pve = 26
 
 /obj/item/projectile/bullet/heavy_rifle_408/scrap
-	damage_types = list(BRUTE = 13)
+	damage_types = list(BRUTE = 15)
 	armor_penetration = 15 //half  of normal
-	affective_damage_range = 3
-	affective_ap_range = 3
-	recoil = 6
+	affective_damage_range = 4
+	affective_ap_range = 4
+	recoil = 8
 	added_damage_bullet_pve = 7
 
 ///Snowflake  ///


### PR DESCRIPTION
## About The Pull Request
Simply - this PR does these few things:
- Ups the effective range of 9mm to not instantly lose its drop off after traveling a single tile from the user firing it.
- Ups the recoil on 12mm / .50 Kurz. The reason being - the rounds are more powerful than even a 7.62 rifle. As such, they deserve a higher recoil. AP is good to have, but with the changes of AP damage to mobs, it is not as powerful as it once was.
- Ups the damage but also the recoil of 8.6mm / .408. The reason the same as above - its AP is strong, but its damage is 'meh'. This should make .408s act as proper hard-hitting battle rifles but hard to fire in large bursts of full-auto.
- Increased some agony damages on HPs to make them more viable. Also upped some of their recoils  - no idea why they were lower.
- 6.5mm has received a slight recoil increase. Why did 6.5mm carbine / rifle calibers have a somehow lower recoil than a 9mm handgun despite a larger casing and velocity?

## Changelog
:cl:
balance: Ups recoil on 12mm and 8.6mm.
balance: Ups effective range on 9mm.
balance: Ups damage on 8.6mm.
balance: Ups some agony damage and some recoil on agony damage bullets.
balance: Ups the recoil on 6.5mm rounds to not make them somehow lower than 9mm.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
