### PR TITLE
more stuff into TGUI and a small cryo buff? (somewhat of a Guild nerf)

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -186,9 +186,9 @@
 		to_chat(user, SPAN_WARNING("Access denied."))
 		return
 	usr.set_machine(src)
-	nano_ui_interact(user)
+	ui_interact(user) //routed to TGUI
 	return
-
+/*
 /obj/machinery/atmospherics/binary/passive_gate/nano_ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = NANOUI_FOCUS)
 	if(stat & (BROKEN|NOPOWER))
 		return
@@ -256,7 +256,7 @@
 	src.update_icon()
 	src.add_fingerprint(usr)
 	return
-
+*/
 /obj/machinery/atmospherics/binary/passive_gate/attackby(var/obj/item/I, var/mob/user)
 	if(!(QUALITY_BOLT_TURNING in I.tool_qualities))
 		return ..()
@@ -278,6 +278,42 @@
 		investigate_log("was unfastened by [key_name(user)]", "atmos")
 		new /obj/item/pipe(loc, make_from=src)
 		qdel(src)
+
+/obj/machinery/atmospherics/binary/passive_gate/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "AtmosPump", name)
+		ui.open()
+
+/obj/machinery/atmospherics/binary/passive_gate/ui_data()
+	var/data = list()
+	data["on"] = unlocked
+	data["pressure"] = round(target_pressure)
+	data["max_pressure"] = round(max_pressure_setting)
+	return data
+
+/obj/machinery/atmospherics/binary/passive_gate/ui_act(action, params)
+	. = ..()
+	if(.)
+		return
+	switch(action)
+		if("power")
+			unlocked = !unlocked
+			investigate_log("was [unlocked ? "disabled" : "enabled"] by [key_name(usr)]", "atmos")
+			. = TRUE
+		if("pressure")
+			var/pressure = params["pressure"]
+			if(pressure == "max")
+				pressure = max_pressure_setting
+				. = TRUE
+			else if(text2num(pressure) != null)
+				pressure = text2num(pressure)
+				. = TRUE
+			if(.)
+				target_pressure = clamp(pressure, 0, ONE_ATMOSPHERE*100)
+				investigate_log("had it's pressure changed to [target_pressure] by [key_name(usr)]", "atmos")
+	update_icon()
+
 
 #undef REGULATE_NONE
 #undef REGULATE_INPUT

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -20,6 +20,7 @@
 	var/obj/item/reagent_containers/glass/beaker = null
 
 	var/current_heat_capacity = 50
+	var/autoeject = FALSE
 
 /obj/machinery/atmospherics/unary/cryo_cell/New()
 	..()
@@ -72,7 +73,7 @@
 	if(!user.stats?.getPerk(PERK_MEDICAL_EXPERT) && !user.stat_check(STAT_BIO, STAT_LEVEL_BASIC) && !usr.stat_check(STAT_COG, 30)) //Are we missing the perk AND to low on bio? Cog needs 30 as bio is 15
 		to_chat(usr, SPAN_WARNING("Your biological understanding isn't enough to use this."))
 		return
-	nano_ui_interact(user)
+	ui_interact(user) //routed to TGUI
 
  /**
   * The nano_ui_interact proc is used to open and update Nano UIs
@@ -85,6 +86,7 @@
   *
   * @return nothing
   */
+  /*
 /obj/machinery/atmospherics/unary/cryo_cell/nano_ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = NANOUI_FOCUS)
 
 	if(user == occupant || user.stat)
@@ -175,7 +177,7 @@
 	add_fingerprint(usr)
 	playsound(loc, 'sound/machines/machine_switch.ogg', 100, 1)
 	return 1 // update UIs attached to this object
-
+*/
 /obj/machinery/atmospherics/unary/cryo_cell/affect_grab(var/mob/user, var/mob/target)
 	for(var/mob/living/carbon/slime/M in range(1,target))
 		if(M.Victim == target)
@@ -253,6 +255,8 @@
 		var/has_cryo_medicine = has_cryo || has_clonexa
 		if(beaker && !has_cryo_medicine)
 			beaker.reagents.trans_to_mob(occupant, 1, CHEM_BLOOD)
+		if ((occupant.health == occupant.maxHealth) && autoeject == TRUE )
+			go_out()
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/heat_gas_contents()
 	if(air_contents.total_moles < 1)
@@ -391,3 +395,78 @@
 
 /datum/data/function/proc/display()
 	return
