### PR TITLE
Less Dump-Stat FBP Backgrounds & Welderproof Eyes

### DIFF
--- a/code/datums/setup_option/backgrounds/origin_synthetic.dm
+++ b/code/datums/setup_option/backgrounds/origin_synthetic.dm
@@ -30,11 +30,11 @@
 
 	stat_modifiers = list(
 		STAT_ROB = 0,
-		STAT_TGH = 15,
+		STAT_TGH = 5,
 		STAT_VIG = 0,
 		STAT_BIO = 0,
 		STAT_MEC = 15,
-		STAT_COG = 0
+		STAT_COG = 10
 	)
 
 /datum/category_item/setup_option/background/ethnicity/sot_synth_combat
@@ -49,9 +49,9 @@
 	restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 15,
-		STAT_TGH = 15,
-		STAT_VIG = 15,
+		STAT_ROB = 20,
+		STAT_TGH = 5,
+		STAT_VIG = 20,
 		STAT_BIO = 0,
 		STAT_MEC = -5,
 		STAT_COG = -5
@@ -89,12 +89,12 @@
 	restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 0,
-		STAT_TGH = 20,
-		STAT_VIG = 0,
+		STAT_ROB = 10,
+		STAT_TGH = 0,
+		STAT_VIG = 5,
 		STAT_BIO = 0,
 		STAT_MEC = 0,
-		STAT_COG = 15
+		STAT_COG = 20
 	)
 
 /datum/category_item/setup_option/background/ethnicity/ag_synth_mine
@@ -114,11 +114,11 @@
 
 	stat_modifiers = list(
 		STAT_ROB = 20,
-		STAT_TGH = 10,
+		STAT_TGH = 0,
 		STAT_VIG = 0,
 		STAT_BIO = 0,
-		STAT_MEC = 10,
-		STAT_COG = 0
+		STAT_MEC = 15,
+		STAT_COG = 5
 	)
 
 /datum/category_item/setup_option/background/ethnicity/blackshield_security
@@ -132,9 +132,9 @@
 	restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 15,
-		STAT_TGH = 15,
-		STAT_VIG = 15,
+		STAT_ROB = 20,
+		STAT_TGH = 5,
+		STAT_VIG = 20,
 		STAT_BIO = 0,
 		STAT_MEC = 0,
 		STAT_COG = 0
@@ -152,9 +152,9 @@
 	restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 20,
-		STAT_TGH = 20,
-		STAT_VIG = 0,
+		STAT_ROB = 30,
+		STAT_TGH = 10,
+		STAT_VIG = 5,
 		STAT_BIO = 0,
 		STAT_MEC = 0,
 		STAT_COG = 0
@@ -171,9 +171,9 @@
 	restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
-		STAT_ROB = 0,
-		STAT_TGH = 20,
-		STAT_VIG = 20,
+		STAT_ROB = 10,
+		STAT_TGH = 10,
+		STAT_VIG = 30,
 		STAT_BIO = 0,
 		STAT_MEC = 0,
 		STAT_COG = 0
