### PR TITLE
Being on fire is now bad for everyone's health (buff or nerf?)

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1197,6 +1197,7 @@
 		speech_problem_flag = 1
 	return stuttering
 
+/* not being activated now, only gettign in the way of burn damage, in case of doubt look at any handle_fire above this
 /mob/living/carbon/human/handle_fire()
 	if(..())
 		return
@@ -1209,6 +1210,7 @@
 		if(world.time >= next_onfire_hal)
 			next_onfire_hal = world.time + 50
 			adjustHalLoss(fire_stacks*5 + 3) //adjusted to be lower. You need time to put yourself out. And each roll only removes 2.5 stacks.
+*/
 
 /mob/living/carbon/human/rejuvenate()
 	sanity.setLevel(sanity.max_level)

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -363,7 +363,7 @@
 	if(!on_fire)
 		return FALSE
 	adjustFireLoss(2 * bodytemperature / max_bodytemperature) // scaling with how much you are over your body temp
-	bodytemperature += fire_stacks * 10 // 5 degrees per firestack
+	bodytemperature += fire_stacks * 5 // 5 degrees per firestack
 	if(isturf(location))
 		location.hotspot_expose( FIRESTACKS_TEMP_CONV(fire_stacks), 50, 1)
 

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -346,6 +346,7 @@
 	//if(breath)
 	//	loc.assume_air(breath) //by default, exhale
 
+/* this is now handled upwards in living_defense
 /mob/living/carbon/superior_animal/handle_fire(flammable_gas, turf/location)
 	if(never_stimulate_air)
 		if (fire_stacks > 0)
@@ -362,7 +363,7 @@
 	if(!on_fire)
 		return FALSE
 	adjustFireLoss(2 * bodytemperature / max_bodytemperature) // scaling with how much you are over your body temp
-	bodytemperature += fire_stacks * 5 // 5 degrees per firestack
+	bodytemperature += fire_stacks * 10 // 5 degrees per firestack
 	if(isturf(location))
 		location.hotspot_expose( FIRESTACKS_TEMP_CONV(fire_stacks), 50, 1)
 
@@ -370,6 +371,7 @@
 	cut_overlay(image("icon"='icons/mob/OnFire.dmi', "icon_state"="Standing"))
 	if(on_fire)
 		add_overlay(image("icon"='icons/mob/OnFire.dmi', "icon_state"="Standing"))
+*/
 
 //The most common cause of an airflow stun is a sudden breach. Evac conditions generally
 /mob/living/carbon/superior_animal/airflow_stun()

--- a/code/modules/mob/living/carbon/superior_animal/superior_defines.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_defines.dm
@@ -146,7 +146,7 @@
 
 	var/toxin_immune = FALSE
 	var/reagent_immune = FALSE
-	var/never_stimulate_air = FALSE
+	//var/never_stimulate_air = FALSE  moved to \code\modules\mob\living\living_defines.dm
 
 	var/contaminant_immunity = FALSE //if TRUE, mob is immune to harmful contaminants in air (plasma), skin contact, does not relate to breathing
 	var/cold_protection = 0 //0 to 1 value, which corresponds to the percentage of protection, affects only bodytemperature
@@ -160,11 +160,12 @@
 
 	colony_friend = FALSE
 
-
+	/*
 	var/min_air_pressure = 50 //below this, brute damage is dealt
 	var/max_air_pressure = 300 //above this, brute damage is dealt
 	var/min_bodytemperature = 200 //below this, burn damage is dealt
-	var/max_bodytemperature = 360 //above this, burn damage is dealt
+	var/max_bodytemperature = 360 //above this, burn damage is dealt  moved to \code\modules\mob\living\living_defines.dm
+	*/
 
 	var/deathmessage = "dies."
 	var/attacktext = "bitten"

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -67,7 +67,7 @@
 	handle_chemicals_in_body()
 
 	//Check if we're on fire
-	handle_fire()
+	handle_fire(environment.gas["oxygen"], loc)
 
 	update_pulling()
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -72,9 +72,6 @@
 	var/update_slimes = 0
 	var/is_busy = FALSE // Prevents stacking of certain actions, like resting and diving
 	var/silent = 0 		// Can't talk. Value goes down every life proc.
-	var/on_fire = 0 //The "Are we on fire?" var
-	var/fire_stacks
-	var/next_onfire_hal = 0 //burn
 
 	var/failed_last_breath = 0 //This is used to determine if the mob failed a breath. If they did fail a brath, they will attempt to breathe each tick, otherwise just once per 4 ticks.
 	var/possession_candidate // Can be possessed by ghosts if unplayed.
@@ -132,3 +129,13 @@
 	var/delay_for_rapid_range = 0 SECONDS
 	var/delay_for_melee = 0 SECONDS
 	var/delay_for_all = 0 SECONDS
+
+	//vars pertaining to the mob's relation to atmos and if they are on fire
+	var/never_stimulate_air = FALSE
+	var/min_air_pressure = 50 //below this, brute damage is dealt
+	var/max_air_pressure = 300 //above this, brute damage is dealt
+	var/min_bodytemperature = 200 //below this, burn damage is dealt
+	var/max_bodytemperature = 360 //above this, burn damage is dealt
+	var/on_fire = 0 //The "Are we on fire?" var
+	var/fire_stacks
+	var/next_onfire_brn = 0 //burn

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -706,7 +706,7 @@
 		return
 	return ..()
 
-
+/*
 /mob/living/simple_animal/handle_fire()
 	return
 
@@ -714,9 +714,9 @@
 	return
 /mob/living/simple_animal/IgniteMob()
 	return
-/mob/living/simple_animal/ExtinguishMob()
+/mob/living/simple_animal/ExtinguishMob()		no simplmobs made of abestos anymore
 	return
-
+*/
 
 //I wanted to call this proc alert but it already exists.
 //Basically makes the mob pay attention to the world, resets sleep timers, awakens it from a sleeping state sometimes


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>

- being set on fire is as harmful as most mobs as it is for players now (other sources of burning like being in a too hot room, accidentally stepping into a burn chamber and others unaffected, so no setting deep maints on fire to kill the king, you need to set him on fire directly and maybe survive the encounter)
- tested on several mobs from different folders, results are very similar across the board, processing impact was pitiful, apparently 50 roaches on fire are more of a strain to their AI while trying to murder you than anything
-  to tweak the burn damage go to code\modules\mob\living\living_defense.dm line 396 and adjust the math to your will
- pr made with the purpose to make mobs a bit easier to buff/nerf all in one move

</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
refactor: being on fire now gives burn damage instead of haloss, old code to manage the burn commented out
balance: nearly all mobs (silicon's unchanged) now can be set on fire and will take the same damage as you do
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
