### PR TITLE
Banana Republic

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -91,6 +91,7 @@
 	var/list/initialized_upgrades = list()
 
 	var/max_upgrades = 3
+	var/allow_greyson_mods = FALSE
 	prefixes = list()
 	var/list/blacklist_upgrades = list() //Zebra list. /item/upgrade/thing = TRUE means it IS  blacklisted, /item/upgrade/thing/subtype = FALSE means it won't b blacklisted. subtypes go first.
 	var/my_fuel = "fuel" //If we use fuel, what do we use?
@@ -199,6 +200,10 @@
 
 	for(var/Q in tool_qualities)
 		message += "\n<blue>It possesses [tool_qualities[Q]] tier of [Q] quality.<blue>"
+
+	if(allow_greyson_mods)
+		message += "\n<blue>This allows for Greyson Positronic based mods to be integrated without normal constraints.<blue>"
+
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -590,6 +595,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	item_flags = initial(item_flags)
 	name = initial(name)
 	max_upgrades = initial(max_upgrades)
+	allow_greyson_mods = initial(allow_greyson_mods)
 	color = initial(color)
 	sharp = initial(sharp)
 	prefixes = list()

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -845,6 +845,7 @@
 	item_flags = initial(item_flags)
 	name = initial(name)
 	max_upgrades = initial(max_upgrades)
+	allow_greyson_mods = initial(allow_greyson_mods)
 	color = initial(color)
 	sharp = initial(sharp)
 	prefixes = list()

--- a/code/game/objects/items/weapons/tools/crowbars.dm
+++ b/code/game/objects/items/weapons/tools/crowbars.dm
@@ -41,6 +41,7 @@
 	degradation = 2
 	workspeed = 1.2
 	price_tag = 180 // Fancy but still just a crowbar.
+	allow_greyson_mods = TRUE
 
 /obj/item/tool/crowbar/pneumatic
 	name = "pneumatic crowbar"

--- a/code/game/objects/items/weapons/tools/hammer.dm
+++ b/code/game/objects/items/weapons/tools/hammer.dm
@@ -88,6 +88,7 @@
 	use_power_cost = 1.5
 	workspeed = 1.5
 	max_upgrades = 2
+	allow_greyson_mods = TRUE
 
 /obj/item/tool/hammer/foremansledge
 	name = "foreman's sledgehammer"

--- a/code/game/objects/items/weapons/tools/misc.dm
+++ b/code/game/objects/items/weapons/tools/misc.dm
@@ -63,6 +63,7 @@
 	workspeed = 1.2
 	price_tag = 1400 // Super fancy
 	degradation = 2
+	allow_greyson_mods = TRUE
 
 /obj/item/tool/medmultitool/medimplant
 	name = "soteria medical omnitool"
@@ -78,6 +79,7 @@
 	degradation = 0.5
 	workspeed = 0.8
 	price_tag = 600 // Not nearly as fancy.
+	allow_greyson_mods = FALSE
 
 	use_power_cost = 1.2
 	suitable_cell = /obj/item/cell/medium

--- a/code/game/objects/items/weapons/tools/mods/_defines.dm
+++ b/code/game/objects/items/weapons/tools/mods/_defines.dm
@@ -16,6 +16,8 @@
 #define UPGRADE_BALLISTIC_ARMOR "bullet"
 #define UPGRADE_ENERGY_ARMOR "energy"
 #define UPGRADE_BOMB_ARMOR "bomb"
+#define UPGRADE_ALLOW_GREYON_MODS "allow_gp"
+#define GUN_UPGRADE_ALLOW_GREYON_MODS "allow_gp_gun"
 // ------------------
 
 #define SANCTIFIED "saint" //Used for weapons that was sanctified

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -39,6 +39,7 @@
 	var/destroy_on_removal = FALSE
 	var/unique_removal = FALSE 		//Flag for unique removals.
 	var/unique_removal_type 		//What slot do we remove when this is removed? Used for rails.
+	var/greyson_moding = FALSE
 
 /datum/component/item_upgrade/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_IATTACK, .proc/attempt_install)
@@ -124,6 +125,10 @@
 				if(user)
 					to_chat(user, SPAN_WARNING("This tool can not accept the modification!"))
 				return FALSE
