### PR TITLE
No More Infinite Perks from Oddities

### DIFF
--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -280,7 +280,8 @@
 			to_chat(owner, SPAN_NOTICE("Your [stat] stat goes up by [stat_up]"))
 			owner.stats.changeStat(stat, stat_up)
 		if(I.perk)
-			owner.stats.addPerk(I.perk)
+			if(owner.stats.addPerk(I.perk))
+				I.perk = null
 		for(var/mob/living/carbon/human/H in viewers(owner))
 			LEGACY_SEND_SIGNAL(H, COMSIG_HUMAN_ODDITY_LEVEL_UP, owner, O)
 		for(var/mob/living/carbon/human/H in viewers(owner))


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	This PR does one simple thing - effectively reverting the code that made oddities keep their perk after usage. This was a change Eris did last year as well that I still feel is not exactly well balanced and makes oddity perks a 'pass-around' thing instead of encouraging the buying and/or selling of oddity perks. Similarly, some oddity perks are rather strong perks (i.e - Gunslinger, Springheel, etc) and therefor should be limited and treated as rare commodities rather than something to be freely passed around as: "I got my use out of it, here, on the house." _How will the Oddity economy ever recover from this mean rebel-man???_
</summary>
<hr>
<hr>
</details>

## Changelog
:cl:
tweak: Tweaks oddities to be a 1-time use in terms of perks. After the use, the perk disappears but the oddity will keep its stats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
