### PR TITLE
Guild TEG changes + small bar mapfix

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -31,7 +31,6 @@
 	deepmaint_entry_point = 1;
 	desc = "Cracks on the floor, yet you can see shifting lights and hear the tick of crawling clawed beasts below...";
 	isRevealed = 1;
-	isSealed = 1;
 	name = "strange cracks"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -62,8 +61,7 @@
 "aas" = (
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -169,8 +167,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/box/white/corners,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -233,8 +230,7 @@
 	},
 /obj/structure/mirror{
 	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -381,7 +377,6 @@
 	frequency = 1379;
 	master_tag = "xeno_airlock_control";
 	name = "Xenobiology Access Button";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(55)
 	},
@@ -463,8 +458,7 @@
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/orangedouble,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/crew_quarters/dorm1{
@@ -481,12 +475,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -544,8 +536,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "adU" = (
@@ -666,7 +657,6 @@
 "aeS" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/pen/multi,
@@ -720,7 +710,6 @@
 /obj/random/gun_normal,
 /obj/random/gun_fancy/low_chance,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -947,7 +936,6 @@
 "ahR" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/item/device/radio/intercom{
@@ -1054,7 +1042,6 @@
 	},
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
-	icon_state = "danger";
 	tag = "icon-danger (EAST)"
 	},
 /obj/structure/ore_box,
@@ -1085,7 +1072,6 @@
 "ajf" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -1102,8 +1088,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/maintenance/surface_maints_1)
 "ajA" = (
@@ -1291,8 +1276,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -1335,8 +1319,7 @@
 /area/colony)
 "amy" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/machinery/light{
 	light_color = "#b9e8ea"
@@ -1423,8 +1406,7 @@
 "anB" = (
 /obj/machinery/vending/assist,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -1467,8 +1449,7 @@
 /area/nadezhda/quartermaster/miningdock)
 "aoh" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -1497,17 +1478,14 @@
 /obj/item/storage/freezer,
 /obj/structure/closet/secure_closet/freezer/blood,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
 "aoq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
@@ -1621,12 +1599,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
@@ -1641,8 +1617,7 @@
 /area/nadezhda/outside/forest)
 "aqo" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -1669,8 +1644,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -1705,8 +1679,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 1
@@ -1816,7 +1789,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -1935,19 +1907,16 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/crew_quarters/kitchen)
 "atk" = (
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
@@ -1971,8 +1940,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -2261,7 +2229,6 @@
 /area/nadezhda/security/tactical)
 "avU" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4;
 	name = "Marshals Brig";
 	req_one_access = list(63)
 	},
@@ -2318,8 +2285,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "awx" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
@@ -2414,8 +2380,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -2501,8 +2466,7 @@
 /area/eris/crew_quarters/plasma_tag)
 "azp" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/machinery/vending/fortune,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -2570,7 +2534,6 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/white/cargo,
@@ -2599,15 +2562,13 @@
 	icon_state = "16-0"
 	},
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /obj/structure/railing/grey{
 	dir = 1
 	},
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey,
 /obj/structure/cable/yellow,
@@ -2647,7 +2608,6 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/wood/wild5,
@@ -2768,8 +2728,7 @@
 /area/nadezhda/rnd/research)
 "aCl" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -2904,8 +2863,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "aDX" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/captain/quarters)
@@ -3276,8 +3234,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
@@ -3421,7 +3378,6 @@
 "aJv" = (
 /obj/structure/table/bench/wooden,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/camera/network/colony_underground,
@@ -3488,7 +3444,6 @@
 "aJQ" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
-	icon_state = "danger";
 	tag = "icon-danger (EAST)"
 	},
 /obj/structure/cable/yellow{
@@ -3522,8 +3477,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "aJU" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/structure/table/rack/shelf,
 /obj/random/surgery_tool/low_chance,
@@ -3580,8 +3534,7 @@
 "aKr" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "aKt" = (
@@ -3622,7 +3575,6 @@
 /obj/machinery/button/remote/airlock{
 	id = "F2-A3";
 	name = "Door Bolt Control";
-	pixel_x = 0;
 	pixel_y = -20;
 	specialfunctions = 4
 	},
@@ -3708,7 +3660,6 @@
 	dir = 5
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/wood,
@@ -3798,8 +3749,7 @@
 /obj/structure/table/standard,
 /obj/random/boxes,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -3990,8 +3940,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -4187,8 +4136,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -4300,8 +4248,7 @@
 "aQL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -4423,7 +4370,6 @@
 "aSw" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
-	icon_state = "danger";
 	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -4508,7 +4454,6 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/effect/floor_decal/spline/plain{
@@ -4781,8 +4726,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4803,7 +4747,6 @@
 "aWH" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -4883,8 +4826,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4898,8 +4840,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/hallway/side/f2section1)
@@ -4958,7 +4899,6 @@
 	pixel_y = 16
 	},
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
@@ -5004,8 +4944,7 @@
 	},
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Science - Upper";
@@ -5145,7 +5084,6 @@
 /obj/effect/floor_decal/border/techfloor,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/cluster/roaches/low_chance,
@@ -5180,15 +5118,13 @@
 "aZN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/structure/cable/yellow{
@@ -5238,11 +5174,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -5323,12 +5257,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/construction)
@@ -5411,8 +5343,7 @@
 "bbP" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -5442,8 +5373,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "bch" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5569,8 +5499,7 @@
 /area/nadezhda/maintenance/substation/section7)
 "bdl" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -5603,7 +5532,6 @@
 /obj/item/clothing/under/costume/history/pirate,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/item/toy/weapon/sword,
@@ -5639,17 +5567,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/hallway/surface/section1)
-"bdR" = (
-/obj/machinery/ai_slipper{
-	icon_state = "motion0"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
 "bdT" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5698,8 +5615,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "bew" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -5723,8 +5639,7 @@
 "beC" = (
 /obj/machinery/autolathe/loaded,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -5823,7 +5738,6 @@
 /obj/effect/floor_decal/industrial/outline,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/vending/wallmed/lobby{
@@ -5853,7 +5767,6 @@
 "bfK" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -5886,8 +5799,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
@@ -6029,13 +5941,6 @@
 "bhK" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
-"bhP" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/open,
-/area/nadezhda/security/prisoncells)
 "bhS" = (
 /obj/structure/holostool,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -6056,12 +5961,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/structure/cable/cyan{
 	d1 = 16;
@@ -6401,9 +6304,7 @@
 /obj/structure/closet/crate/secure,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/random/material_rare/low_chance,
 /obj/random/material_rare/low_chance,
@@ -6431,8 +6332,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "blE" = (
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/mineral,
 /area/nadezhda/outside/inside_colony)
@@ -6520,8 +6420,7 @@
 /area/nadezhda/medical/organ_lab)
 "bms" = (
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -6534,7 +6433,6 @@
 "bmy" = (
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -6616,8 +6514,7 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "bny" = (
@@ -6656,7 +6553,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = null;
 	name = "Chem/Viro Labs";
 	req_access = list(5)
 	},
@@ -6746,11 +6642,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -6771,8 +6665,7 @@
 /area/shuttle/rocinante_shuttle_area)
 "boU" = (
 /obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -6799,16 +6692,13 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/hallway/side/f2section1)
@@ -6895,8 +6785,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "bpW" = (
@@ -6924,7 +6813,6 @@
 "bqj" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/computer/general_air_control{
@@ -6938,7 +6826,6 @@
 "bqq" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -6987,8 +6874,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/curtain/open,
 /turf/simulated/floor/tiled/cafe,
@@ -7099,8 +6985,7 @@
 /obj/random/mob/spiders,
 /obj/effect/spider/stickyweb,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -7108,12 +6993,10 @@
 "bsi" = (
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -7289,8 +7172,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "bum" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 6;
-	icon_state = "spline_fancy"
+	dir = 6
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7316,8 +7198,7 @@
 "buH" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
@@ -7382,8 +7263,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "bvd" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/quartermaster/miningdock)
@@ -7430,7 +7310,6 @@
 "bvv" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -7452,7 +7331,6 @@
 "bvA" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/window/reinforced,
@@ -7576,8 +7454,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "bwA" = (
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/plating/under,
@@ -7602,7 +7479,6 @@
 	},
 /obj/structure/window/basic{
 	dir = 4;
-	icon_state = "window";
 	pixel_x = 3
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -7637,8 +7513,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
@@ -7687,8 +7562,7 @@
 	dir = 9
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -7709,8 +7583,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -7722,9 +7595,7 @@
 "bxQ" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spider/stickyweb,
@@ -7878,17 +7749,13 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/medical/organ_lab)
 "bzT" = (
-/mob/living/simple_animal/goose{
-	faction = "pond"
-	},
+/mob/living/simple_animal/goose,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
 "bzZ" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
-	icon_state = "door_closed";
 	id_tag = "cargo_bay_door";
-	locked = 0;
 	name = "Cargo Factory Floor";
 	req_access = list(50)
 	},
@@ -8021,8 +7888,7 @@
 /area/nadezhda/outside/lakeside)
 "bBv" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/captain/quarters)
@@ -8044,8 +7910,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "bBR" = (
@@ -8068,8 +7933,7 @@
 "bBW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /obj/structure/flora/small/grassa4,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -8440,8 +8304,7 @@
 "bGe" = (
 /obj/structure/catwalk,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey{
 	dir = 1
@@ -8492,8 +8355,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "bGL" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 9;
-	icon_state = "spline_fancy"
+	dir = 9
 	},
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/asteroid/grass,
@@ -8542,15 +8404,13 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bHh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -8600,13 +8460,9 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "bHq" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8761,8 +8617,7 @@
 /obj/structure/flora/small/bushc2,
 /obj/structure/flora/small/grassb5,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
@@ -8993,19 +8848,16 @@
 /area/nadezhda/command/bridge)
 "bMd" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/steel,
@@ -9066,8 +8918,7 @@
 /area/nadezhda/dungeon/outside/burned_outpost)
 "bMK" = (
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -9098,7 +8949,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -9113,8 +8963,7 @@
 "bNv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
@@ -9175,8 +9024,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/white/violetcorener,
@@ -9341,15 +9189,13 @@
 	icon_state = "0-8"
 	},
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /obj/structure/railing/grey{
 	dir = 1
 	},
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/section3)
@@ -9367,8 +9213,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -9444,8 +9289,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/medical/reception)
@@ -9664,7 +9508,6 @@
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/spray/plantbgone{
@@ -9687,9 +9530,7 @@
 /area/nadezhda/outside/bcave)
 "bTi" = (
 /obj/machinery/door/airlock/multi_tile/metal/mait{
-	dir = 2;
-	icon_state = "door_closed";
-	name = "Airlock"
+	dir = 2
 	},
 /obj/random/traps/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -9774,14 +9615,6 @@
 	opacity = 0
 	},
 /area/shuttle/rocinante_shuttle_area)
-"bTV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/sechall)
 "bUg" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/bush,
@@ -9826,8 +9659,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "bVe" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/open,
 /area/nadezhda/medical/sleeper)
@@ -9900,8 +9732,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/security/maingate{
@@ -9976,7 +9807,6 @@
 /area/nadezhda/medical/psych)
 "bWW" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -10165,11 +9995,9 @@
 /area/nadezhda/engineering/atmos/storage)
 "bYL" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -10220,8 +10048,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "bZn" = (
@@ -10293,8 +10120,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/maintenance/surface_maints_1)
 "bZL" = (
@@ -10474,7 +10300,6 @@
 "caY" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -10558,7 +10383,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
@@ -10587,7 +10411,6 @@
 "ccb" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/decal/cleanable/rubble,
@@ -10686,8 +10509,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "cdb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -10833,13 +10655,6 @@
 "cfu" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"cfH" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/engineering/atmos/storage)
 "cfK" = (
 /obj/machinery/camera/xray/security{
 	dir = 9
@@ -10859,8 +10674,7 @@
 /area/nadezhda/storage/primary)
 "cfQ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -10978,7 +10792,6 @@
 /obj/machinery/button/remote/airlock{
 	id = "shuttle_props_hatch_bolts";
 	name = "Door Bolt Control";
-	pixel_x = 0;
 	specialfunctions = 4
 	},
 /turf/simulated/shuttle/wall/mining{
@@ -11008,12 +10821,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -11074,12 +10885,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -11149,8 +10958,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/random/traps/low_chance,
 /obj/effect/spider/stickyweb,
@@ -11200,7 +11008,6 @@
 	},
 /obj/effect/floor_decal/corner_techfloor_grid/diagonal,
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5{
@@ -11320,7 +11127,6 @@
 /area/shuttle/rocinante_shuttle_area)
 "ckc" = (
 /obj/structure/sink/kitchen{
-	name = "kitchen sink";
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/cafe,
@@ -11360,8 +11166,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/tiled/steel,
@@ -11407,7 +11212,6 @@
 "ckV" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -11417,7 +11221,6 @@
 /obj/effect/floor_decal/industrial/arrows/white,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/cafe,
@@ -11489,7 +11292,6 @@
 "clY" = (
 /obj/structure/disposalpipe/up{
 	dir = 8;
-	icon_state = "pipe-u";
 	tag = "icon-pipe-u (WEST)"
 	},
 /turf/simulated/open,
@@ -11515,12 +11317,10 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -11531,10 +11331,7 @@
 /area/nadezhda/hallway/surface/section1)
 "cmD" = (
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/effect/decal/cleanable/dirt,
@@ -11600,7 +11397,6 @@
 "cnI" = (
 /obj/structure/disposalpipe/down{
 	dir = 4;
-	icon_state = "pipe-d";
 	tag = "icon-pipe-d (EAST)"
 	},
 /turf/simulated/open,
@@ -11667,8 +11463,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking{
@@ -11739,8 +11534,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
@@ -11854,7 +11648,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -11868,9 +11661,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -11897,8 +11688,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/light/small,
@@ -11941,8 +11731,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -11952,8 +11741,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/docking)
@@ -12232,12 +12020,10 @@
 /obj/structure/flora/pottedplant/flower,
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/crematorium)
@@ -12252,8 +12038,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -12286,8 +12071,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/tactical_blackshield)
@@ -12357,8 +12141,7 @@
 	input_level = 250000;
 	inputting = 1;
 	output_attempt = 1;
-	output_level = 250000;
-	outputting = 0
+	output_level = 250000
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
@@ -12433,7 +12216,6 @@
 /obj/effect/floor_decal/spline/plain,
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -12474,8 +12256,7 @@
 	},
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Command";
@@ -12511,7 +12292,6 @@
 /area/nadezhda/outside/bcave)
 "cwf" = (
 /obj/structure/sink/kitchen{
-	name = "kitchen sink";
 	pixel_y = 28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -12659,8 +12439,7 @@
 /area/nadezhda/medical/cryo)
 "cxR" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/alarm{
 	desc = "This one has no access lock to allow for the vents to be turned on and off when needed.";
@@ -12746,8 +12525,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "cyt" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -12860,11 +12638,9 @@
 /area/nadezhda/hallway/surface/section1)
 "czs" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -12929,8 +12705,7 @@
 "cAl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "cAn" = (
@@ -13161,7 +12936,6 @@
 	dir = 1
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/random/furniture/pottedplant,
@@ -13266,8 +13040,7 @@
 /area/nadezhda/outside/forest)
 "cCP" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -13418,12 +13191,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -13455,8 +13226,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "cEc" = (
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /turf/simulated/mineral,
 /area/colony)
@@ -13598,8 +13368,7 @@
 "cFL" = (
 /obj/structure/curtain/open,
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -13617,7 +13386,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
@@ -13704,8 +13472,7 @@
 /area/nadezhda/crew_quarters/pool)
 "cHc" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13881,7 +13648,6 @@
 "cIY" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
-	icon_state = "danger";
 	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -13932,8 +13698,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
@@ -14121,11 +13886,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -14168,8 +13931,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14344,7 +14106,6 @@
 "cNE" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/industrial/arrows/white{
@@ -14405,8 +14166,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "cOf" = (
@@ -14450,9 +14210,7 @@
 "cOp" = (
 /obj/structure/lattice,
 /obj/machinery/light,
-/obj/machinery/ai_slipper{
-	icon_state = "motion0"
-	},
+/obj/machinery/ai_slipper,
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "cOu" = (
@@ -14461,11 +14219,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
@@ -14619,8 +14375,7 @@
 /area/eris/crew_quarters/plasma_tag)
 "cRe" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -14712,7 +14467,6 @@
 /area/nadezhda/maintenance/guild)
 "cSs" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/structure/cable/green{
@@ -14825,12 +14579,10 @@
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -14935,8 +14687,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "cUC" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 5;
-	icon_state = "spline_fancy"
+	dir = 5
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -15036,7 +14787,6 @@
 "cVH" = (
 /obj/structure/bed/chair/wood{
 	dir = 1;
-	icon_state = "wooden_chair";
 	tag = "icon-wooden_chair (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -15089,8 +14839,7 @@
 /area/nadezhda/medical/virology)
 "cWp" = (
 /obj/effect/floor_decal/industrial/danger/corner{
-	dir = 1;
-	icon_state = "dangercorner"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/crew_quarters/plasma_tag)
@@ -15134,8 +14883,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -15333,8 +15081,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/decal/cleanable/dirt,
@@ -15379,8 +15126,7 @@
 "dar" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -15422,11 +15168,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/janitor)
@@ -15440,7 +15184,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -15527,7 +15270,6 @@
 /area/shuttle/surface_transport_lz)
 "dbw" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -15548,8 +15290,7 @@
 	})
 "dbK" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/structure/table/rack/shelf,
 /obj/random/medical_lowcost/low_chance,
@@ -15588,8 +15329,7 @@
 "dbQ" = (
 /obj/structure/flora/small/grassa2,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -15599,7 +15339,6 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "dbS" = (
 /obj/structure/flora/church_tree{
-	density = 0;
 	icon_state = "red_tree"
 	},
 /turf/simulated/floor/wood,
@@ -15647,8 +15386,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/security/prisoncells{
@@ -15703,8 +15441,7 @@
 "ddi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -15798,8 +15535,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/door/window/southleft{
 	name = "shower door"
@@ -15852,12 +15588,10 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "deu" = (
 /obj/item/device/radio/intercom/private{
-	dir = 2;
 	pixel_x = 28;
 	pixel_y = 4
 	},
 /obj/item/device/radio/intercom/custom{
-	dir = 2;
 	pixel_x = -28;
 	pixel_y = 4
 	},
@@ -15957,8 +15691,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
@@ -16087,7 +15820,6 @@
 "dgZ" = (
 /obj/structure/table/bench/marble,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/white/cargo,
@@ -16159,8 +15891,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -16175,8 +15906,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/decal/cleanable/dirt,
@@ -16213,8 +15943,7 @@
 /obj/structure/table/rack/shelf,
 /obj/random/powercell/low_chance,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/quartermaster/miningdock)
@@ -16336,7 +16065,6 @@
 	},
 /obj/structure/window/basic{
 	dir = 4;
-	icon_state = "window";
 	pixel_x = 3
 	},
 /obj/machinery/light,
@@ -16384,8 +16112,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/pros/prep)
@@ -16527,8 +16254,7 @@
 /obj/item/device/scanner/plant,
 /obj/item/storage/makeshift_grinder,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
@@ -16619,9 +16345,7 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "dmz" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
@@ -16639,8 +16363,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
@@ -16722,8 +16445,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -16751,8 +16473,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/hallway/surface/section1)
@@ -16760,8 +16481,7 @@
 /obj/structure/table/reinforced,
 /obj/item/aiModule/corp,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/aiModule/asimov,
 /obj/item/aiModule/robocop,
@@ -16871,15 +16591,13 @@
 "doN" = (
 /obj/machinery/washing_machine,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/crew_quarters/toilet/public)
 "doT" = (
@@ -16889,7 +16607,6 @@
 "doV" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/pen/multi,
@@ -16927,10 +16644,7 @@
 /area/nadezhda/outside/forest)
 "dpi" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 1
@@ -16960,7 +16674,6 @@
 	charge = 2.5e+006;
 	input_attempt = 1;
 	input_level = 250000;
-	inputting = 0;
 	output_attempt = 1;
 	output_level = 250000
 	},
@@ -16975,8 +16688,7 @@
 /area/nadezhda/command/tcommsat/computer)
 "dpu" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -16997,7 +16709,6 @@
 "dpy" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -17252,8 +16963,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "drN" = (
@@ -17296,8 +17006,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -17543,12 +17252,10 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/disposal/deliveryChute,
 /obj/machinery/door/window/southright{
-	dir = 2;
 	icon_state = "left";
 	name = "Containment Pen";
 	req_access = newlist()
@@ -17662,8 +17369,7 @@
 /area/nadezhda/command/bridge)
 "dvG" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/structure/reagent_dispensers/fueltank/huge,
 /obj/effect/decal/cleanable/dirt,
@@ -17706,7 +17412,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -17732,8 +17437,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/machinery/constructable_frame/machine_frame{
 	state = 2
@@ -17855,8 +17559,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "dxC" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -18291,7 +17994,6 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -18511,7 +18213,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -18724,8 +18425,7 @@
 /area/nadezhda/hallway/surface/section1)
 "dFH" = (
 /obj/item/device/radio/intercom/department/security{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/cable{
@@ -18803,7 +18503,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/scrap/sparse_weighted,
@@ -18903,7 +18602,6 @@
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -18958,8 +18656,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
@@ -19062,9 +18759,7 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/cbo)
@@ -19124,8 +18819,7 @@
 /area/nadezhda/pros/prep)
 "dKq" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -19138,7 +18832,6 @@
 "dKv" = (
 /obj/structure/table/steel,
 /obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/item/device/radio/intercom{
@@ -19207,7 +18900,6 @@
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_weighted,
@@ -19266,12 +18958,10 @@
 "dLW" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
-	id = null;
 	name = "Outpost Cell"
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
-	id = null;
 	name = "Outpost Cell"
 	},
 /obj/structure/disposalpipe/segment,
@@ -19503,7 +19193,6 @@
 "dNI" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Bioreactor - Main - 1";
-	capacity = 5e+006;
 	charge = 5e+006;
 	cur_coils = 4;
 	input_attempt = 1;
@@ -19579,9 +19268,7 @@
 "dOk" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -19649,8 +19336,7 @@
 "dOT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19688,8 +19374,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "dPK" = (
 /obj/effect/floor_decal/industrial/danger/corner{
-	dir = 4;
-	icon_state = "dangercorner"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/crew_quarters/plasma_tag)
@@ -19854,8 +19539,7 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "dRC" = (
@@ -19944,14 +19628,11 @@
 /area/nadezhda/security/prisoncells)
 "dSo" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -20054,7 +19735,9 @@
 	pixel_x = 9;
 	pixel_y = -22
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "dTH" = (
@@ -20081,8 +19764,7 @@
 /area/nadezhda/engineering/construction)
 "dTV" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/techshop)
@@ -20126,9 +19808,7 @@
 /area/nadezhda/quartermaster/office)
 "dUr" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/machinery/hologram/holopad,
 /obj/structure/noticeboard/marshal{
@@ -20321,7 +20001,6 @@
 /area/nadezhda/quartermaster/office)
 "dWw" = (
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = null;
 	name = "Monkey Containment";
 	req_access = list(39)
 	},
@@ -20362,7 +20041,6 @@
 "dWJ" = (
 /obj/structure/table/standard,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -20414,7 +20092,6 @@
 "dXG" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -20427,8 +20104,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dXL" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/carpet/bcarpet,
@@ -20556,8 +20232,7 @@
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "dYM" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20573,8 +20248,7 @@
 /area/nadezhda/absolutism/bioreactor)
 "dYQ" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20602,8 +20276,7 @@
 	},
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -20615,7 +20288,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -20715,8 +20387,7 @@
 /obj/landmark/join/start/officer,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
@@ -20848,7 +20519,6 @@
 "ebp" = (
 /obj/structure/disposalpipe/down{
 	dir = 4;
-	icon_state = "pipe-d";
 	tag = "icon-pipe-d (EAST)"
 	},
 /turf/simulated/open,
@@ -20865,9 +20535,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ebB" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -20951,7 +20619,6 @@
 	pixel_y = 16
 	},
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white/techfloor,
@@ -20963,8 +20630,7 @@
 	req_access = list(3)
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/item/gun/energy/ionpistol{
 	pixel_y = 4
@@ -21134,8 +20800,7 @@
 "edS" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -21421,8 +21086,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "egh" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -21563,7 +21227,6 @@
 "ehF" = (
 /obj/structure/cryofeed{
 	dir = 4;
-	icon_state = "cryo_rear";
 	tag = "icon-cryo_rear (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -21596,8 +21259,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "eip" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -21715,14 +21377,11 @@
 "ejZ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/table/woodentable,
 /obj/item/paper_bin,
 /obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/turcarpet,
@@ -21984,8 +21643,7 @@
 /area/nadezhda/outside/forest)
 "enq" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -22046,8 +21704,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/curtain/open,
 /obj/effect/floor_decal/corner_techfloor_grid,
@@ -22069,7 +21726,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
@@ -22179,9 +21835,7 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/machinery/light/small,
 /obj/machinery/light_switch{
-	dir = 2;
 	name = "light switch ";
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /obj/machinery/button/remote/blast_door{
@@ -22297,8 +21951,7 @@
 /area/nadezhda/outside/inside_colony)
 "eqk" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
@@ -22334,7 +21987,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/lattice,
@@ -22432,7 +22084,6 @@
 "erP" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -22481,8 +22132,7 @@
 	icon_state = "spline_fancy_corner"
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -22507,11 +22157,9 @@
 /area/nadezhda/absolutism/vectorrooms)
 "esA" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -22561,8 +22209,7 @@
 	req_access = list(3)
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -22669,8 +22316,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "etU" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
@@ -22914,9 +22560,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/cluster/roaches/low_chance,
@@ -23037,7 +22681,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/lattice,
@@ -23068,10 +22711,7 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/engine_room)
 "eyT" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/machinery/atm{
 	dir = 1;
 	pixel_y = -34
@@ -23114,8 +22754,7 @@
 /obj/random/material/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -23303,12 +22942,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/cafe,
@@ -23731,7 +23368,6 @@
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -23752,8 +23388,7 @@
 	opacity = 0
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/chemistry)
@@ -23833,7 +23468,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/lattice,
@@ -23911,7 +23545,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -23924,8 +23557,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
@@ -23953,7 +23585,6 @@
 /obj/structure/sign/faction/derelict1{
 	desc = "ATTENTION: This teleporter is a highly dangerous piece of equipment, we recommend caution when using it. The device can and will take you to a section of nearby space to salvage equipment, however you will need a void suit and weapons to avoid hostile life forms among the ruins and derelicts. We suggest bringing a team!";
 	name = "NOTICE: Dangerous Equipment";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark/danger,
@@ -23962,8 +23593,7 @@
 /obj/structure/bed/roller,
 /obj/effect/floor_decal/industrial/outline,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
@@ -24036,7 +23666,6 @@
 "eJe" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/decal/cleanable/generic,
@@ -24093,7 +23722,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
@@ -24187,8 +23815,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "eKd" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -24236,9 +23863,7 @@
 /obj/random/junkfood,
 /obj/random/junkfood,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/pros/foreman)
@@ -24257,11 +23882,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -24313,8 +23936,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/docking)
@@ -24349,7 +23971,6 @@
 /obj/machinery/power/apc/critical{
 	dir = 1;
 	name = "APC";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/structure/cable/cyan{
@@ -24360,8 +23981,7 @@
 /area/turret_protected/ai)
 "eLQ" = (
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /obj/structure/flora/small/bushc2,
 /turf/simulated/floor/asteroid/grass,
@@ -24397,14 +24017,12 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "eMk" = (
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
@@ -24454,8 +24072,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -24473,9 +24090,7 @@
 	name = "\improper Outdoors - Pad"
 	})
 "eMC" = (
-/mob/living/simple_animal/goose{
-	faction = "pond"
-	},
+/mob/living/simple_animal/goose,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "eMJ" = (
@@ -24498,7 +24113,6 @@
 	dir = 9
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/wood,
@@ -24519,8 +24133,7 @@
 	})
 "eNl" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -24546,7 +24159,6 @@
 /obj/item/folder/yellow,
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -24582,8 +24194,7 @@
 /area/nadezhda/security/tactical_blackshield)
 "eNR" = (
 /obj/machinery/computer/drone_control{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/hallway/side/f2section1)
@@ -24631,8 +24242,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "eOD" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
@@ -24714,8 +24324,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -24767,8 +24376,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate{
@@ -24782,14 +24390,11 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -24807,10 +24412,7 @@
 	pixel_x = 7;
 	pixel_y = 1
 	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/structure/table/glass,
 /obj/item/device/radio/intercom{
@@ -24932,14 +24534,12 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "eRc" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	locked = 0;
 	name = "South APC";
 	pixel_y = -28
@@ -25095,9 +24695,7 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_weighted,
@@ -25120,8 +24718,7 @@
 /area/nadezhda/command/captain/quarters)
 "eSY" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25138,8 +24735,7 @@
 /area/nadezhda/rnd/docking)
 "eSZ" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -25170,7 +24766,6 @@
 "eTe" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/pen{
@@ -25266,8 +24861,7 @@
 	pixel_x = -22
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
@@ -25305,12 +24899,10 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/scrap/sparse_weighted,
@@ -25523,8 +25115,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
@@ -25549,7 +25140,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -25574,8 +25164,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/machinery/power/apc/hyper{
 	dir = 1;
@@ -25685,13 +25274,10 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -25740,8 +25326,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -25781,8 +25366,7 @@
 /area/nadezhda/security/armory)
 "eYh" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -25804,8 +25388,7 @@
 "eYz" = (
 /obj/structure/multiz/stairs/enter,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/hallway/main/stairwell)
@@ -25830,8 +25413,7 @@
 "eYN" = (
 /obj/structure/closet/lasertag/green,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/eris/crew_quarters/plasma_tag)
@@ -25880,8 +25462,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
@@ -25905,11 +25486,9 @@
 	pixel_y = -28
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -26026,7 +25605,6 @@
 "fau" = (
 /obj/structure/closet/secure_closet/personal/security,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -26173,12 +25751,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
@@ -26267,11 +25843,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/techshop)
@@ -26380,9 +25954,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/rock,
@@ -26480,8 +26052,7 @@
 /area/colony)
 "ffc" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/crew_quarters/dorm2{
@@ -26509,9 +26080,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/ai_slipper{
-	icon_state = "motion0"
-	},
+/obj/machinery/ai_slipper,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -26547,8 +26116,7 @@
 "ffX" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
@@ -26601,8 +26169,7 @@
 	pixel_y = 30
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 5;
-	icon_state = "spline_fancy"
+	dir = 5
 	},
 /obj/structure/bed/chair/custom/wood/wings{
 	icon_state = "dogbed"
@@ -26635,10 +26202,7 @@
 /area/nadezhda/rnd/rbreakroom)
 "fgz" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 1
@@ -26714,8 +26278,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -26798,8 +26361,7 @@
 /area/nadezhda/outside/forest)
 "fic" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/meter,
 /obj/structure/cable/cyan{
@@ -26869,8 +26431,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -26916,8 +26477,7 @@
 "fjd" = (
 /obj/random/junk/cigbutt,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -27026,7 +26586,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/scrap/sparse_weighted,
@@ -27051,7 +26610,6 @@
 /obj/effect/floor_decal/border/techfloor,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/scrap/sparse_weighted,
@@ -27096,8 +26654,7 @@
 /obj/effect/decal/cleanable/ash,
 /obj/random/common_oddities/low_chance,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/item/contraband/poster/placed/pinup/kate{
 	pixel_x = 32
@@ -27529,8 +27086,7 @@
 /obj/structure/catwalk,
 /obj/structure/railing,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/security/maingate{
@@ -27630,8 +27186,7 @@
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "fpL" = (
 /obj/structure/bed/chair/custom/bar_special{
-	dir = 4;
-	icon_state = "bar_chair"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -27907,8 +27462,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -27965,7 +27519,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mining{
-	id_tag = null;
 	name = "Foreman Quarters";
 	req_access = list(79)
 	},
@@ -28008,7 +27561,6 @@
 /area/nadezhda/command/bridgebar)
 "fsR" = (
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -28082,8 +27634,7 @@
 /area/nadezhda/medical/psych)
 "fte" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -28112,7 +27663,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -28315,16 +27865,14 @@
 /area/nadezhda/medical/chemistry)
 "fvx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /obj/machinery/camera/network/engineering,
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -28365,12 +27913,10 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -28480,8 +28026,7 @@
 "fxq" = (
 /obj/structure/computerframe{
 	anchored = 1;
-	dir = 1;
-	icon_state = "0"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -28513,8 +28058,7 @@
 /area/nadezhda/security/tactical_blackshield)
 "fxz" = (
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
@@ -28586,7 +28130,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/scrap/sparse_even,
@@ -28598,8 +28141,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/hangarsupply)
@@ -28662,12 +28204,10 @@
 /obj/item/device/scanner/petite_scanner,
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/white/techfloor,
@@ -28720,11 +28260,9 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "fzC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -28751,7 +28289,6 @@
 /obj/structure/table/bench/standard,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white/techfloor,
@@ -28869,11 +28406,9 @@
 "fBw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -28881,7 +28416,6 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/dark/golden,
@@ -28949,12 +28483,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/triage_blackshield)
@@ -28987,8 +28519,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/hallway/surface/section1)
@@ -29021,11 +28552,9 @@
 /area/nadezhda/medical/cryo)
 "fCn" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -29129,15 +28658,13 @@
 /area/nadezhda/absolutism/chapel)
 "fDb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "fDc" = (
 /obj/structure/bed/chair/custom/bar_special{
-	dir = 4;
-	icon_state = "bar_chair"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild2,
@@ -29168,8 +28695,7 @@
 /area/nadezhda/engineering/atmos)
 "fDr" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/telecomms/bus/preset_four,
 /turf/simulated/floor/bluegrid{
@@ -29316,7 +28842,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -29327,8 +28852,7 @@
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "fEm" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -29400,7 +28924,6 @@
 "fES" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/industrial/arrows/white{
@@ -29445,8 +28968,7 @@
 "fFq" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/random/lathe_disk/advanced/low_chance,
 /obj/machinery/light/small,
@@ -29458,8 +28980,7 @@
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "fFx" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp/green,
@@ -29525,8 +29046,7 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -29543,8 +29063,7 @@
 	icon_state = "road_edge_decal1"
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/kitchen)
@@ -29788,8 +29307,7 @@
 "fIK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/barracks)
@@ -29799,8 +29317,7 @@
 	},
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm4{
@@ -29808,8 +29325,7 @@
 	})
 "fJl" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -29882,7 +29398,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -29892,8 +29407,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/lab)
@@ -29948,8 +29462,7 @@
 "fKt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -29993,8 +29506,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate{
@@ -30007,8 +29519,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -30071,8 +29582,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -30081,7 +29591,6 @@
 /area/nadezhda/hallway/side/f2section1)
 "fLG" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -30165,7 +29674,6 @@
 "fMs" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc{
-	dir = 2;
 	locked = 0;
 	name = "South APC";
 	operating = 0;
@@ -30227,8 +29735,7 @@
 "fNi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -30357,11 +29864,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
@@ -30417,16 +29922,14 @@
 /area/colony)
 "fPq" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/door/window/westright{
 	name = "grenades closet";
 	req_access = list(3)
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/closet{
 	name = "LTL / EMP grenades"
@@ -30462,13 +29965,11 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "fPB" = (
@@ -30535,8 +30036,7 @@
 /area/nadezhda/outside/forest)
 "fQr" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -30635,8 +30135,7 @@
 /area/nadezhda/command/tcommsat/computer)
 "fRP" = (
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /obj/structure/lattice,
 /obj/effect/floor_decal/spline/wood{
@@ -30699,13 +30198,6 @@
 "fSv" = (
 /turf/simulated/open,
 /area/nadezhda/medical/sleeper)
-"fSD" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 8;
-	icon_state = "spline_fancy"
-	},
-/turf/simulated/floor/carpet/turcarpet,
-/area/nadezhda/crew_quarters/cafeteria)
 "fSF" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -30815,9 +30307,7 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -31011,8 +30501,7 @@
 /area/nadezhda/medical/reception)
 "fWh" = (
 /obj/effect/floor_decal/industrial/danger/corner{
-	dir = 4;
-	icon_state = "dangercorner"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -31149,12 +30638,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -31374,7 +30861,6 @@
 /obj/effect/floor_decal/border/techfloor,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating,
@@ -31438,8 +30924,7 @@
 "fZZ" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -31496,19 +30981,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
-"gaC" = (
-/obj/effect/floor_decal/border/techfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/techfloor{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
-	},
-/turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1north)
 "gaH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31564,9 +31036,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/dorm4{
@@ -31611,8 +31081,7 @@
 /area/shuttle/rocinante_shuttle_area)
 "gbt" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -32237,7 +31706,6 @@
 /obj/structure/table/woodentable,
 /obj/machinery/recharger,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -32259,7 +31727,6 @@
 "ggC" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -32285,20 +31752,16 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -32405,8 +31868,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j1"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
@@ -32439,8 +31901,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
@@ -32688,8 +32149,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "gkC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
@@ -32740,15 +32200,13 @@
 /area/nadezhda/command/merchant)
 "gkZ" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey{
 	dir = 8
 	},
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -32837,8 +32295,7 @@
 	})
 "glI" = (
 /obj/structure/bed/chair/custom/bar_special{
-	dir = 8;
-	icon_state = "bar_chair"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
@@ -32928,8 +32385,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "gmx" = (
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -33192,8 +32648,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/plating,
@@ -33333,8 +32788,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -33343,7 +32797,6 @@
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "gpW" = (
 /obj/machinery/atmospherics/unary/freezer{
-	dir = 2;
 	icon_state = "freezer"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -33439,7 +32892,6 @@
 /area/nadezhda/hallway/side/f2section1)
 "gre" = (
 /obj/machinery/atmospherics/unary/heater{
-	dir = 2;
 	icon_state = "heater"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -33601,8 +33053,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -33670,8 +33121,7 @@
 "gty" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -33788,7 +33238,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/lattice,
@@ -33836,8 +33285,7 @@
 "gvO" = (
 /obj/structure/table/bench/standard,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
@@ -33874,9 +33322,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "gvZ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -33946,7 +33392,6 @@
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lamp/green,
 /obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/carpet/purcarpet,
@@ -34027,7 +33472,6 @@
 /obj/structure/railing,
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -34099,8 +33543,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/section1)
@@ -34139,8 +33582,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -34163,7 +33605,6 @@
 "gzo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -34180,8 +33621,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -34194,12 +33634,10 @@
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
@@ -34257,11 +33695,9 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "gzI" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -34300,8 +33736,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/lab)
@@ -34332,8 +33767,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
@@ -34354,16 +33788,12 @@
 	dir = 8;
 	icon_state = "road_edge_decal4"
 	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/kitchen)
 "gAA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
-	dir = 2;
 	icon_state = "spline_fancy_cee"
 	},
 /turf/simulated/floor/carpet/turcarpet,
@@ -34372,7 +33802,6 @@
 /obj/machinery/button/remote/airlock{
 	id = "shuttle_props_hatch_bolts";
 	name = "Door Bolt Control";
-	pixel_x = 0;
 	specialfunctions = 4
 	},
 /turf/simulated/shuttle/wall/mining{
@@ -34416,7 +33845,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
@@ -34445,9 +33873,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/ai_slipper{
-	icon_state = "motion0"
-	},
+/obj/machinery/ai_slipper,
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "gBd" = (
@@ -34463,7 +33889,6 @@
 "gBm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light/small{
@@ -34572,11 +33997,9 @@
 "gCx" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -34602,8 +34025,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -34623,8 +34045,7 @@
 /area/nadezhda/outside/inside_colony)
 "gCI" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/maingate{
@@ -34664,8 +34085,7 @@
 /obj/structure/table/woodentable,
 /obj/structure/mirror{
 	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/item/paper_bin{
 	pixel_y = 3
@@ -34687,8 +34107,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "gDo" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -34841,15 +34260,13 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "gFm" = (
 /obj/machinery/atmospherics/unary/vent_pump{
-	dir = 2;
 	external_pressure_bound = 0;
 	external_pressure_bound_default = 0;
 	icon_state = "map_vent_in";
@@ -34904,7 +34321,6 @@
 	},
 /obj/structure/window/basic{
 	dir = 4;
-	icon_state = "window";
 	pixel_x = 3
 	},
 /obj/machinery/light,
@@ -35050,7 +34466,6 @@
 /area/colony)
 "gGY" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -35229,7 +34644,6 @@
 "gIY" = (
 /obj/machinery/cryopod{
 	dir = 4;
-	icon_state = "cryopod_0";
 	tag = "icon-cryopod_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -35271,9 +34685,7 @@
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "gJu" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -35294,11 +34706,9 @@
 /area/nadezhda/command/courtroom)
 "gJG" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green,
@@ -35364,11 +34774,9 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "gKf" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/closet/wardrobe/misc/pjs,
 /obj/structure/cable/green{
@@ -35386,7 +34794,6 @@
 "gKg" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 4;
-	frequency = 1441;
 	input_tag = "tox_in";
 	name = "Plasma Supply Control";
 	output_tag = "tox_out";
@@ -35465,8 +34872,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "gLh" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -35488,7 +34894,6 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -35497,8 +34902,7 @@
 /obj/structure/table/rack/shelf,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/item/stack/material/cardboard/random,
 /obj/random/material,
@@ -35568,8 +34972,7 @@
 	dir = 8
 	},
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
@@ -35716,8 +35119,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
@@ -35728,8 +35130,7 @@
 	},
 /obj/structure/table/bar_special,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/floor_light,
@@ -35832,7 +35233,6 @@
 /area/nadezhda/outside/fnest)
 "gOf" = (
 /obj/machinery/door/window/southright{
-	dir = 2;
 	icon_state = "left";
 	name = "Containment Pen";
 	req_access = list(55)
@@ -35845,9 +35245,7 @@
 /area/nadezhda/rnd/xenobiology)
 "gOj" = (
 /obj/structure/railing{
-	anchored = 1;
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /obj/structure/railing{
 	dir = 8
@@ -35866,8 +35264,7 @@
 	},
 /obj/structure/mirror{
 	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -35953,8 +35350,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "gPb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/carpet/purcarpet,
@@ -35983,8 +35379,7 @@
 /area/nadezhda/outside/forest)
 "gPf" = (
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "gPh" = (
@@ -36045,8 +35440,7 @@
 /area/nadezhda/quartermaster/office)
 "gPI" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -36064,8 +35458,7 @@
 /area/nadezhda/quartermaster/office)
 "gPR" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -36280,7 +35673,6 @@
 	dir = 5
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/structure/cable/green{
@@ -36293,8 +35685,7 @@
 /area/nadezhda/hallway/surface/section1)
 "gSP" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/invislight,
@@ -36458,8 +35849,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
@@ -36596,8 +35986,7 @@
 "gWh" = (
 /obj/structure/catwalk,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/mine/gulag)
@@ -36674,7 +36063,6 @@
 "gWQ" = (
 /obj/structure/bed/chair/sofa/beige/right,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/carpet/sblucarpet,
@@ -36734,12 +36122,10 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -36786,8 +36172,7 @@
 /obj/structure/catwalk,
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
@@ -36845,9 +36230,7 @@
 "gXS" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/floor_decal/spline/plain,
@@ -37003,12 +36386,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/command/tcommsat/computer)
@@ -37037,8 +36418,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Marshals Brig";
-	req_one_access = list()
+	name = "Marshals Brig"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -37250,8 +36630,7 @@
 "hcb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "hce" = (
@@ -37291,8 +36670,7 @@
 /area/nadezhda/crew_quarters/fitness)
 "hcj" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -37385,8 +36763,7 @@
 /area/turret_protected/ai)
 "hdo" = (
 /obj/structure/bed/chair/comfy/teal{
-	dir = 1;
-	icon_state = "comfychair_preview"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
@@ -37517,9 +36894,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	anchored = 1;
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -37752,8 +37127,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/plating,
@@ -37803,7 +37177,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating,
@@ -37880,12 +37253,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -37934,8 +37305,7 @@
 /area/nadezhda/outside/forest)
 "hiY" = (
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -37949,9 +37319,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "hjf" = (
-/mob/living/simple_animal/crab{
-	faction = "pond"
-	},
+/mob/living/simple_animal/crab,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
 "hjp" = (
@@ -37997,7 +37365,6 @@
 "hkb" = (
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
@@ -38184,9 +37551,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/decal/cleanable/generic,
@@ -38207,7 +37572,6 @@
 	deepmaint_entry_point = 1;
 	desc = "Cracks on the floor, yet you can see shifting lights and hear the tick of crawling clawed beasts below...";
 	isRevealed = 1;
-	isSealed = 1;
 	name = "strange cracks"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -38296,8 +37660,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
@@ -38358,9 +37721,7 @@
 	})
 "hns" = (
 /obj/structure/railing{
-	anchored = 1;
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/crew_quarters)
@@ -38376,8 +37737,7 @@
 /area/nadezhda/storage/primary)
 "hnC" = (
 /obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+	dir = 8
 	},
 /obj/machinery/camera/network/colony_underground{
 	dir = 1
@@ -38411,8 +37771,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -38483,10 +37842,8 @@
 	},
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	dir = 2;
 	locked = 0;
 	name = "South APC";
-	operating = 1;
 	pixel_y = -28
 	},
 /turf/simulated/floor/wood,
@@ -38574,8 +37931,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "hpx" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/random/toolbox,
@@ -38598,9 +37954,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/item/stash_spawner,
 /turf/simulated/floor/tiled/white,
@@ -38627,8 +37981,7 @@
 "hpV" = (
 /obj/effect/floor_decal/industrial/road/straight1,
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
@@ -38895,15 +38248,13 @@
 /area/nadezhda/command/cbo)
 "hsB" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 5;
-	icon_state = "spline_fancy"
+	dir = 5
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/bridgebar)
 "hsH" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/door/window/southright,
 /obj/item/towel,
@@ -38986,12 +38337,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -39108,8 +38457,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -39145,9 +38493,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	anchored = 1;
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -39219,7 +38565,6 @@
 "hvI" = (
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
@@ -39290,8 +38635,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
-	dir = 8;
-	icon_state = "spline_fancy"
+	dir = 8
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -39584,7 +38928,6 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	frequency = 1441;
-	icon_state = "map_injector";
 	id = "tox_in";
 	pixel_y = 1;
 	use_power = 1
@@ -39768,13 +39111,10 @@
 /area/turret_protected/ai)
 "hBR" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -39812,15 +39152,13 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security)
 "hCc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
@@ -39906,8 +39244,7 @@
 "hDG" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
@@ -40019,8 +39356,7 @@
 /area/nadezhda/security/triage_blackshield)
 "hFt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -40054,8 +39390,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40065,8 +39400,7 @@
 /area/nadezhda/engineering/construction)
 "hFN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating/under,
@@ -40321,8 +39655,7 @@
 "hJh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
-	dir = 5;
-	icon_state = "spline_fancy"
+	dir = 5
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -40443,8 +39776,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/clownoffice)
@@ -40543,8 +39875,7 @@
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "hLF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
@@ -40671,8 +40002,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "hMQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -40683,8 +40013,7 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/floor_decal/industrial/warningred{
@@ -40792,11 +40121,9 @@
 /area/nadezhda/medical/virology)
 "hNT" = (
 /obj/machinery/atmospherics/omni/filter{
-	tag_east = 0;
 	tag_north = 1;
 	tag_south = 2;
-	tag_west = 6;
-	use_power = 1
+	tag_west = 6
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -40882,16 +40209,13 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/white/gray_perforated,
@@ -41002,8 +40326,7 @@
 "hPJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
-	dir = 6;
-	icon_state = "spline_fancy"
+	dir = 6
 	},
 /obj/machinery/light,
 /turf/simulated/floor/carpet/turcarpet,
@@ -41011,7 +40334,6 @@
 "hPN" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -41031,7 +40353,6 @@
 "hPT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/white/violetcorener,
@@ -41095,11 +40416,9 @@
 /area/nadezhda/crew_quarters/botanist)
 "hQO" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -41127,9 +40446,7 @@
 /area/colony)
 "hQQ" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -41151,11 +40468,9 @@
 /area/nadezhda/engineering/atmos/surface)
 "hQV" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -41305,8 +40620,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -41326,8 +40640,7 @@
 "hSR" = (
 /obj/structure/table/bar_special,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/floor_light,
@@ -41478,8 +40791,7 @@
 	})
 "hUD" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 10;
-	icon_state = "spline_fancy"
+	dir = 10
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -41492,8 +40804,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "hUR" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -41553,8 +40864,7 @@
 	})
 "hVw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -41636,16 +40946,13 @@
 "hWj" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/hallway/main/stairwell)
 "hWk" = (
 /obj/structure/railing{
-	anchored = 1;
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /obj/structure/railing{
 	dir = 4
@@ -41733,7 +41040,6 @@
 /obj/structure/catwalk,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/plating/under,
@@ -41925,8 +41231,7 @@
 "hZa" = (
 /obj/structure/low_wall,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
@@ -41956,7 +41261,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/cluster/spiders/low_chance,
@@ -42046,8 +41350,7 @@
 /area/colony)
 "iai" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -42179,7 +41482,6 @@
 "ibB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4;
-	icon_state = "map";
 	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/plating/under,
@@ -42264,12 +41566,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
@@ -42336,8 +41636,7 @@
 /area/nadezhda/hallway/main/stairwell)
 "idD" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/steel,
@@ -42389,8 +41688,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j1"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -42438,7 +41736,6 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "iek" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -42487,8 +41784,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/reception)
@@ -42512,8 +41808,7 @@
 /area/nadezhda/command/bridgebar)
 "ifk" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -42552,7 +41847,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -42619,7 +41913,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
-	icon_state = "danger";
 	tag = "icon-danger (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -42666,7 +41959,6 @@
 /obj/effect/floor_decal/border/techfloor,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -42674,8 +41966,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "igs" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -42730,9 +42021,7 @@
 "ihh" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
-/mob/living/simple_animal/crab{
-	faction = "pond"
-	},
+/mob/living/simple_animal/crab,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/pond)
 "ihk" = (
@@ -42846,8 +42135,7 @@
 	dir = 6
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
@@ -42879,8 +42167,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -42946,9 +42233,7 @@
 "ijW" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -43041,8 +42326,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ikK" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -43345,8 +42629,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ioF" = (
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -43419,8 +42702,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ipO" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 6;
-	icon_state = "spline_fancy"
+	dir = 6
 	},
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/pumpkin{
@@ -43461,8 +42743,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/decal/cleanable/dirt,
@@ -43473,9 +42754,7 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	anchored = 1;
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -43563,9 +42842,7 @@
 	dir = 10
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -43600,7 +42877,6 @@
 "irp" = (
 /obj/machinery/light/small,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -43612,8 +42888,7 @@
 /area/nadezhda/command/teleporter)
 "iru" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 10;
-	icon_state = "spline_fancy"
+	dir = 10
 	},
 /obj/structure/bed/chair/sofa/black/corner{
 	icon_state = "sofamiddle"
@@ -43638,8 +42913,7 @@
 "irH" = (
 /obj/structure/curtain/open,
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
@@ -43711,7 +42985,6 @@
 "ise" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -43821,8 +43094,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
@@ -43858,9 +43130,7 @@
 "itA" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/camera/network/security{
 	dir = 1
@@ -43939,7 +43209,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/scrap/sparse_even,
@@ -43992,8 +43261,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
@@ -44148,8 +43416,7 @@
 	pixel_y = 30
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/effect/floor_decal/spline/wood{
 	dir = 8;
@@ -44202,8 +43469,7 @@
 	})
 "ivY" = (
 /obj/effect/floor_decal/industrial/danger/corner{
-	dir = 8;
-	icon_state = "dangercorner"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
@@ -44268,8 +43534,7 @@
 /area/nadezhda/engineering/atmos)
 "iwX" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -44443,7 +43708,6 @@
 	master_tag = "xeno_airlock_control";
 	name = "Xenobiology Access Button";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access = list(55)
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -44472,25 +43736,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
-"iyW" = (
-/obj/effect/floor_decal/border/techfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0";
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1west)
 "izd" = (
 /obj/effect/spider/spiderling,
 /obj/effect/spider/stickyweb,
@@ -44521,8 +43766,7 @@
 "izp" = (
 /obj/structure/flora/small/trailrocka3,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -44753,8 +43997,7 @@
 /area/shuttle/rocinante_shuttle_area)
 "iBP" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
@@ -44948,8 +44191,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -44994,8 +44236,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/arrows/white,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
@@ -45010,8 +44251,7 @@
 /area/eris/crew_quarters/plasma_tag)
 "iEA" = (
 /obj/effect/floor_decal/industrial/danger/corner{
-	dir = 8;
-	icon_state = "dangercorner"
+	dir = 8
 	},
 /obj/item/slime_extract/grey,
 /turf/simulated/floor/reinforced,
@@ -45067,8 +44307,7 @@
 "iER" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/structure/lattice,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -45085,7 +44324,6 @@
 /obj/machinery/button/remote/airlock{
 	id = "F2-A1";
 	name = "Door Bolt Control";
-	pixel_x = 0;
 	pixel_y = -20;
 	specialfunctions = 4
 	},
@@ -45250,8 +44488,7 @@
 /area/nadezhda/hallway/surface/section1)
 "iGz" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
@@ -45388,8 +44625,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "iHZ" = (
@@ -45484,8 +44720,7 @@
 /area/nadezhda/crew_quarters/kitchen)
 "iIH" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm1{
@@ -45502,7 +44737,6 @@
 "iIP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = null;
 	name = "Chemistry Lab";
 	req_access = list(33)
 	},
@@ -45586,7 +44820,6 @@
 "iJp" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4;
-	icon_state = "map";
 	tag = "icon-map (EAST)"
 	},
 /obj/machinery/meter,
@@ -45612,14 +44845,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
@@ -45682,20 +44912,17 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "iKp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -45806,7 +45033,6 @@
 "iLh" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/arrows/white,
@@ -45890,7 +45116,6 @@
 /area/nadezhda/security/tactical_blackshield)
 "iMs" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -45910,8 +45135,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -45937,9 +45161,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm3{
@@ -46066,7 +45288,6 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "iOm" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -46109,7 +45330,6 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/camera/network/colony_underground,
@@ -46132,8 +45352,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/camera/network/research{
 	dir = 1
@@ -46362,8 +45581,7 @@
 /area/nadezhda/security/sechall)
 "iQW" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -46409,10 +45627,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/table/bench/steel,
 /turf/simulated/floor/tiled/cafe,
@@ -46446,8 +45661,7 @@
 /area/nadezhda/dungeon/outside/burned_outpost)
 "iRu" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/structure/catwalk,
@@ -46571,7 +45785,6 @@
 	pixel_y = 16
 	},
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white/cargo,
@@ -46619,7 +45832,6 @@
 /obj/machinery/button/remote/blast_door{
 	id = "maint_hatch_atmos";
 	name = "Maintenance Hatch Control";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = newlist()
 	},
@@ -46657,11 +45869,9 @@
 "iTT" = (
 /obj/structure/table/standard,
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/item/storage/box/donkpockets,
 /obj/structure/cable/green{
@@ -46777,7 +45987,6 @@
 /obj/structure/closet/l3closet/janitor,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -46796,7 +46005,6 @@
 "iVl" = (
 /obj/machinery/light,
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/table/woodentable,
@@ -46850,12 +46058,10 @@
 "iVR" = (
 /obj/structure/curtain/open,
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -46882,7 +46088,6 @@
 "iWb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -47121,7 +46326,6 @@
 "iYh" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
-	frequency = 1441;
 	input_tag = "waste_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "waste_out";
@@ -47250,8 +46454,7 @@
 	},
 /obj/landmark/join/start/clubworker,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	pixel_y = -10
@@ -47269,8 +46472,7 @@
 	department = "Prime's Office";
 	departmentType = 22;
 	name = "Prime's RC";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
@@ -47372,7 +46574,6 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/door/airlock/glass{
@@ -47473,8 +46674,7 @@
 	},
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Medical";
@@ -47580,8 +46780,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -47683,7 +46882,6 @@
 "jdM" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -47728,22 +46926,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
-"jeq" = (
-/obj/effect/floor_decal/border/techfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/random/scrap/sparse_even,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1west)
 "jes" = (
 /obj/structure/table/rack,
 /obj/random/gun_cheap,
@@ -47762,7 +46944,6 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "jey" = (
 /obj/structure/sink/kitchen{
-	name = "kitchen sink";
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -47840,8 +47021,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -47869,11 +47049,9 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -47887,8 +47065,7 @@
 /obj/random/junk/low_chance,
 /obj/structure/railing,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
@@ -48023,8 +47200,7 @@
 	},
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -48214,7 +47390,6 @@
 "jiM" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 4;
-	frequency = 1441;
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
@@ -48244,8 +47419,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "jjd" = (
@@ -48257,7 +47431,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/effect/decal/cleanable/generic,
@@ -48272,7 +47445,6 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
-	id = null;
 	name = "chute windoor";
 	req_access = list(70)
 	},
@@ -48304,7 +47476,6 @@
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/plating/under,
@@ -48336,8 +47507,7 @@
 /area/nadezhda/hallway/main/stairwell)
 "jjy" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -48359,8 +47529,7 @@
 /area/nadezhda/crew_quarters/botanist)
 "jjJ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -48369,7 +47538,6 @@
 	id = "maint_hatch_telecomm";
 	name = "Maintenance Hatch Control";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/tiled/steel/panels,
@@ -48513,8 +47681,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jkX" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/cyan{
 	d2 = 4;
@@ -48547,7 +47714,6 @@
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -48573,7 +47739,6 @@
 "jlP" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark,
@@ -48671,8 +47836,7 @@
 "jnp" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -48746,8 +47910,7 @@
 "joj" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey,
 /turf/simulated/floor/asteroid/grass,
@@ -48773,8 +47936,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -48848,8 +48010,7 @@
 "jpp" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -48897,10 +48058,7 @@
 	dir = 8;
 	icon_state = "road_edge_decal4"
 	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/machinery/button/remote/blast_door{
 	id = "bar1";
 	name = "north bar access";
@@ -48948,8 +48106,7 @@
 /area/nadezhda/crew_quarters/clownoffice)
 "jpM" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /obj/machinery/meter{
 	frequency = 1443;
@@ -49009,9 +48166,7 @@
 "jqF" = (
 /obj/machinery/vending/engineering,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/dark/golden,
@@ -49150,7 +48305,6 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -49223,8 +48377,7 @@
 /area/nadezhda/crew_quarters/cafeteria)
 "jsA" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 4;
-	icon_state = "map"
+	dir = 4
 	},
 /obj/machinery/meter{
 	frequency = 1443;
@@ -49309,8 +48462,7 @@
 /area/nadezhda/security/prisoncells)
 "jte" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -49461,9 +48613,7 @@
 /area/nadezhda/outside/forest)
 "juE" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/asteroid/dirt,
@@ -49699,7 +48849,6 @@
 "jwT" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1;
-	icon_state = "map";
 	tag = "icon-map (NORTH)"
 	},
 /obj/machinery/meter,
@@ -49785,8 +48934,7 @@
 "jyg" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
@@ -49795,12 +48943,10 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/machinery/camera/network/medbay{
 	dir = 4
@@ -49851,20 +48997,17 @@
 "jyK" = (
 /obj/structure/curtain/open,
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/door/window/southleft{
 	name = "shower door"
@@ -49875,9 +49018,7 @@
 "jyL" = (
 /obj/effect/floor_decal/corner_techfloor_grid/diagonal,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -49962,8 +49103,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plating/under,
@@ -49978,8 +49118,7 @@
 /obj/item/bedsheet/medical,
 /obj/structure/curtain/open/privacy,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/medical/cryo)
@@ -50059,8 +49198,7 @@
 /area/nadezhda/security/prisoncells)
 "jAi" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -50128,11 +49266,9 @@
 /area/nadezhda/hallway/side/f2section1)
 "jAT" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -50221,8 +49357,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -50268,8 +49403,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jCs" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/stand_clear,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -50562,7 +49696,6 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
 	frequency = 1441;
-	icon_state = "map_injector";
 	id = "teg_outlit";
 	pixel_y = 1;
 	use_power = 1
@@ -50635,7 +49768,6 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	frequency = 1441;
-	icon_state = "map_injector";
 	id = "n2o_in";
 	pixel_y = 1;
 	use_power = 1
@@ -50663,11 +49795,9 @@
 	})
 "jGv" = (
 /obj/machinery/atmospherics/omni/filter{
-	tag_east = 0;
 	tag_north = 1;
 	tag_south = 2;
-	tag_west = 7;
-	use_power = 1
+	tag_west = 7
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -50687,15 +49817,13 @@
 	},
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
 "jGM" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/button/switch/holosign{
 	id = "robo_sugery";
@@ -50778,8 +49906,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/absolutism/storage)
@@ -50868,17 +49995,13 @@
 /area/nadezhda/security/tactical)
 "jIv" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -50887,8 +50010,7 @@
 /area/nadezhda/engineering/atmos)
 "jIA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -51019,15 +50141,13 @@
 	},
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/section1)
 "jKc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -51059,8 +50179,7 @@
 /area/nadezhda/crew_quarters/kitchen)
 "jKt" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -51120,11 +50239,9 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jLd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
