### PR TITLE
Minor hotfixes

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -361,7 +361,8 @@
 		/obj/item/folder,
 		/obj/item/reagent_containers/food/snacks,
 		/obj/item/reagent_containers/food/drinks,
-		/obj/item/device/binoculars // By popular demand. - Seb
+		/obj/item/device/binoculars, // By popular demand. - Seb
+		/obj/item/tool/baton/mini
 	)
 
 /obj/item/storage/belt/holding

--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -77,6 +77,10 @@
 	path = /obj/item/clothing/suit/storage/miljacket
 	flags = GEAR_HAS_TYPE_SELECTION
 
+/datum/gear/suit/soyfedjacket
+	display_name = "old SolFed military jacket"
+	path = /obj/item/clothing/suit/storage/toggle/miljacket_soyfed
+
 /datum/gear/suit/punk_vest
 	display_name = "punk vest"
 	path = /obj/item/clothing/suit/storage/punkvest

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -671,6 +671,7 @@ var/list/name_to_material
 /material/cloth //todo
 	name = MATERIAL_CLOTH
 	stack_origin_tech = list(TECH_MATERIAL = 2)
+	stack_type = /obj/item/stack/material/cloth
 	door_icon_base = "wood"
 	ignition_point = T0C+232
 	melting_point = T0C+300
@@ -679,6 +680,7 @@ var/list/name_to_material
 /material/silk //todo
 	name = MATERIAL_SILK
 	stack_origin_tech = list(TECH_MATERIAL = 2)
+	stack_type = /obj/item/stack/material/silk
 	composite_material = list(MATERIAL_BIOMATTER = 1) //So we have a vaule to more then one faction
 	door_icon_base = "wood"
 	ignition_point = T0C+232
@@ -705,6 +707,7 @@ var/list/name_to_material
 //TODO PLACEHOLDERS:
 /material/leather
 	name = MATERIAL_LEATHER
+	stack_type = /obj/item/stack/material/leather
 	icon_colour = "#5C4831"
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	flags = MATERIAL_PADDING
@@ -713,6 +716,7 @@ var/list/name_to_material
 
 /material/bone
 	name = MATERIAL_BONE
+	stack_type = /obj/item/stack/material/bone
 	icon_colour = "#EDE1D1"
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	flags = MATERIAL_PADDING
@@ -724,6 +728,7 @@ var/list/name_to_material
 /material/carpet
 	name = "carpet"
 	display_name = "comfy"
+	stack_type = /obj/item/stack/tile/carpet // The icon is red, thus red carpet by default
 	use_name = "red upholstery"
 	icon_colour = "#DA020A"
 	flags = MATERIAL_PADDING
@@ -735,6 +740,7 @@ var/list/name_to_material
 /material/cotton
 	name = "cotton"
 	display_name ="cotton"
+	stack_type = /obj/item/stack/material/cloth
 	icon_colour = "#FFFFFF"
 	flags = MATERIAL_PADDING
 	ignition_point = T0C+232

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -266,7 +266,7 @@
 							if("1")
 								playsound(src, 'sound/effects/mob_effects/f_chuckle.ogg', 70)
 							if("2")
-								playsound(src, 'sound/effects/mob_effects/f_chuckle2.ogg', 70)
+								playsound(src, 'sound/effects/mob_effects/f_chuckle2.ogg', 40)
 					else
 						switch(pick("1", "2"))
 							if("1")
@@ -404,13 +404,13 @@
 							if("1")
 								playsound(src, 'sound/effects/mob_effects/f_giggle.ogg', 70)
 							if("2")
-								playsound(src, 'sound/effects/mob_effects/f_giggle2.ogg', 70)
+								playsound(src, 'sound/effects/mob_effects/f_giggle2.ogg', 50)
 					else
 						switch(pick("1", "2"))
 							if("1")
-								playsound(src, 'sound/effects/mob_effects/m_giggle.ogg', 70)
+								playsound(src, 'sound/effects/mob_effects/m_giggle.ogg', 50)
 							if("2")
-								playsound(src, 'sound/effects/mob_effects/m_giggle2.ogg', 70)
+								playsound(src, 'sound/effects/mob_effects/m_giggle2.ogg', 50)
 				else
 					message = "makes a noise."
 					m_type = 2
@@ -487,7 +487,7 @@
 					message = "sighs."
 					m_type = 2
 					if(get_sex() == FEMALE)
-						playsound(loc, 'sound/effects/mob_effects/f_sigh.ogg', 80)
+						playsound(loc, 'sound/effects/mob_effects/f_sigh.ogg', 70)
 					else
 						playsound(loc, 'sound/effects/mob_effects/m_sigh.ogg', 70)
 				else
@@ -507,17 +507,17 @@
 							if("1")
 								playsound(src, 'sound/voice/f_laugh.ogg', 70)
 							if("2")
-								playsound(src, 'sound/voice/f_laugh2.ogg', 70)
+								playsound(src, 'sound/voice/f_laugh2.ogg', 50)
 							if("3")
-								playsound(src, 'sound/voice/f_laugh3.ogg', 70)
+								playsound(src, 'sound/voice/f_laugh3.ogg', 50)
 					else
 						switch(pick("1", "2", "3"))
 							if("1")
 								playsound(src, 'sound/voice/m_laugh.ogg', 70)
 							if("2")
-								playsound(src, 'sound/voice/m_laugh2.ogg', 70)
+								playsound(src, 'sound/voice/m_laugh2.ogg', 20)
 							if("3")
-								playsound(src, 'sound/voice/m_laugh3.ogg', 70)
+								playsound(src, 'sound/voice/m_laugh3.ogg', 20)
 				else
 					message = "makes a noise."
 					m_type = 2
@@ -561,7 +561,7 @@
 				if(get_sex() == FEMALE)
 					switch(pick("1", "2", "3"))
 						if("1")
-							playsound(loc, 'sound/effects/mob_effects/moan_f1.ogg', 80)
+							playsound(loc, 'sound/effects/mob_effects/moan_f1.ogg', 40)
 						if("2")
 							playsound(loc, 'sound/effects/mob_effects/moan_f2.ogg', 80)
 						if("3")

--- a/code/modules/mob/living/carbon/taste.dm
+++ b/code/modules/mob/living/carbon/taste.dm
@@ -49,5 +49,5 @@ calculate text size per text.
 				else if(percent <= minimum_percent)
 					continue
 				out.Add("[size][tastes[i]]")
-	to_chat(src, "<span class='notice'>You can't taste [english_list(out,"anything discernible.")]</span>" ) // Either your species lack taste, or whatever you were consuming is so watered down you can't taste it.
+	to_chat(src, "<span class='notice'>You can taste [english_list(out,"nothing worthy of note.")]</span>" ) // Either your species lack taste, or whatever you were consuming is so watered down you can't taste it.
 	from.trans_to_holder(target,amount,multiplier,copy) //complete transfer

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -582,10 +582,10 @@
 
 /obj/item/paper/voidwolfwarning
 	name = "paper- 'Read this you vat grown retards!'"
-	info = "<h1>Good you got a few fucking brain cells</h1><p>For those limp dicks who fucking forgot ever since the colony killed Preston and his Jackels they can't reset this teleporter, its stuck \
-	on forever because none of our boffins know how the fuck it works. Doesn't matter anyways, the fortress got taken over by Preston's formerly caged face rippers so none of you should be getting \
-	your shit stained arses ripped in half trying to loot the place. The teleporter has enough juice to get you back and forth but thats it. Guard this side until we can get enough boys to \
-	take out that huge queen looking bitch. P.S. Watch out for the landmines we laced a few spots with, might cause a breach so keep your void suits on and your oxygen tanks filled.</p>"
+	info = "<h1>Good, you got a few fucking functional brain cells</h1><p>For those limp dicks who fucking forgot, ever since the colony killed the Hivemind Overminds, the space fortress got blown to kingdom come, \
+	forever, along with all of Preston's formerly caged face rippers and both of the Overminds with them. <b>The teleporter itself was also blown by them</b> to prevent anyone stupid enough (that's all of ya') from ever \
+	setting foot in that accursed place ever again. All our fucking loot is gone, along with those two fleshy-metallic freaks and the queen-looking bitch, so you at least better guard up our armory tight since that's all we got left. \
+	Oh, and if your sad excuse of a flashgrown brain made it this far reading, don't forget the satellite dish is also fried to shit, so I wouldn't suggest touching that shit unless you want your energy weapons drained and your electronics scrambled.</p>"
 
 
 /obj/item/paper/solar

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -11766,9 +11766,6 @@
 /obj/random/powercell/low_chance,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
-"Va" = (
-/turf/simulated/floor/rock/manmade/concrete,
-/area/asteroid/rogue)
 "Vb" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha2,
@@ -22486,7 +22483,7 @@ Km
 Kl
 Kl
 ER
-ad
+ER
 ER
 ER
 ER
@@ -44395,7 +44392,7 @@ aV
 aV
 aV
 aV
-Va
+aV
 aV
 aV
 aV

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -12906,6 +12906,9 @@
 /obj/item/oddity/common/old_newspaper,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"ZX" = (
+/turf/simulated/floor/rock/manmade/concrete,
+/area/asteroid/rogue)
 "ZZ" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/machinery/light/floor,
@@ -44392,7 +44395,7 @@ aV
 aV
 aV
 aV
-aV
+ZX
 aV
 aV
 aV


### PR DESCRIPTION
## About The Pull Request

A recollection of fixes I noticed from my last PR, and player feedback.
	
<hr>
</details>

## Changelog
:cl:
add: Properly adds SoyFed jacket to loadout
tweak: Security belt can now take mini stunbatons.
balance: Removed random chance for a mob right outside Void Wolf outsider spawn as it was sometimes an instant game ending Nightmare Stalker.
fix: Certain materials now assigned their proper sheets. This solves the bug of not gaining back material (like cloth) used to pad a bed with, when you use a tool of wire cutting property to take off the padding of a bed.
soundfix: Lowered the volume on certain emotes that were too loud, through player feedback.
lore: Rewrites the paper in the Ironhammer Compound to symbolize the end of the hivemind arc and the disappearance of a teleporter that's no longer there, also a hint for players regarding the nearby satelite dish.
map: Removes a random undeground mob spawn right outside and outsider spawn as it sometimes had a nightmare stalker right off the bat, also replaces a random concrete block floating around with rocks
/:cl: