### PR TITLE
Sawcon (further tool refactors and minor balance tweaks)

### DIFF
--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -256,12 +256,14 @@
 	switched_on_item_state = "nt_force_on"
 	force = WEAPON_FORCE_DANGEROUS
 	armor_penetration = ARMOR_PEN_MODERATE
-	w_class = ITEM_SIZE_HUGE
+	w_class = ITEM_SIZE_BULKY
 	matter = list(MATERIAL_BIOMATTER = 50, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 4, MATERIAL_GOLD = 3)
 	toggleable = TRUE
-	switched_on_force = WEAPON_FORCE_BRUTAL
-	switched_on_pen = ARMOR_PEN_MASSIVE
+	switched_on_forcemult = 1.75 //35 total; slightly better than a halberd
+	switched_on_penmult = 2 //30 total; same as a halberd
 	switched_on_qualities = list(QUALITY_CUTTING = 30, QUALITY_SAWING = 30)
+	switched_off_qualities = list(QUALITY_CUTTING = 10, QUALITY_SAWING = 10)
+	tool_qualities = list(QUALITY_CUTTING = 10, QUALITY_SAWING = 10)
 	active_time = 50
 	var/faith_cost = 50 //How much faith does it take to use this?
 

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -58,8 +58,8 @@
 	var/toggleable = FALSE	//Determines if it can be switched ON or OFF, for example, if you need a tool that will consume power/fuel upon turning it ON only. Such as welder.
 	var/switched_on = FALSE	//Curent status of tool. Dont edit this in subtypes vars, its for procs only.
 	var/switched_on_qualities = list()	//This var will REPLACE tool_qualities when tool will be toggled on.
-	var/switched_on_force = null
-	var/switched_on_pen = null
+	var/switched_on_forcemult = null
+	var/switched_on_penmult = null
 	var/switched_on_icon_state = null
 	var/switched_on_item_state = null
 	var/switched_off_qualities = list()	//This var will REPLACE tool_qualities when tool will be toggled off. So its possible for tool to have diferent qualities both for ON and OFF state.
@@ -683,12 +683,10 @@
 		to_chat(user, SPAN_NOTICE("\The [src] turns on."))
 	switched_on = TRUE
 	tool_qualities = switched_on_qualities
-	if(!isnull(switched_on_force))
-		force = switched_on_force
-		if(wielded)
-			force *= 1.3
-	if(switched_on_pen)
-		armor_penetration = switched_on_pen
+	if(switched_on_forcemult)
+		force *= switched_on_forcemult
+	if(switched_on_penmult)
+		armor_penetration *= switched_on_penmult
 	if(glow_color)
 		set_light(l_range = 1.7, l_power = 1.3, l_color = glow_color)
 	if(switched_on_icon_state)
@@ -711,10 +709,10 @@
 	switched_on = FALSE
 	STOP_PROCESSING(SSobj, src)
 	tool_qualities = switched_off_qualities
-	if(switched_on_force)
-		force = initial(force)
-	if(switched_on_pen)
-		armor_penetration = initial(armor_penetration)
+	if(switched_on_forcemult)
+		force /= switched_on_forcemult
+	if(switched_on_forcemult)
+		armor_penetration /= switched_on_penmult
 	if(glow_color)
 		set_light(l_range = 0, l_power = 0, l_color = glow_color)
 	if(switched_on_icon_state)
@@ -842,7 +840,7 @@
 	stunforce = initial(stunforce)
 	agonyforce = initial(agonyforce)
 
-	switched_on_force = initial(switched_on_force)
+
 	extra_bulk = initial(extra_bulk)
 	item_flags = initial(item_flags)
 	name = initial(name)

--- a/code/game/objects/items/weapons/tools/hammer.dm
+++ b/code/game/objects/items/weapons/tools/hammer.dm
@@ -33,7 +33,7 @@
 	icon_state = "powered_hammer"
 	item_state = "powered_hammer"
 	wielded_icon = "powered_hammer_on"
