### PR TITLE
Exalt Nerve Fix

### DIFF
--- a/code/modules/organs/internal/nerves.dm
+++ b/code/modules/organs/internal/nerves.dm
@@ -52,7 +52,7 @@
 	name = "exalt nerve synapses"
 	desc = "Extra sensitive to poorness. This exalted organ is bigger and more complex than standard nerves.\
 	Likely worth more on the black market."
-	organ_efficiency = list(OP_NERVE = 120)
+	organ_efficiency = list(OP_NERVE = 105)
 	price_tag = 125
 
 /obj/item/organ/internal/nerve/sensitive_nerve/exalt_leg


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This was originally left open for vote but - funny story - TURNS OUT that you can't even use oxycodone as an Exalt because ALL the nerves in your body fire when hit, making even oxycodone in surgery ineffective.

So sedatives didn't even fully work properly on Exalts. I tried. RIP.

## Changelog
:cl:
fixes: Exalts no longer are basically immune to painkillers due to being such special snowflakes. Intended to follow the vote, after testing with a player - proved surgery using sedatives can't even be done on them. RIP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
