### PR TITLE
Gun Wield Delays ('B-BUT I NEED MY INSTANT DRAW AMR!!!')

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -261,13 +261,13 @@ Proc for attack log creation, because really why not
 			progbar.update(world.time - starttime)
 
 		if(immobile)
-			if(!user || user.incapacitated(incapacitation_flags) || user.loc != original_loc)
+			if(user.loc != original_loc)
 				. = 0
 				break
 
-			if(target_loc && (!target || target_loc != target.loc))
-				. = 0
-				break
+		if(target_loc && (!target || target_loc != target.loc))
+			. = 0
+			break
 
 		if(needhand)
 			if(user.get_active_hand() != holding)

--- a/code/modules/mob/mob_grab_specials.dm
+++ b/code/modules/mob/mob_grab_specials.dm
@@ -85,6 +85,7 @@
 	if(!organ || organ.nerve_struck == -1)
 		return
 
+	visible_message(SPAN_WARNING("[attacker] tries to put [target]'s [organ.name] into a jointlock."))
 	if(!do_after(attacker, 7 SECONDS, target))
 		to_chat(attacker, SPAN_WARNING("You must stand still to jointlock [target]!"))
 	else

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -126,6 +126,9 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	var/folded = TRUE //IS are stock folded? - and that is yes we start folded
 	var/currently_firing = FALSE
 
+	var/wield_delay = 0 // Gun wielding delay , generally in seconds.
+	var/wield_delay_factor = 0 // A factor that characterizes weapon size , this makes it require more vig to insta-wield this weapon or less , values below 0 reduce the vig needed and above 1 increase it
+
 	//Gun numbers and stuf
 	var/serial_type = "INDEX" // Index will be used for detective scanners, if there is a serial type , the gun will add a number onto its final , if none , it won;'t show on examine
 	var/serial_shown = TRUE
@@ -135,6 +138,18 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	var/overcharge_rate = 1 //Base overcharge additive rate for the gun
 	var/overcharge_level = 0 //What our current overcharge level is. Peaks at overcharge_max
 	var/overcharge_max = 10
+
+/obj/item/gun/wield(mob/user)
+	if(!wield_delay)
+		..()
+		return
+	var/calculated_delay = wield_delay
+	if(ishuman(user))
+		calculated_delay = wield_delay - (wield_delay * (user.stats.getStat(STAT_VIG) / (100 * wield_delay_factor))) // wield delay - wield_delay * user vigilance / 100 * wield_factor
+	if (calculated_delay > 0 && do_after(user, calculated_delay, immobile = FALSE))
+		..()
+	else if (calculated_delay <= 0)
+		..()
 
 /obj/item/gun/proc/loadAmmoBestGuess()
 	return

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -27,6 +27,9 @@
 	var/charge_tick = 0
 	gun_tags = list(GUN_ENERGY)
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/energy/loadAmmoBestGuess()
 	var/obj/item/cell/chosenCell = null
 

--- a/code/modules/projectiles/guns/energy/laser/centauri.dm
+++ b/code/modules/projectiles/guns/energy/laser/centauri.dm
@@ -28,3 +28,6 @@
 		BURST_5_ROUND
 		)
 	serial_type = "SI"
+
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // 20 vig

--- a/code/modules/projectiles/guns/energy/laser/cog.dm
+++ b/code/modules/projectiles/guns/energy/laser/cog.dm
@@ -21,6 +21,9 @@
 	serial_type = "GP"
 	max_upgrades = 4 //Older platform meaning 1 less
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/energy/cog/gear
 	name = "\"Gear\" lasgun"
 	desc = "A Greyson Positronic design, cheap and widely produced. In the distant past - this was the main weapon of low-rank police forces, billions of copies of this gun were made. They are ubiquitous. \

--- a/code/modules/projectiles/guns/energy/laser/egun.dm
+++ b/code/modules/projectiles/guns/energy/laser/egun.dm
@@ -23,6 +23,9 @@
 		)
 	serial_type = "H&S"
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/energy/gun/mounted
 	name = "mounted energy gun"
 	self_recharge = 1
@@ -46,6 +49,9 @@
 	modifystate = null
 	suitable_cell = /obj/item/cell/small
 	cell_type = /obj/item/cell/small
+
+	wield_delay = 0.2 SECOND
+	wield_delay_factor = 0.2 // 20 vig
 
 /obj/item/gun/energy/gun/martin/preloaded
 

--- a/code/modules/projectiles/guns/energy/laser/firestorm.dm
+++ b/code/modules/projectiles/guns/energy/laser/firestorm.dm
@@ -28,6 +28,9 @@
 	folding_stock = TRUE //we can fold are stocks
 	serial_type = "H&S"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/energy/firestorm/update_icon()
 	var/iconstring = initial(icon_state)
 	var/itemstring = ""

--- a/code/modules/projectiles/guns/energy/laser/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser/laser.dm
@@ -22,6 +22,9 @@
 	twohanded = TRUE
 	serial_type = "Absolute"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/energy/laser/mounted
 	self_recharge = TRUE
 	use_external_power = TRUE
@@ -81,6 +84,9 @@
 	twohanded = FALSE
 	serial_type = "GP"
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/energy/zwang
 	name = "\"Zwang\" energy revolver"
 	desc = "The \"Zwang\" is a law enforcer's best friend of a sidearm. Carrying both an extremely effective lethal and non-lethal firemode. \
@@ -99,6 +105,9 @@
 		list(mode_name="lethal", projectile_type=/obj/item/projectile/beam/midlaser, fire_sound='sound/weapons/energy/Laser.ogg', fire_delay=10, icon="kill"),
 	)
 	serial_type = "NM"
+
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // 20 vig
 
 /obj/item/gun/energy/zwang/update_icon()
 	..()