-	switched_on_force = WEAPON_FORCE_BRUTAL
+	switched_on_forcemult = 2.2 //33 total
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
 	w_class = ITEM_SIZE_BULKY
 	slot_flags = SLOT_BELT|SLOT_BACK
@@ -42,7 +42,7 @@
 	switched_on_qualities = list(QUALITY_HAMMERING = 45)
 	switched_off_qualities = list(QUALITY_HAMMERING = 30)
 	toggleable = TRUE
-	armor_penetration = ARMOR_PEN_EXTREME
+	armor_penetration = ARMOR_PEN_EXTREME // Retains AP when turned off - it's a hammer.
 	degradation = 0.7
 	use_power_cost = 2
 	suitable_cell = /obj/item/cell/medium
@@ -76,8 +76,8 @@
 	icon_state = "onehammer"
 	item_state = "onehammer"
 	wielded_icon = "onehammer_on"
-	switched_on_force = WEAPON_FORCE_LETHAL
-	armor_penetration = ARMOR_PEN_EXTREME // Somehow was not inheriting
+	switched_on_forcemult = 2.6 // 39 total
+	armor_penetration = ARMOR_PEN_EXTREME // Retains AP when turned off - it's a hammer.
 	structure_damage_factor = STRUCTURE_DAMAGE_DESTRUCTIVE
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLATINUM = 3, MATERIAL_DIAMOND = 3)
 	price_tag = 860
@@ -181,8 +181,8 @@
 	wielded_icon = "chargehammer1"
 	item_state = "chargehammer0"
 	w_class = ITEM_SIZE_HUGE
-	switched_on_force = WEAPON_FORCE_BRUTAL
-	armor_penetration = ARMOR_PEN_EXTREME // On par with powered hammers
+	switched_on_forcemult = 2.2
+	armor_penetration = ARMOR_PEN_EXTREME // Retains AP when turned off - it's a hammer.
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
 	switched_on_qualities = list(QUALITY_HAMMERING = 60)
 	switched_off_qualities = list(QUALITY_HAMMERING = 35)

--- a/code/game/objects/items/weapons/tools/misc.dm
+++ b/code/game/objects/items/weapons/tools/misc.dm
@@ -188,7 +188,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "multitool_improvised"
 	force = WEAPON_FORCE_PAINFUL
-	switched_on_force = WEAPON_FORCE_PAINFUL * 0.8
+	switched_on_forcemult = 0.8
 	worksound = WORKSOUND_DRIVER_TOOL
 	flags = CONDUCT
 	switched_on_qualities = list(

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -380,7 +380,6 @@
 				T.suitable_cell = /obj/item/cell/medium
 				prefix = "medium-cell"
 	T.force = initial(T.force) * T.force_upgrade_mults + T.force_upgrade_mods
-	T.switched_on_force = initial(T.switched_on_force) * T.force_upgrade_mults + T.force_upgrade_mods
 	T.prefixes |= prefix
 
 /datum/component/item_upgrade/proc/apply_values_gun(var/obj/item/gun/G)

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -62,7 +62,7 @@
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLATINUM = 2, MATERIAL_DIAMOND = 2)
 	price_tag = 900 //Diamond and fancy.
 	origin_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 2, TECH_POWER = 3)
-	switched_on_force = WEAPON_FORCE_ROBUST
+	switched_on_forcemult = 1.3 //26
 	tool_qualities = list(QUALITY_EXCAVATION = 50, QUALITY_PRYING = 25)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 50, QUALITY_PRYING = 25)
 	switched_on_qualities = list(QUALITY_DIGGING = 50, QUALITY_PRYING = 25)

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -87,13 +87,17 @@
 	icon_state = "chainsaw"
 	hitsound = WORKSOUND_CHAINSAW
 	worksound = WORKSOUND_CHAINSAW
