### PR TITLE
Catwalk and underplating categorization fix

### DIFF
--- a/code/datums/craft/recipes/floor.dm
+++ b/code/datums/craft/recipes/floor.dm
@@ -7,6 +7,26 @@
 	time = 1 //Crafting individual tiles is fast
 	related_stats = list(STAT_MEC)
 
+/datum/craft_recipe/floor/underplating
+	name = "underplating"
+	result = /obj/effect/flooring_type_spawner
+	time = WORKTIME_SLOW
+	flags = CRAFT_ON_FLOOR|CRAFT_ONE_PER_TURF
+	steps = list(
+		list(CRAFT_MATERIAL, 15, MATERIAL_STEEL)
+	)
+	related_stats = list(STAT_MEC)
+
+/datum/craft_recipe/floor/catwalk
+	name = "catwalk"
+	result = /obj/structure/catwalk
+	time = WORKTIME_FAST
+	flags = CRAFT_ON_FLOOR|CRAFT_ONE_PER_TURF
+	steps = list(
+		list(CRAFT_MATERIAL, 8, MATERIAL_STEEL)
+	)
+	related_stats = list(STAT_MEC)
+
 /datum/craft_recipe/floor/wood
 	name = "wood floor tile"
 	result = /obj/item/stack/tile/wood

--- a/code/datums/craft/recipes/wall.dm
+++ b/code/datums/craft/recipes/wall.dm
@@ -62,26 +62,6 @@
 	)
 	related_stats = list(STAT_MEC)
 
-/datum/craft_recipe/wall/underplating
-	name = "underplating"
-	result = /obj/effect/flooring_type_spawner
-	time = WORKTIME_SLOW
-	flags = CRAFT_ON_FLOOR|CRAFT_ONE_PER_TURF
-	steps = list(
-		list(CRAFT_MATERIAL, 15, MATERIAL_STEEL)
-	)
-	related_stats = list(STAT_MEC)
-
-/datum/craft_recipe/wall/catwalk
-	name = "catwalk"
-	result = /obj/structure/catwalk
-	time = WORKTIME_FAST
-	flags = CRAFT_ON_FLOOR|CRAFT_ONE_PER_TURF
-	steps = list(
-		list(CRAFT_MATERIAL, 8, MATERIAL_STEEL)
-	)
-	related_stats = list(STAT_MEC)
-
 /datum/craft_recipe/wall/lattice
 	name = "lattice"
 	result = /obj/structure/lattice


### PR DESCRIPTION
## About The Pull Request

Moves the catwalk and underplating craft recipe from the wall category to the floor category in the crafting menu.

## Changelog
:cl:
tweak: tweaked wall.dm & floor.dm
/:cl: