### PR TITLE
Gun Bloat Finals (For Now)

### DIFF
--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -30,10 +30,6 @@
 	name = "H&S HG 9mm \"Colt\""
 	build_path = /obj/item/gun/projectile/colt
 
-/datum/design/autolathe/gun/NM_colt
-	name = "BR 9mm \"Bronco\""
-	build_path = /obj/item/gun/projectile/colt/NM_colt
-
 /datum/design/autolathe/gun/detective
 	name = "H&S REV 9mm \"Havelock\""
 	build_path = /obj/item/gun/projectile/revolver/detective
@@ -71,10 +67,6 @@
 /datum/design/autolathe/gun/ten
 	name = "SA HG 10mm \"Delta Elite\""
 	build_path = /obj/item/gun/projectile/colt/ten
-
-/datum/design/autolathe/gun/ten_dark
-	name = "SolFed 10mm \"Stallion\""
-	build_path = /obj/item/gun/projectile/colt/ten/dark
 
 /datum/design/autolathe/gun/revolver
 	name = "H&S REV 10mm Magnum \"Minotaur\""
@@ -222,9 +214,9 @@
 	name = "Seinemetall Defense GmbH AR 6.5x39mm \"Ostwind\""
 	build_path = /obj/item/gun/projectile/automatic/ostwind
 
-/datum/design/autolathe/gun/saw
-	name = "SA LMG 6.5x39mm \"Pegasus\""
-	build_path = /obj/item/gun/projectile/automatic/lmg/saw
+/datum/design/autolathe/gun/tk
+	name = "SD GmbH LMG 6.5x39mm \"Takeshi\""
+	build_path = /obj/item/gun/projectile/automatic/lmg/tk
 
 /datum/design/autolathe/gun/roe
 	name = "Hunters Inc BR 6.5x39mm \"Roe\""
@@ -243,11 +235,7 @@
 	build_path = /obj/item/gun/projectile/automatic/mamba
 
 ///R I F L E S
-//7 . 5 m m
-
-/datum/design/autolathe/gun/zatvor
-	name = "BR 7.62x39mm \"Zatvor\""
-	build_path = /obj/item/gun/projectile/boltgun/zatvor
+//7 . 6 2 m m
 
 /datum/design/autolathe/gun/vintorez
 	name = "Excelsior 7.62x39mm \"Vintorez\""

--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -283,19 +283,6 @@
 		list(QUALITY_ADHESIVE, 15, 70)
 	)
 
-/datum/craft_recipe/gun/zatvor
-	name = "Makeshift 7.62 \"Zatvor\" boltrifle"
-	result = /obj/item/gun/projectile/boltgun/zatvor
-	steps = list(
-		list(/obj/item/gun/projectile/boltgun, 1),
-		list(CRAFT_MATERIAL, 6, MATERIAL_STEEL),
-		list(QUALITY_WELDING, 10, 20),
-		list(QUALITY_SCREW_DRIVING, 10),
-		list(CRAFT_MATERIAL, 4, MATERIAL_WOOD),
-		list(QUALITY_HAMMERING, 10),
-		list(QUALITY_ADHESIVE, 15, 70)
-	)
-
 /datum/craft_recipe/gun/rxd
 	name = "RXD - rapid crossbow device"
 	result = /obj/item/gun/projectile/crossbow/RCD

--- a/code/game/machinery/excelsior/blackshield_teleporter.dm
+++ b/code/game/machinery/excelsior/blackshield_teleporter.dm
@@ -55,8 +55,7 @@ var/global/blackshield_max_energy //Maximaum combined energy of all teleporters
 		//Guns
 		/obj/item/gun/projectile/automatic/slaught_o_matic = 15, //So blackshiled can trade with propis :P
 		/obj/item/gun/projectile/boltgun/flare_gun = 10, //DAZZLATION!
-		/obj/item/gun/projectile/colt/NM_colt = 50,
-		/obj/item/gun/projectile/colt/ten/dark = 75,
+		/obj/item/gun/projectile/colt/ten = 75,
 		/obj/item/gun/projectile/boltgun/light = 50,
 		/obj/item/gun/projectile/boltgun = 75,
 		/obj/item/gun/projectile/boltgun/lever/shotgun/bounty = 400,

--- a/code/game/machinery/vendor/weapon_kit_vendors.dm
+++ b/code/game/machinery/vendor/weapon_kit_vendors.dm
@@ -14,7 +14,7 @@
 		/obj/item/storage/box/bs_kit/drozd = 2,
 		/obj/item/storage/box/bs_kit/ekaterina = 3,
 		/obj/item/storage/box/bs_kit/bounty = 3,
