### PR TITLE
Add Food Qualifiers

### DIFF
--- a/code/modules/cooking_with_jane/cooking.dm
+++ b/code/modules/cooking_with_jane/cooking.dm
@@ -315,8 +315,8 @@ Food quality is calculated based on the steps taken.
 			if("max" in step_list)
 				set_step_max_quality(step_list["max"])
 
-			if("result_desc" in step_list)
-				set_step_custom_result_desc(step_list["result_desc"])
+			if("prod_desc" in step_list)
+				set_step_custom_result_desc(step_list["prod_desc"])
 
 			if("qmod" in step_list)
 				if(!set_inherited_quality_modifier(step_list["qmod"]))
@@ -701,9 +701,18 @@ Food quality is calculated based on the steps taken.
 
 			var/reagent_quality = calculate_reagent_quality(pointer)
 
+
+			//Produce Item descriptions based on the steps taken
+			var/cooking_description_modifier = ""
+			for(var/id in pointer.steps_taken)
+				if(pointer.steps_taken[id] != "skip")
+					cooking_description_modifier += "[pointer.steps_taken[id]]\n"
+
 			for(var/i = 0; i < product_count; i++)
 				var/obj/item/new_item = new product_type(container)
-				log_debug("Item created with reagents of [new_item.reagents.total_volume]")
+				#ifdef CWJ_DEBUG
+				log_debug("/recipe/proc/create_product: Item created with reagents of [new_item.reagents.total_volume]")
+				#endif
 				if(replace_reagents)
 					//Clearing out reagents in data. If initialize hasn't been called, we also null that out here.
 					#ifdef CWJ_DEBUG
@@ -716,6 +725,7 @@ Food quality is calculated based on the steps taken.
 				slurry.trans_to_holder(new_item.reagents, amount=slurry.total_volume, copy=1)
 
 				new_item?:food_quality = pointer.tracked_quality + reagent_quality
+				new_item?:cooking_description_modifier = cooking_description_modifier
 				//TODO: Consider making an item's base components show up in the reagents of the product.
 		else
 			//Purge the contents of the container we no longer need it

--- a/code/modules/cooking_with_jane/cooking_catalog.dm
+++ b/code/modules/cooking_with_jane/cooking_catalog.dm
@@ -164,6 +164,28 @@
 	data["description"] = recipe.description
 	data["recipe_guide"] = recipe.recipe_guide
 
+	switch(recipe.cooking_container)
+		if(PLATE)
+			data["create_in"] = "Made with a debug-only serving plate."
+		if(CUTTING_BOARD)
+			data["create_in"] = "Made on a cutting board."
+		if(PAN)
+			data["create_in"] = "Made with a pan or skillet."
+		if(POT)
+			data["create_in"] = "Made in a cooking pot."
+		if(BOWL)
+			data["create_in"] = "Made in a prep bowl."
+		if(DF_BASKET)
+			data["create_in"] = "Made in a deep frying basket."
+		if(DF_BASKET)
+			data["create_in"] = "Made in an air frying basket."
+		if(OVEN)
+			data["create_in"] = "Made with an oven dish."
+		if(GRILL)
+			data["create_in"] = "Made on a grill."
+		else
+			data["create_in"] = "Made with a ~//SEGMENTATION FAULT//~ 00110001"
+
 	return data
 
 //===========================================================

--- a/code/modules/cooking_with_jane/food_overrides.dm
+++ b/code/modules/cooking_with_jane/food_overrides.dm
@@ -2,6 +2,8 @@
 	if(!..(user, get_dist(user, src)))
 		return
 
+	if(cooking_description_modifier)
+		to_chat(user, SPAN_NOTICE(cooking_description_modifier))
 
 	to_chat(user, SPAN_NOTICE("The food's level of quality is [food_quality]"))
 

--- a/code/modules/cooking_with_jane/porting_readme.txt
+++ b/code/modules/cooking_with_jane/porting_readme.txt
@@ -18,5 +18,5 @@ to function.
 
 - Add # exclusion to the sanitizeFileName function.
 
-- The statment ard_drive.store_file(new/datum/computer_file/program/cook_catalog()) should be
+- The statment hard_drive.store_file(new/datum/computer_file/program/cook_catalog()) should be
 added to any PDA's install_default_programs() proc if they should have it at round start

--- a/code/modules/cooking_with_jane/porting_readme.txt
+++ b/code/modules/cooking_with_jane/porting_readme.txt
@@ -3,19 +3,20 @@ Things to keep in mind when porting to eris:
 - Cooking has to be initialized with initialize_cooking_recipes() in /datum/global_init/New().
 It has to be ran AFTER initialize_chemical_reagents() and initialize_chemical_reactions()!
 
-- The CtrlShiftClickOn, CtrlShiftClick, CtrlClickOn and CtrlClick procs need to be updated to 
-recieve the params value from the ClickOn function. This is needed for the stove and grill 
+- The CtrlShiftClickOn, CtrlShiftClick, CtrlClickOn and CtrlClick procs need to be updated to
+recieve the params value from the ClickOn function. This is needed for the stove and grill
 to function.
 
-- Food, snacks, and any atom used as an ingredient in cooking needs a food_quality value. This
-is needed for the add_item recipe step type.
+- Any atom used as an ingredient in cooking needs a 'food_quality' variable.
+
+- Any atom produced by cooking needs a 'food_quality' variable AND a 'cooking_description_modifier' variable.
 
 - Modify slicable food to inherit the food quality of their parent.
 
-- The function call createCookingCatalogs() has to be added at the end of the 
+- The function call createCookingCatalogs() has to be added at the end of the
 /hook/startup/proc/createCatalogs() function.
 
 - Add # exclusion to the sanitizeFileName function.
 
-- The statment ard_drive.store_file(new/datum/computer_file/program/cook_catalog()) should be 
+- The statment ard_drive.store_file(new/datum/computer_file/program/cook_catalog()) should be
 added to any PDA's install_default_programs() proc if they should have it at round start

--- a/code/modules/cooking_with_jane/recipes/_read_me.dm
+++ b/code/modules/cooking_with_jane/recipes/_read_me.dm
@@ -80,9 +80,9 @@ list(<CWJ_STEP_CLASS><_OPTIONAL>, <REQUIRED_ARGS>, <CUSTOM_ARGS>=value)
 			If not defined, there is no maximum quality a step can add.
 			Example: max=10
 
-		result_desc
+		prod_desc
 			Adds a custom description to the result of the recipe step. This will be read off on the item product.
-			Example: result_desc="A Slice of Bread is in the sandwich."
+			Example: prod_desc="A Slice of Bread is in the sandwich."
 
 		exact
 			CWJ_ADD_ITEM or CWJ_USE_ITEM ONLY:

--- a/code/modules/cooking_with_jane/recipes/example_recipes.dm
+++ b/code/modules/cooking_with_jane/recipes/example_recipes.dm
@@ -7,7 +7,7 @@
 	product_type = /obj/item/reagent_containers/food/snacks/sandwich
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cutlet.", result_desc="There is meat between the bread."),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cutlet.", prod_desc="There is meat between the bread."),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5)
 	)
 	appear_in_default_catalog = FALSE
@@ -17,7 +17,7 @@
 	product_type = /obj/item/reagent_containers/food/snacks/sandwich
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cutlet.", result_desc="There is meat between the bread."),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cutlet.", prod_desc="There is meat between the bread."),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5)
 	)
 	appear_in_default_catalog = FALSE
@@ -27,7 +27,7 @@
 	product_type = /obj/item/reagent_containers/food/snacks/sandwich
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cutlet.", result_desc="There is meat between the bread."),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cutlet.", prod_desc="There is meat between the bread."),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5)
 	)
 	appear_in_default_catalog = FALSE
@@ -37,7 +37,7 @@
 	product_type = /obj/item/reagent_containers/food/snacks/sandwich
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cutlet.", result_desc="There is meat between the bread."),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cutlet.", prod_desc="There is meat between the bread."),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5)
 	)
 	appear_in_default_catalog = FALSE
@@ -47,7 +47,7 @@
 	product_type = /obj/item/reagent_containers/food/snacks/sandwich
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cutlet.", result_desc="There is meat between the bread."),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cutlet.", prod_desc="There is meat between the bread."),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5)
 	)
 	appear_in_default_catalog = FALSE
@@ -58,8 +58,8 @@
 	product_type = /obj/item/reagent_containers/food/snacks/sandwich
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, desc="Add any kind of cutlet.", result_desc="There is meat between the bread."),
-		list(CWJ_ADD_PRODUCE, "tomato", result_desc="There is a whole tomato stuffed in the sandwich."),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, desc="Add any kind of cutlet.", prod_desc="There is meat between the bread."),
+		list(CWJ_ADD_PRODUCE, "tomato", prod_desc="There is a whole tomato stuffed in the sandwich."),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice)
 	)
 	appear_in_default_catalog = FALSE
@@ -70,8 +70,8 @@
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
 		CWJ_BEGIN_EXCLUSIVE_OPTIONS,
-		list(CWJ_ADD_ITEM_OPTIONAL, /obj/item/reagent_containers/food/snacks/tofu, desc="Add tofu to it.", result_desc="There is tofu between the bread."),
-		list(CWJ_USE_ITEM_OPTIONAL, /obj/item/reagent_containers/food/snacks/tofu, desc="Brush Tofu on it.", result_desc="It has been in contact with tofu."),
+		list(CWJ_ADD_ITEM_OPTIONAL, /obj/item/reagent_containers/food/snacks/tofu, desc="Add tofu to it.", prod_desc="There is tofu between the bread."),
+		list(CWJ_USE_ITEM_OPTIONAL, /obj/item/reagent_containers/food/snacks/tofu, desc="Brush Tofu on it.", prod_desc="It has been in contact with tofu."),
 		CWJ_END_EXCLUSIVE_OPTIONS,
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice)
 	)
@@ -82,8 +82,8 @@
 	product_type = /obj/item/reagent_containers/food/snacks/sandwich
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, desc="Add any kind of cutlet.", result_desc="There is meat between the bread."),
-		list(CWJ_ADD_ITEM_OPTIONAL, /obj/item/reagent_containers/food/snacks/cutlet, desc="Add even more of any kind of cutlet.", result_desc="There is additional meat between the bread."),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, desc="Add any kind of cutlet.", prod_desc="There is meat between the bread."),
+		list(CWJ_ADD_ITEM_OPTIONAL, /obj/item/reagent_containers/food/snacks/cutlet, desc="Add even more of any kind of cutlet.", prod_desc="There is additional meat between the bread."),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice)
 	)
 	appear_in_default_catalog = FALSE
@@ -93,7 +93,7 @@
 	product_type = /obj/item/reagent_containers/food/snacks/sandwich
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, desc="Add any kind of cutlet.", result_desc="There is meat between the bread."),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, desc="Add any kind of cutlet.", prod_desc="There is meat between the bread."),
 		list(CWJ_ADD_REAGENT, "sodiumchloride", 5),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice)
 	)
@@ -115,7 +115,7 @@
 	product_type = /obj/item/reagent_containers/food/snacks/sandwich
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/sandwich),
-		list(CWJ_USE_GRILL, J_LO, 30 SECONDS, result_desc="It has been toasted.")
+		list(CWJ_USE_GRILL, J_LO, 30 SECONDS, prod_desc="It has been toasted.")
 	)
 	appear_in_default_catalog = FALSE
 

