### PR TITLE
Object verbs for cooking

### DIFF
--- a/code/modules/cooking_with_jane/cooking_appliances/grill.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/grill.dm
@@ -396,7 +396,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_1() called to toggle burner 1")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_switch(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/toggle_burner_2()
@@ -407,7 +407,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_2() called to toggle burner 2")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_switch(usr, 2)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_1()
@@ -418,7 +418,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_1() called to change temperature on 1")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_temperature(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_2()
@@ -429,7 +429,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_2() called to change temperature on 2")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_temperature(usr, 2)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_1()
@@ -440,7 +440,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_1() called to change timer on 1")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_timer(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_2()
@@ -451,7 +451,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_2() called to change timer on 2")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_timer(usr, 2)
 
 

--- a/code/modules/cooking_with_jane/cooking_appliances/grill.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/grill.dm
@@ -396,7 +396,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_1() called to toggle burner 1")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_switch(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/toggle_burner_2()
@@ -407,7 +408,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_2() called to toggle burner 2")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_switch(usr, 2)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_1()
@@ -418,7 +420,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_1() called to change temperature on 1")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_temperature(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_2()
@@ -429,7 +432,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_2() called to change temperature on 2")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_temperature(usr, 2)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_1()
@@ -440,7 +444,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_1() called to change timer on 1")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_timer(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_2()
@@ -451,7 +456,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_2() called to change timer on 2")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_timer(usr, 2)
 
 

--- a/code/modules/cooking_with_jane/cooking_appliances/grill.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/grill.dm
@@ -396,7 +396,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_1() called to toggle burner 1")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_switch(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/toggle_burner_2()
@@ -407,7 +407,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_2() called to toggle burner 2")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_switch(usr, 2)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_1()
@@ -418,7 +418,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_1() called to change temperature on 1")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_temperature(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_2()
@@ -429,7 +429,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_2() called to change temperature on 2")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_temperature(usr, 2)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_1()
@@ -440,7 +440,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_1() called to change timer on 1")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_timer(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_2()
@@ -451,7 +451,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_2() called to change timer on 2")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_timer(usr, 2)
 
 

--- a/code/modules/cooking_with_jane/cooking_appliances/grill.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/grill.dm
@@ -396,6 +396,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_1() called to toggle burner 1")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_switch(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/toggle_burner_2()
@@ -406,6 +407,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_2() called to toggle burner 2")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_switch(usr, 2)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_1()
@@ -416,6 +418,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_1() called to change temperature on 1")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_temperature(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_2()
@@ -426,6 +429,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_2() called to change temperature on 2")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_temperature(usr, 2)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_1()
@@ -436,6 +440,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_1() called to change timer on 1")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_timer(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_2()
@@ -446,6 +451,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_2() called to change timer on 2")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_timer(usr, 2)
 
 

--- a/code/modules/cooking_with_jane/cooking_appliances/grill.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/grill.dm
@@ -396,7 +396,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_1() called to toggle burner 1")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_switch(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/toggle_burner_2()
@@ -407,7 +407,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_2() called to toggle burner 2")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_switch(usr, 2)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_1()
@@ -418,7 +418,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_1() called to change temperature on 1")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_temperature(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_2()
@@ -429,7 +429,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_2() called to change temperature on 2")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_temperature(usr, 2)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_1()
@@ -440,7 +440,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_1() called to change timer on 1")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_timer(usr, 1)
 
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_2()
@@ -451,7 +451,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_2() called to change timer on 2")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_timer(usr, 2)
 
 

--- a/code/modules/cooking_with_jane/cooking_appliances/grill.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/grill.dm
@@ -42,7 +42,7 @@
 
 	//if(on_fire)
 		//Do bad things if it is on fire.
-	
+
 	for(var/i=1, i<=2, i++)
 		if(switches[i])
 			handle_cooking(null, i, FALSE)
@@ -367,7 +367,7 @@
 				our_item.pixel_x = 7
 				our_item.pixel_y = 0
 		src.add_to_visible(our_item, i)
-	
+
 	if(play_scan)
 		add_overlay(image('icons/obj/cwj_cooking/scan.dmi', icon_state=play_scan, layer=ABOVE_WINDOW_LAYER))
 		spawn(100)
@@ -391,7 +391,7 @@
 /obj/machinery/cooking_with_jane/grill/verb/toggle_burner_1()
 	set src in view(1)
 	set name = "Grill burner 1 - Toggle"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Turn on a burner on the grill"
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_1() called to toggle burner 1")
@@ -401,7 +401,7 @@
 /obj/machinery/cooking_with_jane/grill/verb/toggle_burner_2()
 	set src in view(1)
 	set name = "Grill burner 2 - Toggle"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Turn on a burner on the grill"
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/toggle_burner_2() called to toggle burner 2")
@@ -411,7 +411,7 @@
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_1()
 	set src in view(1)
 	set name = "Grill burner 1 - Set Temp"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a temperature for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_1() called to change temperature on 1")
@@ -421,7 +421,7 @@
 /obj/machinery/cooking_with_jane/grill/verb/change_temperature_2()
 	set src in view(1)
 	set name = "Grill burner 2 - Set Temp"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a temperature for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_temperature_2() called to change temperature on 2")
@@ -431,7 +431,7 @@
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_1()
 	set src in view(1)
 	set name = "Grill burner 1 - Set Timer"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a timer for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_1() called to change timer on 1")
@@ -441,7 +441,7 @@
 /obj/machinery/cooking_with_jane/grill/verb/change_timer_2()
 	set src in view(1)
 	set name = "Grill burner 2 - Set Timer"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a timer for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/grill/verb/change_timer_2() called to change timer on 2")

--- a/code/modules/cooking_with_jane/cooking_appliances/oven.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/oven.dm
@@ -355,6 +355,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_burner_1() called")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_switch(usr)
 
 
@@ -366,6 +367,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_temperature_1() called")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_temperature(usr)
 
 /obj/machinery/cooking_with_jane/oven/verb/change_timer()
@@ -376,6 +378,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_timer() called")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_timer(usr)
 
 /obj/machinery/cooking_with_jane/oven/verb/toggle_door()
@@ -386,4 +389,5 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_door() called")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_open(usr)

--- a/code/modules/cooking_with_jane/cooking_appliances/oven.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/oven.dm
@@ -34,7 +34,7 @@
 
 	//if(on_fire)
 		//Do bad things if it is on fire.
-	
+
 	if(switches)
 		handle_cooking(null, FALSE)
 
@@ -54,7 +54,7 @@
 
 /obj/machinery/cooking_with_jane/oven/RefreshParts()
 	..()
-	
+
 	var/las_rating = 0
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
 		las_rating += M.rating
@@ -109,7 +109,7 @@
 /obj/machinery/cooking_with_jane/oven/attackby(var/obj/item/used_item, var/mob/user, params)
 	if(default_deconstruction(used_item, user))
 		return
-	
+
 	var/center_selected = getInput(params)
 
 	if(opened && center_selected)
@@ -350,7 +350,7 @@
 /obj/machinery/cooking_with_jane/oven/verb/toggle_burner()
 	set src in view(1)
 	set name = "Oven - Toggle"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Turn on the oven"
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_burner_1() called")
@@ -361,7 +361,7 @@
 /obj/machinery/cooking_with_jane/oven/verb/change_temperature()
 	set src in view(1)
 	set name = "Oven - Set Temp"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a temperature for the oven."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_temperature_1() called")
@@ -371,7 +371,7 @@
 /obj/machinery/cooking_with_jane/oven/verb/change_timer()
 	set src in view(1)
 	set name = "Oven - Set Timer"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a timer for the oven."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_timer() called")
@@ -381,7 +381,7 @@
 /obj/machinery/cooking_with_jane/oven/verb/toggle_door()
 	set src in view(1)
 	set name = "Oven - Open/Close door"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Open/Close the door of the oven."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_door() called")

--- a/code/modules/cooking_with_jane/cooking_appliances/oven.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/oven.dm
@@ -355,7 +355,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_burner_1() called")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_switch(usr)
 
 
@@ -367,7 +367,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_temperature_1() called")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_temperature(usr)
 
 /obj/machinery/cooking_with_jane/oven/verb/change_timer()
@@ -378,7 +378,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_timer() called")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_timer(usr)
 
 /obj/machinery/cooking_with_jane/oven/verb/toggle_door()
@@ -389,5 +389,5 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_door() called")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_open(usr)

--- a/code/modules/cooking_with_jane/cooking_appliances/oven.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/oven.dm
@@ -355,7 +355,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_burner_1() called")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_switch(usr)
 
 
@@ -367,7 +368,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_temperature_1() called")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_temperature(usr)
 
 /obj/machinery/cooking_with_jane/oven/verb/change_timer()
@@ -378,7 +380,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_timer() called")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_timer(usr)
 
 /obj/machinery/cooking_with_jane/oven/verb/toggle_door()
@@ -389,5 +392,6 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_door() called")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_open(usr)

--- a/code/modules/cooking_with_jane/cooking_appliances/oven.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/oven.dm
@@ -355,7 +355,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_burner_1() called")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_switch(usr)
 
 
@@ -367,7 +367,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_temperature_1() called")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_temperature(usr)
 
 /obj/machinery/cooking_with_jane/oven/verb/change_timer()
@@ -378,7 +378,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_timer() called")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_timer(usr)
 
 /obj/machinery/cooking_with_jane/oven/verb/toggle_door()
@@ -389,5 +389,5 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_door() called")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_open(usr)

--- a/code/modules/cooking_with_jane/cooking_appliances/oven.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/oven.dm
@@ -355,7 +355,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_burner_1() called")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_switch(usr)
 
 
@@ -367,7 +367,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_temperature_1() called")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_temperature(usr)
 
 /obj/machinery/cooking_with_jane/oven/verb/change_timer()
@@ -378,7 +378,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/change_timer() called")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_timer(usr)
 
 /obj/machinery/cooking_with_jane/oven/verb/toggle_door()
@@ -389,5 +389,5 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/oven/verb/toggle_door() called")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_open(usr)

--- a/code/modules/cooking_with_jane/cooking_appliances/stove.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/stove.dm
@@ -358,7 +358,7 @@
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_1()
 	set src in view(1)
 	set name = "Stove burner 1 - Toggle"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Turn on a burner on the stove"
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_1() called to toggle burner 1")
@@ -368,7 +368,7 @@
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_2()
 	set src in view(1)
 	set name = "Stove burner 2 - Toggle"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Turn on a burner on the stove"
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_2() called to toggle burner 2")
@@ -378,7 +378,7 @@
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_3()
 	set src in view(1)
 	set name = "Stove burner 3 - Toggle"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Turn on a burner on the stove"
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_3() called to toggle burner 3")
@@ -388,7 +388,7 @@
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_4()
 	set src in view(1)
 	set name = "Stove burner 4 - Toggle"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Turn on a burner on the stove"
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_4() called to toggle burner 4")
@@ -398,7 +398,7 @@
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_1()
 	set src in view(1)
 	set name = "Stove burner 1 - Set Temp"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a temperature for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_1() called to change temperature on 1")
@@ -408,7 +408,7 @@
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_2()
 	set src in view(1)
 	set name = "Stove burner 2 - Set Temp"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a temperature for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_2() called to change temperature on 2")
@@ -418,7 +418,7 @@
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_3()
 	set src in view(1)
 	set name = "Stove burner 3 - Set Temp"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a temperature for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_3() called to change temperature on 3")
@@ -428,7 +428,7 @@
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_4()
 	set src in view(1)
 	set name = "Stove burner 4 - Set Temp"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a temperature for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_4() called to change temperature on 4")
@@ -438,7 +438,7 @@
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_1()
 	set src in view(1)
 	set name = "Stove burner 1 - Set Timer"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a timer for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_1() called to change timer on 1")
@@ -448,7 +448,7 @@
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_2()
 	set src in view(1)
 	set name = "Stove burner 2 - Set Timer"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a timer for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_2() called to change timer on 2")
@@ -458,17 +458,17 @@
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_3()
 	set src in view(1)
 	set name = "Stove burner 3 - Set Timer"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a timer for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_3() called to change timer on 3")
 	#endif
 	handle_timer(usr, 3)
-	
+
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_4()
 	set src in view(1)
 	set name = "Stove burner 4 - Set Timer"
-	set category = "Cooking"
+	set category = "Object"
 	set desc = "Set a timer for a burner."
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_4() called to change timer on 4")

--- a/code/modules/cooking_with_jane/cooking_appliances/stove.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/stove.dm
@@ -363,6 +363,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_1() called to toggle burner 1")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_switch(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_2()
@@ -373,6 +374,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_2() called to toggle burner 2")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_switch(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_3()
@@ -383,6 +385,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_3() called to toggle burner 3")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_switch(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_4()
@@ -393,6 +396,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_4() called to toggle burner 4")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_switch(usr, 4)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_1()
@@ -403,6 +407,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_1() called to change temperature on 1")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_temperature(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_2()
@@ -413,6 +418,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_2() called to change temperature on 2")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_temperature(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_3()
@@ -423,6 +429,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_3() called to change temperature on 3")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_temperature(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_4()
@@ -433,6 +440,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_4() called to change temperature on 4")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_temperature(usr, 4)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_1()
@@ -443,6 +451,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_1() called to change timer on 1")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_timer(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_2()
@@ -453,6 +462,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_2() called to change timer on 2")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_timer(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_3()
@@ -463,6 +473,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_3() called to change timer on 3")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_timer(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_4()
@@ -473,6 +484,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_4() called to change timer on 4")
 	#endif
+	(ishuman(usr) || isrobot(usr)(usr)) ? :return
 	handle_timer(usr, 4)
 #undef ICON_SPLIT_X
 #undef ICON_SPLIT_Y

--- a/code/modules/cooking_with_jane/cooking_appliances/stove.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/stove.dm
@@ -363,7 +363,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_1() called to toggle burner 1")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_switch(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_2()
@@ -374,7 +375,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_2() called to toggle burner 2")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_switch(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_3()
@@ -385,7 +387,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_3() called to toggle burner 3")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_switch(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_4()
@@ -396,7 +399,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_4() called to toggle burner 4")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_switch(usr, 4)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_1()
@@ -407,7 +411,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_1() called to change temperature on 1")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_temperature(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_2()
@@ -418,7 +423,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_2() called to change temperature on 2")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_temperature(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_3()
@@ -429,7 +435,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_3() called to change temperature on 3")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_temperature(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_4()
@@ -440,7 +447,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_4() called to change temperature on 4")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_temperature(usr, 4)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_1()
@@ -451,7 +459,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_1() called to change timer on 1")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_timer(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_2()
@@ -462,7 +471,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_2() called to change timer on 2")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_timer(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_3()
@@ -473,7 +483,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_3() called to change timer on 3")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_timer(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_4()
@@ -484,7 +495,8 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_4() called to change timer on 4")
 	#endif
-	(ishuman(usr) || isrobot(usr))? :return
+	if(!ishuman(usr) && !isrobot(usr))
+		return
 	handle_timer(usr, 4)
 #undef ICON_SPLIT_X
 #undef ICON_SPLIT_Y

--- a/code/modules/cooking_with_jane/cooking_appliances/stove.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/stove.dm
@@ -363,7 +363,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_1() called to toggle burner 1")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_switch(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_2()
@@ -374,7 +374,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_2() called to toggle burner 2")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_switch(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_3()
@@ -385,7 +385,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_3() called to toggle burner 3")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_switch(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_4()
@@ -396,7 +396,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_4() called to toggle burner 4")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_switch(usr, 4)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_1()
@@ -407,7 +407,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_1() called to change temperature on 1")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_temperature(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_2()
@@ -418,7 +418,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_2() called to change temperature on 2")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_temperature(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_3()
@@ -429,7 +429,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_3() called to change temperature on 3")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_temperature(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_4()
@@ -440,7 +440,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_4() called to change temperature on 4")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_temperature(usr, 4)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_1()
@@ -451,7 +451,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_1() called to change timer on 1")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_timer(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_2()
@@ -462,7 +462,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_2() called to change timer on 2")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_timer(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_3()
@@ -473,7 +473,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_3() called to change timer on 3")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_timer(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_4()
@@ -484,7 +484,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_4() called to change timer on 4")
 	#endif
-	ishuman(usr) || isrobot(usr)(usr) ? :return
+	ishuman(usr) || isrobot(usr)? :return
 	handle_timer(usr, 4)
 #undef ICON_SPLIT_X
 #undef ICON_SPLIT_Y

--- a/code/modules/cooking_with_jane/cooking_appliances/stove.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/stove.dm
@@ -363,7 +363,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_1() called to toggle burner 1")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_switch(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_2()
@@ -374,7 +374,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_2() called to toggle burner 2")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_switch(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_3()
@@ -385,7 +385,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_3() called to toggle burner 3")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_switch(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_4()
@@ -396,7 +396,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_4() called to toggle burner 4")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_switch(usr, 4)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_1()
@@ -407,7 +407,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_1() called to change temperature on 1")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_temperature(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_2()
@@ -418,7 +418,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_2() called to change temperature on 2")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_temperature(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_3()
@@ -429,7 +429,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_3() called to change temperature on 3")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_temperature(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_4()
@@ -440,7 +440,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_4() called to change temperature on 4")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_temperature(usr, 4)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_1()
@@ -451,7 +451,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_1() called to change timer on 1")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_timer(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_2()
@@ -462,7 +462,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_2() called to change timer on 2")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_timer(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_3()
@@ -473,7 +473,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_3() called to change timer on 3")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_timer(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_4()
@@ -484,7 +484,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_4() called to change timer on 4")
 	#endif
-	ishuman(usr) || isrobot(usr)? :return
+	(ishuman(usr) || isrobot(usr))? :return
 	handle_timer(usr, 4)
 #undef ICON_SPLIT_X
 #undef ICON_SPLIT_Y

--- a/code/modules/cooking_with_jane/cooking_appliances/stove.dm
+++ b/code/modules/cooking_with_jane/cooking_appliances/stove.dm
@@ -363,7 +363,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_1() called to toggle burner 1")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_switch(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_2()
@@ -374,7 +374,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_2() called to toggle burner 2")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_switch(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_3()
@@ -385,7 +385,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_3() called to toggle burner 3")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_switch(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/toggle_burner_4()
@@ -396,7 +396,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/toggle_burner_4() called to toggle burner 4")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_switch(usr, 4)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_1()
@@ -407,7 +407,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_1() called to change temperature on 1")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_temperature(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_2()
@@ -418,7 +418,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_2() called to change temperature on 2")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_temperature(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_3()
@@ -429,7 +429,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_3() called to change temperature on 3")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_temperature(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_temperature_4()
@@ -440,7 +440,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_temperature_4() called to change temperature on 4")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_temperature(usr, 4)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_1()
@@ -451,7 +451,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_1() called to change timer on 1")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_timer(usr, 1)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_2()
@@ -462,7 +462,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_2() called to change timer on 2")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_timer(usr, 2)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_3()
@@ -473,7 +473,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_3() called to change timer on 3")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_timer(usr, 3)
 
 /obj/machinery/cooking_with_jane/stove/verb/change_timer_4()
@@ -484,7 +484,7 @@
 	#ifdef CWJ_DEBUG
 	log_debug("/cooking_with_jane/stove/verb/change_timer_4() called to change timer on 4")
 	#endif
-	(ishuman(usr) || isrobot(usr)(usr)) ? :return
+	ishuman(usr) || isrobot(usr)(usr) ? :return
 	handle_timer(usr, 4)
 #undef ICON_SPLIT_X
 #undef ICON_SPLIT_Y


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
Relegates all object verbs for the cooking machines to the object tab. (The 'cooking' tab caused lag with its creation and deletion)
Prevents the dead from rising bread
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
