### PR TITLE
Autolathe Rebalancing

### DIFF
--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -63,6 +63,8 @@
 	var/have_recycling = FALSE //Also dictates auto-input
 	var/have_design_selector = TRUE
 
+	var/max_efficiency = 0.5
+
 	var/list/selectively_recycled_types = list()	// Allows recycling of specified types if have_recycling = FALSE
 
 	var/list/unsuitable_materials = list(MATERIAL_BIOMATTER)
@@ -976,7 +978,7 @@
 	queue_max = initial(queue_max) + mb_rating + (hacked ? 8 : 0) //So the more matter bin levels the more we can queue!
 
 	speed = initial(speed) + man_rating + las_rating
-	mat_efficiency = max(0.5, 1.0 - (man_rating * 0.1))
+	mat_efficiency = max(max_efficiency, 1.0 - (man_rating * 0.1))
 
 
 
@@ -1021,6 +1023,7 @@
 	circuit = /obj/item/circuitboard/autolathe_industrial
 	speed = 4
 	storage_capacity = 240
+	max_efficiency = 0.3
 	have_recycling = TRUE
 
 /obj/machinery/autolathe/greyson

--- a/code/game/machinery/autolathe/mechfab.dm
+++ b/code/game/machinery/autolathe/mechfab.dm
@@ -11,7 +11,7 @@
 	have_disk = FALSE
 	have_reagents = FALSE
 	have_recycling = FALSE
-	max_efficiency = 0.2
+	max_efficiency = 0.5
 
 	special_actions = list(
 		list("action" = "sync", "name" = "Sync with R&D console", "icon" = "refresh")

--- a/code/game/machinery/autolathe/mechfab.dm
+++ b/code/game/machinery/autolathe/mechfab.dm
@@ -11,6 +11,7 @@
 	have_disk = FALSE
 	have_reagents = FALSE
 	have_recycling = FALSE
+	max_efficiency = 0.2
 
 	special_actions = list(
 		list("action" = "sync", "name" = "Sync with R&D console", "icon" = "refresh")

--- a/code/game/machinery/bioprinter_nt.dm
+++ b/code/game/machinery/bioprinter_nt.dm
@@ -8,6 +8,7 @@
 	speed = 5
 	have_recycling = TRUE
 	queue_max = 16 //Might be 8 in game do to wires
+	mat_efficiency = .3
 
 /obj/machinery/autolathe/bioprinter/attackby(obj/item/I, mob/user)
 	//hacky way to forbid deconstruction but use ..()
@@ -20,11 +21,6 @@
 		return
 
 	..(I, user)
-
-/obj/machinery/autolathe/bioprinter/RefreshParts()
-	..()
-	speed = initial(speed) + 4 + 2
-	mat_efficiency = max(0.2, 1.0 - (4 * 0.1))
 
 /obj/machinery/autolathe/bioprinter/disk
 	default_disk = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter

--- a/code/game/machinery/bioprinter_nt.dm
+++ b/code/game/machinery/bioprinter_nt.dm
@@ -22,6 +22,10 @@
 
 	..(I, user)
 
+/obj/machinery/autolathe/bioprinter/RefreshParts()
+	..()
+	speed = initial(speed) + 4 + 2
+
 /obj/machinery/autolathe/bioprinter/disk
 	default_disk = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter
 

--- a/code/game/machinery/bioprinter_nt.dm
+++ b/code/game/machinery/bioprinter_nt.dm
@@ -25,6 +25,7 @@
 /obj/machinery/autolathe/bioprinter/RefreshParts()
 	..()
 	speed = initial(speed) + 4 + 2
+	mat_efficiency = 0.5
 
 /obj/machinery/autolathe/bioprinter/disk
 	default_disk = /obj/item/computer_hardware/hard_drive/portable/design/nt_bioprinter

--- a/code/game/machinery/bioprinter_nt.dm
+++ b/code/game/machinery/bioprinter_nt.dm
@@ -8,7 +8,7 @@
 	speed = 5
 	have_recycling = TRUE
 	queue_max = 16 //Might be 8 in game do to wires
-	mat_efficiency = .3
+	mat_efficiency = 0.3
 
 /obj/machinery/autolathe/bioprinter/attackby(obj/item/I, mob/user)
 	//hacky way to forbid deconstruction but use ..()

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -38,7 +38,7 @@
 	icon_state = "protolathe"
 	circuit = /obj/item/circuitboard/protolathe
 	unsuitable_materials = list() //So we can use biomatter and others
-	mat_efficiency = .2
+	mat_efficiency = 0.2
 	build_type = PROTOLATHE
 	storage_capacity = 120
 
@@ -48,7 +48,7 @@
 	desc = "A machine used for printing advanced circuit boards. Operated from an R\&D console."
 	icon_state = "imprinter"
 	circuit = /obj/item/circuitboard/circuit_imprinter
-	mat_efficiency = .2
+	mat_efficiency = 0.2
 	build_type = IMPRINTER
 	storage_capacity = 60
 	speed = 3

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -38,7 +38,7 @@
 	icon_state = "protolathe"
 	circuit = /obj/item/circuitboard/protolathe
 	unsuitable_materials = list() //So we can use biomatter and others
-
+	mat_efficiency = .2
 	build_type = PROTOLATHE
 	storage_capacity = 120
 
@@ -48,7 +48,7 @@
 	desc = "A machine used for printing advanced circuit boards. Operated from an R\&D console."
 	icon_state = "imprinter"
 	circuit = /obj/item/circuitboard/circuit_imprinter
-
+	mat_efficiency = .2
 	build_type = IMPRINTER
 	storage_capacity = 60
 	speed = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>

</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
- Returns balance to this world

- Industrial Autolathe maximum material Efficiency is now 30% (was 50%)

- Circuit printer maximum material Efficiency is now 20% (was 50%)

- Protolathe maximum material Efficiency is now 20% (was 50%)

- Exosuit Fabricator maximum material Efficiency is still 50% (Troublesome cat)

- Asserts Soterian gigachad dominance over the Absolutist sheep (and goats)

- Church Biovomiter material Efficiency is now 50% (Was 60%) (It cannot change it has no components don't @ me)

- Regular Autolathe maximum material Efficiency is still 50%

- Order a printer from Soteria today!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
