### PR TITLE
firestack hallos buff

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1205,7 +1205,7 @@
 		bodytemperature += round(BODYTEMP_HEATING_MAX*(1-thermal_protection), 1)
 		if(world.time >= next_onfire_hal)
 			next_onfire_hal = world.time + 50
-			adjustHalLoss(fire_stacks*10 + 3)
+			adjustHalLoss(fire_stacks*5 + 3) //adjusted to be lower. You need time to put yourself out. And each roll only removes 2.5 stacks.
 
 /mob/living/carbon/human/rejuvenate()
 	sanity.setLevel(sanity.max_level)


### PR DESCRIPTION
halfs the hallos damage fire stacks do.



Testing information:
Keep in mind fire stacks only deal hallos damage every 50 seconds. So people saying they go down in a single hit of hallos are far weaker then my testing server spawned in puppet. Even having 4 stacks put on the puppet instantly, took more then then two procs (the initial, a second and the 3rd finally crit him)