### PR TITLE
gives lodge roles access to alchemy

### DIFF
--- a/code/game/jobs/job/offcolony.dm
+++ b/code/game/jobs/job/offcolony.dm
@@ -15,7 +15,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/off_colony/hunt_master
 	health_modifier = 15
 
-	perks = list(/datum/perk/job/butcher, /datum/perk/job/master_herbalist, /datum/perk/greenthumb)
+	perks = list(/datum/perk/job/butcher, /datum/perk/job/master_herbalist, /datum/perk/greenthumb, /datum/perk/alchemist)
 	access = list(access_huntmaster, access_hunter)
 
 	stat_modifiers = list(
@@ -57,7 +57,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/off_colony/hunter
 	health_modifier = 10
 
-	perks = list(/datum/perk/job/butcher)
+	perks = list(/datum/perk/job/butcher, /datum/perk/alchemist)
 	access = list(access_hunter)
 
 	stat_modifiers = list(
@@ -99,7 +99,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/off_colony/herbalist
 	health_modifier = 5
 
-	perks = list(/datum/perk/job/butcher, /datum/perk/job/master_herbalist, /datum/perk/greenthumb)
+	perks = list(/datum/perk/job/butcher, /datum/perk/job/master_herbalist, /datum/perk/greenthumb, /datum/perk/alchemist)
 	access = list(access_hunter)
 
 	stat_modifiers = list(

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -34,7 +34,8 @@
 	/obj/item/folder,
 	/obj/item/paper,
 	/obj/item/paper_bundle,
-	/obj/item/photo
+	/obj/item/photo,
+	/obj/item/alchemy/recipe_scroll
 	)
 	var/hex_code_for_ui_backround = "#C4A484"
 

--- a/code/modules/organs/internal/psionic.dm
+++ b/code/modules/organs/internal/psionic.dm
@@ -23,6 +23,7 @@
 	nutriment_req = 6
 	var/psi_points = 0         //How many points we have currently
 	var/max_psi_points = 0
+	var/burn
 	var/disabled = TRUE        //Whether or not the implant functions.
 	var/psi_point_cost
 	var/inhibited = FALSE      //Whether or not the organ has been inhibited by an external force

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -31,6 +31,7 @@
 		/obj/item/folder,
 		/obj/item/photo,
 		/obj/item/paper_bundle,
+		/obj/item/alchemy/recipe_scroll,
 		/obj/item/sample)
 	var/hex_code_for_ui_backround = "#897E75"
 

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -11,7 +11,8 @@
 	/obj/item/folder,
 	/obj/item/paper,
 	/obj/item/paper_bundle,
-	/obj/item/photo
+	/obj/item/photo,
+	/obj/item/alchemy/recipe_scroll
 	)
 
 /obj/item/folder/black

--- a/code/modules/reagents/machinery/alchemy.dm
+++ b/code/modules/reagents/machinery/alchemy.dm
@@ -96,16 +96,20 @@
 
 /obj/item/alchemy/recipe_scroll/Initialize()
 	var/blurb = pick(list(
-		"iron suppliments tungsten, needs to be reformed with sodiumchloride",
-		"ammonia dissolves carbon, crystalize with sodiumchloride",
-		"water and carbon mixed slowly with sodiumchloride",
-		"detox slowly mixed with viroputine, boil with citalopram",
-		"detox combined with purger and boiled off with citalopram",
-		"iron ground into flakes, absorbed by silicon and enriched with sodiumchloride",
-		"oil to suspend sodiumchloride then slowly dissolved with iron",
-		"gold ground into a powder, combine after mixing sodiumchloride with tatonka_milk",
-		"protein enriched egg, further enrich with tatonka_milk",
-		"protein enriched honey thats slowly steamed with ethanol",
-		"blackpepper ground into flakes. Combine with milk and drops of ethanol",
-		"blood dissolved with gold, boil with lively_concoxion"))
-	desc = "A list of various ingredients on a tatty paper. Something about [blurb]"
+		"Iron binds with tungsten, but needs to be recondensed with salt",
+		"Ammonia dissolves carbon - crystalize with salt",
+		"Water and carbon can be mixed with salt",
+		"Detox can be purified when mixed with viroputine and citalopram",
+		"Citalopram and purger bring out the purest essence of detox",
+		"Iron and silicon, ground into flakes, and enriched with sodiumchloride",
+		"Suspend salt in oil, and stir in iron shavings",
+		"Ground gold and salt, mixed into a tatonka's milk",
+		"Tatonka milk can be fortified with eggs and extra protein",
+		"Honey, ethanol and pure protien make an invigorating brew",
+		"Ethanol and milk, plus a dash of pepper",
+		"Fresh blood and pure gold can distill an elixir of health into its most potent form"))
+	desc = "[desc] It reads \"[blurb]\""
+
+/obj/item/alchemy/recipe_scroll/lodge
+	name = "hunters' recipe"
+	desc = "An old sheet of paper with a carefully-guarded Lodge recipe on it. There's a diagram showing some sort of symbol..."

--- a/maps/_HunterLodge/map/_Hunting_Lodge.dmm
+++ b/maps/_HunterLodge/map/_Hunting_Lodge.dmm
@@ -475,9 +475,12 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "cr" = (
-/obj/structure/table/woodentable,
+/obj/structure/bookcase,
 /obj/item/alchemy/recipe_scroll/lodge,
-/turf/simulated/floor/carpet/bcarpet,
+/obj/item/alchemy/recipe_scroll/lodge,
+/obj/item/alchemy/recipe_scroll/lodge,
+/obj/item/alchemy/recipe_scroll/lodge,
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "ct" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -7866,7 +7869,7 @@ WQ
 jw
 Cb
 aT
-cr
+bY
 es
 wC
 gg
@@ -8334,7 +8337,7 @@ gg
 Ae
 Cb
 Cb
-Xz
+cr
 Rl
 hb
 hb

--- a/maps/_HunterLodge/map/_Hunting_Lodge.dmm
+++ b/maps/_HunterLodge/map/_Hunting_Lodge.dmm
@@ -79,8 +79,8 @@
 /area/nadezhda/outside/forest/hunting_lodge)
 "ao" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 6;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 6
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -295,8 +295,8 @@
 	dir = 1
 	},
 /obj/structure/noticeboard{
-	pixel_y = 28;
-	layer = 3.5
+	layer = 3.5;
+	pixel_y = 28
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -312,9 +312,9 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "bu" = (
 /obj/machinery/button/remote/blast_door{
-	pixel_x = -24;
 	id = "huntercase";
-	name = "Display Case Shutters"
+	name = "Display Case Shutters";
+	pixel_x = -24
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -475,11 +475,9 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "cr" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 8;
-	color = "#6c3d26"
-	},
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable,
+/obj/item/alchemy/recipe_scroll/lodge,
+/turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "ct" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -831,8 +829,8 @@
 /area/nadezhda/outside/forest/hunting_lodge)
 "ec" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 4;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 4
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -961,8 +959,8 @@
 "eN" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/spline/fancy{
-	dir = 8;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 8
 	},
 /obj/item/towel/random,
 /turf/simulated/floor/wood/wild2,
@@ -1033,8 +1031,8 @@
 /area/nadezhda/outside/forest/hunting_lodge)
 "fl" = (
 /obj/structure/sink/kitchen{
-	name = "utility sink";
 	dir = 4;
+	name = "utility sink";
 	pixel_x = -20
 	},
 /turf/simulated/floor/tiled/white,
@@ -1171,8 +1169,8 @@
 "ga" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy{
-	dir = 1;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 1
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -1235,8 +1233,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "gm" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 8;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge)
@@ -1294,8 +1292,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "gA" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 4;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge)
@@ -1433,18 +1431,18 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "hs" = (
 /obj/effect/floor_decal/border/stoneborder{
-	dir = 4;
 	color = "8f8f8f";
+	dir = 4;
 	pixel_y = 15
 	},
 /obj/effect/floor_decal/border/stoneborder{
-	dir = 4;
 	color = "8f8f8f";
+	dir = 4;
 	pixel_y = -16
 	},
 /obj/effect/floor_decal/border/stoneborder{
-	dir = 4;
-	color = "8f8f8f"
+	color = "8f8f8f";
+	dir = 4
 	},
 /obj/structure/railing/grey{
 	dir = 8
@@ -1461,8 +1459,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "hv" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 9;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 9
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -1719,8 +1717,8 @@
 "jC" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/spline/fancy{
-	dir = 4;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 4
 	},
 /obj/item/towel/random,
 /turf/simulated/floor/wood/wild2,
@@ -1842,13 +1840,6 @@
 "kG" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/wild1,
-/area/nadezhda/outside/forest/hunting_lodge_dark)
-"kI" = (
-/obj/effect/floor_decal/spline/fancy{
-	color = "#6c3d26";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "kZ" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -1997,8 +1988,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/buildable{
-	name = "simple power storage unit";
 	desc = "A overly simplified high-capacity superconducting magnetic energy storage (SMES) unit. It goes as far as to have big red arrows pointing to the switches, and indentations on the controles to allow even the blind or unable to read to set this SMES.";
+	name = "simple power storage unit";
 	skill_check = -30
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2058,8 +2049,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "on" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 6;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 6
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -2097,8 +2088,8 @@
 "oC" = (
 /obj/structure/table/bench/wooden,
 /obj/effect/floor_decal/spline/fancy{
-	dir = 6;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 6
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -2117,8 +2108,8 @@
 /obj/item/soap/hunters,
 /obj/item/soap/hunters,
 /obj/effect/floor_decal/spline/fancy{
-	dir = 1;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 1
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -2322,8 +2313,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy{
-	dir = 8;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -2416,8 +2407,8 @@
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/chocolatecakeslice,
 /obj/effect/floor_decal/spline/fancy{
-	dir = 4;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 4
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -2753,8 +2744,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "yh" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 8;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 8
 	},
 /obj/effect/floor_decal/spline/fancy{
 	color = "#6c3d26";
@@ -2788,8 +2779,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "yK" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 2;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 2
 	},
 /obj/effect/floor_decal/spline/fancy/corner{
 	color = "#8f8f8f";
@@ -2841,8 +2832,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "za" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 5;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -2900,8 +2891,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "zW" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 10;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 10
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -2928,8 +2919,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "Ai" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 1;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 1
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -3002,8 +2993,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "BB" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 5;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 5
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -3058,8 +3049,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "Cx" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 8;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 8
 	},
 /obj/effect/floor_decal/spline/fancy{
 	color = "#6c3d26";
@@ -3071,8 +3062,8 @@
 /obj/structure/table/woodentable,
 /obj/item/clothing/under/bathrobe,
 /obj/effect/floor_decal/spline/fancy{
-	dir = 1;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 1
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -3188,18 +3179,18 @@
 	icon_state = "grey_railing0"
 	},
 /obj/effect/floor_decal/border/stoneborder{
-	dir = 8;
 	color = "8f8f8f";
+	dir = 8;
 	pixel_y = 15
 	},
 /obj/effect/floor_decal/border/stoneborder{
-	dir = 8;
 	color = "8f8f8f";
+	dir = 8;
 	pixel_y = -16
 	},
 /obj/effect/floor_decal/border/stoneborder{
-	dir = 8;
-	color = "8f8f8f"
+	color = "8f8f8f";
+	dir = 8
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -3304,8 +3295,8 @@
 /area/nadezhda/outside/forest/hunting_lodge)
 "EM" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 9;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -3358,15 +3349,15 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "FF" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 8;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 8
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "FJ" = (
 /obj/effect/floor_decal/border/stoneborder{
-	dir = 1;
-	color = "8f8f8f"
+	color = "8f8f8f";
+	dir = 1
 	},
 /obj/structure/railing/grey,
 /turf/simulated/floor/asteroid/dirt,
@@ -3788,8 +3779,8 @@
 "ML" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/spline/fancy{
-	dir = 1;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 1
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -3844,8 +3835,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "NV" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 2;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 2
 	},
 /obj/effect/floor_decal/spline/fancy/corner{
 	color = "#8f8f8f";
@@ -3914,8 +3905,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "OA" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 10;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 10
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -4125,8 +4116,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "Rt" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 8;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 8
 	},
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood,
@@ -4187,8 +4178,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "SF" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 4;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 4
 	},
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood,
@@ -4263,8 +4254,8 @@
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "Uv" = (
 /obj/effect/floor_decal/spline/fancy{
-	dir = 4;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -4447,8 +4438,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy{
-	dir = 4;
-	color = "#6c3d26"
+	color = "#6c3d26";
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -4456,8 +4447,8 @@
 /obj/structure/closet,
 /obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy{
-	dir = 1;
-	color = "#8f8f8f"
+	color = "#8f8f8f";
+	dir = 1
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -4540,20 +4531,20 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical{
-	pixel_y = 9;
-	layer = 2.9
+	layer = 2.9;
+	pixel_y = 9
 	},
 /obj/item/storage/toolbox/electrical{
-	pixel_y = 9;
-	layer = 2.9
+	layer = 2.9;
+	pixel_y = 9
 	},
 /obj/item/storage/toolbox/electrical{
-	pixel_y = 9;
-	layer = 2.9
+	layer = 2.9;
+	pixel_y = 9
 	},
 /obj/item/storage/toolbox/electrical{
-	pixel_y = 9;
-	layer = 2.9
+	layer = 2.9;
+	pixel_y = 9
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -7875,7 +7866,7 @@ WQ
 jw
 Cb
 aT
-bY
+cr
 es
 wC
 gg
@@ -11982,7 +11973,7 @@ ZD
 om
 WQ
 us
-kI
+EM
 Lx
 TX
 RR
@@ -12133,7 +12124,7 @@ tz
 WQ
 jj
 zs
-cr
+Lx
 TX
 jj
 WQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Alchemy was recently updated to be usable in-game via blood magic, but the faction it was originally for - the Lodge - can't use it without going to the colony to maint-dive. This grants all three lodge roles PERK_ALCHEMY.
	
<hr>
</details>

## Changelog
:cl:
balance: Hunter, Herbalist and Huntmaster spawn with PERK_ALCHEMY
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
