### PR TITLE
water and bots

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -515,6 +515,19 @@
 			to_chat(user, SPAN_NOTICE("You empty the [O] into the [src]."))
 
 
+/obj/structure/sink/fountain
+	name = "water fountain"
+	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water."
+	icon_state = "BaptismFont_Water"
+	refill_rate = 2
+
+/obj/structure/sink/basion
+	name = "water basion"
+	desc = "A deep basion of polished stone and has prefilled with fresh water."
+	icon_state = "BaptismFont_Water"
+	limited_reagents = FALSE
+	refill_rate = 200
+
 /obj/structure/sink/kitchen
 	name = "kitchen sink"
 	desc = "A HV-11B sink. Used for washing the hands and face, and utensils."
@@ -524,6 +537,8 @@
 	name = "puddle"
 	desc = "A puddle of still water. Great for splashing others."
 	icon_state = "puddle"
+	limited_reagents = FALSE
+	refill_rate = 200
 
 /obj/structure/sink/puddle/attack_hand(mob/M as mob)
 	icon_state = "puddle-splash"

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -517,13 +517,13 @@
 
 /obj/structure/sink/fountain
 	name = "water fountain"
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water."
+	desc = "A small fountain of polished stone that has a small pump at the bottom which helps pump out fresh water."
 	icon_state = "BaptismFont_Water"
 	refill_rate = 2
 
 /obj/structure/sink/basion
 	name = "water basion"
-	desc = "A deep basion of polished stone and has prefilled with fresh water."
+	desc = "A deep basin of polished stone that has been pre-filled with fresh water."
 	icon_state = "BaptismFont_Water"
 	limited_reagents = FALSE
 	refill_rate = 200

--- a/code/modules/mob/living/silicon/Cyborg_AI/remote_control.dm
+++ b/code/modules/mob/living/silicon/Cyborg_AI/remote_control.dm
@@ -64,7 +64,7 @@
 		return
 
 	if(user.amount_of_borgs_printed >= 1)
-		to_chat(user, "<span class='warning'>Maxium AI borgs per Unit Dispenced.</span>")
+		to_chat(user, "<span class='warning'>Maximum AI borgs per unit already dispensed.</span>")
 		return
 
 	user.amount_of_borgs_printed += 1

--- a/code/modules/mob/living/silicon/Cyborg_AI/remote_control.dm
+++ b/code/modules/mob/living/silicon/Cyborg_AI/remote_control.dm
@@ -14,7 +14,7 @@
 		to_chat(user, "<span class='warning'>You cannot take control of an autonomous, active drone.</span>")
 		return
 
-	if(health < -35 || HasTrait(CYBORG_TRAIT_EMAGGED))
+	if(health < 1 || HasTrait(CYBORG_TRAIT_EMAGGED))
 		to_chat(user, "<span class='notice'><b>WARNING:</b> connection timed out.</span>")
 		return
 
@@ -62,6 +62,12 @@
 	if(count_drones() >= config.max_maint_drones)
 		to_chat(user, "<span class='warning'>The control subsystems are tasked to capacity; they cannot support any more cyborgs.</span>")
 		return
+
+	if(user.amount_of_borgs_printed >= 1)
+		to_chat(user, "<span class='warning'>Maxium AI borgs per Unit Dispenced.</span>")
+		return
+
+	user.amount_of_borgs_printed += 1
 
 	var/mob/living/silicon/robot/new_borg = new drone_type(get_turf(src))
 	new_borg.assume_controll(user)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -111,6 +111,8 @@ var/list/ai_verbs_default = list(
 
 	var/multitool_mode = 0
 
+	var/amount_of_borgs_printed = 0				// How many borgs we have printed per AI
+
 	defaultHUD = "Eris"
 
 /mob/living/silicon/ai/proc/add_ai_verbs()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -11,6 +11,7 @@
 
 	if(client)
 		handle_regular_hud_updates()
+		handle_regular_status_updates()
 		update_items()
 	if (src.stat != DEAD) //still using power
 		use_power()
@@ -25,6 +26,36 @@
 
 	for(var/mob/living/L in view(7)) //Sucks to put this here, but otherwise mobs will ignore them
 		L.try_activate_ai()
+
+/mob/living/silicon/robot/Life_Check_Light()
+	set invisibility = 0
+	set background = 1
+
+	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))
+		return
+
+	//Status updates, death etc.
+	clamp_values()
+	handle_actions()
+
+	if(client)
+		handle_regular_hud_updates()
+		handle_regular_status_updates()
+		update_items()
+	if (src.stat != DEAD) //still using power
+		use_power()
+		process_killswitch()
+		process_locks()
+		process_queued_alarms()
+	else
+		if (!src.death_notified && src.connected_ai)
+			src.notify_ai(ROBOT_NOTIFICATION_SIGNAL_LOST)
+			src.death_notified = TRUE
+	update_lying_buckled_and_verb_status()
+
+	for(var/mob/living/L in view(7)) //Sucks to put this here, but otherwise mobs will ignore them
+		L.try_activate_ai()
+
 
 /mob/living/silicon/robot/proc/clamp_values()
 
@@ -158,16 +189,9 @@
 		return
 
 
-
-
-
-
-
 	for (var/obj/screen/H in HUDprocess)
 //		var/obj/screen/B = H
 		H.Process()
-
-
 
 	return 1
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -36,6 +36,8 @@
 	mob_classification = CLASSIFICATION_SYNTHETIC
 	colony_friend = TRUE
 
+	status_flags = CANWEAKEN|CANSTUN|CANPUSH
+
 /mob/living/silicon/Initialize()
 	GLOB.silicon_mob_list |= src
 	. = ..()

--- a/maps/_HunterLodge/map/_Hunting_Lodge.dmm
+++ b/maps/_HunterLodge/map/_Hunting_Lodge.dmm
@@ -175,15 +175,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest/hunting_lodge)
 "aR" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
 /obj/effect/floor_decal/spline/fancy{
 	color = "#6c3d26"
 	},
+/obj/structure/sink/basion,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/outside/forest/hunting_lodge)
 "aS" = (
@@ -1968,9 +1963,6 @@
 /obj/machinery/honey_extractor,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
-"mP" = (
-/turf/simulated/wall/wood,
-/area/nadezhda/outside/forest/hunting_lodge_dark)
 "np" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1;
@@ -2272,12 +2264,7 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "rd" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
+/obj/structure/sink/basion,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest/hunting_lodge)
 "rg" = (
@@ -9498,7 +9485,7 @@ ar
 ar
 ar
 ar
-mP
+WQ
 jj
 jj
 Cb

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -37453,12 +37453,7 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/barbackroom)
 "hcq" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
+/obj/structure/sink/fountain,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "hct" = (
@@ -81604,12 +81599,7 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
 "pnr" = (
-/obj/structure/sink{
-	density = 1;
-	desc = "A small fountain of polished stone and has a small pump at the bottom that helps push fresh water.";
-	icon_state = "BaptismFont_Water";
-	name = "Water Fountain"
-	},
+/obj/structure/sink/fountain,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "pns" = (


### PR DESCRIPTION
Makes AI cyborgs limited to 1 print pr AI core
Makes hunter water basions no longer run out of water
Vastly improves churchs water fountains to be less likely to run dry
Fixes borgs being perma stunned/weakened/paralized