-		/obj/item/storage/box/bs_kit/stallion = 5,
+		/obj/item/storage/box/bs_kit/delta = 5,
 		/obj/item/storage/box/bs_kit/rex10 = 3,
 		/obj/item/storage/box/bs_kit/pilgrim = 3,
 		/obj/item/storage/box/bs_kit/makarov = 3,
@@ -37,7 +37,7 @@
 		/obj/item/storage/box/bs_kit/drozd = 800,
 		/obj/item/storage/box/bs_kit/ekaterina = 750,
 		/obj/item/storage/box/bs_kit/bounty = 750,
-		/obj/item/storage/box/bs_kit/stallion = 750,
+		/obj/item/storage/box/bs_kit/delta = 750,
 		/obj/item/storage/box/bs_kit/rex10 = 500,
 		/obj/item/storage/box/bs_kit/pilgrim = 750,
 		/obj/item/storage/box/bs_kit/makarov = 500,
@@ -127,7 +127,7 @@
 /obj/machinery/vending/blackshield_kit/proc/RedeemSecondary(obj/item/voucher/voucher, mob/redeemer)
 	var/items = list(
 					"Makarov Kit" = /obj/item/storage/box/bs_kit/makarov,
-					"Stallion Kit" = /obj/item/storage/box/bs_kit/stallion,
+					"Delta Elite Kit" = /obj/item/storage/box/bs_kit/delta,
 					"Cowboy Kit" = /obj/item/storage/box/bs_kit/rex10,
 					"Pilgrim Kit" = /obj/item/storage/box/bs_kit/pilgrim,
 					"Sawn-Off Shotgun Kit" = /obj/item/storage/box/bs_kit/sawn_shotgun,

--- a/code/game/objects/items/weapons/autolathe_disk/blackshield_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/blackshield_disks.dm
@@ -130,24 +130,6 @@
 		/datum/design/autolathe/ammo/pistol,
 		)
 
-/obj/item/computer_hardware/hard_drive/portable/design/blackshield/NM_colt
-	name = "NM HG 9mm \"Bronco\""
-	disk_name = ""
-	icon_state = "blackshield"
-	license = 8
-
-	designs = list(
-		/datum/design/autolathe/gun/NM_colt = 3,
-		/datum/design/autolathe/ammo/pistol_practice = 0,
-		/datum/design/autolathe/ammo/pistol_rubber,
-		/datum/design/autolathe/ammo/pistol,
-		/datum/design/autolathe/ammo/pistol_lethal = 2,
-		/datum/design/autolathe/ammo/hpistol_practice = 1,
-		/datum/design/autolathe/ammo/hpistol_rubber = 2,
-		/datum/design/autolathe/ammo/hpistol = 2,
-		/datum/design/autolathe/ammo/hpistol_lethal = 2,
-		)
-
 /obj/item/computer_hardware/hard_drive/portable/design/blackshield/semyonovich
 	name = "NM - 9mm PPV \"Semyonovich\""
 	disk_name = ""

--- a/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
@@ -506,7 +506,7 @@
 
 /obj/item/computer_hardware/hard_drive/portable/design/guns/tk
 	disk_name = "SD GmbH - 6.5mm Takeshi LMG"
-	icon_state = "sa"
+	icon_state = "frozenstar"
 
 	license = 8 //So we can print 2 and some ammo
 	designs = list(

--- a/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
@@ -504,13 +504,13 @@
 
 // 6.5mm Carbine
 
-/obj/item/computer_hardware/hard_drive/portable/design/guns/saw
-	disk_name = "SA - 6.5mm Pegasus LMG"
+/obj/item/computer_hardware/hard_drive/portable/design/guns/tk
+	disk_name = "SD GmbH - 6.5mm Takeshi LMG"
 	icon_state = "sa"
 
 	license = 8 //So we can print 2 and some ammo
 	designs = list(
-		/datum/design/autolathe/gun/saw = 3,
+		/datum/design/autolathe/gun/tk = 3,
 		/datum/design/autolathe/ammo/lrifle_ammobox = 2,
 		/datum/design/autolathe/ammo/lrifle_belt, //This is its linked ammo
 		/datum/design/autolathe/ammo/lrifle_belt_empty = 0,
@@ -597,20 +597,6 @@
 		/datum/design/autolathe/ammo/rifle_ammobox_small_lethal = 2,
 		/datum/design/autolathe/ammo/sl_rifle,
 	)
-
-/obj/item/computer_hardware/hard_drive/portable/design/zatvor
-	disk_name = "Unlicensed - 7.62mm bolt \"Zatvor\" rifle"
-	icon_state = "onestar"
-	license = 8
-
-	designs = list(
-		/datum/design/autolathe/gun/zatvor = 3,
-		/datum/design/autolathe/ammo/rifle_ammobox_small = 2,
-		/datum/design/autolathe/ammo/rifle_ammobox_small_practice = 0,
-		/datum/design/autolathe/ammo/rifle_ammobox_small_rubber = 2,
-		/datum/design/autolathe/ammo/rifle_ammobox_small_lethal = 3,
-		/datum/design/autolathe/ammo/sl_rifle = 2
-		)
 
 //8.6mm heavy rifles
 

--- a/code/game/objects/items/weapons/storage/blackshield_kits.dm
+++ b/code/game/objects/items/weapons/storage/blackshield_kits.dm
@@ -17,7 +17,7 @@
 		new /obj/item/ammo_magazine/speed_loader_rifle_75(src)
 		new /obj/item/ammo_magazine/speed_loader_rifle_75(src)
 		new /obj/item/ammo_magazine/speed_loader_rifle_75(src)
-		new /obj/item/gun/projectile/colt/ten/dark(src)
+		new /obj/item/gun/projectile/colt/ten(src)
 		new /obj/item/ammo_magazine/magnum_40(src)
 		new /obj/item/ammo_magazine/magnum_40(src)
 		new /obj/item/clothing/accessory/holster/hip(src)
@@ -171,13 +171,13 @@
 		new /obj/item/storage/pouch/ammo(src)
 
 // Side-arms Kits
-/obj/item/storage/box/bs_kit/stallion
-	name = "\improper Stallion Secondary Kit"
-	desc = "The standard Blackshield equipment kit containing a stallion, a design based of the original M1911, modernized and given an auto eject system with built in audio alerts. Unlike the \
+/obj/item/storage/box/bs_kit/delta
+	name = "\improper Delta Elite Secondary Kit"
+	desc = "The standard Blackshield equipment kit containing a Delta Elite, a design based of the original M1911, modernized. Unlike the \
 	standard colt, it uses 10mm magnum rounds."
 
 	populate_contents()
-		new /obj/item/gun/projectile/colt/ten/dark(src)
+		new /obj/item/gun/projectile/colt/ten(src)
 		new /obj/item/ammo_magazine/magnum_40(src)
 		new /obj/item/ammo_magazine/magnum_40(src)
 		new /obj/item/clothing/accessory/holster/hip(src)

--- a/code/game/objects/items/weapons/storage/marshal_kits.dm
+++ b/code/game/objects/items/weapons/storage/marshal_kits.dm
@@ -1,5 +1,5 @@
 /obj/item/storage/box/m_kit
-	name = "\improper Marshal Kit"
+	name = "Marshal Kit"
 	desc = "A standard kit."
 	cant_hold = list(/obj/item) //stops them from being used as storage solutions - items can't be put back in.
 	w_class = ITEM_SIZE_BULKY //these carry guns and lots of items! Makes sense to make them bigger than some tiny box
@@ -18,7 +18,7 @@
 		new /obj/item/storage/pouch/ammo(src)
 
 /obj/item/storage/box/m_kit/breacher
-	name = "\improper Breaching Hammer Kit"
+	name = "Breaching Hammer Kit"
 	desc = "The standard Marshal box kit, containing a single heavy-duty breaching hammer. Equally beloved by Marshals more interested in utility than firepower, and those \
 	strange enough to take such an unwieldy thing into close combat"
 
@@ -26,7 +26,7 @@
 		new /obj/item/tool/hammer/ironhammer(src)
 
 /obj/item/storage/box/m_kit/mamba
-	name = "\improper Mamba Kit"
+	name = "Mamba Kit"
 	desc = "The standard Marshal box kit containing a Mamba, a proper carbine for a proper policemen."
 
 	populate_contents()
@@ -62,7 +62,7 @@
 
 //supply-specs kits
 /obj/item/storage/box/m_kit/typewriter
-	name = "\improper Sunrise Laser SMG kit"
+	name = "Sunrise Laser SMG kit"
 	desc = "The standard Marshal box kit containing a Marshal Gunsmith made laser SMG, for the discerning specialist."
 
 	populate_contents()
@@ -73,7 +73,7 @@
 		new /obj/item/storage/pouch/tubular(src)
 
 /obj/item/storage/box/m_kit/state_auto
-	name = "\improper State Auto-Shotgun Kit"
+	name = "State Auto-Shotgun Kit"
 	desc = "The standard Marshal box kit containing a state auto shotgun. What is lacks in penetration it makes up for with ammo capacity and fire rate."
 
 	populate_contents()
@@ -124,7 +124,7 @@
 
 // Secondary kits
 /obj/item/storage/box/m_kit/taser
-	name = "\improper Counselor Secondary kit"
+	name = "Counselor Secondary kit"
 	desc = "The standard Marshal box kit containing a counselor stun gun. An all round solid sidearm to round out the Marshals non-lethal kit."
 
 	populate_contents()
@@ -216,7 +216,7 @@
 
 // Armor Kits
 /obj/item/storage/box/m_kit/standard_armor
-	name = "\improper Standard Visor Armor Kit"
+	name = "Standard Visor Armor Kit"
 	desc = "An standard Marshal armor kit with a plate carrier and visor helmet."
 
 	populate_contents()
@@ -224,7 +224,7 @@
 		new /obj/item/clothing/head/helmet/marshal_full(src)
 
 /obj/item/storage/box/m_kit/bullet_proof
-	name = "\improper Bullet Proof Kit"
+	name = "Bullet Proof Kit"
 	desc = "An standard Marshal armor kit containing bullet proof armor and a helmet, perfect for dealing with hostile colonist and infiltrators, but bulky and slowing."
 
 	populate_contents()
@@ -232,7 +232,7 @@
 		new /obj/item/clothing/head/helmet/faceshield/altyn/ironhammer(src)
 
 /obj/item/storage/box/m_kit/laser_armor
-	name = "\improper Ablative Armor Kit"
+	name = "Ablative Armor Kit"
 	desc = "An standard Marshal armor kit containing a full ablative marshal branded suit for countering laser weaponry."
 
 	populate_contents()
@@ -242,7 +242,7 @@
 		new /obj/item/clothing/shoes/ablasive(src)
 
 /obj/item/storage/box/m_kit/riot
-	name = "\improper Riot Armor Kit"
+	name = "Riot Armor Kit"
 	desc = "An standard Marshal armor kit containing riot armor and a riot helmet, perfect for dealing with hostile fauna and anyone in melee, but bulky and slowing."
 
 	populate_contents()

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -14,7 +14,6 @@
 				/obj/item/gun/projectile/giskard = 1.5,\
 				/obj/item/gun/projectile/automatic/luger = 1,\
 				/obj/item/gun/projectile/boltgun/sa = 3,\
-				/obj/item/gun/projectile/boltgun/zatvor = 1,\
 				/obj/item/gun/projectile/shotgun/pump = 0.5,\
 				/obj/item/gun/projectile/revolver/sixshot/sawn = 0.5,\
 				/obj/item/gun/projectile/shotgun/pump/sawn = 1,\
@@ -23,7 +22,6 @@
 				/obj/item/gun/projectile/boltgun/sawn/true = 0.5,\
 				/obj/item/gun/projectile/boltgun/sawn/sa = 1,\
 				/obj/item/gun/projectile/automatic/luger = 1, \
-				/obj/item/gun/projectile/boltgun/zatvor = 2, \
 				/obj/item/gun/projectile/automatic/omnirifle/solmarine/shotgunless = 0.5, \
 				/obj/item/gun/projectile/olivaw = 2,
 				/obj/item/gun_upgrade/barrel/forged = 2))