--- a/code/modules/projectiles/guns/energy/plasma/centurio_auretian.dm
+++ b/code/modules/projectiles/guns/energy/plasma/centurio_auretian.dm
@@ -18,6 +18,9 @@
 		)
 	serial_type = "SI"
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/energy/plasma/auretian
 	name = "\"Auretian\" energy pistol"
 	desc = "\"Soteria\" brand energy pistol, for personal overprotection. It has the advantage of using laser and plasma firing methods, \

--- a/code/modules/projectiles/guns/energy/plasma/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma/plasma.dm
@@ -88,6 +88,9 @@
 		list(mode_name="Melt", mode_desc="A heavier plasma bolt designed to melt through armor and flesh alike", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/energy/pulse.ogg', fire_delay=14, icon="destroy", projectile_color = "#FFFFFF"),
 	)
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/energy/plasma/super_heavy
 	name = "\"Ragefire\" Experimental Plasma Gun"
 	desc = "An \"Soteria\" brand experimental weapon that uses coolant to fire deadly plasma projectiles without needing to cool down between shots, however the gun is extremly unstable without cooling."

--- a/code/modules/projectiles/guns/energy/plasma/variant.dm
+++ b/code/modules/projectiles/guns/energy/plasma/variant.dm
@@ -18,6 +18,9 @@
 		list(mode_name = "overclock", mode_desc="A large ball of volatile hydrogen to blow up cover or targets", projectile_type = /obj/item/projectile/hydrogen/pistol/max, fire_sound = 'sound/effects/supermatter.ogg', icon = "kill", heat_per_shot = 40, use_plasma_cost = 20)
 	)
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/hydrogen/cannon
 	name = "\improper \"Sollex\" hydrogen-plasma cannon"
 	desc = "A volatile but powerful weapon that uses hydrogen flasks to fire destructive plasma bolts. The brainchild of Soteria Director Nakharan Mkne, meant to compete with and exceed capabilities of Absolutist \

--- a/code/modules/projectiles/guns/energy/projectile/crossbow.dm
+++ b/code/modules/projectiles/guns/energy/projectile/crossbow.dm
@@ -18,6 +18,9 @@
 	price_tag = 1250
 	serial_type = "Absolute"
 
+	wield_delay = 0.8 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/energy/crossbow/ninja
 	name = "energy dart thrower"
 	desc = "Mini energy crossbow, though this looks black market and doesn't at all resemble existing similar weapons."

--- a/code/modules/projectiles/guns/energy/pulse/glock.dm
+++ b/code/modules/projectiles/guns/energy/pulse/glock.dm
@@ -32,6 +32,9 @@
 	)
 	serial_type = "NM"
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/energy/glock/update_icon()
 	var/iconstring = initial(icon_state)
 	var/itemstring = ""

--- a/code/modules/projectiles/guns/energy/pulse/ionrifle.dm
+++ b/code/modules/projectiles/guns/energy/pulse/ionrifle.dm
@@ -20,6 +20,9 @@
 	gun_tags = list(GUN_ENERGY, GUN_SCOPE)
 	serial_type = "Absolute"
 
+	wield_delay = 0.7 SECOND
+	wield_delay_factor = 0.3 // 30 vig
+
 /obj/item/gun/energy/ionrifle/emp_act(severity)
 	..(max(severity, 2)) //so it doesn't EMP itself, I guess
 

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -18,6 +18,9 @@
 	var/list/rockets = new/list()
 	serial_type = "SA"
 
+	wield_delay = 2 SECOND
+	wield_delay_factor = 0.6 // 60 vig , heavy stuff
+
 /obj/item/gun/launcher/rocket/examine(mob/user)
 	if(!..(user, 2))
 		return

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -25,6 +25,9 @@
 		BURST_5_ROUND
 		)
 
+	wield_delay = 1 SECOND
+	wield_delay_factor = 0.3 // 30 vig for insta wield
+
 
 //Automatic firing
 //Todo: Way more checks and safety here

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -115,6 +115,8 @@
 	damage_multiplier = 1
 	saw_off = FALSE
 	serial_type = "SA"
+	wield_delay = 0.8 SECOND
+	wield_delay_factor = 0.2 // 20 vig for insta wield
 
 /obj/item/gun/projectile/automatic/ak47/sa/tac
 	name = "Breacher \"Kalashnikov\" rifle"

--- a/code/modules/projectiles/guns/projectile/automatic/armsmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/armsmg.dm
@@ -27,6 +27,9 @@
 	serial_type = "INDEX"
 	serial_shown = FALSE
 
+	wield_delay = 0.5 SECOND
+	wield_delay_factor = 0.1 // 10 vig for instant
+
 /obj/item/gun/projectile/automatic/armsmg/blackshield
 
 /obj/item/gun/projectile/automatic/armsmg/blackshield/New()

--- a/code/modules/projectiles/guns/projectile/automatic/bastard.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/bastard.dm
@@ -25,6 +25,9 @@
 		)
 	serial_type = "NM"
 
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/projectile/automatic/bastard/update_icon()
 	var/iconstring = initial(icon_state)
 	var/itemstring = ""

--- a/code/modules/projectiles/guns/projectile/automatic/battlerifle.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/battlerifle.dm
@@ -34,6 +34,8 @@
 	SEMI_AUTO_NODELAY
 	)
 	serial_type = "Sol Fed"
+	wield_delay = 1.6 SECOND
+	wield_delay_factor = 0.5 // 50 vig to insta wield , heavy class battle rifle
 
 /obj/item/gun/projectile/automatic/omnirifle/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/automatic/buckler.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/buckler.dm
@@ -30,6 +30,9 @@
 		)
 	serial_type = "NM"
 
+	wield_delay = 0.5 SECOND
+	wield_delay_factor = 0.1 // 10 vig
+
 /obj/item/gun/projectile/automatic/buckler/update_icon()
 	..()
 	var/iconstring = initial(icon_state)

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -32,6 +32,9 @@
 		BURST_3_ROUND_NOLOSS
 		)
 
