### PR TITLE
Deepmaintsbuff

### DIFF
--- a/code/game/objects/structures/salvageable.dm
+++ b/code/game/objects/structures/salvageable.dm
@@ -580,3 +580,83 @@ obj/structure/salvageable/bliss/Initialize()
 		/obj/item/trash/material/circuit = 60,
 		/obj/item/circuitboard/os_generator = 30
 	)
+
+
+// Deepmaints cryo pod
+
+
+/obj/structure/salvageable/deepmaints_cryopod
+	name = "locked cryopod"
+	desc = "A old cryo pod thats sealed shut. What wounders could be inside..."
+	icon = 'icons/obj/cryogenics.dmi' // map only
+	icon_state = "pod_preview"
+	salvageable_parts = list(
+		/obj/item/stock_parts/console_screen = 80,
+		/obj/item/stock_parts/micro_laser = 50,
+		/obj/item/stock_parts/micro_laser = 20,
+		/obj/item/scrap_lump = 40,
+		/obj/item/scrap_lump = 40,
+		/obj/item/stock_parts/capacitor = 50,
+		/obj/item/trash/material/circuit = 60,
+		/obj/item/reagent_containers/glass/beaker = 40,
+		/obj/item/storage/freezer/medical/contains_teratomas = 10
+	)
+	var/mob/occupant = null
+	var/on = FALSE
+
+/obj/structure/salvageable/deepmaints_cryopod/dismantle()
+	new /obj/machinery/constructable_frame/machine_frame/vertical (src.loc)
+	for(var/path in salvageable_parts)
+		if(prob(salvageable_parts[path]))
+			new path (loc)
+	return
+
+/obj/structure/salvageable/deepmaints_cryopod/Initialize()
+	. = ..()
+	if(prob(80))
+		occupant = pick(subtypesof(/mob/living/simple_animal/hostile/hivemind))
+
+	if(prob(40))
+		on = TRUE
+
+	salvageable_parts = list(
+		/obj/item/stock_parts/console_screen = 80,
+		/obj/item/stock_parts/micro_laser = 50,
+		/obj/item/stock_parts/micro_laser = 20,
+		/obj/item/scrap_lump = 40,
+		/obj/item/scrap_lump = 40,
+		/obj/item/stock_parts/capacitor = 50,
+		/obj/item/trash/material/circuit = 60,
+		/obj/item/reagent_containers/glass/beaker = 40,
+		/obj/item/storage/freezer/medical/contains_teratomas = 50,
+		occupant = 100
+	)
+
+	icon = 'icons/obj/cryogenics_split.dmi'
+	update_icon()
+
+/obj/structure/salvageable/deepmaints_cryopod/update_icon()
+	cut_overlays()
+	icon_state = "pod[on]"
+	var/image/I
+
+	I = image(icon, "pod[on]_top")
+	I.layer = WALL_OBJ_LAYER
+	I.pixel_z = 32
+	add_overlay(I)
+
+	if(occupant)
+		var/image/pickle = image(occupant.icon, occupant.icon_state)
+		pickle.copy_overlays(occupant.overlays, TRUE)
+		pickle.pixel_z = 18
+		pickle.layer = WALL_OBJ_LAYER
+		add_overlay(pickle)
+
+	I = image(icon, "lid[on]")
+	I.layer = WALL_OBJ_LAYER
+	add_overlay(I)
+
+	I = image(icon, "lid[on]_top")
+	I.layer = WALL_OBJ_LAYER
+	I.pixel_z = 32
+	add_overlay(I)

--- a/code/game/objects/structures/salvageable.dm
+++ b/code/game/objects/structures/salvageable.dm
@@ -609,6 +609,8 @@ obj/structure/salvageable/bliss/Initialize()
 	for(var/path in salvageable_parts)
 		if(prob(salvageable_parts[path]))
 			new path (loc)
+	if(occupant)
+		new occupant(src.loc)
 	return
 
 /obj/structure/salvageable/deepmaints_cryopod/Initialize()
@@ -628,8 +630,7 @@ obj/structure/salvageable/bliss/Initialize()
 		/obj/item/stock_parts/capacitor = 50,
 		/obj/item/trash/material/circuit = 60,
 		/obj/item/reagent_containers/glass/beaker = 40,
-		/obj/item/storage/freezer/medical/contains_teratomas = 50,
-		occupant = 100
+		/obj/item/storage/freezer/medical/contains_teratomas = 50
 	)
 
 	icon = 'icons/obj/cryogenics_split.dmi'
@@ -644,13 +645,6 @@ obj/structure/salvageable/bliss/Initialize()
 	I.layer = WALL_OBJ_LAYER
 	I.pixel_z = 32
 	add_overlay(I)
-
-	if(occupant)
-		var/image/pickle = image(occupant.icon, occupant.icon_state)
-		pickle.copy_overlays(occupant.overlays, TRUE)
-		pickle.pixel_z = 18
-		pickle.layer = WALL_OBJ_LAYER
-		add_overlay(pickle)
 
 	I = image(icon, "lid[on]")
 	I.layer = WALL_OBJ_LAYER

--- a/code/modules/dungeons/procedural/deepmaint.dm
+++ b/code/modules/dungeons/procedural/deepmaint.dm
@@ -179,7 +179,7 @@ var/global/list/big_deepmaint_room_templates = list()
 /obj/procedural/jp_DungeonGenerator/deepmaint/proc/populateCorridors()
 	var/niche_count = 20
 	var/try_count = niche_count * 7 //In case it somehow zig-zags all of the corridors and stucks in a loop
-	var/trap_count = 150
+	var/trap_count = 200
 	var/list/path_turfs_copy = path_turfs.Copy()
 	while(niche_count > 0 && try_count > 0)
 		try_count = try_count - 1
@@ -191,7 +191,7 @@ var/global/list/big_deepmaint_room_templates = list()
 		trap_count = trap_count - 1
 		var/turf/N = pick(path_turfs_copy)
 		path_turfs_copy -= N
-		if(prob(90))
+		if(prob(60))
 			new /obj/random/traps(N)
 		else
 			new /obj/random/mob/psi_monster(N)

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
@@ -85,7 +85,9 @@
 					Victim.adjustToxLoss(rand(2,4))
 				if(prob(steal_odds))
 					Victim.stats.changeStat(stat_to_steal, steal_amount)
-
+					var/health_addition_mod = steal_amount * -1 //So we became non-negtive
+					maxHealth += (30 * health_addition_mod)
+					health += (30 * health_addition_mod)
 
 
 			else

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
@@ -3,9 +3,18 @@
 
 	if(isliving(A))
 		var/mob/living/L = A
-		if(istype(L) && L.reagents)
-			L.reagents.add_reagent(poison_type, poison_per_bite)
-	alpha = 255
+
+		if(poison_per_bite > 0)
+			if(istype(L) && L.reagents)
+				var/zone_armor =  L.getarmor(targeted_organ, ARMOR_MELEE)
+				var/poison_injected = zone_armor ? poison_per_bite * (-0.01 * zone_armor + 1) : poison_per_bite
+				L.reagents.add_reagent(poison_type, poison_injected)
+
+		alpha = 255
+
+		if(!is_leaching && can_leach && ishuman(L))
+			if(prob(leach_on_odds))
+				Wrap(A)
 
 
 /mob/living/carbon/superior_animal/psi_monster/pus_maggot/UnarmedAttack(var/atom/A, var/proximity)
@@ -19,6 +28,7 @@
 			playsound(src, burn_attack_sound, 50, 1, -3)
 			L.visible_message(SPAN_DANGER(burn_attack_text))
 
+
 /mob/living/carbon/superior_animal/psi_monster/dreaming_king/UnarmedAttack(var/atom/A, var/proximity)
 	. = ..()
 
@@ -26,3 +36,92 @@
 		var/mob/living/L = A
 		if(istype(L))
 			shake_camera(L, 3, 1)