-	force = WEAPON_FORCE_BRUTAL //Rip and tear!
+	force = WEAPON_FORCE_WEAK
+	switched_on_forcemult = 4 //28 total
 	w_class = ITEM_SIZE_NORMAL
 	armor_penetration = ARMOR_PEN_SHALLOW
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 2)
-	tool_qualities = list(QUALITY_SAWING = 60, QUALITY_CUTTING = 50, QUALITY_WIRE_CUTTING = 20) //not the best choice to cut wires
+	tool_qualities = list(QUALITY_SAWING = 5, QUALITY_CUTTING = 5, QUALITY_WIRE_CUTTING = 5) //barely usable when off, but allows mods to be applied
+	switched_off_qualities = list(QUALITY_CUTTING = 5)
 	max_upgrades = 3
 	use_fuel_cost = 0.1
+	toggleable = TRUE
+	switched_on_qualities = list(QUALITY_SAWING = 60, QUALITY_CUTTING = 50, QUALITY_WIRE_CUTTING = 20)
 	max_fuel = 80
 	price_tag = 550
 
@@ -103,13 +107,17 @@
 	icon_state = "hypersaw"
 	hitsound = WORKSOUND_CHAINSAW
 	worksound = WORKSOUND_CHAINSAW
-	force = WEAPON_FORCE_BRUTAL
+	force = WEAPON_FORCE_WEAK
+	switched_on_forcemult = 4 //28 total
 	w_class = ITEM_SIZE_NORMAL
 	armor_penetration = ARMOR_PEN_SHALLOW
 	matter = list(MATERIAL_SILVER = 2, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 3)
-	tool_qualities = list(QUALITY_SAWING = 60, QUALITY_CUTTING = 50, QUALITY_WIRE_CUTTING = 20)
+	tool_qualities = list(QUALITY_SAWING = 5, QUALITY_CUTTING = 5, QUALITY_WIRE_CUTTING = 5) //barely usable when off, but allows mods to be applied
+	switched_off_qualities = list(QUALITY_CUTTING = 5)
 	max_upgrades = 2
 	degradation = 0.7
 	use_power_cost = 1
+	toggleable = TRUE
+	switched_on_qualities = list(QUALITY_SAWING = 60, QUALITY_CUTTING = 50, QUALITY_WIRE_CUTTING = 20)
 	suitable_cell = /obj/item/cell/medium
 	price_tag = 720

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -245,7 +245,7 @@
 
 	switched_on_qualities = list(QUALITY_CUTTING = 25, QUALITY_SAWING = 15)
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 6)
-	switched_on_force = WEAPON_FORCE_LETHAL
+	switched_on_forcemult = 1.2 //40
 	price_tag = 800
 
 /obj/item/tool/sword/katana/nano/turn_on(mob/user)
@@ -283,7 +283,7 @@
 	switched_on_qualities = list(QUALITY_CUTTING = 25, QUALITY_SAWING = 15, QUALITY_CAUTERIZING = 10, QUALITY_WELDING = 15)
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 4)
 	force = WEAPON_FORCE_NORMAL
-	switched_on_force = WEAPON_FORCE_BRUTAL
+	switched_on_forcemult = 3.3 //33
 	//Weaker than the Muramasa and other high end weapons, as it's not LETHAL, but sets the target on fire. 1 stack though.
 	structure_damage_factor = STRUCTURE_DAMAGE_BLUNT
 	//A heated blade can not be sharp, it's just shaped like a sword while being a blunt object. When turned off it has as much damage as other blunt implements.
@@ -427,7 +427,7 @@
 	item_state = "powerfist"
 	toggleable = TRUE
 	worksound = WORKSOUND_HAMMER
-	switched_on_force = WEAPON_FORCE_BRUTAL
+	switched_on_forcemult = 3.3 //33
 	armor_penetration = ARMOR_PEN_MODERATE
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_COMBAT = 7)

--- a/code/game/objects/items/weapons/tools/stunbatons.dm
+++ b/code/game/objects/items/weapons/tools/stunbatons.dm
@@ -282,7 +282,7 @@
 	use_power_cost = 1.2
 	sparks_on_use = TRUE
 	force = WEAPON_FORCE_WEAK
-	switched_on_force = WEAPON_FORCE_PAINFUL
+	switched_on_forcemult = 2.1 //15
 	throwforce = WEAPON_FORCE_WEAK
 	suitable_cell = /obj/item/cell/medium
 	toggleable = TRUE

