### PR TITLE
Ghetto Chem Revamp (And minor typo fix)

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -7,6 +7,7 @@
 	icon_state = "bodybag_folded"
 	w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_PLASTIC = 2)
+	preloaded_reagents = list("plasticide" = 30,)
 	price_tag = 10
 
 	attack_self(mob/user)

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -6,6 +6,7 @@
 	var/code = "electronic"
 	origin_tech = list(TECH_BLUESPACE = 1)
 	matter = list (MATERIAL_STEEL = 3, MATERIAL_GLASS = 1)
+	preloaded_reagents = list("silicon" = 20, "copper" = 5, "plasticide" = 12)
 
 /obj/item/device/radio/beacon/hear_talk()
 	return

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -12,6 +12,7 @@
 	var/syndie = 0
 	var/list/channels = list()
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1)
+	preloaded_reagents = list("silicon" = 6, "copper" = 5, "plasticide" = 9)
 
 /obj/item/device/encryptionkey/attackby(obj/item/W as obj, mob/user as mob)
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -5,6 +5,7 @@
 	icon_state = "headset"
 	item_state = "headset"
 	matter = list(MATERIAL_PLASTIC = 1)
+	preloaded_reagents = list("silicon" = 15, "plasticide" = 9)
 	subspace_transmission = 1
 	canhear_range = 0 // can't hear headsets from very far away
 

--- a/code/game/objects/items/devices/scanners/gas.dm
+++ b/code/game/objects/items/devices/scanners/gas.dm
@@ -6,6 +6,7 @@
 	item_state = "analyzer"
 
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
+	preloaded_reagents = list("mercury" = 15, "lithium" = 5, "plasticide" = 9)
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
 
 	charge_per_use = 5

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -9,6 +9,7 @@
 	charge_per_use = 2
 
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
+	preloaded_reagents = list("mercury" = 15, "lithium" = 5, "plasticide" = 9)
 	origin_tech = list(TECH_MAGNET = 1, TECH_BIO = 1)
 
 	var/mode = 1

--- a/code/game/objects/items/devices/scanners/plant.dm
+++ b/code/game/objects/items/devices/scanners/plant.dm
@@ -8,6 +8,7 @@
 	charge_per_use = 2
 
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1)
+	preloaded_reagents = list("mercury" = 15, "lithium" = 5, "plasticide" = 9)
 
 	var/global/list/valid_targets = list(
 		/obj/item/reagent_containers/food/snacks/grown,

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -24,6 +24,7 @@
 	throw_speed = 4
 	throw_range = 20
 	matter = list(MATERIAL_PLASTIC = 3)
+	preloaded_reagents = list("plasticide" = 12)
 	force = NONE
 	price_tag = 10
 

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/trash.dmi'
 	w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_PLASTIC = 1)
+	preloaded_reagents = list("plasticide" = 4)
 
 /obj/item/trash/attack(mob/M, mob/living/user)
 	return

--- a/code/game/objects/items/weapons/phone.dm
+++ b/code/game/objects/items/weapons/phone.dm
@@ -11,3 +11,5 @@
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("called", "rang")
 	hitsound = 'sound/weapons/ring.ogg'
+	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC =)
+	preloaded_reagents = list("plasticide" = 20, "copper" = 6, "silicon" = 10)

--- a/code/game/objects/items/weapons/phone.dm
+++ b/code/game/objects/items/weapons/phone.dm
@@ -11,5 +11,5 @@
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("called", "rang")
 	hitsound = 'sound/weapons/ring.ogg'
-	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC =)
+	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 4)
 	preloaded_reagents = list("plasticide" = 20, "copper" = 6, "silicon" = 10)

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -6,6 +6,7 @@
 	icon_state = "b_st"
 	maxcharge = 2000
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3)
+	preloaded_reagents = list("lithium" = 25)
 	price_tag = 200
 
 /obj/item/cell/large/high
@@ -61,6 +62,7 @@
 	desc = "Soteria Institute-brand rechargeable L-standardized power cell. This one being part of the Omega line, making it the be-all-end-all power cell of its type, yet to hit the open market."
 	icon_state = "meb_b_omega"
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3, MATERIAL_GOLD = 6)
+	preloaded_reagents = list("lithium" = 15, "radium" = 10)
 	origin_tech = list(TECH_POWER = 7)
 	maxcharge = 20000
 	max_chargerate = 0.24