+
+
+/mob/living/carbon/superior_animal/psi_monster/proc/Wrap(var/mob/living/M) // This is a proc for the clicks
+	if (Victim == M || src == M)
+		Feedstop()
+		return
+
+	if (Victim)
+		to_chat(src, "I am already draining...")
+		return
+
+	var t = invalidFeedTarget(M)
+	if (t)
+		to_chat(src, t)
+		return
+
+	Feedon(M)
+
+/mob/living/carbon/superior_animal/psi_monster/proc/invalidFeedTarget(mob/living/carbon/human/M)
+	if (!M || !ishuman(M))
+		return "This subject is incomparable..."
+	if (!Adjacent(M))
+		return "This subject is too far away..."
+	if (iscarbon(M) && M.getFireLoss() >= M.maxHealth * 1.5 || isanimal(M) && M.stat == DEAD)
+		return "This subject does not have an edible life energy..."
+	return 0
+
+/mob/living/carbon/superior_animal/psi_monster/proc/Feedon(mob/living/carbon/human/M)
+	Victim = M
+	loc = M.loc
+	canmove = 0
+	anchored = 1
+	is_leaching = TRUE
+
+	regenerate_icons()
+
+	while(Victim && !invalidFeedTarget(M) && stat != 2)
+		canmove = 0
+
+		if(Adjacent(M))
+			UpdateFeed(M)
+
+			if(ishuman(M))
+				Victim.adjustFireLoss(rand(5,6))
+				Victim.adjustCloneLoss(rand(1,2))
+				if(Victim.health <= 0)
+					Victim.adjustToxLoss(rand(2,4))
+				if(prob(steal_odds))
+					Victim.stats.changeStat(stat_to_steal, steal_amount)
+
+
+
+			else
+				to_chat(src, "<span class='warning'>[pick("This subject is incompatable", "This subject does not have a life energy", "This subject is empty", "I am not satisified", "I can not feed from this subject", "I do not feel nourished", "This subject is not food")]...</span>")
+				Feedstop()
+				break
+
+			if(prob(15) && M.client)
+				var/painMes = pick("You can feel your body becoming weak!", "You feel like you're about to die!", "You feel every part of your body screaming in agony!", "A low, rolling pain passes through your body!", "Your body feels as if it's falling apart!", "You feel extremely weak!", "A sharp, deep pain bathes every inch of your body!")
+				H.custom_pain(painMes)
+
+			adjustBruteLoss(-16)
+			adjustFireLoss(-16)
+			adjustToxLoss(-16)
+			updatehealth()
+			if(Victim)
+				Victim.updatehealth()
+
+			sleep(30) // Deal damage every 3 seconds
+		else
+			break
+
+	canmove = 1
+	anchored = 0
+
+	Victim = null
+	is_leaching = FALSE
+
+/mob/living/carbon/superior_animal/psi_monster/proc/Feedstop()
+	if(Victim)
+		if(Victim.client) Victim << "[src] has let go of you!"
+		Victim = null
+
+	is_leaching = FALSE
+
+/mob/living/carbon/superior_animal/psi_monster/proc/UpdateFeed(var/mob/M)
+	if(Victim)
+		if(Victim == M)
+			loc = M.loc // simple "attach to head" effect!

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
@@ -95,7 +95,7 @@
 
 			if(prob(15) && M.client)
 				var/painMes = pick("You can feel your body becoming weak!", "You feel like you're about to die!", "You feel every part of your body screaming in agony!", "A low, rolling pain passes through your body!", "Your body feels as if it's falling apart!", "You feel extremely weak!", "A sharp, deep pain bathes every inch of your body!")
-				H.custom_pain(painMes)
+				M.custom_pain(painMes)
 
 			adjustBruteLoss(-16)
 			adjustFireLoss(-16)

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
@@ -93,6 +93,14 @@
 	var/respawn_mob_type = /obj/random/mob/psi_monster
 	var/affects_chaos = FALSE
 
+	var/leach_on_odds = 0
+	var/can_leach = FALSE
+	var/is_leaching = FALSE
+	var/steal_odds = 0
+	var/stat_to_steal = STAT_VIV
+	var/steal_amount = 1
+	var/mob/living/Victim = null
+
 
 /mob/living/carbon/superior_animal/psi_monster/New()
 	..()

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/Ploge.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/Ploge.dm
@@ -29,6 +29,7 @@
 	can_burrow = FALSE
 	melee_damage_lower = 15
 	melee_damage_upper = 25
+	armor_penetration = 50
 	ranged = TRUE
 
 	pixel_x = 0
@@ -59,6 +60,7 @@
 		knockdown_odds = 50
 		melee_damage_lower = 30
 		melee_damage_upper = 35
+		armor_penetration = 60
 		transform_ed = TRUE
 		projectiletype = /obj/item/projectile/tether/lash
 		for(var/mob/living/target in targets_in_range(in_hear_range = TRUE))

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiImpressive.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiImpressive.dm
@@ -36,6 +36,11 @@
 	attacktext = "rammed"
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
 	armor_penetration = 20
+	leach_on_odds = 30
+	can_leach = TRUE
+	steal_odds = 15
+	stat_to_steal = STAT_VIG
+	steal_amount = -4
 
 /mob/living/carbon/superior_animal/psi_monster/pus_maggot/ash_wendigo
 	name = "ash wendigo"

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiImpressive.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiImpressive.dm
@@ -18,6 +18,7 @@
 	death_spawn_gift = /obj/random/cluster/psi_monster/maggot_death_gasp
 	death_gasp = "<b><font size='3px'>The flesh behemoth heaves as its body crumbles, wriggling pus maggots bursting from its failing rotted bulk!</font></b>!"
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
+	armor_penetration = 15
 
 /mob/living/carbon/superior_animal/psi_monster/mind_gazer
 	name = "mind gazer"
@@ -34,6 +35,7 @@
 	healing_factor = 10
 	attacktext = "rammed"
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
+	armor_penetration = 20
 
 /mob/living/carbon/superior_animal/psi_monster/pus_maggot/ash_wendigo
 	name = "ash wendigo"
@@ -54,6 +56,7 @@
 	light_color = COLOR_LIGHTING_RED_BRIGHT
 	attacktext = "clawed"
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
+	armor_penetration = 50
 
 /mob/living/carbon/superior_animal/psi_monster/cerebral_crusher
 	name = "cerebral crusher"
@@ -72,6 +75,7 @@
 	healing_factor = 10
 	attacktext = "slammed"
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
+	armor_penetration = 30
 
 /mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly
 	name = "crimson jelly"
@@ -95,6 +99,7 @@
 	knockdown_odds = 15
 	armor = list(melee = 20, bullet = 10, energy = 5, bomb = 30, bio = 100, rad = 100)
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/weapons/always_spawn)
+	armor_penetration = 50
 
 /mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly/pitch_horror
 	name = "pitch horror"
@@ -107,6 +112,7 @@
 	health = 1250
 	knockdown_odds = 30
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/weapons/always_spawn, /obj/random/psi/always_spawn, /obj/random/psi/weapons/always_spawn)
+	armor_penetration = 70
 
 // King's Court. Special named psi mobs with better stats and custom voice lines, they are spawned whenever the king of the hound journey.
 /mob/living/carbon/superior_animal/psi_monster/flesh_behemoth/baron

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiMega.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiMega.dm
@@ -20,6 +20,7 @@
 	default_pixel_x = -16
 	default_pixel_y = 0
 	size_pixel_offset_x = -16
+	armor_penetration = 65
 	momento_mori = /obj/effect/decal/cleanable/psi_ash/king
 	first_teleport_callout = "<b><font size='3px'>\the Dreaming King looses a terrible scream before journeying to nowhere, his words bellowing in rage, \"Only the king may wear the crown!\" The answering calls of his court echoing through the realm!</font></b>"
 	second_teleport_callout = "<b><font size='3px'>\the Dreaming King looses an agonized howl before journeying to nowhere, his words bellowing in rage, \"I will never die!\" The strongest of his court heard affirming his call!</font></b>"

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
@@ -29,6 +29,11 @@
 	armor_penetration = 25
 	emote_see = list("begins to melt, blackened skin sloughing down its form until it pulls taut.", "howls, \"Birth, flesh, death, decay, birth, flesh, death, decay!\"", "howls in agony!")
 	turns_per_move = 10
