### PR TITLE
Enclave Bot Salt

### DIFF
--- a/code/modules/hivemind/mobs.dm
+++ b/code/modules/hivemind/mobs.dm
@@ -308,7 +308,7 @@
 	name = "Bomber"
 	desc = "This hovering cyborg emits a faint smell of welding fuel."
 	icon_state = "bomber"
-	density = 0
+	density = 1
 	speak_chance = 3
 	malfunction_chance = 1
 	speak_chance = 4


### PR DESCRIPTION
## About The Pull Request
We increased explosive damage to cause death so easily due to something as simple as bleed damage - which even rough life cannot prevent.

Mob should not be density of 0 when it can nearly instant-kill the target and, if they somehow survive, will bleed out 70% of the time.

## Changelog
:cl:
balance: fixes the Enclave-eyebot rip to be less broken.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