+
+	//Bypasses any other checks.
+	if(greyson_moding && T.allow_greyson_mods)
+		return TRUE
 
 	if((req_fuel_cell & REQ_FUEL) && !T.use_fuel_cost)
 		if(user)
@@ -221,6 +226,10 @@
 			if(user)
 				to_chat(user, SPAN_WARNING("There is already something attached to \the [G]'s [gun_loc_tag]!"))
 			return FALSE
+
+	//Bypasses any other checks.
+	if(greyson_moding && G.allow_greyson_mods)
+		return TRUE
 
 	for(var/I in req_gun_tags)
 		if(!G.gun_tags.Find(I))
@@ -333,6 +342,8 @@
 /datum/component/item_upgrade/proc/apply_values_tool(var/obj/item/tool/T)
 	if(tool_upgrades[UPGRADE_SANCTIFY])
 		T.aspects += list(SANCTIFIED)
+	if(tool_upgrades[UPGRADE_ALLOW_GREYON_MODS])
+		T.allow_greyson_mods = tool_upgrades[UPGRADE_ALLOW_GREYON_MODS]
 	if(tool_upgrades[UPGRADE_PRECISION])
 		T.precision += tool_upgrades[UPGRADE_PRECISION]
 	if(tool_upgrades[UPGRADE_WORKSPEED])
@@ -383,6 +394,8 @@
 	T.prefixes |= prefix
 
 /datum/component/item_upgrade/proc/apply_values_gun(var/obj/item/gun/G)
+	if(weapon_upgrades[GUN_UPGRADE_ALLOW_GREYON_MODS])
+		G.allow_greyson_mods = weapon_upgrades[GUN_UPGRADE_ALLOW_GREYON_MODS]
 	if(weapon_upgrades[GUN_UPGRADE_DAMAGE_MULT])
 		G.damage_multiplier *= weapon_upgrades[GUN_UPGRADE_DAMAGE_MULT]
 	if(weapon_upgrades[GUN_UPGRADE_PAIN_MULT])
@@ -560,6 +573,9 @@
 	if(tool_upgrades[UPGRADE_BOMB_ARMOR])
 		to_chat(user, SPAN_NOTICE("Increases explosive defense by [tool_upgrades[UPGRADE_BOMB_ARMOR]]"))
 
+	if(tool_upgrades[UPGRADE_ALLOW_GREYON_MODS])
+		to_chat(user, SPAN_NOTICE("This mod allows you to install Greyson Positronic mods"))
+
 	if(required_qualities.len)
 		to_chat(user, SPAN_WARNING("Requires a tool with one of the following qualities:"))
 		to_chat(user, english_list(required_qualities, and_text = " or "))
@@ -730,6 +746,9 @@
 
 		if(weapon_upgrades[GUN_UPGRADE_RAIL])
 			to_chat(user, SPAN_WARNING("Adds a scope slot."))
+
+		if(weapon_upgrades[GUN_UPGRADE_ALLOW_GREYON_MODS])
+			to_chat(user, SPAN_NOTICE("This mod allows you to install Greyson Positronic mods"))
 
 		if(weapon_upgrades[GUN_UPGRADE_ZOOM])
 			var/amount = weapon_upgrades[GUN_UPGRADE_ZOOM]

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -857,10 +857,11 @@
 /obj/item/tool_upgrade/augment/ai_tool
 	name = "nanointegrated AI"
 	desc = "A forgotten Greyson Positronic tech. Due to its unique installation method of \"slapping it hard enough onto anything should do the trick\", it is highly sought after. \
-		A powerful AI will integrate itself into this tool with the aid of nanotechnology and improve it in every way possible."
+		A powerful AI will integrate itself into this tool with the aid of nanotechnology and improve it in every way possible. Once added its embeding into the object making it a permanent integration."
 	icon_state = "ai_tool"
 	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_PLASTEEL = 3, MATERIAL_PLATINUM = 3, MATERIAL_GOLD = 3, MATERIAL_DIAMOND = 1)
 	price_tag = 725
+	can_remove = FALSE
 
 /obj/item/tool_upgrade/augment/ai_tool/New()
 	..()
