### PR TITLE
Fix point deductions for Church for dirty areas

### DIFF
--- a/code/game/gamemodes/scores.dm
+++ b/code/game/gamemodes/scores.dm
@@ -67,7 +67,7 @@ GLOBAL_VAR_INIT(grup_ritual_score, 0)
 GLOBAL_VAR_INIT(new_neothecnology_convert_score, 0)
 GLOBAL_VAR_INIT(new_neothecnology_convert, 0)
 
-//guild
+//guild (Sojourn: Lonestar!)
 GLOBAL_VAR_INIT(initial_guild_score, 0)
 GLOBAL_VAR_INIT(guild_score, 0)
 
@@ -154,7 +154,7 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 	var/obj/item/cell/large/high/HC = /obj/item/cell/large/high
 	var/min_charge = initial(HC.maxcharge) * 0.6
 
-	//calculate guild profits in a sane way
+	//calculate guild (Sojourn: Lonestar!) profits in a sane way
 	var/ending_balance = get_account_credits(department_accounts[DEPARTMENT_LSS])
 	var/datum/department/guild/guild_var = new/datum/department/guild
 	GLOB.supply_profit = ending_balance - guild_var.account_initial_balance
@@ -187,7 +187,7 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 		GLOB.field_radius += S.field_radius
 	GLOB.field_radius = CLAMP(GLOB.field_radius, 0, world.maxx)
 
-	//Technomancer Modifiers
+	//Artificer's Guild (not to be confused with "Guild" as it is used in code, which means Lonestar on Sojourn!) Modifiers
 	if(GLOB.all_smes_powered)
 		GLOB.score_smes_powered = 350 //max = 350
 	GLOB.score_technomancer_objectives = GLOB.technomancer_objectives_completed * 25 //max: ~= 100
@@ -198,7 +198,7 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 
 	GLOB.technomancer_score = GLOB.initial_technomancer_score + GLOB.score_smes_powered + GLOB.score_technomancer_objectives + GLOB.score_ship_shield + GLOB.score_fireloss + GLOB.score_powerloss + GLOB.score_technomancer_faction_item_loss
 
-	// NeoTheology score
+	// Church score
 	var/list/dirt_areas = list()
 	//Check how much uncleaned mess is on the station
 	for(var/obj/effect/decal/cleanable/M in world)
@@ -211,18 +211,17 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 	GLOB.dirt_areas = dirt_areas.len
 
 
-	//NeoTheology Modifiers
+	//Church Modifiers
 	GLOB.score_neotheology_faction_item_loss -= GLOB.neotheology_faction_item_loss * 150 //300
 	GLOB.neotheology_objectives_score = GLOB.neotheology_objectives_completed * 25 // ~100
-	GLOB.score_mess -= GLOB.dirt_areas * 25 //~250
 	GLOB.biomatter_score = round(GLOB.biomatter_neothecnology_amt/10) //350?  //target_max~1750//
 	GLOB.grup_ritual_score += GLOB.grup_ritual_performed * 5
 	GLOB.new_neothecnology_convert_score = GLOB.new_neothecnology_convert * 50 // ~150-300
 
-	GLOB.neotheology_score = GLOB.initial_neotheology_score + GLOB.score_neotheology_faction_item_loss + GLOB.neotheology_objectives_score + GLOB.score_mess + GLOB.grup_ritual_score + GLOB.biomatter_score + GLOB.new_neothecnology_convert_score
+	GLOB.neotheology_score = GLOB.initial_neotheology_score + GLOB.score_neotheology_faction_item_loss + GLOB.neotheology_objectives_score + GLOB.grup_ritual_score + GLOB.biomatter_score + GLOB.new_neothecnology_convert_score
 
 
-	//Moebius score
+	//Soteria score
 	GLOB.score_moebius_faction_item_loss -= GLOB.moebius_faction_item_loss * 150 //300
 	GLOB.moebius_objectives_score = GLOB.moebius_objectives_completed * 25 // ~100
 	GLOB.score_crew_dead -=	GLOB.crew_dead * 25 // ~200
