### PR TITLE
Fixes Marshal 'Do It Yourself' Disk & More LSS Beacon Parts

### DIFF
--- a/code/datums/autolathe/parts.dm
+++ b/code/datums/autolathe/parts.dm
@@ -310,7 +310,7 @@
 	name = "firearm 20mm shotgun barrel"
 	build_path = /obj/item/part/gun/barrel/shotgun
 
-/datum/design/autolathe/part/barrel/heavy
+/datum/design/autolathe/part/barrel/amr
 	name = "firearm 14.5mm anti-material rifle barrel"
 	build_path = /obj/item/part/gun/barrel/antim
 

--- a/code/game/objects/items/weapons/autolathe_disk/gun_parts_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/gun_parts_disks.dm
@@ -54,9 +54,9 @@ Avoid any disks here being found or used commonly beyond an intended purpose, ot
 		/datum/design/autolathe/part/barrel/kurtz = 2,
 		/datum/design/autolathe/part/barrel/carbine = 2,
 		/datum/design/autolathe/part/barrel/rifle = 2,
-		/datum/design/autolathe/part/barrel/heavy = 3,
+		/datum/design/autolathe/part/barrel/heavy = 2,
 		/datum/design/autolathe/part/barrel/shotgun,
-		/datum/design/autolathe/part/barrel/heavy = 4,
+		/datum/design/autolathe/part/barrel/amr = 4,
 	)
 
 // Bootleg-gun production stuff. Found in loot-piles, can be bought by LSS for a slightly inflated price.

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/illegalbeacon1.dm
@@ -51,6 +51,12 @@
 			/obj/item/gun_upgrade/barrel/gauss,
 			/obj/item/gun_upgrade/muzzle/pain_maker, //Clearly so you can get those
 			/obj/item/gun_upgrade/scope/killer
+		),
+		"Sydnicate Gun Parts" = list (
+			/obj/item/part/gun/grip/rubber,
+			/obj/item/part/gun/barrel/hrifle,
+			/obj/item/part/gun/mechanism/machinegun,
+			/obj/item/part/gun/barrel/antim
 		)
 	)
 	offer_types = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bad pathing caused the 8.6mm barrel to be not printable. Fixed the pathing. Also reduced its license cost by 1 since the barrels are in high demand.

Similarly added the ability to buy 8.6mm barrels, 14.5 AMR barrels, machine gun mechanisms, and rubber grips from Syndicate trade beacon if enough rep is had now.
## Changelog
:cl:
fixes: Marshal disk now has proper 8.6 barrel on it. Also reduces license cost by 1.
adds: LSS now able to buy in-demand rare parts for guns from Syndicate beacon. Hopefully takes some stress away from rare loot spawns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