@@ -870,8 +871,10 @@
 	UPGRADE_PRECISION = 12,
 	UPGRADE_WORKSPEED = 3,
 	UPGRADE_HEALTH_THRESHOLD = -10,
+	UPGRADE_ALLOW_GREYON_MODS = TRUE,
 	)
 	I.weapon_upgrades = list(
+	GUN_UPGRADE_ALLOW_GREYON_MODS = TRUE,
 	GUN_UPGRADE_RECOIL = 0.8,
 	GUN_UPGRADE_PVE_PROJ_MULT_DAMAGE = 1.1,
 	GUN_UPGRADE_DAMAGE_MULT = 1.1,
@@ -884,14 +887,17 @@
 	GUN_UPGRADE_OVERCHARGE_RATE = 1.2
 	)
 	I.prefix = "intelligent"
-	I.req_fuel_cell = REQ_FUEL_OR_CELL
+	I.req_fuel_cell = REQ_CELL
+	I.greyson_moding = TRUE
 
 /obj/item/tool_upgrade/augment/ai_tool_excelsior
 	name = "excelsior nanointegrated AI"
-	desc = "An attempt by the excelsior to copy the superior Greyson nano-AI for their weaponry. It isn't nearly as good, but its cheaper to produce and can fit any weapon, not just energy based, as it draws its power from excelsior teleporation technology."
+	desc = "An attempt by the excelsior to copy the superior Greyson nano-AI for their weaponry. It isn't nearly as good, but its cheaper to produce and can fit any tool, not just energy based, as it draws its power from excelsior teleporation technology.\
+	 Once added its embeding into the object making it a permanent integration."
 	icon_state = "ai_tool_excelsior"
 	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_PLASTEEL = 3, MATERIAL_GOLD = 3)
 	price_tag = 325 //freee markeetttt
+	can_remove = FALSE
 
 /obj/item/tool_upgrade/augment/ai_tool_excelsior/New()
 	..()
@@ -929,6 +935,8 @@
 	UPGRADE_DEGRADATION_MULT = 0.01,
 	UPGRADE_HEALTH_THRESHOLD = 10
 	)
+	I.greyson_moding = TRUE
+	I.req_fuel_cell = REQ_FUEL_OR_CELL
 	I.prefix = "self-repairing"
 
 /obj/item/tool_upgrade/augment/hydraulic

--- a/code/game/objects/items/weapons/tools/multitool.dm
+++ b/code/game/objects/items/weapons/tools/multitool.dm
@@ -41,6 +41,7 @@
 	workspeed = 1.6
 	max_upgrades = 5 //UNLIMITED MODS!
 	price_tag = 1500 // Diamond and super fancy/rare.
+	allow_greyson_mods = TRUE
 
 /obj/item/tool/multitool/advanced
 	name = "advanced multitool"

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -70,6 +70,7 @@
 	degradation = 2
 	workspeed = 1.2
 	use_power_cost = 0
+	allow_greyson_mods = TRUE
 
 /obj/item/tool/pickaxe/onestar/turn_on(mob/user)
 	..(null, TRUE)

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -31,6 +31,7 @@
 	max_upgrades = 2
 	workspeed = 1.2
 	price_tag = 500 //Still just a saw.
+	allow_greyson_mods = TRUE
 
 /obj/item/tool/saw/improvised
 	name = "choppa"

--- a/code/game/objects/items/weapons/tools/screwdrivers.dm
+++ b/code/game/objects/items/weapons/tools/screwdrivers.dm
@@ -76,3 +76,4 @@
 	suitable_cell = /obj/item/cell/small
 	max_upgrades = 2
 	price_tag = 1200 // Very prized.
+	allow_greyson_mods = TRUE

--- a/code/game/objects/items/weapons/tools/shovel.dm
+++ b/code/game/objects/items/weapons/tools/shovel.dm
@@ -67,6 +67,7 @@
 	degradation = 2
 	max_upgrades = 2
 	price_tag = 320 // Still just a shovel.
+	allow_greyson_mods = TRUE
 
 /obj/item/tool/shovel/spade
 	name = "spade"

--- a/code/game/objects/items/weapons/tools/weldingtools.dm
+++ b/code/game/objects/items/weapons/tools/weldingtools.dm
@@ -101,6 +101,7 @@
 	max_upgrades = 2
 	workspeed = 1.5
 	price_tag = 900