@@ -210,9 +210,9 @@
 
 	//Compared to the soteria combat model and blackshield synths you get 20 armor across the body vs. 30/35 respectively, so what you lack in natural defense is made up in offense. -Kaz
 	stat_modifiers = list(
-		STAT_ROB = 20,
-		STAT_TGH = 20,
-		STAT_VIG = 20,
+		STAT_ROB = 25,
+		STAT_TGH = 10,
+		STAT_VIG = 25,
 		STAT_BIO = 0,
 		STAT_MEC = 0,
 		STAT_COG = 0
@@ -231,11 +231,11 @@
 
 	stat_modifiers = list(
 		STAT_ROB = 10,
-		STAT_TGH = 10,
+		STAT_TGH = 0,
 		STAT_VIG = 10,
-		STAT_BIO = 0, //Given 10 bio racially.
+		STAT_BIO = 5, //Given 10 bio racially.
 		STAT_MEC = 10,
-		STAT_COG = 10
+		STAT_COG = 15
 	)
 
 // FBP's lack a base racial bonus, what you see here is all they get.
@@ -250,11 +250,11 @@
 
 	stat_modifiers = list(
 		STAT_ROB = 15,
-		STAT_TGH = 15,
+		STAT_TGH = 0,
 		STAT_VIG = 15,
-		STAT_BIO = 15,
-		STAT_MEC = 15,
-		STAT_COG = 15
+		STAT_BIO = 20,
+		STAT_MEC = 20,
+		STAT_COG = 20
 	)
 
 /datum/category_item/setup_option/background/ethnicity/full_body_prosthetic_fighter
@@ -268,9 +268,9 @@
 	restricted_to_species = list(FORM_FBP, FORM_UNBRANDED)
 
 	stat_modifiers = list(
-		STAT_ROB = 25, // No inbuilt weapons.
-		STAT_TGH = 25,
-		STAT_VIG = 25,
+		STAT_ROB = 32, // No inbuilt weapons.
+		STAT_TGH = 10,
+		STAT_VIG = 32,
 		STAT_BIO = 0,
 		STAT_MEC = 0,
 		STAT_COG = 0

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -719,7 +719,7 @@
 	has_process = list(    // which required-process checks are conducted and default organs for them.
 		OP_CELL = /obj/item/organ/internal/cell,
 		BP_BRAIN = /obj/item/organ/internal/brain,
-		OP_EYES = /obj/item/organ/internal/eyes/prosthetic
+		OP_EYES = /obj/item/organ/internal/eyes/prosthetic/fbp
 		)
 
 	heat_discomfort_strings = list(
@@ -769,7 +769,7 @@
 	has_process = list(    // which required-process checks are conducted and default organs for them.
 		OP_CELL = /obj/item/organ/internal/cell,
 		BP_BRAIN = /obj/item/organ/internal/brain,
-		OP_EYES = /obj/item/organ/internal/eyes/prosthetic
+		OP_EYES = /obj/item/organ/internal/eyes/prosthetic/fbp
 		)
 
 	heat_discomfort_strings = list(
@@ -828,7 +828,7 @@
 	has_process = list(    // which required-process checks are conducted and default organs for them.
 		OP_CELL = /obj/item/organ/internal/cell,
 		BP_BRAIN = /obj/item/organ/internal/brain/synthetic,
-		OP_EYES = /obj/item/organ/internal/eyes/prosthetic
+		OP_EYES = /obj/item/organ/internal/eyes/prosthetic/fbp
 		)
 
 	heat_discomfort_strings = list(
@@ -891,7 +891,7 @@
 	has_process = list(    // which required-process checks are conducted and defalut organs for them.
 		OP_CELL = /obj/item/organ/internal/cell,
 		BP_BRAIN = /obj/item/organ/internal/brain/synthetic,
-		OP_EYES = /obj/item/organ/internal/eyes/prosthetic
+		OP_EYES = /obj/item/organ/internal/eyes/prosthetic/fbp
 		)
 
 	heat_discomfort_strings = list(
@@ -951,7 +951,7 @@
 	has_process = list(    // which required-process checks are conducted and default organs for them.
 		OP_CELL = /obj/item/organ/internal/cell,
 		BP_BRAIN = /obj/item/organ/internal/brain/synthetic,
-		OP_EYES = /obj/item/organ/internal/eyes/prosthetic
+		OP_EYES = /obj/item/organ/internal/eyes/prosthetic/fbp
 		)
 
 	heat_discomfort_strings = list(
@@ -1012,7 +1012,7 @@
 	has_process = list(    // which required-process checks are conducted and default organs for them.
 		OP_CELL = /obj/item/organ/internal/cell,
 		BP_BRAIN = /obj/item/organ/internal/brain/synthetic,
-		OP_EYES = /obj/item/organ/internal/eyes/prosthetic
+		OP_EYES = /obj/item/organ/internal/eyes/prosthetic/fbp
 		)
 
 	heat_discomfort_strings = list(
@@ -1072,7 +1072,7 @@
 	has_process = list(    // which required-process checks are conducted and default organs for them.
 		OP_CELL = /obj/item/organ/internal/cell,
 		BP_BRAIN = /obj/item/organ/internal/brain/synthetic,
-		OP_EYES = /obj/item/organ/internal/eyes/prosthetic
+		OP_EYES = /obj/item/organ/internal/eyes/prosthetic/fbp
 		)
 
 	heat_discomfort_strings = list(

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -34,6 +34,12 @@
 	matter = list(MATERIAL_STEEL = 1)
 	organ_efficiency = list(OP_EYES = 200)
 
+/obj/item/organ/internal/eyes/prosthetic/fbp
+	name = "advanced optical sensors"
+	desc = "A pair of advanced optical sensors, providing sight for synthetics."
+	price_tag = 200
+	var/flash_protection = FLASH_PROTECTION_MODERATE	//For welding
+
 /obj/item/organ/internal/eyes/proc/get_icon()
 	var/icon/eyes_icon = new/icon('icons/mob/human_face.dmi', "eye_l")
 	eyes_icon.Blend(icon('icons/mob/human_face.dmi', "eye_r"), ICON_OVERLAY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Complaint was levied how useless toughness is on FBPs besides countering grabs; so I've taken most of the toughness-additions away and replaced it into other more useful stats.

Added FBPs to have welder-proof eyes now. This should prevent issues regarding welding. FBPs can no longer be flash-stunned but - who the hell cares, the instant go-to anyway for dealing with them is ions or lethals half the time anyway.

## Changelog
:cl:
tweak: Removes most toughness additions to FBP perks.
add: Addes new welder-proof eyes.
/:cl: