### PR TITLE
Basic Chemist Offers, Combination Driver Slash. Famine.

### DIFF
--- a/code/game/objects/items/weapons/tools/screwdrivers.dm
+++ b/code/game/objects/items/weapons/tools/screwdrivers.dm
@@ -45,13 +45,13 @@
 	w_class = ITEM_SIZE_NORMAL
 	worksound = WORKSOUND_DRIVER_TOOL
 	slot_flags = SLOT_BELT
-	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTEEL = 1, MATERIAL_PLASTIC = 2)
+	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLASTEEL = 2, MATERIAL_PLASTIC = 2)
 	tool_qualities = list(QUALITY_SCREW_DRIVING = 40, QUALITY_BOLT_TURNING = 40, QUALITY_DRILLING = 20)
 	degradation = 1.5
 	use_power_cost = 0.54
 	suitable_cell = /obj/item/cell/small
 	max_upgrades = 4
-	price_tag = 600 // Highly prized
+	price_tag = 325 // Highly prized (BUT, no longer an economic powerhouse. Also affordable.)
 
 /obj/item/tool/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M) || user.a_intent == "help")
@@ -67,7 +67,7 @@
 	name = "Greyson Positronic combination drill"
 	desc = "Does better than the standard combination drivers on the market, but has less slots for tool mods."
 	icon_state = "one_star_combidriver"
-	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLATINUM = 2)
+	matter = list(MATERIAL_STEEL = 6, MATERIAL_PLATINUM = 3)
 	tool_qualities = list(QUALITY_SCREW_DRIVING = 60, QUALITY_BOLT_TURNING = 60, QUALITY_DRILLING = 25)
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2)
 	degradation = 2.5
@@ -75,4 +75,4 @@
 	use_power_cost = 0.3
 	suitable_cell = /obj/item/cell/small
 	max_upgrades = 2
-	price_tag = 1800 // Very prized.
+	price_tag = 1200 // Very prized.

--- a/code/modules/trade/datums/trade_stations_presets/1-common/boozefood.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/boozefood.dm
@@ -15,13 +15,13 @@
 	stations_recommended = list("mcronalds", "serbian")
 	inventory = list(
 		"Basic Ingredients" = list(
-			/obj/item/reagent_containers/food/condiment/flour,
-			/obj/item/reagent_containers/food/drinks/milk,
-			/obj/item/storage/fancy/egg_box,
-			/obj/item/reagent_containers/food/snacks/tofu,
-			/obj/item/reagent_containers/food/snacks/meat,
+			/obj/item/reagent_containers/food/condiment/flour = good_data("flour sack", list(1, 2), 250),
+			/obj/item/reagent_containers/food/drinks/milk = good_data("milk carton", list(1, 2), 100),
+			/obj/item/storage/fancy/egg_box = good_data("egg box", list(1, 2), 300),
+			/obj/item/reagent_containers/food/snacks/tofu = good_data("tofu", list(1, 2), 20),
+			/obj/item/reagent_containers/food/snacks/meat = good_data("meat", list(1, 2), 25),
 			/obj/item/reagent_containers/food/condiment/enzyme,
-			/obj/item/reagent_containers/food/condiment/cookingoil
+			/obj/item/reagent_containers/food/condiment/cookingoil = good_data("cooking oil bottle", list(1, 2), 200)
 		),
 		"Drinks" = list(
 			/obj/item/reagent_containers/food/drinks/bottle/gin,

--- a/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
@@ -120,6 +120,9 @@
 	offer_types = list(
 		/obj/item/organ/internal/scaffold = offer_data_mods("aberrant organ (input, process, output)", 1200, 4, OFFER_ABERRANT_ORGAN, 3),
 		/datum/reagent/medicine/ossisine = offer_data("ossissine bottle (60u)", 2000, 1),
+		/datum/reagent/medicine/bicaridine = offer_data("bicard bottle (60u)", 150, 3),
+		/datum/reagent/medicine/kelotane = offer_data("kelotane bottle (60u)", 150, 3),
+		/datum/reagent/medicine/dylovene = offer_data("dylovene bottle (60u)", 150, 3),
 		/datum/reagent/nanites/uncapped/control_booster_utility = offer_data("Control Booster Utility bottle (60u)", 30000, 1),
 		/datum/reagent/nanites/uncapped/control_booster_combat = offer_data("Control Booster Combat bottle (60u)", 30000, 1)
 		)

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/advmoe.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/advmoe.dm
@@ -29,7 +29,7 @@
 		),
 		"Chemical Surplus" = list(
 			/obj/item/reagent_containers/glass/bottle/inaprovaline = custom_good_amount_range(list(1, 3)),
-			/obj/item/reagent_containers/glass/bottle/antitoxin = custom_good_amount_range(list(1, 3)),
+			/obj/item/reagent_containers/glass/bottle/antitoxin = good_data("dylovene bottle", list(1,3), 200),
 			/obj/item/reagent_containers/glass/bottle/trade/kelotane = good_data("kelotane bottle", list(1, 3), 200),
 			/obj/item/reagent_containers/glass/bottle/trade/bicaridine = good_data("bicaridine bottle", list(1, 3), 200),
 			/obj/item/reagent_containers/glass/bottle/trade/cronexidone = good_data("cronexidone bottle", list(1, 3), 800),


### PR DESCRIPTION
Sets non-default prices for meat, tofu, eggs, flour, and milk for Vermouth station.

Cad station has gotten a set of basic medicine bottles as offers, to give something chemists to do quickly and easily. Or the church/garden that knows how to work with plants.

Gives Dylovene a non-default price for the SI station.

Decreases the value of both normal and Greyson combination drills, and ups the required materials to print both.