+	allow_greyson_mods = TRUE
 
 //Alchemy thingy
 /obj/item/tool/weldingtool/oil_burner

--- a/code/game/objects/items/weapons/tools/wirecutters.dm
+++ b/code/game/objects/items/weapons/tools/wirecutters.dm
@@ -65,6 +65,7 @@
 	max_upgrades = 2
 	workspeed = 1.5
 	price_tag = 300
+	allow_greyson_mods = TRUE
 
 /obj/item/tool/wirecutters/attack(mob/living/carbon/C as mob, mob/user as mob)
 	if(istype(C) && user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/handcuffs/cable)))

--- a/code/modules/projectiles/guns/ameridian.dm
+++ b/code/modules/projectiles/guns/ameridian.dm
@@ -22,7 +22,8 @@
 	var/use_amount = 10 // How much fuel is used per shot
 	var/ammo_type = MATERIAL_AMERIDIAN // What kind of chem do we use?
 	var/obj/item/ameridian_core/core // The ameridian core the gun need to work
-	serial_type = "GP" //Cog?
+	serial_type = "SI"
+	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 
 /obj/item/gun/ameridian/Initialize(mapload, ...)
 	..()

--- a/code/modules/projectiles/guns/energy/laser/cog.dm
+++ b/code/modules/projectiles/guns/energy/laser/cog.dm
@@ -4,7 +4,7 @@
 	icon_state = "cog"
 	item_state = null	//so the human update icon uses the icon_state instead.
 	item_charge_meter = TRUE
-	desc = "A Greyson Positronic design, cheap and widely produced. In the distant past - this was the main weapon of low-rank police forces, billions of copies of this gun were made. They are ubiquitous."
+	desc = "A Greyson Positronic design, cheap and widely produced. In the distant past - this was the main weapon of low-rank police forces, billions of copies of this gun were made. They are ubiquitous, and has the ablity to have a Master Unmaker integrated into it."
 	fire_sound = 'sound/weapons/energy/Laser.ogg'
 	slot_flags = SLOT_BELT|SLOT_BACK
 	w_class = ITEM_SIZE_BULKY
@@ -23,6 +23,7 @@
 
 	wield_delay = 0.4 SECOND
 	wield_delay_factor = 0.2 // 20 vig
+	allow_greyson_mods = TRUE
 
 /obj/item/gun/energy/cog/gear
 	name = "\"Gear\" lasgun"
@@ -38,6 +39,8 @@
 		list(mode_name="lethal", mode_desc="fires a concentrated laser blast", projectile_type=/obj/item/projectile/beam, charge_cost = 50, icon="kill", fire_sound='sound/weapons/energy/Laser4.ogg')
 	)
 	serial_type = "NM"
+	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
+	allow_greyson_mods = FALSE
 
 /obj/item/gun/energy/cog/sprocket
 	name = "Soteria \"Sprocket\" lasgun"
@@ -53,6 +56,7 @@
 	price_tag = 1000
 	fire_delay = 8 // Old platform modded to hell and tinkered by two factions
 	matter = list(MATERIAL_STEEL = 10, MATERIAL_PLASTIC = 10, MATERIAL_SILVER = 10)
+	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 	init_firemodes = list(
 		list(mode_name="stun", mode_desc="fires a highly concentrated stun beam", projectile_type=/obj/item/projectile/beam/hardstun, charge_cost = 200, fire_delay=40, icon="grenade", fire_sound='sound/weapons/energy/Taser.ogg'), // Three shots on a T1 M-cell should be enough to reduce someone
 		list(mode_name="lethal", mode_desc="Fires a concentrated laser blast", projectile_type=/obj/item/projectile/beam, charge_cost = 50, icon="kill", fire_sound='sound/weapons/energy/Laser.ogg')
@@ -62,6 +66,7 @@
 							  /obj/item/tool_upgrade/augment/expansion = TRUE, // No cheating either. You get three upgrades, make the most of them.
 							  )
 	serial_type = "GP-SI"
+	allow_greyson_mods = FALSE
 
 /obj/item/gun/energy/cog/sprocket/update_icon() // Necessary for the folded and unfolded states
 	var/iconstring = initial(icon_state)
