### PR TITLE
Adds RPG to BS Armory

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -79205,7 +79205,6 @@
 /obj/item/gun/projectile/rpg,
 /obj/item/ammo_casing/rocket,
 /obj/item/ammo_casing/rocket,
-/obj/item/ammo_casing/rocket,
 /obj/item/ammo_casing/rocket/emp,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -60660,11 +60660,11 @@
 /area/nadezhda/pros/prep)
 "lNd" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/storage/box/teargas{
-	pixel_x = 8
-	},
 /obj/item/storage/box/flashbangs{
 	pixel_x = -8
+	},
+/obj/item/storage/box/frag{
+	pixel_x = 6
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
@@ -67648,8 +67648,9 @@
 /obj/item/storage/box/explosive{
 	pixel_x = -10
 	},
-/obj/item/storage/box/frag{
-	pixel_x = 6
+/obj/item/toy/figure/character/discontinued/dsquad{
+	pixel_x = 4;
+	pixel_y = -2
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
@@ -79197,8 +79198,15 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/detectives_office)
 "pun" = (
-/obj/structure/closet/crate/serbcrate,
-/obj/item/gun/projectile/automatic/lmg/heroic,
+/obj/item/storage/pouch/tubular,
+/obj/structure/closet/crate/serbcrate{
+	name = "Heavy ordinance crate"
+	},
+/obj/item/gun/projectile/rpg,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket/emp,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "puu" = (
@@ -123144,6 +123152,7 @@
 /obj/structure/closet/crate/serbcrate,
 /obj/item/gun/projectile/automatic/omnirifle,
 /obj/item/gun/projectile/automatic/omnirifle,
+/obj/item/gun/projectile/automatic/lmg/heroic,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "xVT" = (
@@ -182641,7 +182650,7 @@ dNb
 psV
 cCd
 ikW
-nev
+lrJ
 eEn
 hSx
 hSx
@@ -183247,7 +183256,7 @@ ikW
 ikW
 phu
 ikW
-lrJ
+nev
 eEn
 hSx
 hSx


### PR DESCRIPTION
## About The Pull Request
Adds in Blackshield RPG. I'm personally still iffy on the EMP rocket but - Trilby suggested to let it be tried. So, added one to it. 

Blackshield get a total of 2 regular RPG rockets and 1 EMP, plus a tubular pouch. I did remove their single box of teargas grenades though (this violates the Geneva Convention to use them on uniformed combatants........) - but I gave them a nice bobble head in their place (: 

![image](https://user-images.githubusercontent.com/47883419/217018441-3991b06e-bcad-483c-be17-7fcee2fb1be2.png)

## Changelog
:cl:
adds: RPG and rockets to Blackshield armory.
removes: Tear gas grenades from Blackshield armory. (Why have these?)
adds: small figurine to BS armory (: 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
