### PR TITLE
Fixes AP on the Luty/homemade Kalash

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -193,7 +193,7 @@
 	origin_tech = list(TECH_COMBAT = 2)	//bad copies don't give good science
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_WOOD = 10)
 	damage_multiplier = 1.1
-	penetration_multiplier = 0
+	penetration_multiplier = 0.8
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY	//too poorly made for burst or automatic

--- a/code/modules/projectiles/guns/projectile/automatic/luty.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/luty.dm
@@ -20,7 +20,7 @@
 		)
 	can_dual = 1
 	damage_multiplier = 0.8
-	penetration_multiplier = 0
+	penetration_multiplier = 0.6
 	init_recoil = SMG_RECOIL(0.6)
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	serial_type = "INDEX"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Currently, the 9mm "Luty" and scrap Kalashnikov have a penetration_multiplier of 0. No matter what ammo you use, it'll always have 0 AP. I'm _fairly sure_ this is an oversight - they're the _only guns_ with _no AP_, and giving them this wouldn't disrupt their place as "acceptable but mediocre".
This PR gives the Kalash 0.8 and the Luty 0.6, compared to their damage_multipliers of 1.1 and 0.8 respectively.
	
<hr>
</details>

## Changelog
:cl:
add: Added new things
balance: Luty/homemade AK now have low armour pen rather than none at all
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