@@ -110,9 +115,11 @@
 	penetration_multiplier = 0.7
 	charge_cost = 50
 	price_tag = 400
+	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 	init_firemodes = list(
 		WEAPON_NORMAL
 	)
 	twohanded = FALSE
 	init_recoil = HANDGUN_RECOIL(0.2)
 	serial_type = "GP-SI"
+	allow_greyson_mods = FALSE

--- a/code/modules/projectiles/guns/energy/laser/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser/laser.dm
@@ -36,12 +36,14 @@
 
 /obj/item/gun/energy/laser/mounted/blitz
 	name = "SDF LR \"Strahl\""
-	desc = "A miniaturized laser rifle, remounted for robotic use only."
+	desc = "A miniaturized laser rifle, remounted for robotic use only. Also has the ablity to have a Master Unmaker integrated into it."
 	icon_state = "laser_turret"
 	damage_multiplier = 0.9
 	charge_meter = FALSE
 	twohanded = FALSE
 	serial_type = "GP"
+	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
+	allow_greyson_mods = TRUE
 
 /obj/item/gun/energy/laser/mounted/cyborg
 	name = "integrated \"Cog\" lasgun"
@@ -67,7 +69,7 @@
 	icon_state = "caplaser"
 	item_state = "caplaser"
 	item_charge_meter = TRUE
-	desc = "This weapon is old, yet still robust and reliable. It's marked with an old Greyson Positronic brand, a distant reminder of what this corporation was, before it fell to ruin."
+	desc = "This weapon is old, yet still robust and reliable. It's marked with an old Greyson Positronic brand, a distant reminder of what this corporation was, before it fell to ruin. Also has the ablity to have a Master Unmaker integrated into it."
 	force = WEAPON_FORCE_PAINFUL
 	fire_sound = 'sound/weapons/energy/Laser.ogg'
 	slot_flags = SLOT_BELT|SLOT_BACK|SLOT_HOLSTER
@@ -77,11 +79,13 @@
 	origin_tech = null
 	self_recharge = TRUE
 	price_tag = 2250
+	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 	init_firemodes = list(
 		WEAPON_NORMAL,
 		WEAPON_CHARGE
 	)
 	twohanded = FALSE
+	allow_greyson_mods = TRUE
 	serial_type = "GP"
 
 	wield_delay = 0.3 SECOND

--- a/code/modules/projectiles/guns/energy/plasma/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma/plasma.dm
@@ -37,10 +37,12 @@
 
 /obj/item/gun/energy/plasma/mounted/blitz
 	name = "SDF PR \"Sprengen\""
-	desc = "A miniaturized plasma rifle, remounted for robotic use only."
+	desc = "A miniaturized plasma rifle, remounted for robotic use only. Also has the ablity to have a Master Unmaker integrated into it."
 	icon_state = "plasma_turret"
 	charge_meter = FALSE
 	serial_type = "GP"
+	gun_tags = list(GUN_ENERGY, GUN_SCOPE)
+	allow_greyson_mods = TRUE
 
 /obj/item/gun/energy/plasma/destroyer
 	name = "\"Purger\" plasma rifle"

--- a/code/modules/projectiles/guns/energy/projectile/railgun.dm
+++ b/code/modules/projectiles/guns/energy/projectile/railgun.dm
@@ -148,7 +148,7 @@
 
 /obj/item/gun/energy/laser/railgun/mounted
 	name = "SDF SC \"Schrapnell\""
-	desc = "An energy-based railgun, employing a matter fabricator to pull shotgun rounds from thin air and energy before launching them at faster than light speeds."
+	desc = "An energy-based railgun, employing a matter fabricator to pull shotgun rounds from thin air and energy before launching them at faster than light speeds. Has the ablity to have a Master Unmaker integrated into it."
 	icon_state = "shrapnel"
 	self_recharge = 1
 	use_external_power = 1
@@ -163,6 +163,8 @@
 		list(mode_name="Blast", mode_desc="Fires a slug synth-shell", projectile_type=/obj/item/projectile/bullet/shotgun, charge_cost=null, icon="destroy"),
 	)
 	serial_type = "GP"
