### PR TITLE
Smelter fix, ana not with levels and nsa changes

### DIFF
--- a/code/game/machinery/smelter.dm
+++ b/code/game/machinery/smelter.dm
@@ -134,7 +134,11 @@
 			if(!(material in stored_material))
 				stored_material[material] = 0
 
-			stored_material[material] += (materials[material] *= scrap_multiplier)
+			if(istype(smelting, /obj/item/stack))
+				var/obj/item/stack/stacked_item = smelting
+				stored_material[material] += (materials[material] * stacked_item.amount)
+			else
+				stored_material[material] += (materials[material] *= scrap_multiplier)
 
 	for(var/obj/O in smelting.contents)
 		smelt_item(O)

--- a/code/modules/aberrants/organs/_defines.dm
+++ b/code/modules/aberrants/organs/_defines.dm
@@ -38,8 +38,7 @@
 // Blacklist all reagents with no name or ones that cannot be produced
 #define REAGENT_BLACKLIST list(/datum/reagent/organic, /datum/reagent/metal, /datum/reagent/drug,\
 								/datum/reagent/other, /datum/reagent/nanites, /datum/reagent/medicine,\
-								/datum/reagent/stim, /datum/reagent/adminordrazine, /datum/reagent/other/matter_deconstructor,\
-								/datum/reagent/other/xenomicrobes)
+								/datum/reagent/stim, /datum/reagent/adminordrazine, /datum/reagent/other/matter_deconstructor)
 
 #define REAGENTS_DISPENSER list(/datum/reagent/acetone, /datum/reagent/metal/aluminum, /datum/reagent/toxin/ammonia, /datum/reagent/carbon, /datum/reagent/metal/copper,\
 								/datum/reagent/ethanol, /datum/reagent/toxin/hydrazine, /datum/reagent/metal/iron, /datum/reagent/metal/lithium, /datum/reagent/metal/mercury,\

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -123,7 +123,7 @@
 	var/nsa_amount = get_nsa()
 	if(nsa_amount < nsa_threshold*1.1)
 		return
-	parent.shake_animation(2)
+	parent.make_jittery(2)
 
 	if(nsa_amount < nsa_threshold*1.2)
 		return

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -117,21 +117,54 @@
 	var/obj/screen/nsa/hud = parent.HUDneed["neural system accumulation"]
 	hud?.update_icon()
 
+//NSA Overloads!
+//First we have a tell were over are limit, harmless shaking
 /datum/metabolism_effects/proc/nsa_breached_effect()
-	if(get_nsa() < nsa_threshold*1.2) // 20% more
+	var/nsa_amount = get_nsa()
+	if(nsa_amount < nsa_threshold*1.1)
 		return
-	parent.vomit()
+	parent.shake_animation(2)
 
-	if(get_nsa() < nsa_threshold*1.6)
+	if(nsa_amount < nsa_threshold*1.2)
 		return
 	parent.drop_l_hand()
 	parent.drop_r_hand()
 
-	if(get_nsa() < nsa_threshold*1.8)
+	if(nsa_amount < nsa_threshold*1.3)
+		return
+	parent.vomit()
+
+	if(nsa_amount < nsa_threshold*1.4)
+		return
+	parent.adjust_hallucination(8,12)
+
+	if(nsa_amount < nsa_threshold*1.5)
 		return
 	parent.adjustToxLoss(1)
+	parent.eye_blurry = max(parent.eye_blurry, 3)
 
-	if(get_nsa() < nsa_threshold*2)
+	if(nsa_amount < nsa_threshold*1.6)
+		return
+	parent.drip_blood(10) //This is quite a bit but your also suffering a lot
+
+	//At this point were starting to have a heart attack
+	if(nsa_amount < nsa_threshold*1.7)
+		return
+	if(ishuman(parent))
+		var/mob/living/carbon/human/H = parent
+		var/obj/item/organ/internal/heart/C = H.random_organ_by_process(OP_HEART)
+		if(H && istype(H))
+			C.take_damage(0.5, FALSE)
+
+	if(nsa_amount < nsa_threshold*1.8)
+		return
+	parent.confused = max(parent.confused, 3)
+
+	if(nsa_amount < nsa_threshold*1.9)
+		return
+	parent.paralysis = max(parent.paralysis, 10)
+
+	if(nsa_amount < nsa_threshold*2)
 		return
 	parent.Sleeping(2)
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -71,7 +71,7 @@
 	color = "#FF69B4" //rgb(255,105,180)hotpink
 	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = TRUE
-	nerve_system_accumulations = 15
+	nerve_system_accumulations = 20
 
 /datum/reagent/medicine/varceptol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.heal_organ_damage(9 * removed, 0)

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -37,7 +37,7 @@
 	color = "#BF0000"
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
-	nerve_system_accumulations = 35 //Cheap
+	nerve_system_accumulations = 15 // Basic chems shouldn't hurt the body as much as higher potency ones.
 
 /datum/reagent/medicine/bicaridine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.species?.reagent_tag == IS_CHTMANT)
@@ -56,7 +56,7 @@
 	color = "#964e06"
 	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = TRUE
-	nerve_system_accumulations = 15
+	nerve_system_accumulations = 30
 
 /datum/reagent/medicine/vermicetol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.heal_organ_damage(12 * removed, 0)
@@ -87,7 +87,7 @@
 	color = "#E6666C"
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
-	nerve_system_accumulations = 15
+	nerve_system_accumulations = 30
 
 /datum/reagent/medicine/meralyne/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.heal_organ_damage(0.6 * effect_multiplier, 0, 5 * effect_multiplier)
@@ -102,7 +102,7 @@
 	color = "#FFA800"
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
-	nerve_system_accumulations = 30
+	nerve_system_accumulations = 10
 
 /datum/reagent/medicine/kelotane/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.species?.reagent_tag == IS_CHTMANT)
@@ -133,7 +133,7 @@
 	color = "#00A000"
 	scannable = TRUE
 	overdose = REAGENTS_OVERDOSE
-	nerve_system_accumulations = 15
+	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/dylovene/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.drowsyness = max(0, M.drowsyness - 0.6 * effect_multiplier)
@@ -263,7 +263,7 @@
 	color = "#000080"
 	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = TRUE
-	nerve_system_accumulations = 30
+	nerve_system_accumulations = -30
 
 /datum/reagent/medicine/respirodaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed = REM)
 	if(ishuman(M))
@@ -557,7 +557,7 @@
 	metabolism = REM * 0.25
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
-	nerve_system_accumulations = 10
+	nerve_system_accumulations = -15
 
 /datum/reagent/medicine/alkysine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.adjustBrainLoss(-(3 + (M.getBrainLoss() * 0.05)) * effect_multiplier)
@@ -593,7 +593,7 @@
 	color = "#561EC3"
 	overdose = 10
 	scannable = TRUE
-	nerve_system_accumulations = 40
+	nerve_system_accumulations = 30
 
 /datum/reagent/medicine/peridaxon/affect_blood(mob/living/carbon/M, alien, effect_multiplier, var/removed)
 	if(M.species?.reagent_tag == IS_CHTMANT)
@@ -687,7 +687,7 @@
 	metabolism = REM * 0.25
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
-	nerve_system_accumulations = -5
+	nerve_system_accumulations = 15
 
 /datum/reagent/medicine/hyronalin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.radiation = max(M.radiation - (3 * effect_multiplier), 0)
@@ -701,7 +701,7 @@
 	metabolism = REM * 0.25
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
-	nerve_system_accumulations = -15
+	nerve_system_accumulations = 30
 
 /datum/reagent/medicine/arithrazine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.radiation = max(M.radiation - (7 + (M.radiation * 0.10)) * effect_multiplier, 0)
@@ -719,7 +719,7 @@
 	metabolism = REM * 0.05 //Infections are already a pain in the neck to treat, this should ease having to re-dose every time above the 5u threshold.
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
-	nerve_system_accumulations = 5
+	nerve_system_accumulations = -5
 
 /datum/reagent/medicine/spaceacillin/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	M.adjustToxLoss(-((0.1 + (M.getToxLoss() * 0.01)) * effect_multiplier))
@@ -848,7 +848,7 @@
 	color = "#669900"
 	overdose = REAGENTS_OVERDOSE * 0.4 // Should OD at 12 units, you still shouldn't ever use more than 2u at a time anyways. - Seb
 	scannable = TRUE
-	nerve_system_accumulations = 0
+	nerve_system_accumulations = 40
 
 /datum/reagent/medicine/rezadone/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.adjustCloneLoss(-(2 + (M.getCloneLoss() * 0.05)) * effect_multiplier)
@@ -944,7 +944,7 @@
 	color = "#bc018a"
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
-	nerve_system_accumulations = -35
+	nerve_system_accumulations = -50
 
 /datum/reagent/medicine/noexcutite/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.make_jittery(-50)
@@ -993,7 +993,7 @@
 	scannable = TRUE
 	metabolism = REM/2
 	overdose = REAGENTS_OVERDOSE
-	nerve_system_accumulations = 15
+	nerve_system_accumulations = 5
 
 /datum/reagent/medicine/polystem/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.heal_organ_damage(0.3 * effect_multiplier, 0, 3 * effect_multiplier)
@@ -1012,7 +1012,7 @@
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
 	metabolism = REM/2
-	nerve_system_accumulations = -15
+	nerve_system_accumulations = -100
 
 /datum/reagent/medicine/detox/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(!M.metabolism_effects.nsa_chem_bonus)
@@ -1091,7 +1091,7 @@
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
 	metabolism = REM/2
-	nerve_system_accumulations = -10
+	nerve_system_accumulations = -15
 
 /datum/reagent/medicine/aminazine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_NOWITHDRAW, 1)
@@ -1106,7 +1106,7 @@
 	overdose = REAGENTS_OVERDOSE/2
 	scannable = TRUE
 	metabolism = REM/2
-	nerve_system_accumulations = -10
+	nerve_system_accumulations = -50
 
 /datum/reagent/medicine/haloperidol/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.bloodstr)

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -12,10 +12,12 @@
 	overdose = REAGENTS_OVERDOSE * 2
 	metabolism = REM * 0.5
 	scannable = TRUE
+	nerve_system_accumulations = -5
 
 /datum/reagent/medicine/inaprovaline/holy
 	id = "holyinaprovaline"
 	scannable = FALSE
+	appear_in_default_catalog = FALSE
 
 /datum/reagent/medicine/inaprovaline/affect_blood(mob/living/carbon/M, alien, effect_multiplier) // No more useless chem of leftover baycode with no inference on health due to pulse not affecting anything. - Seb
 	M.add_chemical_effect(CE_PULSE, 1)
@@ -35,6 +37,7 @@
 	color = "#BF0000"
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
+	nerve_system_accumulations = 35 //Cheap
 
 /datum/reagent/medicine/bicaridine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.species?.reagent_tag == IS_CHTMANT)
@@ -53,6 +56,7 @@
 	color = "#964e06"
 	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = TRUE
+	nerve_system_accumulations = 15
 
 /datum/reagent/medicine/vermicetol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.heal_organ_damage(12 * removed, 0)
@@ -67,6 +71,7 @@
 	color = "#FF69B4" //rgb(255,105,180)hotpink
 	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = TRUE
+	nerve_system_accumulations = 15
 
 /datum/reagent/medicine/varceptol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.heal_organ_damage(9 * removed, 0)
@@ -82,6 +87,7 @@
 	color = "#E6666C"
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
+	nerve_system_accumulations = 15
 
 /datum/reagent/medicine/meralyne/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.heal_organ_damage(0.6 * effect_multiplier, 0, 5 * effect_multiplier)
@@ -96,6 +102,7 @@
 	color = "#FFA800"
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
+	nerve_system_accumulations = 30
 
 /datum/reagent/medicine/kelotane/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.species?.reagent_tag == IS_CHTMANT)
@@ -112,6 +119,7 @@
 	color = "#FF8000"
 	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = TRUE
+	nerve_system_accumulations = 20
 
 /datum/reagent/medicine/dermaline/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.heal_organ_damage(0, 1.2 * effect_multiplier, 0, 5 * effect_multiplier)
@@ -125,6 +133,7 @@
 	color = "#00A000"
 	scannable = TRUE
 	overdose = REAGENTS_OVERDOSE
+	nerve_system_accumulations = 15
 
 /datum/reagent/medicine/dylovene/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.drowsyness = max(0, M.drowsyness - 0.6 * effect_multiplier)
@@ -155,10 +164,11 @@
 /datum/reagent/medicine/carthatoline
 	name = "Carthatoline"
 	id = "carthatoline"
-	description = "Carthatoline is a strong evacuant used to treat severe poisoning."
+	description = "Carthatoline is a strong evacuant used to treat severe poisoning. As well as a mild nerve system relaxant."
 	reagent_state = LIQUID
 	color = "#225722"
 	scannable = TRUE
+	nerve_system_accumulations = -10
 
 /datum/reagent/medicine/carthatoline/affect_blood(var/mob/living/carbon/M, var/alien, effect_multiplier, var/removed = REM)
 	M.adjustToxLoss(-6 * removed)
@@ -184,10 +194,11 @@
 /datum/reagent/medicine/cordradaxon
 	name = "Cordradaxon"
 	id = "cordradaxon"
-	description = "An intense organ repair chemical used to treat damage to the heart."
+	description = "An intense organ repair chemical used to treat damage to the heart. As well as used as a nerve system relaxant."
 	reagent_state = LIQUID
 	color = "#8B0000" // rgb(139,0,0)
 	scannable = TRUE
+	nerve_system_accumulations = -30
 
 /datum/reagent/medicine/cordradaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed = REM)
 	if(ishuman(M))
@@ -208,6 +219,7 @@
 	color = "#0080FF"
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
+	nerve_system_accumulations = 5
 
 /datum/reagent/medicine/dexalin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.species?.reagent_tag == IS_CHTMANT)
@@ -225,6 +237,7 @@
 	color = "#0040FF"
 	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = TRUE
+	nerve_system_accumulations = 10
 
 /datum/reagent/medicine/dexalinp/affect_blood(mob/living/carbon/M, alien, effect_multiplier, var/removed = REM)
 	M.adjustOxyLoss(-30 * effect_multiplier)
@@ -250,6 +263,7 @@
 	color = "#000080"
 	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = TRUE
+	nerve_system_accumulations = 30
 
 /datum/reagent/medicine/respirodaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed = REM)
 	if(ishuman(M))
@@ -270,6 +284,7 @@
 	color = "#8040FF"
 	scannable = TRUE
 	overdose = REAGENTS_OVERDOSE
+	nerve_system_accumulations = 15
 
 /datum/reagent/medicine/tricordrazine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.species?.reagent_tag == IS_CHTMANT)
@@ -358,13 +373,14 @@
 /datum/reagent/medicine/paracetamol
 	name = "Paracetamol"
 	id = "paracetamol"
-	description = "Most probably know this as Tylenol, this chemical is a mild, simple painkiller."
+	description = "Most probably know this as Tylenol, this chemical is a mild, simple painkiller and nerve relaxant."
 	taste_description = "sickness"
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose = 60
 	scannable = TRUE
 	metabolism = 0.1 // Who thought it was a good idea for such a mild painkiller to last a lifetime?
+	nerve_system_accumulations = -10
 
 /datum/reagent/medicine/paracetamol/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_PAINKILLER, 50, TRUE)
@@ -433,7 +449,7 @@
 	scannable = FALSE
 	metabolism = 0.2
 	appear_in_default_catalog = FALSE
-	nerve_system_accumulations = 0
+	nerve_system_accumulations = -100
 
 /datum/reagent/medicine/nepenthe/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_PAINKILLER, 1000)
@@ -450,6 +466,7 @@
 	metabolism = 0.2
 	nerve_system_accumulations = 0
 	appear_in_default_catalog = FALSE
+	nerve_system_accumulations = -30
 
 /datum/reagent/medicine/anodyne/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_PAINKILLER, 90) // Tweaking the numbers here so that they are closer to what litanies used to do, this one is a flat -10 loss to what it used to be...
@@ -466,6 +483,7 @@
 	metabolism = 0.5
 	nerve_system_accumulations = 0
 	appear_in_default_catalog = FALSE
+	nerve_system_accumulations = -15
 
 /datum/reagent/medicine/laudanum/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_PAINKILLER, 40) // ...yet this one is a buff, making it an acceptably low painkiller range while keeping a 50 difference between tiers like Tram-to-Para ratio - Seb
@@ -477,6 +495,7 @@
 	scannable = FALSE
 	appear_in_default_catalog = FALSE
 	overdose = 0
+	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/cindpetamol/holy
 	name = "Alignitol"
@@ -490,6 +509,7 @@
 	constant_metabolism = TRUE
 	scannable = FALSE
 	overdose = 0
+	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/spaceacillin/holy
 	name = "Holycilin"
@@ -500,6 +520,7 @@
 	constant_metabolism = TRUE
 	scannable = FALSE
 	overdose = 0
+	nerve_system_accumulations = 0
 
 /* Other medicine */
 
@@ -536,6 +557,7 @@
 	metabolism = REM * 0.25
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
+	nerve_system_accumulations = 10
 
 /datum/reagent/medicine/alkysine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.adjustBrainLoss(-(3 + (M.getBrainLoss() * 0.05)) * effect_multiplier)
@@ -550,6 +572,7 @@
 	color = "#C8A5DC"
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
+	nerve_system_accumulations = 10
 
 /datum/reagent/medicine/imidazoline/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.eye_blurry = max(M.eye_blurry - (5 * effect_multiplier), 0)
@@ -570,6 +593,7 @@
 	color = "#561EC3"
 	overdose = 10
 	scannable = TRUE
+	nerve_system_accumulations = 40
 
 /datum/reagent/medicine/peridaxon/affect_blood(mob/living/carbon/M, alien, effect_multiplier, var/removed)
 	if(M.species?.reagent_tag == IS_CHTMANT)
@@ -599,6 +623,7 @@
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE // This is a mostly beneficial chem, it should show up on scanners
 	affects_dead = TRUE
+	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/ryetalyn/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	src.on_mob_add(M, alien, effect_multiplier) //I'm going with this to make it both affect dead people for unhusking, and to update on every life tick. Thanks Hydro!
@@ -636,10 +661,11 @@
 /datum/reagent/medicine/ethylredoxrazine
 	name = "Ethylredoxrazine"
 	id = "ethylredoxrazine"
-	description = "A powerful oxidizer that reacts with ethanol."
+	description = "A powerful oxidizer that reacts with ethanol and overstimulation."
 	reagent_state = SOLID
 	color = "#605048"
 	overdose = REAGENTS_OVERDOSE
+	nerve_system_accumulations = -15
 
 /datum/reagent/medicine/ethylredoxrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	M.dizziness = 0
@@ -661,6 +687,7 @@
 	metabolism = REM * 0.25
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
+	nerve_system_accumulations = -5
 
 /datum/reagent/medicine/hyronalin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.radiation = max(M.radiation - (3 * effect_multiplier), 0)
@@ -674,6 +701,7 @@
 	metabolism = REM * 0.25
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
+	nerve_system_accumulations = -15
 
 /datum/reagent/medicine/arithrazine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.radiation = max(M.radiation - (7 + (M.radiation * 0.10)) * effect_multiplier, 0)
@@ -691,6 +719,7 @@
 	metabolism = REM * 0.05 //Infections are already a pain in the neck to treat, this should ease having to re-dose every time above the 5u threshold.
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
+	nerve_system_accumulations = 5
 
 /datum/reagent/medicine/spaceacillin/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	M.adjustToxLoss(-((0.1 + (M.getToxLoss() * 0.01)) * effect_multiplier))
@@ -704,6 +733,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	touch_met = 5
+	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/sterilizine/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
 	M.germ_level -= min(effect_multiplier * 2, M.germ_level)
@@ -732,6 +762,7 @@
 	color = "#C8A5DC"
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
+	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/leporazine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.bodytemperature > 310)
@@ -752,6 +783,7 @@
 	color = "#BF80BF"
 	metabolism = 0.01
 	data = 0
+	nerve_system_accumulations = -20
 
 /datum/reagent/medicine/methylphenidate/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(volume <= 0.1 && data != -1)
@@ -771,6 +803,7 @@
 	color = "#FF80FF"
 	metabolism = 0.01
 	data = 0
+	nerve_system_accumulations = -30
 
 /datum/reagent/medicine/citalopram/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(volume <= 0.1 && data != -1)
@@ -790,6 +823,7 @@
 	color = "#FF80BF"
 	metabolism = 0.01
 	data = 0
+	nerve_system_accumulations = -60
 
 /datum/reagent/medicine/paroxetine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(volume <= 0.1 && data != -1)
@@ -814,6 +848,7 @@
 	color = "#669900"
 	overdose = REAGENTS_OVERDOSE * 0.4 // Should OD at 12 units, you still shouldn't ever use more than 2u at a time anyways. - Seb
 	scannable = TRUE
+	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/rezadone/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.adjustCloneLoss(-(2 + (M.getCloneLoss() * 0.05)) * effect_multiplier)
@@ -839,6 +874,7 @@
 	overdose = REAGENTS_OVERDOSE/2
 	metabolism = REM/4 //we take a LONG time to remove areselfs!
 	scannable = TRUE
+	nerve_system_accumulations = -5
 
 /datum/reagent/medicine/quickclot/affect_blood(mob/living/carbon/M, alien, effect_multiplier, var/removed = REM)
 	M.add_chemical_effect(CE_BLOODCLOT, min(1,0.1 * effect_multiplier))	// adding 0.01 to be more than 0.1 in order to stop int bleeding from growing
@@ -868,6 +904,7 @@
 	overdose = 11 //Can be used in hypos and the like
 	metabolism = REM * 1.5 // Hard stun, impractical use for the situations it's used, and healing per removed unit, this was needed.
 	scannable = TRUE
+	nerve_system_accumulations = 45
 
 /datum/reagent/medicine/ossisine/affect_blood(mob/living/carbon/M, alien, effect_multiplier, var/removed = REM)
 	M.add_chemical_effect(CE_BLOODCLOT, 0.1)
@@ -901,12 +938,13 @@
 /datum/reagent/medicine/noexcutite
 	name = "Noexcutite"
 	id = "noexcutite"
-	description = "A thick, syrupy liquid that has a lethargic effect. Used to cure cases of jitteriness."
+	description = "A thick, syrupy liquid that has a lethargic effect. Used to cure cases of jitteriness and overstimulation."
 	taste_description = "numbing coldness"
 	reagent_state = LIQUID
 	color = "#bc018a"
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
+	nerve_system_accumulations = -35
 
 /datum/reagent/medicine/noexcutite/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.make_jittery(-50)
@@ -955,6 +993,7 @@
 	scannable = TRUE
 	metabolism = REM/2
 	overdose = REAGENTS_OVERDOSE
+	nerve_system_accumulations = 15
 
 /datum/reagent/medicine/polystem/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.heal_organ_damage(0.3 * effect_multiplier, 0, 3 * effect_multiplier)
@@ -973,6 +1012,7 @@
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
 	metabolism = REM/2