@@ -108,9 +106,8 @@
 				/obj/item/gun/projectile/revolver/tacticool_revolver = 1,\
 				/obj/item/gun/projectile/silenced = 2,\
 				/obj/item/gun/projectile/revolver/mistral = 2,\
-				/obj/item/gun/projectile/colt/NM_colt = 2,\
 				/obj/item/gun/projectile/colt/ten = 2,\
-				/obj/item/gun/projectile/colt/ten/dark = 1,\
+				/obj/item/gun/projectile/colt/ten = 1,\
 				/obj/item/gun/projectile/automatic/nordwind/strelki = 0.3, \
 				/obj/item/gun/projectile/boltgun/lever = 1, \
 				/obj/item/gun/projectile/lamia/scoped = 1,\

--- a/code/game/objects/random/lathe_disks/guns.dm
+++ b/code/game/objects/random/lathe_disks/guns.dm
@@ -66,7 +66,6 @@
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/custer = 4,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/roe = 4,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/boltgun_sa = 6,
-				/obj/item/computer_hardware/hard_drive/portable/design/zatvor = 3,
 				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/bounty_lever = 2))
 
 /obj/random/lathe_disk/lmg
@@ -83,7 +82,7 @@
 				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/dp = 3,
 				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/semyonovich = 4,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/sa_pk = 2,