+	gun_tags = list(GUN_PROJECTILE, GUN_LASER, GUN_ENERGY, GUN_SCOPE)
+	allow_greyson_mods = TRUE
 
 
 //Gauss-rifle type, snowflake launcher mixed with rail rifle and hydrogen gun code. Consumes matter-stack and cell charge to fire. - Rebel0

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -611,7 +611,9 @@
 	)
 	I.removal_time *= 10
 	I.gun_loc_tag = GUN_MECHANISM
+	I.req_fuel_cell = REQ_CELL
 	I.prefix = "catalytic"
+	I.greyson_moding = TRUE
 
 /obj/item/gun_upgrade/barrel/gauss
 	name = "Void Wolf \"Gauss Coil\" barrel"

--- a/code/modules/projectiles/guns/oddity_items.dm
+++ b/code/modules/projectiles/guns/oddity_items.dm
@@ -198,6 +198,7 @@
 	charge_meter = FALSE
 	price_tag = 1500
 	serial_type = "BlueCross"
+	allow_greyson_mods = FALSE
 
 /obj/item/gun/energy/xray/psychic_cannon
 	name = "\"Manta-RAY\" cannon"

--- a/code/modules/projectiles/guns/projectile/automatic/nail_gun.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/nail_gun.dm
@@ -1,7 +1,7 @@
 /obj/item/gun/projectile/automatic/nail_gun
 	name = "Greyson Positronic \"Nail\" rifle"
 	desc = "A old and lost gun design of a rifle by Greyson Positronic, its high fire rate stopping power and more make it the perfect tool for war. \
-	Its'caliber is 6.5mm and shockingly can be fitted with a silencer and has room for a scope."
+	Its'caliber is 6.5mm and shockingly can be fitted with a silencer, room for a scope, and the ablity to have a Master Unmaker integrated into it."
 	icon = 'icons/obj/guns/projectile/nail_gun.dmi'
 	icon_state = "nail_gun"
 	item_state = "nail_gun"
@@ -24,6 +24,7 @@
 	init_recoil = CARBINE_RECOIL(0.2)
 
 	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE, GUN_SCOPE, GUN_MAGWELL)
+	allow_greyson_mods = TRUE
 
 	init_firemodes = list(
 		FULL_AUTO_300,

--- a/code/modules/projectiles/guns/projectile/automatic/scaffold.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/scaffold.dm
@@ -1,7 +1,7 @@
 /obj/item/gun/projectile/automatic/scaffold
 	name = "Greyson Positronic \"Scaffold\" caseless rifle"
 	desc = "A old and lost gun design of a caseless rifle by Greyson Positronic, its high fire rate stopping power and more make it the perfect frame for war. \
-	Its'caliber is 10mm and shockingly can be fitted with a silencer and has room for a scope."
+	Its'caliber is 10mm and shockingly can be fitted with a silencer, has room for a scope and the ablity for a Master Unmaker to be integrated into it."
 	icon = 'icons/obj/guns/projectile/scaffold.dmi'
 	icon_state = "scaffold"
 	item_state = "scaffold"
@@ -28,6 +28,7 @@
 	wield_delay_factor = 0.4 // 40 vig for insta wield
 
 	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE ,GUN_SCOPE, GUN_MAGWELL)
+	allow_greyson_mods = TRUE
 
 	init_firemodes = list(
 		FULL_AUTO_300,

--- a/code/modules/projectiles/guns/projectile/automatic/trouble_shooter.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/trouble_shooter.dm
@@ -1,7 +1,7 @@
 /obj/item/gun/projectile/trouble_shooter
 	name = "GP \"Trouble Shooter\" rifle"
 	desc = "With many issues being raised from rogue robots and people alike, the Greyson Positronic answer was a gun to shoot though several layers of armor \
-	Its material cost lead to it being mainly used in-house rather than in mass production."
+	Its material cost lead to it being mainly used in-house rather than in mass production. With the ablity to have a Master Unmaker integrated into it."
 	icon = 'icons/obj/guns/projectile/type_21.dmi'
 	icon_state = "type_21" //Sprite by Valo#3611
 	item_state = "type_21"
@@ -21,6 +21,7 @@
 		)
 	serial_type = "GP"
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_SILENCABLE)
+	allow_greyson_mods = TRUE
 
 	wield_delay = 1.5 SECOND
 	wield_delay_factor = 0.4 // 40 vig to insta wield , heavy class rifle