+	nerve_system_accumulations = -15
 
 /datum/reagent/medicine/detox/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(!M.metabolism_effects.nsa_chem_bonus)
@@ -1001,6 +1041,7 @@
 	color = "#d4cf3b"
 	scannable = TRUE
 	metabolism = REM/2
+	nerve_system_accumulations = -25
 
 /datum/reagent/medicine/purger/affect_blood(mob/living/carbon/M, alien, effect_multiplier, var/removed = REM)
 	M.add_chemical_effect(CE_PURGER, 1)
@@ -1022,6 +1063,7 @@
 	color = "#0179e7"
 	scannable = TRUE
 	metabolism = REM/2
+	nerve_system_accumulations = -35
 
 /datum/reagent/medicine/addictol/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	var/mob/living/carbon/C = M
@@ -1049,6 +1091,7 @@
 	overdose = REAGENTS_OVERDOSE
 	scannable = TRUE
 	metabolism = REM/2
+	nerve_system_accumulations = -10
 
 /datum/reagent/medicine/aminazine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_NOWITHDRAW, 1)
@@ -1063,6 +1106,7 @@
 	overdose = REAGENTS_OVERDOSE/2
 	scannable = TRUE
 	metabolism = REM/2
+	nerve_system_accumulations = -10
 
 /datum/reagent/medicine/haloperidol/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.bloodstr)
@@ -1126,11 +1170,12 @@
 /datum/reagent/medicine/suppressital
 	name = "Suppressital"
 	id = "suppressital"
-	description = "Medication designed to make breakdowns less likely to happen."
+	description = "Medication designed to make breakdowns less likely to happen. Also is a robust nerve relaxant."
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#001aff"
 	overdose = REAGENTS_OVERDOSE
+	nerve_system_accumulations = -50
 
 /datum/reagent/medicine/suppressital/affect_ingest/(mob/living/carbon/M)
 	if(!M.stats.getPerk(PERK_NJOY))
@@ -1153,6 +1198,7 @@
 	color = "#BF0000"
 	scannable = TRUE
 	overdose = REAGENTS_OVERDOSE
+	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/tangu_extract/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
 	M.adjustOxyLoss(-1.2 * effect_multiplier)
@@ -1178,6 +1224,7 @@
 	overdose = 60
 	scannable = TRUE
 	metabolism = 0.02
+	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/clucker_extract/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_PAINKILLER, 130, TRUE)
@@ -1192,3 +1239,4 @@
 	id = "tahcacillin"
 	description = "An all-purpose antiviral agent derived from tahca horns crushed into a blood mixed extract."
 	constant_metabolism = TRUE
+	nerve_system_accumulations = 0

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -12,6 +12,7 @@
 	var/strength = 0.05 // How much damage it deals per unit
 	reagent_type = "Toxin"
 	scannable = TRUE
+	nerve_system_accumulations = 35 //Baseline toxin is going to heck you up
 
 /datum/reagent/toxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(strength)
@@ -40,6 +41,7 @@
 	reagent_state = LIQUID
 	color = "#CF3600"
 	strength = 0.6
+	nerve_system_accumulations = 45 //Plastic in blood or stomic is going to make you rather sick
 
 /datum/reagent/toxin/oil
 	name = "Oil"
@@ -49,6 +51,7 @@
 	reagent_state = LIQUID
 	color = "#0C0C0C"
 	common = TRUE //Identifiable on sight
+	nerve_system_accumulations = 15
 
 /datum/reagent/toxin/amatoxin
 	name = "Amatoxin"
@@ -73,7 +76,7 @@
 	strength = 0.1
 	overdose = REAGENTS_OVERDOSE/3
 	addiction_chance = 10
-	nerve_system_accumulations = 5
+	nerve_system_accumulations = 45 //Bad suishie
 	heating_point = 523
 	heating_products = list("toxin")
 	reagent_type = "Toxin/Stimulator"
@@ -111,6 +114,7 @@
 	color = "#9D14DB"
 	strength = 0.3
 	touch_met = 5
+	nerve_system_accumulations = 75 //Burning your insides
 
 /datum/reagent/toxin/plasma/touch_mob(mob/living/L, var/amount)
 	if(istype(L))
@@ -131,16 +135,17 @@
 /datum/reagent/toxin/cyanide //Fast and Lethal
 	name = "Cyanide"
 	id = "cyanide"
-	description = "A highly toxic chemical that prevents cellular respiration."
+	description = "A highly toxic chemical that prevents cellular respiration as it builds up. Has uses in helping treating nerve system overstimulation"
 	taste_mult = 0.6
 	reagent_state = LIQUID
 	color = "#CF3600"
 	strength = 0.2
 	metabolism = REM * 2
+	nerve_system_accumulations = -35 //Gives some use
 
 /datum/reagent/toxin/cyanide/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	..()
-	M.adjustOxyLoss(2 * effect_multiplier)
+	M.adjustOxyLoss(2 * dose)
 	M.AdjustSleeping(1)
 
 /datum/reagent/toxin/potassium_chloride
@@ -152,6 +157,7 @@
 	color = "#FFFFFF"
 	strength = 0
 	overdose = REAGENTS_OVERDOSE
+	nerve_system_accumulations = 45
 
 /datum/reagent/toxin/potassium_chloride/overdose(mob/living/carbon/M, alien)
 	..()
@@ -174,6 +180,7 @@
 	color = "#FFFFFF"
 	strength = 0.1
 	overdose = 20
+	nerve_system_accumulations = 85
 
 /datum/reagent/toxin/potassium_chlorophoride/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	..()
@@ -196,6 +203,7 @@
 	metabolism = REM
 	strength = 0.04
 	illegal = TRUE
+	nerve_system_accumulations = -50
 
 /datum/reagent/toxin/zombiepowder/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	..()
@@ -222,6 +230,7 @@
 	strength = 0.01 // It's not THAT poisonous.
 	color = "#664330"
 	common = TRUE
+	nerve_system_accumulations = 30
 
 /datum/reagent/toxin/fertilizer/eznutrient
 	name = "EZ Nutrient"
@@ -234,6 +243,7 @@
 /datum/reagent/toxin/fertilizer/robustharvest
 	name = "Robust Harvest"
 	id = "robustharvest"
+	nerve_system_accumulations = 10
 
 /datum/reagent/toxin/plantbgone
 	name = "Plant-B-Gone"
@@ -243,6 +253,7 @@
 	reagent_state = LIQUID
 	color = "#49002E"
 	strength = 0.04
+	nerve_system_accumulations = 25
 
 /datum/reagent/toxin/plantbgone/touch_turf(turf/T)
 	if(istype(T, /turf/simulated/wall))
@@ -274,6 +285,7 @@
 	power = 10
 	meltdose = 4
 	illegal = TRUE
+	nerve_system_accumulations = 45
 
 
 /datum/reagent/toxin/lexorin
@@ -284,6 +296,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose = REAGENTS_OVERDOSE
+	nerve_system_accumulations = 30
 
 /datum/reagent/toxin/lexorin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.take_organ_damage(0.3 * effect_multiplier, 0)
@@ -298,6 +311,7 @@
 	taste_mult = 0.9
 	reagent_state = LIQUID
 	color = "#13BC5E"
+	nerve_system_accumulations = 70
 
 /datum/reagent/toxin/mutagen/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
 	if(prob(33))
@@ -332,6 +346,7 @@
 	reagent_state = LIQUID
 	color = "#801E28"
 	illegal = TRUE
+	nerve_system_accumulations = 90
 
 /datum/reagent/medicine/slimejelly/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(prob(10))
@@ -349,6 +364,7 @@
 	reagent_state = LIQUID
 	color = "#801E28"
 	illegal = TRUE
+	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/pureslimejelly/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.adjustToxLoss(rand(15,20) * effect_multiplier)
@@ -361,12 +377,13 @@
 /datum/reagent/medicine/soporific
 	name = "Soporific"
 	id = "stoxin"
-	description = "An effective hypnotic used to treat insomnia."
+	description = "An effective hypnotic used to treat insomnia. As well as nerve system overstimulation."
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#009CA8"
 	metabolism = REM * 5
 	overdose = REAGENTS_OVERDOSE
+	nerve_system_accumulations = -50
 
 /datum/reagent/medicine/soporific/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	var/effective_dose = dose
@@ -390,13 +407,14 @@
 /datum/reagent/medicine/chloralhydrate
 	name = "Chloral Hydrate"
 	id = "chloralhydrate"
-	description = "A powerful sedative."
+	description = "A powerful sedative and affective nerve relaxant."
 	taste_description = "bitterness"
 	reagent_state = SOLID
 	color = "#000067"
 	metabolism = REM * 5
 	overdose = REAGENTS_OVERDOSE * 0.5
 	illegal = TRUE
+	nerve_system_accumulations = -90
 
 /datum/reagent/medicine/chloralhydrate/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	var/effective_dose = dose
@@ -438,6 +456,7 @@
 	taste_description = "sludge"
 	reagent_state = LIQUID
 	color = "#13BC5E"
+	nerve_system_accumulations = 0
 
 /datum/reagent/toxin/slimetoxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(ishuman(M))
@@ -453,6 +472,7 @@
 	taste_description = "sludge"
 	reagent_state = LIQUID
 	color = "#13BC5E"
+	nerve_system_accumulations = 0
 
 /datum/reagent/toxin/aslimetoxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier) // TODO: check if there's similar code anywhere else
 	if(HAS_TRANSFORMATION_MOVEMENT_HANDLER(M))
@@ -479,14 +499,6 @@
 		new_mob.key = M.key
 	qdel(M)
 
-/datum/reagent/other/xenomicrobes
-	name = "Xenomicrobes"
-	id = "xenomicrobes"
-	description = "Microbes with an entirely alien cellular structure."
-	taste_description = "sludge"
-	reagent_state = LIQUID
-	color = "#535E66"
-
 /datum/reagent/toxin/pararein
 	name = "Pararein"
 	id = "pararein"
@@ -496,7 +508,7 @@
 	color = "#a37d9c"
 	overdose = REAGENTS_OVERDOSE/3
 	addiction_chance = 0.01 //Will STILL likely always be addicting
-	nerve_system_accumulations = 10
+	nerve_system_accumulations = 30
 	metabolism = REM * 0.2 //but processes much faster than other toxins
 	strength = 0.3 //Rather lethal
 	heating_point = 523
@@ -517,7 +529,7 @@
 	color = "#acc107"
 	overdose = REAGENTS_OVERDOSE
 	addiction_chance = 10
-	nerve_system_accumulations = 5
+	nerve_system_accumulations = 15
 
 /datum/reagent/toxin/aranecolmin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_ANTITOX, 0.3)
@@ -693,7 +705,7 @@
 	color = "#a6b85b"
 	overdose = 16
 	addiction_chance = 30
-	nerve_system_accumulations = 4
+	nerve_system_accumulations = 10
 	heating_point = 573
 	heating_products = list("radium", "mercury", "lithium", "nutriment")
 
@@ -732,6 +744,7 @@
 	color = "#527f4f"
 	strength = 0.3
 	common = TRUE //Church should know if they actually have biomatter or something else.
+	nerve_system_accumulations = 50
 
 /datum/reagent/toxin/biomatter/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	..()
@@ -765,7 +778,7 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#ffb3b7"
-	nerve_system_accumulations = 5
+	nerve_system_accumulations = 30
 	addiction_chance = 10
 	scannable = TRUE
 	metabolism = REM/4
@@ -804,6 +817,7 @@
 	strength = 0.8
 	overdose = REAGENTS_OVERDOSE/2
 	illegal = TRUE
+	nerve_system_accumulations = 90
 
 /datum/reagent/toxin/combat/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	..()
@@ -850,6 +864,7 @@
 	color = "#CF3600"
 	strength = 0.2
 	metabolism = REM * 2
+	nerve_system_accumulations = 40
 	var/agony_amount = 4
 
 /datum/reagent/toxin/wasp_toxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -456,7 +456,7 @@
 	taste_description = "sludge"
 	reagent_state = LIQUID
 	color = "#13BC5E"
-	nerve_system_accumulations = 0
+	nerve_system_accumulations = 50
 
 /datum/reagent/toxin/slimetoxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(ishuman(M))
@@ -508,7 +508,7 @@
 	color = "#a37d9c"
 	overdose = REAGENTS_OVERDOSE/3
 	addiction_chance = 0.01 //Will STILL likely always be addicting
-	nerve_system_accumulations = 30
+	nerve_system_accumulations = 15
 	metabolism = REM * 0.2 //but processes much faster than other toxins
 	strength = 0.3 //Rather lethal
 	heating_point = 523
@@ -864,7 +864,7 @@
 	color = "#CF3600"
 	strength = 0.2
 	metabolism = REM * 2
-	nerve_system_accumulations = 40
+	nerve_system_accumulations = 30
 	var/agony_amount = 4
 
 /datum/reagent/toxin/wasp_toxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -315,7 +315,7 @@
 			owner.give_health_via_stats()
 			while(stat_pool > 0)
 				stat_pool--
-				LAZYAPLUS(stat_change, pick(ALL_STATS), 3)
+				LAZYAPLUS(stat_change, pick(ALL_STATS_FOR_LEVEL_UP), 3)
 
 			for(var/stat in stat_change)
 				owner.stats.changeStat(stat, stat_change[stat])


### PR DESCRIPTION
Long time no see from dah cat, back at with todays deal with Satin themself.
Lets start with the good news
Smelters now properly respect stack items once again and no longer reduces its materals so its 1:1 wooh
Thats about it for good news
Now for the greate changes ya been waiting for
Ana no longer is randomly and for free given out, it was a nice test to see how it would work and sadly its a bit to powerful.
Second NSA now has a much bigger selection of malus affects from making you see things, to giving you a heart attack so its actually lethal. But wait theirs more, most toxins now give **way** more nsa, most medical aid as well. 
On the flip side many more useless chems or sleeping agents now also help lower nsa build up to help treat overstimulation without needing to fully purge and swap mixes.