--- a/code/modules/cooking_with_jane/recipes/recipe.dm
+++ b/code/modules/cooking_with_jane/recipes/recipe.dm
@@ -109,10 +109,10 @@
 		list(CWJ_ADD_PRODUCE_OPTIONAL, "plumphelmet", qmod=0.4, reagent_skip=TRUE),
 		CWJ_END_EXCLUSIVE_OPTIONS,
 		CWJ_BEGIN_EXCLUSIVE_OPTIONS,
-		list(CWJ_ADD_REAGENT_OPTIONAL, "capsaicin", 5, base=6, prod_desc="The prok was Spiced with chili powder."),
-		list(CWJ_ADD_REAGENT_OPTIONAL, "pineapplejuice", 5, remain_percent=0.1, base=5, prod_desc="The prok was rosted in pineapple juice."),
-		list(CWJ_ADD_REAGENT_OPTIONAL, "honey", 5, remain_percent=0.1 ,base=3, prod_desc="The prok was glazed with honey"),
-		list(CWJ_ADD_REAGENT_OPTIONAL, "bbqsauce", 3, remain_percent=0.5 ,base=8, prod_desc="The prok was layered with BBQ sauce"),
+		list(CWJ_ADD_REAGENT_OPTIONAL, "capsaicin", 5, base=6, prod_desc="The pork was Spiced with chili powder."),
+		list(CWJ_ADD_REAGENT_OPTIONAL, "pineapplejuice", 5, remain_percent=0.1, base=5, prod_desc="The pork was rosted in pineapple juice."),
+		list(CWJ_ADD_REAGENT_OPTIONAL, "honey", 5, remain_percent=0.1 ,base=3, prod_desc="The pork was glazed with honey"),
+		list(CWJ_ADD_REAGENT_OPTIONAL, "bbqsauce", 3, remain_percent=0.5 ,base=8, prod_desc="The pork was layered with BBQ sauce"),
 		CWJ_END_EXCLUSIVE_OPTIONS,
 		list(CWJ_USE_STOVE, J_MED, 30 SECONDS)
 	)
@@ -160,7 +160,7 @@
 	product_type = /obj/item/reagent_containers/food/snacks/sandwich
 	step_builder = list(
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5),
-		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cutlet.", result_desc="There is meat between the bread."),
+		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/cutlet, qmod=0.5, desc="Add any kind of cooked cutlet."),
 		list(CWJ_ADD_ITEM, /obj/item/reagent_containers/food/snacks/breadslice, qmod=0.5)
 	)
 

--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -138,6 +138,7 @@
 /obj/item/modular_computer/pda/club_worker/install_default_programs()
 	..()
 	hard_drive.store_file(new /datum/computer_file/program/drink_catalog())
+	hard_drive.store_file(new /datum/computer_file/program/cook_catalog())
 
 
 // PDA box

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -26,6 +26,7 @@
 	center_of_mass = list("x"=16, "y"=16)
 	w_class = ITEM_SIZE_SMALL
 	var/food_quality = 1
+	var/cooking_description_modifier
 	var/sanity_gain = 0.2 //Per bite
 	var/cooked = FALSE
 	var/appraised = 0 //Has this piece of food been appraised? We can only do that once.

--- a/nano/templates/catalog_entry_cooking.tmpl
+++ b/nano/templates/catalog_entry_cooking.tmpl
@@ -6,8 +6,8 @@
 	<br><br>
 	<img src='{{:data.icon}}' style ="display: block; margin: auto; width: 30%;">
 	<div class="item"><h1>{{:data.name}}</h1></div>
+	<div class="item">{{:data.create_in}}</div>
 	<div class="item">{{:data.description}}</div>
-
 	<div class="item">
 		<h4>Specifications:</h4>
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
- Implements cooking food in certain ways having the potential to change how the resulting food is described. (IE: If you add mushrooms to a steak recipe, its description can mention being sauteed with mushrooms.)

- Removes typos and vagueness from some recipes.

- Clarifies what cooking utensil to use when cooking in the VIKA

- Updates the eris port readme

- The cooking catalog now appears on Bar staff's PDA by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