+	wield_delay = 0.5 SECOND
+	wield_delay_factor = 0.1 // 10 vig
+
 /obj/item/gun/projectile/automatic/c20r/update_icon()
 	cut_overlays()
 	icon_state = "[initial(icon_state)][silenced ? "_s" : ""]"

--- a/code/modules/projectiles/guns/projectile/automatic/chaingun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/chaingun.dm
@@ -41,6 +41,9 @@
 
 	var/cover_open = 0
 
+	wield_delay = 2.5 SECOND
+	wield_delay_factor = 0.6 // 60 vig , holy shit big gun
+
 /obj/item/gun/projectile/automatic/chaingun/special_check(mob/user)
 	if(cover_open)
 		to_chat(user, SPAN_WARNING("[src]'s mechanism is open! Close it before firing!"))

--- a/code/modules/projectiles/guns/projectile/automatic/dp.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dp.dm
@@ -34,6 +34,9 @@
 		)
 	serial_type = "NM"
 
+	wield_delay = 1 SECOND
+	wield_delay_factor = 0.5 // 50 vig for instant wield
+
 obj/item/gun/projectile/automatic/dp/update_icon()
 	..()
 	if(ammo_magazine)

--- a/code/modules/projectiles/guns/projectile/automatic/drozd.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/drozd.dm
@@ -24,6 +24,9 @@
 		)
 	serial_type = "EXC"
 
+	wield_delay = 0.5 SECOND
+	wield_delay_factor = 0.1 // 10 vig
+
 /obj/item/gun/projectile/automatic/drozd/NM_colony
 	name = "\"Kompleks\" SMG"
 	desc = "An excellent fully automatic submachinegun. Famous for it's perfomance in close quarters. Uses 9mm rounds."

--- a/code/modules/projectiles/guns/projectile/automatic/freedom.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/freedom.dm
@@ -27,6 +27,9 @@
 		)
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SILENCABLE)
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.3 // Heavy smg , 30 vig to insta wield
+
 /obj/item/gun/projectile/automatic/freedom/update_icon()
 	..()
 	var/iconstring = initial(icon_state)

--- a/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/greasegun.dm
@@ -24,6 +24,9 @@
 		)
 	serial_type = "Sol Fed"
 
+	wield_delay = 0.5 SECOND
+	wield_delay_factor = 0.1 // 10 vig
+
 /obj/item/gun/projectile/automatic/greasegun/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -32,6 +32,9 @@
 
 	var/cover_open = 0
 
+	wield_delay = 2 SECOND
+	wield_delay_factor = 0.6 // 60 vig for instant wield
+
 /obj/item/gun/projectile/automatic/lmg/special_check(mob/user)
 	if(cover_open)
 		to_chat(user, SPAN_WARNING("[src]'s cover is open! Close it before firing!"))

--- a/code/modules/projectiles/guns/projectile/automatic/luger.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/luger.dm
@@ -20,6 +20,9 @@
 		)
 	serial_type = ""
 
+	wield_delay = 0.5 SECOND
+	wield_delay_factor = 0.1 // 10 vig
+
 /obj/item/gun/projectile/automatic/luger/update_icon()
 	..()
 	var/iconstring = initial(icon_state)

--- a/code/modules/projectiles/guns/projectile/automatic/luty.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/luty.dm
@@ -27,6 +27,8 @@
 	serial_shown = FALSE
 	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE, GUN_CALIBRE_9MM, GUN_MAGWELL)
 
+	wield_delay = 0 // No delay for this , its litteraly a junk gun
+
 /obj/item/gun/projectile/automatic/luty/update_icon()
 	..()
 	cut_overlays()

--- a/code/modules/projectiles/guns/projectile/automatic/mamba.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/mamba.dm
@@ -177,5 +177,8 @@
 		list(mode_name="semi-automatic", mode_desc = "A semi-automatic firemode.", mode_type = /datum/firemode/automatic, fire_delay=15, icon="auto"
 		))
 
+	wield_delay = 1.5 SECOND
+	wield_delay_factor = 0.4 // 40 vig to insta wield , heavy class rifle
+
 /obj/item/gun/projectile/automatic/mamba/python/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/projectile/automatic/maxim.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/maxim.dm
@@ -33,6 +33,9 @@
 		list(mode_name="suppressing fire", mode_desc="DAKKA 16 shots back to back to keep targets inside cover",  burst=16, burst_delay=4, move_delay=11,  icon="burst")
 		)
 
+	wield_delay = 2 SECOND
+	wield_delay_factor = 0.5 // 50 vig , excels are not as trained
+
 /obj/item/gun/projectile/automatic/maxim/NM_colony
 	name = "\"Maxim\" machine gun"
 	desc = "An old and surprisingly deprecated gun from the Excelsior. One of their more dangerous weapons, effective at dealing with crowds or suppressing firing lines."

--- a/code/modules/projectiles/guns/projectile/automatic/motherfucker.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/motherfucker.dm
@@ -29,6 +29,9 @@
 	serial_type = "INDEX"
 	serial_shown = FALSE
 
+	wield_delay = 1 SECOND
+	wield_delay_factor = 0.4 // 40 vig to insta wield
+
 /obj/item/gun/projectile/automatic/motherfucker/attack_self(mob/living/user)
 	if(world.time >= recentpumpmsg + 10)
 		recentpumpmsg = world.time

--- a/code/modules/projectiles/guns/projectile/automatic/nail_gun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/nail_gun.dm
@@ -32,6 +32,9 @@
 		)
 	serial_type = "GP"
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // SMG level
+
 /obj/item/gun/projectile/automatic/nail_gun/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/automatic/nordwind.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/nordwind.dm
@@ -30,6 +30,9 @@
 		)
 	serial_type = "SD GmbH"
 