--- a/code/modules/projectiles/guns/projectile/pistol/rebar.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/rebar.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/projectile/rebar
 	name = "\"Rebar\" heavy pistol"
-	desc = "A GP heavy pistol that could punch a whole into several layers of plasteel. Uses 12mm rounds."
+	desc = "A GP heavy pistol that could punch a whole into several layers of plasteel. Uses 12mm rounds. Also has the ablity to have a Master Unmaker integrated into it."
 	icon = 'icons/obj/guns/projectile/rebar.dmi'
 	icon_state = "type_90"
 	item_state = "type_90"
@@ -16,6 +16,7 @@
 	init_recoil = HANDGUN_RECOIL(1)
 	penetration_multiplier = 2
 	gun_tags = list(GUN_PROJECTILE, GUN_MAGWELL, GUN_CALIBRE_12MM, GUN_SILENCABLE)
+	allow_greyson_mods = TRUE
 
 	fire_sound = 'sound/weapons/guns/fire/deckard_fire.ogg'
 	unload_sound 	= 'sound/weapons/guns/interact/hpistol_magout.ogg'

--- a/code/modules/projectiles/guns/projectile/pistol/rivet.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/rivet.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/projectile/rivet
 	name = "Greyson Positronic \"Rivet\" magnum pistol"
-	desc = "GP \"Rivet\" magnum pistol, lost tech of a high power pistol using only 10mm Auto-Mag."
+	desc = "GP \"Rivet\" magnum pistol, lost tech of a high power pistol using only 10mm Auto-Mag. Also has the ablity to have a Master Unmaker integrated into it."
 	icon = 'icons/obj/guns/projectile/rivet_gun.dmi'
 	icon_state = "rivet"
 	damage_multiplier = 1.2
@@ -16,6 +16,7 @@
 	fire_sound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	load_method = SINGLE_CASING|MAGAZINE
 	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE, GUN_MAGWELL)
+	allow_greyson_mods = TRUE
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY

--- a/code/modules/projectiles/guns/projectile/pistol/spring.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/spring.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/projectile/spring
 	name = "Greyson Positronic \"Spring\" pistol"
-	desc = "GP \"Spring\" pistol, lost tech of a high power pistol using only 9mm rounds. "
+	desc = "GP \"Spring\" pistol, lost tech of a high power pistol using only 9mm rounds. Also has the ablity to have a Master Unmaker integrated into it."
 	icon = 'icons/obj/guns/projectile/spring.dmi'
 	icon_state = "spring"
 	damage_multiplier = 1.1
@@ -16,6 +16,7 @@
 	load_method = SINGLE_CASING|MAGAZINE
 	mag_well = MAG_WELL_PISTOL | MAG_WELL_H_PISTOL | MAG_WELL_DRUM
 	gun_tags = list(GUN_PROJECTILE, GUN_SILENCABLE, GUN_CALIBRE_9MM, GUN_MAGWELL)
+	allow_greyson_mods = TRUE
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY

--- a/code/modules/research/xenoarchaeology/finds/finds_eguns.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_eguns.dm
@@ -8,6 +8,7 @@
 	charge_cost = 200
 	self_recharge = TRUE
 	projectile_type = /obj/item/projectile/beam/tesla/shotgun // thats right. Its a shotgun cog.
+	allow_greyson_mods = FALSE
 
 /obj/item/gun/energy/cog/xenoarch/refresh_upgrades()
 	return
@@ -33,6 +34,7 @@
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	item_state_slots = null
 	icon_contained = FALSE
+	allow_greyson_mods = FALSE
 
 /obj/item/gun/energy/captain/xenoarch/refresh_upgrades()
 	return


### PR DESCRIPTION
GP Nano-AI now requires the tool/gun to have either power or be GP compatible
GP Nano-AI once added cant be removed from a tool/gun
GP Nano-Repair now requires the tool to have either power or be GP compatible
GP Master Unmaker now requires the gun to have either power or be GP compatible

GP Nano-AI when added to any tool/gun makes that item GP compatible
All GP guns and tools are by default GP compatible