-	dir = 2;
 	name = "Port to Supply"
 	},
 /obj/structure/cable/cyan{
@@ -51175,7 +50292,6 @@
 	pixel_y = -12
 	},
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/white/cargo,
@@ -51196,8 +50312,7 @@
 /area/colony)
 "jLZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -51327,8 +50442,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -51356,8 +50470,7 @@
 /area/nadezhda/outside/forest)
 "jNx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -51430,7 +50543,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/lattice,
@@ -51442,8 +50554,7 @@
 "jNW" = (
 /obj/structure/table/glass,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/camera/network/medbay{
 	dir = 1
@@ -51462,8 +50573,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "jOe" = (
@@ -51584,7 +50694,6 @@
 "jOX" = (
 /obj/structure/catwalk,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/spider/stickyweb,
@@ -51620,8 +50729,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "jPn" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -51633,15 +50741,13 @@
 "jPo" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "jPp" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -51810,8 +50916,7 @@
 /area/nadezhda/medical/psych)
 "jQP" = (
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
@@ -51888,8 +50993,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -52007,13 +51111,11 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "jTG" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/atmos/storage)
@@ -52191,8 +51293,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jVf" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -52234,7 +51335,6 @@
 /obj/structure/railing,
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -52248,8 +51348,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -52295,16 +51394,14 @@
 /area/eris/crew_quarters/barquarters)
 "jVP" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
 "jWc" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -52343,8 +51440,7 @@
 "jWv" = (
 /obj/structure/table/bench/standard,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/crew_quarters/plasma_tag)
@@ -52529,9 +51625,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_weighted,
@@ -52554,8 +51648,7 @@
 /area/nadezhda/crew_quarters/botanist)
 "jYE" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/crew_quarters/dorm1{
@@ -52600,7 +51693,6 @@
 	dir = 1
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -52628,8 +51720,7 @@
 	})
 "jYZ" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -52857,11 +51948,9 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kaN" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/structure/cable/cyan{
@@ -52931,8 +52020,7 @@
 	})
 "kbl" = (
 /obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -53021,8 +52109,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -53169,8 +52256,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kdT" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/noticeboard/lonestar_supply{
 	pixel_x = 32
@@ -53259,7 +52345,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
@@ -53268,8 +52353,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
@@ -53323,9 +52407,7 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
@@ -53520,8 +52602,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -53572,8 +52653,7 @@
 /area/nadezhda/security/sechall)
 "khq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -53610,8 +52690,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/security/tactical_blackshield)
@@ -53650,7 +52729,6 @@
 /area/nadezhda/security/barracks)
 "kim" = (
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/photocopier,
@@ -53717,8 +52795,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "kiI" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/bridge)
@@ -53741,8 +52818,7 @@
 /area/nadezhda/security/prisoncells)
 "kjb" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -53757,7 +52833,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -53831,8 +52906,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "kjV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -53840,8 +52914,7 @@
 "kjX" = (
 /obj/machinery/vending/drip,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "kka" = (
@@ -53885,8 +52958,7 @@
 /area/turret_protected/ai)
 "kkJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -53908,8 +52980,7 @@
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/small/busha2,
 /obj/effect/floor_decal/spline/wood{
-	dir = 8;
-	icon_state = "spline_fancy"
+	dir = 8
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/botanist)
@@ -53932,7 +53003,6 @@
 "kle" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/floor_decal/spline/plain{
@@ -54145,7 +53215,6 @@
 "kmK" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/arrows/white,
@@ -54272,8 +53341,7 @@
 /area/nadezhda/maintenance/substation/section6)
 "knN" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
@@ -54311,8 +53379,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "koe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -54363,9 +53430,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -54381,8 +53446,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
@@ -54596,9 +53660,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/cluster/roaches/low_chance,
@@ -54769,8 +53831,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "ksa" = (
@@ -54829,8 +53890,7 @@
 "ksB" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -54883,9 +53943,7 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm2{
@@ -55050,8 +54108,7 @@
 "kuK" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
@@ -55101,8 +54158,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kvf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
@@ -55110,8 +54166,7 @@
 /area/nadezhda/engineering/atmos)
 "kvi" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -55152,8 +54207,7 @@
 /area/nadezhda/crew_quarters/botanist)
 "kvq" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -55187,8 +54241,7 @@
 /area/nadezhda/engineering/atmos)
 "kvM" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/crew_quarters/dorm3{
@@ -55196,8 +54249,7 @@
 	})
 "kvR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -55253,7 +54305,6 @@
 "kwq" = (
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -55290,8 +54341,7 @@
 /area/nadezhda/outside/pond)
 "kwG" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -55343,7 +54393,6 @@
 "kxz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	dir = 2;
 	locked = 0;
 	name = "South APC";
 	pixel_y = -28
@@ -55499,8 +54548,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -55511,8 +54559,7 @@
 	},
 /obj/structure/mirror{
 	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/cro)
@@ -55617,8 +54664,7 @@
 /area/nadezhda/crew_quarters/techshop)
 "kAh" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -55652,8 +54698,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/door/window/southleft{
 	name = "shower door"
@@ -55702,8 +54747,7 @@
 /area/shuttle/surface_transport_lz)
 "kAK" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cyberplant,
@@ -55772,8 +54816,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/reception)
@@ -55842,7 +54885,6 @@
 "kCc" = (
 /obj/structure/table/bench/wooden,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
@@ -55903,8 +54945,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "kCt" = (
@@ -55920,16 +54961,13 @@
 	},
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /turf/simulated/open,
 /area/nadezhda/maintenance{
@@ -55941,10 +54979,7 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kCz" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -55973,8 +55008,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -56028,9 +55062,7 @@
 /obj/structure/table/steel,
 /obj/item/hand_labeler,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/item/paper_bin,
 /obj/item/pen/multi,
@@ -56252,8 +55284,7 @@
 "kFV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
@@ -56408,7 +55439,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating,
@@ -56419,8 +55449,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "kHw" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/structure/table/rack/shelf,
 /obj/random/pouch/low_chance,
@@ -56529,9 +55558,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/small/trailrockb1,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -56743,8 +55770,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kLc" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -56770,7 +55796,6 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kLp" = (
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -56825,8 +55850,7 @@
 "kLK" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/cryo)
@@ -56867,7 +55891,6 @@
 	department = "Captain's Desk";
 	departmentType = 5;
 	name = "Captain RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/table/standard,
@@ -56908,7 +55931,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
@@ -56959,7 +55981,6 @@
 /obj/effect/floor_decal/border/techfloor,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating,
@@ -56984,8 +56005,7 @@
 /obj/structure/catwalk,
 /obj/random/mob/roaches/low_chance,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
@@ -57152,7 +56172,6 @@
 "kOD" = (
 /obj/machinery/light,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -57164,8 +56183,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "kOQ" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/quartermaster/miningdock)
@@ -57202,13 +56220,11 @@
 "kPg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
@@ -57235,8 +56251,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kPS" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -57391,14 +56406,12 @@
 /obj/random/furniture/pottedplant,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/bridgebar)
 "kRw" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -57487,8 +56500,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -57570,8 +56582,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -57699,7 +56710,6 @@
 /area/nadezhda/crew_quarters/janitor)
 "kTP" = (
 /obj/machinery/door/window/southright{
-	dir = 2;
 	icon_state = "left";
 	name = "Containment Pen";
 	req_access = list(55)
@@ -57725,7 +56735,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/cluster/roaches/low_chance,
@@ -57735,7 +56744,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -57775,8 +56783,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -57794,8 +56801,7 @@
 "kUu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/pros/prep)
@@ -57999,9 +57005,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -58059,8 +57063,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -58132,8 +57135,7 @@
 "kXw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -58162,10 +57164,7 @@
 	name = "\improper Outdoors - Pad"
 	})
 "kYd" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/botanist)
@@ -58276,12 +57275,10 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -58296,15 +57293,12 @@
 	},
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -58383,8 +57377,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -58439,7 +57432,6 @@
 "kZQ" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -58451,7 +57443,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -58469,7 +57460,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/lattice,
@@ -58490,8 +57480,7 @@
 "laa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
@@ -58510,8 +57499,7 @@
 "laf" = (
 /obj/item/stool,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
@@ -58588,7 +57576,6 @@
 /area/nadezhda/hallway/main/stairwell)
 "laV" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/item/storage/firstaid/fire{
@@ -58611,12 +57598,8 @@
 /obj/item/reagent_containers/syringe/stim/machine_spirit{
 	pixel_x = 10
 	},
-/obj/item/reagent_containers/syringe/stim/ultra_surgeon{
-	pixel_x = 0
-	},
-/obj/item/reagent_containers/syringe/stim/ultra_surgeon{
-	pixel_x = 0
-	},
+/obj/item/reagent_containers/syringe/stim/ultra_surgeon,
+/obj/item/reagent_containers/syringe/stim/ultra_surgeon,
 /obj/item/reagent_containers/syringe/stim/ultra_surgeon{
 	pixel_x = -5
 	},
@@ -58822,12 +57805,10 @@
 	},
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -58942,10 +57923,7 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/pool)
 "leq" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
@@ -59128,7 +58106,6 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/spider/stickyweb,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -59164,7 +58141,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
-	icon_state = "danger";
 	tag = "icon-danger (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -59343,8 +58319,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -59375,7 +58350,6 @@
 /obj/machinery/button/remote/airlock{
 	id = "panicRoom";
 	name = "Door Bolt Control";
-	pixel_x = 0;
 	pixel_y = -28;
 	specialfunctions = 4
 	},
@@ -59397,12 +58371,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
@@ -59435,7 +58407,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/light/small,
@@ -59456,9 +58427,7 @@
 "ljg" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -59482,8 +58451,7 @@
 /area/nadezhda/medical/reception)
 "ljl" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -59531,12 +58499,10 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ljQ" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/scrap_lump,
 /obj/structure/cable/green{
@@ -59550,7 +58516,6 @@
 /obj/structure/table/standard,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/danger,
@@ -59569,8 +58534,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -59628,8 +58592,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/absolutism/vectorrooms)
 "lkK" = (
@@ -59656,8 +58619,7 @@
 /area/nadezhda/medical/reception)
 "lkW" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/reinforced,
@@ -59679,8 +58641,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
@@ -59724,10 +58685,7 @@
 /area/nadezhda/quartermaster/miningdock)
 "llM" = (
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
@@ -59753,8 +58711,7 @@
 /area/mine/gulag)
 "lmh" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
@@ -59961,14 +58918,6 @@
 /obj/random/firstaid/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"loa" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
 "lob" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
@@ -60124,8 +59073,7 @@
 "lpi" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 10
@@ -60176,7 +59124,6 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/item/modular_computer/telescreen/preset/generic{
@@ -60219,7 +59166,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/structure/cable/yellow{
@@ -60259,8 +59205,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "lqr" = (
@@ -60306,12 +59251,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/medical/sleeper)
@@ -60407,9 +59350,7 @@
 "lrW" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -60424,8 +59365,7 @@
 "lsb" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
@@ -60442,8 +59382,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -60519,8 +59458,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
@@ -60540,12 +59478,10 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -60598,8 +59534,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -60685,8 +59620,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -60820,15 +59754,13 @@
 "lwh" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/reagent_containers/food/snacks/breadslice,
 /obj/item/reagent_containers/food/snacks/breadslice,
 /obj/item/reagent_containers/food/snacks/breadslice,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood/wild3,
@@ -60932,8 +59864,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -61121,8 +60052,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -61203,8 +60133,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -61311,7 +60240,6 @@
 "lAZ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white/monofloor,
@@ -61407,7 +60335,6 @@
 "lBD" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 4;
-	frequency = 1441;
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
@@ -61469,8 +60396,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "lCf" = (
@@ -61510,8 +60436,7 @@
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/circuitlab)
@@ -61532,7 +60457,6 @@
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lamp/green,
 /obj/item/paper_bin{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/pen{
@@ -61642,7 +60566,6 @@
 /obj/structure/toilet,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/industrial/arrows/white{
@@ -61658,9 +60581,7 @@
 "lDX" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -61691,21 +60612,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/cafeteria)
-"lEz" = (
-/obj/effect/floor_decal/border/techfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/techfloor{
-	dir = 4
-	},
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1west)
 "lEB" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -61874,7 +60780,6 @@
 "lGV" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/floor_decal/spline/plain{
@@ -61999,7 +60904,6 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "lIa" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -62016,12 +60920,10 @@
 /obj/structure/flora/pottedplant/flower,
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/crematorium)
@@ -62035,8 +60937,7 @@
 "lIg" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/atmos/surface)
@@ -62210,8 +61111,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
@@ -62281,8 +61181,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters)
@@ -62308,8 +61207,7 @@
 	},
 /obj/landmark/join/start/hydro,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	pixel_y = -10
@@ -62324,14 +61222,10 @@
 /obj/machinery/atmospherics/omni/mixer{
 	active_power_usage = 7500;
 	tag_east = 2;
-	tag_east_con = null;
-	tag_north = 0;
-	tag_north_con = null;
 	tag_south = 1;
 	tag_south_con = 0.79;
 	tag_west = 1;
-	tag_west_con = 0.21;
-	use_power = 1
+	tag_west_con = 0.21
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -62341,9 +61235,7 @@
 "lLG" = (
 /obj/structure/flora/small/rock5,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -62351,8 +61243,7 @@
 "lLN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -62405,7 +61296,6 @@
 "lMK" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/cable/green{
@@ -62522,7 +61412,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/steel,
@@ -62536,8 +61425,7 @@
 /area/nadezhda/command/bridgebar)
 "lNA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating/under,
@@ -62600,8 +61488,7 @@
 "lOg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -62638,8 +61525,7 @@
 "lOw" = (
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
@@ -62680,7 +61566,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -62693,8 +61578,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -62748,8 +61632,7 @@
 	})
 "lPz" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/grass,
@@ -62777,8 +61660,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/lab)
@@ -62848,8 +61730,7 @@
 	name = "Mixed Air Tank In"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
@@ -62940,7 +61821,6 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
 	frequency = 1443;
-	icon_state = "map_injector";
 	id = "air_in";
 	use_power = 1
 	},
@@ -62985,8 +61865,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -63022,8 +61901,7 @@
 "lRB" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security{
@@ -63095,8 +61973,7 @@
 	pixel_x = -27
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -63158,7 +62035,6 @@
 /area/nadezhda/command/teleporter)
 "lTi" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -63204,9 +62080,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/cluster/roaches/low_chance,
@@ -63244,8 +62118,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "lUf" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm4{
@@ -63253,8 +62126,7 @@
 	})
 "lUh" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/item/stool,
 /obj/effect/floor_decal/corner_techfloor_grid,
@@ -63279,8 +62151,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "lUy" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/personal/hydroponics{
 	name = "gardener's locker";
@@ -63338,8 +62209,7 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
@@ -63448,8 +62318,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
 /obj/machinery/atmospherics/unary/vent_pump,
@@ -63466,8 +62335,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/storage)
@@ -63515,8 +62383,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -63567,7 +62434,6 @@
 /area/nadezhda/command/teleporter)
 "lWy" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -63732,7 +62598,6 @@
 	},
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
-	icon_state = "danger";
 	tag = "icon-danger (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -63826,12 +62691,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
@@ -64030,8 +62893,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/sign/levels/stairsdown{
 	pixel_x = 32;
@@ -64074,7 +62936,6 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	frequency = 1441;
-	icon_state = "map_injector";
 	id = "co2_in";
 	pixel_y = 1;
 	use_power = 1
@@ -64085,9 +62946,7 @@
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 2;
 	tag_north = 1;
-	tag_south = 0;
-	tag_west = 5;
-	use_power = 1
+	tag_west = 5
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
@@ -64120,8 +62979,7 @@
 /area/nadezhda/command/bridgebar)
 "mcI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/dark/danger,
@@ -64187,12 +63045,10 @@
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
@@ -64203,7 +63059,6 @@
 /obj/effect/floor_decal/border/techfloor,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/scrap/sparse_even,
@@ -64229,10 +63084,8 @@
 "mdt" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 2;
-	tag_north = 0;
 	tag_south = 3;
-	tag_west = 1;
-	use_power = 1
+	tag_west = 1
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
@@ -64276,8 +63129,7 @@
 "mdD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
@@ -64340,11 +63192,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
@@ -64353,8 +63203,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -64390,11 +63239,9 @@
 /area/nadezhda/command/prime)
 "meB" = (
 /obj/machinery/atmospherics/omni/filter{
-	tag_east = 0;
 	tag_north = 2;
 	tag_south = 4;
-	tag_west = 1;
-	use_power = 1
+	tag_west = 1
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
@@ -64462,8 +63309,7 @@
 /area/nadezhda/engineering/atmos)
 "mfB" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -64560,8 +63406,7 @@
 "mgk" = (
 /obj/structure/table/glass,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -64675,8 +63520,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/showcase/skeleton,
 /turf/simulated/floor/tiled/white,
@@ -64708,8 +63552,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/computerframe{
 	anchored = 1;
-	dir = 1;
-	icon_state = "0"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/danger{
 	dir = 9
@@ -64735,8 +63578,7 @@
 /area/nadezhda/hallway/surface/section1)
 "mhW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
@@ -64755,11 +63597,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -64833,8 +63673,7 @@
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "mjd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
@@ -64895,10 +63734,7 @@
 	dir = 1
 	},
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/floor_decal/corner_techfloor_grid,
 /turf/simulated/floor/tiled/white/techfloor_grid,
@@ -64932,8 +63768,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -64987,8 +63822,7 @@
 "mku" = (
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/flora/small/rock4,
 /turf/simulated/floor/asteroid/grass/dry,
@@ -65050,7 +63884,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/scrap/sparse_weighted,
@@ -65073,8 +63906,7 @@
 /area/nadezhda/rnd/server)
 "mlj" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
@@ -65118,12 +63950,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/crew_quarters/barbackroom)
@@ -65159,8 +63989,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -65168,7 +63997,6 @@
 "mlP" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -65197,8 +64025,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "mmb" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/random/lowkeyrandom/low_chance,
@@ -65308,12 +64135,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -65343,7 +64168,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
@@ -65390,8 +64214,7 @@
 /obj/effect/floor_decal/industrial/loading/white,
 /obj/effect/floor_decal/industrial/box/white/corners,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -65418,8 +64241,7 @@
 "mnr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -65717,8 +64539,7 @@
 	req_access = list(3)
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/item/gun/energy/cog/gear,
 /obj/item/gun/energy/cog/gear{
@@ -65777,7 +64598,6 @@
 	pixel_x = 30
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/carpet,
@@ -65827,12 +64647,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
@@ -65850,8 +64668,7 @@
 /area/nadezhda/command/merchant)
 "mrf" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/effect/floor_decal/spline/wood{
 	dir = 4;
@@ -65927,8 +64744,7 @@
 /obj/random/furniture/pottedplant,
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -66005,8 +64821,7 @@
 /area/nadezhda/absolutism/storage)
 "msE" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -66070,8 +64885,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "mtn" = (
@@ -66083,8 +64897,7 @@
 /area/nadezhda/security/prisoncells)
 "mtx" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
@@ -66142,8 +64955,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/showcase/sign2{
 	density = 0;
@@ -66192,12 +65004,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barbackroom)
@@ -66326,9 +65136,7 @@
 /area/eris/medical/exam_room)
 "mvz" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/mineral,
@@ -66432,7 +65240,6 @@
 /obj/effect/floor_decal/industrial/road/warning4,
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/wood/wild5,
@@ -66474,11 +65281,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -66508,10 +65313,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "mxq" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/invislight,
@@ -66724,8 +65526,7 @@
 	})
 "mzR" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/salvageable/machine,
 /turf/simulated/floor/bluegrid{
@@ -66758,9 +65559,7 @@
 	},
 /obj/effect/floor_decal/corner_techfloor_grid/diagonal,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 10
@@ -66862,7 +65661,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
@@ -67092,12 +65890,10 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_weighted,
@@ -67114,7 +65910,6 @@
 "mDc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/danger,
@@ -67134,9 +65929,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_weighted,
@@ -67159,8 +65952,7 @@
 /area/nadezhda/quartermaster/disposaldrop)
 "mDt" = (
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /turf/simulated/open,
 /area/nadezhda/medical/sleeper)
@@ -67192,7 +65984,6 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
@@ -67515,8 +66306,7 @@
 	})
 "mGr" = (
 /obj/effect/floor_decal/industrial/danger/corner{
-	dir = 1;
-	icon_state = "dangercorner"
+	dir = 1
 	},
 /obj/item/slime_extract/grey,
 /turf/simulated/floor/reinforced,
@@ -67533,8 +66323,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/security/maingate{
@@ -67709,7 +66498,6 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /mob/living/simple_animal/hostile/dino/tagilla,
@@ -67797,8 +66585,7 @@
 /area/nadezhda/command/bridgebar)
 "mJn" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -67830,7 +66617,6 @@
 "mJF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1;
-	icon_state = "map";
 	tag = "icon-map (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/danger,
@@ -67929,8 +66715,7 @@
 "mKX" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/storage/fancy/candle_box,
 /turf/simulated/floor/wood/wild3,
@@ -68009,12 +66794,10 @@
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -68053,7 +66836,6 @@
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/item/material/shard,
@@ -68161,8 +66943,7 @@
 /obj/item/pen/multi,
 /obj/item/paper_bin,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "mNE" = (
@@ -68200,7 +66981,6 @@
 "mNI" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -68243,7 +67023,6 @@
 /obj/machinery/flasher{
 	dir = 6;
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/lattice,
@@ -68280,8 +67059,7 @@
 	icon_state = "road_edge_decal8"
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 10;
-	icon_state = "spline_fancy"
+	dir = 10
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/kitchen)
@@ -68379,7 +67157,6 @@
 "mPC" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/washing_machine,
@@ -68478,11 +67255,9 @@
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "mQx" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -68522,7 +67297,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
@@ -68544,8 +67318,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
@@ -68618,7 +67391,6 @@
 /obj/random/lowkeyrandom/low_chance,
 /obj/random/lowkeyrandom/low_chance,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -68778,7 +67550,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/danger,
@@ -68807,8 +67578,7 @@
 "mUh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -68881,9 +67651,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
@@ -68894,12 +67662,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -68925,11 +67691,9 @@
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "mUJ" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -68983,8 +67747,7 @@
 	})
 "mVb" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
@@ -69199,13 +67962,10 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
@@ -69266,8 +68026,7 @@
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "mXM" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 9;
-	icon_state = "spline_fancy"
+	dir = 9
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/bridgebar)
@@ -69286,7 +68045,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -69368,8 +68126,7 @@
 "mYM" = (
 /obj/structure/flora/small/bushc1,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/main/stairwell)
@@ -69378,8 +68135,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/turret_protected/ai_upload)
@@ -69421,7 +68177,6 @@
 /obj/structure/table/marble,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
@@ -69597,8 +68352,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -69613,8 +68367,7 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/leafybush,
 /obj/effect/floor_decal/spline/wood{
-	dir = 8;
-	icon_state = "spline_fancy"
+	dir = 8
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/botanist)
@@ -69790,8 +68543,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "ndy" = (
@@ -69862,8 +68614,7 @@
 /area/nadezhda/maintenance/substation/section6)
 "nem" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/hallway/surface/section1)
@@ -69952,8 +68703,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "neR" = (
@@ -70001,8 +68751,7 @@
 	},
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/clownoffice)
@@ -70109,9 +68858,7 @@
 	},
 /area/shuttle/surface_transport_lz)
 "ngu" = (
-/mob/living/simple_animal/goose{
-	faction = "pond"
-	},
+/mob/living/simple_animal/goose,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
 "ngA" = (
@@ -70119,8 +68866,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/sign/levels/stairsup{
 	pixel_x = 32;
@@ -70131,7 +68877,6 @@
 "ngE" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 1;
-	frequency = 1441;
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
@@ -70311,8 +69056,7 @@
 /area/nadezhda/command/captain/quarters)
 "nil" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
@@ -70364,8 +69108,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "niU" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/flora/small/bushb1,
 /obj/structure/railing/grey,
@@ -70406,7 +69149,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = null;
 	name = "Front Desk";
 	req_access = list(5)
 	},
@@ -70480,8 +69222,7 @@
 "njU" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
@@ -70508,12 +69249,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -70601,8 +69340,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1
@@ -70697,12 +69435,10 @@
 /obj/machinery/space_heater,
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
@@ -70770,9 +69506,7 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
 "nne" = (
-/obj/machinery/ai_slipper{
-	icon_state = "motion0"
-	},
+/obj/machinery/ai_slipper,
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "nnn" = (
@@ -70782,15 +69516,13 @@
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "nnr" = (
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
@@ -70815,7 +69547,6 @@
 "nnM" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -70850,8 +69581,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
@@ -70893,11 +69623,9 @@
 /area/nadezhda/quartermaster/hangarsupply)
 "nop" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -70933,7 +69661,6 @@
 	dir = 8
 	},
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
@@ -70988,8 +69715,7 @@
 "npj" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
@@ -71003,8 +69729,7 @@
 /area/nadezhda/crew_quarters/techshop)
 "npm" = (
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -71028,8 +69753,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
@@ -71040,8 +69764,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "npA" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -71094,12 +69817,10 @@
 /area/nadezhda/hallway/side/f2section1)
 "nqg" = (
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/open,
 /area/nadezhda/medical/sleeper)
@@ -71133,8 +69854,7 @@
 /area/nadezhda/security/triage_blackshield)
 "nqG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
@@ -71189,8 +69909,7 @@
 /area/eris/crew_quarters/plasma_tag)
 "nrl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
@@ -71250,16 +69969,14 @@
 /area/eris/medical/exam_room)
 "nrS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "nrX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
