### PR TITLE
Xenoarch Types and QOL

### DIFF
--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -11,8 +11,13 @@ SUBSYSTEM_DEF(xenoarch)
 
 	var/list/artifact_spawning_turfs = list()
 	var/list/digsite_spawning_turfs = list()
+	var/list/map_data_list = list()
 
 /datum/controller/subsystem/xenoarch/Initialize(start_timeofday)
+	//fill list of map data so we can use it to determine digsite types
+	for(var/obj/map_data/MD in world)
+		if (MD.digsites)
+			map_data_list += MD
 	//create digsites
 	for(var/turf/simulated/mineral/M in block(locate(1,1,1), locate(world.maxx, world.maxy, world.maxz)))
 		if(isnull(M.geologic_data))
@@ -21,8 +26,11 @@ SUBSYSTEM_DEF(xenoarch)
 		if(!prob(xenoarch_spawn_chance))
 			continue
 
+		if(!(is_allowed_digsites(M.z)))
+			continue
+
 		digsite_spawning_turfs.Add(M)
-		var/digsite = get_random_digsite_type(M.z)
+		var/digsite = get_digsite_type(M.z, map_data_list)
 		var/target_digsite_size = rand(digsite_size_lower, digsite_size_upper)
 		var/list/processed_turfs = list()
 		var/list/turfs_to_process = list(M)

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -55,6 +55,9 @@ GLOBAL_DATUM_INIT(maps_data, /datum/maps_data, new)
 		return TRUE
 	return FALSE
 
+/proc/is_allowed_digsites(var/level)
+	return level in GLOB.maps_data.allowed_digsites
+
 ADMIN_VERB_ADD(/client/proc/test_MD, R_DEBUG, null)
 /client/proc/test_MD()
 	set name = "Check level data"
@@ -79,6 +82,8 @@ ADMIN_VERB_ADD(/client/proc/test_MD, R_DEBUG, null)
 
 	to_chat(mob, "isAcessableLevel: [GLOB.maps_data.accessable_levels[num2text(mob.z)]]")
 
+	to_chat(mob, "allowed_digsites: [is_allowed_digsites(mob.z)]")
+
 	if(GLOB.maps_data.asteroid_levels[num2text(T.z)])
 		to_chat(mob, "Asteroid will be generated here")
 	else
@@ -95,6 +100,7 @@ ADMIN_VERB_ADD(/client/proc/test_MD, R_DEBUG, null)
 	var/list/accessable_levels = new
 	var/list/empty_levels = null     // Empty Z-levels that may be used for various things
 	var/list/names = new
+	var/list/allowed_digsites = list()
 	var/security_state = /decl/security_state/default // The default security state system to use.
 
 	var/list/loadout_blacklist	//list of types of loadout items that will not be pickable
@@ -195,6 +201,9 @@ ADMIN_VERB_ADD(/client/proc/test_MD, R_DEBUG, null)
 	if(MD.is_sealed)
 		sealed_levels += level
 
+	if(MD.digsites)
+		allowed_digsites += level
+
 /datum/maps_data/proc/get_empty_zlevel()
 	if(empty_levels == null)
 		world.incrementMaxZ()
@@ -241,6 +250,7 @@ ADMIN_VERB_ADD(/client/proc/test_MD, R_DEBUG, null)
 	var/is_sealed = FALSE //No transit at map edge
 	var/tmp/z_level
 	var/height = -1	///< The number of Z-Levels in the map.
+	var/digsites = null /// determines if digsites spawn if they do which types. (GARDEN,ANIMAL,HOUSE,TECHNICAL,TEMPLE,WAR,ANY)
 
 
 // If the height is more than 1, we mark all contained levels as connected.

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -6,7 +6,7 @@
 /datum/find
 	var/find_type = 0				//random according to the digsite type
 	var/excavation_required = 0		//random 5-95%
-	var/view_range = 20				//how close excavation has to come to show an overlay on the turf
+	var/view_range = 50				//how close excavation has to come to show an overlay on the turf
 	var/clearance_range = 3			//how close excavation has to come to extract the item
 									//if excavation hits var/excavation_required exactly, it's contained find is extracted cleanly without the ore
 	var/prob_delicate = 90			//probability it requires an active suspension field to not insta-crumble

--- a/code/modules/research/xenoarchaeology/finds/finds_defines.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_defines.dm
@@ -124,15 +124,35 @@
 			return "carbon"
 	return "plasma"
 