@@ -72,6 +74,7 @@
 	autorecharging = TRUE
 	origin_tech = list(TECH_POWER = 6)
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 6)
+	preloaded_reagents = list("radium" = 10, "lithium" = 10, "phosphorus" = 5)
 	maxcharge = 14000
 	price_tag = 400
 
@@ -83,6 +86,7 @@
 	autorecharging = TRUE
 	autorecharge_rate = 0.06
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 3, MATERIAL_PLATINUM = 3, MATERIAL_URANIUM = 6)
+	preloaded_reagents = list("radium" = 10, "lithium" = 10, "phosphorus" = 5)
 	price_tag = 600
 
 /obj/item/cell/large/excelsior
@@ -135,6 +139,7 @@
 	throw_range = 7
 	maxcharge = 600
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2)
+	preloaded_reagents = list("lithium" = 15)
 	price_tag = 100
 
 /obj/item/cell/medium/depleted
@@ -202,6 +207,7 @@
 	desc = "Soteria Institute branded rechargeable M-standardized power cell. This one being part of the Omega line, making it the be-all-end-all power cell of its type, yet to hit the open market."
 	icon_state = "meb_m_omega"
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_GOLD = 4)
+	preloaded_reagents = list("lithium" = 10, "radium" = 5)
 	origin_tech = list(TECH_POWER = 7)
 	maxcharge = 1600
 	max_chargerate = 0.24
@@ -212,6 +218,7 @@
 	icon_state = "meb_m_nu"
 	autorecharging = TRUE
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 2, MATERIAL_URANIUM = 4)
+	preloaded_reagents = list("lithium" = 5, "radium" = 5, "phosphorus" = 5)
 	origin_tech = list(TECH_POWER = 6)
 	maxcharge = 1000
 	price_tag = 200
@@ -224,6 +231,7 @@
 	autorecharging = TRUE
 	autorecharge_rate = 0.06
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_PLATINUM = 2, MATERIAL_URANIUM = 4)
+	preloaded_reagents = list("lithium" = 5, "radium" = 5, "phosphorus" = 5)
 	price_tag = 300
 
 /obj/item/cell/medium/excelsior
@@ -262,6 +270,7 @@
 	throw_range = 7
 	maxcharge = 100
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1)
+	preloaded_reagents = list("lithium" = 5)
 	price_tag = 50
 
 /obj/item/cell/small/depleted
@@ -325,6 +334,7 @@
 	desc = "Soteria Institute branded rechargeable S-standardized power cell. This one being part of the Omega line making it the be-all-end-all power cell of its type, yet to hit the open market."
 	icon_state = "meb_s_omega"
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1, MATERIAL_GOLD = 2)
+	preloaded_reagents = list("radium" = 5)
 	origin_tech = list(TECH_POWER = 7)
 	maxcharge = 500
 	max_chargerate = 0.24
@@ -336,6 +346,7 @@
 	autorecharging = TRUE
 	origin_tech = list(TECH_POWER = 6)
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_SILVER = 1, MATERIAL_URANIUM = 2)
+	preloaded_reagents = list("radium" = 5)
 	maxcharge = 300
 	price_tag = 100
 
@@ -345,6 +356,7 @@
 	icon_state = "meb_pda"
 	origin_tech = list(TECH_POWER = 4)
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_URANIUM = 1)
+	preloaded_reagents = list("radium" = 5)
 	maxcharge = 50
 	// Autorecharge rate is buffed compared to eris, to compensate for the cell's cooldown.
 	autorecharging = TRUE
@@ -360,6 +372,7 @@
 	autorecharging = TRUE
 	autorecharge_rate = 0.06
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_PLATINUM = 1, MATERIAL_URANIUM = 2)
+	preloaded_reagents = list("radium" = 5)
 	price_tag = 150
 
 /obj/item/cell/small/excelsior

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -13,6 +13,7 @@
 
 	price_tag = 120
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 1)
+	preloaded_reagents = list("iron" = 15, "plasticide" = 5)
 
 //list/tool_upgrades, list/required_qualities, list/negative_qualities, prefix, req_fuel, req_cell
 
