### PR TITLE
Duplicate Table fix

### DIFF
--- a/maps/_DeepForest/map/_River_Forest.dmm
+++ b/maps/_DeepForest/map/_River_Forest.dmm
@@ -907,7 +907,6 @@
 /area/nadezhda/outside/forest/river_forest_underground)
 "mO" = (
 /obj/structure/table/marble,
-/obj/structure/table/marble,
 /obj/item/toy/plushie/mouse,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/forest/river_forest_light)


### PR DESCRIPTION
## About The Pull Request
Removes a duplicate table for an outsider spawn on river forest.  Noticed by a friend a while ago, thought I'd fix.


## Changelog
:cl:
tweak: tweaked _River_Forest.dmm
/:cl:


