### PR TITLE
Adds Outsider Slots

### DIFF
--- a/code/game/jobs/job/offcolony.dm
+++ b/code/game/jobs/job/offcolony.dm
@@ -124,8 +124,8 @@
 
 /datum/job/outsider
 	title = "Outsider"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 10
+	spawn_positions = 10
 	flag = OUTSIDER
 	faction = MAP_FACTION
 	department = DEPARTMENT_INDEPENDENT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds 7 more Outsider slots. Reason being that Outsiders commonly die early on and clog up the ability for more to join. The comment of 'well staff can open more slots' is moot considering the lack of response from staff when slots are requested to be opened. **Preferably** at some point this can be code-changed to open a slot every 30 minutes instead of all at once. But oh-well.

Especially stupid since they start in dungeons, many of which have mobs with over-screens length range, where they are meant to effectively die.

## Changelog
:cl:
add: More outside slots. (Total of 10)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