@@ -71268,8 +69985,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/rnd/docking{
@@ -71306,7 +70022,6 @@
 "nsd" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 1;
-	frequency = 1441;
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
@@ -71406,15 +70121,13 @@
 /obj/structure/ore_box,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
-	icon_state = "danger";
 	tag = "icon-danger (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "ntA" = (
 /obj/structure/bed/chair/custom/bar_special{
-	dir = 8;
-	icon_state = "bar_chair"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -71424,8 +70137,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ntC" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/table/rack/shelf,
 /obj/effect/decal/cleanable/dirt,
@@ -71674,7 +70386,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -71768,7 +70479,6 @@
 "nxR" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/wood/wild5,
@@ -71850,7 +70560,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
-	icon_state = "danger";
 	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -71875,7 +70584,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -72000,8 +70708,7 @@
 /area/nadezhda/outside/forest)
 "nAa" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -72143,8 +70850,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
@@ -72250,8 +70956,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -72343,8 +71048,7 @@
 "nDn" = (
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -72355,7 +71059,6 @@
 /obj/effect/floor_decal/border/techfloor,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating,
@@ -72397,12 +71100,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals3,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -72478,7 +71179,6 @@
 /area/nadezhda/command/bridgebar)
 "nET" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/slotmachine,
@@ -72538,7 +71238,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/effect/decal/cleanable/generic,
@@ -72565,12 +71264,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/gmaster)
@@ -72772,8 +71469,7 @@
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "nHg" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/fitness)
@@ -72850,12 +71546,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security{
@@ -72927,10 +71621,8 @@
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "nIE" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	locked = 0;
 	name = "South APC";
-	operating = 1;
 	pixel_y = -28
 	},
 /obj/structure/cable/green,
@@ -72962,9 +71654,7 @@
 /obj/item/reagent_containers/enricher,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/structure/table/marble,
 /turf/simulated/floor/wood,
@@ -72985,7 +71675,6 @@
 "nJk" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -73062,8 +71751,7 @@
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/kitchen)
@@ -73224,8 +71912,7 @@
 /obj/structure/sign/faction/derelict1{
 	desc = "ATTENTION: This area is Soteria Institute property, all trespassers and looters will be prosecuted to the full extent of the law.";
 	name = "NOTICE: Soteria Property";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/dungeon/outside/abandoned_solars)
@@ -73234,8 +71921,7 @@
 /obj/item/weldpack/canister,
 /obj/item/weldpack/canister,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -73288,7 +71974,6 @@
 /area/nadezhda/outside/dcave)
 "nLL" = (
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = null;
 	name = "Chemistry Lab";
 	req_access = list(33)
 	},
@@ -73505,7 +72190,6 @@
 "nOM" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Engine - Main - 1";
-	capacity = 5e+006;
 	charge = 5e+006;
 	cur_coils = 4;
 	input_attempt = 1;
@@ -73560,8 +72244,7 @@
 "nPm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -73575,8 +72258,7 @@
 /area/nadezhda/security/armory_blackshield)
 "nPq" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -73650,12 +72332,10 @@
 "nQo" = (
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/wood/wild5,
@@ -73669,8 +72349,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/item/scrap_lump,
 /obj/machinery/atmospherics/pipe/zpipe/down{
-	dir = 1;
-	icon_state = "down"
+	dir = 1
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -73700,8 +72379,7 @@
 "nQK" = (
 /obj/structure/flora/small/busha1,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
@@ -73728,7 +72406,6 @@
 "nRg" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Engine - Main - 2";
-	capacity = 5e+006;
 	charge = 5e+006;
 	cur_coils = 4;
 	input_attempt = 1;
@@ -73767,19 +72444,6 @@
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"nRp" = (
-/obj/effect/floor_decal/border/techfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/techfloor{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1west)
 "nRJ" = (
 /obj/structure/sign/department/ai,
 /turf/simulated/wall/r_wall,
@@ -73812,12 +72476,10 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/lattice,
@@ -73852,7 +72514,6 @@
 "nSD" = (
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -73872,12 +72533,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
@@ -73911,7 +72570,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/table/woodentable,
@@ -74031,8 +72689,7 @@
 	req_access = list(3)
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/suit/armor/flackvest/marshal/full,
@@ -74073,8 +72730,7 @@
 /area/nadezhda/engineering/engine_room)
 "nUC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -74158,8 +72814,7 @@
 	input_level = 250000;
 	inputting = 1;
 	output_attempt = 1;
-	output_level = 250000;
-	outputting = 0
+	output_level = 250000
 	},
 /obj/structure/cable/cyan{
 	d2 = 8;
@@ -74220,9 +72875,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -74246,7 +72899,6 @@
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -74468,15 +73120,13 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/maintenance/surface_maints_1)
 "nYn" = (
@@ -74497,9 +73147,7 @@
 /area/nadezhda/outside/forest)
 "nYy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/comfy/teal{
-	icon_state = "comfychair_preview"
-	},
+/obj/structure/bed/chair/comfy/teal,
 /obj/landmark/join/start/cmo,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
@@ -74549,8 +73197,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -74610,8 +73257,7 @@
 /area/nadezhda/outside/forest)
 "nZl" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -74619,8 +73265,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "nZm" = (
@@ -74762,7 +73407,6 @@
 /area/nadezhda/outside/inside_colony)
 "oas" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -74777,8 +73421,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/maingate{
@@ -74821,8 +73464,7 @@
 "oaS" = (
 /obj/machinery/camera/network/colony_surface,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "oaT" = (
@@ -74834,8 +73476,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "oaU" = (
@@ -74917,8 +73558,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "obQ" = (
@@ -74966,8 +73606,7 @@
 /area/nadezhda/outside/forest)
 "oci" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
@@ -75102,17 +73741,14 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "odJ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/catwalk,
 /obj/structure/railing/grey,
@@ -75339,7 +73975,6 @@
 /area/eris/crew_quarters/plasma_tag)
 "ofu" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/random/furniture/pottedplant,
@@ -75398,8 +74033,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -75500,8 +74134,7 @@
 "ogx" = (
 /obj/structure/table/glass,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -75531,7 +74164,6 @@
 	},
 /obj/structure/window/basic{
 	dir = 4;
-	icon_state = "window";
 	pixel_x = 3
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -75550,14 +74182,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/reception)
 "ogM" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -75585,7 +74215,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/cluster/spiders/low_chance,
@@ -75795,8 +74424,7 @@
 	name = "Xenobiology Operating Table"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
@@ -75977,9 +74605,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "olq" = (
 /obj/machinery/power/breakerbox{
-	RCon_tag = "Shield Substation Bypass";
-	icon_state = "bbox_off";
-	on = 0
+	RCon_tag = "Shield Substation Bypass"
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
@@ -76077,12 +74703,10 @@
 "olY" = (
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/floor_decal/spline/plain{
@@ -76104,8 +74728,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -76273,7 +74896,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -76363,8 +74985,7 @@
 "ooP" = (
 /obj/random/material/low_chance,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -76408,8 +75029,7 @@
 "ooV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -76521,8 +75141,7 @@
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "oqd" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -76614,9 +75233,7 @@
 "oqE" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
-/mob/living/simple_animal/hostile/frog{
-	faction = "pond"
-	},
+/mob/living/simple_animal/hostile/frog,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/pond)
 "oqI" = (
@@ -76638,12 +75255,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -76687,7 +75302,6 @@
 "orJ" = (
 /obj/structure/bed/chair/wood{
 	dir = 4;
-	icon_state = "wooden_chair";
 	tag = "icon-wooden_chair (EAST)"
 	},
 /turf/simulated/floor/carpet,
@@ -76704,9 +75318,7 @@
 "orN" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 24
@@ -76771,8 +75383,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "osA" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/mineral,
 /area/colony)
@@ -76845,8 +75456,7 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
@@ -76876,7 +75486,6 @@
 "otH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -76905,8 +75514,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/chips,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -77019,8 +75627,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -77034,8 +75641,7 @@
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -77163,8 +75769,7 @@
 /area/nadezhda/rnd/docking)
 "ovI" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77385,8 +75990,7 @@
 	dir = 4
 	},
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
@@ -77516,8 +76120,7 @@
 /area/nadezhda/engineering/engine_room)
 "oyN" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -77629,8 +76232,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -77742,8 +76344,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -77822,9 +76423,7 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -77841,13 +76440,10 @@
 /area/shuttle/surface_transport_lz)
 "oCh" = (
 /obj/structure/lattice,
-/obj/machinery/ai_slipper{
-	icon_state = "motion0"
-	},
+/obj/machinery/ai_slipper,
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
@@ -77930,7 +76526,6 @@
 "oDt" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
-	icon_state = "danger";
 	tag = "icon-danger (WEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -77941,15 +76536,13 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/disposal/deliveryChute,
 /obj/machinery/door/window/southright{
-	dir = 2;
 	icon_state = "left";
 	name = "Containment Pen";
 	req_access = newlist()
@@ -78053,8 +76646,7 @@
 /area/nadezhda/command/panic_room)
 "oEi" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -78165,8 +76757,7 @@
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/box/red,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -78450,7 +77041,6 @@
 /obj/machinery/flasher{
 	dir = 6;
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
@@ -78549,8 +77139,7 @@
 	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -78691,8 +77280,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -78737,8 +77325,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/box/white/corners,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -78801,13 +77388,10 @@
 "oLe" = (
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -78906,8 +77490,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "oLP" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -78942,7 +77525,6 @@
 "oMs" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/power/apc{
-	dir = 2;
 	locked = 0;
 	name = "South APC";
 	operating = 0;
@@ -78998,7 +77580,6 @@
 "oML" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/steel,
@@ -79023,7 +77604,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -79095,8 +77675,7 @@
 "oNP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
@@ -79120,12 +77699,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -79135,8 +77712,7 @@
 "oOO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/woodentable,
@@ -79180,7 +77756,6 @@
 /area/nadezhda/command/crematorium)
 "oPl" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/cable/cyan{
@@ -79345,8 +77920,7 @@
 /obj/item/pen/multi,
 /obj/item/paper_bin,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "oQx" = (
@@ -79376,8 +77950,7 @@
 /area/nadezhda/outside/fnest)
 "oQR" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -79426,8 +77999,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/medical/sleeper)
@@ -79469,14 +78041,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"oRA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/wood{
-	dir = 8;
-	icon_state = "spline_fancy"
-	},
-/turf/simulated/floor/carpet/turcarpet,
-/area/nadezhda/crew_quarters/cafeteria)
 "oRB" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
@@ -79502,7 +78066,6 @@
 /area/eris/crew_quarters/barquarters)
 "oRV" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -79661,8 +78224,7 @@
 	dir = 1
 	},
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/flora/small/rock4,
 /turf/simulated/floor/asteroid/grass,
@@ -79711,7 +78273,6 @@
 "oTB" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/floor_decal/spline/plain{
@@ -79722,7 +78283,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/effect/floor_decal/spline/plain{
@@ -79884,9 +78444,7 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -79990,8 +78548,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "oYg" = (
 /obj/machinery/sorter/biomatter{
-	input_side = 1;
-	refuse_output_side = 2
+	input_side = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
@@ -80003,8 +78560,7 @@
 	})
 "oYn" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -80032,7 +78588,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -80173,8 +78728,7 @@
 "paP" = (
 /obj/structure/cyberplant,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/barbackroom)
@@ -80195,7 +78749,6 @@
 "pbl" = (
 /obj/machinery/power/terminal{
 	dir = 1;
-	icon_state = "term";
 	tag = "icon-term (NORTH)"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -80395,8 +78948,7 @@
 /area/nadezhda/rnd/rbreakroom)
 "pda" = (
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j1"
+	dir = 1
 	},
 /turf/unsimulated/mineral,
 /area/colony)
@@ -80482,7 +79034,6 @@
 "pdY" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -80520,9 +79071,7 @@
 "ped" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -80564,9 +79113,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/structure/reagent_dispensers/fueltank/huge,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -80595,8 +79142,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/turret_protected/ai_upload)
@@ -80695,8 +79241,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -80888,8 +79433,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "phb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -80925,8 +79469,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "phk" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -81043,8 +79586,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "piX" = (
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
@@ -81316,8 +79858,7 @@
 "plY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -81563,12 +80104,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
@@ -81683,8 +80222,7 @@
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/beer,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/kitchen)
@@ -81974,20 +80512,6 @@
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
-"pte" = (
-/obj/effect/floor_decal/border/techfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
-	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1west)
 "ptm" = (
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
@@ -82000,8 +80524,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "ptn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -82059,8 +80582,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -82143,8 +80665,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "puT" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82235,8 +80756,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "pvB" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
@@ -82303,8 +80823,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -82325,7 +80844,6 @@
 "pwG" = (
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/dirt,
@@ -82457,8 +80975,7 @@
 /area/nadezhda/crew_quarters)
 "pxX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -82511,7 +81028,6 @@
 /obj/random/lathe_disk/low_chance,
 /obj/item/toy/junk/bosunwhistle,
 /obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/wood,
@@ -82526,8 +81042,7 @@
 "pyJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -82721,19 +81236,16 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
 "pBj" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 5;
-	icon_state = "spline_fancy"
+	dir = 5
 	},
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
@@ -82753,10 +81265,8 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "pBq" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	locked = 0;
 	name = "South APC";
-	operating = 1;
 	pixel_y = -28
 	},
 /obj/structure/cable/cyan{
@@ -82764,8 +81274,7 @@
 	icon_state = "0-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/gmaster)
@@ -82788,12 +81297,10 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "pBw" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/cafe,
@@ -82817,10 +81324,7 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "pBI" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "pBL" = (
@@ -82895,8 +81399,7 @@
 "pCm" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "pCq" = (
@@ -82943,7 +81446,6 @@
 "pCG" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4;
 	name = "Marshals Brig";
 	req_one_access = list(63)
 	},
@@ -82952,8 +81454,7 @@
 /area/nadezhda/security/sechall)
 "pCH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -83012,8 +81513,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -83024,10 +81524,8 @@
 "pDo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	dir = 2;
 	locked = 0;
 	name = "South APC";
-	operating = 1;
 	pixel_y = -28
 	},
 /obj/structure/cable/cyan{
@@ -83097,8 +81595,7 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/machinery/camera/network/church{
 	dir = 4
@@ -83131,7 +81628,6 @@
 "pEa" = (
 /obj/structure/bed/chair/wood{
 	dir = 1;
-	icon_state = "wooden_chair";
 	tag = "icon-wooden_chair (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -83350,7 +81846,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/power/sensor{
@@ -83371,8 +81866,7 @@
 /area/nadezhda/quartermaster/miningdock)
 "pGl" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/modular_computer/console/preset/engineering/rcon,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -83498,7 +81992,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -83607,12 +82100,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -83622,7 +82113,6 @@
 /area/nadezhda/outside/inside_colony)
 "pIA" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -83858,7 +82348,6 @@
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "pKQ" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -83894,8 +82383,7 @@
 	},
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
@@ -84001,7 +82489,6 @@
 "pMw" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/structure/table/marble,
@@ -84103,13 +82590,11 @@
 "pNu" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /turf/simulated/open,
 /area/nadezhda/engineering/foyer)
@@ -84176,7 +82661,6 @@
 "pOo" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/pen{
@@ -84196,28 +82680,23 @@
 	icon_state = "1-4"
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
 "pOA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4;
-	icon_state = "warningcorner"
+	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/steel,
@@ -84287,15 +82766,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/ai_slipper{
-	icon_state = "motion0"
-	},
+/obj/machinery/ai_slipper,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/turret_protected/ai)
 "pOX" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/dark/panels,
@@ -84332,17 +82808,14 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/cbo)
 "pPn" = (
 /obj/random/science/low_chance,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -84372,8 +82845,7 @@
 /area/nadezhda/outside/inside_colony)
 "pPM" = (
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /obj/structure/lattice,
 /obj/effect/floor_decal/spline/wood{
@@ -84481,12 +82953,10 @@
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -84502,8 +82972,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -84533,8 +83002,7 @@
 "pQP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/wood,
@@ -84554,7 +83022,6 @@
 "pQS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4;
-	icon_state = "map";
 	tag = "icon-map (EAST)"
 	},
 /turf/simulated/floor/bluegrid{
@@ -84633,8 +83100,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/noticeboard/lonestar_supply{
 	pixel_x = 32
@@ -84681,7 +83147,6 @@
 "pSe" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/item/paper_bin{
@@ -84723,8 +83188,7 @@
 	name = "meeting room holopad"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -84736,8 +83200,7 @@
 	},
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass/soda,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -84797,8 +83260,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
@@ -84812,8 +83274,7 @@
 /area/nadezhda/outside/pond)
 "pTz" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /turf/simulated/floor/plating/under,
@@ -84894,8 +83355,7 @@
 /obj/random/lowkeyrandom,
 /obj/random/lowkeyrandom,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
@@ -84915,8 +83375,7 @@
 	dir = 8
 	},
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /turf/simulated/open,
 /area/nadezhda/medical/sleeper)
@@ -85088,13 +83547,11 @@
 "pWC" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /obj/structure/railing/grey,
 /obj/structure/cable/cyan{
 	d1 = 32;
-	d2 = 1;
 	icon_state = "32-1"
 	},
 /turf/simulated/open,
@@ -85110,8 +83567,7 @@
 "pWO" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
@@ -85129,7 +83585,6 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -85188,8 +83643,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/rocinante_shuttle_area)
@@ -85215,7 +83669,6 @@
 "pXE" = (
 /obj/structure/catwalk,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -85228,13 +83681,10 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
-	anchored = 1;
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -85317,8 +83767,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -85326,7 +83775,6 @@
 "pYZ" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -85373,7 +83821,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -85384,7 +83831,6 @@
 /area/nadezhda/command/meeting_room)
 "pZy" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/computer/prisoner{
@@ -85475,20 +83921,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
-"qar" = (
-/obj/effect/floor_decal/border/techfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/techfloor{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1north)
 "qau" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -85528,8 +83960,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/reinforced,
@@ -85574,8 +84005,7 @@
 /area/colony)
 "qbr" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
@@ -85592,15 +84022,10 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/sleeper)
 "qbz" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/machinery/power/apc{
-	dir = 2;
 	locked = 0;
 	name = "South APC";
-	operating = 1;
 	pixel_y = -28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -85616,9 +84041,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qbD" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
-	input_tag = null;
 	name = "Coolant Tank Control";
-	output_tag = null;
 	sensors = list("coolant_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/danger,
@@ -85656,8 +84079,7 @@
 "qcx" = (
 /obj/structure/window/reinforced,
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 1
@@ -85683,21 +84105,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/techshop)
-"qcL" = (
-/obj/effect/floor_decal/border/techfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/border/techfloor{
-	dir = 4
-	},
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1north)
 "qcS" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
@@ -85717,10 +84124,7 @@
 	dir = 1
 	},
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/floor_decal/corner_techfloor_grid,
 /turf/simulated/floor/tiled/white/techfloor_grid,
@@ -85851,8 +84255,7 @@
 /obj/item/tool/screwdriver,
 /obj/item/stack/cable_coil/random,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/item/storage/belt,
 /turf/simulated/floor/tiled/white/gray_perforated,
@@ -85999,8 +84402,7 @@
 	icon_state = "road_edge_decal1"
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 5;
-	icon_state = "spline_fancy"
+	dir = 5
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/kitchen)
@@ -86083,8 +84485,7 @@
 "qgn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -86122,8 +84523,7 @@
 "qgG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -86193,7 +84593,6 @@
 /area/nadezhda/dungeon/outside/burned_outpost)
 "qhv" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -86210,8 +84609,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -86285,8 +84683,7 @@
 "qiq" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -86309,8 +84706,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -86331,7 +84727,6 @@
 	pixel_y = 16
 	},
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white/techfloor,
@@ -86508,7 +84903,6 @@
 /obj/structure/catwalk,
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -86596,9 +84990,7 @@
 /obj/structure/catwalk,
 /obj/structure/railing,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
@@ -86741,8 +85133,7 @@
 /area/nadezhda/hallway/surface/section1)
 "qmE" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 6;
-	icon_state = "spline_fancy"
+	dir = 6
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	pixel_y = -10
@@ -86828,8 +85219,7 @@
 "qnl" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -86898,7 +85288,6 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
 	frequency = 1441;
-	icon_state = "map_injector";
 	id = "o2_in";
 	use_power = 1
 	},
@@ -86955,8 +85344,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -87034,8 +85422,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/wood,
@@ -87090,12 +85477,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/turret_protected/ai_upload)
@@ -87167,8 +85552,7 @@
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/coffee_master,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/kitchen)
@@ -87312,8 +85696,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/crematorium)
@@ -87325,7 +85708,6 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
 	frequency = 1441;
-	icon_state = "map_injector";
 	id = "n2_in";
 	use_power = 1
 	},
@@ -87394,8 +85776,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -87426,9 +85807,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/cluster/spiders/low_chance,
@@ -87445,14 +85824,11 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/newscaster{
 	dir = 4;
@@ -87470,8 +85846,7 @@
 /obj/machinery/light/small,
 /obj/random/contraband/low_chance,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/quartermaster/miningdock)
