### PR TITLE
Exalt Rebalance

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -51,18 +51,19 @@
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
 	min_age = 18
 	max_age = 200 //Effectively ageless, but human history is only so long.
-	hunger_factor = 1.1
+	hunger_factor = 1.3
 
 	dark_color = "#ffffff"
 	light_color = "#000000"
 
 	stat_modifiers = list(
-		STAT_BIO = 5,
-		STAT_COG = 5,
-		STAT_MEC = 5,
-		STAT_ROB = 5,
-		STAT_TGH = 5,
-		STAT_VIG = 5
+		STAT_BIO = 10,
+		STAT_COG = 10,
+		STAT_MEC = 10,
+		STAT_ROB = 10,
+		STAT_TGH = 10,
+		STAT_VIG = 10,
+		STAT_VIV = -10
 	)
 
 	darksight = 3


### PR DESCRIPTION


## About The Pull Request

This PR increases the round start stats of Exalt from the base 5 to 10. The reason for this stat increase is bring Exalts inline (not above) other races because Exalts are supposed to be faster, stronger, smarter, etc. etc. though when it comes to stats, they only get an extra 3 points more than a base human AND without having decent human perks.  Their speed boast and other parts of them had been nerfed into the ground in the past which brought them more inline to a base human...just worse. Alongside their current debuffs, increased pain, organ damage increase, debtor, plus to genetics instability, hunger, etc their benefits do not match their debuffs. 

To match this stat increase to bring the usefulness of this race in line with others I have also increased their debuffs by increasing their hunger rate and -10 viv (willing to make -15 if that is more responsible) to simulate the fact that due to their sensitive bodies, drugs would have a more significant effect upon them.  
<hr>
	
<hr>
</details>