@@ -33,6 +34,7 @@
 	desc = "An array of plasteel fins which dissipates heat, reducing damage and extending the lifespan of power tools or improving energy weapon cooling."
 	icon_state = "heatsink"
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 1)
+	preloaded_reagents = list("iron" = 15, "plasticide" = 5)
 
 /obj/item/tool_upgrade/reinforcement/heatsink/New()
 	..()
@@ -56,6 +58,7 @@
 	desc = "A sturdy bit of plasteel that can be bolted onto any tool to protect it. Tough, but bulky."
 	icon_state = "plate"
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 2) //steel to compensate for metal rods used in crafting
+	preloaded_reagents = list("iron" = 20)
 
 /obj/item/tool_upgrade/reinforcement/plating/New()
 	..()
@@ -74,6 +77,7 @@
 	desc = "A bent piece of metal that wraps around sensitive parts of a tool, protecting it from impacts, debris, and stray fingers. Could be added to the back of a gun to help stablize it as well."
 	icon_state = "guard"
 	matter = list(MATERIAL_PLASTEEL = 5)
+	preloaded_reagents = list("aluminum" = 9, "iron" = 9)
 	price_tag = 160
 
 /obj/item/tool_upgrade/reinforcement/guard/New()
@@ -97,6 +101,7 @@
 	desc = "A plasmablock is way more efficient to dissipate heat than classic heatsinks or waterblocks thanks to the tremendous heat-transfer capacity of liquid plasma. The fluid that is actively pumped through a radiator and cooled by fans. It greatly extends the lifespan of power tools or heat dissipation of energy weapons."
 	icon_state = "plasmablock"
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 2, MATERIAL_PLASMA = 1)
+	preloaded_reagents = list("iron" = 15, "plasticide" = 5, "plasma" = 3)
 
 /obj/item/tool_upgrade/reinforcement/plasmablock/New()
 	..()
@@ -122,6 +127,7 @@
 	desc = "A rubber mesh that can wrapped around sensitive parts of a tool to protecting them from impacts and debris."
 	icon_state = "rubbermesh"
 	matter = list(MATERIAL_PLASTIC = 3)
+	preloaded_reagents = list("plasticide" = 8)
 	price_tag = 60
 
 /obj/item/tool_upgrade/reinforcement/rubbermesh/New()
@@ -141,6 +147,7 @@
 	desc = "A replacement grip for a tool which allows it to be more precisely controlled with one hand. Can be placed under a gun\'s barrel to reduce recoil. However, it also makes bracing impossible."
 	icon_state = "ergonomic"
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 5)
+	preloaded_reagents = list("aluminum" = 9, "plasticide" = 3)
 	price_tag = 120
 
 /obj/item/tool_upgrade/productivity/ergonomic_grip/New()
@@ -162,6 +169,7 @@
 	desc = "A mechanical upgrade for wrenches and screwdrivers which allows the tool to only turn in one direction."
 	icon_state = "ratchet"
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASTEEL = 4, MATERIAL_PLASTIC = 1)
+	preloaded_reagents = list("iron" = 15, "plasticide" = 5)
 
 /obj/item/tool_upgrade/productivity/ratchet/New()
 	..()
@@ -177,6 +185,7 @@
 	desc = "Do red tools really work faster or is the effect purely psychological? Needless to say, you can't strip it off once applied. Ye'z boyz kin' put in on ya shootahz too!"
 	icon_state = "paint_red"
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 1)
+	preloaded_reagents = list("acetone" = 15, "iron" = 5)
 	can_remove = FALSE
 	price_tag = 60
 
@@ -251,6 +260,7 @@
 	desc = "A canister of pure, compressed oxygen with adapters for mounting onto a welding tool. Used alongside fuel, it allows for higher burn temperatures."
 	icon_state = "oxyjet"
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_PLASTIC = 1)
+	preloaded_reagents = list("iron" = 15, "plasticide" = 5)
 	price_tag = 180
 
 /obj/item/tool_upgrade/productivity/oxyjet/New()
@@ -271,6 +281,7 @@
 	desc = "A motor for power tools with a higher horsepower than usually expected. Significantly enhances productivity and lifespan, but more expensive to run and harder to control."
 	icon_state = "motor"
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASTEEL = 4)
+	preloaded_reagents = list("iron" = 15, "oil"= 9)
 
 /obj/item/tool_upgrade/productivity/motor/New()
 	..()
