### PR TITLE
Fixing scrap rocket damage

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -58,7 +58,7 @@
 	return TRUE
 
 /obj/item/projectile/bullet/rocket/scrap
-	damage_types = list(BRUTE = 30)
+	damage_types = list(BRUTE = 45)
 
 /obj/item/projectile/bullet/rocket/scrap/on_impact(atom/target)
 	explosion(target, 0, 0, 2, 3)


### PR DESCRIPTION
A scrap rocket shouldn’t be doing the same damage as a regular 8.6 bullet, so I propose it does slightly more, it’s a rocket, even if a scrap one.