### PR TITLE
Alchemy Addition

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -89,6 +89,14 @@
 				if((spell.message == "The End." || spell.message == "The Beginning.") && candle_amount >= 1)
 					end_spell(M)
 					continue
+
+				if(spell.message == "Brew." && candle_amount >= 2)
+					brew_spell(M)
+					continue
+
+				if(spell.message == "Recipe." && candle_amount >= 1)
+					recipe_spell(M)
+					continue
 			return
 
 	if(istype(I, /obj/item/tool/knife/ritual) || istype(I, /obj/item/tool/knife/neotritual))
@@ -134,6 +142,26 @@
 	M.health -= 20
 	B.remove_self(50)
 	M.unnatural_mutations.total_instability += 15
+	return
+
+/obj/effect/decal/cleanable/crayon/proc/recipe_spell(mob/living/carbon/human/M)
+	var/datum/reagent/organic/blood/B = M.get_blood()
+	for(var/obj/item/paper/P in oview(1)) // Must be on the spell circle
+		to_chat(M, "<span class='info'>A echoing sound of scribbling fills the air.</span>")
+		B.remove_self(20)
+		var/obj/item/alchemy/recipe_scroll/S = new /obj/item/alchemy/recipe_scroll
+		S.loc = P.loc
+		qdel(P)
+	return
+
+/obj/effect/decal/cleanable/crayon/proc/brew_spell(mob/living/carbon/human/M)
+	var/datum/reagent/organic/blood/B = M.get_blood()
+	M.maxHealth -= 25
+	M.health -= 25
+	B.remove_self(50)
+	M.metabolism_effects.nsa_bonus -= 25 //Works to balance out the NSA given from the perk. That way those who get it naturally have a bonus.
+	M.stats.addPerk(PERK_ALCHEMY)
+	to_chat(M, "<span class='warning'>Your mind expands with creations lost. Your body feels sick.</span>")
 	return
 
 /obj/effect/decal/cleanable/crayon/proc/ignorance_spell(mob/living/carbon/human/M)

--- a/code/modules/reagents/machinery/alchemy.dm
+++ b/code/modules/reagents/machinery/alchemy.dm
@@ -17,7 +17,7 @@
 		set name = "Start Alchemical Reaction"
 		set src in view(1)
 
-		if (usr.stat || usr.restrained() || anchored)
+		if (usr.stat || usr.restrained() || anchored || !usr.stats.getPerk(PERK_ALCHEMY))
 			return
 
 		if (!beaker)
@@ -87,3 +87,25 @@
 	amount_per_transfer_from_this = 1
 	possible_transfer_amounts = list(1,2,3)
 	reagent_flags = TRANSPARENT | NO_REACT // It's a stasis BIDON, shouldn't allow chems to react inside it.
+
+/obj/item/alchemy/recipe_scroll
+	name = "alchemy recipe"
+	desc = "A tatty paper written in a strange language."
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "scroll"
+
+/obj/item/alchemy/recipe_scroll/Initialize()
+	var/blurb = pick(list(
+		"iron suppliments tungsten, needs to be reformed with sodiumchloride",
+		"ammonia dissolves carbon, crystalize with sodiumchloride",
+		"water and carbon mixed slowly with sodiumchloride",
+		"detox slowly mixed with viroputine, boil with citalopram",
+		"detox combined with purger and boiled off with citalopram",
+		"iron ground into flakes, absorbed by silicon and enriched with sodiumchloride",
+		"oil to suspend sodiumchloride then slowly dissolved with iron",
+		"gold ground into a powder, combine after mixing sodiumchloride with tatonka_milk",
+		"protein enriched egg, further enrich with tatonka_milk",
+		"protein enriched honey thats slowly steamed with ethanol",
+		"blackpepper ground into flakes. Combine with milk and drops of ethanol",
+		"blood dissolved with gold, boil with lively_concoxion"))
+	desc = "A list of various ingredients on a tatty paper. Something about [blurb]"


### PR DESCRIPTION
Alchemy perk is now required to use the Alchemy equipment.
Adds in Alchemy Recipe papers.