### PR TITLE
Small EMP rocket nerf

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -60,8 +60,8 @@
 /obj/item/projectile/bullet/rocket/emp
 	name = "EMP rocket"
 	icon_state = "rocket_e"
-	damage_types = list(BRUTE = 10, BURN = 30)
-	armor_penetration = 100
+	damage_types = list(BRUTE = 20, BURN = 15)
+	armor_penetration = 30
 	check_armour = ARMOR_BULLET
 	var/heavy_emp_range = 3
 	var/light_emp_range = 8


### PR DESCRIPTION
The EMP rocket is essentially a specialised ammunition type made against mechas or generally, things that are vulnerable to EMPs. It's understandable that the EMP warhead will likely take the place of most sorts of kinetic penetrators, HE filler and so on, in order to make it able to do its role. So I nerfed the penetration value of the rocket which made no sense, now and some damage, EMP aside, it's just essentially not gonna hurt you as much, to not make it as unbalanced. Just buy regular rockets against people now.
It still hurts a bit in terms of brute because it's still a very heavy projectile going against you really fast.