--- a/code/game/objects/items/weapons/tools/weldingtools.dm
+++ b/code/game/objects/items/weapons/tools/weldingtools.dm
@@ -4,7 +4,7 @@
 	item_state = "welder"
 	flags = CONDUCT
 	force = WEAPON_FORCE_WEAK
-	switched_on_force = WEAPON_FORCE_PAINFUL
+	switched_on_forcemult = 2.1 //15
 	throwforce = WEAPON_FORCE_WEAK
 	worksound = WORKSOUND_WELDING
 	matter = list(MATERIAL_STEEL = 5)
@@ -50,7 +50,7 @@
 	desc = "An assembly of pipes attached to a little gas tank. Serves capably as a welder, though a bit risky. Can be improved greatly with a large amount of tool mods."
 	icon_state = "ghettowelder"
 	item_state = "ghettowelder"
-	switched_on_force = WEAPON_FORCE_PAINFUL * 0.8
+	switched_on_forcemult = 1.7 //12
 	max_fuel = 15
 	switched_on_qualities = list(QUALITY_WELDING = 15, QUALITY_CAUTERIZING = 10, QUALITY_WIRE_CUTTING = 10)
 	degradation = 1.5
@@ -71,7 +71,7 @@
 	switched_on_qualities = list(QUALITY_WELDING = 45, QUALITY_CAUTERIZING = 15, QUALITY_WIRE_CUTTING = 15)
 	max_fuel = 40
 	matter = list(MATERIAL_PLASTEEL = 5)
-	switched_on_force = WEAPON_FORCE_PAINFUL * 1.15 //Slightly more powerful, not much more so
+	switched_on_forcemult = 2.5 //17
 	heat = 3773
 	degradation = 0.7
 	max_upgrades = 4

--- a/code/modules/projectiles/guns/oddity_items.dm
+++ b/code/modules/projectiles/guns/oddity_items.dm
@@ -361,9 +361,11 @@
 	icon_state = "rip_and_tear"
 	hitsound = WORKSOUND_CHAINSAW
 	worksound = WORKSOUND_CHAINSAW
-	force = WEAPON_FORCE_GODLIKE
+	force = WEAPON_FORCE_DANGEROUS
+	switched_on_forcemult = 4.4 //88
 	w_class = ITEM_SIZE_NORMAL
-	armor_penetration = ARMOR_PEN_HALF
+	armor_penetration = ARMOR_PEN_DEEP
+	switched_on_penmult = 2.5 //50
 	matter = list(MATERIAL_SILVER = 2, MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 3)
 	tool_qualities = list(QUALITY_SAWING = 70, QUALITY_CUTTING = 60, QUALITY_WIRE_CUTTING = 30)
 	max_upgrades = 1//Already over powered.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Totally gets rid of the `switched_on_force` var, in favour of `switched_on_forcemult`. This means that, rather than setting a specific value for a tool's force when active, you set a multiplier for their initial force. _Why?_ Right now, a key issue with tools is that - as soon as you turn them on and off again - they will lose any force bonuses from applied mods. This fixes that, allowing any previously-applied damage modifiers to remain when a tool is toggled. This also applies to armour penetration. All tools have been altered to use this, while keeping their previous values - except for a couple.

The chainsaw and hypersaw (**not** the Doombringer) have been brought down from 33 to 28 damage.  In addition, they now have to be toggled on to get this full damage, which passively drains fuel/power in addition to the active power use on every attack. They're still good, and better than most other melee weapons, but not _as_ dominant as before.

Finally, the Vexilar now gets 35 damage while powered up, rather than 33, just to make it a little more compelling over a more traditional Church melee weapon.
	
<hr>
</details>

## Changelog
:cl:
balance: nerfed chainsaw/hypersaw damage from 33 to 28
balance: chainsaws must be turned on, draining power over time, in order to deal full damage
refactor: tools now have a force multiplier when switched on, rather than a fixed "switched on force"
balance: "vexilar" forceblade now does 35 damage when powered up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