@@ -306,6 +317,7 @@
 	name = "anti-staining paint"
 	desc = "Applying a thin coat of this paint on a tool prevents blood stains, dirt or dust to adhere to its surface. Everyone works better and faster with clean tools. Once applied, it can't ever be stripped."
 	icon_state = "antistaining"
+	preloaded_reagents = list("oil" = 5, "aluminum" = 5, "mercury" = 5)
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_PLASMA = 3)
 	can_remove = FALSE
 	price_tag = 180
@@ -350,6 +362,7 @@
 	desc = "If the words \"safety regulations\" do not mean anything to you, you may consider installing this fine piece of technology on your tool. It injects small amounts of plasma in the fuel mix before combustion to greatly increase its power output, making all kinds of tasks easier to perform. If you're insane, you could attach it to an energy weapon's barrel."
 	icon_state = "injector"
 	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_PLASMA = 2)
+	preloaded_reagents = list("iron" = 15, "plasticide" = 5, "plasma" = 3)
 	price_tag = 280
 
 /obj/item/tool_upgrade/productivity/injector/New()
@@ -381,6 +394,7 @@
 	icon_state = "rocket_engine"
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_POWER = 4)
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_GOLD = 1)
+	preloaded_reagents = list("iron" = 15, "oil"= 9)
 
 /obj/item/tool_upgrade/productivity/rocket_engine/New()
 	..()
@@ -431,6 +445,7 @@
 	desc = "A small visible laser which can be strapped onto any tool, giving an accurate representation of its target. Helps improve precision."
 	icon_state = "laser_guide"
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_URANIUM = 1)
+	preloaded_reagents = list("plasticide" = 3, "radium" = 5, "phosphorus" = 15)
 	price_tag = 90
 
 /obj/item/tool_upgrade/refinement/laserguide/New()
@@ -452,6 +467,7 @@
 	desc = "A fancy mechanical grip that partially floats around a tool, absorbing tremors and shocks. Allows precise work with a shaky hand."
 	icon_state = "stabilizing"
 	matter = list(MATERIAL_PLASTIC = 3)
+	preloaded_reagents = list("plasticide" = 5)
 	price_tag = 30
 
 /obj/item/tool_upgrade/refinement/stabilized_grip/New()
@@ -472,6 +488,7 @@
 	desc = "Magnetises tools used for handling small objects, reducing instances of dropping screws and bolts."
 	icon_state = "magnetic"
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTEEL = 2)
+	preloaded_reagents = list("iron" = 15)
 	price_tag = 100
 
 /obj/item/tool_upgrade/refinement/magbit/New()
@@ -488,6 +505,7 @@
 	desc = "A barrel extension for a welding tool (or gun) which helps manage gas pressure and keep the torch (or barrel) steady. When attached to a gun it allows for greater recoil control and a smaller flash at the cost of stopping power."
 	icon_state = "ported_barrel"
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTEEL = 2)
+	preloaded_reagents = list("aluminum" = 9, "iron" = 9)
 	price_tag = 100
 
 /obj/item/tool_upgrade/refinement/ported_barrel/New()
@@ -517,6 +535,7 @@
 	desc = "A barrel extension for welding tools that integrates a miniaturized gravity generator that help keep the torch steady by compensating the weight of the tool. It can also be attached to guns both energy and projectile to offer greater recoil control at the cost of stopping power."
 	icon_state = "compensatedbarrel"
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GOLD = 1)
+	preloaded_reagents = list("aluminum" = 15, "plasticide" = 5, "iron" = 3)
 	price_tag = 175
 
 /obj/item/tool_upgrade/refinement/compensatedbarrel/New()
@@ -546,6 +565,7 @@
 	desc = "A ground-breaking innovation that dampens the vibration of a tool by emitting sound waves in a frequency nobody can hear. It does not make any sense but neither will you by installing that on your tool. Alternatively, it could fit a gun grip to lessen recoil."
 	icon_state = "vibcompensator"
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 1, MATERIAL_GOLD = 1)
+	preloaded_reagents = list("aluminum" = 15, "plasticide" = 5, "iron" = 3)
 	price_tag = 120
 
 /obj/item/tool_upgrade/refinement/vibcompensator/New()