@@ -87489,8 +85864,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -87510,8 +85884,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate{
@@ -87576,8 +85949,7 @@
 "quT" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/sign/faction/neotheology{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
@@ -87751,7 +86123,6 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "qwE" = (
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/sink{
@@ -87765,8 +86136,7 @@
 /area/nadezhda/absolutism/vectorrooms)
 "qwI" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
@@ -87874,14 +86244,12 @@
 "qxg" = (
 /obj/structure/curtain/open,
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -88010,7 +86378,6 @@
 "qyA" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/structure/catwalk,
@@ -88035,8 +86402,7 @@
 /area/shuttle/rocinante_shuttle_area)
 "qyT" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/structure/flora/small/lavarock1,
 /turf/simulated/floor/asteroid/grass,
@@ -88297,8 +86663,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -88313,8 +86678,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/random/furniture/pottedplant,
@@ -88322,7 +86686,6 @@
 /area/nadezhda/engineering/foyer)
 "qBf" = (
 /obj/machinery/door/window/southright{
-	dir = 2;
 	icon_state = "left";
 	name = "Containment Pen";
 	req_access = list(55)
@@ -88336,8 +86699,7 @@
 "qBh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey{
 	dir = 1
@@ -88356,11 +86718,9 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -88382,8 +86742,7 @@
 "qBQ" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/sign/faction/neotheology{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
@@ -88455,9 +86814,7 @@
 "qDa" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
@@ -88508,11 +86865,9 @@
 /area/nadezhda/security/hut_cell1)
 "qDl" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 4;
 	name = "Guild Master RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/light_switch{
@@ -88598,7 +86953,6 @@
 "qEl" = (
 /obj/structure/closet/cabinet,
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/item/clothing/under/rank/first_officer/skirt,
@@ -88625,9 +86979,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -88683,9 +87035,7 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	anchored = 1;
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -88828,8 +87178,7 @@
 /area/nadezhda/quartermaster/hangarsupply)
 "qGe" = (
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "qGp" = (
@@ -88855,8 +87204,7 @@
 "qGy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -89059,8 +87407,7 @@
 /area/nadezhda/maintenance/substation/section6)
 "qIH" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/conveyor/east{
 	dir = 1;
@@ -89271,8 +87618,7 @@
 /area/nadezhda/outside/inside_colony)
 "qKR" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -89336,8 +87682,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
@@ -89372,9 +87717,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "qLJ" = (
-/mob/living/simple_animal/hostile/frog{
-	faction = "pond"
-	},
+/mob/living/simple_animal/hostile/frog,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
 "qLN" = (
@@ -89394,8 +87737,7 @@
 /area/nadezhda/command/bridge)
 "qLT" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -89584,12 +87926,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -89673,7 +88013,6 @@
 /area/nadezhda/command/cbo)
 "qOW" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -89808,8 +88147,7 @@
 /area/nadezhda/security/armoryshop)
 "qPT" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
@@ -89887,7 +88225,6 @@
 /area/nadezhda/hallway/surface/section1)
 "qQW" = (
 /obj/machinery/door/window/southright{
-	dir = 2;
 	icon_state = "left";
 	name = "Containment Pen"
 	},
@@ -90053,7 +88390,6 @@
 /area/nadezhda/crew_quarters/techshop)
 "qSH" = (
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/cable/cyan{
@@ -90069,8 +88405,7 @@
 /area/nadezhda/command/tcommsat/computer)
 "qSJ" = (
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/circuitlab{
@@ -90143,12 +88478,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -90176,15 +88509,13 @@
 	})
 "qTC" = (
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /obj/structure/railing/grey{
 	dir = 1
 	},
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey,
 /obj/structure/cable/green{
@@ -90200,8 +88531,7 @@
 /area/nadezhda/absolutism/bioreactor)
 "qTD" = (
 /obj/effect/floor_decal/industrial/danger/corner{
-	dir = 4;
-	icon_state = "dangercorner"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
@@ -90243,9 +88573,7 @@
 "qUf" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
-	icon_state = "door_closed";
 	id_tag = "cargo_bay_door";
-	locked = 0;
 	name = "Cargo Factory Floor";
 	req_access = list(50)
 	},
@@ -90277,15 +88605,13 @@
 "qUs" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/atmos/storage)
 "qUt" = (
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -90614,7 +88940,6 @@
 "qXf" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
-	icon_state = "danger";
 	tag = "icon-danger (EAST)"
 	},
 /obj/structure/ore_box,
@@ -90653,8 +88978,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "qXI" = (
 /obj/effect/floor_decal/industrial/danger/corner{
-	dir = 8;
-	icon_state = "dangercorner"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/crew_quarters/plasma_tag)
@@ -90668,12 +88992,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -90802,12 +89124,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
@@ -90909,8 +89229,7 @@
 /area/nadezhda/outside/inside_colony)
 "rac" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
@@ -90931,7 +89250,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -90939,7 +89257,6 @@
 "rai" = (
 /obj/structure/bed/chair/wood{
 	dir = 8;
-	icon_state = "wooden_chair";
 	tag = "icon-wooden_chair (WEST)"
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -91007,8 +89324,7 @@
 "raR" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/reagent_containers/food/drinks/bottle/ntcahors,
 /obj/machinery/light{
@@ -91029,11 +89345,9 @@
 	pixel_y = 3
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -91111,8 +89425,7 @@
 /area/nadezhda/command/captain/quarters)
 "rbG" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/closet/wardrobe/color/black,
 /turf/simulated/floor/wood/wild3,
@@ -91174,8 +89487,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "rco" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/laber_area)
@@ -91453,7 +89765,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
@@ -91589,8 +89900,7 @@
 /area/nadezhda/rnd/research)
 "rfM" = (
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /obj/structure/flora/small/bushc3,
 /obj/structure/flora/ausbushes/brflowers,
@@ -91764,8 +90074,7 @@
 /area/nadezhda/outside/lakeside)
 "rhS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -91929,7 +90238,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -92080,8 +90388,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -92111,8 +90418,7 @@
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "rll" = (
 /obj/structure/bed/chair/custom/bar_special{
-	dir = 8;
-	icon_state = "bar_chair"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -92126,7 +90432,6 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
 	frequency = 1441;
-	icon_state = "map_injector";
 	id = "waste_in";
 	pixel_y = 1;
 	use_power = 1
@@ -92233,8 +90538,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "rmx" = (
 /obj/structure/window/basic{
-	dir = 4;
-	icon_state = "window"
+	dir = 4
 	},
 /obj/random/scrap/sparse_even/low_chance,
 /turf/simulated/floor/tiled/steel,
@@ -92307,7 +90611,6 @@
 "rng" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /mob/living/carbon/superior_animal/roach/nanite,
@@ -92344,7 +90647,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/pen{
@@ -92490,8 +90792,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "roM" = (
 /obj/structure/window/basic{
-	dir = 4;
-	icon_state = "window"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -92499,8 +90800,7 @@
 "roS" = (
 /obj/structure/window/reinforced,
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 1
@@ -92544,9 +90844,7 @@
 /obj/structure/table/reinforced,
 /obj/item/device/lighting/toggleable/lamp,
 /obj/item/stamp{
-	name = "Quartermaster's stamp";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Quartermaster's stamp"
 	},
 /obj/item/stamp/denied,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -92564,9 +90862,7 @@
 "rpC" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -92585,12 +90881,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 4
@@ -92754,8 +91048,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -92824,13 +91117,11 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	id_tag = "xeno_airlock_control";
 	name = "Xenobiology Access Console";
-	pixel_x = 0;
 	pixel_y = -28;
 	tag_exterior_door = "xeno_airlock_exterior";
 	tag_interior_door = "xeno_airlock_interior"
@@ -92844,8 +91135,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "rsb" = (
@@ -92868,7 +91158,6 @@
 /obj/item/tool/multitool,
 /obj/item/tool/multitool,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -92903,8 +91192,7 @@
 /area/shuttle/rocinante_shuttle_area)
 "rsm" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
@@ -92916,8 +91204,7 @@
 "rsr" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -92974,10 +91261,7 @@
 /area/eris/crew_quarters/barbackroom)
 "rtf" = (
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/effect/floor_decal/spline/plain{
@@ -92996,8 +91280,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -93148,8 +91431,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/cyan{
 	d2 = 4;
@@ -93195,8 +91477,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "rvd" = (
@@ -93219,17 +91500,14 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "rvu" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -93267,8 +91545,7 @@
 /area/nadezhda/crew_quarters)
 "rvz" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -93424,8 +91701,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -93434,8 +91710,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/maintenance/surface_maints_1)
 "rxs" = (
@@ -93549,8 +91824,7 @@
 	pixel_x = -28
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -93670,13 +91944,10 @@
 "rzC" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
@@ -93686,8 +91957,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -93788,8 +92058,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
@@ -93844,7 +92113,6 @@
 /area/nadezhda/engineering/engine_room)
 "rAH" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen/prechilled,
@@ -93964,8 +92232,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -93987,8 +92254,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -94143,7 +92409,6 @@
 "rDu" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/machinery/vending/dinnerware,
@@ -94154,7 +92419,6 @@
 /obj/machinery/button/remote/blast_door{
 	id = "buffet2";
 	name = "kitchen access";
-	pixel_x = 0;
 	pixel_y = 30;
 	req_access = list(25)
 	},
@@ -94163,7 +92427,6 @@
 "rDw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -94199,8 +92462,7 @@
 "rDJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/machinery/light/small,
 /obj/random/contraband/low_chance,
@@ -94209,8 +92471,7 @@
 "rDK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/noticeboard/marshal{
 	pixel_x = -32
@@ -94234,7 +92495,6 @@
 "rDQ" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
-	icon_state = "danger";
 	tag = "icon-danger (EAST)"
 	},
 /obj/machinery/conveyor_switch{
@@ -94337,7 +92597,6 @@
 /obj/structure/sign/faction/derelict1{
 	desc = "ATTENTION: The scrap beacon is a dangerous device, listen to all alarms and avoid standing in hazard areas when the machine is active. Failure to do so will result in serious consequences, up to and including a messy death!";
 	name = "NOTICE: Dangerous Equipment";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -94515,7 +92774,6 @@
 /obj/machinery/button/remote/airlock{
 	id = "shuttle_hatch_bolts";
 	name = "Door Bolt Control";
-	pixel_x = 0;
 	pixel_y = 20;
 	req_one_access = list(1,19,80);
 	specialfunctions = 4
@@ -94687,8 +92945,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "rIy" = (
@@ -94792,10 +93049,7 @@
 /area/nadezhda/command/courtroom)
 "rJS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -95078,8 +93332,7 @@
 "rMK" = (
 /obj/structure/multiz/stairs/enter/bottom,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/side/f2section1)
@@ -95231,9 +93484,7 @@
 "rOs" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -95247,8 +93498,7 @@
 "rOw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
-	dir = 10;
-	icon_state = "spline_fancy"
+	dir = 10
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -95288,8 +93538,7 @@
 /area/nadezhda/security/sechall)
 "rOL" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -95393,7 +93642,6 @@
 "rPn" = (
 /obj/structure/disposalpipe/up{
 	dir = 8;
-	icon_state = "pipe-u";
 	tag = "icon-pipe-u (WEST)"
 	},
 /turf/simulated/floor/plating/under,
@@ -95433,7 +93681,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/random/furniture/pottedplant,
@@ -95479,12 +93726,10 @@
 /area/nadezhda/maintenance/substation/section4)
 "rQd" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
@@ -95560,8 +93805,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
@@ -95627,7 +93871,6 @@
 "rRF" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4;
 	name = "Marshals Brig";
 	req_one_access = list(63)
 	},
@@ -95645,14 +93888,11 @@
 "rRK" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/table/woodentable,
 /obj/item/paper_bin,
 /obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/sblucarpet,
@@ -95770,7 +94010,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/lattice,
@@ -95921,9 +94160,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "rTS" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -96004,8 +94241,7 @@
 "rUZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "rVb" = (
@@ -96023,9 +94259,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -96063,13 +94297,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/prisoncells)
-"rVM" = (
-/obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
 "rVP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -96111,8 +94338,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/showcase/sign2{
 	density = 0;
@@ -96293,7 +94519,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/scrap/sparse_even,
@@ -96397,8 +94622,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/shuttle/floor/mining,
@@ -96562,8 +94786,7 @@
 "rZU" = (
 /obj/structure/multiz/stairs/active,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/hallway/main/stairwell)
@@ -96582,24 +94805,20 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "sad" = (
@@ -96644,7 +94863,6 @@
 	master_tag = "xeno_airlock_control";
 	name = "Xenobiology Access Button";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access = list(55)
 	},
 /obj/machinery/disposal,
@@ -96822,8 +95040,7 @@
 /obj/item/rig/combat/blackshield/equipped,
 /obj/structure/table/woodentable,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
@@ -96851,8 +95068,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -96870,7 +95086,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -97041,8 +95256,7 @@
 "set" = (
 /obj/structure/barricade,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/crew_quarters/plasma_tag)
@@ -97139,8 +95353,7 @@
 /obj/structure/table/standard,
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass/soda,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -97181,8 +95394,7 @@
 /area/nadezhda/rnd/server)
 "sfM" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/merchant)
@@ -97314,12 +95526,10 @@
 "sgY" = (
 /obj/structure/mirror{
 	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -97338,8 +95548,7 @@
 /area/nadezhda/security/armoryshop)
 "shp" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/asteroid/grass,
@@ -97449,8 +95658,7 @@
 	},
 /obj/structure/mirror{
 	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/smc/quarters)
@@ -97589,8 +95797,7 @@
 "skc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "genetics2";
@@ -97614,8 +95821,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -97777,13 +95983,11 @@
 	dir = 8
 	},
 /obj/machinery/computer/rdservercontrol{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/server)
@@ -97828,8 +96032,7 @@
 /area/nadezhda/outside/forest)
 "slX" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
@@ -97903,9 +96106,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -97939,7 +96140,6 @@
 "smS" = (
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -98219,8 +96419,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "spJ" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/circuitlab)
@@ -98319,16 +96518,12 @@
 	},
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
-/obj/machinery/ai_slipper{
-	icon_state = "motion0"
-	},
+/obj/machinery/ai_slipper,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/turret_protected/ai)
 "sqI" = (
@@ -98359,7 +96554,6 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -98587,8 +96781,7 @@
 /area/nadezhda/medical/chemistry)
 "sty" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -98663,15 +96856,13 @@
 	icon_state = "16-0"
 	},
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /obj/structure/railing/grey{
 	dir = 1
 	},
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey,
 /obj/structure/cable/cyan{
@@ -98750,8 +96941,7 @@
 /area/nadezhda/command/bridge)
 "svg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -98771,7 +96961,6 @@
 /obj/item/bedsheet/medical,
 /obj/structure/curtain/open/privacy,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/mirror{
@@ -98782,7 +96971,6 @@
 "svq" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/item/material/shard,
@@ -98801,7 +96989,6 @@
 /obj/item/device/taperecorder,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -98880,8 +97067,7 @@
 /area/nadezhda/medical/sleeper)
 "swj" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp,
@@ -99025,9 +97211,7 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/captain/quarters)
@@ -99071,13 +97255,10 @@
 /obj/structure/table/bar_special,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
@@ -99095,8 +97276,7 @@
 	req_access = list(3)
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/item/gun/projectile/automatic/mamba{
 	pixel_y = 7
@@ -99131,8 +97311,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
@@ -99143,8 +97322,7 @@
 /area/nadezhda/outside/inside_colony)
 "syX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -99155,8 +97333,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
@@ -99205,8 +97382,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/decal/cleanable/dirt,
@@ -99232,8 +97408,7 @@
 	},
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -99256,7 +97431,6 @@
 /area/nadezhda/hallway/surface/section1)
 "sAo" = (
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/sink{
@@ -99268,7 +97442,6 @@
 "sAN" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -99385,16 +97558,13 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/crew_quarters/barbackroom)
 "sCn" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/table/standard,
@@ -99524,15 +97694,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
-	icon_state = "danger";
 	tag = "icon-danger (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "sEv" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/asteroid/grass,
@@ -99581,8 +97749,7 @@
 "sFC" = (
 /obj/structure/bed/chair/wood,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -99784,8 +97951,7 @@
 "sIf" = (
 /obj/structure/computerframe{
 	anchored = 1;
-	dir = 1;
-	icon_state = "0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -99795,12 +97961,10 @@
 	pixel_x = 32
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -99904,8 +98068,7 @@
 "sIW" = (
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -99971,8 +98134,7 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -99988,8 +98150,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "sJD" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
@@ -100030,8 +98191,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 1
@@ -100093,8 +98253,7 @@
 /obj/item/trash/plate,
 /obj/effect/decal/cleanable/vomit,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -100345,14 +98504,11 @@
 /area/nadezhda/hallway/main/stairwell)
 "sNF" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -100442,8 +98598,7 @@
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "sOu" = (
@@ -100469,7 +98624,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -100505,7 +98659,6 @@
 "sOY" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
-	icon_state = "danger";
 	tag = "icon-danger (WEST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -100607,7 +98760,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/effect/window_lwall_spawn/reinforced,
@@ -100619,7 +98771,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
@@ -100706,7 +98857,6 @@
 	})
 "sRf" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
@@ -100741,13 +98891,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
@@ -100813,8 +98961,7 @@
 "sRV" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/item/device/aicard,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -100917,8 +99064,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -100956,8 +99102,7 @@
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/hopdouble,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/dorm4{
@@ -101000,7 +99145,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/cluster/roaches/low_chance,
@@ -101058,11 +99202,9 @@
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -101074,7 +99216,6 @@
 /obj/structure/catwalk,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -101092,7 +99233,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -101131,7 +99271,6 @@
 "sUM" = (
 /obj/structure/bed/chair/wood{
 	dir = 4;
-	icon_state = "wooden_chair";
 	tag = "icon-wooden_chair (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -101228,12 +99367,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -101378,7 +99515,6 @@
 	pixel_y = 16
 	},
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white/cargo,
@@ -101440,11 +99576,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -101459,8 +99593,7 @@
 	pixel_y = 4
 	},
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -101514,8 +99647,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking{
@@ -101543,7 +99675,6 @@
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating,
@@ -101607,9 +99738,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -101652,18 +99781,14 @@
 	},
 /obj/structure/curtain/open,
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/cro)
 "sZx" = (
 /obj/effect/floor_decal/industrial/loading/white,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
 /obj/effect/decal/cleanable/dirt,
@@ -101685,8 +99810,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "sZI" = (
@@ -101749,12 +99873,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/disposaldrop)
@@ -101787,8 +99909,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
@@ -101886,12 +100007,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
@@ -101924,7 +100043,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
@@ -102013,7 +100131,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/arrows/white,
@@ -102203,8 +100320,7 @@
 /area/eris/crew_quarters/plasma_tag)
 "tfg" = (
 /obj/machinery/computer/message_monitor{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/server)
@@ -102251,8 +100367,7 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
+	dir = 4
 	},
 /obj/structure/bed/chair/sofa/black/corner{
 	icon_state = "sofaend_left"
@@ -102293,8 +100408,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/section2)
@@ -102410,7 +100524,6 @@
 "thp" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -102437,8 +100550,7 @@
 	pixel_y = -23
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/steel,
@@ -102498,7 +100610,6 @@
 /area/nadezhda/outside/forest)
 "tif" = (
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/item/modular_computer/console/preset/command{
@@ -102524,8 +100635,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -102645,8 +100755,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "tjl" = (
@@ -103012,8 +101121,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/command/courtroom)
@@ -103053,7 +101161,6 @@
 	id = "buffet";
 	name = "kitchen access";
 	pixel_x = 27;
-	pixel_y = 0;
 	req_access = list(25)
 	},
 /turf/simulated/floor/tiled/cafe,
@@ -103075,12 +101182,10 @@
 "tnR" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/white/golden,
@@ -103161,8 +101266,7 @@
 /area/nadezhda/quartermaster/miningdock)
 "toU" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -103183,8 +101287,7 @@
 /area/nadezhda/crew_quarters/botanist)
 "tpj" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/pistachios,
@@ -103229,15 +101332,13 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "tpX" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -103383,7 +101484,6 @@
 /area/nadezhda/pros/prep)
 "trE" = (
 /obj/machinery/atmospherics/unary/freezer{
-	dir = 2;
 	icon_state = "freezer_1";
 	power_setting = 20;
 	set_temperature = 73;
@@ -103562,8 +101662,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -103628,8 +101727,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/tactical_blackshield)
@@ -103679,7 +101777,6 @@
 "tuI" = (
 /obj/structure/bed/chair/wood{
 	dir = 1;
-	icon_state = "wooden_chair";
 	tag = "icon-wooden_chair (NORTH)"
 	},
 /turf/simulated/floor/carpet,
@@ -103691,7 +101788,6 @@
 "tuU" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/machinery/hologram/holopad,
@@ -103769,10 +101865,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "tvw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "tvC" = (
@@ -103914,8 +102007,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -103955,7 +102047,6 @@
 "twP" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/mineral,
@@ -104060,7 +102151,6 @@
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -104145,8 +102235,7 @@
 	req_access = list(10)
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -104211,7 +102300,6 @@
 "tzn" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Bioreactor - Main - 2";
-	capacity = 5e+006;
 	charge = 5e+006;
 	cur_coils = 4;
 	input_attempt = 1;
@@ -104266,8 +102354,7 @@
 "tzJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -104398,7 +102485,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light/small,
@@ -104571,7 +102657,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -104675,7 +102760,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/disposalpipe/segment{
@@ -104736,8 +102820,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -104762,8 +102845,7 @@
 "tEO" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/main/stairwell)
@@ -104795,8 +102877,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -104947,7 +103028,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -104984,9 +103064,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -104995,8 +103073,7 @@
 "tHA" = (
 /obj/structure/salvageable/autolathe,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/quartermaster/miningdock)
@@ -105085,8 +103162,7 @@
 /area/nadezhda/quartermaster/miningdock)
 "tIq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
@@ -105142,10 +103218,7 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
 "tIP" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/asteroid/grass,
@@ -105201,9 +103274,7 @@
 "tJn" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -105217,7 +103288,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating,
@@ -105243,8 +103313,7 @@
 /area/nadezhda/medical/sleeper)
 "tJz" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-s"
+	dir = 4
 	},
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/machinery/door/blast/regular/open{
@@ -105254,8 +103323,7 @@
 /area/nadezhda/command/crematorium)
 "tJK" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
@@ -105364,8 +103432,7 @@
 /obj/structure/bed/padded,
 /obj/item/bedsheet/ce,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/panic_room)
@@ -105391,8 +103458,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -105408,9 +103474,7 @@
 "tLu" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -105454,8 +103518,7 @@
 /area/nadezhda/crew_quarters/clownoffice)
 "tLL" = (
 /obj/effect/floor_decal/industrial/danger/corner{
-	dir = 1;
-	icon_state = "dangercorner"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/pros/shuttle)
@@ -105484,8 +103547,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -105523,8 +103585,7 @@
 /area/turret_protected/ai)
 "tMq" = (
 /obj/machinery/mineral/processing_unit_console/laber{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/laber_area)
@@ -105536,8 +103597,7 @@
 "tMy" = (
 /obj/structure/computerframe{
 	anchored = 1;
-	dir = 1;
-	icon_state = "0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -105651,8 +103711,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/main/stairwell)
@@ -105782,8 +103841,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
@@ -105844,19 +103902,16 @@
 	},
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "tPG" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
@@ -105898,8 +103953,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "tPN" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -106181,11 +104235,9 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "tTz" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -106196,7 +104248,6 @@
 "tTA" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -106205,7 +104256,6 @@
 "tTI" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -106308,7 +104358,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
@@ -106365,7 +104414,6 @@
 "tWk" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/floor_decal/spline/plain{
@@ -106385,8 +104433,7 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -106491,7 +104538,6 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "tXP" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/structure/cable/green{
@@ -106574,8 +104620,7 @@
 "tYE" = (
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/structure/table/bench/marble,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -106724,8 +104769,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -106735,8 +104779,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/rnd/docking{
@@ -106797,8 +104840,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate{
@@ -106824,9 +104866,7 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	dir = 2;
 	name = "light switch ";
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -106922,7 +104962,6 @@
 "uaO" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/table/standard,
@@ -107078,7 +105117,6 @@
 "ucT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen{
-	name = "kitchen sink";
 	pixel_y = 28
 	},
 /obj/effect/damagedfloor/rust,
@@ -107220,7 +105258,6 @@
 "ueE" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /obj/structure/cable/green{
@@ -107275,8 +105312,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 5;
-	icon_state = "spline_fancy"
+	dir = 5
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -107392,7 +105428,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/table/reinforced,
@@ -107462,7 +105497,6 @@
 "ugz" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/machinery/camera/network/research{
@@ -107558,12 +105592,10 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -107714,11 +105746,9 @@
 /area/nadezhda/outside/forest)
 "ujB" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -107897,8 +105927,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -107941,7 +105970,6 @@
 /area/nadezhda/hallway/side/f2section1)
 "ulY" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -107975,8 +106003,7 @@
 "umG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -108017,8 +106044,7 @@
 /area/nadezhda/rnd/circuitlab)
 "umY" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -108060,7 +106086,6 @@
 /obj/machinery/button/remote/airlock{
 	id = "F2-A2";
 	name = "Door Bolt Control";
-	pixel_x = 0;
 	pixel_y = -20;
 	specialfunctions = 4
 	},
@@ -108152,7 +106177,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/lattice,
@@ -108188,8 +106212,7 @@
 "uoA" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/security/detectives_office)
@@ -108246,9 +106269,7 @@
 "upB" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 24
@@ -108271,8 +106292,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -108327,9 +106347,7 @@
 "uqn" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -108395,7 +106413,6 @@
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
@@ -108478,8 +106495,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/item/clothing/shoes/magboots,
 /obj/structure/cable/cyan{
@@ -108545,7 +106561,6 @@
 "usa" = (
 /obj/structure/table/standard,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -108564,8 +106579,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
@@ -108584,11 +106598,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
@@ -108734,8 +106746,7 @@
 	})
 "utL" = (
 /obj/structure/window/basic{
-	dir = 4;
-	icon_state = "window"
+	dir = 4
 	},
 /obj/random/scrap/sparse_even/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -108812,9 +106823,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -108855,9 +106864,7 @@
 "uuM" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -108911,8 +106918,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
@@ -108930,8 +106936,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -108983,8 +106988,7 @@
 /area/nadezhda/engineering/construction)
 "uvX" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -108995,8 +106999,7 @@
 /area/nadezhda/quartermaster/miningdock)
 "uwa" = (
 /obj/structure/bed/chair/custom/bar_special{
-	dir = 4;
-	icon_state = "bar_chair"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spider/stickyweb,
@@ -109098,8 +107101,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/plating,
@@ -109156,12 +107158,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -109298,7 +107298,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -109346,12 +107345,10 @@
 	pixel_x = -32
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 9;
-	icon_state = "spline_fancy"
+	dir = 9
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	pixel_y = -10
@@ -109628,7 +107625,6 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -109799,11 +107795,9 @@
 /area/nadezhda/absolutism/bioreactor)
 "uBU" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -109851,8 +107845,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "uCM" = (
@@ -109899,7 +107892,6 @@
 "uDr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -109938,8 +107930,7 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/medical/reception)
@@ -109989,12 +107980,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/pros/prep)
@@ -110077,8 +108066,7 @@
 	},
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/section2)
@@ -110140,12 +108128,10 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -110348,8 +108334,7 @@
 /area/nadezhda/security/sechall)
 "uHq" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -110366,8 +108351,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
@@ -110402,8 +108386,7 @@
 "uHN" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -110520,8 +108503,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
@@ -110605,7 +108587,6 @@
 "uJm" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
-	icon_state = "danger";
 	tag = "icon-danger (EAST)"
 	},
 /turf/simulated/floor/tiled/steel,
@@ -110728,8 +108709,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "uKM" = (
@@ -110831,8 +108811,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "uLT" = (
@@ -110946,8 +108925,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "uML" = (
@@ -111035,12 +109013,10 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "uOC" = (
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /obj/structure/flora/small/bushc2,
 /turf/simulated/floor/wood/wild5,
@@ -111126,8 +109102,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -111136,8 +109111,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "uOU" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -111150,8 +109124,7 @@
 "uPa" = (
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/camera/network/colony_surface{
 	dir = 4
@@ -111170,7 +109143,6 @@
 /area/nadezhda/quartermaster/disposaldrop)
 "uPd" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -111470,8 +109442,7 @@
 "uSo" = (
 /obj/machinery/vending/engivend,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -111529,8 +109500,7 @@
 	},
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm1{
@@ -111565,8 +109535,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/pros/proelav)
@@ -111595,16 +109564,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
-"uTl" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
 "uTn" = (
 /obj/structure/shuttle_part/escpod{
 	icon_state = "escpodwall10";
@@ -111847,10 +109806,7 @@
 	name = "shower door"
 	},
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
@@ -111941,8 +109897,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "uVU" = (
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -112009,7 +109964,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/random/cluster/roaches/low_chance,
@@ -112067,8 +110021,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "uXz" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey,
 /turf/simulated/open,
@@ -112121,8 +110074,7 @@
 "uXZ" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/security/maingate{
@@ -112266,8 +110218,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
@@ -112330,8 +110281,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -112411,8 +110361,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1
@@ -112486,8 +110435,7 @@
 	},
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
-	dir = 8;
-	icon_state = "grey_railing0"
+	dir = 8
 	},
 /obj/structure/railing/grey{
 	dir = 1
@@ -112567,12 +110515,10 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/lattice,
@@ -112837,7 +110783,6 @@
 /area/nadezhda/command/bridge)
 "vfA" = (
 /obj/machinery/door/window{
-	dir = 4;
 	name = "AI Core Door";
 	req_access = list(16)
 	},
@@ -112951,8 +110896,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
@@ -113092,8 +111036,7 @@
 "vig" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/inside_colony)
@@ -113159,8 +111102,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j1"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -113355,7 +111297,6 @@
 "vkA" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
@@ -113490,8 +111431,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/dungeon/outside/abandoned_solars)
@@ -113508,8 +111448,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/steel,
@@ -113521,8 +111460,7 @@
 /area/nadezhda/hallway/main/stairwell)
 "vme" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
+	dir = 1
 	},
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = -32
@@ -113555,7 +111493,6 @@
 	dir = 4
 	},
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -113690,8 +111627,7 @@
 /area/nadezhda/rnd/docking)
 "vnB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -113705,12 +111641,10 @@
 	pixel_x = 32
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -113795,8 +111729,7 @@
 "voc" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/landmark/storyevent/hidden_vent_antag,
@@ -113842,10 +111775,7 @@
 "vov" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower";
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 1
@@ -113939,8 +111869,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/security/barracks)
@@ -114010,8 +111939,7 @@
 "vqg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -114058,7 +111986,6 @@
 	dir = 9
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -114278,7 +112205,6 @@
 "vts" = (
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
@@ -114339,8 +112265,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
@@ -114348,7 +112273,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/industrial/box/red,
@@ -114371,15 +112295,13 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "vuf" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "vug" = (
 /obj/machinery/door/window/southright{
-	dir = 2;
 	icon_state = "left";
 	name = "Containment Pen";
 	req_access = list(55)
@@ -114433,8 +112355,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "vuU" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 6;
-	icon_state = "spline_fancy"
+	dir = 6
 	},
 /obj/structure/bed/chair/sofa/black/corner,
 /obj/machinery/light_switch{
@@ -114445,8 +112366,7 @@
 /area/nadezhda/command/bridgebar)
 "vuW" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/green{
@@ -114462,7 +112382,6 @@
 /area/nadezhda/security/tactical_blackshield)
 "vvb" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -114483,8 +112402,7 @@
 "vvk" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/random/tool_upgrade/low_chance,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -114655,12 +112573,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -114675,13 +112591,10 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -114795,8 +112708,7 @@
 	departmentType = 5;
 	dir = 4;
 	name = "Warrant Officer RC";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/item/biosyphon,
 /obj/structure/table/woodentable,
@@ -114850,8 +112762,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "medbay exit";
@@ -115082,16 +112993,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/medical/reception)
 "vzS" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -115117,12 +113026,10 @@
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -115133,20 +113040,17 @@
 	},
 /obj/structure/railing/grey,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/structure/railing/grey{
-	dir = 1;
-	icon_state = "grey_railing0"
+	dir = 1
 	},
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/nadezhda/absolutism/storage)
 "vAB" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -115222,8 +113126,7 @@
 /area/nadezhda/security/sechall)
 "vBn" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -115279,8 +113182,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "vBO" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -115425,8 +113327,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -115630,12 +113531,10 @@
 /area/nadezhda/security/tactical_blackshield)
 "vFR" = (
 /obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /obj/structure/railing{
 	dir = 8
@@ -115648,8 +113547,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/security/vacantoffice2)
 "vFY" = (
@@ -116001,8 +113899,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -116125,8 +114022,7 @@
 /area/nadezhda/dungeon/outside/abandoned_solars)
 "vKw" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -116173,8 +114069,7 @@
 "vKZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/machinery/light/small,
 /obj/machinery/recharge_station,
@@ -116229,9 +114124,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/decal/cleanable/generic,
@@ -116258,11 +114151,9 @@
 /area/nadezhda/pros/prep)
 "vLu" = (
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -116286,8 +114177,7 @@
 "vLR" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -116621,8 +114511,7 @@
 	})
 "vPo" = (
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
 /obj/effect/floor_decal/industrial/warningwhite{
@@ -116676,8 +114565,7 @@
 	dir = 5
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
@@ -116695,7 +114583,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/scrap/sparse_weighted,
@@ -116817,8 +114704,7 @@
 /area/nadezhda/crew_quarters/hydroponics)
 "vQX" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/green{
@@ -116847,8 +114733,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/tactical_blackshield)
@@ -116923,7 +114808,6 @@
 "vRT" = (
 /obj/structure/bed/chair/wood{
 	dir = 4;
-	icon_state = "wooden_chair";
 	tag = "icon-wooden_chair (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -116978,12 +114862,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -117004,12 +114886,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
@@ -117051,8 +114931,7 @@
 /area/nadezhda/pros/prep)
 "vTf" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/door/window/westright{
 	name = "Sniper rifles";
@@ -117069,8 +114948,7 @@
 /area/nadezhda/security/armory)
 "vTg" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/door/window/southright,
 /obj/item/towel,
@@ -117360,7 +115238,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -117519,17 +115396,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
-"vWW" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
 "vWY" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -117551,7 +115417,6 @@
 "vXa" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -117661,7 +115526,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/carpet/purcarpet,
@@ -117673,9 +115537,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/dorm1{
@@ -117801,9 +115663,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/decal/cleanable/blood/oil,
@@ -117856,7 +115716,6 @@
 "vZI" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/arrows/white,
@@ -117948,8 +115807,7 @@
 "waY" = (
 /obj/structure/multiz/stairs/active/bottom,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/side/f2section1)
@@ -117963,8 +115821,7 @@
 /area/nadezhda/absolutism/vectorrooms)
 "wbm" = (
 /obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair"
+	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
@@ -117996,7 +115853,6 @@
 "wbA" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white,
@@ -118179,7 +116035,6 @@
 "wcM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -118206,13 +116061,9 @@
 /area/nadezhda/engineering/atmos/storage)
 "wdj" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -118349,7 +116200,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/disposalpipe/segment,
@@ -118366,8 +116216,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
@@ -118422,11 +116271,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -118697,8 +116544,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/main/stairwell)
@@ -118747,7 +116593,6 @@
 "wiw" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -118787,8 +116632,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/workshop)
@@ -118822,7 +116666,6 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "wjy" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/industrial/warningred,
@@ -118885,8 +116728,7 @@
 /area/nadezhda/medical/genetics)
 "wjQ" = (
 /obj/structure/bed/chair/custom/bar_special{
-	dir = 4;
-	icon_state = "bar_chair"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
@@ -119019,9 +116861,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/asteroid/grass/dry,
@@ -119029,7 +116869,6 @@
 "wlr" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/plating/under,
@@ -119039,8 +116878,7 @@
 "wly" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -119183,8 +117021,7 @@
 "wms" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
-	dir = 9;
-	icon_state = "spline_fancy"
+	dir = 9
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -119281,7 +117118,6 @@
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor/plating/under,
@@ -119321,8 +117157,7 @@
 /area/colony)
 "wnN" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/beach/water/jungledeep{
 	desc = "Filthy, stinking bilge water.";
@@ -119568,8 +117403,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/sechall)
@@ -119740,7 +117574,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/sink/kitchen{
-	name = "kitchen sink";
 	pixel_y = 28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -119769,12 +117602,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/turret_protected/ai_upload)
@@ -119782,8 +117613,7 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
@@ -119867,9 +117697,7 @@
 	blue_ink_tk_blocker = 1;
 	desc = "A remote control switch.";
 	id = "medbay exit";
-	name = "Medbay Exit Button";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Medbay Exit Button"
 	},
 /obj/structure/table/glass,
 /obj/machinery/door/blast/regular{
@@ -119960,7 +117788,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating,
@@ -119971,8 +117798,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -120130,17 +117956,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/nadezhda/medical/psych)
-"wuw" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/beach/water/jungledeep{
-	desc = "Filthy, stinking bilge water.";
-	name = "murky water"
-	},
-/area/nadezhda/maintenance/undergroundfloor1south)
 "wuB" = (
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
@@ -120231,7 +118046,6 @@
 	dir = 4
 	},
 /obj/machinery/door/window/southright{
-	dir = 2;
 	icon_state = "left";
 	name = "Containment Pen";
 	req_access = newlist()
@@ -120311,8 +118125,7 @@
 /area/nadezhda/engineering/atmos/surface)
 "wwA" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -120488,17 +118301,14 @@
 	pixel_y = -32
 	},
 /obj/machinery/newscaster{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
@@ -120601,8 +118411,7 @@
 /obj/structure/table/reinforced,
 /obj/random/rig_module/low_chance,
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1;
-	icon_state = "danger"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/quartermaster/miningdock)
@@ -120616,7 +118425,6 @@
 /area/nadezhda/crew_quarters/pool)
 "wzg" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -120629,8 +118437,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -120683,7 +118490,6 @@
 "wzQ" = (
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/random/scrap/sparse_even,
@@ -120788,8 +118594,7 @@
 	},
 /obj/random/scrap/sparse_even,
 /obj/structure/railing{
-	dir = 4;
-	icon_state = "railing0"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -120990,8 +118795,7 @@
 /area/nadezhda/medical/chemistry)
 "wCl" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal,
@@ -121124,8 +118928,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "wDH" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/crew_quarters/dorm4{
@@ -121149,9 +118952,7 @@
 	})
 "wDO" = (
 /obj/machinery/power/breakerbox{
-	RCon_tag = "Surface Substation Bypass";
-	icon_state = "bbox_off";
-	on = 0
+	RCon_tag = "Surface Substation Bypass"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/engineering/atmos/surface)
@@ -121236,12 +119037,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -121266,8 +119065,7 @@
 /area/nadezhda/engineering/engine_room)
 "wEU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -121395,8 +119193,7 @@
 /area/nadezhda/outside/lakeside)
 "wGd" = (
 /obj/machinery/mineral/processing_unit_console{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/steel,
@@ -121593,7 +119390,6 @@
 "wHS" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
-	icon_state = "danger";
 	tag = "icon-danger (WEST)"
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -121673,7 +119469,6 @@
 /obj/machinery/flasher{
 	dir = 6;
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/camera/network/command{
@@ -121701,8 +119496,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
@@ -121829,8 +119623,7 @@
 "wKu" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
@@ -121922,7 +119715,6 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -122056,12 +119848,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals3,
 /obj/effect/decal/cleanable/dirt,
@@ -122084,9 +119874,7 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "wNN" = (
-/mob/living/simple_animal/crab{
-	faction = "pond"
-	},
+/mob/living/simple_animal/crab,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
 "wNV" = (
@@ -122144,7 +119932,6 @@
 "wOS" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/floor_decal/spline/plain{
@@ -122271,10 +120058,7 @@
 	name = "\improper Blackshield - Firing Range"
 	})
 "wQm" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 2;
-	icon_state = "spline_fancy"
-	},
+/obj/effect/floor_decal/spline/wood,
 /obj/machinery/light,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -122285,11 +120069,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/security/hut_cell1)
@@ -122368,7 +120150,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/effect/decal/cleanable/blood/oil,
@@ -122476,7 +120257,6 @@
 	icon_state = "spline_fancy_corner"
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
 /obj/effect/floor_decal/spline/wood{
@@ -122754,7 +120534,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -122791,8 +120570,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/main/stairwell)
@@ -122945,8 +120723,7 @@
 "wXC" = (
 /obj/machinery/photocopier,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/rbreakroom)
@@ -123107,8 +120884,7 @@
 "wYZ" = (
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/machinery/door/window/eastleft,
 /turf/simulated/floor/tiled/cafe,
@@ -123116,12 +120892,10 @@
 "wZb" = (
 /obj/structure/bed/chair/wood{
 	dir = 1;
-	icon_state = "wooden_chair";
 	tag = "icon-wooden_chair (NORTH)"
 	},
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/colony_underground{
@@ -123167,7 +120941,6 @@
 	},
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
-	icon_state = "danger";
 	tag = "icon-danger (EAST)"
 	},
 /obj/machinery/camera/network/engineering,
@@ -123221,8 +120994,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/bodybags,
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -123323,9 +121095,7 @@
 /obj/effect/floor_decal/spline/plain,
 /obj/structure/railing,
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/wood/wild1,
@@ -123347,9 +121117,7 @@
 /area/nadezhda/engineering/workshop)
 "xbv" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/flora/ausbushes/ppflowers,
@@ -123423,7 +121191,6 @@
 "xcg" = (
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/beach/water/jungledeep{
@@ -123720,8 +121487,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -123821,8 +121587,7 @@
 "xfk" = (
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
@@ -123942,8 +121707,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -124043,7 +121807,6 @@
 	pixel_y = -12
 	},
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/white/cargo,
@@ -124076,12 +121839,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
@@ -124187,8 +121948,7 @@
 "xjP" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/crew_quarters/toilet/public)
 "xjZ" = (
@@ -124203,8 +121963,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "xke" = (
@@ -124364,8 +122123,7 @@
 /area/nadezhda/absolutism/vectorrooms)
 "xlW" = (
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -124381,8 +122139,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/security/tactical_blackshield)
@@ -124412,8 +122169,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xmj" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/dark,
@@ -124435,7 +122191,6 @@
 	},
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating,
@@ -124555,8 +122310,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xna" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 10;
-	icon_state = "spline_fancy"
+	dir = 10
 	},
 /turf/simulated/floor/wood/wild3,
 /area/eris/crew_quarters/barbackroom)
@@ -124585,8 +122339,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "xnn" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -124609,8 +122362,7 @@
 "xnw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -124624,8 +122376,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -124715,8 +122466,7 @@
 	})
 "xox" = (
 /obj/structure/bed/chair/custom/bar_special{
-	dir = 8;
-	icon_state = "bar_chair"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -124726,7 +122476,6 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "xoC" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/spider/stickyweb,
@@ -124752,7 +122501,6 @@
 /obj/effect/floor_decal/border/techfloor,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/effect/decal/cleanable/generic,
@@ -124767,7 +122515,6 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
-	id = null;
 	name = "chute windoor";
 	req_access = newlist()
 	},
@@ -124787,7 +122534,6 @@
 /obj/effect/floor_decal/border/techfloor,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/effect/decal/cleanable/blood/oil,
@@ -124896,8 +122642,7 @@
 	})
 "xpR" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/rock/manmade/ruin3,
@@ -125031,11 +122776,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
@@ -125124,21 +122867,12 @@
 /area/nadezhda/quartermaster/office)
 "xrZ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
-"xsf" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced,
-/area/nadezhda/pros/prep)
 "xsg" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "10,0"
@@ -125282,8 +123016,7 @@
 /obj/structure/catwalk,
 /obj/item/paper/laber_camp,
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/mine/gulag)
@@ -125296,7 +123029,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
@@ -125867,8 +123599,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/medical/sleeper)
@@ -126078,7 +123809,6 @@
 /area/nadezhda/security)
 "xCK" = (
 /obj/item/modular_computer/telescreen/preset/generic{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/structure/table/standard,
@@ -126148,7 +123878,6 @@
 "xCQ" = (
 /obj/structure/cable/cyan{
 	d1 = 32;
-	d2 = 1;
 	icon_state = "32-1"
 	},
 /turf/simulated/open,
@@ -126325,8 +124054,7 @@
 /area/nadezhda/crew_quarters/pool)
 "xEl" = (
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/invislight,
@@ -126378,7 +124106,6 @@
 "xEV" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -126459,8 +124186,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/cyan,
 /turf/simulated/floor/tiled/steel/danger,
@@ -126497,8 +124223,7 @@
 "xFN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -126534,8 +124259,7 @@
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -126555,8 +124279,7 @@
 	icon_state = "road_edge_decal2"
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 9;
-	icon_state = "spline_fancy"
+	dir = 9
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/kitchen)
@@ -126565,8 +124288,7 @@
 /area/colony)
 "xGk" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warningred{
@@ -126587,13 +124309,10 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -126638,8 +124357,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -126913,12 +124631,10 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/panic_room)
@@ -127125,7 +124841,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/multi_tile/metal/mait{
 	dir = 1;
-	icon_state = "door_closed";
 	name = "Lost Outpost"
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -127245,8 +124960,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/bioreactor)
@@ -127314,7 +125028,6 @@
 "xNj" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
@@ -127372,8 +125085,7 @@
 /obj/item/grenade/chem_grenade/antiweed,
 /obj/item/storage/bag/trash,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/janitor)
@@ -127485,8 +125197,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-s"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -127508,8 +125219,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -127555,8 +125265,7 @@
 /area/nadezhda/engineering/workshop)
 "xPy" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 1
@@ -127768,7 +125477,6 @@
 /area/nadezhda/command/bridgebar)
 "xRZ" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -128003,9 +125711,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/gmaster)
@@ -128042,13 +125748,11 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/steel/monofloor{
-	dir = 4;
-	icon_state = "monofloor"
+	dir = 4
 	},
 /area/nadezhda/hallway/surface/section1)
 "xUD" = (
@@ -128116,7 +125820,6 @@
 "xVb" = (
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/effect/floor_decal/spline/plain{
@@ -128147,7 +125850,6 @@
 "xVk" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/machinery/light/small{
@@ -128175,8 +125877,7 @@
 "xVy" = (
 /obj/machinery/newscaster{
 	dir = 8;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/structure/table/bench/padded,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -128241,7 +125942,6 @@
 "xVW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -128413,8 +126113,7 @@
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 8;
-	icon_state = "box_corners_white"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
@@ -128522,7 +126221,6 @@
 "xYr" = (
 /obj/random/scrap/dense_weighted,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/effect/spider/stickyweb,
@@ -128709,8 +126407,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -128793,8 +126490,7 @@
 /area/nadezhda/outside/forest)
 "ybD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
@@ -128807,8 +126503,7 @@
 /area/nadezhda/quartermaster/miningdock)
 "ybR" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
@@ -128831,8 +126526,7 @@
 	id = "labor_internal"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/security/laber_area)
@@ -128890,14 +126584,12 @@
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/rbreakroom)
 "ydq" = (
 /obj/structure/sink/kitchen{
-	name = "kitchen sink";
 	pixel_y = 28
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -128919,20 +126611,17 @@
 	},
 /obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8;
-	icon_state = "box_corners_red"
+	dir = 8
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/security/tactical_blackshield)
 "ydE" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/computer_hardware/hard_drive/portable/design/security{
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
@@ -128978,7 +126667,6 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/lattice,
@@ -129031,6 +126719,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "yex" = (
@@ -129163,8 +126852,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -129213,8 +126901,7 @@
 "ygZ" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/structure/bed/chair/comfy/beige{
-	dir = 1;
-	icon_state = "comfychair_preview"
+	dir = 1
 	},
 /obj/landmark/join/start/mining,
 /turf/simulated/floor/tiled/steel,
@@ -129272,7 +126959,6 @@
 "yhR" = (
 /obj/structure/railing{
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/machinery/light/small{
@@ -129316,8 +127002,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
@@ -129328,7 +127013,6 @@
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating,
@@ -129343,14 +127027,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
-"yir" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
 "yiA" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall4";
@@ -129427,8 +127103,7 @@
 	icon_state = "road_edge_decal7"
 	},
 /obj/effect/floor_decal/spline/wood{
-	dir = 6;
-	icon_state = "spline_fancy"
+	dir = 6
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/kitchen)
@@ -129468,12 +127143,10 @@
 "yjC" = (
 /obj/structure/mirror{
 	dir = 8;
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -129503,8 +127176,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "yjJ" = (
 /obj/structure/railing/grey{
-	dir = 4;
-	icon_state = "grey_railing0"
+	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -129692,8 +127364,7 @@
 /area/nadezhda/command/tcommsat/computer)
 "ylF" = (
 /obj/structure/sign/faction/neotheology{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
@@ -132928,11 +130599,11 @@ pwB
 pwB
 pwB
 pwB
-lEz
+eGw
 euZ
 qqZ
-lEz
-lEz
+eGw
+eGw
 xnj
 abh
 abh
@@ -133135,7 +130806,7 @@ eqz
 mwd
 xWs
 xWs
-iyW
+eQe
 xnj
 euZ
 hCw
@@ -133264,7 +130935,7 @@ wbV
 hCw
 kjM
 bky
-pte
+pBu
 xWs
 xWs
 xWs
@@ -133700,7 +131371,7 @@ euZ
 euZ
 euZ
 euZ
-yir
+asp
 euZ
 euZ
 euZ
@@ -133889,7 +131560,7 @@ euZ
 euZ
 euZ
 taS
-yir
+asp
 euZ
 euZ
 euZ
@@ -134147,10 +131818,10 @@ vUC
 xWs
 xWs
 eQe
-lEz
-lEz
-lEz
-lEz
+eGw
+eGw
+eGw
+eGw
 eGw
 eGw
 dKX
@@ -134259,7 +131930,7 @@ kxs
 kxs
 kxs
 kxs
-vWW
+vAU
 bky
 jYT
 jYT
@@ -134450,18 +132121,18 @@ obx
 kxs
 kxs
 kxs
-vWW
+vAU
 bky
-lEz
-lEz
-lEz
-lEz
-lEz
-lEz
-lEz
-lEz
-lEz
-lEz
+eGw
+eGw
+eGw
+eGw
+eGw
+eGw
+eGw
+eGw
+eGw
+eGw
 beA
 xWs
 xWs
@@ -134642,15 +132313,15 @@ img
 trc
 hCw
 aRa
-vWW
+vAU
 bky
 hlP
-lEz
-lEz
-lEz
-lEz
+eGw
+eGw
+eGw
+eGw
 vZg
-lEz
+eGw
 uuu
 uuu
 fTE
@@ -136305,8 +133976,8 @@ jjD
 lNr
 hCw
 bky
-nRp
-pte
+jYT
+pBu
 xWs
 yig
 kjx
@@ -136863,7 +134534,7 @@ pTC
 gSb
 gSb
 gSb
-vWW
+vAU
 dyE
 xWs
 xWs
@@ -137061,12 +134732,12 @@ dGQ
 trc
 ufG
 snT
-qar
-qar
-qar
+rVc
+rVc
+rVc
 sYt
 nWf
-jeq
+fTE
 xWs
 xWs
 yig
@@ -137670,7 +135341,7 @@ bby
 hOs
 hOs
 ldt
-gaC
+uQi
 tpU
 tpU
 tpU
@@ -139392,7 +137063,7 @@ wwg
 bWh
 dSX
 dSX
-yir
+asp
 deQ
 hCw
 hCw
@@ -141093,14 +138764,14 @@ rXA
 hNK
 npT
 npT
-loa
+fwl
 npT
 npT
 npT
 npT
 npT
 npT
-loa
+fwl
 npT
 npT
 npT
@@ -142551,7 +140222,7 @@ vzB
 lmC
 rMY
 nch
-bTV
+bkd
 rAb
 hQt
 oLf
@@ -142770,10 +140441,10 @@ mZZ
 uVU
 iFX
 jAd
-oRA
-oRA
+eNx
+eNx
 hwU
-fSD
+mZZ
 rOw
 sDv
 ngh
@@ -150986,11 +148657,11 @@ hOs
 hOs
 gXn
 dHE
-qar
-qar
-qar
-qar
-qar
+rVc
+rVc
+rVc
+rVc
+rVc
 eaa
 npT
 hwH
@@ -156804,7 +154475,7 @@ jDZ
 jDZ
 jDZ
 jDZ
-wuw
+wnN
 guy
 guy
 sFI
@@ -157471,7 +155142,7 @@ jve
 mGt
 hPt
 npT
-loa
+fwl
 npT
 npT
 npT
@@ -157479,7 +155150,7 @@ npT
 xjB
 gkI
 gkI
-loa
+fwl
 npT
 npT
 trc
@@ -158659,7 +156330,7 @@ trc
 trc
 trc
 trc
-rVM
+tnQ
 aZu
 lGK
 lHx
@@ -160282,9 +157953,9 @@ trc
 rWK
 tEM
 snT
-qcL
+sYt
 ewu
-qcL
+sYt
 xHB
 xHB
 qMn
@@ -166944,32 +164615,32 @@ cUx
 hOs
 hOs
 xGm
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
 kov
 kov
 kov
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
-qcL
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
+sYt
 kpY
 smH
 smH
@@ -167837,7 +165508,7 @@ rXp
 rXp
 rXp
 rXp
-uTl
+qGL
 rXp
 rXp
 rXp
@@ -178306,7 +175977,7 @@ sFI
 sFI
 gEI
 gSj
-bhP
+pUX
 gSj
 gSj
 gSj
@@ -178713,7 +176384,7 @@ sFI
 gEI
 gSj
 gSj
-bhP
+pUX
 gSj
 gSj
 gEI
@@ -200182,12 +197853,12 @@ aDB
 aDB
 jgQ
 jPn
-bdR
+uej
 sIW
 vpk
 yax
 sIW
-bdR
+uej
 jPn
 idV
 iVE
@@ -200711,7 +198382,7 @@ vIm
 pBF
 rcV
 tgh
-cfH
+sMN
 uNP
 beK
 xxc
@@ -245117,16 +242788,16 @@ hib
 hib
 hib
 nYR
-xsf
+rwj
 hib
 hib
-xsf
+rwj
 hib
 hib
 hib
 hib
 nYR
-xsf
+rwj
 hib
 hib
 hib

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -3100,12 +3100,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "aFY" = (
@@ -4448,6 +4442,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "aSG" = (
@@ -5529,6 +5528,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "bdd" = (
@@ -6600,17 +6604,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/detectives_office)
-"bnl" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access = newlist();
-	req_one_access = list(24,10)
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "bnm" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -10752,13 +10745,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
-"cer" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/contraband/poster/placed/generic/firesafety{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "ces" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -10801,13 +10787,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
-"ceS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "ceX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -12927,11 +12906,6 @@
 /obj/machinery/dnaforensics,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/detectives_office)
-"czX" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_storage_unit/engineering/atmos,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/construction)
 "czZ" = (
 /obj/structure/table/standard,
 /obj/structure/extinguisher_cabinet{
@@ -13397,17 +13371,13 @@
 	req_access = list(25)
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
-"cDI" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "cDJ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -13692,14 +13662,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
-"cGr" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/nadezhda/engineering/construction)
 "cGt" = (
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
@@ -13741,12 +13703,17 @@
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/pool)
 "cHc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 4;
-	icon_state = "intact"
+/obj/effect/floor_decal/spline/wood{
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/carpet/turcarpet,
+/area/nadezhda/crew_quarters/cafeteria)
 "cHl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14215,14 +14182,6 @@
 /obj/random/cluster/roaches,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"cLN" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "cLW" = (
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/wood/wild5,
@@ -14250,13 +14209,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
-"cMn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "cMp" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/big/bush1,
@@ -14781,14 +14733,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
-"cSu" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6;
-	icon_state = "intact";
-	tag = "icon-intact (SOUTHEAST)"
-	},
-/turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/construction)
 "cSy" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/busha1,
@@ -14901,15 +14845,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/security/barracks)
-"cTP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6;
-	icon_state = "intact";
-	tag = "icon-intact (SOUTHEAST)"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "cTQ" = (
 /obj/structure/catwalk,
 /obj/machinery/conveyor_switch{
@@ -14947,14 +14882,6 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"cTX" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1;
-	icon_state = "map";
-	tag = "icon-map (NORTH)"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "cUa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -15551,11 +15478,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"daX" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "daY" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -16502,15 +16424,13 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dkl" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 1;
-	icon_state = "intact";
-	tag = "icon-intact (NORTH)"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/nadezhda/engineering/construction)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "dkm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -16519,10 +16439,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
-"dku" = (
-/obj/structure/sign/warning/compressed_gas,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/construction)
 "dkw" = (
 /obj/effect/floor_decal/border/techfloor{
 	dir = 10
@@ -16897,6 +16813,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "dof" = (
@@ -18285,17 +18202,6 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"dAV" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/meter,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "dAW" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -18339,13 +18245,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
-"dBt" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "dBJ" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -19748,9 +19647,18 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/bridgebar)
 "dOT" = (
-/obj/machinery/constructable_frame/machine_frame,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/spline/wood{
+	dir = 1;
+	icon_state = "spline_fancy"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/turcarpet,
+/area/nadezhda/crew_quarters/cafeteria)
 "dPb" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/machinery/door/firedoor,
@@ -20064,23 +19972,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/construction)
-"dSB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "dSI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -20161,12 +20053,6 @@
 	dir = 1;
 	pixel_x = 9;
 	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -20771,14 +20657,14 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "dZp" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1;
-	icon_state = "map";
-	tag = "icon-map (NORTH)"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "dZq" = (
 /obj/machinery/door/airlock/glass{
 	name = "Sauna"
@@ -21237,14 +21123,6 @@
 /obj/item/storage/freezer,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
-"edQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "edR" = (
 /obj/structure/flora/rock/variant1,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -21434,6 +21312,11 @@
 /area/nadezhda/outside/inside_colony)
 "efv" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "efz" = (
@@ -21522,14 +21405,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"ega" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "egd" = (
 /obj/machinery/door/unpowered/simple/wood/saloon{
 	name = "Church Foyer"
@@ -21658,11 +21533,14 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "ehu" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/nadezhda/engineering/construction)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/nadezhda/crew_quarters/cafeteria)
 "ehy" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lamp,
@@ -21690,13 +21568,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"ehJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "ehV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -22424,20 +22295,6 @@
 "eqh" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/inside_colony)
-"eqj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "eqk" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1;
@@ -22515,9 +22372,6 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/side/f2section1)
 "eqY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 4;
@@ -22983,10 +22837,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"evz" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "evD" = (
 /obj/random/boxes,
 /obj/effect/decal/cleanable/rubble,
@@ -23365,11 +23215,6 @@
 /obj/random/lathe_disk/advanced/low_chance,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"ezW" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/power/generator,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/construction)
 "eAi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/medical_stand,
@@ -23864,15 +23709,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/hut_cell1)
-"eFO" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access = newlist();
-	req_one_access = list(24,10)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "eFP" = (
 /obj/structure/flora/big/rocks2,
 /turf/unsimulated/wall/jungle,
@@ -24825,14 +24661,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"eOZ" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warningdust/fulltile,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
 "ePe" = (
 /obj/structure/closet{
 	name = "high explosive grenades"
@@ -27696,15 +27524,6 @@
 	icon_state = "7,18"
 	},
 /area/nadezhda/hallway/main/stairwell)
-"fpj" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5;
-	icon_state = "intact";
-	tag = "icon-intact (NORTHEAST)"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "fpl" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/catwalk,
@@ -28082,12 +27901,6 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"frE" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/construction)
 "frF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -28527,12 +28340,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/captain/quarters)
-"fwb" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/construction)
 "fwc" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -29436,8 +29243,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/sensor{
 	long_range = 1;
 	name = "Powernet Sensor - Thermoelectric";
@@ -30001,11 +29806,6 @@
 /area/nadezhda/crew_quarters/dorm4{
 	name = "Dormitory 4"
 	})
-"fIX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/structures,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "fJl" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -30821,11 +30621,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
-"fRt" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/warningdust/fulltile,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
 "fRx" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -31890,16 +31685,6 @@
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
-"gcc" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "gce" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -32243,13 +32028,13 @@
 "geX" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
@@ -37420,6 +37205,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "hbM" = (
@@ -40288,11 +40074,6 @@
 "hFT" = (
 /turf/simulated/floor/tiled/white,
 /area/shuttle/rocinante_shuttle_area)
-"hFW" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "hFY" = (
 /obj/machinery/door/airlock/multi_tile/metal/mait,
 /obj/random/traps/low_chance,
@@ -43636,12 +43417,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"ipN" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
-/turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/construction)
 "ipO" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 6;
@@ -46226,12 +46001,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"iNR" = (
-/obj/machinery/light{
-	light_color = "#b9e8ea"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "iNS" = (
 /obj/machinery/door/airlock/command{
 	name = "Front Desk";
@@ -46551,11 +46320,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"iQA" = (
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/nadezhda/engineering/construction)
 "iQD" = (
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/maingate{
@@ -47376,11 +47140,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"iYq" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "iYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -52107,12 +51866,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"jRF" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "jRG" = (
 /obj/random/furniture/pottedplant,
 /obj/structure/extinguisher_cabinet{
@@ -54807,12 +54560,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"kpR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "kpT" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/random/scrap/dense_weighted/low_chance,
@@ -55725,11 +55472,14 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "kyL" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "kyV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard,
@@ -59951,14 +59701,6 @@
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /turf/simulated/floor/reinforced/airmix,
 /area/nadezhda/engineering/atmos)
-"llv" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "llx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -61971,11 +61713,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"lEE" = (
-/obj/machinery/camera/network/engineering,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "lEH" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -62370,10 +62107,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"lIO" = (
-/obj/effect/floor_decal/industrial/warningdust/fulltile,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
 "lIR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -64231,13 +63964,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/surface/section1)
-"mbk" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/obj/machinery/door/window/westright,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "mbm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -64698,11 +64424,6 @@
 "meM" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 28
@@ -67844,12 +67565,6 @@
 /obj/structure/invislight,
 /turf/simulated/mineral,
 /area/asteroid/cave)
-"mHa" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/binary/circulator,
-/turf/simulated/floor/tiled/dark/techfloor_grid,
-/area/nadezhda/engineering/construction)
 "mHf" = (
 /obj/structure/table/woodentable,
 /obj/machinery/reagentgrinder/portable,
@@ -68570,15 +68285,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/kitchen)
-"mOI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "mON" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/vending/serbomat,
@@ -71775,15 +71481,6 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"nuq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "nur" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
@@ -71802,16 +71499,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"nuE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/window_lwall_spawn,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
-/area/nadezhda/crew_quarters/kitchen)
 "nuH" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -74623,14 +74310,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
-"nWT" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access = newlist();
-	req_one_access = list(24,10)
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "nWU" = (
 /obj/machinery/optable,
 /obj/machinery/camera/network/mining,
@@ -74829,16 +74508,6 @@
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
-"nYB" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/machinery/air_sensor{
-	frequency = 1441;
-	id_tag = "coolant_sensor"
-	},
-/turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/construction)
 "nYD" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering";
@@ -74896,16 +74565,14 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/quartermaster/miningdock)
 "nYP" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
+/obj/effect/decal/cleanable/generic,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "nYR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/mining{
@@ -76831,14 +76498,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
-"opP" = (
-/obj/effect/floor_decal/industrial/warningdust/fulltile,
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
 "opS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -78455,6 +78114,11 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "oEM" = (
 /obj/landmark/join/start/clubworker,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "oEN" = (
@@ -78828,15 +78492,6 @@
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"oIo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "oIu" = (
 /obj/structure/table/rack/shelf,
 /obj/random/lowkeyrandom/low_chance,
@@ -79250,13 +78905,17 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "oLP" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 8
+/obj/effect/floor_decal/spline/wood{
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
-/obj/effect/floor_decal/industrial/box,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/turcarpet,
+/area/nadezhda/crew_quarters/cafeteria)
 "oLQ" = (
 /obj/machinery/suit_storage_unit/medical,
 /obj/machinery/light/small{
@@ -82504,25 +82163,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
-"puU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall_mounted/emcloset{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
-	},
-/obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "puV" = (
 /obj/structure/table/reinforced,
 /obj/random/powercell,
@@ -82607,10 +82247,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/teleporter)
-"pvK" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "pvM" = (
 /obj/structure/table/marble,
 /obj/machinery/recharger,
@@ -83062,14 +82698,16 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "pAr" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 10;
-	icon_state = "intact"
+/obj/effect/floor_decal/spline/wood{
+	dir = 8
 	},
-/obj/machinery/meter,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/turcarpet,
+/area/nadezhda/crew_quarters/cafeteria)
 "pAw" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -83384,9 +83022,6 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "pDo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
 	dir = 2;
@@ -83448,13 +83083,6 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/cryo)
-"pDA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "pDF" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -84061,11 +83689,6 @@
 /area/nadezhda/security/maingate{
 	name = "\improper Outdoors - Pad"
 	})
-"pJa" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "pJg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/security{
@@ -84079,16 +83702,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
-"pJs" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/meter,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "pJv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -84438,9 +84051,6 @@
 /area/nadezhda/crew_quarters)
 "pNb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
 /obj/structure/noticeboard/guild{
 	pixel_x = 32
 	},
@@ -85694,14 +85304,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"pYQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/construction)
 "pYX" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -86480,14 +86082,17 @@
 /area/nadezhda/engineering/engine_room)
 "qgn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/spline/wood{
+	dir = 1;
+	icon_state = "spline_fancy"
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/construction)
+/turf/simulated/floor/carpet/turcarpet,
+/area/nadezhda/crew_quarters/cafeteria)
 "qgq" = (
 /obj/structure/bed/chair/sofa/beige/left{
 	dir = 4
@@ -96883,6 +96488,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "rZe" = (
@@ -97505,6 +97111,11 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/crew_quarters/cafeteria)
 "seQ" = (
@@ -97733,17 +97344,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/botanist)
-"shq" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/carpet/turcarpet,
-/area/nadezhda/crew_quarters/cafeteria)
 "shs" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/techmaint,
@@ -98135,10 +97735,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"slm" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "slo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -99212,17 +98808,6 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
-"svA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/machinery/light{
-	light_color = "#b9e8ea"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "svB" = (
 /obj/item/device/lighting/toggleable/lantern,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -99886,12 +99471,6 @@
 /obj/machinery/door/unpowered/simple/wood/saloon,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/cafeteria)
-"sDA" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
-	},
-/turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/construction)
 "sDD" = (
 /obj/structure/flora/small/bushb1,
 /obj/random/flora/small_jungle_tree,
@@ -100900,13 +100479,6 @@
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/surface_maints_1)
-"sOI" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "sOJ" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -103477,11 +103049,6 @@
 "tnN" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/button/remote/blast_door{
 	id = "buffet";
 	name = "kitchen access";
@@ -106893,12 +106460,7 @@
 /area/nadezhda/quartermaster/miningdock)
 "tXC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/general_air_control/large_tank_control{
-	input_tag = null;
-	name = "Coolant Tank Control";
-	output_tag = null;
-	sensors = list("coolant_sensor"="Tank")
-	},
+/obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "tXJ" = (
@@ -107242,13 +106804,6 @@
 /area/nadezhda/security/maingate{
 	name = "\improper Outdoors - Pad"
 	})
-"uap" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warningdust/fulltile,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/construction)
 "uaw" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/port_gen/pacman/super/anchored,
@@ -108019,13 +107574,6 @@
 /obj/effect/floor_decal/industrial/loading,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/hangarsupply)
-"uhD" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "uhF" = (
 /obj/machinery/camera/network/security{
 	dir = 4
@@ -112025,6 +111573,7 @@
 "uTf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "uTj" = (
@@ -113526,9 +113075,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/rocinante_shuttle_area)
 "vhU" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "via" = (
 /obj/effect/floor_decal/industrial/loading/red{
 	dir = 4
@@ -113758,13 +113311,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "vkn" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/box,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/boulder,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/colony)
 "vkp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -116263,12 +115813,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos/storage)
-"vHb" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/obj/effect/floor_decal/industrial/box,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "vHf" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony)
@@ -116713,16 +116257,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
 "vLu" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	cell_type = /obj/item/cell/large/high;
 	dir = 4;
 	name = "East APC";
 	pixel_x = 28;
 	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
@@ -117365,6 +116909,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/flour,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "vRM" = (
@@ -119995,15 +119544,6 @@
 /obj/machinery/vending/signal_electronics,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/circuitlab)
-"wpH" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "wpL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -120491,13 +120031,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
-"wtC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 6;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "wtE" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -122433,12 +121966,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"wMn" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/nitrogen,
-/area/nadezhda/engineering/construction)
 "wMt" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 1
@@ -129051,16 +128578,6 @@
 /obj/machinery/vending/engivend,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
-"xYJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "xYO" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
@@ -129339,14 +128856,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/surface/section1)
-"ycE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 4;
-	icon_state = "intact"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/construction)
 "ycP" = (
 /obj/structure/closet/custodial,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -129522,8 +129031,6 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/construction)
 "yex" = (
@@ -144675,13 +144182,13 @@ mOH
 mhb
 cev
 jdf
-plY
+qgn
 efv
-mZZ
+pAr
 seJ
 seJ
 aSB
-shq
+seJ
 qpB
 dJB
 saL
@@ -144877,7 +144384,7 @@ gAq
 brf
 cev
 jdf
-jPp
+oLP
 eya
 ugy
 jbZ
@@ -145079,7 +144586,7 @@ gAq
 vxM
 sZz
 xoD
-plY
+dOT
 wQm
 kEC
 pLS
@@ -145281,7 +144788,7 @@ jpv
 brf
 cfS
 jdf
-jPp
+oLP
 pBI
 pLS
 kdB
@@ -145483,7 +144990,7 @@ yjf
 rPe
 eqF
 xoD
-jPp
+oLP
 pBI
 pLS
 kPd
@@ -145685,7 +145192,7 @@ opd
 cud
 iNL
 xoD
-jPp
+oLP
 pBI
 pLS
 jZp
@@ -145887,7 +145394,7 @@ dma
 smm
 jdf
 jdf
-plY
+dOT
 pBI
 kEC
 cSW
@@ -146085,11 +145592,11 @@ wCl
 tHK
 sdX
 oEM
-uTS
+dZp
 cDF
-jdf
-jdf
-jPp
+ehu
+ehu
+cHc
 pBI
 kEC
 nxv
@@ -146286,7 +145793,7 @@ dFv
 jKs
 ybD
 dma
-dma
+dkl
 rvd
 vUi
 qgq
@@ -146488,7 +145995,7 @@ nFL
 fgU
 rjo
 ccV
-dma
+dkl
 egs
 vUi
 ntp
@@ -146690,7 +146197,7 @@ liL
 uTS
 szv
 iIG
-uTS
+kyL
 uTx
 vUi
 oeR
@@ -146892,7 +146399,7 @@ uTS
 uTS
 rjo
 cSa
-rvd
+nYP
 sdX
 vUi
 qSk
@@ -147094,7 +146601,7 @@ cIN
 cIN
 vRG
 bcX
-dma
+vhU
 nnJ
 vUi
 ntp
@@ -147298,7 +146805,7 @@ geX
 meM
 sWT
 tnN
-nuE
+vUi
 sfB
 wlA
 hJh
@@ -199548,12 +199055,12 @@ sFI
 sFI
 sFI
 sFI
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 sFI
 sFI
 crV
@@ -199750,12 +199257,12 @@ sFI
 sFI
 sFI
 sFI
-aXo
-kpR
-eFO
-evz
-fpj
-aXo
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 sFI
 sFI
 crV
@@ -199946,19 +199453,19 @@ hSx
 hSx
 hSx
 sFI
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
-aXo
-mbk
-aXo
-aXo
-bnl
-aXo
-aXo
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 crV
 crV
 fDm
@@ -200148,19 +199655,19 @@ hSx
 hSx
 hSx
 sFI
-aXo
-czX
-aar
-iNR
-aXo
-iQA
-iQA
-nWT
-iQA
-aXo
-cDI
-aar
-edQ
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 crV
 crV
 fEj
@@ -200350,19 +199857,19 @@ hSx
 hSx
 hSx
 sFI
-aXo
-aXo
-lEE
-wtC
-ehu
-sDA
-frE
-sDA
-cSu
-dkl
-vhU
-fIX
-ega
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+vkn
+vkn
+vkn
+vkn
+vkn
 crV
 faC
 crV
@@ -200552,19 +200059,19 @@ hSx
 hSx
 hSx
 sFI
-aXo
-mHa
-aar
-ycE
-aXo
-wMn
-wMn
-nYB
-wMn
-aXo
-cTX
-dOT
-ehJ
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+vkn
+vkn
+vkn
+vkn
+vkn
 crV
 crV
 crV
@@ -200754,19 +200261,19 @@ hSx
 hSx
 hSx
 sFI
-aXo
-mHa
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+vkn
+vkn
+vkn
 fMq
-ycE
-aXo
-wMn
-wMn
-wMn
-wMn
-aXo
-dZp
-dOT
-eqj
+aar
 crV
 faL
 fJl
@@ -200956,17 +200463,17 @@ hSx
 hSx
 hSx
 sFI
-aXo
-ezW
-aar
-ycE
-iQA
-fwb
-ipN
-wMn
-fwb
-dkl
-iYq
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+vkn
+vkn
+xdf
 tXC
 eqY
 csb
@@ -201158,18 +200665,18 @@ hSx
 hSx
 hSx
 sFI
-aXo
-aXo
-ceS
-svA
-aXo
-iQA
-iQA
-cGr
-iQA
-dku
-dAV
-pvK
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+vkn
+vkn
+vkn
+fMq
 pDo
 crV
 fcl
@@ -201361,18 +200868,18 @@ hSx
 hSx
 sFI
 sFI
-aXo
-aar
-uhD
-gcc
-eOZ
-uTf
-cHc
-fRt
-wpH
-iYq
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+vkn
+vkn
+vkn
+vkn
 fMq
-pDA
+aar
 crV
 faL
 fKn
@@ -201563,18 +201070,18 @@ hSx
 hSx
 sFI
 sFI
-aXo
-aar
-uhD
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
 vkn
-uap
-aar
-ycE
-fRt
 vkn
-dBt
-dSB
-oIo
+vkn
+vkn
+tXC
+fMq
 crV
 crV
 crV
@@ -201765,15 +201272,15 @@ hSx
 hSx
 sFI
 sFI
-aXo
-sOI
-oLP
-fMq
-pvK
-aar
-cLN
-fMq
-aar
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+vkn
+vkn
+tXC
 uTf
 dSI
 aXo
@@ -201967,14 +201474,14 @@ hSx
 hSx
 sFI
 sFI
-aXo
-cer
-pAr
-lIO
-hFW
-lIO
-cMn
-uTf
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+vkn
+vkn
 uTf
 uTf
 dTG
@@ -202169,14 +201676,14 @@ hSx
 hSx
 sFI
 sFI
-aXo
-uTf
-uTf
-opP
-mOI
-opP
-llv
-aar
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+vkn
+vkn
 lgi
 fga
 dTL
@@ -202371,16 +201878,16 @@ hSx
 hSx
 sFI
 sFI
-aXo
-cTP
-kyL
-lIO
-xYJ
-lIO
-xYJ
-vHb
+sFI
+sFI
+sFI
+sFI
+sFI
+sFI
+vkn
+xdf
 dmz
-aar
+tXC
 dUb
 aXo
 eHm
@@ -202573,14 +202080,14 @@ hSx
 hSx
 sFI
 sFI
-aXo
-oLP
-aar
-aar
-nuq
-fMq
-nuq
-daX
+sFI
+sFI
+vkn
+vkn
+vkn
+vkn
+vkn
+vkn
 doc
 aar
 dUb
@@ -202775,14 +202282,14 @@ hSx
 hSx
 sFI
 sFI
-aXo
-nYP
-pJa
-pJa
-pJs
-slm
-xYJ
-pJa
+sFI
+sFI
+vkn
+vkn
+vkn
+xdf
+vkn
+vkn
 dsf
 iaX
 dVz
@@ -202977,9 +202484,9 @@ hSx
 hSx
 sFI
 sFI
-aXo
-jRF
-puU
+sFI
+sFI
+vkn
 mXQ
 hbL
 vOU
@@ -203179,14 +202686,14 @@ hSx
 hSx
 sFI
 sFI
-aXo
-aXo
+sFI
+sFI
 aXo
 aXo
 aXo
 nAC
 lXa
-qgn
+lXa
 rXb
 hTt
 mpd
@@ -203388,7 +202895,7 @@ sFI
 aXo
 qbD
 qaO
-pYQ
+lXa
 rXb
 vUX
 dSy

--- a/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
@@ -130,6 +130,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
+"aJ" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
 "aL" = (
 /obj/structure/table/glass,
 /obj/random/booze/low_chance,
@@ -600,6 +609,14 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"cx" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact";
+	tag = "icon-intact (NORTHWEST)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
 "cy" = (
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/asteroid/grass,
@@ -621,6 +638,18 @@
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"cC" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "cD" = (
 /obj/structure/railing{
@@ -775,8 +804,15 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "da" = (
-/obj/structure/flora/small/bushb3,
-/turf/simulated/floor/asteroid/grass,
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	frequency = 1442;
+	icon_state = "map_injector";
+	id = "SM_in";
+	pixel_y = 1;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/nadezhda/outside/mountainsolars)
 "db" = (
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -933,13 +969,23 @@
 /obj/effect/floor_decal/industrial/inputgate,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"dL" = (
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/turf/simulated/floor/plating,
+/area/nadezhda/outside/mountainsolars)
 "dM" = (
 /turf/simulated/mineral,
 /area/nadezhda/outside/mountainsolars)
-"dR" = (
-/obj/structure/catwalk,
-/obj/machinery/pipedispenser,
+"dN" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"dR" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/space,
 /area/nadezhda/outside/mountainsolars)
 "ee" = (
 /obj/structure/catwalk,
@@ -976,6 +1022,11 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"eE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/vehicle/train/cargo/trolley,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "eI" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -984,7 +1035,11 @@
 "eM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "eT" = (
 /obj/structure/flora/big/bush2,
@@ -1015,26 +1070,55 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"fq" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"fD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warningnew/radiation,
+/turf/simulated/wall,
+/area/nadezhda/outside/mountainsolars)
 "fH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
 "fK" = (
-/obj/random/toolbox,
-/obj/structure/table/standard,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6;
+	icon_state = "intact";
+	tag = "icon-intact (SOUTHEAST)"
+	},
+/turf/space,
 /area/nadezhda/outside/mountainsolars)
 "fL" = (
-/obj/structure/largecrate,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/vehicle/train/cargo/trolley,
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "gr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/mountainsolars)
+"gD" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact";
+	tag = "icon-intact (NORTHEAST)"
+	},
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
 "gS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1048,6 +1132,10 @@
 /obj/effect/floor_decal/industrial/box,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
+"gT" = (
+/obj/machinery/door/window/southright,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "hb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -1055,6 +1143,13 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
+"hd" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
 "hy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1078,9 +1173,35 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
+"hV" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"ik" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "is" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/rock,
+/area/nadezhda/outside/mountainsolars)
+"it" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/radiation,
+/obj/item/contraband/poster/placed/generic/firesafety{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "ix" = (
 /obj/machinery/vending/dinnerware,
@@ -1106,9 +1227,16 @@
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
 "ji" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"jm" = (
+/obj/structure/sign/warning/hazard_hotloop,
+/turf/simulated/wall,
 /area/nadezhda/outside/mountainsolars)
 "jo" = (
 /obj/structure/cable{
@@ -1118,6 +1246,19 @@
 	pixel_x = 0
 	},
 /turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/outside/mountainsolars)
+"jr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"ju" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "jE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1141,11 +1282,41 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/mineral,
 /area/nadezhda/outside/mountainsolars)
+"kp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/circulator,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "kq" = (
 /obj/structure/closet/crate/solar,
 /obj/effect/floor_decal/industrial/box,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
+"kC" = (
+/obj/machinery/atmospherics/trinary/filter/m_filter{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"kE" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"kG" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "kO" = (
 /obj/structure/flora/small/bushc3,
 /turf/simulated/floor/asteroid/grass,
@@ -1160,17 +1331,47 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"lm" = (
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
 "lx" = (
-/obj/structure/sign/department/atmos,
-/turf/simulated/wall/r_wall,
+/obj/structure/sign/warning/hazard_coldloop,
+/turf/simulated/wall,
+/area/nadezhda/outside/mountainsolars)
+"lB" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/space,
 /area/nadezhda/outside/mountainsolars)
 "lI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
+"lK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/circulator,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"lL" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
+"lW" = (
+/turf/simulated/floor/reinforced/airless,
+/area/nadezhda/outside/mountainsolars)
+"lX" = (
+/obj/vehicle/train/cargo/trolley,
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "mz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1181,11 +1382,18 @@
 "mI" = (
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/mountainsolars)
+"mN" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
 "ng" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/plating/under,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "nl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1196,6 +1404,13 @@
 "no" = (
 /obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
+"np" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "nt" = (
 /turf/simulated/wall,
@@ -1217,6 +1432,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
+"nK" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/space,
+/area/nadezhda/outside/mountainsolars)
 "nM" = (
 /obj/structure/railing{
 	anchored = 1;
@@ -1231,6 +1452,15 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
+"nY" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "nZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1239,13 +1469,27 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
+"on" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/radiation,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"ou" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "ox" = (
 /obj/item/reagent_containers/food/drinks/bottle/small/beer_two,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "oG" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "oJ" = (
 /obj/structure/railing{
@@ -1256,15 +1500,56 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"oM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "oP" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
 "oV" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact";
+	tag = "icon-intact (NORTHEAST)"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"oX" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact";
+	tag = "icon-intact (NORTHWEST)"
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"pl" = (
+/obj/machinery/computer/general_air_control/supermatter_core{
+	sensors = list("SM_sensor"="Tank");
+	output_tag = "SM_out";
+	name = "Supermatter Supply Control";
+	input_tag = "SM_in";
+	dir = 1;
+	frequency = 1442
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "pp" = (
 /obj/structure/railing{
@@ -1280,6 +1565,19 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
+"pU" = (
+/obj/structure/sign/warning/high_voltage,
+/turf/simulated/wall,
+/area/nadezhda/outside/mountainsolars)
+"pV" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/mountainsolars)
+"qg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "ql" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted,
@@ -1305,9 +1603,23 @@
 /obj/structure/flora/small/rock4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"qX" = (
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "rm" = (
 /obj/random/flora/jungle_tree/low,
 /turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"rC" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "rF" = (
 /obj/structure/cable{
@@ -1333,6 +1645,13 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
+"rW" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "sh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1341,6 +1660,34 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"sj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/obj/item/circuitboard/powermonitor,
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"st" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"sw" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "sS" = (
 /obj/structure/cable{
@@ -1353,10 +1700,38 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"sX" = (
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"sZ" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	light_color = "#b9e8ea"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
 "tc" = (
 /obj/structure/bookcase/manuals/engineering,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
+"te" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/space,
+/area/nadezhda/outside/mountainsolars)
+"tr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/southleft,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "tv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1375,6 +1750,11 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/dorm)
+"tK" = (
+/obj/machinery/camera/network/engineering,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
 "ug" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/unsimulated/mineral,
@@ -1388,6 +1768,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
+"uz" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"uY" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"vb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/northright,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"vk" = (
+/obj/machinery/pipedispenser,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "vl" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -1416,9 +1818,25 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/mountainsolars)
+"wl" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "wm" = (
 /obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "wu" = (
 /obj/machinery/power/apc/hyper{
@@ -1438,8 +1856,12 @@
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
 "wO" = (
-/obj/vehicle/train/cargo/engine,
-/turf/simulated/floor/asteroid/dirt,
+/obj/machinery/air_sensor{
+	id_tag = "SM_sensor";
+	frequency = 1442;
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/nadezhda/outside/mountainsolars)
 "wR" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -1454,8 +1876,24 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
+"wZ" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
 "xb" = (
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/mountainsolars)
+"xf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/bottle/small/beer,
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "xg" = (
 /obj/structure/closet/crate/solar,
@@ -1471,6 +1909,15 @@
 "xk" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/rock,
+/area/nadezhda/outside/mountainsolars)
+"xP" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "yc" = (
 /obj/random/scrap/sparse_even/low_chance,
@@ -1501,6 +1948,13 @@
 /obj/structure/railing,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"yC" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/effect/window_lwall_spawn/smartspawnplasma,
+/turf/simulated/floor/plating,
+/area/nadezhda/outside/mountainsolars)
 "yG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1517,9 +1971,22 @@
 "yU" = (
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
+"zb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact";
+	tag = "icon-intact (NORTHEAST)"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "zi" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"zG" = (
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/floor/reinforced/airless,
 /area/nadezhda/outside/mountainsolars)
 "zI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1527,10 +1994,22 @@
 /obj/structure/closet/secure_closet/personal/engineering_personal,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
+"zV" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "Af" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
+"Az" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
 "AA" = (
 /obj/random/junk/cigbutt,
@@ -1541,10 +2020,28 @@
 /obj/random/powercell/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
+"AN" = (
+/obj/machinery/atmospherics/valve/digital/open{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
 "Bi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/mountainsolars)
+"Br" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"BD" = (
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
 "BI" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
@@ -1559,6 +2056,12 @@
 "BY" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
+/area/nadezhda/outside/mountainsolars)
+"Cg" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "Cm" = (
 /obj/structure/table/glass,
@@ -1577,6 +2080,25 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"CP" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"CY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "Dg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1586,6 +2108,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
+"Dm" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "Dt" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/fixed/hydrotile,
@@ -1594,14 +2123,66 @@
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"DA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"DI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"DJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/generator,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "DS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
+"DU" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access = list(24,10)
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"DV" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 1;
+	icon_state = "intact";
+	tag = "icon-intact (NORTH)"
+	},
+/turf/space,
+/area/nadezhda/outside/mountainsolars)
 "DZ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
+"El" = (
+/obj/effect/floor_decal/industrial/inputgate,
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
 "En" = (
@@ -1611,11 +2192,33 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
 "Eq" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/machinery/door/window/westright,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/camera/network/engineering,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"Es" = (
+/obj/item/modular_computer/console/preset/engineering/supermatter{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"Ev" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"Ew" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "EI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1637,7 +2240,27 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact";
+	tag = "icon-intact (NORTHEAST)"
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"EU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"Fk" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/space,
 /area/nadezhda/outside/mountainsolars)
 "Fm" = (
 /obj/structure/cable{
@@ -1662,6 +2285,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/mountainsolars)
+"FC" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"FD" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/vehicle/train/cargo/engine,
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "FF" = (
 /obj/structure/flora/small/busha3,
@@ -1693,11 +2330,42 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"GD" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "GU" = (
 /obj/structure/closet/crate/solar,
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
+"Hk" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact";
+	tag = "icon-intact (NORTHWEST)"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"Hs" = (
+/obj/structure/cable,
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"Ht" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6;
+	icon_state = "intact";
+	tag = "icon-intact (SOUTHEAST)"
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "Hw" = (
 /obj/structure/railing{
 	anchored = 1;
@@ -1713,12 +2381,13 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
 "HP" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/obj/structure/catwalk,
-/obj/item/circuitboard/powermonitor,
-/obj/item/key/cargo_train,
-/turf/simulated/floor/plating/under,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/nadezhda/outside/mountainsolars)
 "HT" = (
 /obj/structure/cable{
@@ -1737,7 +2406,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/nadezhda/outside/mountainsolars)
 "Ib" = (
 /obj/structure/cable{
@@ -1750,10 +2419,33 @@
 /obj/structure/invislight,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"Io" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"IQ" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
 "IT" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
+"JB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "JU" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/grass,
@@ -1764,7 +2456,19 @@
 /area/nadezhda/engineering/dorm)
 "JZ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"Kb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "Kf" = (
 /obj/random/scrap/dense_weighted,
@@ -1776,7 +2480,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "Kn" = (
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact";
+	tag = "icon-intact (NORTHEAST)"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "KB" = (
 /obj/structure/railing{
@@ -1785,6 +2494,31 @@
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
+"KO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"KR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6;
+	icon_state = "intact";
+	tag = "icon-intact (SOUTHEAST)"
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "KX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1812,6 +2546,19 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/mountainsolars)
+"Lf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact";
+	tag = "icon-intact (NORTHEAST)"
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "Lv" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -1827,11 +2574,29 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "LS" = (
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"Mg" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
 "Mr" = (
 /obj/structure/catwalk,
@@ -1851,6 +2616,22 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
+"MM" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"MP" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
 "Nh" = (
 /obj/structure/flora/small/bushc2,
 /turf/simulated/floor/asteroid/grass,
@@ -1863,20 +2644,43 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
 /area/nadezhda/outside/mountainsolars)
+"NF" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	icon_state = "intact";
+	tag = "icon-intact (NORTHEAST)"
+	},
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
 "NK" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/window/eastleft,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "NQ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/scrap/moderate_weighted,
 /turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"Od" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "Og" = (
 /obj/structure/low_wall,
@@ -1922,7 +2726,7 @@
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
 "OM" = (
-/obj/random/furniture/pottedplant,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
 "OU" = (
@@ -1940,6 +2744,21 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
+"PQ" = (
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engineering";
+	req_access = list(10)
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"PU" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/nadezhda/outside/mountainsolars)
 "PX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -1952,14 +2771,20 @@
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
 "Qh" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/window/eastleft,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"Qm" = (
+/obj/structure/flora/small/bushb1,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0";
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "Qq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1979,6 +2804,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
+"QP" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
 "QX" = (
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/carpet/oracarpet,
@@ -1988,12 +2819,27 @@
 /obj/structure/flora/small/bushc3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"Rd" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "Ri" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
+/area/nadezhda/outside/mountainsolars)
+"Rj" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "Rm" = (
 /obj/structure/boulder,
@@ -2020,9 +2866,39 @@
 /obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"RS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
 "SE" = (
 /obj/random/tool_upgrade/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/mountainsolars)
+"SG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"SI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"SM" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/space,
+/area/nadezhda/outside/mountainsolars)
+"Td" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "Tq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2030,42 +2906,120 @@
 /obj/random/tool/advanced/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
+"Tz" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"TB" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "TD" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"TO" = (
-/obj/structure/catwalk,
-/obj/machinery/camera/network/engineering{
-	dir = 4
+"TF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/turf/simulated/floor/plating/under,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9;
+	icon_state = "intact";
+	tag = "icon-intact (NORTHWEST)"
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"TO" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	frequency = 1442;
+	icon_state = "map_vent_in";
+	id_tag = "SM_out";
+	internal_pressure_bound = 2000;
+	internal_pressure_bound_default = 2000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/nadezhda/outside/mountainsolars)
 "Uc" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/door/window/eastright,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"Uj" = (
+/obj/machinery/atmospherics/valve/digital{
+	dir = 4;
+	name = "EMERGENCY COOLING"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"Uk" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "Um" = (
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
+"Un" = (
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "Uo" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/mountainsolars)
+"Us" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "Uu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
+"UE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "UF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2078,14 +3032,29 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "UT" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/turf/space,
 /area/nadezhda/outside/mountainsolars)
 "UX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
+"Vd" = (
+/obj/structure/sign/warning/nosmoking/largeburnt,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/outside/mountainsolars)
+"Vz" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
 "VL" = (
 /obj/machinery/holoposter{
@@ -2097,15 +3066,36 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"VW" = (
+/obj/structure/sign/warningnew/radiation,
+/turf/simulated/wall/r_wall,
 /area/nadezhda/outside/mountainsolars)
 "VZ" = (
 /obj/structure/boulder,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"Wd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "Wo" = (
-/obj/vehicle/train/cargo/trolley,
-/turf/simulated/floor/asteroid/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
 "WE" = (
 /obj/structure/railing{
@@ -2119,6 +3109,11 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"WH" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "WR" = (
 /obj/structure/catwalk,
@@ -2134,6 +3129,22 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"WV" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"Xa" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "Xc" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -2142,6 +3153,13 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/under,
+/area/nadezhda/outside/mountainsolars)
+"Xj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "Xp" = (
 /obj/structure/catwalk,
@@ -2158,6 +3176,21 @@
 /obj/structure/low_wall,
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/dorm)
+"Xt" = (
+/obj/structure/railing{
+	anchored = 1;
+	dir = 8;
+	icon_state = "railing0";
+	tag = "icon-railing0 (WEST)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
+"XQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
 "XR" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2234,11 +3267,42 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
 "Zy" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"ZC" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
+"ZY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"ZZ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/railing{
+	anchored = 1;
+	dir = 4;
+	icon_state = "railing0";
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
 
 (1,1,1) = {"
@@ -7823,7 +8887,7 @@ al
 aS
 al
 al
-al
+aU
 al
 ac
 ac
@@ -8420,15 +9484,15 @@ ac
 ac
 ac
 ac
-ac
-al
-av
-aU
-al
-al
-al
-cR
-al
+bi
+bi
+bi
+bi
+bi
+bi
+bi
+bi
+bi
 dk
 al
 al
@@ -8522,15 +9586,15 @@ ac
 ac
 ac
 ac
-ac
-al
-al
-al
-da
-al
-al
-al
-al
+bi
+ad
+fq
+ad
+ad
+ad
+fq
+ad
+bi
 dk
 dk
 al
@@ -8619,20 +9683,20 @@ aS
 av
 cR
 al
-al
-al
-aS
-al
-al
-al
-al
-da
-al
-al
-al
-al
-al
-al
+bi
+bi
+bi
+bi
+ac
+bi
+ad
+bi
+dL
+dL
+dL
+bi
+ad
+bi
 al
 al
 al
@@ -8721,24 +9785,24 @@ cN
 av
 al
 aS
-bL
-av
-aS
+SM
+qX
+Es
+mN
+ac
+mN
+Tz
+dL
+lW
+lW
+lW
+dL
+ad
+bi
 al
-bL
-al
-al
-cW
-al
-al
-aU
-al
-cy
 al
 al
 al
-al
-bT
 al
 al
 al
@@ -8823,20 +9887,20 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-al
-al
-al
-al
-al
-al
-al
-al
+SM
+qg
+pl
+mN
+ZZ
+aJ
+Hs
+dL
+lW
+zG
+lW
+dL
+BD
+bi
 dl
 dl
 cN
@@ -8925,20 +9989,20 @@ ac
 ac
 al
 al
-al
-ac
-ac
-al
-al
-al
-al
-al
-al
-al
-al
-al
-cw
-al
+SM
+sX
+Us
+PQ
+wZ
+DU
+JB
+DU
+TO
+da
+wO
+dL
+ad
+bi
 al
 al
 al
@@ -9027,20 +10091,20 @@ ac
 al
 al
 al
-al
-al
-al
-av
-al
-aS
-al
-aS
-aS
-aS
-al
-al
-al
-al
+bi
+bi
+bi
+VW
+wZ
+SM
+bw
+bi
+yC
+yC
+dL
+bi
+ad
+bi
 al
 al
 al
@@ -9133,16 +10197,16 @@ av
 aS
 al
 al
-aS
-aS
-al
-aS
-bL
-bL
-cc
-al
-al
-al
+wZ
+Vd
+bw
+WV
+AN
+AN
+ad
+QP
+ad
+bi
 al
 al
 al
@@ -9235,16 +10299,16 @@ al
 bP
 bP
 aS
-aS
-aS
-al
-av
-bL
-bL
-al
-al
-al
-al
+sZ
+bi
+bi
+dN
+uY
+gD
+NF
+bi
+bi
+bi
 al
 al
 al
@@ -9254,7 +10318,7 @@ ac
 ac
 al
 al
-al
+bT
 al
 al
 ac
@@ -9336,15 +10400,15 @@ al
 al
 cN
 av
-bT
 al
-cw
+wZ
+Qm
 al
-aS
-bQ
-bP
-aS
-aS
+hV
+Az
+kC
+Hk
+xP
 al
 al
 av
@@ -9439,20 +10503,20 @@ ac
 ac
 ac
 al
-al
-aS
-al
-cw
-aS
-bP
-aS
-aS
+wZ
+IQ
+jm
+bw
+Az
+Mg
+ZC
+kE
 al
 al
 av
 al
 al
-cc
+al
 al
 ac
 ac
@@ -9541,14 +10605,14 @@ cq
 jM
 bw
 bw
+Vz
+MP
 bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
+lm
+MM
+Td
+uz
+rC
 bw
 bw
 bw
@@ -9641,20 +10705,20 @@ cz
 cg
 au
 bw
-bi
-bi
-cg
+aj
+aj
+fD
 Eq
+Ew
+Ew
+Uk
+Un
 Zy
-bi
-bi
-bi
-bi
 Zy
 oV
-bw
-bi
-bi
+aj
+aj
+aj
 bw
 al
 al
@@ -9743,21 +10807,21 @@ cg
 au
 cg
 bw
-bi
-cz
-cg
-VU
-JZ
+pU
+lK
+DJ
+TB
+SG
 eM
-eM
-JZ
+Kb
+UE
 Kn
-Kn
+ou
 ji
-bw
-TO
-bi
-bw
+ik
+cg
+aj
+hd
 ac
 ac
 ac
@@ -9845,20 +10909,20 @@ au
 cz
 ca
 bw
-cz
+vb
 KX
 cg
-LA
-eM
-JZ
-JZ
-Kn
-JZ
-Kn
-ji
-bw
-jM
-bw
+kG
+CY
+SI
+TF
+XQ
+oM
+ad
+oX
+xf
+Xj
+mN
 bw
 al
 al
@@ -9946,21 +11010,21 @@ ak
 bd
 bk
 bi
-fK
-cg
+bw
+EU
 fo
 cz
 LA
-JZ
-JZ
-JZ
-JZ
-Kn
-JZ
+ZY
+RS
+np
+Uj
+Xa
+RS
 oG
 au
 cg
-cz
+tr
 bw
 ac
 ac
@@ -10048,21 +11112,21 @@ am
 cg
 cg
 bi
-fL
-cg
-cg
+bw
+EU
+kp
 au
-VU
+TB
+Ht
+ad
+Lf
 JZ
-Kn
-JZ
-JZ
-eM
-JZ
+KR
+SI
 EN
 cg
 cg
-au
+gT
 bw
 al
 ac
@@ -10150,21 +11214,21 @@ cg
 cH
 cS
 bi
-HP
 bw
-bw
-bw
+mN
+on
+cz
 VU
-Kn
-JZ
+DI
+Od
 wm
-Kn
-JZ
-eM
-EN
-bw
-bw
-bw
+DA
+st
+jr
+Dm
+cg
+vk
+mN
 bw
 ac
 ac
@@ -10252,22 +11316,22 @@ cz
 cH
 au
 ak
-dR
-bi
-Xp
 bw
-VU
-Kn
-Kn
-Kn
-JZ
-JZ
-JZ
-ji
-bw
-bw
-bi
-bw
+aj
+it
+Wd
+cC
+Rj
+sw
+ju
+KO
+KO
+zb
+CP
+Cg
+sj
+aj
+hd
 ac
 ac
 ac
@@ -10303,20 +11367,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fK
+te
+fK
+te
+fK
+te
+fK
+te
+fK
+te
+fK
+te
+fK
+te
 aa
 aa
 aa
@@ -10355,20 +11419,20 @@ cg
 cT
 ak
 bw
-bi
-UT
-bw
+aj
+aj
+aj
 NK
 HX
-bi
-bi
-bi
+aj
+aj
+aj
 lx
 Qh
 Uc
-bw
-bi
-bi
+aj
+aj
+aj
 bw
 ac
 ac
@@ -10405,20 +11469,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -10458,18 +11522,18 @@ bi
 ak
 jM
 bw
-bw
+Io
 bw
 Mr
 bw
 bw
 bw
+Io
 bw
-TO
 lh
-lh
+nY
 bw
-bw
+Io
 bw
 jM
 ac
@@ -10507,20 +11571,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -10560,20 +11624,20 @@ bi
 bi
 ab
 ac
-Wo
+ac
 bw
 WE
 bB
 ac
 ac
-ac
-ac
-ng
-ng
-ac
-ac
-ac
-ac
+bw
+bw
+rW
+GD
+Ev
+WH
+Ev
+fL
 ac
 al
 al
@@ -10609,20 +11673,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -10662,20 +11726,20 @@ bi
 bi
 ab
 ab
-Wo
+ac
 bw
 WE
 bB
 ac
 ac
-ac
-ac
-ng
-ng
-ac
-ac
-ac
-ac
+wl
+uz
+Br
+rW
+au
+au
+cz
+eE
 al
 al
 al
@@ -10711,20 +11775,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -10764,20 +11828,20 @@ bi
 bi
 ab
 ab
-Wo
+ac
 bw
 WE
 bB
 ac
 ac
-ac
-ac
-ng
-ng
-ac
-ac
-ac
-al
+zV
+ZC
+Rd
+FC
+cg
+au
+cg
+lX
 al
 al
 al
@@ -10813,20 +11877,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -10866,20 +11930,20 @@ bi
 bi
 ab
 ab
-wO
+ac
 bw
 WE
 bB
 ac
 ac
-ac
-ac
+bw
+bw
 ng
-ng
-ac
-ac
-ac
-al
+rW
+Ev
+Ev
+WH
+FD
 al
 al
 ab
@@ -10915,20 +11979,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -10976,8 +12040,8 @@ ac
 jM
 bw
 bw
-lh
-lh
+HP
+PU
 bw
 bw
 bw
@@ -11017,20 +12081,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -11077,10 +12141,10 @@ bB
 al
 bw
 eA
-iZ
-iZ
-iZ
-iZ
+pp
+lL
+lL
+pp
 pp
 pp
 pp
@@ -11119,20 +12183,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -11180,8 +12244,8 @@ al
 bw
 KB
 iZ
-iZ
-iZ
+lL
+lL
 iZ
 iZ
 iZ
@@ -11221,20 +12285,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -11282,8 +12346,8 @@ al
 bw
 KB
 iZ
-iZ
-iZ
+lL
+lL
 iZ
 iZ
 iZ
@@ -11323,20 +12387,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -11384,8 +12448,8 @@ al
 bw
 KB
 iZ
-iZ
-iZ
+lL
+lL
 iZ
 iZ
 iZ
@@ -11425,20 +12489,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -11486,8 +12550,8 @@ al
 bw
 KB
 iZ
-iZ
-iZ
+lL
+lL
 iZ
 iZ
 iZ
@@ -11527,20 +12591,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -11588,8 +12652,8 @@ al
 bw
 KB
 iZ
-iZ
-iZ
+lL
+lL
 iZ
 iZ
 iZ
@@ -11629,20 +12693,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -11690,8 +12754,8 @@ al
 bw
 KB
 iZ
-iZ
-iZ
+lL
+lL
 iZ
 iZ
 iZ
@@ -11731,20 +12795,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -11787,13 +12851,13 @@ aa
 aa
 aa
 bi
-bD
-al
+tK
+bw
 em
 KB
 iZ
-iZ
-iZ
+lL
+lL
 iZ
 iZ
 iZ
@@ -11833,20 +12897,20 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
+UT
 aa
 aa
 aa
@@ -11889,13 +12953,13 @@ iZ
 iZ
 iZ
 iZ
+Xt
+Xt
+Xt
 iZ
 iZ
-iZ
-iZ
-iZ
-iZ
-iZ
+lL
+lL
 iZ
 iZ
 iZ
@@ -11935,69 +12999,69 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-dK
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
+UT
+Fk
+nK
+Fk
+nK
+Fk
+nK
+Fk
+nK
+Fk
+nK
+Fk
+nK
+Fk
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+lB
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+lB
+dR
+dR
+dR
+dR
+DV
+pV
+El
+Wo
+Wo
+Wo
+Wo
+Wo
+Wo
+Wo
+Wo
+Wo
+Wo
+cx
+lL
 iZ
 iZ
 iZ
@@ -12037,69 +13101,69 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-dK
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
-iZ
+Fk
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+lB
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+lB
+lB
+dR
+dR
+dR
+dR
+DV
+pV
+El
+Wo
+Wo
+Wo
+Wo
+Wo
+Wo
+Wo
+Wo
+Wo
+Wo
+Wo
+cx
 iZ
 iZ
 iZ

--- a/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
@@ -78,6 +78,11 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"aw" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "ax" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/asteroid/grass,
@@ -1027,16 +1032,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"fv" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access = newlist();
-	req_one_access = list(24,10)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall,
-/area/nadezhda/engineering/dorm)
 "fD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warningnew/radiation,
@@ -1134,6 +1129,15 @@
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
+"hZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "ik" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -1159,15 +1163,6 @@
 /obj/machinery/vending/dinnerware,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/engineering/dorm)
-"iE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
 "iH" = (
 /obj/random/traps/wire_splicing/low_chance,
@@ -1252,6 +1247,10 @@
 /obj/effect/floor_decal/industrial/box,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
+"ku" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "kC" = (
 /obj/machinery/atmospherics/trinary/filter/m_filter{
 	dir = 8
@@ -1313,6 +1312,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/outside/mountainsolars)
+"lJ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "lK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1412,6 +1417,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
+"nW" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "nY" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -1432,12 +1442,6 @@
 "on" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/radiation,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/outside/mountainsolars)
-"or" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "ou" = (
@@ -1565,6 +1569,17 @@
 /obj/item/storage/pill_bottle/dice,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
+"qN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "qU" = (
 /obj/structure/flora/small/rock4,
 /turf/simulated/floor/asteroid/grass,
@@ -1579,11 +1594,6 @@
 /obj/random/flora/jungle_tree/low,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"ro" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "rC" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -1662,11 +1672,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
-"sz" = (
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/outside/mountainsolars)
 "sS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1704,6 +1709,12 @@
 	},
 /turf/space,
 /area/nadezhda/outside/mountainsolars)
+"tg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/engineering/dorm)
 "tr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1903,11 +1914,6 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
-"yn" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "yo" = (
 /obj/structure/railing{
 	dir = 8;
@@ -1959,48 +1965,21 @@
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"zv" = (
-/turf/unsimulated/mineral,
-/area/nadezhda/engineering/dorm)
 "zG" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/reinforced/airless,
 /area/nadezhda/outside/mountainsolars)
-"zH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/engineering/dorm)
 "zI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/personal/engineering_personal,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
-"zN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
-"zQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/outside/mountainsolars)
 "zV" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
-"zW" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "Af" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted,
@@ -2028,12 +2007,16 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"Bg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
+"Be" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
+"Bg" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/outside/mountainsolars)
 "Bi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -2043,6 +2026,15 @@
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
+"BA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "BD" = (
 /obj/machinery/camera/network/engineering{
 	dir = 1
@@ -2075,12 +2067,11 @@
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
 "Cn" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/engineering/dorm)
 "CE" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/fixed/hydrotile,
@@ -2221,6 +2212,12 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
+"EB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "EI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2321,11 +2318,21 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
 "Gh" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on{
-	dir = 1;
-	target_pressure = 295
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
 	},
-/turf/simulated/floor/tiled/steel/orangecorner,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"Gj" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access = newlist();
+	req_one_access = list(24,10)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall,
 /area/nadezhda/engineering/dorm)
 "GD" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -2337,15 +2344,6 @@
 /obj/structure/closet/crate/solar,
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/engineering/dorm)
-"Ha" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
 "Hk" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -2382,9 +2380,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"HC" = (
-/turf/simulated/mineral/planet,
-/area/nadezhda/engineering/dorm)
 "HP" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -2429,10 +2424,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"Ii" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/engineering/dorm)
 "Io" = (
 /obj/structure/catwalk,
 /obj/machinery/light{
@@ -2440,12 +2431,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"IK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/engineering/dorm)
 "IQ" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/railing{
@@ -2458,11 +2443,23 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
+"Jl" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "JB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
+"JJ" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	target_pressure = 5000
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "JU" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/grass,
@@ -2610,8 +2607,13 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
 "Mr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
@@ -2643,6 +2645,12 @@
 /obj/structure/flora/small/bushc2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"Nn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "Nq" = (
 /obj/structure/flora/small/trailrocka4,
 /turf/simulated/floor/asteroid/dirt,
@@ -2707,16 +2715,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
-"Or" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "Ot" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -2747,12 +2745,6 @@
 "OU" = (
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
-"OV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "Pd" = (
 /obj/effect/decal/cleanable/rubble,
@@ -2811,6 +2803,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/mineral,
 /area/nadezhda/outside/mountainsolars)
+"Qr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/engineering/dorm)
 "QH" = (
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/fixed/hydrotile,
@@ -2891,9 +2887,12 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"Sn" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on{
-	target_pressure = 5000
+"Se" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
@@ -2908,17 +2907,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
-"SH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "SI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
@@ -2926,6 +2914,10 @@
 "SM" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/space,
+/area/nadezhda/outside/mountainsolars)
+"SO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/outside/mountainsolars)
 "Td" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -2937,6 +2929,12 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
+"Te" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "Tq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3092,12 +3090,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"VE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/engineering/dorm)
 "VL" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -3139,6 +3131,22 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/outside/mountainsolars)
+"Wv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
+"Wy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "WE" = (
 /obj/structure/railing{
 	dir = 1;
@@ -3194,17 +3202,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
-"Xf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "Xj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/office/light{
@@ -3286,10 +3283,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
-"Zh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor/tiled/steel/orangecorner,
-/area/nadezhda/engineering/dorm)
 "Zj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3331,6 +3324,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
+"ZH" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 1;
+	target_pressure = 295
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "ZY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warning,
@@ -9808,11 +9808,11 @@ ab
 ab
 ab
 ab
-HC
-HC
-HC
-zv
-zv
+nt
+nt
+nt
+nt
+nt
 nt
 Yv
 Um
@@ -9910,13 +9910,13 @@ ab
 ab
 ab
 ab
-HC
-yn
-Sn
-Zh
-Bg
 nt
-zW
+aw
+JJ
+ku
+Wy
+nt
+Te
 iY
 aE
 aL
@@ -10012,14 +10012,14 @@ ab
 ab
 ab
 ab
-HC
+nt
+EB
 Um
 Um
-Um
-iE
-fv
-zN
-SH
+BA
+Gj
+hZ
+qN
 Di
 Cm
 OC
@@ -10114,14 +10114,14 @@ ab
 ab
 ab
 ab
-HC
-ro
-Gh
-Zh
-Mr
+nt
+nW
+ZH
+ku
+Nn
 nt
 RO
-Xf
+Mr
 aE
 aM
 aM
@@ -10216,14 +10216,14 @@ ab
 ab
 ab
 ab
-HC
-HC
-HC
-HC
-zv
+nt
+nt
+nt
+nt
+nt
 nt
 xh
-Ha
+Se
 rL
 aE
 Di
@@ -10325,7 +10325,7 @@ ab
 aa
 nt
 VL
-Or
+Wv
 Og
 aB
 aA
@@ -10427,7 +10427,7 @@ aa
 nt
 nt
 YM
-Or
+Wv
 aA
 aA
 aA
@@ -10435,8 +10435,8 @@ kq
 gS
 ak
 fp
-Cn
-Cn
+Gh
+Gh
 yp
 cg
 cz
@@ -10535,8 +10535,8 @@ XR
 qB
 wU
 EI
-sz
-or
+Bg
+Jl
 cg
 au
 au
@@ -10632,13 +10632,13 @@ nt
 tE
 jH
 nl
-Ii
-zH
-VE
-IK
+Qr
+Be
+Cn
+tg
 YR
-zQ
-OV
+SO
+lJ
 cg
 cz
 cz
@@ -11353,7 +11353,7 @@ cp
 be
 bw
 bC
-Cn
+Gh
 al
 ac
 ak

--- a/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
@@ -37,8 +37,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -103,8 +102,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/paper/solarsteup,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
@@ -112,8 +110,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -125,8 +122,7 @@
 	},
 /obj/machinery/power/solar_control,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
@@ -151,9 +147,7 @@
 /area/nadezhda/engineering/dorm)
 "aN" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
@@ -172,8 +166,7 @@
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/electrical,
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
@@ -189,8 +182,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/outside/mountainsolars)
@@ -263,8 +255,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
@@ -355,8 +346,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
@@ -375,19 +365,16 @@
 /area/nadezhda/outside/mountainsolars)
 "bB" = (
 /obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
 "bC" = (
 /obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/asteroid/dirt,
@@ -409,9 +396,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
@@ -498,12 +483,10 @@
 "cd" = (
 /obj/structure/table/standard,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
@@ -522,8 +505,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -532,8 +514,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -547,8 +528,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -558,8 +538,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/oracarpet,
@@ -568,8 +547,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -583,25 +561,21 @@
 /area/nadezhda/outside/mountainsolars)
 "cq" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
 "cr" = (
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "ct" = (
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
@@ -612,7 +586,6 @@
 "cx" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
 	},
 /turf/simulated/floor/fixed/hydrotile,
@@ -628,8 +601,7 @@
 /area/nadezhda/outside/mountainsolars)
 "cA" = (
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /obj/structure/railing,
 /turf/simulated/floor/asteroid/grass,
@@ -653,8 +625,7 @@
 /area/nadezhda/outside/mountainsolars)
 "cD" = (
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -681,7 +652,6 @@
 "cI" = (
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/dirt,
@@ -698,26 +668,21 @@
 /area/nadezhda/engineering/dorm)
 "cL" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
 "cM" = (
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/flora/ausbushes/ywflowers,
@@ -729,14 +694,11 @@
 /area/nadezhda/outside/mountainsolars)
 "cO" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -744,17 +706,14 @@
 /area/nadezhda/outside/mountainsolars)
 "cP" = (
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "cQ" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -807,7 +766,6 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	frequency = 1442;
-	icon_state = "map_injector";
 	id = "SM_in";
 	pixel_y = 1;
 	use_power = 1
@@ -879,9 +837,7 @@
 "dp" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
-/mob/living/simple_animal/crab{
-	faction = "pond"
-	},
+/mob/living/simple_animal/crab,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/mountainsolars)
 "dq" = (
@@ -936,8 +892,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/engineering/dorm)
@@ -1014,7 +969,6 @@
 "eA" = (
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
@@ -1050,8 +1004,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/engineering/dorm)
@@ -1062,9 +1015,7 @@
 /area/nadezhda/outside/mountainsolars)
 "fp" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/invislight,
@@ -1072,12 +1023,20 @@
 /area/nadezhda/outside/mountainsolars)
 "fq" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"fv" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access = newlist();
+	req_one_access = list(24,10)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall,
+/area/nadezhda/engineering/dorm)
 "fD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warningnew/radiation,
@@ -1091,7 +1050,6 @@
 "fK" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/space,
@@ -1109,12 +1067,10 @@
 /area/nadezhda/outside/mountainsolars)
 "gD" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/effect/window_lwall_spawn/reinforced,
@@ -1125,8 +1081,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/closet/crate/solar,
 /obj/effect/floor_decal/industrial/box,
@@ -1166,8 +1121,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1185,9 +1139,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
@@ -1207,6 +1159,15 @@
 /obj/machinery/vending/dinnerware,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/engineering/dorm)
+"iE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
 "iH" = (
 /obj/random/traps/wire_splicing/low_chance,
@@ -1242,8 +1203,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/outside/mountainsolars)
@@ -1399,6 +1359,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
 "no" = (
@@ -1423,7 +1386,6 @@
 "nz" = (
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -1440,9 +1402,7 @@
 /area/nadezhda/outside/mountainsolars)
 "nM" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/asteroid/dirt,
@@ -1474,6 +1434,12 @@
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
+"or" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/outside/mountainsolars)
 "ou" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -1493,8 +1459,7 @@
 /area/nadezhda/outside/mountainsolars)
 "oJ" = (
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/invislight,
@@ -1504,8 +1469,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -1517,7 +1481,6 @@
 "oV" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/window/reinforced{
@@ -1534,7 +1497,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/machinery/meter,
@@ -1560,8 +1522,11 @@
 "pq" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = 32
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
@@ -1591,6 +1556,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
 "qL" = (
@@ -1613,6 +1579,11 @@
 /obj/random/flora/jungle_tree/low,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"ro" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "rC" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -1625,8 +1596,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1656,8 +1626,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
@@ -1688,6 +1661,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/nadezhda/outside/mountainsolars)
+"sz" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/outside/mountainsolars)
 "sS" = (
 /obj/structure/cable{
@@ -1741,8 +1719,7 @@
 /area/nadezhda/outside/mountainsolars)
 "tE" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = 0
+	dir = 4
 	},
 /obj/machinery/telecomms/relay/preset/telecomms,
 /obj/machinery/door/window/northleft{
@@ -1833,8 +1810,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
@@ -1874,6 +1850,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
 "wZ" = (
@@ -1913,9 +1890,7 @@
 "xP" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
@@ -1928,11 +1903,14 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/mountainsolars)
+"yn" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "yo" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/railing,
@@ -1940,9 +1918,7 @@
 /area/nadezhda/outside/mountainsolars)
 "yp" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing,
@@ -1975,7 +1951,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -1984,21 +1959,48 @@
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"zv" = (
+/turf/unsimulated/mineral,
+/area/nadezhda/engineering/dorm)
 "zG" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/reinforced/airless,
 /area/nadezhda/outside/mountainsolars)
+"zH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/engineering/dorm)
 "zI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/personal/engineering_personal,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
+"zN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
+"zQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/outside/mountainsolars)
 "zV" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
+"zW" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "Af" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted,
@@ -2026,15 +2028,19 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"Bg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "Bi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/mountainsolars)
 "Br" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "BD" = (
@@ -2071,7 +2077,6 @@
 "Cn" = (
 /obj/structure/railing{
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -2093,8 +2098,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -2150,9 +2154,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/generator,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
@@ -2170,7 +2172,6 @@
 "DV" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1;
-	icon_state = "intact";
 	tag = "icon-intact (NORTH)"
 	},
 /turf/space,
@@ -2226,14 +2227,14 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
 "EN" = (
@@ -2245,7 +2246,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/machinery/meter,
@@ -2266,8 +2266,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/camera/network/engineering{
 	dir = 1
@@ -2322,14 +2321,12 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
 "Gh" = (
-/obj/structure/railing{
-	anchored = 1;
-	dir = 4;
-	icon_state = "railing0";
-	tag = "icon-railing0 (EAST)"
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 1;
+	target_pressure = 295
 	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/mountainsolars)
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "GD" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -2341,10 +2338,18 @@
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/engineering/dorm)
+"Ha" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "Hk" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/structure/catwalk,
@@ -2360,7 +2365,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/machinery/meter,
@@ -2368,9 +2372,7 @@
 /area/nadezhda/outside/mountainsolars)
 "Hw" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /obj/structure/cable{
@@ -2380,6 +2382,9 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"HC" = (
+/turf/simulated/mineral/planet,
+/area/nadezhda/engineering/dorm)
 "HP" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -2396,6 +2401,12 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
 "HW" = (
@@ -2412,27 +2423,33 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /obj/structure/invislight,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"Ii" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/engineering/dorm)
 "Io" = (
 /obj/structure/catwalk,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"IK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/engineering/dorm)
 "IQ" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -2482,7 +2499,6 @@
 "Kn" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -2490,7 +2506,6 @@
 "KB" = (
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/fixed/hydrotile,
@@ -2509,12 +2524,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6;
-	icon_state = "intact";
 	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/machinery/meter,
@@ -2530,8 +2543,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/railing,
 /obj/structure/invislight,
@@ -2553,7 +2565,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/machinery/meter,
@@ -2599,15 +2610,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
 "Mr" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/outside/mountainsolars)
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "My" = (
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/dirt,
@@ -2647,7 +2654,6 @@
 "NF" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/effect/window_lwall_spawn/reinforced,
@@ -2688,8 +2694,7 @@
 /area/nadezhda/engineering/dorm)
 "Oj" = (
 /obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
@@ -2702,6 +2707,16 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
+"Or" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "Ot" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -2732,6 +2747,12 @@
 "OU" = (
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/mountainsolars)
+"OV" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/outside/mountainsolars)
 "Pd" = (
 /obj/effect/decal/cleanable/rubble,
@@ -2781,7 +2802,6 @@
 /obj/structure/flora/small/bushb1,
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/asteroid/grass,
@@ -2820,9 +2840,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/mountainsolars)
 "Rd" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -2836,8 +2854,7 @@
 /area/nadezhda/outside/mountainsolars)
 "Rj" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
@@ -2859,6 +2876,9 @@
 "RO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/engineering,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
 "RP" = (
@@ -2871,6 +2891,12 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"Sn" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	target_pressure = 5000
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "SE" = (
 /obj/random/tool_upgrade/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -2882,6 +2908,17 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
+"SH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "SI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
@@ -2935,7 +2972,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9;
-	icon_state = "intact";
 	tag = "icon-intact (NORTHWEST)"
 	},
 /obj/machinery/meter,
@@ -3056,6 +3092,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"VE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/engineering/dorm)
 "VL" = (
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -3100,7 +3142,6 @@
 "WE" = (
 /obj/structure/railing{
 	dir = 1;
-	icon_state = "railing0";
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/cable{
@@ -3120,8 +3161,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
@@ -3154,6 +3194,17 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/mountainsolars)
+"Xf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/nadezhda/engineering/dorm)
 "Xj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/office/light{
@@ -3170,17 +3221,14 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/low_wall,
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/dorm)
 "Xt" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 8;
-	icon_state = "railing0";
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/fixed/hydrotile,
@@ -3198,6 +3246,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/dorm)
 "Ye" = (
@@ -3232,10 +3281,14 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
+/area/nadezhda/engineering/dorm)
+"Zh" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/engineering/dorm)
 "Zj" = (
 /obj/structure/cable{
@@ -3258,9 +3311,7 @@
 /area/nadezhda/outside/mountainsolars)
 "Zx" = (
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/invislight,
@@ -3297,9 +3348,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/railing{
-	anchored = 1;
 	dir = 4;
-	icon_state = "railing0";
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
@@ -9759,11 +9808,11 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-aa
-aa
+HC
+HC
+HC
+zv
+zv
 nt
 Yv
 Um
@@ -9861,13 +9910,13 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
+HC
+yn
+Sn
+Zh
+Bg
 nt
-Um
+zW
 iY
 aE
 aL
@@ -9963,14 +10012,14 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
-nt
+HC
 Um
-DS
+Um
+Um
+iE
+fv
+zN
+SH
 Di
 Cm
 OC
@@ -10065,14 +10114,14 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
+HC
+ro
+Gh
+Zh
+Mr
 nt
 RO
-DS
+Xf
 aE
 aM
 aM
@@ -10167,14 +10216,14 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-aa
+HC
+HC
+HC
+HC
+zv
 nt
 xh
-Um
+Ha
 rL
 aE
 Di
@@ -10276,7 +10325,7 @@ ab
 aa
 nt
 VL
-jH
+Or
 Og
 aB
 aA
@@ -10378,7 +10427,7 @@ aa
 nt
 nt
 YM
-jH
+Or
 aA
 aA
 aA
@@ -10386,8 +10435,8 @@ kq
 gS
 ak
 fp
-Gh
-Gh
+Cn
+Cn
 yp
 cg
 cz
@@ -10486,8 +10535,8 @@ XR
 qB
 wU
 EI
-bc
-au
+sz
+or
 cg
 au
 au
@@ -10583,13 +10632,13 @@ nt
 tE
 jH
 nl
-aB
-aA
-aA
-ut
+Ii
+zH
+VE
+IK
 YR
-bd
-au
+zQ
+OV
 cg
 cz
 cz
@@ -11524,7 +11573,7 @@ jM
 bw
 Io
 bw
-Mr
+wZ
 bw
 bw
 bw

--- a/maps/__Nadezhda/nadezhda.dm
+++ b/maps/__Nadezhda/nadezhda.dm
@@ -67,7 +67,7 @@
 
 /obj/map_data/nadezda_solars
 	name = "Nadezhda Mountain Solars"
-	is_station_level = FALSE
+	is_station_level = TRUE
 	is_player_level = TRUE
 	is_contact_level = TRUE
 	is_accessable_level = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	moves the TEG room to solars, adapts it to be more supermatter friendly, for the event of a delamination, the server will suffer little due to the size of solars and lack of direct interaction with the main colony/atmos tanks.
</summary>
<br />Tests done: <br />
Ran a supermatter for 2+hours with it, cold loop went from 20c to 100c, basic setup deemed safe enough to run a whole shift with emitter on without delamination.  <br />
Caused a delamination, solars and most of the path to the elevator were unaffected, air still got deadly hot without a suit and internals.  <br />
There is "radiation" in the nearby area, but radiation closets were provided and to reach them negligible radiation MAY occur (who said Guild was OSHA compliant anyways?).  <br /><br />
Things changed:<br />
Cyborg recharging station added near the solars controller to help cyborgs/drones case they have to wire it. <br />
TEG was moved to solars and the original room suffered a cave-in, destroying most of it.<br />
Bar area got the wiring fixed.<br />
Changed solars something in nadezhda.dm, so the area can count as part of the colony and the supermatter monitor program may detect and supermatter there.<br />
Now solars also has air vents and scrubbers to appease the map checks <br />
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
add: TEG engine added in solars
add: cyborg recharger to solars level
add: solars now has a rudimentary atmos
del: most of the TEG room by atmos
tweak: solars is now part of the colony, so the supermatter monitor may work there
fix: various minor wiring issues in the recent bar changes
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