+	leach_on_odds = 10
+	can_leach = TRUE
+	steal_odds = 50
+	stat_to_steal = STAT_COG
+	steal_amount = -3
 
 /mob/living/carbon/superior_animal/psi_monster/licker
 	name = "licker"
@@ -66,7 +71,7 @@
 	can_leach = TRUE
 	steal_odds = 5
 	stat_to_steal = STAT_VIV
-	steal_amount = 1
+	steal_amount = -1
 
 /mob/living/carbon/superior_animal/psi_monster/flesh_tower
 	name = "flesh tower"

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
@@ -13,6 +13,7 @@
 	poison_per_bite = 2
 	turns_per_move = 4 // Slow
 	attacktext = "punched"
+	armor_penetration = 30
 
 /mob/living/carbon/superior_animal/psi_monster/hovering_nightmare
 	name = "hovering nightmare"
@@ -25,6 +26,7 @@
 	health = 100
 	melee_damage_lower = 20
 	melee_damage_upper = 25
+	armor_penetration = 25
 	emote_see = list("begins to melt, blackened skin sloughing down its form until it pulls taut.", "howls, \"Birth, flesh, death, decay, birth, flesh, death, decay!\"", "howls in agony!")
 	turns_per_move = 10
 
@@ -41,9 +43,10 @@
 	melee_damage_upper = 18
 	emote_see = list("extends its tongue to the floor.", "chitters, whipping its tail wildly about!", "hisses with barely contained rage.")
 	turns_per_move = 8
-	poison_per_bite = 1
+	poison_per_bite = 3
 	poison_type = "xenotoxin"
 	attacktext = "tongued"
+	armor_penetration = 45
 
 /mob/living/carbon/superior_animal/psi_monster/memory
 	name = "memory"
@@ -58,6 +61,12 @@
 	emote_see = list("screams, \"They did this they did this!\"", "howls, \"They could have done something!\"", "whispers, \"I could have done something...\"", "groans, \"Kill me, please...\"", "weeps, \"It will never end.\"")
 	speak_chance = 15
 	attacktext = "stroked"
+	armor_penetration = 15
+	leach_on_odds = 70
+	can_leach = TRUE
+	steal_odds = 50
+	stat_to_steal = STAT_VIV
+	steal_amount = 1
 
 /mob/living/carbon/superior_animal/psi_monster/flesh_tower
 	name = "flesh tower"

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
@@ -64,7 +64,7 @@
 	armor_penetration = 15
 	leach_on_odds = 70
 	can_leach = TRUE
-	steal_odds = 50
+	steal_odds = 5
 	stat_to_steal = STAT_VIV
 	steal_amount = 1
 

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiTrash.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiTrash.dm
@@ -17,6 +17,7 @@
 	chameleon_skill = 1
 	speak_chance = 2
 	attacktext = "clawed"
+	armor_penetration = 20
 
 /mob/living/carbon/superior_animal/psi_monster/thought_melter
 	name = "thought melter"
@@ -32,6 +33,7 @@
 	speak_chance = 10
 	poison_per_bite = 1
 	attacktext = "caressed"
+	armor_penetration = 30
 
 /mob/living/carbon/superior_animal/psi_monster/pus_maggot
 	name = "pus maggot"
@@ -43,6 +45,7 @@
 	health = 110
 	melee_damage_lower = 10
 	melee_damage_upper = 15
+	armor_penetration = 20
 	emote_see = list("drools acid onto the floor.", "wriggles in glee!", "rolls over!")
 	var/burn_attack_text = "The pus maggot vomits up some acidic pus all over!"
 	var/burn_attack_sound = 'sound/effects/splat.ogg'

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiTrash.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiTrash.dm
@@ -51,8 +51,18 @@
 	var/burn_attack_sound = 'sound/effects/splat.ogg'
 	attacktext = "gnawed"
 
+	leach_on_odds = 30
+	can_leach = TRUE
+	steal_odds = 10
+	stat_to_steal = STAT_VIV
+	steal_amount = -2
+
 /mob/living/carbon/superior_animal/psi_monster/pus_maggot/summoned
 	momento_mori = /obj/effect/decal/cleanable/psi_ash/low_chance
 	drop_items = list(/obj/random/psi/low_chance)
 	psionic_respawn = FALSE
 
+
+/mob/living/carbon/superior_animal/psi_monster/Initialize()
+	..()
+	stat_to_steal = pick(ALL_STATS_FOR_LEVEL_UP)

--- a/maps/submaps/deepmaint_rooms/core/Lab.dmm
+++ b/maps/submaps/deepmaint_rooms/core/Lab.dmm
@@ -554,6 +554,29 @@
 /obj/machinery/light_construct,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/awaymission)