+
+//tgui stuff
+/obj/machinery/atmospherics/unary/cryo_cell/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "Cryo", name)
+		ui.open()
+
+/obj/machinery/atmospherics/unary/cryo_cell/ui_data()
+	var/list/data = list()
+	data["isOperating"] = on
+	data["hasOccupant"] = occupant ? TRUE : FALSE
+	//data["isOpen"] = state_open
+	data["autoEject"] = autoeject
+
+	data["occupant"] = list()
+	if(occupant)
+		var/mob/living/mob_occupant = occupant
+		data["occupant"]["name"] = mob_occupant.name
+		if(mob_occupant.stat == DEAD)
+			data["occupant"]["stat"] = "Dead"
+			data["occupant"]["statstate"] = "bad"
+		else if (mob_occupant.stat == UNCONSCIOUS)
+			data["occupant"]["stat"] = "Unconscious"
+			data["occupant"]["statstate"] = "good"
+		else
+			data["occupant"]["stat"] = "Conscious"
+			data["occupant"]["statstate"] = "bad"
+
+		data["occupant"]["bodyTemperature"] = round(mob_occupant.bodytemperature, 1)
+		if(mob_occupant.bodytemperature < T0C) // Green if the mob can actually be healed by cryoxadone.
+			data["occupant"]["temperaturestatus"] = "good"
+		else
+			data["occupant"]["temperaturestatus"] = "bad"
+
+		data["occupant"]["health"] = round(mob_occupant.health, 1)
+		data["occupant"]["maxHealth"] = mob_occupant.maxHealth
+		data["occupant"]["minHealth"] = HEALTH_THRESHOLD_DEAD
+		data["occupant"]["bruteLoss"] = round(mob_occupant.getBruteLoss(), 1)
+		data["occupant"]["oxyLoss"] = round(mob_occupant.getOxyLoss(), 1)
+		data["occupant"]["toxLoss"] = round(mob_occupant.getToxLoss(), 1)
+		data["occupant"]["fireLoss"] = round(mob_occupant.getFireLoss(), 1)
+
+	var/datum/gas_mixture/air1 = air_contents
+	data["cellTemperature"] = round(air1.temperature, 1)
+
+	data["isBeakerLoaded"] = beaker ? TRUE : FALSE
+	var/beakerContents = list()
+	if(beaker && beaker.reagents && beaker.reagents.reagent_list.len)
+		for(var/datum/reagent/R in beaker.reagents.reagent_list)
+			beakerContents += list(list("name" = R.name, "volume" = R.volume))
+	data["beakerContents"] = beakerContents
+	return data
+
+/obj/machinery/atmospherics/unary/cryo_cell/ui_act(action, params)
+	. = ..()
+	if(.)
+		return
+	switch(action)
+		if("power")
+			on=!on
+			update_icon()
+			. = TRUE
+		if("door")
+			go_out()
+		if("autoeject")
+			autoeject = !autoeject
+			. = TRUE
+		if("ejectbeaker")
+			if(beaker)
+				beaker.forceMove(drop_location())
+				if(Adjacent(usr) && !issilicon(usr))
+					usr.put_in_hands(beaker)
+				beaker = null
+				. = TRUE

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -258,7 +258,7 @@
 		if ((occupant.health == occupant.maxHealth) && autoeject == TRUE )
 			go_out()
 			on=!on
-			update_icons()
+			update_icon()
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/heat_gas_contents()
 	if(air_contents.total_moles < 1)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -257,6 +257,8 @@
 			beaker.reagents.trans_to_mob(occupant, 1, CHEM_BLOOD)
 		if ((occupant.health == occupant.maxHealth) && autoeject == TRUE )
 			go_out()
+			on=!on
+			update_icons()
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/heat_gas_contents()
 	if(air_contents.total_moles < 1)

--- a/tgui/packages/tgui/interfaces/Cryo.js
+++ b/tgui/packages/tgui/interfaces/Cryo.js
@@ -84,7 +84,7 @@ const CryoContent = (props, context) => {
           <LabeledList.Item label="Temperature">
             <AnimatedNumber value={data.cellTemperature} /> K
           </LabeledList.Item>
-          <LabeledList.Item label="Door">
+          <LabeledList.Item label="Eject">
             <Button
               icon={data.isOpen ? 'unlock' : 'lock'}
               onClick={() => act('door')}

--- a/tgui/packages/tgui/interfaces/Cryo.js
+++ b/tgui/packages/tgui/interfaces/Cryo.js
@@ -84,7 +84,7 @@ const CryoContent = (props, context) => {
           <LabeledList.Item label="Temperature">
             <AnimatedNumber value={data.cellTemperature} /> K
           </LabeledList.Item>
-          <LabeledList.Item label="Eject">
+          <LabeledList.Item label="Door">
             <Button
               icon={data.isOpen ? 'unlock' : 'lock'}
               onClick={() => act('door')}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	pumps, passive pumps and cryo cells now use TGUI, cryo also got autoeject functionality that is rudimentary, but works
</summary>
<hr>
the door button on the cryo menu will eject people, I can't edit the Cryo.js to change that button to Eject 😔 , also the autoeject only cares about the occupants health in relation to it's max health, if the occupant can't reach max health for any reason, it will not autoeject
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
add: cryo now has an autoeject function, it starts off, will eject and turn off the cryo **if the occupant is at full health**
tweak: gas pumps now use TGUI
tweak: passive gas pumps now use TGUI
tweak: cryo cells now use TGUI, door button will eject occupant (because I can't edit the associated .js properly, sorry)
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