+	wield_delay = 1.5 SECOND
+	wield_delay_factor = 0.4 // 40 vig to insta wield , heavy class rifle
+
 /obj/item/gun/projectile/automatic/nordwind/watchtower
 	name = "\"Watchtower\" DMR"
 	desc = "A designated marksman rifle designed in cooperation between the marshals and the blackshield, made with lightweight materials and simple, easy to maintain components. \
@@ -81,6 +84,9 @@
 	sawn = /obj/item/gun/projectile/automatic/nordwind/strelki/sawn
 	serial_type = "NM"
 
+	wield_delay = 1.3 SECOND
+	wield_delay_factor = 0.3 // 30 vig to insta wield , not heavy class but not light
+
 /obj/item/gun/projectile/automatic/nordwind/update_icon()
 	..()
 
@@ -116,3 +122,6 @@
 	damage_multiplier = 0.8
 	saw_off = FALSE
 	serial_type = "NM"
+
+	wield_delay = 0.8 SECOND
+	wield_delay_factor = 0.2 // 20 vig to insta wield, sawn

--- a/code/modules/projectiles/guns/projectile/automatic/ppsh.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ppsh.dm
@@ -29,6 +29,9 @@
 		)
 	serial_type = "EXC"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.3 // Heavy smg , 30 vig to insta wield
+
 /obj/item/gun/projectile/automatic/ppsh/NM_colony
 	name = "\"Ekaterina\" assault SMG"
 	desc = "An expirimental sub-machine gun design made for urban combat with a built in silencer and chambered in 9mm; taking only specific drum magizines."

--- a/code/modules/projectiles/guns/projectile/automatic/pulse_rifle.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/pulse_rifle.dm
@@ -32,6 +32,9 @@
 	serial_type = "INDEX"
 	serial_shown = FALSE
 
+	wield_delay = 1.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig for insta wield
+
 /obj/item/gun/projectile/automatic/dallas/update_icon()
 	..()
 	if(ammo_magazine)

--- a/code/modules/projectiles/guns/projectile/automatic/scaffold.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/scaffold.dm
@@ -24,6 +24,9 @@
 	init_recoil = LMG_RECOIL(0.6)
 	serial_type = "GP"
 
+	wield_delay = 1.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig for insta wield
+
 	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE ,GUN_SCOPE, GUN_MAGWELL)
 
 	init_firemodes = list(

--- a/code/modules/projectiles/guns/projectile/automatic/slaught_o_matic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/slaught_o_matic.dm
@@ -33,6 +33,8 @@
 		FULL_AUTO_600
 		)
 
+	wield_delay = 0
+
 /obj/item/gun/projectile/automatic/slaught_o_matic/Initialize()
 	. = ..()
 	ammo_magazine = new magazine_type(src)

--- a/code/modules/projectiles/guns/projectile/automatic/specop.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/specop.dm
@@ -25,6 +25,8 @@
 		FULL_AUTO_600_NOLOSS
 		)
 	serial_type = "NM"
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.3 // Heavy smg , 30 vig to insta wield
 
 /obj/item/gun/projectile/automatic/specop/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/automatic/sts.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts.dm
@@ -97,6 +97,8 @@
 	price_tag = 600
 	init_recoil = RIFLE_RECOIL(1.2)
 	saw_off = FALSE
+	wield_delay = 0.8 SECOND
+	wield_delay_factor = 0.2 // 20 vig for insta wield
 
 /obj/item/gun/projectile/automatic/sts/rifle
 	name = "\"STS\" battle rifle"
@@ -141,6 +143,8 @@
 		BURST_2_ROUND,
 		FULL_AUTO_300
 		)
+	wield_delay = 0.8 SECOND
+	wield_delay_factor = 0.2 // 20 vig for insta wield
 
 /obj/item/gun/projectile/automatic/sts/rifle/blackshield
 	name = "\"STS PARA\" Blackshield rifle"
@@ -201,3 +205,5 @@
 		BURST_2_ROUND,
 		FULL_AUTO_300
 		)
+	wield_delay = 0.8 SECOND
+	wield_delay_factor = 0.2 // 20 vig for insta wield

--- a/code/modules/projectiles/guns/projectile/automatic/texan.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/texan.dm
@@ -24,6 +24,8 @@
 		SEMI_AUTO_NODELAY,
 		BURST_3_ROUND_NOLOSS
 		)
+	wield_delay = 0.5 SECOND
+	wield_delay_factor = 0.1 // 10 vig
 
 /obj/item/gun/projectile/automatic/texan/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/automatic/tommygun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/tommygun.dm
@@ -27,6 +27,9 @@
 		)
 	serial_type = "Sol Fed"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.3 // Heavy smg , 30 vig to insta wield
+
 /obj/item/gun/projectile/automatic/thompson/update_icon()
 	..()
 	var/iconstring = initial(icon_state)

--- a/code/modules/projectiles/guns/projectile/automatic/trouble_shooter.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/trouble_shooter.dm
@@ -22,6 +22,9 @@
 	serial_type = "GP"
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SILENCABLE)
 
+	wield_delay = 1.5 SECOND
+	wield_delay_factor = 0.4 // 40 vig to insta wield , heavy class rifle
+
 /obj/item/gun/projectile/trouble_shooter/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/automatic/vector.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vector.dm
@@ -34,6 +34,9 @@
 		)
 	serial_type = "SA"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.3 // Heavy smg , 30 vig to insta wield
+
 /obj/item/gun/projectile/automatic/vector/update_icon()
 	..()
 	var/iconstring = initial(icon_state)

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -29,6 +29,9 @@
 		)
 	serial_type = "EXC"
 
+	wield_delay = 1.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig to insta wield , heavy class assault rifle. Why is this 7.62 instead of 9mm? I'll never know.
+
 /obj/item/gun/projectile/automatic/vintorez/NM_colony
 	name = "\"Val\" silenced rifle"
 	desc = "A powerful armor-piercing rifle. Utilises a defunct design, but remains a popular armament. Uses 7.62mm Rifle rounds."