@@ -231,7 +230,7 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 
 	GLOB.moebius_score = GLOB.initial_moebius_score + GLOB.score_moebius_faction_item_loss + GLOB.moebius_objectives_score + GLOB.score_crew_dead + GLOB.score_research_point_gained + GLOB.score_moebius_autopsies_mobs
 
-	//Ironhammer score
+	//Marshals score
 	GLOB.score_ironhammer_faction_item_loss -= 150 * GLOB.ironhammer_faction_item_loss
 	GLOB.ironhammer_objectives_score = GLOB.ironhammer_objectives_completed * 25
 	GLOB.score_antag_contracts -= GLOB.completed_antag_contracts * 30
@@ -241,13 +240,14 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 
 	GLOB.ironhammer_score = GLOB.initial_ironhammer_score + GLOB.ironhammer_objectives_score + GLOB.score_antag_contracts + GLOB.ironhammer_operative_dead_score + GLOB.captured_or_dead_antags_score
 
-	//Guild score
+	//Lonestar score 
 	GLOB.score_guild_faction_item_loss -= 150 * GLOB.guild_faction_item_loss // ~-300
 	GLOB.guild_objectives_score = GLOB.guild_objectives_completed * 25 // ~100
 	GLOB.guild_profit_score	= round(GLOB.supply_profit/50) // ? review it //target_max~500//
 	GLOB.guild_shared_gears_score = GLOB.guild_shared_gears * 30 // ~150-300
+    GLOB.score_mess -= GLOB.dirt_areas * 25 //~250
 
-	GLOB.guild_score = GLOB.initial_guild_score + GLOB.guild_objectives_score + GLOB.guild_profit_score
+	GLOB.guild_score = GLOB.initial_guild_score + GLOB.guild_objectives_score + GLOB.guild_profit_score + GLOB.score_mess
 
 
 	for(var/mob/E in GLOB.player_list)
@@ -274,7 +274,7 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 /mob/proc/scorestats()
 	var/dat = "<b>Faction Scores</b><br><hr><br>"
 
