### PR TITLE
Allows outsiders to be robots + have core implants

### DIFF
--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -10,7 +10,7 @@
 		/datum/job/cmo,
 		/datum/job/chief_engineer,
 		/datum/job/smc,
-		/datum/job/outsider,
+		//datum/job/outsider,
 		/datum/job/cyborg, //To stop people auto dropping these
 		/datum/job/ai
 		)
@@ -23,9 +23,9 @@
 	desc = "An unusual organ implanted by the Soteria research or obtained through other methods. It is presently unknown what it is truly capable of and psions are entirely unknown outside of Nadezhda. \
 	Those with this organ must maintain purity of their bodies, any implants, cruciforms, or synthetic limbs will be violently and painfully rejected while this organ exists in the body."
 	implant_organ_type = "psionic tumor"
-	restricted_jobs = list(
+	/*restricted_jobs = list(
 		/datum/job/outsider //Psions are only available to colonist or allies.
-		)
+		)*/
 	allow_modifications = FALSE
 	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_MYCUS, FORM_FOLKEN, FORM_CHTMANT)
 
@@ -57,9 +57,9 @@
 	name = "Nanogate"
 	desc = "A custom built nanogate designed from the far superior opifex blueprints. It is implanted right where the spine meets the skull and provides a wide variety of nanite based uses."
 	implant_organ_type = "nanogate"
-	restricted_jobs = list(
+	/*restricted_jobs = list(
 		/datum/job/outsider // Nanogates are only available to colonist or allies.
-		)
+		)*/
 	allow_modifications = TRUE
 	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_CINDAR, FORM_AGSYNTH)
 
@@ -91,7 +91,7 @@
 	particular design is an opifex original and one of the best that can be found in the galaxy."
 	implant_organ_type = "opifex nanogate"
 	restricted_jobs = list(
-		/datum/job/outsider, // Nanogates are only available to colonist or allies.
+		//datum/job/outsider, // Nanogates are only available to colonist or allies.
 		/datum/job/cyborg, //To stop people auto dropping these
 		/datum/job/ai
 		)

--- a/code/game/jobs/job/offcolony.dm
+++ b/code/game/jobs/job/offcolony.dm
@@ -138,7 +138,7 @@
 //	minimal_access = list(access_maint_tunnels)
 	outfit_type = /decl/hierarchy/outfit/job/outsider
 	difficulty = "Impossible!"
-	disallow_species = list(FORM_FBP, FORM_UNBRANDED, FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
+//	disallow_species = list(FORM_FBP, FORM_UNBRANDED, FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 	has_id = FALSE
 
 	stat_modifiers = list(


### PR DESCRIPTION
With the general thrust of removing the 'dante must die' difficulty of outsiders, it seems apt to allow them to have access to synths and core implants, particularly because the balance benefit of restricting these to colony only seems offset by the loss to roleplay. EG, in the past we've had wayward church members arrive, we've had opifex who reasonably would have nanogates of their own arrive, we've had synths who are only recently arrived to the planet(from their perspective) arrive - even as far as psionics go we have seen that the colony has had these things for much time, and colonists with these things may reasonably have left the colony, they may have still found their way to deepmaints and found a cube to allow them to bestow it- so on.

By allowing outsiders once again to be unrestricted, we allow greater forms of roleplay. If outsiders become an issue of doing others jobs, taking over the jungle, etc- then it is perhaps better to handle it from an OOC perspective per our powergaming rules.

Particularly regarding dept synths, those restrictions may be wise to keep given that they ARE departmentally owned- but I would still argue for keeping the restrictions all gone for the above reasons, and adjusting as needed after seeing in play. I include zero restrictions in this initial version of the PR for the sake of arguments being cast one way or another. 

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
