### PR TITLE
buffs the heck out of the lever guns

### DIFF
--- a/code/modules/projectiles/guns/projectile/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun.dm
@@ -156,12 +156,6 @@
 	if(!bolt_open)
 		to_chat(user, SPAN_WARNING("You add in ammo [src] while the bolt is closed!"))
 		return
-	//Prevents a bug, banaid-fix
-	if(istype(A, /obj/item/ammo_casing))
-		var/obj/item/ammo_casing/C = A
-		if(C.is_caseless)
-			to_chat(user, SPAN_WARNING("Adding in caseless ammo into [src] would trigger a chain reaction in the chamber!"))
-			return
 	..()
 
 /obj/item/gun/projectile/boltgun/unload_ammo(mob/user, var/allow_dump=1)


### PR DESCRIPTION
Bolt guns now properly use caseless ammo (the lever is the only gun that can)
In doing so you no longer have to cycle the bolt for caseless ammo, making the bolt reaction perk a conflicting perk with caseless ammo so do be warned