### PR TITLE
Nanogate Balancing

### DIFF
--- a/code/modules/organs/internal/nanogate.dm
+++ b/code/modules/organs/internal/nanogate.dm
@@ -23,6 +23,7 @@
 	var/mob/living/carbon/superior_animal/nanobot/Stand // The personal robot of the owner. I wonder how many people will get the reference... -R4d6
 	var/obj/item/rig/nanite/nanite_rig // The nanite rig you can make
 	var/list/perk_list = list() //List of activated perks for later removal
+	min_broken_damage = 10 //Should break when organ is at 10 health of its 60.
 
 	owner_verbs = list(
 		/obj/item/organ/internal/nanogate/proc/nanite_antenna,
@@ -79,3 +80,26 @@ obj/item/organ/internal/nanogate/artificer
 		// Rig Upgrades
 		/obj/item/organ/internal/nanogate/proc/nanite_rig_opifex
 		)
+
+
+// Nanogates use either nanomachines or electromagnetic nanites. So - you would be impacted by EMPs.
+/obj/item/organ/internal/nanogate/emp_act(severity)
+	..()
+	switch (severity)
+		if(1)
+			owner.apply_effect(40, AGONY)
+		if(2)
+			owner.apply_effect(30, AGONY)
+		if(3)
+			owner.apply_effect(20, AGONY)
+
+// If the organ goes below is theshold it dies. And does bad effects.
+/obj/item/organ/internal/nanogate/die()
+	if(status & ORGAN_BROKEN)
+		var/obj/item/organ/internal/targeted_organ
+		to_chat(owner, SPAN_DANGER("You are in absolute agony as your nanites attack your own body!"))
+		var/list/listed_organs  = list("brain",OP_EYES,"heart")
+		targeted_organ = owner.random_organ_by_process(pick(listed_organs))
+		targeted_organ.damage += rand (5,10)
+		owner.apply_effect(60, AGONY)
+		addtimer(CALLBACK(src, .proc/die), 1 MINUTES, TIMER_STOPPABLE)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -284,7 +284,7 @@
 /obj/item/organ/emp_act(severity)
 	if(!BP_IS_ROBOTIC(src))
 		return
-	
+
 	//Robotic body parts conduct EMPs way better than flesh
 	if(parent && BP_IS_ROBOTIC(parent))
 		switch (severity)
@@ -302,7 +302,7 @@
 				take_damage(20)
 			if(3)
 				take_damage(10)
-		
+
 
 // Gets the limb this organ is located in, if any
 /obj/item/organ/proc/get_limb()


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	Balanced out nanogates finally. Nanogates now actually have IMPACTS from being EMPed and damaged. When the Nanogate takes and EMP, depending on its severity, it does temporary agony damage to the user. If the Nanogate goes below 10 health, it will break, causing the user intense looping pain and organ damage to either their heart, eyes, or brain, until the implant is removed or fixed. This will **FINALLY** provide a proper downside to Nanogate; as genetics is rarely used with a nanogate anyhow and the inspiration is honestly negligible due to perks you can get from 1 inspiration usage.
</summary>
<hr>
<hr>
</details>

## Changelog
:cl:
balance: Finally adds an effect for Nanogates when they get damaged rather than being funni meme: "YOU HATH NO EFFECT ON ME!!!" when they are damaged via an EMP or brain-trauma.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