--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -33,6 +33,9 @@
 	allow_racking = FALSE
 	serial_type = "Hunter Inc"
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/projectile/boltgun/sawn //subtype for code
 	name = "\"obrez\" mosin boltgun"
 	desc = "A crudly mangled and sawn-down 7.62mm bolt action rifle. The rifle was fine."

--- a/code/modules/projectiles/guns/projectile/boltgun/anti_materiel_sniper.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/anti_materiel_sniper.dm
@@ -35,6 +35,9 @@
 	action_button_name = "Switch zoom level"
 	action_button_proc = "switch_zoom"
 
+	wield_delay = 2 SECOND
+	wield_delay_factor = 0.6 // 60 vig, heavy as shit
+
 
 /obj/item/weaponparts
 	var/part_color = ""

--- a/code/modules/projectiles/guns/projectile/boltgun/baroque.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/baroque.dm
@@ -41,3 +41,6 @@ Own a musket for department defense, since that's what the founding hunters inte
 	bolt_training = FALSE
 	gun_tags = list(GUN_PROJECTILE, GUN_SIGHT)
 	serial_type = "Kriosan"
+
+	wield_delay = 1 SECOND
+	wield_delay_factor = 0.4 // 40 vig, it's a LITERAL MUSKET. Just as the founding fathers intended.......

--- a/code/modules/projectiles/guns/projectile/boltgun/scout.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/scout.dm
@@ -23,6 +23,9 @@
 	slowdown_hold = 1
 	serial_type = "H&S"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.3 // 30 vig, little heavier than normal
+
 
 /obj/item/gun/projectile/boltgun/sawn/scout
 	name = "\"obrez\" heavy boltgun"

--- a/code/modules/projectiles/guns/projectile/other/RPG.dm
+++ b/code/modules/projectiles/guns/projectile/other/RPG.dm
@@ -27,6 +27,9 @@
 	auto_rack = TRUE //so if we get loaded were good
 	serial_type = "SA"
 
+	wield_delay = 2 SECOND
+	wield_delay_factor = 0.6 // 60 vig , heavy stuff
+
 /obj/item/gun/projectile/rpg/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/other/lenar.dm
+++ b/code/modules/projectiles/guns/projectile/other/lenar.dm
@@ -13,6 +13,9 @@
 	price_tag = 1200
 	serial_type = "SD GmbH"
 
+	wield_delay = 1.5 SECOND
+	wield_delay_factor = 0.6 // 60 vig , heavy stuff
+
 /obj/item/gun/projectile/grenade/lenar/proc/update_charge()
 	var/ratio = loaded.len / max_shells
 	if(ratio < 0.33 && ratio != 0)

--- a/code/modules/projectiles/guns/projectile/other/protector.dm
+++ b/code/modules/projectiles/guns/projectile/other/protector.dm
@@ -23,6 +23,9 @@
 	twohanded = TRUE
 	serial_type = "Absolute"
 
