### PR TITLE
Adds multi-z transmission to radios

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -8,6 +8,7 @@
 	preloaded_reagents = list("silicon" = 15, "plasticide" = 9)
 	subspace_transmission = 1
 	canhear_range = 0 // can't hear headsets from very far away
+	multi_z_capable = FALSE
 
 	slot_flags = SLOT_EARS
 	body_parts_covered = EARS

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -94,7 +94,6 @@ var/global/list/default_medbay_channels = list(
 	if(frequency < RADIO_LOW_FREQ || frequency > RADIO_HIGH_FREQ)
 		frequency = sanitize_frequency(frequency, RADIO_LOW_FREQ, RADIO_HIGH_FREQ)
 	set_frequency(frequency)
-	update_transmit_levels()
 
 	for (var/ch_name in channels)
 		secure_radio_connections[ch_name] = SSradio.add_object(src, radiochannels[ch_name],  RADIO_CHAT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Adds multi-z transmission and reception to hand-helds
</summary>
<hr>
	This lets Ham Radios (handhelds) transmit and listen to radio messages through multi-z environments like Scrap Haven without needing a telecomms setup, Robots are able to do the same, and headsets of all kinds are unchanged as they can only hear and transmit in their own z-level like before. Fallback-capable headsets like those belonging to the prospectors or marshals can hear multi-z, but not transmit. 
	
<hr>
</details>

## Changelog
:cl:
add: Ham radios are now able to transmit in multi-z areas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
