### PR TITLE
Adds Exotic Ammo Disk to Factio

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/1-common/factio.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/factio.dm
@@ -59,7 +59,8 @@
 			/obj/item/computer_hardware/hard_drive/portable/design/components = custom_good_nameprice("Artificer's ARK-034 Components", list(800, 1000)),
 			/obj/item/computer_hardware/hard_drive/portable/design/adv_tools = custom_good_nameprice("Artificer's IJIRO-451 Advanced Tools", list(800, 1000)),
 			/obj/item/computer_hardware/hard_drive/portable/design/circuits = custom_good_nameprice("Artificer's ESPO-830 Circuits", list(800, 1000)),
-			/obj/item/computer_hardware/hard_drive/portable/design/logistics = custom_good_nameprice("Artificer's LAT-018 Logistics", list(800, 1000))
+			/obj/item/computer_hardware/hard_drive/portable/design/logistics = custom_good_nameprice("Artificer's LAT-018 Logistics", list(800, 1000)),
+			/obj/item/computer_hardware/hard_drive/portable/design/exotic_ammo = custom_good_nameprice("Exotic Ammo Disk", list(800, 1000))
 		),
 		"Printed II" = list(
 			/obj/item/tool/crowbar = good_data("Crowbar", list(-100, -50), 60),


### PR DESCRIPTION
## About The Pull Request
Allows Lonestar to buy the Exotic Ammunition disk they used to have on their console through the Factio seller.

## Changelog
:cl:
adds: Exotic Ammo disk to Factor trader on beacon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