+	wield_delay = 1.5 SECOND
+	wield_delay_factor = 0.6 // 60 vig , heavy stuff
+
 /* We no longer fire grenades like this. As we now use internal ammo
 /obj/item/gun/projectile/grenade/proc/load_grenade(obj/item/grenade/A, mob/user)  //For loading hand grenades, not ammo
 	if(!A.loadable)

--- a/code/modules/projectiles/guns/projectile/pistol/basilisk.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/basilisk.dm
@@ -22,6 +22,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_CALIBRE_12MM)
 	serial_type = "H&S"
 
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.6 // 60 vig
+
 /obj/item/gun/projectile/basilisk/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
@@ -21,6 +21,8 @@
 	init_recoil = HANDGUN_RECOIL(0.2)
 	serial_type = "SA"
 
+	wield_delay = 0 SECOND
+
 /obj/item/gun/projectile/clarissa/preloaded
 
 /obj/item/gun/projectile/clarissa/preloaded/New()
@@ -68,6 +70,8 @@
 		SEMI_AUTO_NODELAY
 		)
 	serial_type = "Sol Fed"
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // 20 vig
 
 /obj/item/gun/projectile/makarov/preloaded
 

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -17,6 +17,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_9MM, GUN_SILENCABLE, GUN_MAGWELL)
 	serial_type = "H&S"
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/projectile/colt/NM_colt
 	name = "\"Bronco\" pistol"
 	desc = "A rugged derivative of the venerable M1911, built on double-stack frames and modified by the Nadezhda Marshals gunsmiths from new or refitted weapons to meet match-grade standards. Uses 9mm rounds."
@@ -51,6 +54,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SILENCABLE)
 	serial_type = "SA"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig
+
 /obj/item/gun/projectile/colt/ten/dark
 	name = "\"Stallion\" magnum pistol"
 	desc = "A rugged derivative of the venerable M1911, modernized to the M1911A5 standard and produced by SolFed armories across the galaxy, this one bears defaced serial numbers and the insignia of the Blackshield. Uses 10mm Auto-Mag."
@@ -75,6 +81,9 @@
 	init_recoil = HANDGUN_RECOIL(0.6)
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SILENCABLE)
 	serial_type = "NM"
+
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig
 
 
 /obj/item/gun/projectile/colt/update_icon()

--- a/code/modules/projectiles/guns/projectile/pistol/deaglebolt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/deaglebolt.dm
@@ -24,6 +24,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_CALIBRE_12MM, GUN_CALIBRE_9MM)
 	serial_type = "BlueCross"
 
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.6 // 60 vig
+
 /obj/item/gun/projectile/deaglebolt/verb/change_caliber()
 	set name = "Change Caliber"
 	set desc = "For when you need to change your guns caliber, handy when you have more ammo of one type."

--- a/code/modules/projectiles/guns/projectile/pistol/giskard.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/giskard.dm
@@ -20,6 +20,8 @@
 	init_recoil = HANDGUN_RECOIL(1)
 	serial_type = "H&S"
 
+	wield_delay = 0 SECOND
+
 /obj/item/gun/projectile/giskard/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/pistol/glock.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/glock.dm
@@ -23,6 +23,9 @@
 		)
 	serial_type = "SD GmbH"
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.3 // 30 vig
+
 /obj/item/gun/projectile/glock/update_icon()
 	..()
 	var/iconstring = initial(icon_state)

--- a/code/modules/projectiles/guns/projectile/pistol/gyropistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/gyropistol.dm
@@ -22,6 +22,9 @@
 	cocked_sound 	= 'sound/weapons/guns/interact/hpistol_cock.ogg'
 	serial_type = "SA"
 
+	wield_delay = 1 SECOND
+	wield_delay_factor = 0.6 // 60 vig
+
 /obj/item/gun/projectile/gyropistol/update_icon()
 	..()
 	if(ammo_magazine)

--- a/code/modules/projectiles/guns/projectile/pistol/judiciary.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/judiciary.dm
@@ -24,6 +24,9 @@
 		)
 	serial_type = "NM"
 
+	wield_delay = 0.2 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/projectile/judiciary/update_icon()
 	..()
 	var/iconstring = initial(icon_state)

--- a/code/modules/projectiles/guns/projectile/pistol/ladon.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/ladon.dm
@@ -19,6 +19,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL)
 	serial_type = "SD GmbH"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig
+
 /obj/item/gun/projectile/ladon/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -21,6 +21,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_CALIBRE_12MM)
 	serial_type = "H&S"
 
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.6 // 60 vig
+
 /obj/item/gun/projectile/lamia/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/pistol/mk58.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mk58.dm
@@ -18,6 +18,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_9MM, GUN_SILENCABLE, GUN_MAGWELL)
 	serial_type = "Absolute"
 
+	wield_delay = 0.2 SECOND
+	wield_delay_factor = 0.2 // 20 vig
+
 /obj/item/gun/projectile/mk58/update_icon()
 	..()
 	var/iconstring = initial(icon_state)

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -23,6 +23,9 @@
 		)
 	serial_type = "H&S"
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.3 // 30 vig
+
 /obj/item/gun/projectile/olivaw/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/pistol/rivet.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/rivet.dm
@@ -22,6 +22,9 @@
 		)
 	serial_type = "GP"
 
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.1 // 10 vig, Greyson & rare
+
 /obj/item/gun/projectile/rivet/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/pistol/silenced.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/silenced.dm
@@ -20,6 +20,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL)
 	serial_type = "SD GmbH"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig
+
 /obj/item/gun/projectile/silenced/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/pistol/silver_eye.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/silver_eye.dm
@@ -26,6 +26,9 @@
 	fire_sound = 'sound/weapons/guns/fire/fire_silver.ogg'
 	serial_type = "NM"
 
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.6 // 60 vig
+
 /obj/item/gun/projectile/silvereye/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/pistol/spring.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/spring.dm
@@ -22,6 +22,8 @@
 		)
 	serial_type = "GP"
 
+	wield_delay = 0 SECOND
+
 /obj/item/gun/projectile/spring/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/revolver/breakaction.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/breakaction.dm
@@ -20,6 +20,9 @@
 	can_dual = TRUE
 	serial_type = "H&S"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig
+
 /obj/item/gun/projectile/revolver/rev10/update_icon()
 	..()
 	var/iconstring = initial(icon_state)

--- a/code/modules/projectiles/guns/projectile/revolver/deckard.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/deckard.dm
@@ -15,3 +15,6 @@
 	fire_sound = 'sound/weapons/guns/fire/deckard_fire.ogg'
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_REVOLVER, GUN_CALIBRE_12MM)
 	serial_type = "Sol Fed"
+
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.6 // 60 vig

--- a/code/modules/projectiles/guns/projectile/revolver/detective.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/detective.dm
@@ -18,6 +18,8 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_9MM, GUN_INTERNAL_MAG, GUN_REVOLVER, GUN_SILENCABLE)
 	serial_type = "H&S"
 
+	wield_delay = 0 SECOND //god it's bad
+
 /obj/item/gun/projectile/revolver/detective/update_icon()
 	..()
 

--- a/code/modules/projectiles/guns/projectile/revolver/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/handmade.dm
@@ -13,3 +13,5 @@
 	init_recoil = HANDGUN_RECOIL(0.8)
 	serial_type = "INDEX"
 	serial_shown = FALSE
+
+	wield_delay = 0 SECOND

--- a/code/modules/projectiles/guns/projectile/revolver/hornet.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/hornet.dm
@@ -21,3 +21,6 @@
 	cocked_sound 	= 'sound/weapons/guns/interact/hpistol_cock.ogg'
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_REVOLVER, GUN_CALIBRE_12MM)
 	serial_type = "SA"
+
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.6 // 60 vig

--- a/code/modules/projectiles/guns/projectile/revolver/judge.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/judge.dm
@@ -17,3 +17,6 @@
 	fire_sound = 'sound/weapons/guns/fire/batrifle_fire.ogg'
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_REVOLVER)
 	serial_type = "NM"
+
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.6 // 60 vig

--- a/code/modules/projectiles/guns/projectile/revolver/lemant.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/lemant.dm
@@ -23,6 +23,9 @@
 		)
 	serial_type = "Absolute"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig
+
 	var/obj/item/gun/projectile/underslung_shotgun/shotgun
 	var/reload_delay = 5 // Delay between bullets when reloading from a box.
 
@@ -51,6 +54,8 @@
 	max_shells = 17
 	price_tag = 550
 	init_recoil = HANDGUN_RECOIL(0.3)// Exceptional weight helps with recoil control, but unwieldy enough to merely match the claw. -Kaz
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.6 // 60 vig
 
 /obj/item/gun/projectile/revolver/lemant/uppercut
 	name = "\"Pilgrim Hero\" kurtz revolver"
@@ -67,6 +72,8 @@
 	max_shells = 6
 	price_tag = 500
 	init_recoil = HANDGUN_RECOIL(1.3)// Massive recoil due to being a kurtz revolver without the weight to compensate for the blast. -Kaz
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.6 // 60 vig
 
 //Defined here, may be used elsewhere but for now its only used here. -Kaz
 /obj/item/gun/projectile/underslung_shotgun

--- a/code/modules/projectiles/guns/projectile/revolver/longboi.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/longboi.dm
@@ -17,3 +17,5 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_REVOLVER, GUN_CALIBRE_12MM)
 	twohanded = TRUE
 	serial_type = "LSS"
+	wield_delay = 0.5 SECOND
+	wield_delay_factor = 0.5 // 50 vig

--- a/code/modules/projectiles/guns/projectile/revolver/mistral.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/mistral.dm
@@ -16,3 +16,5 @@
 	init_recoil = RIFLE_RECOIL(0.6)
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_REVOLVER)
 	serial_type = "SD GmbH"
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig

--- a/code/modules/projectiles/guns/projectile/revolver/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/revolver.dm
@@ -28,6 +28,9 @@
 	allow_racking = FALSE
 	serial_type = "H&S"
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig
+
 /obj/item/gun/projectile/revolver/verb/spin_cylinder()
 	set name = "Spin revolver"
 	set desc = "Fun when you're bored out of your skull."

--- a/code/modules/projectiles/guns/projectile/revolver/sixshot.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/sixshot.dm
@@ -19,6 +19,9 @@
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_REVOLVER)
 	serial_type = "SA"
 
+	wield_delay = 1 SECOND
+	wield_delay_factor = 0.4 // 40 vig
+
 /obj/item/gun/projectile/revolver/sixshot/conversion
 	name = "\"Ten-Shot\" conversion shotgun"
 	desc = "A unique, revolving shotgun using a revolver cylinder. You can't tell if the person who made it deserves an award or to be tried as a criminal. This one has been given a belt \
@@ -54,3 +57,6 @@
 	damage_multiplier = 0.7
 	penetration_multiplier = 0.8
 	init_recoil = RIFLE_RECOIL(2.3)
+
+	wield_delay = 0.8 SECOND
+	wield_delay_factor = 0.6 // 60 vig

--- a/code/modules/projectiles/guns/projectile/revolver/tacticool_revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/tacticool_revolver.dm
@@ -17,3 +17,5 @@
 	init_recoil = HANDGUN_RECOIL(1.2)
 	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG, GUN_REVOLVER, GUN_CALIBRE_12MM)
 	serial_type = "SA"
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.6 // 60 vig

--- a/code/modules/projectiles/guns/projectile/revolver/wayfarer.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/wayfarer.dm
@@ -24,3 +24,5 @@
 	max_upgrades = 7 //Holds more slots do to being exl gun and not that good cal wise/easy to get
 	serial_type = "INDEX"
 	serial_shown = FALSE
+	wield_delay = 0.3 SECOND
+	wield_delay_factor = 0.3 // 30 vig

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -1,4 +1,7 @@
 /obj/item/gun/projectile/shotgun
-    //  New shotgun dm, could be expanded
-      var/recentpumpmsg = 0 //  Variable to prevent chat message spam
-      gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG)
+	//  New shotgun dm, could be expanded
+	var/recentpumpmsg = 0 //  Variable to prevent chat message spam
+	gun_tags = list(GUN_PROJECTILE, GUN_INTERNAL_MAG)
+
+	wield_delay = 2 SECOND
+	wield_delay_factor = 0.5// 50 vig

--- a/code/modules/projectiles/guns/projectile/shotgun/bull.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bull.dm
@@ -32,6 +32,9 @@
 		)
 	serial_type = "H&S"
 
+	wield_delay = 0.9 SECOND
+	wield_delay_factor = 0.2 // 40 vig
+
 /obj/item/gun/projectile/shotgun/bull/bison
 	name = "\"Bison\" shotgun"
 	desc = "A \"Holland & Sullivan\" double-barreled pump-action shotgun. A nightmare of engineering turned sleek room-clearer by the Artificers guild. Its snub barrel reinforced and lengthened, \

--- a/code/modules/projectiles/guns/projectile/shotgun/combatsg.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/combatsg.dm
@@ -19,6 +19,9 @@
 	sawn = /obj/item/gun/projectile/shotgun/pump/combat/sawn
 	serial_type = "Absolute"
 
+	wield_delay = 1 SECOND
+	wield_delay_factor = 0.4 // 40 vig
+
 /obj/item/gun/projectile/shotgun/pump/combat/sawn
 	name = "\"Regulator\" stakeout shotgun"
 	desc = "Designed for close encounters, the Regulator is widely regarded as a weapon of choice for protecting against boarders. \
@@ -33,3 +36,6 @@
 	damage_multiplier = 0.9
 	fire_delay = 12
 	saw_off = FALSE
+
+	wield_delay = 0.7 SECOND
+	wield_delay_factor = 0.3 // 30 vig

--- a/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/doublebarrel.dm
@@ -30,6 +30,8 @@
 	saw_off = TRUE
 	sawn = /obj/item/gun/projectile/shotgun/doublebarrel/sawn
 	serial_type = "SA"
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.3 // 30 vig , great as a surprise
 
 /obj/item/gun/projectile/shotgun/doublebarrel/update_icon()
 	..()
@@ -103,6 +105,8 @@
 	damage_multiplier = 0.8 //slightly weaker due to sawn-off barrels
 	init_recoil = RIFLE_RECOIL(1.1)
 	saw_off = FALSE
+
+	wield_delay = 0 SECOND //KER-BLAM!!!
 
 /obj/item/gun/projectile/shotgun/doublebarrel/axe
 	name = "axe double-barreled shotgun"

--- a/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
@@ -19,6 +19,9 @@
 	sawn = /obj/item/gun/projectile/shotgun/pump/gladstone/sawn
 	serial_type = "H&S"
 
+	wield_delay = 1 SECOND
+	wield_delay_factor = 0.4 // 40 vig
+
 /obj/item/gun/projectile/shotgun/pump/gladstone/sawn
 	name = "\"Gladstone\" stakeout shotgun"
 	desc = "A venerable shotgun that's been destroyed by some sort of heartless monster. Can hold up to 4+1 20mm shells in its tube magazine."
@@ -33,6 +36,9 @@
 	price_tag = 550
 	init_recoil = RIFLE_RECOIL(2.4)
 	saw_off = FALSE
+
+	wield_delay = 0.7 SECOND
+	wield_delay_factor = 0.3 // 30 vig
 
 /obj/item/gun/projectile/shotgun/pump/gladstone/queen
 	name = "\"Fallen Empress\" hunting shotgun"

--- a/code/modules/projectiles/guns/projectile/shotgun/handmade.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/handmade.dm
@@ -19,3 +19,6 @@
 	price_tag = 250 //cheap as they get
 	serial_type = "INDEX"
 	serial_shown = FALSE
+
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.4 // 40 vig

--- a/code/modules/projectiles/guns/projectile/shotgun/pug.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/pug.dm
@@ -27,6 +27,9 @@
 		SEMI_AUTO_NODELAY
 		)
 
+	wield_delay = 0.8 SECOND
+	wield_delay_factor = 0.4 // 40 vig , after all its designed for CQC
+
 /obj/item/gun/projectile/shotgun/pug/update_icon()
 	cut_overlays()
 	var/iconstring = initial(icon_state)

--- a/code/modules/projectiles/guns/projectile/shotgun/pump.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/pump.dm
@@ -25,6 +25,9 @@
 	allow_racking = FALSE
 	serial_type = "H&S"
 
+	wield_delay = 0.6 SECOND
+	wield_delay_factor = 0.3 // 30 vig
+
 /obj/item/gun/projectile/shotgun/pump/consume_next_projectile()
 	if(chambered)
 		return chambered.BB
@@ -66,6 +69,9 @@
 	saw_off = TRUE
 	sawn = /obj/item/gun/projectile/shotgun/pump/obrez
 
+	wield_delay = 0.4 SECOND
+	wield_delay_factor = 0.3 // 30 vig
+
 /obj/item/gun/projectile/shotgun/pump/obrez
 	name = "obrez \"Grizzly\" shotgun"
 	desc = "A common open-source pump-action shotgun, hacked up, sawn down, and ready to rob a liquor store."
@@ -82,3 +88,6 @@
 	penetration_multiplier = 0.8
 	init_recoil = RIFLE_RECOIL(1.3)
 	saw_off = FALSE
+
+	wield_delay = 0.2 SECOND
+	wield_delay_factor = 0.2 // 20 vig

--- a/code/modules/projectiles/guns/projectile/shotgun/riot.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/riot.dm
@@ -29,6 +29,9 @@
 		)
 	serial_type = "SD GmbH"
 
+	wield_delay = 0.9 SECOND
+	wield_delay_factor = 0.4 // 40 vig
+
 /obj/item/gun/projectile/automatic/riot_autoshotgun/robo
 	name = "intergrated \"State\" riot shotgun"
 	desc = "A Seinemetall Defense GmbH riot auto action shotgun, its uncommonly seen deployed in most police operation due to the success of the \"stolen\" \"Gladstone\" design. \
@@ -69,6 +72,9 @@
 	init_recoil = RIFLE_RECOIL(1.4)
 	folding_stock = TRUE //we can fold are stocks
 	can_dual = FALSE
+
+	wield_delay = 0.8 SECOND
+	wield_delay_factor = 0.4 // 40 vig , after all its designed for CQC
 
 /obj/item/gun/projectile/automatic/riot_autoshotgun/opshot/update_icon()
 	..()


### PR DESCRIPTION
## About The Pull Request
Ports https://github.com/discordia-space/CEV-Eris/pull/6713 with some changes over to here. Original coder did some amazing work so this is my attempt at replicating some of the values with the same base system.

Simply put - the values are a little 'random' when looking at them but most account for:
- **The gun's caliber determines delay.** Guns with 9mm typically sport no delay or a 0.2 second delay, 10mm sport a 0.4 delay, and 12mm sport a 0.6 delay. Similarly, guns with 6.5 are typically 1 second delay, heavier 7.62 firearms are a 1.5 delay, and .408 fire arms are roughly a 1.6+ delay.
- **Trash guns get a low or outright 0 delay.** When I say 'trash', I mean - bad. Classandria, Luty, etc.
- **Sawn offs get lower delays for being sawn down.** This should make sawn offs have another slight 'plus' over their non-sawn counterparts to compensate for the accuracy and sometimes damage dropoff.

Also - guns all have vigilance skill checks to outright bypass the delays.
Most guns are:
- Vig 10-20 for 9mm firearms
- Vig 30-40 for 10mm firearms, rifles, and shotguns
- Vig 60+ for LMGs, heavy rifles, and 12mm pistols

This should also treat vig as a proper 'gunslinger' perk and incentivize its use rather than just for extra AP or slight reduction in recoil buildup.

Also included Eris' small addition of a warning when joint locking someone. It's one line, and it's small, and I put it on the wrong branch. Oh well. 

## Changelog
:cl:
add: Ports Eris' gun wield delay system.
add: Small port of warning when jointlocking someone from Eris.
/:cl: