### PR TITLE
loadout clearing and balance

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/armament.dm
+++ b/code/modules/client/preference_setup/loadout/lists/armament.dm
@@ -43,11 +43,6 @@
 	path = /obj/item/device/flash
 	cost = 1
 
-/datum/gear/armament/boot_knife
-	display_name = "boot knife"
-	path = /obj/item/tool/knife/boot
-	cost = 2
-
 /datum/gear/armament/tacboot_knife
 	display_name = "tactical knife"
 	path = /obj/item/tool/knife/tacknife
@@ -57,11 +52,6 @@
 	display_name = "ritual knife"
 	path = /obj/item/tool/knife/ritual
 	cost = 3
-
-/datum/gear/armament/dagger
-	display_name = "dagger"
-	path = /obj/item/tool/knife/dagger
-	cost = 2
 
 /datum/gear/armament/dagger/family
 	display_name = "heirloom dagger"
@@ -114,22 +104,12 @@
 /datum/gear/armament/cutlass
 	display_name = "cutlass"
 	path = /obj/item/tool/sword/saber/cutlass
-	cost = 2
+	cost = 3
 
 /datum/gear/armament/machete
 	display_name = "Machete"
 	path = /obj/item/tool/sword/machete
-	cost = 2
-
-/datum/gear/armament/katana
-	display_name = "Katana"
-	path = /obj/item/tool/sword/katana
-	cost = 4 // Highest damage, same cost as the spear for balance
-
-/datum/gear/armament/spear
-	display_name = "Steel Spear"
-	path = /obj/item/tool/spear/steel
-	cost = 4
+	cost = 3
 
 /datum/gear/armament/holster/nt
 	display_name = "short sword"

--- a/code/modules/client/preference_setup/loadout/lists/factionabsolute.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionabsolute.dm
@@ -88,3 +88,9 @@
 	slot = slot_wear_suit
 	path = /obj/item/clothing/suit/hooded/absolutecloak
 	cost = 0
+
+/datum/gear/factionabsolute/ritual_book
+	display_name = "absolutism ritual book"
+	path = /obj/item/book/ritual/cruciform
+	cost = 0
+

--- a/code/modules/client/preference_setup/loadout/lists/factionsecurity.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionsecurity.dm
@@ -248,21 +248,18 @@
 	display_name = "security HUD"
 	path = /obj/item/clothing/glasses/hud/security
 	allowed_roles = list(JOBS_SECURITY)
-	slot = slot_glasses
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/secpatch
 	display_name = "HUD eyepatch"
 	path = /obj/item/clothing/glasses/eyepatch/secpatch
 	allowed_roles = list(JOBS_SECURITY)
-	slot = slot_glasses
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/security_tact
 	display_name = "tactical security HUD"
 	path = /obj/item/clothing/glasses/sechud/tactical
 	allowed_roles = list(JOBS_SECURITY)
-	slot = slot_glasses
 	sort_category = "Faction: Security"
 	cost = 2 //has flash protection
 
@@ -270,7 +267,6 @@
 	display_name = "HUD Glasses"
 	path = /obj/item/clothing/glasses/sechud
 	allowed_roles = list(JOBS_SECURITY)
-	slot = slot_glasses
 	sort_category = "Faction: Security"
 	cost = 2 //has flash protection
 

--- a/code/modules/client/preference_setup/loadout/lists/factionsoteria.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionsoteria.dm
@@ -80,21 +80,18 @@
 	display_name = "medical HUD"
 	path = /obj/item/clothing/glasses/hud/health
 	allowed_roles = list(JOBS_MEDICAL)
-	slot = slot_glasses
 	sort_category = "Faction: Soteria"
 
 /datum/gear/factionsoteria/medicalscouter
 	display_name = "medical HUD, scouter"
 	path = /obj/item/clothing/glasses/hud/health/scouter
 	allowed_roles = list("Chief Biolab Overseer","Soteria Doctor","Soteria Lifeline Technician","Corpsman")
