### PR TITLE
Adds hexcooking equipment to the Lodge

### DIFF
--- a/maps/_HunterLodge/map/_Hunting_Lodge.dmm
+++ b/maps/_HunterLodge/map/_Hunting_Lodge.dmm
@@ -167,6 +167,11 @@
 /obj/item/tool/fireaxe/woodsman,
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
+"aM" = (
+/obj/structure/table/marble,
+/obj/machinery/cooking_with_jane/grill,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/outside/forest/hunting_lodge_dark)
 "aN" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
@@ -4016,6 +4021,11 @@
 /obj/structure/invislight,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest/hunting_lodge)
+"Qo" = (
+/obj/structure/table/marble,
+/obj/machinery/cooking_with_jane/stove,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/outside/forest/hunting_lodge_dark)
 "Qp" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -4214,6 +4224,10 @@
 /obj/structure/railing,
 /turf/simulated/floor/asteroid/dirt/dark/plough,
 /area/nadezhda/outside/forest/hunting_lodge)
+"To" = (
+/obj/machinery/cooking_with_jane/oven,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/outside/forest/hunting_lodge_dark)
 "Tv" = (
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/dark/brown_platform,
@@ -7852,8 +7866,8 @@ tz
 WQ
 ew
 bq
-bq
-bq
+bn
+bn
 bq
 bq
 sI
@@ -7931,7 +7945,7 @@ WQ
 fB
 bq
 ee
-bn
+aM
 bq
 Xq
 WQ
@@ -8009,7 +8023,7 @@ WQ
 iX
 bq
 UY
-xc
+To
 bq
 bq
 jv
@@ -8086,8 +8100,8 @@ tz
 WQ
 oZ
 bq
-bn
-bX
+xc
+Qo
 bq
 bq
 jv
@@ -8165,7 +8179,7 @@ WQ
 jn
 bq
 jF
-bn
+bX
 bq
 bq
 jv


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Adds the three hexcooking machines and extends the tablespace one tile west
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
add: Added hexcooking equipment to the Lodge
/:cl:

![image](https://user-images.githubusercontent.com/21104734/218833825-dbba0dc3-9924-4db9-acb7-f16fdab3a2ae.png)

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