-	//ironhammer
+	//Marshals
 	dat += {"
 	<u>Marshal scores</u><br>
 	<b>Base score:</b> [green_text(GLOB.initial_ironhammer_score)]<br>
@@ -287,7 +287,7 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 	<b>Final Marshal score:</b> [get_color_score(GLOB.ironhammer_score, GLOB.ironhammer_score)] Points<br><br>
 	"}
 
-	//moebius
+	//Soteria
 	dat += {"
 	<u>Soteria Institution scores</u><br>
 	<b>Base score:</b> [green_text(GLOB.initial_moebius_score)]<br>
@@ -299,20 +299,19 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 	<b>Final Soteria Institution score:</b> [get_color_score(GLOB.moebius_score, GLOB.moebius_score)] Points<br><br>
 	"}
 
-	//nt
+	//Church
 	dat += {"
 	<u>Church of Absolute scores</u><br>
 	<b>Base score:</b> [green_text(GLOB.initial_neotheology_score)]<br>
 	<b>Lost faction items:</b> [GLOB.neotheology_faction_item_loss] ([to_score_color(GLOB.score_neotheology_faction_item_loss)] Points)<br>
 	<b>Faction objectives completed:</b> [GLOB.neotheology_objectives_completed] ([to_score_color(GLOB.neotheology_objectives_score)] Points)<br>
-	<b>Dirty areas:</b> [GLOB.dirt_areas] ([to_score_color(GLOB.score_mess)] Points)<br>
 	<b>Biomatter produced:</b> [GLOB.biomatter_neothecnology_amt] ([to_score_color(GLOB.biomatter_score)] Points)<br>
 	<b>Total of conversions:</b> [GLOB.new_neothecnology_convert] ([to_score_color(GLOB.new_neothecnology_convert_score)] Points)<br>
 	<b>Group rituals performed:</b> [GLOB.grup_ritual_performed] ([to_score_color(GLOB.grup_ritual_score)] Points)<br>
 	<b>Final Church of Absolute score:</b> [get_color_score(GLOB.neotheology_score, GLOB.neotheology_score)] Points<br><br>
 	"}
 
-	//guild
+	//Lonestar
 	dat += {"
 	<u>Lonestar Shipping Solutions scores</u><br>
 	<b>Base score:</b> [green_text(GLOB.initial_guild_score)]<br>
@@ -320,10 +319,11 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 	<b>Faction objectives completed:</b> [GLOB.guild_objectives_completed] ([to_score_color(GLOB.guild_objectives_score)] Points)<br>
 	<b>Profit profits:</b> [GLOB.supply_profit] ([to_score_color(GLOB.guild_profit_score)] Points)<br>
 	<b>Crew with items distributed by the Lonestar Shipping Solutions:</b> [GLOB.guild_shared_gears] ([to_score_color(GLOB.guild_shared_gears_score)] Points)<br>
+    <b>Dirty areas:</b> [GLOB.dirt_areas] ([to_score_color(GLOB.score_mess)] Points)<br>
 	<b>Final Lonestar Shipping Solutions score:</b> [get_color_score(GLOB.guild_score, GLOB.guild_score)] Points<br><br><br>
 	"}
 
-	//Technomancers
+	//Guild (Sojourn)
 	dat += {"
 	<u>Artificer's Guild scores</u><br>
 	<b>Base score:</b> [green_text(GLOB.initial_technomancer_score)]<br>

--- a/code/game/gamemodes/scores.dm
+++ b/code/game/gamemodes/scores.dm
@@ -245,7 +245,7 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 	GLOB.guild_objectives_score = GLOB.guild_objectives_completed * 25 // ~100
 	GLOB.guild_profit_score	= round(GLOB.supply_profit/50) // ? review it //target_max~500//
 	GLOB.guild_shared_gears_score = GLOB.guild_shared_gears * 30 // ~150-300
-    GLOB.score_mess -= GLOB.dirt_areas * 25 //~250
+	GLOB.score_mess -= GLOB.dirt_areas * 25 //~250
 
 	GLOB.guild_score = GLOB.initial_guild_score + GLOB.guild_objectives_score + GLOB.guild_profit_score + GLOB.score_mess
 
@@ -319,7 +319,7 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 	<b>Faction objectives completed:</b> [GLOB.guild_objectives_completed] ([to_score_color(GLOB.guild_objectives_score)] Points)<br>
 	<b>Profit profits:</b> [GLOB.supply_profit] ([to_score_color(GLOB.guild_profit_score)] Points)<br>
 	<b>Crew with items distributed by the Lonestar Shipping Solutions:</b> [GLOB.guild_shared_gears] ([to_score_color(GLOB.guild_shared_gears_score)] Points)<br>
-    <b>Dirty areas:</b> [GLOB.dirt_areas] ([to_score_color(GLOB.score_mess)] Points)<br>
+	<b>Dirty areas:</b> [GLOB.dirt_areas] ([to_score_color(GLOB.score_mess)] Points)<br>
 	<b>Final Lonestar Shipping Solutions score:</b> [get_color_score(GLOB.guild_score, GLOB.guild_score)] Points<br><br><br>
 	"}
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Move penalties for dirty floors from Church to Lonestar
</summary>
<hr>
Points were taken from Church for dirty floors. Unlike on Eris, it's not Church's responsibility (Janitor is a Church job on Eris). It's Lonestar's responsibility. So they get the points taken from them. 

I'm sure a lot of Church players were despaired because of their low points. Pain and suffering. Lifes ruined forever. Maybe one or two ritual suicides. Don't look at me that way, I _know_ that no one cares about the points.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl: dutop
tweak: Move point deductions for dirty areas from Church to Lonestar
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
