### PR TITLE
Spec Op & Misc

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disk/gun_parts_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/gun_parts_disks.dm
@@ -42,7 +42,7 @@ Avoid any disks here being found or used commonly beyond an intended purpose, ot
 		/datum/design/autolathe/part/grip/wood = 0,
 		/datum/design/autolathe/part/grip/plastic,
 		/datum/design/autolathe/part/grip/serb,
-		/datum/design/autolathe/part/grip/rubber = 2,
+		/datum/design/autolathe/part/grip/rubber,
 		/datum/design/autolathe/part/mechanism/pistol,
 		/datum/design/autolathe/part/mechanism/revolver,
 		/datum/design/autolathe/part/mechanism/shotgun,

--- a/code/modules/projectiles/guns/projectile/automatic/specop.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/specop.dm
@@ -19,7 +19,7 @@
 	damage_multiplier = 1.2
 	penetration_multiplier = 1.15
 	zoom_factors = list(0.2)
-	init_recoil = LMG_RECOIL(0.4)
+	init_recoil = LMG_RECOIL(0.6)
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
 		FULL_AUTO_600_NOLOSS

--- a/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/clarissa.dm
@@ -84,7 +84,7 @@
 	serial_type = "Sol Fed"
 	wield_delay = 0.3 SECOND
 	wield_delay_factor = 0.2 // 20 vig
-	gun_parts = list(/obj/item/part/gun/frame/makarov = 1, /obj/item/part/gun/grip/excel = 1, /obj/item/part/gun/mechanism/pistol = 1, /obj/item/part/gun/barrel/pistol = 1)
+	gun_parts = list(/obj/item/part/gun/frame/makarov = 1, /obj/item/part/gun/grip/black = 1, /obj/item/part/gun/mechanism/pistol = 1, /obj/item/part/gun/barrel/pistol = 1)
 
 /obj/item/part/gun/frame/makarov
 	name = "Makarov frame"
@@ -92,7 +92,7 @@
 	icon_state = "frame_makarov"
 	result = /obj/item/gun/projectile/makarov
 	resultvars = list(/obj/item/gun/projectile/makarov)
-	gripvars = list(/obj/item/part/gun/grip/excel)
+	gripvars = list(/obj/item/part/gun/grip/black)
 	mechanismvar = /obj/item/part/gun/mechanism/pistol
 	barrelvars = list(/obj/item/part/gun/barrel/pistol)
 


### PR DESCRIPTION
## About The Pull Request
Small misc PR.
- Makarov no longer takes or gives Excel grips. 
- Spec Op now has slightly higher recoil modifier (it's literally a 10x24 caliber)
- Rubber grips now use 1 license instead of 2 on Marshal disk after feedback was given.

## Changelog
:cl:
balance: Makarov grip fix, Spec-op balance to have higher recoil, grip on Marshal disk no longer costs 2 licenses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