-//see /turf/simulated/mineral/New() in code/modules/mining/mine_turfs.dm
-/proc/get_random_digsite_type(Z)
-	switch (Z)
-		if (2, 3, 4) return DIGSITE_HOUSE // all colony besides mines
-		if (8, 9) return DIGSITE_TECHNICAL //deep jungle
-		if (10) return DIGSITE_TEMPLE // swamp
-		if (15, 16) return pick(50;DIGSITE_GARDEN, 50;DIGSITE_ANIMAL) // hunter field
-		if (17, 18, 19, 20, 21) return DIGSITE_WAR // scrap haven
-		else return pick(100;DIGSITE_GARDEN,95;DIGSITE_ANIMAL,90;DIGSITE_HOUSE,85;DIGSITE_TECHNICAL,80;DIGSITE_TEMPLE,75;DIGSITE_WAR)
+/*
+	see /turf/simulated/mineral/New() in code/modules/mining/mine_turfs.dm
+	Uses map_data files from the map section to determine xenoarch digsite spawns.
+	Is fed the Z level and mapdata list from xenoarch subsystem.
+*/
+/proc/get_digsite_type(Z, Maps)
+	var/obj/map_data/map_found = null
+	for(var/obj/map_data/MD in Maps)
+		if (map_found != null)
+			continue
+		if (Z == MD.z)
+			map_found = MD
+			continue
+		while(Z >= 1 && !map_found)
+			Z--
+			if (Z == MD.z)
+				map_found = MD
+				continue
+	if (map_found.digsites != null)
+		switch (map_found.digsites)
+			if ("GARDEN") return DIGSITE_GARDEN
+			if ("ANIMAL") return DIGSITE_ANIMAL
+			if ("HOUSE") return DIGSITE_HOUSE
+			if ("TECHNICAL") return DIGSITE_TECHNICAL
+			if ("TEMPLE") return DIGSITE_TEMPLE
+			if ("WAR") return DIGSITE_WAR
+			if ("ANY") return pick(100;DIGSITE_GARDEN,95;DIGSITE_ANIMAL,90;DIGSITE_HOUSE,85;DIGSITE_TECHNICAL,80;DIGSITE_TEMPLE,75;DIGSITE_WAR)
+			else return DIGSITE_GARDEN
+	else return DIGSITE_GARDEN//safty catch just in case.
 
 /proc/get_random_find_type(var/digsite)
 

--- a/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
+++ b/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
@@ -214,7 +214,7 @@
 			//modify the optimal wavelength
 			tleft_retarget_optimal_wavelength -= deltaT
 			if(tleft_retarget_optimal_wavelength <= 0)
-				tleft_retarget_optimal_wavelength = pick(4,8,15)
+				tleft_retarget_optimal_wavelength = pick(9,12,15)
 				optimal_wavelength_target = rand() * 9900 + 100
 			//
 			if(optimal_wavelength < optimal_wavelength_target)

--- a/maps/_DeepForest/deepforest.dm
+++ b/maps/_DeepForest/deepforest.dm
@@ -12,6 +12,7 @@
 	is_accessable_level = FALSE
 	is_sealed = TRUE
 	height = 2
+	digsites = "TECHNICAL"
 
 /obj/map_data/beast_cave
 	name = "Beast Cave"
@@ -20,6 +21,7 @@
 	is_accessable_level = FALSE
 	is_sealed = TRUE
 	height = 1
+	digsites = "TEMPLE"
 
 /obj/map_data/greyson_field_offices
 	name = "Greyson Field Offices"
@@ -44,6 +46,7 @@
 	is_accessable_level = FALSE
 	is_sealed = TRUE
 	height = 2
+	digsites = "Fossil"
 
 /obj/map_data/river_to_colony
 	name = "Scrap Haven"
@@ -54,4 +57,4 @@
 	is_sealed = TRUE
 	height = 5
 	generate_asteroid = TRUE
-
+	digsites = "WAR"

--- a/maps/__DeepTunnels/deeptunnels.dm
+++ b/maps/__DeepTunnels/deeptunnels.dm
@@ -8,5 +8,6 @@
 	generate_asteroid = TRUE
 	is_sealed = TRUE
 	height = 1
+	digsites = "ANY"
 
 //MINING

--- a/maps/__Nadezhda/nadezhda.dm
+++ b/maps/__Nadezhda/nadezhda.dm
@@ -28,6 +28,7 @@
 	is_sealed = TRUE
 	generate_asteroid = TRUE
 	height = 3
+	digsites = "HOUSE"
 
 
 /obj/map_data/nadezda_s


### PR DESCRIPTION
Gives mappers more control over xenoarch spawning
Causes finds in digsites to appear at lower depths
Makes geosampling less of a hassle
