### PR TITLE
fix some drink bottles having invalid empty sprites

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -24,7 +24,8 @@
 
 /obj/item/reagent_containers/food/drinks/bottle/Initialize()
 	icon_state_full = "[icon_state]"
-	icon_state_empty = "[icon_state]_empty"
+	if (icon_state_empty == null)
+		icon_state_empty = "[icon_state]_empty"
 	. = ..()
 	if(isGlass)
 		unacidable = TRUE

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -306,7 +306,7 @@
 	icon_state = "alco-white"
 	center_of_mass = list("x"=16, "y"=6)
 	preloaded_reagents = list("nanatsunoumi" = 100)
-	icon_state_empty = "alco-white_empty"
+	icon_state_empty = "alco-empty"
 
 /obj/item/reagent_containers/food/drinks/bottle/grenadine
 	name = "Briar Rose Grenadine Syrup"


### PR DESCRIPTION
The correct sprite name was set to icon_state_empty, but later overwritten in Initialize.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	An incorrect sprite name was set
</summary>
<hr>
Some drink bottles have a sprite for a full bottle and one for an empty one (NAME_empty). Some other drink bottles, like "Emeraldine Melon Liquor", "Miss Blue Curacao", "Mister Red Candy Liquor", ... follow another pattern where they get the "icon_state_empty" property set in their definition (multiple drinks use the "alco-empty" sprite, for example). But this value was overwritten in the Initialize method.

I've added an if-clause checking if the said variable was already set. Only if it's still null, it's set to the full-bottle-sprite with suffix "_empty".

While writing this, I noticed that one icon_state_empty was set to "alco-white_empty", which doesn't exist. Fixed that to "alco-empty".
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl: dutop
fix: Use correct sprite for some drink bottles
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