@@ -575,6 +595,7 @@
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASTEEL = 2, MATERIAL_PLASTIC = 1)
 	can_remove = FALSE // To fix exploit of fitting large cells on tools then taking out the mod while conserving a large cell.
 	price_tag = 115
+	preloaded_reagents = list("iron" = 8, "plasticide" = 5)
 
 /obj/item/tool_upgrade/augment/cell_mount/New()
 	..()
@@ -595,6 +616,7 @@
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLASTEEL = 2, MATERIAL_PLASTIC = 1)
 	can_remove = FALSE // To fix exploit of fitting large cells on tools then taking out the mod while conserving a large cell.
 	price_tag = 115
+	preloaded_reagents = list("iron" = 8, "plasticide" = 5)
 
 /obj/item/tool_upgrade/augment/cell_adapt/New()
 	..()
@@ -619,6 +641,7 @@
 	desc = "An auxiliary tank which stores 100 extra units of fuel at the cost of degradation."
 	icon_state = "canister"
 	matter = list(MATERIAL_PLASTEEL = 4, MATERIAL_PLASTIC = 1)
+	preloaded_reagents = list("aluminum" = 15, "plasticide" = 5, "plasma" = 3)
 	price_tag = 90
 
 /obj/item/tool_upgrade/augment/fuel_tank/New()
@@ -660,6 +683,7 @@
 	icon_state = "expand"
 	desc = "A bulky adapter which allows more modifications to be attached to the tool or gun. A bit fragile but you can compensate. Due to its complex design it cannot be removed once installed."
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 1)
+	preloaded_reagents = list("aluminum" = 9, "plasticide" = 5, "iron" = 9)
 	can_remove = FALSE
 	price_tag = 125
 
@@ -687,6 +711,7 @@
 	icon_state = "spike"
 	desc = "An array of sharp bits of steel, seemingly adapted for easy affixing to a tool. Would make it into a better weapon, but won't do much for productivity. Alternatively you could slap it on the end of a gun barrel as a ghetto bayonet at the cost of some accuracy."
 	matter = list(MATERIAL_STEEL = 2)
+	preloaded_reagents = list("iron" = 9)
 	price_tag = 10
 
 /obj/item/tool_upgrade/augment/spikes/New()
@@ -841,6 +866,7 @@
 	desc = "This aural dampener is a cutting edge tool attachment which mostly nullifies sound waves within a tiny radius. It minimises the noise created during use, perfect for stealth operations."
 	icon_state = "dampener"
 	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_PLASTEEL = 1, MATERIAL_PLATINUM = 1)
+	preloaded_reagents = list("mercury" = 20, "lithium" = 15, "iron" = 3)
 	price_tag = 155
 
 /obj/item/tool_upgrade/augment/dampener/New()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -20,6 +20,7 @@
 	body_parts_covered = HEAD
 	attack_verb = list("bapped")
 	matter = list(MATERIAL_BIOMATTER = 1)
+	preloaded_reagents = list("woodpulp" = 3)
 
 	var/info		//What's actually written on the paper.
 	var/info_links	//A different version of the paper which includes html links at fields and EOF

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -21,6 +21,7 @@
 	throw_speed = 7
 	throw_range = 15
 	matter = list(MATERIAL_STEEL = 1)
+	preloaded_reagents = list("acetone" = 9,"aluminum"= 3, "tungsten" = 5)
 	var/colour = "black"	//what colour the ink is!
 
 

--- a/code/modules/psionics/psion.dm
+++ b/code/modules/psionics/psion.dm
@@ -167,7 +167,7 @@
 		to_chat(src, "You are dead.")
 		return
 	if(owner.stat == UNCONSCIOUS)
-		to_chat(src, "You cannot use your psionic powers while unconsious.")
+		to_chat(src, "You cannot use your psionic powers while unconscious.")
 		return
 	if(psi_points < psi_cost)
 		to_chat(usr,"You lack the psionic essence to do this.")

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -51,8 +51,9 @@
 	desc = "A slab of sickly-green bubbling meat cut from a giant termite. It looks to be rather rich in minerals. Delicious!"
 	icon_state = "xenomeat"
 	filling_color = "#E2FFDE"
-	preloaded_reagents = list("protein" = 5, "iron" = 4)
+	preloaded_reagents = list("protein" = 5, "hclacid" = 4, "sacid" = 4, "phosphorus" = 8)
 	//Todo make each termite meat have their ground up mineral inside
+	// IDK if anyone is ever going to do this, so, adding some of the otherwise unobtainable ghetto chems to it - obey
 
 /obj/item/reagent_containers/food/snacks/meat/roachmeat
 	desc = "A slab of sickly-green bubbling meat cut from a giant roach. You swear you can see it still twitching occasionally. Delicious!"
@@ -63,7 +64,8 @@
 	preloaded_reagents = list("protein" = 4, "blattedin" = 8, "diplopterum" = 7)
 
 /obj/item/reagent_containers/food/snacks/meat/roachmeat/seuche
-	preloaded_reagents = list("protein" = 4, "seligitillin" = 8, "diplopterum" = 6)
+	preloaded_reagents = list("protein" = 2, "blattedin"= 12, "seligitillin" = 8, "diplopterum" = 6)
+	// The roach that produces giant clouds of blattedin doesn't contain any blattedin in it's system? Tweaked. To compensate, making Jagers give even less blatt
 
 /obj/item/reagent_containers/food/snacks/meat/roachmeat/panzer
 	preloaded_reagents = list("protein" = 8, "blattedin" = 12, "starkellin" = 15, "diplopterum" = 4)
@@ -75,7 +77,7 @@
 	preloaded_reagents = list("protein" = 6, "blattedin" = 12, "seligitillin" = 6, "starkellin" = 15, "fuhrerole" = 12, "diplopterum" = 6)
 
 /obj/item/reagent_containers/food/snacks/meat/roachmeat/jager
-	preloaded_reagents = list("protein" = 6, "blattedin" = 6, "gewaltine" = 8, "diplopterum" = 2)
+	preloaded_reagents = list("protein" = 6, "blattedin" = 2, "gewaltine" = 8, "diplopterum" = 2)
 
 /obj/item/reagent_containers/food/snacks/meat/roachmeat/kraftwerk
 	preloaded_reagents = list("protein" = 6, "blattedin" = 6, "gewaltine" = 6, "uncap nanites" = 2, "nanites" = 3)
@@ -96,7 +98,7 @@
 	filling_color = "#E2FFDE"
 
 	bitesize = 6
-	preloaded_reagents = list("protein" = 7, "pararein" = 12)
+	preloaded_reagents = list("protein" = 7, "pararein" = 12, "ammonia" = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/spider/hunter
 	desc = "A bloated slab of sickly-green meat cut from a spider. The venom just gives it more flavor. Delicious!"
@@ -104,7 +106,7 @@
 	filling_color = "#E2FFDE"
 
 	bitesize = 6
-	preloaded_reagents = list("protein" = 9, "aranecolmin" = 8, "pararein" = 2)
+	preloaded_reagents = list("protein" = 9, "aranecolmin" = 8, "pararein" = 2, "ammonia" = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/spider/plasma
 	desc = "A bloated slab of sickly-green meat cut from a spider. The venom just gives it more flavor. Delicious!"
@@ -112,7 +114,7 @@
 	filling_color = "#E2FFDE"
 
 	bitesize = 6
-	preloaded_reagents = list("protein" = 9, "aranecolmin" = 8, "plasma" = 5)
+	preloaded_reagents = list("protein" = 9, "aranecolmin" = 8, "plasma" = 5, "ammonia" = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/spider/pepper
 	desc = "A bloated slab of sickly-green meat cut from a spider. The venom just gives it more flavor. Delicious!"
@@ -120,7 +122,7 @@
 	filling_color = "#E2FFDE"
 
 	bitesize = 6
-	preloaded_reagents = list("protein" = 9, "aranecolmin" = 8, "condensedcapsaicinspider" = 5)
+	preloaded_reagents = list("protein" = 9, "aranecolmin" = 8, "condensedcapsaicinspider" = 5, "ammonia" = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/spider/emperor
 	desc = "A bloated slab of sickly-green meat cut from a spider. This one smells like cognitive improvement drugs."
@@ -128,7 +130,7 @@
 	filling_color = "#E2FFDE"
 	//Emperor Spider's meat contains party drops, big brain chemical. 8 seems fine. Emperors are dangerous.
 	bitesize = 6
-	preloaded_reagents = list("protein" = 8, "pararein" = 8, "party drops" =8)
+	preloaded_reagents = list("protein" = 8, "pararein" = 8, "party drops" =8, "ammonia" = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/spider/reaper_spider
 	desc = "A bloated slab of sickly-green meat cut from a spider. This one smells like cognitive improvement drugs."
@@ -136,7 +138,7 @@
 	filling_color = "#E2FFDE"
 	//Emperor Spider's meat contains party drops, big brain chemical. 8 seems fine. Emperors are dangerous.
 	bitesize = 6
-	preloaded_reagents = list("protein" = 8, "pararein" = 8, "stoxin" =8)
+	preloaded_reagents = list("protein" = 8, "pararein" = 8, "stoxin" =8, "ammonia" = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/spider/nurse
 	desc = "A bloated slab of sickly-green meat cut from a spider. The venom just gives it more flavor. Delicious!"
@@ -144,7 +146,7 @@
 	filling_color = "#E2FFDE"
 
 	bitesize = 6
-	preloaded_reagents = list("protein" = 8, "pararein" = 8)
+	preloaded_reagents = list("protein" = 8, "pararein" = 8, "stoxin" = 12, "ammonia" = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/spider/midwife
 	desc = "A bloated slab of sickly-green meat cut from a spider. It twitches and shudders as you look it as if actively mutating even in death."
@@ -152,7 +154,7 @@
 	filling_color = "#E2FFDE"
 
 	bitesize = 6
-	preloaded_reagents = list("protein" = 8, "pararein" = 8, "mutagen" = 8)
+	preloaded_reagents = list("protein" = 8, "pararein" = 8, "mutagen" = 8, "ammonia" = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/spider/cave_spider
 	desc = "A bloated slab of sickly-green meat cut from a spider. It seems to always be cold and even when warmed by flames it cools quickly."
@@ -160,7 +162,7 @@
 	filling_color = "#E2FFDE"
 
 	bitesize = 6
-	preloaded_reagents = list("protein" = 8, "pararein" = 8, "frostoil" = 8)
+	preloaded_reagents = list("protein" = 8, "pararein" = 8, "frostoil" = 8, "ammonia" = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/spider/recluse
 	desc = "A bloated slab of sickly-green meat cut from a spider. The smell from this one makes your nose go numb."
@@ -168,7 +170,7 @@
 	filling_color = "#E2FFDE"
 	//Zombie Powder is fairly dangerous and recluses are easy to kill. 6 units per slab is good enough.
 	bitesize = 6
-	preloaded_reagents = list("protein" = 8, "pararein" = 8, "zombiepowder" = 6)
+	preloaded_reagents = list("protein" = 8, "pararein" = 8, "zombiepowder" = 6, "ammonia" = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/spider/queen
 	desc = "A bloated slab of sickly-green meat cut from a spider queen. This one smells of combat stimulants for some reason."
@@ -176,7 +178,7 @@
 	filling_color = "#E2FFDE"
 	//Queens aren't hard to kill and aren't too rare. 6 units of menace should be enough per slab.
 	bitesize = 6
-	preloaded_reagents = list("protein" = 8, "pararein" = 8, "menace" = 6)
+	preloaded_reagents = list("protein" = 8, "pararein" = 8, "menace" = 6, "ammonia" = 4)
 
 /obj/item/reagent_containers/food/snacks/meat/carp
 	name = "carp fillet"


### PR DESCRIPTION

## About The Pull Request

- Adds preloaded reagents to a bunch of items, specifically focused on making some chemicals easier to access without a dispenser.

    - Makes termite meat contain phosphorus, hydrochloric acid and sulphuric acid.
    - Adds preloaded reagents to most tool mods.
    - Adds plasticide (among other things) to phones, body bags, radio headsets, encryption keys, toys and trash.
    - Adds ammonia to spider meat.
    - Tweaks roach chemical values to make slightly more sense.
    - Adds wood pulp to paper when ground, letting anyone make their own cardboard. (Guild buff)
    - Adds lithium to batteries, radium and phosphorus to higher tier batteries.
    - Adds mercury to scanners.
    - Adds acetone to pens and paint.

- Fixes a typo in psion.dm

- Adds material quantities to phones.