### PR TITLE
Department Account Tweaks

### DIFF
--- a/code/game/jobs/department.dm
+++ b/code/game/jobs/department.dm
@@ -48,8 +48,9 @@
 	In future, we will implement largescale missions and research contracts to earn money, and then set it
 	to a much lower starting value
 	*/
-	account_initial_balance = 50000
+	account_initial_balance = 50000 //Emergency / Discression funding. 50k acceptable; used to cover costs of other departments as needed by the Premier / Steward. Consider reducing by 10-20k if too much.
 	jobs_in_department = list("/datum/job/premier","/datum/job/pg")
+
 /*************
 	Retainers
 **************/
@@ -60,14 +61,14 @@
 	//This is balanced around full team in 6 hours with nepitism
 	//Without nepitsm a full team 27000 in 6 hours
 	//With nepitsm a full team 35100 in 6 hours
-	account_initial_balance = 50000 //+15k~ do to being state funded
+	account_initial_balance = 40000 //Estimated 5k extra credits than what is required for wages on a full roster.
 	jobs_in_department = list("/datum/job/smc","/datum/job/swo","/datum/job/supsec","/datum/job/serg","/datum/job/inspector","/datum/job/medspec","/datum/job/trooper","/datum/job/officer")
 
 
 /datum/department/technomancers
 	name = "Artificer's Guild"
 	id = DEPARTMENT_ENGINEERING
-	account_initial_balance = 25000 //+15k~ do to being state funded
+	account_initial_balance = 14000 //Few extra thousand credits than needed for wages, covers material cost. Any extra money should be aquired through sales.
 	//Full team with nepitsm in 6 hours is 11900
 	//A full crew GM + 4 adpets is 1700 an hour, takes 10~ hours to drain the department funds
 	jobs_in_department = list("/datum/job/chief_engineer","/datum/job/technomancer")
@@ -89,7 +90,7 @@
 	id = DEPARTMENT_MEDICAL
 	//18600 in 6 hours with full crew
 	//24180 in 6 hours with full crew + nep
-	account_initial_balance = 30000 //5~k For buying medical and items and payments
+	account_initial_balance = 24200 //Covers crew-cost. Rest should be made up for by medical fees and chem sales.
 	jobs_in_department = list("datum/job/cmo","/datum/job/doctor","/datum/job/recovery_team","/datum/job/psychiatrist")
 
 /datum/department/moebius_research
@@ -97,7 +98,7 @@
 	id = DEPARTMENT_SCIENCE
 	//15000 in 6 hours with full crew
 	//19500 in 6 hours with full crew + nepitism
-	account_initial_balance = 20000 //+10k~ For buying materials and components and things of scientific value as well as pay the demanding staff
+	account_initial_balance = 20000 //Covers basic fees of employees. Sell posis and whatever else to make up for material cost.
 	jobs_in_department = list("/datum/job/rd","/datum/job/scientist","/datum/job/roboticist")
 
 /datum/department/church
@@ -105,7 +106,7 @@
 	id = DEPARTMENT_CHURCH
 	//9600 in 6 hours with full crew
 	//12480 with all nep in 6 hours
-	account_initial_balance = 25000 //Materals, and they are the faith, they donate and get a lot to the colony thus they have a lot to spend
+	account_initial_balance = 12500 //Covers base wages. Biomatter, farm, solars, trash beacon - fully self-sufficent. Sell things for more money.
 	jobs_in_department = list ("/datum/job/chaplain","/datum/job/acolyte")
 
 /******************
@@ -123,7 +124,7 @@
 	if you manage to get this variable refferenced there you're a better man than me. godspeed
 	*/
 	//Note: LSS isnt accounted for wages when starting money as they have the easyest ways to make money
-	account_initial_balance = 25000 //has a lot of workers thus needs a higher starting to off-set its paychecks if no one actively runs the cargo shuttle
+	account_initial_balance = 17000 //Has a lot of workers to pay - but their /entire/ job is literally to make money. Should cover the base nessessities of hourly payment.
 	jobs_in_department = list("/datum/job/merchant","/datum/job/cargo_tech","/datum/job/mining")
 
 /datum/department/prospector
@@ -132,7 +133,7 @@
 	//Full team in 6 hours is 6600
 	//Full team with Nep in 6 hours is 6600
 	//Nep in 6 hours with full team is 8580
-	account_initial_balance = 12500 //5k+6~hours of work. should be good for them to make money
+	account_initial_balance = 8500 //Starts with an even wage to cover payment-expenses. Their job is to make money and, thus, should not start with more money than needed.
 	jobs_in_department = list("/datum/job/foreman","/datum/job/salvager","/datum/job/pro")
 
 /datum/department/independent


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hello,

Bad rebelman back with a new PR that deflates our economy, allowing us to finally advanced past the need for the Zimbabwe hyper inflated currency.

Basically does what should have been done ages ago as agreed upon to reduce department accounts to cover wages with a tiny bit of discretion funding to encourage a want to participate in sales to earn money. Similarly, the command department has kept its emergency funding to allow them some level of negotiating authority in an emergency situation.

This can be adjusted or tweaked as we go, this should serve fine as we rarely max out departments let alone max them out with every player having nepotism. Even if everyone _did_ have nepotism - their wages would still be covered.

## Changelog
:cl:
balance: Balances budgets of departments.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
