### PR TITLE
Parrying Dagger

### DIFF
--- a/code/datums/craft/recipes/weapon.dm
+++ b/code/datums/craft/recipes/weapon.dm
@@ -27,6 +27,16 @@
 		list(QUALITY_WELDING, 10, "time" = 30),
 		list(QUALITY_HAMMERING, 10, "time" = 20)
 	)
+	
+/datum/craft_recipe/weapon/parrying_dagger
+	name = "parrying dagger"
+	result = /obj/item/shield/parrying
+	steps = list(
+		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL),
+		list(QUALITY_WELDING, 10, "time" = 30),
+		list(QUALITY_HAMMERING, 10, "time" = 20)
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 10)
+	)
 
 /datum/craft_recipe/weapon/knife_blade
 	name = "butterfly knife blade"

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -624,3 +624,50 @@
 		set_light(1.5, 1.5, COLOR_LIGHTING_RED_BRIGHT)
 	else
 		set_light(0)
+		
+/obj/item/shield/parry
+	name = "parry dagger"
+	desc = "A parry dagger forged in a specific way to easily parry other melee attacks with ease, sacrificing its lethality in exchange."
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "dagger"
+	item_state = "dagger"
+	flags = CONDUCT
+	w_class = ITEM_SIZE_SMALL
+	slot_flags = SLOT_BELT
+	force = WEAPON_FORCE_NORMAL
+	throwforce = WEAPON_FORCE_DANGEROUS
+	throw_speed = 2
+	throw_range = 6
+	armor_list = list(melee = 15, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
+	matter = list(MATERIAL_PLASTEEL = 6, MATERIAL_PLASTIC = 2)
+	price_tag = 250
+	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	max_durability = 100 //So we can brake and need healing time to time
+	durability = 100
+	var/cooldown = 0 //shield bash cooldown. based on world.time
+	var/picked_by_human = FALSE
+	var/mob/living/carbon/human/picking_human
+
+/obj/item/shield/parry/handle_shield(mob/user)
+	. = ..()
+	if(.) playsound(user.loc, 'sound/weapons/Genhit.ogg', 50, 1)
+
+/obj/item/shield/buckler/get_protected_area(mob/user)
+	var/list/p_area = list(BP_CHEST)
+
+	if(user.get_equipped_item(slot_l_hand) == src)
+		p_area.Add(BP_L_ARM)
+	else if(user.get_equipped_item(slot_r_hand) == src)
+		p_area.Add(BP_R_ARM)
+
+	return p_area
+
+/obj/item/shield/parry/get_partial_protected_area(mob/user)
+	return list(BP_GROIN,BP_HEAD)
+
+
+/obj/item/shield/buckler/proc/on_bash(var/obj/item/W, var/mob/user)
+	if(cooldown < world.time - 25)
+		user.visible_message(SPAN_WARNING("[user] slashes [src] with [W]!"))
+		playsound(user.loc, 'sound/weapons/sharphit.ogg', 50, 1)
+		cooldown = world.time

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -625,9 +625,9 @@
 	else
 		set_light(0)
 		
-/obj/item/shield/parry
-	name = "parry dagger"
-	desc = "A parry dagger forged in a specific way to easily parry other melee attacks with ease, sacrificing its lethality in exchange."
+/obj/item/shield/parrying
+	name = "parrying dagger"
+	desc = "A parrying dagger forged in a specific way to easily parry other melee attacks with ease, sacrificing its lethality in exchange."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "dagger"
 	item_state = "dagger"
@@ -639,20 +639,20 @@
 	throw_speed = 2
 	throw_range = 6
 	armor_list = list(melee = 15, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
-	matter = list(MATERIAL_PLASTEEL = 6, MATERIAL_PLASTIC = 2)
+	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 2)
 	price_tag = 250
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	max_durability = 100 //So we can brake and need healing time to time
-	durability = 100
+	durability = 125
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 	var/picked_by_human = FALSE
 	var/mob/living/carbon/human/picking_human
 
-/obj/item/shield/parry/handle_shield(mob/user)
+/obj/item/shield/parrying/handle_shield(mob/user)
 	. = ..()
 	if(.) playsound(user.loc, 'sound/weapons/Genhit.ogg', 50, 1)
 
-/obj/item/shield/buckler/get_protected_area(mob/user)
+/obj/item/shield/parrying/get_protected_area(mob/user)
 	var/list/p_area = list(BP_CHEST)
 
 	if(user.get_equipped_item(slot_l_hand) == src)
@@ -662,11 +662,11 @@
 
 	return p_area
 
-/obj/item/shield/parry/get_partial_protected_area(mob/user)
+/obj/item/shield/parrying/get_partial_protected_area(mob/user)
 	return list(BP_GROIN,BP_HEAD)
 
 
-/obj/item/shield/buckler/proc/on_bash(var/obj/item/W, var/mob/user)
+/obj/item/shield/parrying/proc/on_bash(var/obj/item/W, var/mob/user)
 	if(cooldown < world.time - 25)
 		user.visible_message(SPAN_WARNING("[user] slashes [src] with [W]!"))
 		playsound(user.loc, 'sound/weapons/sharphit.ogg', 50, 1)


### PR DESCRIPTION

## About The Pull Request
	This is a simple addition, it is a craftable parrying dagger which is simply a dagger which has the ability to block melee attacks. Knife wise, it has near the same stats as a kitchen knife (not the stats of the normal dagger) and shield stats of a altered buckler. Its not better then any of the current shields, and has low durability though the entire purpose of the Parrying Dagger is primarily for style for those using cutlass' and sabres who wish to look the part. 
<hr>
	