### PR TITLE
Fixes typo in Tips and Tricks.

### DIFF
--- a/code/modules/tips_and_tricks/jobs.dm
+++ b/code/modules/tips_and_tricks/jobs.dm
@@ -324,7 +324,7 @@
 
 /tipsAndTricks/jobs/skyfall_timer
     jobs_list = list(/datum/job/chaplain, /datum/job/acolyte)
-    tipText = "Scrap Beacon has an thirty minute delay before it can be used again, meaning in a productive shift you can use it 8 times before its end."
+    tipText = "Scrap Beacon has a thirty minute delay before it can be used again."
 
 /tipsAndTricks/jobs/plants_n_meat
     jobs_list = list(/datum/job/chaplain, /datum/job/acolyte)

--- a/code/modules/tips_and_tricks/jobs.dm
+++ b/code/modules/tips_and_tricks/jobs.dm
@@ -324,7 +324,7 @@
 
 /tipsAndTricks/jobs/skyfall_timer
     jobs_list = list(/datum/job/chaplain, /datum/job/acolyte)
-    tipText = "Scrap Beacon has an one hour delay before it can be used again, meaning in a productive shift you can use it 8 times before its end."
+    tipText = "Scrap Beacon has an thirty minute delay before it can be used again, meaning in a productive shift you can use it 8 times before its end."
 
 /tipsAndTricks/jobs/plants_n_meat
     jobs_list = list(/datum/job/chaplain, /datum/job/acolyte)


### PR DESCRIPTION
## About The Pull Request

This PR fixes a singular typo of 
"Scrap Beacon has an one hour delay before it can be used again, meaning in a productive shift you can use it 8 times before its end."
to thirty minutes, as the scrap beacon currently stands at 30 minutes instead of a hour if this changes eventually down the line, then go ahead and add it back to one hour.

	
<hr>
</details>

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: tips and tricks with updated info
/:cl: