### PR TITLE
Fixing the duty rifle

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/duty.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/duty.dm
@@ -17,8 +17,9 @@
 	load_method = SINGLE_CASING|SPEEDLOADER|MAGAZINE
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_PLASTIC = 25)
 	price_tag = 800
-	penetration_multiplier = 1.1
-	init_recoil = CARBINE_RECOIL(0.9)
+	damage_multiplier = 1.3
+	penetration_multiplier = 1.2
+	init_recoil = CARBINE_RECOIL(1)
 	fire_sound = 'sound/weapons/guns/fire/lmg_fire.ogg'
 	force = WEAPON_FORCE_ROBUST
 	gun_tags = list(GUN_PROJECTILE, GUN_BAYONET, GUN_SCOPE)


### PR DESCRIPTION

## About The Pull Request
<details>
<summary>
	Makes the duty into a more powerful rifle, because it was very weak before. As a semi-automatic with no damage modifier, using carbine rounds, it was a rather underwhelming rifle with a very large cost (3 points on the blackshield disk, the same as a boar or omnirifle! With 25 plasteel and steel cost), and it performed overall worse than the STS 25 which is a starting weapon that costs blackshield nothing, as they get it in vouchers. The description says it has the same stopping power as the kardashev mosin, but no, it has less AP, less damage, and more cost. So this fixes it, it still will not be powerful as it's just as good as the kardashev, in itself a starting weapon, but it's something at least.
</summary>

## Changelog
:cl:
balance: Made the duty up to par with the kardashev 
/:cl:

