### PR TITLE
Onmob-examine fixes

### DIFF
--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -86,7 +86,10 @@
 /obj/item/clothing/accessory/holster/examine(mob/user)
 	..(user)
 	if (holstered)
-		to_chat(user, "A [holstered] is holstered here.")
+		if(get_dist(user, src) < 1) //Gotta be close to see what's in there
+			to_chat(user, "A [holstered] is holstered here.")
+		else
+			to_chat(user, "You can't get a good look at that holster...")
 	else
 		to_chat(user, "It is empty.")
 

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -89,7 +89,7 @@
 		if(get_dist(user, src) < 1) //Gotta be close to see what's in there
 			to_chat(user, "A [holstered] is holstered here.")
 		else
-			to_chat(user, "You can't get a good look at that holster...")
+			to_chat(user, "You can't get a good look at the contents of that holster...")
 	else
 		to_chat(user, "It is empty.")
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -63,7 +63,7 @@
 						tie_msg += ","
 					else if(i > 1)
 						tie_msg += " and"
-					tie_msg += " <a href='?src=\ref[src];lookitem=\ref[acc]'>\a [acc]</a>"
+					tie_msg += " <a href='?src=\ref[user];lookitem=\ref[acc]'>\a [acc]</a>"
 					i += 1
 
 		if(w_uniform.blood_DNA)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Fixes an incorrect ref that allowed you to make people examine their own accessories. Also, the contents of holsters can only be seen while on the same tile.

I'm aware of issues where non-carbon mobs can't click the text, but this is a higher priority to me.
	
<hr>
</details>

## Changelog
:cl:
fix: fixed improper ref in examine code
tweak: holsters only show their contents if you're on the same tile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
