### PR TITLE
Ammo Fab access for the people(the security people)

### DIFF
--- a/code/game/machinery/autolathe/fabricators.dm
+++ b/code/game/machinery/autolathe/fabricators.dm
@@ -291,10 +291,10 @@
 	return
 
 /obj/machinery/bulletfabricator/attackby(var/obj/item/I, var/mob/user)
-
+/*
 	if(!check_user(user))
 		return
-
+*/
 	if(istype(I, /obj/item/stack/material/cyborg))
 		return //Prevents borgs throwing their stuff into it
 
@@ -471,10 +471,10 @@
 
 	build_eff = man_rating
 	eat_eff = bin_rating
-
+/*
 /obj/machinery/bulletfabricator/proc/check_user(mob/user)
 	if(user.stats?.getPerk(PERK_HANDYMAN) || user.stats?.getPerk(PERK_GUNSMITH) || user.stat_check(STAT_MEC, STAT_LEVEL_EXPERT))
 		return TRUE
 	to_chat(user, SPAN_NOTICE("You don't know how to make the [src] work, you lack the training or mechanical skill."))
 	return FALSE
-
+*/


### PR DESCRIPTION
Removes the perk check on the bullet fab.

Why? The bullet fab is a great tool for security as a whole, but the fab being locked was something originally done because people would frequently break into the guild to use it when they weren't around where they'd likely suffer 0 consequence due to the guild being a low sec area. 

the fab is not in the guild anymore. It's in the Marshals. Breaking into the armory is a capital crime that carries extremely severe consequences. This change will empower those with access to use the thing when a Spec/WO isnt available which is a fairly frequent case. 

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