-				/obj/item/computer_hardware/hard_drive/portable/design/guns/saw = 2,
+				/obj/item/computer_hardware/hard_drive/portable/design/guns/tk = 1.5,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/ex_ppsh = 1,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/concillium = 2))
 
@@ -153,7 +152,6 @@
 /obj/random/lathe_disk/pistol/item_to_spawn()
 	return pickweight(list(
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/mk58 = 5,
-				/obj/item/computer_hardware/hard_drive/portable/design/blackshield/NM_colt = 3,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/colt = 5,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/rafale = 2,
 				/obj/item/computer_hardware/hard_drive/portable/design/guns/lamia = 2,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -37,7 +37,7 @@
 	new /obj/item/clothing/suit/armor/vest(src)
 	new /obj/item/clothing/head/helmet(src)
 	new /obj/item/device/radio/headset/heads/hop(src)
-	new /obj/item/gun/projectile/colt/ten/dark(src)
+	new /obj/item/gun/projectile/colt/ten(src)
 	new /obj/item/ammo_magazine/magnum_40/rubber(src)
 	new /obj/item/ammo_magazine/magnum_40/rubber(src)
 	new /obj/item/ammo_magazine/magnum_40/rubber(src)

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -97,7 +97,6 @@
 //	update_wear_icon()
 
 
-
 /obj/item/gun/projectile/automatic/lmg/pk
 	name = "Pulemyot Kalashnikova"
 	desc = "\"Kalashnikov's Machinegun\", a well-made copy of what many consider to be the best traditional machinegun ever designed."
@@ -105,34 +104,11 @@
 	icon_base = "pk"
 	icon_state = "pk_closed"
 	item_state = "pk_closed"
-	damage_multiplier = 0.9
+	damage_multiplier = 1.0
 	init_firemodes = list(
 		FULL_AUTO_300,
 		BURST_5_ROUND,
 		BURST_8_ROUND
-		)
-
-//Typical LMG/SAW, use this for the high end of "normal."
-/obj/item/gun/projectile/automatic/lmg/saw
-	name = "\"Pegasus\" light machinegun"
-	desc = "A common LMG chambered in 6.5mm Carbine, accepting either boxes or standard magazines, though this calls into question some reliability issues. \
-	This particular example bears a winged horse in laurels and a \"Pegasus\" nameplate, all other markings have been filed off."
-	icon = 'icons/obj/guns/projectile/lmg.dmi'
-	icon_base = "saw"
-	icon_state = "saw_closed"
-	item_state = "saw_closed"
-	mag_well = MAG_WELL_LINKED_BOX|MAG_WELL_STANMAG
-	caliber = CAL_LRIFLE
-	penetration_multiplier = 0.85
-	damage_multiplier = 1.0
-	matter = list(MATERIAL_PLASTEEL = 30, MATERIAL_PLASTIC = 10)
-	price_tag = 1500
-	fire_sound = 'sound/weapons/guns/fire/sfrifle_fire.ogg'
-	init_recoil = LMG_RECOIL(0.7)
-
-	init_firemodes = list(
-		FULL_AUTO_600,
-		BURST_5_ROUND,
 		)
 
 //This should be in its own file...

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -20,20 +20,6 @@
 	wield_delay = 0.3 SECOND
 	wield_delay_factor = 0.2 // 20 vig
 
-/obj/item/gun/projectile/colt/NM_colt
-	name = "\"Bronco\" pistol"
-	desc = "A rugged derivative of the venerable M1911, built on double-stack frames and modified by the Nadezhda Marshals gunsmiths from new or refitted weapons to meet match-grade standards. Uses 9mm rounds."
-	icon_state = "NM_colt"
-	item_state = "colt"
-	caliber = CAL_PISTOL
-	mag_well = MAG_WELL_PISTOL | MAG_WELL_H_PISTOL
-	price_tag = 500
-	auto_eject = 1
-	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 5)
-	init_recoil = HANDGUN_RECOIL(0.3)
-	serial_type = "NM"
-
 /obj/item/gun/projectile/colt/ten
 	name = "\"Delta Elite\" magnum pistol"
 	desc = "A classy high-powered automatic based on the M1911 series handguns, with significant reinforcements produced by Scarborough Arms. Uses 10mm Auto-Mag."
@@ -57,18 +43,9 @@
 	wield_delay = 0.4 SECOND
 	wield_delay_factor = 0.4 // 40 vig
 
-/obj/item/gun/projectile/colt/ten/dark
-	name = "\"Stallion\" magnum pistol"
-	desc = "A rugged derivative of the venerable M1911, modernized to the M1911A5 standard and produced by SolFed armories across the galaxy, this one bears defaced serial numbers and the insignia of the Blackshield. Uses 10mm Auto-Mag."
-	icon_state = "dark_delta"
-	item_state = "colt"
-	auto_eject = 1
-	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
-	serial_type = "Sol Fed"
-
 /obj/item/gun/projectile/colt/liberty
 	name = "\"Liberty\" magnum pistol"
-	desc = "A common Nadezhda Marshal issue pistol chambered in 10mm Magnum. It appears to be loosely based off a Colt model, albeit with a changed slide and polymer grip and a built-in holographic scope."
+	desc = "A common Nadezhda Marshal issue pistol chambered in 10mm Magnum. It appears to be loosely based off a Colt model, albeit with a changed slide, polymer grip and a built-in holographic sight."
 	icon = 'icons/obj/guns/projectile/liberty.dmi'
 	icon_state = "liberty"
 	item_state = "liberty"

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
@@ -27,7 +27,7 @@
 		"Sol Fed Stockpiles" = list(
 			/obj/item/gun/projectile/automatic/thompson = custom_good_amount_range(list(1, 3)),
 			/obj/item/gun/projectile/lamia/gemini = custom_good_amount_range(list(1, 1)),
-			/obj/item/gun/projectile/colt/ten/dark = custom_good_amount_range(list(1, 1)),
+			/obj/item/gun/projectile/colt/ten = custom_good_amount_range(list(1, 1)),
 			/obj/item/gun/projectile/automatic/omnirifle/solmarine = custom_good_amount_range(list(1, 1)),
 			/obj/item/gun/projectile/automatic/greasegun = custom_good_amount_range(list(2, 3)),
 			/obj/item/gun/projectile/automatic/omnirifle = custom_good_amount_range(list(1, 1))

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -73360,10 +73360,10 @@
 "nLB" = (
 /obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/colt/ten/dark{
+/obj/item/gun/projectile/colt/ten{
 	pixel_y = -5
 	},
-/obj/item/gun/projectile/colt/ten/dark{
+/obj/item/gun/projectile/colt/ten{
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -2827,7 +2827,6 @@
 #include "code\modules\projectiles\guns\projectile\boltgun\novakovic.dm"
 #include "code\modules\projectiles\guns\projectile\boltgun\roe_sika.dm"
 #include "code\modules\projectiles\guns\projectile\boltgun\scout.dm"
-#include "code\modules\projectiles\guns\projectile\boltgun\zatvor_ak.dm"
 #include "code\modules\projectiles\guns\projectile\other\bow.dm"
 #include "code\modules\projectiles\guns\projectile\other\lenar.dm"
 #include "code\modules\projectiles\guns\projectile\other\protector.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simple removals of some more guns. They are as follows:

- **Zatvor**. Reason: No one used it, my original idea of replacing BS' Mosins with actual more modern though jank equipment was accepted but then denied suddenly after. Gun has been in limbo.
- **Pegasus**. Reason: Shitty LMG everyone complains about. Replaced it in loot rotation with the objectively better Takeshi. Why did we port an Eris LMG and only give it to the Marshals, who never use LMGs anyway?
- **Delta Elite Colt - Dark Varient**. Reason: Why would Sol-Gov use a Colt M1911 and just make no changes besides an auto-dropper feature? Conflicts with want for 'sci-fi' guns for Sol-Gov rather than old WWII era guns. (FUDDs go away.) Replaced it on BS disk with its brother, the Delta Elite - identical besides the auto drop function. (There's a gun mod for that anyway.)
- **Bronco Colt**. Reason: Why did we feel the need to make a slightly better Colt pistol for the _colony_ itself? Security doesn't use this anymore and Blackshield tossed it in the garbage ages ago. 

## Changelog
:cl:
del: Removes Pegasus, replaces with Takeshi.
del: Removes Zatvor.
del: Removes Stallion / Delta Elite Variant (Dark), replaced on BS tele and loadouts with the Delta Elite proper.
del: Removes the Colt Bronco.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