-	slot = slot_glasses
 	sort_category = "Faction: Soteria"
 
 /datum/gear/factionsoteria/hudpatch
 	display_name = "medical HUD, eyepatch"
 	path = /obj/item/clothing/glasses/eyepatch/medpatch
 	allowed_roles = list("Chief Biolab Overseer","Soteria Doctor","Soteria Lifeline Technician","Corpsman")
-	slot = slot_glasses
 	sort_category = "Faction: Soteria"
 
 /datum/gear/factionsoteria/sciencegoggles

--- a/code/modules/client/preference_setup/loadout/lists/general.dm
+++ b/code/modules/client/preference_setup/loadout/lists/general.dm
@@ -47,18 +47,10 @@
 	display_name = "holy book"
 	path = /obj/item/book/manual/religion/h_book
 
-/datum/gear/pitcher
-	display_name = "insulated pitcher"
-	path = /obj/item/reagent_containers/food/drinks/pitcher
-
 /datum/gear/mug
 	display_name = "mug selection"
 	path = /obj/item/reagent_containers/food/drinks/mug
 	flags = GEAR_HAS_TYPE_SELECTION
-
-/datum/gear/neotheologybook
-	display_name = "absolutism ritual book"
-	path = /obj/item/book/ritual/cruciform
 
 /datum/gear/psi_juice
 	display_name = "cerebrix inhaler"
@@ -77,10 +69,6 @@
 /datum/gear/spaceball_pack
 	display_name = "spaceball booster pack"
 	path = /obj/item/pack/spaceball
-
-/datum/gear/vacflask
-	display_name = "vacuum flask"
-	path = /obj/item/reagent_containers/food/drinks/flask/vacuumflask
 
 /datum/gear/trackingimplanter
 	display_name = "implanter (tracking)"

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -17,26 +17,32 @@
 	display_name = "lunch box"
 	path = /obj/item/storage/lunchbox
 	cost = 0
+
 /datum/gear/lunchbox_cat
 	display_name = "cat lunch box"
 	path = /obj/item/storage/lunchbox/cat
 	cost = 0
+
 /datum/gear/lunchbox_rainbow
 	display_name = "rainbow lunch box"
 	path = /obj/item/storage/lunchbox/rainbow
 	cost = 0
+
 /datum/gear/lunchbox_church
 	display_name = "church lunch box"
 	path = /obj/item/storage/lunchbox/lemniscate
 	cost = 0
+
 /datum/gear/utility/cane
 	display_name = "cane"
 	path = /obj/item/cane
 	cost = 0
+
 /datum/gear/utility/canewhite
 	display_name = "cane, white"
 	path = /obj/item/cane/whitecane
 	cost = 0
+
 /datum/gear/utility/crutch
 	display_name = "crutch"
 	path = /obj/item/cane/crutch
@@ -56,11 +62,6 @@
 	display_name = "crayon box"
 	path = /obj/item/storage/fancy/crayons
 	cost = 1
-
-/datum/gear/utility/corpreg
-	display_name = "colony law"
-	path = /obj/item/book/manual/security_space_law
-	cost = 0
 
 /datum/gear/utility/folder
 	display_name = "folder selection"
@@ -160,11 +161,11 @@
 /datum/gear/utility/tinfoil
 	display_name = "anti-psion hat"
 	path = /obj/item/clothing/head/psionic/tinfoil
-	cost = 3
+	cost = 1 //Has materas so its still a little bit of costs
 
 /datum/gear/utility/costume
 	display_name = "costume kit"
 	path = /obj/item/storage/box/costume
 	flags = GEAR_HAS_TYPE_SELECTION
-	cost = 2 //Style at a cost! - also cardboard
+	cost = 1 //Style at a cost! - also cardboard
 


### PR DESCRIPTION
Removes Katana, boot knife steel spear, pitcure from loadout
Ups Matchie in loadout
Makes huds spawn in bag rather then on face (this is a code optimization)
Costume kit now costs 1
anti-psion hat now costs one
ritual book is now in the church tab rather then general 