### PR TITLE
Lonestar Miner QoL Change

### DIFF
--- a/code/controllers/subsystems/trade.dm
+++ b/code/controllers/subsystems/trade.dm
@@ -343,8 +343,8 @@ SUBSYSTEM_DEF(trade)
 			invoice_contents_info += "<li>[AM.name]</li>"
 			qdel(AM)
 
-		var/credits_to_account = round(offer_price * 0.8)
-		var/credits_to_lonestar = round(offer_price * 0.2)
+		var/credits_to_account = round(offer_price * 0.2)
+		var/credits_to_lonestar = round(offer_price * 0.8)
 
 		create_log_entry("Special Offer", account.get_name(), invoice_contents_info, offer_price, TRUE, get_turf(beacon))
 
@@ -409,8 +409,8 @@ SUBSYSTEM_DEF(trade)
 					invoice_contents_info += "<li>[AM.name]</li>"
 					qdel(AM)
 
-				var/credits_to_account = round(offer_price * 0.8)
-				var/credits_to_lonestar = round(offer_price * 0.2)
+				var/credits_to_account = round(offer_price * 0.2)
+				var/credits_to_lonestar = round(offer_price * 0.8)
 
 				create_log_entry("Special Offer", account.get_name(), invoice_contents_info, offer_price, FALSE, get_turf(beacon))
 
@@ -541,8 +541,8 @@ SUBSYSTEM_DEF(trade)
 
 		var/datum/money_account/A = account
 		var/datum/money_account/lonestar_account = department_accounts[DEPARTMENT_LSS]
-		var/datum/transaction/TA = new(cost * 0.8, account.get_name(), "Sold item", station.name)
-		var/datum/transaction/T = new(cost * 0.2, lonestar_account.get_name(), "Sold item", TRADE_SYSTEM_IC_NAME)
+		var/datum/transaction/TA = new(cost * 0.2, account.get_name(), "Sold item", station.name)
+		var/datum/transaction/T = new(cost * 0.8, lonestar_account.get_name(), "Sold item", TRADE_SYSTEM_IC_NAME)
 		T.apply_to(lonestar_account)
 		TA.apply_to(A)
 		station.add_to_wealth(cost)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<summary>
	Selling/Exporting/Offers not on the LS Corp Account now takes 80% instead of 20%.

<hr>
	
Reason Why: 
Since realistically the only people who would be using the Lonestar beacons without being signed into the LS Corp Account would only be miners selling their produce. This PR is a Quality of Life change to make it so when accounts aside from LS Corp account sell or do offers from the beacon, 80% goes into the LS Corp Account instead of only 20%. This is due to Miners expressing their confusion and annoyance when having 20% taken from their overall amount and then having to calculate the rest of the money to give to LS. So to assist Miners and the players, that is why its being set to 80%.
</summary>
<hr>


	