+"oH" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/awaymission)
+"Hb" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/awaymission)
+"Kb" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/monofloor,
+/area/awaymission)
+"Zt" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/awaymission)
+"ZG" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/panels,
+/area/awaymission)
 
 (1,1,1) = {"
 ah
@@ -562,7 +585,7 @@ ai
 aa
 aa
 aa
-aa
+Hb
 aa
 ah
 ah
@@ -621,12 +644,12 @@ aj
 aj
 aj
 aj
-aa
+Hb
 aa
 "}
 (4,1,1) = {"
 ah
-aa
+Hb
 aj
 aj
 aj
@@ -695,7 +718,7 @@ ai
 "}
 (7,1,1) = {"
 ah
-aa
+Hb
 aj
 aj
 aE
@@ -703,7 +726,7 @@ aN
 bd
 aK
 az
-aE
+Kb
 aJ
 bY
 aM
@@ -799,7 +822,7 @@ aE
 aV
 bV
 ax
-at
+ZG
 at
 at
 aC
@@ -828,7 +851,7 @@ cb
 aj
 aj
 aj
-bP
+oH
 aa
 "}
 (13,1,1) = {"
@@ -940,7 +963,7 @@ aM
 aF
 aZ
 aL
-aZ
+Zt
 bM
 aj
 aa
@@ -1006,7 +1029,7 @@ ah
 bt
 ah
 aa
-aa
+Hb
 aa
 aa
 ah
@@ -1024,7 +1047,7 @@ ah
 ah
 aa
 aa
-aa
+Hb
 aa
 aa
 aa
@@ -1033,7 +1056,7 @@ aa
 ah
 ah
 aa
-aa
+Hb
 aa
 aa
 aa

--- a/maps/submaps/deepmaint_rooms/core/Lab2.dmm
+++ b/maps/submaps/deepmaint_rooms/core/Lab2.dmm
@@ -451,6 +451,17 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/deepmaint)
+"iA" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel,
+/area/deepmaint)
+"Pa" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel,
+/area/deepmaint)
 
 (1,1,1) = {"
 aa
@@ -459,19 +470,19 @@ ac
 aa
 aa
 aa
-aa
-aa
-aa
-ac
-ac
-ac
+iA
 aa
 aa
 ac
 ac
-aa
 ac
 aa
+aa
+ac
+ac
+aa
+ac
+iA
 aa
 ac
 "}
@@ -488,7 +499,7 @@ ac
 aa
 aa
 aa
-aa
+iA
 aa
 ac
 bo
@@ -523,7 +534,7 @@ aa
 "}
 (4,1,1) = {"
 ac
-aa
+iA
 aX
 ag
 aN
@@ -564,7 +575,7 @@ ay
 ay
 ay
 aX
-aa
+iA
 ac
 "}
 (6,1,1) = {"
@@ -637,7 +648,7 @@ aa
 aa
 "}
 (9,1,1) = {"
-aa
+iA
 aa
 aX
 ao
@@ -679,7 +690,7 @@ aX
 ay
 bB
 aX
-aa
+iA
 ac
 "}
 (11,1,1) = {"
@@ -753,7 +764,7 @@ aa
 "}
 (14,1,1) = {"
 ac
-aa
+iA
 aX
 as
 aa
@@ -795,7 +806,7 @@ aa
 bH
 aX
 ac
-aa
+iA
 "}
 (16,1,1) = {"
 ac
@@ -854,7 +865,7 @@ aS
 aT
 aH
 aX
-aa
+iA
 aX
 aH
 bp
@@ -894,7 +905,7 @@ ac
 aa
 aa
 aa
-aB
+Pa
 aa
 ac
 ac
@@ -919,16 +930,16 @@ aa
 aa
 ac
 aa
+iA
 aa
 aa
 aa
 aa
 aa
-aa
-aa
+iA
 ac
 ac
-aa
+iA
 aa
 aa
 aa

--- a/maps/submaps/deepmaint_rooms/core/ai_core.dmm
+++ b/maps/submaps/deepmaint_rooms/core/ai_core.dmm
@@ -45,6 +45,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
 "ai" = (
@@ -113,11 +114,15 @@
 /turf/simulated/floor/reinforced,
 /area/deepmaint)
 "av" = (
-/obj/machinery/power/smes/buildable,
-/turf/simulated/floor/bluegrid,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/bar_flat,
 /area/deepmaint)
 "aw" = (
 /obj/structure/disposalpipe/segment,
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
 "ax" = (
@@ -125,9 +130,17 @@
 /turf/simulated/floor/bluegrid,
 /area/deepmaint)
 "ay" = (
-/obj/structure/AIcore,
-/turf/simulated/floor/bluegrid,
-/area/space)
+/obj/structure/disposalpipe/segment{
+	icon_state = "pipe-s";
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/plating/under,
+/area/deepmaint)
 "az" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 2;
@@ -185,6 +198,7 @@
 	dir = 4;
 	anchored = 1
 	},
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
 "aG" = (
@@ -197,6 +211,7 @@
 	icon_state = "railing0";
 	dir = 8
 	},
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
 "aI" = (
@@ -406,7 +421,7 @@
 	name = "AI Core"
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
-/area/space)
+/area/deepmaint)
 "cY" = (
 /obj/structure/table/reinforced,
 /obj/random/pack/rare,
@@ -418,6 +433,10 @@
 /obj/random/dungeon_gun_energy,
 /turf/simulated/floor/bluegrid,
 /area/deepmaint)
+"id" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/deepmaint)
 "jp" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -427,11 +446,20 @@
 /obj/random/cluster/psi_monster/low_chance,
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
+"lk" = (
+/obj/random/junk,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/plating/under,
+/area/deepmaint)
 "qh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
 /obj/random/cluster/psi_monster/low_chance,
 /turf/simulated/floor/plating/under,
+/area/deepmaint)
+"rL" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/bar_flat,
 /area/deepmaint)
 "Ff" = (
 /obj/structure/table/reinforced,
@@ -452,6 +480,12 @@
 /obj/random/dungeon_gun_ballistic,
 /turf/simulated/floor/bluegrid,
 /area/deepmaint)
+"Qc" = (
+/obj/random/junk,
+/obj/random/junk,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/plating/under,
+/area/deepmaint)
 
 (1,1,1) = {"
 aa
@@ -470,8 +504,8 @@ aa
 aT
 aa
 aa
-aa
-aa
+rL
+rL
 aa
 bn
 aO
@@ -487,8 +521,8 @@ ab
 ab
 aX
 aa
-aa
-aa
+rL
+rL
 aa
 ab
 ab
@@ -515,16 +549,16 @@ at
 at
 aq
 aA
-aa
+rL
 aa
 aO
 aa
-ac
+id
 aa
 "}
 (4,1,1) = {"
 aa
-ac
+id
 aa
 ae
 ai
@@ -556,7 +590,7 @@ ab
 ab
 aS
 aR
-aQ
+Qc
 aS
 aS
 ab
@@ -576,7 +610,7 @@ af
 ab
 aQ
 aR
-aR
+lk
 aQ
 ab
 ab
@@ -643,7 +677,7 @@ ab
 aN
 af
 ab
-aR
+lk
 ab
 cY
 au
@@ -681,7 +715,7 @@ ab
 aa
 aa
 ab
-aa
+rL
 "}
 (11,1,1) = {"
 aa
@@ -692,9 +726,9 @@ ab
 aR
 ab
 as
-av
+ar
 ab
-ay
+ax
 ac
 au
 ar
@@ -839,7 +873,7 @@ ab
 ab
 ab
 ab
-bj
+ay
 aN
 ab
 aa
@@ -900,7 +934,7 @@ ab
 ab
 ab
 aO
-aa
+rL
 bd
 al
 bf
@@ -933,6 +967,6 @@ aa
 aO
 aa
 aO
-aL
+av
 aa
 "}

--- a/maps/submaps/deepmaint_rooms/core/lab5.dmm
+++ b/maps/submaps/deepmaint_rooms/core/lab5.dmm
@@ -30,11 +30,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/fixed/fgrass,
 /area/deepmaint)
 "ah" = (
 /obj/structure/flora/small/grassb5,
 /obj/item/ammo_casing,
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/fixed/fgrass,
 /area/deepmaint)
 "ai" = (
@@ -122,6 +124,7 @@
 "ay" = (
 /obj/item/ammo_casing,
 /obj/item/ammo_casing,
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/fixed/fgrass,
 /area/deepmaint)
 "az" = (
@@ -273,6 +276,11 @@
 /obj/random/psi_catalyst,
 /turf/simulated/floor/fixed/fgrass,
 /area/deepmaint)
+"tf" = (
+/obj/item/ammo_casing,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/fixed/fgrass,
+/area/deepmaint)
 "uN" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -280,6 +288,10 @@
 	},
 /obj/random/cluster/psi_monster/lower_chance,
 /turf/simulated/floor/tiled/dark,
+/area/deepmaint)
+"Ub" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/fixed/fgrass,
 /area/deepmaint)
 
 (1,1,1) = {"
@@ -405,11 +417,11 @@ ab
 aD
 ab
 aD
-as
+tf
 aD
 aY
 aD
-ab
+Ub
 ai
 ab
 aD
@@ -565,7 +577,7 @@ aJ
 ab
 ab
 aq
-as
+tf
 as
 aD
 aM
@@ -668,7 +680,7 @@ aD
 ab
 al
 ab
-ab
+Ub
 aJ
 aa
 aa
@@ -686,7 +698,7 @@ aU
 aD
 ax
 aB
-ab
+Ub
 aD
 ab
 ap

--- a/maps/submaps/deepmaint_rooms/core/maint_asteroid.dmm
+++ b/maps/submaps/deepmaint_rooms/core/maint_asteroid.dmm
@@ -273,6 +273,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/deepmaint)
 "bg" = (
@@ -286,9 +287,35 @@
 "bi" = (
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/deepmaint)
+"bw" = (
+/obj/random/material_ore,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/asteroid,
+/area/deepmaint)
+"hO" = (
+/obj/random/junk,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/plating,
+/area/deepmaint)
+"ji" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/plating/under,
+/area/deepmaint)
 "kT" = (
 /obj/random/cluster/psi_monster/low_chance,
 /turf/simulated/floor/tiled/steel,
+/area/deepmaint)
+"on" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/deepmaint)
+"so" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/carpet,
+/area/deepmaint)
+"zh" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/asteroid,
 /area/deepmaint)
 "EB" = (
 /obj/structure/table/woodentable,
@@ -297,6 +324,10 @@
 /obj/item/seeds/ambrosiavulgarisseed,
 /obj/random/psi_megafauna,
 /turf/simulated/floor/asteroid,
+/area/deepmaint)
+"Ir" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/plating,
 /area/deepmaint)
 "UE" = (
 /obj/random/cluster/psi_monster/low_chance,
@@ -309,14 +340,7 @@ aa
 ab
 aa
 ab
-aa
-aa
-aa
-aa
-ab
-aa
-aa
-ab
+Ir
 aa
 aa
 aa
@@ -324,6 +348,13 @@ ab
 aa
 aa
 ab
+aa
+Ir
+aa
+ab
+aa
+aa
+hO
 aa
 "}
 (2,1,1) = {"
@@ -373,7 +404,7 @@ af
 ab
 "}
 (4,1,1) = {"
-aa
+Ir
 ag
 ah
 ah
@@ -468,7 +499,7 @@ aa
 ad
 ah
 ak
-an
+ji
 ak
 au
 aA
@@ -479,7 +510,7 @@ aD
 aN
 ak
 aW
-ba
+so
 bd
 ak
 ah
@@ -553,7 +584,7 @@ bf
 bb
 af
 af
-bi
+on
 bi
 "}
 (12,1,1) = {"
@@ -606,7 +637,7 @@ bh
 ab
 ag
 ah
-af
+zh
 af
 af
 af
@@ -658,7 +689,7 @@ ah
 ah
 ah
 af
-af
+zh
 af
 af
 af
@@ -720,7 +751,7 @@ ai
 (19,1,1) = {"
 aa
 aa
-ad
+bw
 ad
 at
 ad
@@ -760,7 +791,7 @@ bg
 aR
 bg
 aI
-ab
+hO
 aa
 "}
 (21,1,1) = {"

--- a/maps/submaps/deepmaint_rooms/core/medbay.dmm
+++ b/maps/submaps/deepmaint_rooms/core/medbay.dmm
@@ -229,6 +229,7 @@
 /area/deepmaint)
 "xb" = (
 /obj/structure/bed/chair/office/dark,
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/tiled/white,
 /area/deepmaint)
 "xq" = (
@@ -273,6 +274,11 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/simulated/floor/tiled/white,
 /area/deepmaint)
+"Ai" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/deepmaint)
 "Aw" = (
 /obj/machinery/light{
 	dir = 1
@@ -305,7 +311,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
 /obj/item/material/shard,
-/obj/item/circuitboard/chemical_dispenser,
 /turf/simulated/floor/tiled/white,
 /area/deepmaint)
 "CK" = (
@@ -446,6 +451,10 @@
 /obj/item/material/shard,
 /turf/simulated/floor/wood,
 /area/deepmaint)
+"OD" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/deepmaint)
 "OL" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -468,7 +477,7 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/deepmaint)
 "SR" = (
-/obj/machinery/sleeper,
+/obj/machinery/sleeper/sarcophagus/random,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/deepmaint)
 "SW" = (
@@ -518,7 +527,7 @@
 /turf/simulated/floor/tiled/white,
 /area/deepmaint)
 "XK" = (
-/obj/structure/showcase/horrific_experiment_cryo,
+/obj/structure/salvageable/deepmaints_cryopod,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/deepmaint)
 "YS" = (
@@ -642,7 +651,7 @@ yi
 fa
 pB
 fa
-fa
+OD
 OL
 fa
 fa
@@ -662,7 +671,7 @@ WG
 ep
 Or
 Eb
-fa
+OD
 pB
 Aw
 JJ
@@ -783,7 +792,7 @@ Id
 CK
 fa
 wp
-CK
+Ai
 Wl
 wp
 Ev
@@ -823,7 +832,7 @@ ZZ
 Id
 fa
 fa
-fa
+OD
 Wl
 fa
 ch
@@ -871,7 +880,7 @@ fA
 Vy
 xA
 fa
-fa
+OD
 pB
 gL
 Sj

--- a/maps/submaps/deepmaint_rooms/normal/anomalysci.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/anomalysci.dmm
@@ -103,8 +103,22 @@
 /obj/random/material/low_chance,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/deepmaint)
+"O" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/deepmaint)
+"P" = (
+/obj/item/stool,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/deepmaint)
+"S" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/deepmaint)
 
 (1,1,1) = {"
+O
 a
 a
 a
@@ -114,8 +128,7 @@ a
 a
 a
 a
-a
-a
+O
 "}
 (2,1,1) = {"
 a
@@ -139,7 +152,7 @@ b
 c
 c
 m
-n
+P
 n
 a
 "}
@@ -147,7 +160,7 @@ a
 a
 b
 e
-g
+S
 g
 g
 i
@@ -199,7 +212,7 @@ a
 a
 b
 e
-g
+S
 g
 g
 i
@@ -217,7 +230,7 @@ b
 c
 c
 m
-n
+P
 n
 a
 "}
@@ -235,6 +248,7 @@ p
 a
 "}
 (11,1,1) = {"
+O
 a
 a
 a
@@ -244,6 +258,5 @@ a
 a
 a
 a
-a
-a
+O
 "}

--- a/maps/submaps/deepmaint_rooms/normal/barricades.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/barricades.dmm
@@ -3,7 +3,7 @@
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/deepmaint)
 "b" = (
-/obj/structure/barricade,
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/deepmaint)
 "c" = (
@@ -86,6 +86,17 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/deepmaint)
+"y" = (
+/turf/simulated/floor/tiled/techmaint_panels,
+/area/deepmaint)
+"B" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/monofloor,
+/area/deepmaint)
+"T" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/techmaint,
+/area/deepmaint)
 "V" = (
 /obj/random/cluster/psi_monster/lower_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -95,17 +106,17 @@
 a
 a
 a
+B
 a
 a
 a
 a
 a
-a
-a
+B
 a
 "}
 (2,1,1) = {"
-b
+y
 c
 c
 c
@@ -115,10 +126,10 @@ c
 c
 c
 c
-b
+y
 "}
 (3,1,1) = {"
-b
+y
 c
 e
 e
@@ -128,7 +139,7 @@ e
 e
 e
 c
-b
+y
 "}
 (4,1,1) = {"
 b
@@ -144,7 +155,7 @@ n
 b
 "}
 (5,1,1) = {"
-b
+y
 c
 g
 h
@@ -154,10 +165,10 @@ i
 f
 m
 c
-b
+y
 "}
 (6,1,1) = {"
-b
+y
 c
 o
 f
@@ -167,20 +178,20 @@ i
 V
 p
 c
-b
+y
 "}
 (7,1,1) = {"
-b
+y
 c
 g
-f
+T
 i
 k
 i
 f
 m
 c
-b
+y
 "}
 (8,1,1) = {"
 b
@@ -196,7 +207,7 @@ d
 b
 "}
 (9,1,1) = {"
-b
+y
 c
 e
 e
@@ -206,10 +217,10 @@ e
 e
 e
 c
-b
+y
 "}
 (10,1,1) = {"
-b
+y
 c
 c
 c
@@ -219,18 +230,18 @@ c
 c
 c
 c
-b
+y
 "}
 (11,1,1) = {"
 a
 a
 a
 a
+B
 a
 a
 a
-a
-a
+B
 a
 a
 "}

--- a/maps/submaps/deepmaint_rooms/normal/catwalks.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/catwalks.dmm
@@ -327,6 +327,15 @@
 /obj/random/dungeon_gun_ballistic/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/deepmaint)
+"Q" = (
+/obj/structure/catwalk,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/plating/under,
+/area/deepmaint)
+"Y" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/deepmaint)
 "Z" = (
 /obj/structure/table/standard,
 /obj/random/pack/rare/low_chance,
@@ -349,7 +358,7 @@ b
 a
 "}
 (2,1,1) = {"
-a
+Q
 c
 g
 a
@@ -372,7 +381,7 @@ x
 a
 C
 F
-a
+Q
 "}
 (4,1,1) = {"
 a
@@ -382,7 +391,7 @@ k
 a
 a
 y
-a
+Q
 D
 G
 a
@@ -407,7 +416,7 @@ i
 a
 o
 t
-z
+Y
 a
 C
 F
@@ -434,7 +443,7 @@ k
 a
 a
 y
-a
+Q
 C
 F
 a
@@ -450,10 +459,10 @@ x
 a
 D
 G
-a
+Q
 "}
 (10,1,1) = {"
-a
+Q
 f
 j
 a

--- a/maps/submaps/deepmaint_rooms/normal/cryo.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/cryo.dmm
@@ -9,104 +9,23 @@
 /turf/simulated/wall,
 /area/deepmaint)
 "d" = (
+/obj/structure/salvageable/implant_container,
 /turf/simulated/floor/tiled/white/techfloor_grid,
-/area/deepmaint)
-"e" = (
-/obj/machinery/atmospherics/unary/freezer{
-	cooling = 1;
-	dir = 2;
-	set_temperature = 73
-	},
-/turf/simulated/floor/tiled/white/cargo,
 /area/deepmaint)
 "f" = (
 /turf/simulated/floor/tiled/white/panels,
 /area/deepmaint)
 "g" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
-/turf/simulated/floor/plating/under,
-/area/deepmaint)
-"h" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/deepmaint)
-"i" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/deepmaint)
-"j" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
+/obj/structure/salvageable/computer,
+/turf/simulated/floor/tiled/white/panels,
 /area/deepmaint)
 "k" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/structure/salvageable/personal,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/deepmaint)
 "l" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
+/obj/structure/salvageable/implant_container,
 /turf/simulated/floor/tiled/white/cargo,
-/area/deepmaint)
-"m" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/deepmaint)
-"n" = (
-/obj/machinery/atmospherics/unary/cryo_cell,
-/turf/simulated/floor/tiled/white/cargo,
-/area/deepmaint)
-"o" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHEAST)";
-	icon_state = "intact";
-	dir = 5
-	},
-/turf/simulated/floor/plating/under,
-/area/deepmaint)
-"p" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/floor/plating/under,
-/area/deepmaint)
-"q" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/deepmaint)
-"r" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	tag = "icon-intact (NORTHWEST)";
-	icon_state = "intact";
-	dir = 9
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
 /area/deepmaint)
 "s" = (
 /obj/structure/table/standard,
@@ -131,14 +50,13 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/deepmaint)
 "v" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper";
+/obj/machinery/sleeper/sarcophagus/random{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/deepmaint)
 "w" = (
-/obj/machinery/sleeper{
+/obj/machinery/sleeper/sarcophagus/random{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -147,6 +65,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/salvageable/implant_container,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/deepmaint)
 "y" = (
@@ -154,6 +73,7 @@
 	dir = 4;
 	pixel_y = 0
 	},
+/obj/structure/salvageable/implant_container,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/deepmaint)
 "z" = (
@@ -167,15 +87,21 @@
 /obj/random/pouch/low_chance,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/deepmaint)
+"B" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white/cargo,
+/area/deepmaint)
 "N" = (
-/obj/structure/table/standard,
-/obj/random/pack/cloth,
-/obj/random/pack/cloth,
-/obj/random/pack/rare,
-/obj/random/firstaid/low_chance,
-/obj/random/medical/low_chance,
-/obj/random/medical_lowcost/low_chance,
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/deepmaint)
+"O" = (
+/obj/structure/salvageable/deepmaints_cryopod,
+/turf/simulated/floor/tiled/white/cargo,
+/area/deepmaint)
+"P" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white/panels,
 /area/deepmaint)
 "S" = (
 /obj/structure/table/standard,
@@ -198,7 +124,7 @@ a
 a
 a
 a
-b
+B
 b
 b
 a
@@ -225,8 +151,8 @@ d
 x
 k
 c
-n
-o
+O
+P
 t
 t
 t
@@ -234,25 +160,25 @@ a
 "}
 (4,1,1) = {"
 a
-e
-g
-l
+B
+f
+S
 c
-n
-p
+O
+f
 t
 t
-t
+N
 a
 "}
 (5,1,1) = {"
 b
 A
-h
+f
 l
 c
-n
-p
+O
+f
 S
 w
 w
@@ -260,41 +186,41 @@ b
 "}
 (6,1,1) = {"
 b
-f
-i
-m
-m
-m
-q
+g
+P
 f
 f
+P
 f
+f
+f
+P
 b
 "}
 (7,1,1) = {"
 b
 T
-h
+f
 l
 c
-n
-q
-N
+O
+f
+S
 v
 v
 b
 "}
 (8,1,1) = {"
 a
-e
-j
-l
+B
+f
+S
 c
-n
-q
+O
+f
 t
 t
-t
+N
 a
 "}
 (9,1,1) = {"
@@ -303,8 +229,8 @@ d
 y
 k
 c
-n
-r
+O
+P
 t
 t
 t
@@ -328,7 +254,7 @@ a
 a
 a
 a
-b
+B
 b
 b
 a

--- a/maps/submaps/deepmaint_rooms/normal/freezer.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/freezer.dmm
@@ -130,6 +130,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/tiled/white/cargo,
 /area/deepmaint)
 "B" = (
@@ -138,6 +139,11 @@
 /obj/random/junkfood/low_chance,
 /obj/random/lathe_disk/advanced/low_chance,
 /turf/simulated/floor/tiled/white/brown_perforated,
+/area/deepmaint)
+"D" = (
+/obj/random/junk,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white/panels,
 /area/deepmaint)
 "E" = (
 /obj/item/remains/mouse,
@@ -155,6 +161,11 @@
 /obj/random/pouch/low_chance,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/deepmaint)
+"P" = (
+/obj/item/remains/mouse,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white/panels,
+/area/deepmaint)
 "Q" = (
 /obj/structure/table/standard,
 /obj/random/psi_megafauna,
@@ -166,11 +177,15 @@
 /obj/random/junkfood/low_chance,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/deepmaint)
+"T" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/deepmaint)
 
 (1,1,1) = {"
 a
 a
-a
+T
 a
 a
 a
@@ -216,7 +231,7 @@ j
 k
 n
 t
-w
+P
 a
 "}
 (5,1,1) = {"
@@ -233,7 +248,7 @@ v
 a
 "}
 (6,1,1) = {"
-a
+T
 c
 c
 c
@@ -268,7 +283,7 @@ i
 k
 m
 B
-v
+D
 q
 "}
 (9,1,1) = {"
@@ -300,7 +315,7 @@ a
 (11,1,1) = {"
 a
 a
-a
+T
 a
 a
 a

--- a/maps/submaps/deepmaint_rooms/normal/garbage.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/garbage.dmm
@@ -124,6 +124,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/deepmaint)
 "u" = (
@@ -145,6 +146,22 @@
 /obj/random/cluster/psi_monster/low_chance,
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
+"A" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/deepmaint)
+"F" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/deepmaint)
+"Q" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/techmaint,
+/area/deepmaint)
 
 (1,1,1) = {"
 a
@@ -155,7 +172,7 @@ a
 a
 a
 a
-a
+Q
 a
 a
 "}
@@ -195,7 +212,7 @@ j
 j
 n
 e
-b
+F
 a
 "}
 (5,1,1) = {"
@@ -239,7 +256,7 @@ a
 "}
 (8,1,1) = {"
 a
-b
+F
 e
 i
 l
@@ -260,7 +277,7 @@ e
 w
 m
 e
-u
+A
 a
 "}
 (10,1,1) = {"
@@ -282,7 +299,7 @@ d
 a
 a
 a
-a
+Q
 a
 a
 a

--- a/maps/submaps/deepmaint_rooms/normal/hydro.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/hydro.dmm
@@ -49,6 +49,7 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/deepmaint)
 "l" = (
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/deepmaint)
 "m" = (
@@ -90,9 +91,25 @@
 	},
 /turf/simulated/floor/wood,
 /area/deepmaint)
+"F" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/wood,
+/area/deepmaint)
+"I" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/deepmaint)
 "N" = (
 /obj/random/cluster/psi_monster/low_chance,
 /turf/simulated/floor/tiled/steel/brown_platform,
+/area/deepmaint)
+"Q" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/deepmaint)
+"S" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/asteroid/dirt,
 /area/deepmaint)
 
 (1,1,1) = {"
@@ -106,7 +123,7 @@ n
 a
 a
 a
-a
+I
 "}
 (2,1,1) = {"
 a
@@ -125,7 +142,7 @@ a
 a
 c
 e
-k
+S
 c
 q
 c
@@ -142,13 +159,13 @@ k
 c
 p
 c
-k
+S
 r
 c
 a
 "}
 (5,1,1) = {"
-a
+I
 c
 g
 t
@@ -158,7 +175,7 @@ b
 u
 h
 c
-a
+I
 "}
 (6,1,1) = {"
 a
@@ -168,7 +185,7 @@ m
 o
 p
 o
-m
+F
 h
 c
 a
@@ -223,14 +240,14 @@ b
 c
 c
 b
-a
+I
 "}
 (11,1,1) = {"
 a
+I
 a
 a
-a
-n
+Q
 n
 n
 N

--- a/maps/submaps/deepmaint_rooms/normal/library.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/library.dmm
@@ -72,6 +72,14 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/deepmaint)
+"L" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/wood,
+/area/deepmaint)
+"O" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/deepmaint)
 
 (1,1,1) = {"
 b
@@ -83,7 +91,7 @@ e
 d
 b
 b
-b
+L
 b
 "}
 (2,1,1) = {"
@@ -139,7 +147,7 @@ h
 e
 "}
 (6,1,1) = {"
-e
+O
 h
 f
 b
@@ -175,7 +183,7 @@ b
 g
 o
 j
-b
+L
 "}
 (9,1,1) = {"
 b
@@ -207,7 +215,7 @@ b
 b
 b
 c
-b
+L
 e
 d
 e

--- a/maps/submaps/deepmaint_rooms/normal/mechbay.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/mechbay.dmm
@@ -124,6 +124,25 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/deepmaint)
+"K" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/deepmaint)
+"M" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/brown_perforated,
+/area/deepmaint)
+"O" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/deepmaint)
+"W" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/gray_platform,
+/area/deepmaint)
 
 (1,1,1) = {"
 t
@@ -144,7 +163,7 @@ c
 c
 f
 w
-h
+W
 h
 d
 c
@@ -155,7 +174,7 @@ t
 a
 c
 e
-d
+O
 h
 m
 h
@@ -191,17 +210,17 @@ c
 s
 "}
 (6,1,1) = {"
-a
+M
 u
 v
-d
+O
 k
 c
 p
-d
+O
 d
 u
-a
+M
 "}
 (7,1,1) = {"
 b
@@ -246,9 +265,9 @@ t
 a
 c
 c
-f
+K
 h
-h
+W
 h
 d
 c

--- a/maps/submaps/deepmaint_rooms/normal/medical.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/medical.dmm
@@ -84,6 +84,10 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/deepmaint)
+"v" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white/panels,
+/area/deepmaint)
 "C" = (
 /obj/random/cluster/psi_monster/low_chance,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -101,6 +105,10 @@
 /obj/random/pouch/low_chance,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/deepmaint)
+"Q" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/deepmaint)
 
 (1,1,1) = {"
 a
@@ -109,14 +117,14 @@ a
 a
 a
 a
-a
+Q
 a
 a
 a
 a
 "}
 (2,1,1) = {"
-a
+Q
 h
 h
 a
@@ -149,7 +157,7 @@ g
 a
 i
 l
-m
+v
 o
 r
 a
@@ -214,13 +222,13 @@ a
 a
 i
 I
-m
+v
 h
 q
 a
 "}
 (10,1,1) = {"
-a
+Q
 h
 h
 a
@@ -239,7 +247,7 @@ a
 a
 a
 a
-a
+Q
 a
 a
 a

--- a/maps/submaps/deepmaint_rooms/normal/morgue.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/morgue.dmm
@@ -117,12 +117,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/deepmaint)
+"v" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/deepmaint)
+"z" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/dark/panels,
+/area/deepmaint)
 "E" = (
 /obj/structure/table/standard,
 /obj/random/card_carp,
 /obj/random/card_carp,
 /obj/random/card_carp,
 /obj/random/card_carp/pelt,
+/turf/simulated/floor/tiled/dark,
+/area/deepmaint)
+"L" = (
+/obj/machinery/light/small,
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/deepmaint)
 "S" = (
@@ -132,6 +145,10 @@
 /obj/random/medical/low_chance,
 /obj/random/firstaid/low_chance,
 /turf/simulated/floor/tiled/dark/gray_perforated,
+/area/deepmaint)
+"U" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/deepmaint)
 "Z" = (
 /obj/structure/table/rack/shelf,
@@ -149,17 +166,17 @@
 a
 a
 a
+v
 a
 a
 a
 a
 a
-a
-a
+v
 a
 "}
 (2,1,1) = {"
-b
+L
 c
 c
 a
@@ -176,7 +193,7 @@ a
 c
 f
 g
-g
+U
 h
 m
 k
@@ -192,7 +209,7 @@ g
 g
 h
 n
-k
+z
 r
 c
 a
@@ -212,7 +229,7 @@ t
 "}
 (6,1,1) = {"
 a
-a
+v
 a
 a
 a
@@ -221,7 +238,7 @@ o
 a
 a
 a
-a
+v
 "}
 (7,1,1) = {"
 a
@@ -263,7 +280,7 @@ s
 a
 "}
 (10,1,1) = {"
-a
+v
 e
 c
 c
@@ -278,12 +295,12 @@ a
 (11,1,1) = {"
 a
 a
-a
+v
 a
 a
 l
 a
-a
+v
 a
 a
 a

--- a/maps/submaps/deepmaint_rooms/normal/office.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/office.dmm
@@ -91,10 +91,23 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/deepmaint)
+"u" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/gray_platform,
+/area/deepmaint)
+"I" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/deepmaint)
+"S" = (
+/obj/structure/bed/chair/office/dark,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/deepmaint)
 
 (1,1,1) = {"
 a
-a
+I
 a
 a
 a
@@ -139,7 +152,7 @@ i
 l
 n
 r
-p
+S
 f
 d
 a
@@ -155,10 +168,10 @@ c
 c
 c
 c
-a
+I
 "}
 (6,1,1) = {"
-a
+I
 d
 e
 h
@@ -176,7 +189,7 @@ d
 f
 i
 l
-n
+u
 r
 p
 f
@@ -223,15 +236,15 @@ c
 a
 "}
 (11,1,1) = {"
+I
 a
 a
 a
 a
 a
+I
 a
 a
 a
-a
-a
-a
+I
 "}

--- a/maps/submaps/deepmaint_rooms/normal/roach.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/roach.dmm
@@ -54,12 +54,8 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/deepmaint)
 "l" = (
-/obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
-	dir = 8
-	},
-/turf/simulated/floor/plating/under,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/techmaint_cargo,
 /area/deepmaint)
 "m" = (
 /obj/structure/table/standard,
@@ -70,25 +66,8 @@
 /obj/random/psi_megafauna,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/deepmaint)
-"n" = (
-/obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/deepmaint)
 "o" = (
-/obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	icon_state = "railing0";
-	dir = 8
-	},
-/obj/structure/railing,
-/turf/simulated/floor/plating/under,
-/area/deepmaint)
-"p" = (
-/obj/structure/railing,
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
 "q" = (
@@ -99,13 +78,8 @@
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/deepmaint)
 "r" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	icon_state = "railing0";
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/techmaint_perforated,
 /area/deepmaint)
 "t" = (
 /obj/random/cluster/psi_monster,
@@ -157,21 +131,21 @@ c
 c
 c
 c
-l
-o
+f
+f
 a
 j
 b
 "}
 (3,1,1) = {"
-b
+r
 c
 d
 f
 f
+o
 f
 f
-p
 a
 j
 b
@@ -187,7 +161,7 @@ h
 c
 w
 j
-b
+r
 "}
 (5,1,1) = {"
 b
@@ -200,20 +174,20 @@ i
 h
 a
 j
-b
+r
 "}
 (6,1,1) = {"
 b
 a
-f
+o
 c
 g
-j
+l
 j
 q
 t
 j
-b
+r
 "}
 (7,1,1) = {"
 b
@@ -226,7 +200,7 @@ m
 h
 a
 j
-b
+r
 "}
 (8,1,1) = {"
 b
@@ -239,7 +213,7 @@ h
 c
 a
 j
-b
+r
 "}
 (9,1,1) = {"
 b
@@ -247,22 +221,22 @@ c
 d
 f
 f
+o
 f
 f
-p
 a
 j
 b
 "}
 (10,1,1) = {"
-b
-c
-c
-c
-c
-c
-n
 r
+c
+c
+c
+c
+c
+f
+f
 a
 j
 b

--- a/maps/submaps/deepmaint_rooms/normal/sm_core.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/sm_core.dmm
@@ -18,6 +18,7 @@
 /area/deepmaint)
 "g" = (
 /obj/structure/catwalk,
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/plating/under,
 /area/deepmaint)
 "h" = (
@@ -59,6 +60,7 @@
 	},
 /area/deepmaint)
 "o" = (
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/reinforced{
 	name = "engine floor";
 	oxygen = 0

--- a/maps/submaps/deepmaint_rooms/normal/storage.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/storage.dmm
@@ -79,6 +79,7 @@
 /area/deepmaint)
 "n" = (
 /obj/machinery/light/small,
+/obj/random/mob/psi_monster/low_chance,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/deepmaint)
 "o" = (
@@ -86,6 +87,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/panels,
+/area/deepmaint)
+"p" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/brown_perforated,
 /area/deepmaint)
 "A" = (
 /obj/structure/table/rack/shelf,
@@ -96,6 +101,10 @@
 /obj/random/pouch/low_chance,
 /obj/random/tool_upgrade/rare/low_chance,
 /turf/simulated/floor/tiled/steel/brown_platform,
+/area/deepmaint)
+"F" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/monofloor,
 /area/deepmaint)
 "L" = (
 /obj/structure/table/rack/shelf,
@@ -119,11 +128,11 @@
 
 (1,1,1) = {"
 a
+p
 a
 a
 a
-a
-a
+p
 a
 a
 a
@@ -184,15 +193,15 @@ a
 "}
 (6,1,1) = {"
 a
+F
+c
+F
 c
 c
+F
 c
 c
-c
-c
-c
-c
-c
+F
 a
 "}
 (7,1,1) = {"
@@ -249,11 +258,11 @@ a
 "}
 (11,1,1) = {"
 a
+p
 a
 a
 a
-a
-a
+p
 a
 a
 a

--- a/maps/submaps/deepmaint_rooms/normal/toilet.dmm
+++ b/maps/submaps/deepmaint_rooms/normal/toilet.dmm
@@ -6,9 +6,9 @@
 /turf/simulated/wall,
 /area/deepmaint)
 "c" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4;
-	icon_state = "tube1"
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/deepmaint)
@@ -19,16 +19,14 @@
 /turf/simulated/floor/tiled/steel,
 /area/deepmaint)
 "e" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/deepmaint)
 "f" = (
 /obj/machinery/recharge_station,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel,
 /area/deepmaint)
 "g" = (
@@ -49,9 +47,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/deepmaint)
 "j" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/random/pack/rare/low_chance,
 /turf/simulated/floor/tiled/steel,
 /area/deepmaint)
@@ -65,18 +60,21 @@
 /turf/simulated/floor/tiled/steel/panels,
 /area/deepmaint)
 "l" = (
+/obj/random/mob/psi_monster/low_chance,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/deepmaint)
 "m" = (
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/random/pack/rare/low_chance,
 /obj/random/pack/rare/low_chance,
 /obj/random/pack/rare/low_chance,
+/obj/random/mob/psi_monster/low_chance,
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel,
 /area/deepmaint)
 "n" = (
@@ -95,11 +93,10 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/random/common_oddities/low_chance,
 /obj/random/pack/rare/low_chance,
+/obj/random/mob/psi_monster/low_chance,
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel,
 /area/deepmaint)
 "q" = (
@@ -120,9 +117,8 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/deepmaint)
 "u" = (
-/obj/machinery/light,
-/obj/random/cluster/psi_monster/lower_chance,
-/turf/simulated/floor/tiled/steel,
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/panels,
 /area/deepmaint)
 "v" = (
 /obj/structure/sink{
@@ -139,6 +135,10 @@
 /obj/random/ammo_fancy,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/deepmaint)
+"x" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/steel/brown_perforated,
+/area/deepmaint)
 "C" = (
 /obj/item/storage/hcases/ammo/blackmarket,
 /obj/random/dungeon_gun_mods,
@@ -148,17 +148,27 @@
 /obj/random/cluster/psi_monster/lower_chance,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/deepmaint)
+"H" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/brown_perforated,
+/area/deepmaint)
 "I" = (
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/random/common_oddities/low_chance,
 /obj/random/pack/rare/low_chance,
 /obj/item/ammo_kit,
+/obj/random/mob/psi_monster/low_chance,
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel,
+/area/deepmaint)
+"L" = (
+/obj/random/mob/psi_monster/low_chance,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/steel/brown_perforated,
 /area/deepmaint)
 "N" = (
 /obj/structure/sink{
@@ -179,6 +189,10 @@
 /obj/random/psi_megafauna,
 /turf/simulated/floor/tiled/steel,
 /area/deepmaint)
+"S" = (
+/obj/random/mob/psi_monster/low_chance,
+/turf/simulated/floor/tiled/steel/brown_perforated,
+/area/deepmaint)
 "T" = (
 /obj/structure/table/rack,
 /obj/random/pack/tech_loot,
@@ -187,6 +201,17 @@
 /obj/random/pack/tech_loot/low_chance,
 /obj/random/powercell/low_chance,
 /turf/simulated/floor/tiled/steel/panels,
+/area/deepmaint)
+"W" = (
+/obj/random/mob/psi_monster/low_chance,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/steel/gray_platform,
+/area/deepmaint)
+"X" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
 /area/deepmaint)
 "Z" = (
 /obj/random/dungeon_ammo,
@@ -199,7 +224,7 @@ c
 a
 a
 a
-a
+S
 a
 a
 E
@@ -233,7 +258,7 @@ b
 a
 "}
 (4,1,1) = {"
-a
+x
 b
 h
 b
@@ -243,23 +268,23 @@ h
 b
 h
 b
-a
+H
 "}
 (5,1,1) = {"
 a
 d
 i
+X
 i
 i
 i
-i
-i
+X
 i
 d
 a
 "}
 (6,1,1) = {"
-a
+L
 b
 j
 n
@@ -267,9 +292,9 @@ i
 P
 i
 i
-u
+n
 b
-a
+H
 "}
 (7,1,1) = {"
 a
@@ -282,7 +307,7 @@ Z
 q
 q
 b
-a
+S
 "}
 (8,1,1) = {"
 a
@@ -293,7 +318,7 @@ o
 b
 C
 Z
-q
+W
 b
 a
 "}
@@ -301,7 +326,7 @@ a
 a
 b
 k
-l
+u
 T
 b
 v
@@ -325,12 +350,12 @@ a
 "}
 (11,1,1) = {"
 a
+a
 e
 a
+e
 a
-a
-a
-a
+S
 a
 a
 e


### PR DESCRIPTION
Deepmaints has many mob mobs now
Reduces the odds of traps in hallways, but increases the max amount of traps in the whole of deepamints
Removes all sleepers (that i know of) Cryo pods and other medical exclusive things (not heaters tho)
Replaces sleepers/cryo pods with salvangeable stuff that so its more worth it to go down
Fixes lickes/other mobs of deepmaints not properly injecting chems
Allows deepmaints mobs to grapple onto people and permitently lower stats 