### PR TITLE
Decreases Overall Pain by 10%, Decreases Oxy Pain by 40%, & Some other changes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -49,7 +49,8 @@
 		if(shoes)
 			tally += shoes.slowdown
 
-	tally += min((shock_stage / 100) * 3, 3) //Scales from 0 to 3 over 0 to 100 shock stage
+	//tally += min((shock_stage / 100) * 3, 3) //Scales from 0 to 3 over 0 to 100 shock stage
+	tally += min((get_dynamic_pain() - get_painkiller()) / 40, 3) // Scales from 0 to 3,
 
 	//if(stats.getPerk(/datum/perk/timeismoney)?.is_active())
 		//tally -= 2

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -29,8 +29,8 @@
 		hard_crit_threshold += 20
 
 	. = 						\
-	1	* get_limb_damage() + 	\
-	1	* getOxyLoss() + 		\
+	0.9	* get_limb_damage() + 	\
+	0.6	* getOxyLoss() + 		\
 	0.5	* getToxLoss() + 		\
 	1.5	* getCloneLoss()
 
@@ -104,23 +104,23 @@
 
 	sanity.onShock(shock_stage)
 
-	if(shock_stage == 10)
+	if(shock_stage == 30)
 		to_chat(src, "<span class='danger'>[pick("It hurts so much", "You really need some painkillers", "Dear god, the pain")]!</span>")
 
-	if(shock_stage >= 30)
+	if(shock_stage >= 60)
 		if(shock_stage == 30) emote("me",1,"is having trouble keeping their eyes open.")
 		stuttering = max(stuttering, 5)
 
-	if(shock_stage == 40)
+	if(shock_stage == 80)
 		to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!</span>")
 
-	if (shock_stage >= 60)
+	if (shock_stage >= 100)
 		if(shock_stage == 60) emote("me",1,"'s body becomes limp.")
 		if (prob(2))
 			to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!</span>")
 			Weaken(10)
 
-	if(shock_stage >= 80)
+	if(shock_stage >= 120)
 		if (prob(5))
 			to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!</span>")
 			Weaken(10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Contains this PR fix I missed on Eris during the Erismed 3 port.
https://github.com/discordia-space/CEV-Eris/pull/6684

Also updates our shock.dm to reflect Eris' shock.dm pain-states.

## Changelog
:cl:
balance: Pain slowdown changes slightly.
balance: Less overall pain taken. Similar for oxyloss damage.
tweak: Redoes shock.dm stages of pain to make paincrit hit less commonly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
