### PR TITLE
Adjusted Robotic Limbs

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -269,14 +269,14 @@
 
 //Note: external organs have their own version of this proc
 /obj/item/organ/proc/take_damage(amount, silent=0)
-	if(BP_IS_ROBOTIC(src))
+	/*if(BP_IS_ROBOTIC(src))
 		damage = between(0, damage + (amount * 0.8), max_damage)
 	else
-		damage = between(0, damage + amount, max_damage)
+		damage = between(0, damage + amount, max_damage)*/
 
-		//only show this if the organ is not robotic
-		if(owner && parent && amount > 0 && !silent)
-			owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
+	//only show this if the organ is not robotic
+	if(owner && parent && amount > 0 && !silent)
+		owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
 
 /obj/item/organ/proc/bruise()
 	damage = max(damage, min_bruised_damage)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -150,7 +150,7 @@
 
 		//For if a user is doing 'surgery' on their own prosthetic bodypart
 		if(nature == MODIFICATION_SILICON)
-			difficulty_adjust = 80
+			difficulty_adjust = 60
 			time_adjust = 20
 
 		// ...unless you are a carrion


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simply makes a change that I believe may have been an oversight when we adjusted our system some time back of max.health and health changes; both by anatomy and changing how buffs/nerfs worked (replacing brute modifiers with health modifiers, etc)

Changes robotic limbs to effectively not get 20% extra 'armor' on top of whatever the limb gave previously. This makes it so robotic limbs actually do feel like they have less health than human limbs. Previously you had to hit a robot's limb more times with a high-damage weapon to gib/knock it off than a human counterpart. This changes that to allow limbs of robots to be more flimsy but allow self repair.

As such - self repair has been made slightly easier as well to compensate for the the fact synthetic limbs will take 20% more damage now (not taking extra, taking the same incoming damage just as human limbs now.)

## Changelog
:cl:
balance: Robotic limbs no longer get a 20% decrease to incoming damage.
balance: Robotic self-surgery has been made slightly easier to compensate for less-strong limbs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
