### PR TITLE
Language and anomaly exploit fixes

### DIFF
--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -49,6 +49,11 @@
 	gain_text = "You feel your pace quickening, your thoughts barely catching up with your stride..."
 	//icon_state = "fast" // https://game-icons.net/1x1/delapouite/fast-forward-button.html
 
+/datum/perk/oddity/fast_walker/assign(mob/living/carbon/human/H)
+	..()
+	if(holder.stats.getPerk(PERK_FAST_WALKER)) // Prevents stacking the same perk over and over for Emperor spider levels of speed. - Seb
+		return FALSE
+
 /datum/perk/oddity/harden
 	name = "Natural Armor"
 	desc = "Your skin has become harder, more durable, able to accept blunt force and endure."

--- a/code/modules/goonchat/browserassets/css/browserOutput_override.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_override.css
@@ -56,6 +56,7 @@
 .jana					{color: #993399}
 .latin					{color: #deb63d}
 .romana					{color: #ed7961}
+.euro					{color: #6533da}
 .yassari				{color: #5fbf4e}
 .marqua					{color: #00FFFF}
 .akula					{color: #f8412c}

--- a/code/modules/mob/language/euro.dm
+++ b/code/modules/mob/language/euro.dm
@@ -3,6 +3,9 @@
 	desc = "Language used by the descendants of Europe, particularly influenced by Germanic derived languages. Typically spoken around core-world colonies of Sol-Fed and among those in government positions."
 	colour = "euro"
 	key = "e"
+	speech_verb = list("enounces")
+	ask_verb = list("inquires")
+	exclaim_verb = list("proclaims")
 	partial_understanding = list(
 		LANGUAGE_ROMANA = 20,
 		LANGUAGE_COMMON = 25,

--- a/code/modules/mob/language/illyrian.dm
+++ b/code/modules/mob/language/illyrian.dm
@@ -1,9 +1,12 @@
 
 /datum/language/illyrian
 	name = LANGUAGE_ILLYRIAN
-	desc = "A language derived from Earth's Balkan regions. Commonly spoken as a linguia franca among urban background mercenaries, pirates, and within criminal trades."
+	desc = "A language derived from Earth's Balkan regions. Commonly spoken as a lingua franca among urban background mercenaries, pirates, and within criminal trades."
 	colour = "illyrian"
 	key = "i"
+	speech_verb = list("utters")
+	ask_verb = list("crudely asks")
+	exclaim_verb = list("yawps")
 	space_chance = 80
 	has_written_form = TRUE
 	partial_understanding = list(

--- a/code/modules/mob/language/jana.dm
+++ b/code/modules/mob/language/jana.dm
@@ -1,10 +1,10 @@
 /datum/language/jana
 	name = LANGUAGE_JANA
-	desc = "A hybrid language of Mandarin, Japanese, and Cantonese written in a modernized verticle fashion."
+	desc = "A hybrid language of Mandarin, Japanese, and Cantonese written in a modernized vertical fashion."
 	speech_verb = list("states")
 	ask_verb = list("implores")
 	exclaim_verb = list("intently states")
-	colour = "brass"
+	colour = "jana"
 	key = "j"
 	shorthand = "JA"
 	partial_understanding = list(

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -92,9 +92,12 @@
 
 /datum/language/russian
 	name = LANGUAGE_CYRILLIC
-	desc = "A language derived from Earth's Eastern European and Central Asian regions. Commonly spoken in frontier colonies, it finds its home on many agricultural worlds."
+	desc = "A language derived from Earth's Eastern European and Central Asian regions. Commonly spoken in frontier colonies, it also finds home on many agricultural worlds."
 	colour = "slavic"
 	key = "r"
+	speech_verb = list("spouts")
+	ask_verb = list("crudely asks")
+	exclaim_verb = list("blurts out")
 	partial_understanding = list(
 		LANGUAGE_ILLYRIAN = 60,
 		LANGUAGE_ROMANA = 20

--- a/code/modules/mob/language/yassari.dm
+++ b/code/modules/mob/language/yassari.dm
@@ -1,6 +1,6 @@
 /datum/language/yassari
 	name = LANGUAGE_YASSARI
-	desc = "A pideon language of sorts adopted by frontier nomads, converts and merchants alike, derived from various Islamic origins back on Earth."
+	desc = "A pidgin language of sorts adopted by frontier nomads, converts and merchants alike, derived from various Islamic origins back on Earth."
 	speech_verb = list("stipulates")
 	ask_verb = list("queries")
 	exclaim_verb = list("rambles")


### PR DESCRIPTION
## Powergamers HATE him!

- Eurolang now has a proper color when spoken
- Jana now has its intended override color from the CSS rather than "brass" (makes it different from church latin)
- Languages got more snowflakey by changing how one speaks, asks and exclaims in them
- Fixes an exploit with the Springheel perk allowing a player to take multiple stackable instances of it
- Minor typo fixes
	
<hr>
</details>

## Changelog
:cl:
fix: Fixes an exploit with anomalies causing a player to have multiple instances of the Springheel perk that stacked for movement speed
fix: Fixed german not having a color when spoken
tweak: Jana no longer "brass" in color, now uses its intended one as per the CSS doc, to differentiate from Latin
tweak: Changed how certain languages talk, ask and exclaim from base english language, to make them different
spellcheck: fixed a few typos
/:cl: