### PR TITLE
Abandoned Safehouse

### DIFF
--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -553,10 +553,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"ci" = (
-/obj/structure/reagent_dispensers/fueltank/huge/derelict,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/dungeon/outside/safehouse)
 "cj" = (
 /obj/structure/catwalk,
 /obj/structure/table/steel_reinforced,
@@ -2097,6 +2093,16 @@
 "hv" = (
 /turf/unsimulated/mineral/transition,
 /area/colony/exposedsun/pastgate)
+"hw" = (
+/obj/structure/table/rack/shelf,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/random/gun_normal,
+/obj/random/melee/low_chance,
+/obj/random/ammo_lowcost,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "hx" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/ausbushes/grassybush,
@@ -2680,6 +2686,12 @@
 /obj/random/material_rare/low_chance,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"jr" = (
+/obj/machinery/door/airlock/sandstone{
+	name = "Generator Room"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "jt" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/under,
@@ -3174,12 +3186,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
-"le" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/dungeon/outside/safehouse)
 "lf" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3895,10 +3901,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
-"nC" = (
-/obj/random/mob/voidwolf,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/safehouse)
 "nD" = (
 /obj/machinery/door/window/southright,
 /obj/machinery/door/window/northleft,
@@ -5301,12 +5303,10 @@
 "sN" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/monster_cave)
-"sO" = (
-/obj/structure/table/rack/shelf,
-/obj/random/contraband/low_chance,
-/obj/random/contraband/low_chance,
-/obj/random/common_oddities,
-/turf/simulated/floor/wood/wild1,
+"sP" = (
+/obj/machinery/light/small,
+/obj/random/tool/low_chance,
+/turf/simulated/floor/wood/wild3,
 /area/nadezhda/dungeon/outside/safehouse)
 "sQ" = (
 /obj/structure/flora/big/bush3,
@@ -5879,6 +5879,15 @@
 /obj/item/oddity/common/old_knife,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"uR" = (
+/obj/structure/closet/crate/serbcrate,
+/obj/item/stack/material/steel/full,
+/obj/random/furniture/bedsheet,
+/obj/random/furniture/bedsheet,
+/obj/random/furniture/bedsheetdouble,
+/obj/random/furniture/bedsheetdouble,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "uS" = (
 /obj/item/remains/unathi,
 /obj/effect/decal/cleanable/blood,
@@ -6078,14 +6087,6 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"vD" = (
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/structure/table/marble,
-/obj/random/rations,
-/obj/random/rations,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/safehouse)
 "vE" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/small/bushb1,
@@ -6167,6 +6168,11 @@
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"vR" = (
+/obj/structure/table/onestar,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "vS" = (
 /obj/structure/flora/small/bushc3,
 /turf/unsimulated/wall/jungle,
@@ -6190,6 +6196,12 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"vX" = (
+/obj/structure/table/onestar,
+/obj/random/gun_cheap/low_chance,
+/obj/random/firstaid/low_chance,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "vY" = (
 /obj/item/mine_old{
 	layer = 2.6
@@ -6878,6 +6890,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"yj" = (
+/obj/structure/table/rack/shelf,
+/obj/item/circuitboard/apc,
+/obj/item/stack/cable_coil,
+/obj/item/tool/multitool/improvised,
+/obj/item/clothing/gloves/insulated,
+/obj/item/frame/apc,
+/obj/random/powercell/large_safe,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/random/tool_upgrade/low_chance,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "yk" = (
 /obj/random/structures,
 /obj/machinery/light,
@@ -6983,11 +7007,10 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"yF" = (
-/obj/structure/flora/big/bush1,
-/obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/meadow)
+"yE" = (
+/obj/random/mob/voidwolf,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "yG" = (
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
@@ -7139,6 +7162,13 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"zi" = (
+/obj/structure/table/rack/shelf,
+/obj/random/contraband/low_chance,
+/obj/random/contraband/low_chance,
+/obj/random/common_oddities,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "zl" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushb1,
@@ -7226,11 +7256,6 @@
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"zG" = (
-/obj/machinery/light/small,
-/obj/random/tool/low_chance,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/dungeon/outside/safehouse)
 "zH" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/big/bush2,
@@ -7248,6 +7273,14 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"zM" = (
+/obj/machinery/door/airlock/vault{
+	id_tag = "safehousebolts";
+	name = "Safehouse"
+	},
+/obj/structure/invislight,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "zN" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/big/bush2,
@@ -7337,6 +7370,12 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/colony/exposedsun/pastgate)
+"Ai" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "Aj" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/big/bush2,
@@ -7357,10 +7396,6 @@
 /area/nadezhda/outside/meadow)
 "An" = (
 /obj/structure/flora/small/bushc1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/meadow)
-"Ao" = (
-/obj/item/beartrap/armed,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "Ap" = (
@@ -7531,6 +7566,10 @@
 /obj/structure/flora/small/bushb2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"Ba" = (
+/obj/structure/reagent_dispensers/fueltank/huge/derelict,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "Bb" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood_old,
@@ -7681,10 +7720,6 @@
 /obj/structure/lattice,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
-"BG" = (
-/obj/random/mob/voidwolf/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/safehouse)
 "BH" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/small/busha1,
@@ -7734,11 +7769,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"BV" = (
-/obj/item/toy/plushie/cat/siamese,
-/mob/living/carbon/superior_animal/human/voidwolf,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/dungeon/outside/safehouse)
 "BW" = (
 /obj/structure/flora/small/grassb1,
 /obj/structure/flora/small/busha1,
@@ -8185,22 +8215,15 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"DL" = (
-/obj/structure/table/rack/shelf,
-/obj/item/circuitboard/apc,
-/obj/item/stack/cable_coil,
-/obj/item/tool/multitool/improvised,
-/obj/item/clothing/gloves/insulated,
-/obj/item/frame/apc,
-/obj/random/powercell/large_safe,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/random/tool_upgrade/low_chance,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/dungeon/outside/safehouse)
 "DM" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/meadow)
+"DN" = (
+/obj/structure/flora/big/bush1,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "DO" = (
 /obj/random/mob/roomba/range,
@@ -8429,12 +8452,6 @@
 /obj/random/traps,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"EK" = (
-/obj/structure/table/onestar,
-/obj/item/flame/lighter/zippo/black,
-/obj/random/cigarettes,
-/turf/simulated/floor/carpet,
-/area/nadezhda/dungeon/outside/safehouse)
 "EL" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/big/bush2,
@@ -8842,16 +8859,6 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"Gt" = (
-/obj/structure/table/rack/shelf,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/random/gun_normal,
-/obj/random/melee/low_chance,
-/obj/random/ammo_lowcost,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/dungeon/outside/safehouse)
 "Gu" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/big/bush2{
@@ -9170,12 +9177,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
-"HI" = (
-/obj/structure/table/standard,
-/obj/item/oddity/common/towel,
-/obj/item/soap/nanotrasen,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/safehouse)
 "HJ" = (
 /obj/structure/flora/small/bushc1,
 /obj/structure/flora/small/busha3,
@@ -9285,9 +9286,6 @@
 /obj/machinery/power/smes/buildable,
 /turf/simulated/shuttle/floor/mining,
 /area/colony/exposedsun/crashed_shop/outsider)
-"If" = (
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/dungeon/outside/safehouse)
 "Ig" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/busha2,
@@ -9404,6 +9402,11 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"IA" = (
+/obj/structure/table/rack/shelf,
+/obj/random/junkfood/onlypizza,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "IB" = (
 /obj/item/oddity/common/healthscanner,
 /turf/simulated/floor/tiled/white/panels,
@@ -10436,14 +10439,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
-"Mq" = (
-/obj/machinery/door/airlock/vault{
-	id_tag = "safehousebolts";
-	name = "Safehouse"
-	},
-/obj/structure/invislight,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/safehouse)
 "Mr" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10459,6 +10454,14 @@
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"Mu" = (
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/structure/table/marble,
+/obj/random/rations,
+/obj/random/rations,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "Mv" = (
 /mob/living/simple_animal/hostile/republicon,
 /turf/unsimulated/mineral,
@@ -10541,6 +10544,11 @@
 /obj/random/junkfood/onlypizza,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
+"ML" = (
+/obj/structure/table/marble,
+/obj/random/junkfood,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "MM" = (
 /turf/simulated/shuttle/floor/mining,
 /area/colony/exposedsun/crashed_shop/outsider)
@@ -10561,11 +10569,6 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
 "MP" = (
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/safehouse)
-"MQ" = (
-/obj/structure/table/marble,
-/obj/random/junkfood,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
 "MR" = (
@@ -10806,9 +10809,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
 "NH" = (
-/obj/structure/table/marble,
-/obj/random/junkfood/low_chance,
-/turf/simulated/floor/wood/wild5,
+/obj/structure/table/standard,
+/obj/item/oddity/common/towel,
+/obj/item/soap/nanotrasen,
+/turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
 "NI" = (
 /obj/structure/bed/chair/sofa/black{
@@ -10891,6 +10895,10 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"Ob" = (
+/obj/random/mob/voidwolf,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "Oc" = (
 /obj/item/trash/cigbutt/ishimura,
 /turf/simulated/floor/tiled/derelict,
@@ -10899,6 +10907,11 @@
 /obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/meadow)
+"Oe" = (
+/obj/structure/table/marble,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "Of" = (
 /obj/structure/sign/departmentold/medical1,
 /obj/structure/window/reinforced{
@@ -11195,11 +11208,6 @@
 /obj/random/oddity_guns,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"Pt" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/big/bush1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/meadow)
 "Pu" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	locked = 1;
@@ -11360,12 +11368,6 @@
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"PZ" = (
-/obj/machinery/door/airlock/sandstone{
-	name = "Generator Room"
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/dungeon/outside/safehouse)
 "Qa" = (
 /obj/effect/floor_decal/industrial/loading/white,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -11518,6 +11520,11 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"QF" = (
+/obj/structure/table/reinforced,
+/obj/random/credits/c5000,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "QG" = (
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/mineral/planet,
@@ -11716,27 +11723,6 @@
 /mob/living/carbon/superior_animal/human/voidwolf/ranged/aerotrooper,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"Rr" = (
-/obj/structure/closet/crate/serbcrate,
-/obj/item/bedsheet/hos{
-	folded = 1;
-	icon_state = "sheet-folded"
-	},
-/obj/item/bedsheet/hos{
-	folded = 1;
-	icon_state = "sheet-folded"
-	},
-/obj/item/bedsheet/hosdouble{
-	folded = 1;
-	icon_state = "sheet-folded"
-	},
-/obj/item/bedsheet/hosdouble{
-	folded = 1;
-	icon_state = "sheet-folded"
-	},
-/obj/item/stack/material/steel/full,
-/turf/simulated/floor/carpet,
-/area/nadezhda/dungeon/outside/safehouse)
 "Rs" = (
 /obj/item/stack/material/cardboard/random,
 /obj/item/stack/material/cardboard/random,
@@ -12046,6 +12032,11 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
+"SC" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
 "SD" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -12112,10 +12103,6 @@
 /obj/item/trash/cigbutt/toha,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"SQ" = (
-/obj/random/mob/voidwolf,
-/turf/simulated/floor/carpet,
-/area/nadezhda/dungeon/outside/safehouse)
 "SR" = (
 /obj/structure/bed/chair/custom/onestar{
 	dir = 1
@@ -12221,6 +12208,10 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"Tl" = (
+/obj/item/beartrap/armed,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
 "Tm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/steel_reinforced,
@@ -12854,11 +12845,6 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"VB" = (
-/obj/structure/table/onestar,
-/obj/random/gun_cheap/low_chance,
-/turf/simulated/floor/carpet,
-/area/nadezhda/dungeon/outside/safehouse)
 "VC" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/syndie_kit/chameleon,
@@ -13036,6 +13022,11 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"Wi" = (
+/obj/item/toy/plushie/cat/siamese,
+/mob/living/carbon/superior_animal/human/voidwolf,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "Wj" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/cloth/armor/low_chance,
@@ -13393,9 +13384,10 @@
 /obj/machinery/door/airlock/highsecurity,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
-"XM" = (
+"XL" = (
 /obj/structure/table/onestar,
-/obj/random/junkfood/low_chance,
+/obj/item/flame/lighter/zippo/black,
+/obj/random/cigarettes,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/safehouse)
 "XN" = (
@@ -13481,6 +13473,9 @@
 /obj/random/junkfood,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"Yc" = (
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "Yd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13936,10 +13931,9 @@
 /obj/structure/scrap/medical/large,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
-"ZR" = (
-/obj/structure/table/reinforced,
-/obj/random/credits/c5000,
-/turf/simulated/floor/wood/wild1,
+"ZS" = (
+/obj/random/mob/voidwolf/low_chance,
+/turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
 "ZT" = (
 /obj/structure/salvageable/console_os{
@@ -72285,12 +72279,12 @@ gf
 gf
 gf
 vL
-sO
-le
+zi
+Ai
 vL
 MP
 vL
-Rr
+uR
 BC
 Bd
 vL
@@ -72494,8 +72488,8 @@ gf
 gf
 gf
 vL
-Gt
-BV
+hw
+Wi
 za
 MP
 hf
@@ -72704,7 +72698,7 @@ gf
 gf
 vL
 Ap
-ZR
+QF
 vL
 MP
 vL
@@ -72915,7 +72909,7 @@ vL
 vL
 vL
 vL
-BG
+ZS
 vL
 vL
 vL
@@ -73328,11 +73322,11 @@ CC
 gf
 vL
 vy
-ci
+Ba
 vL
 TW
-EK
-XM
+XL
+vR
 MP
 zU
 Xt
@@ -73537,12 +73531,12 @@ CC
 gf
 vL
 tt
-zG
+sP
 vL
 VJ
 Qm
-VB
-nC
+vX
+yE
 zU
 Xt
 GD
@@ -73745,17 +73739,17 @@ Cp
 hA
 gf
 vL
-DL
-If
-PZ
-SQ
+yj
+Yc
+jr
+Ob
 BC
 BC
 MP
 zU
 Xt
 GD
-vD
+Mu
 vL
 fF
 "}
@@ -74163,14 +74157,14 @@ hA
 hA
 gf
 vL
-HI
+NH
 GD
 SB
 MP
 MP
-BG
+ZS
 TT
-MQ
+ML
 GD
 GD
 Xy
@@ -74379,7 +74373,7 @@ Mk
 Lv
 MP
 TT
-NH
+Oe
 Ar
 GD
 Xy
@@ -75004,7 +74998,7 @@ IU
 IU
 IU
 IU
-Mq
+zM
 IU
 IU
 IU
@@ -75217,7 +75211,7 @@ vJ
 zL
 DB
 IU
-WA
+IA
 GD
 vL
 fF
@@ -75426,7 +75420,7 @@ zL
 vJ
 Et
 IU
-WA
+GD
 TF
 vL
 fF
@@ -75636,7 +75630,7 @@ gf
 gf
 vL
 WA
-GD
+WA
 vL
 fF
 "}
@@ -75839,7 +75833,7 @@ hA
 hA
 hA
 hA
-Ao
+Tl
 gf
 gf
 fE
@@ -76884,7 +76878,7 @@ hW
 hW
 BL
 CC
-Pt
+SC
 gf
 fE
 fE
@@ -77092,7 +77086,7 @@ hW
 hW
 hW
 hW
-yF
+DN
 vJ
 gf
 fE

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -1788,10 +1788,6 @@
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/asteroid/rogue)
-"gq" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
 "gr" = (
 /obj/structure/flora/small/lavarock1,
 /turf/simulated/floor/asteroid/dirt,
@@ -2009,14 +2005,16 @@
 /obj/structure/invislightsmall,
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
-"hd" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
 "he" = (
 /obj/structure/table/bench/steel,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"hf" = (
+/obj/machinery/door/airlock/glass{
+	name = "Bunkhouse"
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "hg" = (
 /obj/effect/step_trigger/surface_to_forest_2_A,
 /turf/simulated/floor/asteroid/dirt,
@@ -2028,6 +2026,12 @@
 "hi" = (
 /turf/unsimulated/mineral,
 /area/asteroid/rogue)
+"hk" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/grille,
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
 "hl" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/burned,
@@ -2386,6 +2390,14 @@
 /obj/random/tool_upgrade/rare/low_chance,
 /turf/simulated/floor/tiled/dark/orangecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"iE" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/railing,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/safehouse)
 "iF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -2891,9 +2903,10 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "kl" = (
-/obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
+/obj/item/bedsheet/hos,
+/obj/structure/bed,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "km" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -3877,6 +3890,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
+"nC" = (
+/obj/structure/table/onestar,
+/obj/item/flame/lighter/zippo/black,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "nD" = (
 /obj/machinery/door/window/southright,
 /obj/machinery/door/window/northleft,
@@ -4485,11 +4503,6 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"pR" = (
-/obj/structure/table/standard,
-/obj/item/oddity/common/towel,
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
 "pS" = (
 /obj/structure/bed/chair/custom/onestar{
 	dir = 1
@@ -5338,6 +5351,15 @@
 	},
 /turf/simulated/floor/wood_old,
 /area/colony/exposedsun/crashed_shop/outsider)
+"tb" = (
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "tc" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -5469,6 +5491,13 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"tt" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/safehouse)
 "tu" = (
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -6011,6 +6040,14 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"vy" = (
+/obj/machinery/power/port_gen/pacman/diesel/anchored,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/safehouse)
 "vz" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/random/lowkeyrandom/low_chance,
@@ -6028,10 +6065,6 @@
 /area/nadezhda/outside/one_star)
 "vC" = (
 /obj/structure/flora/small/bushb1,
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
-"vD" = (
-/obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
 "vE" = (
@@ -6078,9 +6111,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
 "vL" = (
-/obj/structure/flora/small/bushb2,
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
+/turf/simulated/wall/r_wall,
+/area/nadezhda/dungeon/outside/safehouse)
 "vM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -6876,6 +6908,14 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"ys" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/deferred/crate/alcohol,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "yt" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/big/bush3,
@@ -6885,10 +6925,6 @@
 /obj/structure/flora/small/grassb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"yv" = (
-/obj/item/stool/custom/bar_special,
-/turf/simulated/floor/wood/wild5,
-/area/colony/exposedsun/pastgate)
 "yw" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -7038,6 +7074,14 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"yZ" = (
+/obj/machinery/light,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
+"za" = (
+/obj/machinery/door/airlock/vault,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "zc" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/random/traps,
@@ -7079,11 +7123,6 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
-"zi" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/beer,
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
 "zl" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushb1,
@@ -7222,14 +7261,9 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
 "zU" = (
-/obj/structure/mirror{
-	pixel_y = 30
-	},
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/colony/exposedsun/pastgate)
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "zW" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -7240,6 +7274,10 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"zY" = (
+/obj/structure/reagent_dispensers/fueltank/huge/derelict,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/safehouse)
 "Aa" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/hypospray/autoinjector/drugs,
@@ -7287,6 +7325,11 @@
 /obj/structure/flora/big/bush2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"Ak" = (
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/beer,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "Al" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/unsimulated/wall/jungle,
@@ -7299,6 +7342,15 @@
 /obj/structure/flora/small/bushc1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"Ap" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/deferred/crate/alcohol,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
+"Ar" = (
+/obj/item/stool/custom/bar_special,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "As" = (
 /obj/structure/flora/small/bushc3,
 /obj/random/flora/jungle_tree,
@@ -7401,6 +7453,15 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
+"AM" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/dungeon/outside/safehouse)
 "AN" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
@@ -7458,6 +7519,25 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"Bd" = (
+/obj/structure/closet/crate/serbcrate_gray,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/under/bdu/black,
+/obj/item/clothing/under/bdu/black,
+/obj/item/clothing/under/bdu/black,
+/obj/item/clothing/under/bdu/black,
+/obj/item/clothing/under/bdu/black,
+/obj/item/clothing/gloves/thick,
+/obj/item/clothing/gloves/thick,
+/obj/item/clothing/gloves/thick,
+/obj/item/clothing/gloves/thick,
+/obj/item/clothing/gloves/thick,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "Bf" = (
 /obj/structure/flora/small/bushc3,
 /obj/structure/flora/small/bushc3,
@@ -7536,11 +7616,22 @@
 /obj/random/traps,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"Bx" = (
+/obj/structure/urinal{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/dungeon/outside/safehouse)
 "By" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"Bz" = (
+/obj/structure/table/marble,
+/obj/item/storage/box/drinkingglasses,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "BA" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -7552,6 +7643,9 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"BC" = (
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "BD" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush2,
@@ -7615,6 +7709,13 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"BV" = (
+/obj/machinery/door/airlock/vault{
+	id_tag = "safehousebolts";
+	name = "Safehouse"
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "BW" = (
 /obj/structure/flora/small/grassb1,
 /obj/structure/flora/small/busha1,
@@ -7712,6 +7813,12 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
+"Co" = (
+/obj/machinery/door/airlock/sandstone{
+	name = "Generator Room"
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "Cp" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/mineral/planet,
@@ -7735,12 +7842,6 @@
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"Cu" = (
-/obj/structure/urinal{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/colony/exposedsun/pastgate)
 "Cv" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/random/traps,
@@ -8136,6 +8237,11 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
+"Eb" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/hosdouble,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "Ec" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/small/bushb2,
@@ -8299,15 +8405,6 @@
 /obj/random/traps,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"EK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/colony/exposedsun/pastgate)
 "EL" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/big/bush2,
@@ -8328,6 +8425,10 @@
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
+"EP" = (
+/obj/structure/table/marble,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "EQ" = (
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
@@ -8690,6 +8791,10 @@
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"Go" = (
+/obj/machinery/door/airlock/freezer,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "Gq" = (
 /turf/simulated/shuttle/wall/cargo{
 	icon_state = "cargoshwall3";
@@ -8753,9 +8858,8 @@
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
 "GD" = (
-/obj/structure/bed/chair/sofa/black/left,
-/turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "GE" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/big/bush2,
@@ -8958,6 +9062,19 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"Hu" = (
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower"
+	},
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/dungeon/outside/safehouse)
 "Hv" = (
 /obj/structure/flora/small/grassa4,
 /obj/structure/flora/big/bush3,
@@ -9013,9 +9130,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
-"HI" = (
-/turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
 "HJ" = (
 /obj/structure/flora/small/bushc1,
 /obj/structure/flora/small/busha3,
@@ -9034,6 +9148,9 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"HM" = (
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/safehouse)
 "HN" = (
 /obj/machinery/light/floor,
 /obj/structure/table/rack/shelf,
@@ -9177,12 +9294,21 @@
 /obj/item/clothing/gloves/thick/brown,
 /obj/item/clothing/gloves/thick/brown,
 /turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
+/area/nadezhda/dungeon/outside/safehouse)
 "Im" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"In" = (
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/dungeon/outside/safehouse)
 "Io" = (
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/beach/water/jungle,
@@ -9796,10 +9922,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
 "KE" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/small/busha1,
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
+/turf/simulated/floor/beach/water/ocean,
+/area/nadezhda/dungeon/outside/safehouse)
 "KF" = (
 /obj/item/folder/cyan,
 /obj/item/folder/cyan,
@@ -10046,12 +10170,13 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/zoo)
 "Lv" = (
-/obj/structure/table/reinforced,
-/obj/item/toy/weapon/katana,
-/obj/item/toy/weapon/crossbow,
-/obj/item/toy/weapon/sword,
-/turf/simulated/floor/wood/wild1,
-/area/colony/exposedsun/pastgate)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/safehouse)
 "Lw" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/salvageable/computer_os,
@@ -10244,6 +10369,13 @@
 "Mj" = (
 /turf/simulated/shuttle/wall/cargo,
 /area/colony/exposedsun/crashed_shop/outsider)
+"Mk" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/safehouse)
 "Ml" = (
 /obj/structure/flora/small/bushb2,
 /turf/simulated/mineral/planet,
@@ -10258,14 +10390,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
-"Mp" = (
-/obj/item/toy/plushie/cat/siamese,
-/turf/simulated/floor/wood/wild1,
-/area/colony/exposedsun/pastgate)
-"Mq" = (
-/obj/machinery/door/airlock/freezer,
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
 "Mr" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10324,10 +10448,13 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"MC" = (
-/obj/structure/closet/crate/secure/bin,
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
+"MB" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/weapon/katana,
+/obj/item/toy/weapon/crossbow,
+/obj/item/toy/weapon/sword,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "MD" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/mineral/planet,
@@ -10362,10 +10489,6 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"MJ" = (
-/obj/structure/table/marble,
-/turf/simulated/floor/wood/wild5,
-/area/colony/exposedsun/pastgate)
 "MK" = (
 /obj/structure/table/onestar,
 /obj/random/junkfood/onlypizza,
@@ -10390,12 +10513,9 @@
 /obj/item/oddity/common/old_money,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"MQ" = (
-/obj/structure/bed/chair/sofa/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
+"MP" = (
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "MR" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/bed/chair{
@@ -10436,11 +10556,6 @@
 /obj/structure/invislightsmall,
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/crashed_shop/outsider)
-"MZ" = (
-/obj/structure/table/onestar,
-/obj/item/flame/lighter/zippo/black,
-/turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
 "Na" = (
 /obj/structure/flora/small/busha3,
 /obj/random/traps/low_chance,
@@ -10638,23 +10753,12 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
-"NH" = (
-/obj/structure/table/rack/shelf,
-/obj/item/storage/deferred/crate/alcohol,
-/turf/simulated/floor/wood/wild1,
-/area/colony/exposedsun/pastgate)
 "NI" = (
-/obj/structure/table/onestar,
-/obj/item/storage/fancy/candle_box,
-/turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
-"NK" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/bed/chair/sofa/black{
+	dir = 4
 	},
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "NL" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark/danger,
@@ -10676,12 +10780,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"NQ" = (
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
 "NR" = (
 /obj/structure/scrap/medical/large,
 /obj/structure/table/marble,
@@ -10867,15 +10965,12 @@
 "OD" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
 /turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
-"OG" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
+/area/nadezhda/dungeon/outside/safehouse)
+"OH" = (
+/obj/structure/closet/crate/secure/bin,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "OI" = (
 /obj/structure/flora/big/bush2{
 	pixel_x = -13;
@@ -10910,6 +11005,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"OQ" = (
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "OR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10925,19 +11026,6 @@
 /obj/random/mob/vox,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"OV" = (
-/obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
-	},
-/obj/machinery/door/window{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/colony/exposedsun/pastgate)
 "OW" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall16";
@@ -11011,6 +11099,11 @@
 /obj/item/paper/Court,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"Pl" = (
+/obj/machinery/chemical_dispenser/soda,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "Pm" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall36";
@@ -11046,22 +11139,11 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"Pr" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/grille,
-/obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
 "Ps" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/random/oddity_guns,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"Pt" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/railing,
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
 "Pu" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	locked = 1;
@@ -11081,11 +11163,6 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"Px" = (
-/obj/structure/table/marble,
-/obj/machinery/microwave,
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
 "Py" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -11110,9 +11187,11 @@
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
 "PC" = (
-/obj/machinery/door/airlock/vault,
-/turf/simulated/floor/wood/wild1,
-/area/colony/exposedsun/pastgate)
+/obj/structure/bed/chair/sofa/black/corner{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "PD" = (
 /obj/structure/railing{
 	dir = 1
@@ -11173,10 +11252,6 @@
 /obj/item/storage/secure/briefcase,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"PN" = (
-/obj/machinery/door/airlock/sandstone,
-/turf/simulated/floor/wood/wild5,
-/area/colony/exposedsun/pastgate)
 "PO" = (
 /obj/machinery/light/floor{
 	dir = 8;
@@ -11210,6 +11285,17 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"PU" = (
+/obj/structure/table/rack/shelf,
+/obj/item/circuitboard/apc,
+/obj/item/stack/cable_coil,
+/obj/item/tool/multitool/improvised,
+/obj/item/clothing/gloves/insulated,
+/obj/item/frame/apc,
+/obj/random/powercell/large_safe,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/safehouse)
 "PV" = (
 /obj/structure/grille,
 /obj/structure/barricade,
@@ -11273,15 +11359,20 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "Qk" = (
-/obj/structure/bed/chair/sofa/black/right{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "Ql" = (
 /obj/structure/flora/small/bushb3,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"Qm" = (
+/obj/structure/table/onestar,
+/obj/item/storage/fancy/candle_box,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "Qn" = (
 /obj/structure/table/onestar,
 /obj/item/storage/fancy/cigarettes/toha,
@@ -11316,6 +11407,12 @@
 	tag = "icon-cargoshwall17"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"Qt" = (
+/obj/structure/table/marble,
+/obj/item/storage/box/drinkingglasses,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "Qv" = (
 /obj/random/mob/spiders,
 /turf/simulated/floor/wood/wild5,
@@ -11341,11 +11438,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
 "Qz" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/grille,
-/obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
+/obj/machinery/light,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "QA" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/unsimulated/mineral,
@@ -11372,10 +11467,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
-"QF" = (
-/obj/structure/table/onestar,
-/turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
 "QG" = (
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/mineral/planet,
@@ -11400,10 +11491,6 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"QL" = (
-/obj/structure/bed/chair/sofa/black,
-/turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
 "QM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -11578,10 +11665,6 @@
 /mob/living/carbon/superior_animal/human/voidwolf/ranged/aerotrooper,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"Rr" = (
-/obj/machinery/door/airlock/glass,
-/turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
 "Rs" = (
 /obj/item/stack/material/cardboard/random,
 /obj/item/stack/material/cardboard/random,
@@ -11627,10 +11710,6 @@
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"RA" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/wood/wild5,
-/area/colony/exposedsun/pastgate)
 "RB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11646,10 +11725,6 @@
 	tag = "icon-cargoshwall15"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"RD" = (
-/obj/machinery/door/airlock/glass,
-/turf/simulated/floor/wood/wild5,
-/area/colony/exposedsun/pastgate)
 "RE" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -11831,10 +11906,6 @@
 /obj/machinery/vending/cola,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"Sn" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/wood/wild5,
-/area/colony/exposedsun/pastgate)
 "So" = (
 /obj/structure/flora/small/busha3,
 /obj/random/mob/vox/low_chance,
@@ -11875,16 +11946,10 @@
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
 "Sv" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/drinks/milk,
-/obj/item/reagent_containers/food/drinks/milk,
+/obj/structure/table/standard,
+/obj/item/oddity/common/towel,
 /turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
+/area/nadezhda/dungeon/outside/safehouse)
 "Sw" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/material/shard,
@@ -11896,11 +11961,11 @@
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
 "Sy" = (
-/obj/structure/bed/chair/sofa/black/corner{
-	dir = 1
+/obj/machinery/door/airlock/glass{
+	name = "Kitchen"
 	},
-/turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "Sz" = (
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/outside/meadow)
@@ -11909,9 +11974,11 @@
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
 "SB" = (
-/obj/item/stool/custom/bar_special,
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
+/obj/machinery/door/airlock/sandstone{
+	name = "Bathroom"
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "SD" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -11979,8 +12046,9 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
 "SQ" = (
-/turf/simulated/floor/wood/wild5,
-/area/colony/exposedsun/pastgate)
+/obj/structure/table/onestar,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "SR" = (
 /obj/structure/bed/chair/custom/onestar{
 	dir = 1
@@ -12120,10 +12188,9 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "Ts" = (
-/obj/machinery/chemical_dispenser/soda,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
+/obj/item/toy/plushie/cat/siamese,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "Tt" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/syndie_kit/cigarette,
@@ -12172,6 +12239,10 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"TF" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "TG" = (
 /mob/living/simple_animal/hostile/hivebot{
 	health = 400
@@ -12239,6 +12310,10 @@
 /obj/structure/flora/small/bushc1,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"TT" = (
+/obj/item/stool/custom/bar_special,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "TU" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -12253,6 +12328,10 @@
 	},
 /turf/simulated/floor/wood_old,
 /area/colony/exposedsun/crashed_shop/outsider)
+"TW" = (
+/obj/structure/bed/chair/sofa/black,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "TX" = (
 /obj/structure/table/onestar,
 /obj/item/tool/screwdriver/combi_driver/onestar,
@@ -12334,6 +12413,16 @@
 /obj/random/powercell,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"Un" = (
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "safehousebolts";
+	name = "Safehouse Bolt Control";
+	pixel_x = 24;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "Uo" = (
 /obj/effect/overlay/water,
 /obj/structure/flora/big/bush2,
@@ -12440,25 +12529,11 @@
 /obj/item/stock_parts/console_screen,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"UI" = (
-/obj/structure/closet/crate/serbcrate_gray,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/under/bdu/black,
-/obj/item/clothing/under/bdu/black,
-/obj/item/clothing/under/bdu/black,
-/obj/item/clothing/under/bdu/black,
-/obj/item/clothing/under/bdu/black,
-/obj/item/clothing/gloves/thick,
-/obj/item/clothing/gloves/thick,
-/obj/item/clothing/gloves/thick,
-/obj/item/clothing/gloves/thick,
-/obj/item/clothing/gloves/thick,
+"UH" = (
+/obj/structure/bed,
+/obj/item/bedsheet/hos,
 /turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
+/area/nadezhda/dungeon/outside/safehouse)
 "UJ" = (
 /obj/structure/table/onestar,
 /obj/structure/window/reinforced{
@@ -12470,11 +12545,6 @@
 /obj/random/common_oddities/low_chance,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"UK" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
 "UL" = (
 /obj/random/material_resources,
 /obj/structure/table/rack/shelf,
@@ -12726,10 +12796,6 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"VB" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
 "VC" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/syndie_kit/chameleon,
@@ -12767,6 +12833,10 @@
 /obj/machinery/light_construct,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
+"VJ" = (
+/obj/structure/bed/chair/sofa/black/left,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "VK" = (
 /obj/structure/table/onestar,
 /obj/random/junkfood,
@@ -12839,11 +12909,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"VW" = (
-/obj/structure/grille,
-/obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass,
-/area/colony/exposedsun/pastgate)
 "VX" = (
 /mob/living/carbon/superior_animal/human/voidwolf{
 	health = 250;
@@ -12955,14 +13020,6 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"Wt" = (
-/obj/item/bedsheet/hos,
-/obj/structure/bed,
-/turf/simulated/floor/carpet,
-/area/colony/exposedsun/pastgate)
-"Wu" = (
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
 "Wv" = (
 /obj/structure/salvageable/console_os,
 /turf/simulated/floor/tiled/derelict,
@@ -12987,6 +13044,10 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"WA" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "WB" = (
 /obj/structure/table/rack/shelf,
 /obj/random/tool/advanced/low_chance,
@@ -13184,6 +13245,17 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"Xt" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/drinks/milk,
+/obj/item/reagent_containers/food/drinks/milk,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "Xu" = (
 /obj/structure/closet/secure_closet/freezer,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -13197,6 +13269,11 @@
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"Xy" = (
+/obj/structure/table/marble,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "Xz" = (
 /obj/structure/table/marble,
 /obj/random/medical,
@@ -13217,6 +13294,10 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"XD" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/safehouse)
 "XE" = (
 /obj/random/mob/vox/low_chance,
 /turf/simulated/mineral/planet,
@@ -13264,8 +13345,8 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (WEST)";
-	dir = 4
+	dir = 4;
+	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
@@ -13310,11 +13391,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"XW" = (
-/obj/structure/table/marble,
-/obj/item/storage/box/drinkingglasses,
-/turf/simulated/floor/tiled/cafe,
-/area/colony/exposedsun/pastgate)
 "XX" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -13601,9 +13677,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"Za" = (
-/turf/simulated/floor/beach/water/ocean,
-/area/colony/exposedsun/pastgate)
 "Zb" = (
 /obj/structure/table/rack,
 /obj/item/tool/hammer/dumbbell,
@@ -13750,6 +13823,17 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
+"ZH" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/grille,
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
+"ZI" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "ZK" = (
 /obj/machinery/light{
 	dir = 8;
@@ -71922,16 +72006,16 @@ gf
 gf
 gf
 gf
-go
-go
-go
-go
-go
-go
-go
-go
-go
-go
+vL
+vL
+vL
+vL
+vL
+vL
+vL
+vL
+vL
+vL
 fF
 "}
 (79,1,2) = {"
@@ -72131,16 +72215,16 @@ gf
 gf
 gf
 gf
-go
-NH
-Lv
-go
-SQ
-go
-Wt
-Wt
-UI
-go
+vL
+Ap
+MB
+vL
+MP
+vL
+kl
+kl
+Bd
+vL
 fF
 "}
 (80,1,2) = {"
@@ -72340,16 +72424,16 @@ gf
 gf
 gf
 gf
-go
-NH
-Mp
-PC
-SQ
-Rr
-HI
-HI
-Wt
-go
+vL
+ys
+Ts
+za
+MP
+hf
+BC
+BC
+yZ
+vL
 fF
 "}
 (81,1,2) = {"
@@ -72549,16 +72633,16 @@ gf
 gf
 gf
 gf
-go
-NH
-Lv
-go
-SQ
-go
-Wt
-Wt
+vL
+Ap
+MB
+vL
+MP
+vL
+UH
+Eb
 Il
-go
+vL
 fF
 "}
 (82,1,2) = {"
@@ -72758,16 +72842,16 @@ gf
 gf
 gf
 gf
-go
-go
-go
-go
-SQ
-go
-go
-go
-go
-go
+vL
+vL
+vL
+vL
+MP
+vL
+vL
+vL
+vL
+vL
 fF
 "}
 (83,1,2) = {"
@@ -72964,19 +73048,19 @@ hW
 hW
 BL
 gf
-gf
-gf
-gf
-go
+vL
+vL
+vL
+vL
+PC
+NI
+tb
+MP
 Sy
-MQ
-Qk
-SQ
-RD
-Wu
-Wu
-MC
-go
+GD
+GD
+OH
+vL
 fF
 "}
 (84,1,2) = {"
@@ -73173,19 +73257,19 @@ hW
 hW
 CC
 gf
-gf
-gf
-gf
-go
-QL
-MZ
-QF
+vL
+vy
+zY
+vL
+TW
+nC
 SQ
-RA
-Sv
-Wu
-XW
-go
+MP
+zU
+Xt
+GD
+Qt
+vL
 fF
 "}
 (85,1,2) = {"
@@ -73382,19 +73466,19 @@ PV
 WJ
 CC
 gf
-gf
-gf
-gf
-go
-GD
-NI
-QF
+vL
+tt
+XD
+vL
+VJ
+Qm
 SQ
-RA
-Sv
-Wu
-XW
-go
+MP
+zU
+Xt
+GD
+Bz
+vL
 fF
 "}
 (86,1,2) = {"
@@ -73591,19 +73675,19 @@ hW
 Cp
 hA
 gf
-gf
-gf
-gf
-go
-HI
-HI
-HI
-SQ
-RA
-Sv
-Wu
-NQ
-go
+vL
+PU
+HM
+Co
+BC
+BC
+BC
+MP
+zU
+Xt
+GD
+OQ
+vL
 fF
 "}
 (87,1,2) = {"
@@ -73800,19 +73884,19 @@ hW
 CC
 hA
 gf
-go
-go
-go
-go
-SQ
-SQ
-SQ
-yv
-MJ
-Wu
-Wu
-UK
-go
+vL
+vL
+vL
+vL
+Qk
+MP
+MP
+TT
+EP
+GD
+GD
+ZI
+vL
 fF
 "}
 (88,1,2) = {"
@@ -74009,19 +74093,19 @@ Cp
 hA
 hA
 gf
-go
-pR
-Wu
-PN
-SQ
-SQ
-SQ
-yv
-MJ
-Wu
-Wu
-Px
-go
+vL
+Sv
+GD
+SB
+MP
+MP
+MP
+TT
+EP
+GD
+GD
+Xy
+vL
 fF
 "}
 (89,1,2) = {"
@@ -74218,19 +74302,19 @@ CC
 hA
 hA
 gf
-go
-zU
-Wu
-go
-NK
-OD
-SQ
-yv
-MJ
-SB
-Wu
-Px
-go
+vL
+In
+GD
+vL
+Mk
+Lv
+MP
+TT
+EP
+Ar
+GD
+Xy
+vL
 fF
 "}
 (90,1,2) = {"
@@ -74427,19 +74511,19 @@ CC
 hA
 hA
 gf
-go
-Cu
-Wu
-go
-Za
-Pt
-SQ
-yv
-MJ
-Wu
-Wu
-Wu
-go
+vL
+Bx
+GD
+vL
+KE
+OD
+MP
+TT
+EP
+GD
+GD
+Qz
+vL
 fF
 "}
 (91,1,2) = {"
@@ -74636,19 +74720,19 @@ hA
 hA
 hA
 gf
-go
-EK
-OV
-go
-Za
-Pt
-SQ
-SQ
-RA
-Ts
-zi
-Wu
-go
+vL
+AM
+Hu
+vL
+KE
+iE
+MP
+Un
+zU
+Pl
+Ak
+GD
+vL
 fF
 "}
 (92,1,2) = {"
@@ -74845,19 +74929,19 @@ hA
 hA
 hA
 gf
-go
-go
-go
-go
-go
-go
-Sn
-go
-go
-go
-go
-Mq
-go
+vL
+vL
+vL
+vL
+vL
+vL
+BV
+vL
+vL
+vL
+vL
+Go
+vL
 fF
 "}
 (93,1,2) = {"
@@ -75056,17 +75140,17 @@ hA
 hA
 hA
 hA
-gf
+hA
+DB
+zL
+Et
+vJ
+zL
+DB
 vL
-gq
-OG
-kl
-gq
+WA
+GD
 vL
-go
-VB
-Wu
-go
 fF
 "}
 (94,1,2) = {"
@@ -75266,16 +75350,16 @@ CC
 hA
 hA
 hA
-gf
-KE
-hd
-gq
-kl
-OG
-go
-VB
-Wu
-go
+hA
+DJ
+Da
+zL
+vJ
+Et
+vL
+WA
+TF
+vL
 fF
 "}
 (95,1,2) = {"
@@ -75477,14 +75561,14 @@ hA
 hA
 hA
 hA
-vD
+CF
 gf
 gf
 gf
-go
-VB
-Wu
-go
+vL
+WA
+GD
+vL
 fF
 "}
 (96,1,2) = {"
@@ -75686,14 +75770,14 @@ hA
 hA
 hA
 hA
-gd
+hW
 gf
 gf
 fE
-go
-go
-go
-go
+vL
+vL
+vL
+vL
 fF
 "}
 (97,1,2) = {"
@@ -75895,8 +75979,8 @@ Cp
 hA
 hA
 hA
-hd
-gd
+Da
+hW
 gf
 fE
 fE
@@ -76104,8 +76188,8 @@ Cp
 CC
 hA
 hA
-gf
-Pr
+hA
+hk
 gf
 fE
 fE
@@ -76313,8 +76397,8 @@ hA
 CC
 hA
 hA
-VW
-Qz
+PV
+ZH
 gf
 fE
 fE
@@ -76522,7 +76606,7 @@ hW
 BL
 CC
 hA
-VW
+PV
 fE
 fE
 fE
@@ -76731,7 +76815,7 @@ BJ
 hW
 BL
 CC
-Pr
+hk
 fE
 fE
 fE
@@ -76939,8 +77023,8 @@ hW
 hW
 BJ
 hW
-Cp
-hA
+WJ
+PV
 gf
 fE
 fE

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -553,6 +553,10 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"ci" = (
+/obj/structure/reagent_dispensers/fueltank/huge/derelict,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "cj" = (
 /obj/structure/catwalk,
 /obj/structure/table/steel_reinforced,
@@ -2902,11 +2906,6 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"kl" = (
-/obj/item/bedsheet/hos,
-/obj/structure/bed,
-/turf/simulated/floor/carpet,
-/area/nadezhda/dungeon/outside/safehouse)
 "km" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -3175,6 +3174,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"le" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "lf" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3891,9 +3896,8 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
 "nC" = (
-/obj/structure/table/onestar,
-/obj/item/flame/lighter/zippo/black,
-/turf/simulated/floor/carpet,
+/obj/random/mob/voidwolf,
+/turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
 "nD" = (
 /obj/machinery/door/window/southright,
@@ -5297,6 +5301,13 @@
 "sN" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/monster_cave)
+"sO" = (
+/obj/structure/table/rack/shelf,
+/obj/random/contraband/low_chance,
+/obj/random/contraband/low_chance,
+/obj/random/common_oddities,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "sQ" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/small/busha3,
@@ -6067,6 +6078,14 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"vD" = (
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/structure/table/marble,
+/obj/random/rations,
+/obj/random/rations,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "vE" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/small/bushb1,
@@ -6908,14 +6927,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"ys" = (
-/obj/structure/table/rack/shelf,
-/obj/item/storage/deferred/crate/alcohol,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/dungeon/outside/safehouse)
 "yt" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/big/bush3,
@@ -6971,6 +6982,11 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
+/area/nadezhda/outside/meadow)
+"yF" = (
+/obj/structure/flora/big/bush1,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "yG" = (
 /obj/structure/flora/small/grassb1,
@@ -7164,14 +7180,6 @@
 /obj/structure/morgue,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"zv" = (
-/obj/machinery/door/airlock/vault{
-	id_tag = "safehousebolts";
-	name = "Safehouse"
-	},
-/obj/structure/invislight,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/safehouse)
 "zw" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/meadow)
@@ -7218,6 +7226,11 @@
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"zG" = (
+/obj/machinery/light/small,
+/obj/random/tool/low_chance,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "zH" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/big/bush2,
@@ -7235,10 +7248,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"zM" = (
-/obj/structure/reagent_dispensers/fueltank/huge/derelict,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/dungeon/outside/safehouse)
 "zN" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/big/bush2,
@@ -7348,6 +7357,10 @@
 /area/nadezhda/outside/meadow)
 "An" = (
 /obj/structure/flora/small/bushc1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
+"Ao" = (
+/obj/item/beartrap/armed,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "Ap" = (
@@ -7513,11 +7526,6 @@
 /obj/random/gun_normal,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"AY" = (
-/obj/structure/table/onestar,
-/obj/random/junkfood/low_chance,
-/turf/simulated/floor/carpet,
-/area/nadezhda/dungeon/outside/safehouse)
 "AZ" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/small/bushb2,
@@ -7673,6 +7681,10 @@
 /obj/structure/lattice,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
+"BG" = (
+/obj/random/mob/voidwolf/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "BH" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/small/busha1,
@@ -7722,6 +7734,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"BV" = (
+/obj/item/toy/plushie/cat/siamese,
+/mob/living/carbon/superior_animal/human/voidwolf,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "BW" = (
 /obj/structure/flora/small/grassb1,
 /obj/structure/flora/small/busha1,
@@ -7819,17 +7836,6 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
-"Co" = (
-/obj/structure/table/rack/shelf,
-/obj/item/circuitboard/apc,
-/obj/item/stack/cable_coil,
-/obj/item/tool/multitool/improvised,
-/obj/item/clothing/gloves/insulated,
-/obj/item/frame/apc,
-/obj/random/powercell/large_safe,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/dungeon/outside/safehouse)
 "Cp" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/mineral/planet,
@@ -8179,18 +8185,23 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"DL" = (
+/obj/structure/table/rack/shelf,
+/obj/item/circuitboard/apc,
+/obj/item/stack/cable_coil,
+/obj/item/tool/multitool/improvised,
+/obj/item/clothing/gloves/insulated,
+/obj/item/frame/apc,
+/obj/random/powercell/large_safe,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/random/tool_upgrade/low_chance,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "DM" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
-"DN" = (
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/structure/table/marble,
-/obj/random/junkfood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/safehouse)
 "DO" = (
 /obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -8255,11 +8266,6 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
-"Eb" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/hosdouble,
-/turf/simulated/floor/carpet,
-/area/nadezhda/dungeon/outside/safehouse)
 "Ec" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/small/bushb2,
@@ -8423,6 +8429,12 @@
 /obj/random/traps,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"EK" = (
+/obj/structure/table/onestar,
+/obj/item/flame/lighter/zippo/black,
+/obj/random/cigarettes,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "EL" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/big/bush2,
@@ -8831,10 +8843,14 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "Gt" = (
-/obj/machinery/door/airlock/sandstone{
-	name = "Generator Room"
+/obj/structure/table/rack/shelf,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/wood/wild3,
+/obj/random/gun_normal,
+/obj/random/melee/low_chance,
+/obj/random/ammo_lowcost,
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/safehouse)
 "Gu" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -9154,6 +9170,12 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"HI" = (
+/obj/structure/table/standard,
+/obj/item/oddity/common/towel,
+/obj/item/soap/nanotrasen,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "HJ" = (
 /obj/structure/flora/small/bushc1,
 /obj/structure/flora/small/busha3,
@@ -9263,6 +9285,9 @@
 /obj/machinery/power/smes/buildable,
 /turf/simulated/shuttle/floor/mining,
 /area/colony/exposedsun/crashed_shop/outsider)
+"If" = (
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "Ig" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/busha2,
@@ -10411,6 +10436,14 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
+"Mq" = (
+/obj/machinery/door/airlock/vault{
+	id_tag = "safehousebolts";
+	name = "Safehouse"
+	},
+/obj/structure/invislight,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "Mr" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10469,13 +10502,6 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"MB" = (
-/obj/structure/table/reinforced,
-/obj/item/toy/weapon/katana,
-/obj/item/toy/weapon/crossbow,
-/obj/item/toy/weapon/sword,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/dungeon/outside/safehouse)
 "MD" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/mineral/planet,
@@ -10535,6 +10561,11 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
 "MP" = (
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
+"MQ" = (
+/obj/structure/table/marble,
+/obj/random/junkfood,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
 "MR" = (
@@ -10774,6 +10805,11 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"NH" = (
+/obj/structure/table/marble,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "NI" = (
 /obj/structure/bed/chair/sofa/black{
 	dir = 4
@@ -11159,6 +11195,11 @@
 /obj/random/oddity_guns,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"Pt" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
 "Pu" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	locked = 1;
@@ -11319,6 +11360,12 @@
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"PZ" = (
+/obj/machinery/door/airlock/sandstone{
+	name = "Generator Room"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "Qa" = (
 /obj/effect/floor_decal/industrial/loading/white,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -11572,11 +11619,6 @@
 /obj/random/common_oddities,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"QZ" = (
-/obj/structure/table/marble,
-/obj/random/junkfood,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/safehouse)
 "Ra" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/steel_reinforced,
@@ -11674,6 +11716,27 @@
 /mob/living/carbon/superior_animal/human/voidwolf/ranged/aerotrooper,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"Rr" = (
+/obj/structure/closet/crate/serbcrate,
+/obj/item/bedsheet/hos{
+	folded = 1;
+	icon_state = "sheet-folded"
+	},
+/obj/item/bedsheet/hos{
+	folded = 1;
+	icon_state = "sheet-folded"
+	},
+/obj/item/bedsheet/hosdouble{
+	folded = 1;
+	icon_state = "sheet-folded"
+	},
+/obj/item/bedsheet/hosdouble{
+	folded = 1;
+	icon_state = "sheet-folded"
+	},
+/obj/item/stack/material/steel/full,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "Rs" = (
 /obj/item/stack/material/cardboard/random,
 /obj/item/stack/material/cardboard/random,
@@ -11719,9 +11782,6 @@
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"RA" = (
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/dungeon/outside/safehouse)
 "RB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11986,12 +12046,6 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
-"SC" = (
-/obj/structure/table/standard,
-/obj/item/oddity/common/towel,
-/obj/item/soap/nanotrasen,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/safehouse)
 "SD" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -12020,10 +12074,6 @@
 /obj/random/turret,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
-"SI" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/dungeon/outside/safehouse)
 "SJ" = (
 /obj/item/clothing/head/hairflower,
 /obj/structure/window/reinforced,
@@ -12063,7 +12113,7 @@
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
 "SQ" = (
-/obj/structure/table/onestar,
+/obj/random/mob/voidwolf,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/safehouse)
 "SR" = (
@@ -12204,10 +12254,6 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"Ts" = (
-/obj/item/toy/plushie/cat/siamese,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/dungeon/outside/safehouse)
 "Tt" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/syndie_kit/cigarette,
@@ -12256,14 +12302,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
-"TE" = (
-/obj/structure/table/reinforced,
-/obj/item/toy/weapon/katana,
-/obj/item/toy/weapon/crossbow,
-/obj/item/toy/weapon/sword,
-/obj/random/credits/c100,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/dungeon/outside/safehouse)
 "TF" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/cafe,
@@ -12554,11 +12592,6 @@
 /obj/item/stock_parts/console_screen,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"UH" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hos,
-/turf/simulated/floor/carpet,
-/area/nadezhda/dungeon/outside/safehouse)
 "UJ" = (
 /obj/structure/table/onestar,
 /obj/structure/window/reinforced{
@@ -12821,6 +12854,11 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"VB" = (
+/obj/structure/table/onestar,
+/obj/random/gun_cheap/low_chance,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "VC" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/syndie_kit/chameleon,
@@ -13023,11 +13061,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"Wo" = (
-/obj/structure/table/marble,
-/obj/random/junkfood/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/safehouse)
 "Wp" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/big/bush2,
@@ -13360,6 +13393,11 @@
 /obj/machinery/door/airlock/highsecurity,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
+"XM" = (
+/obj/structure/table/onestar,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "XN" = (
 /obj/structure/multiz/ladder,
 /obj/structure/flora/small/bushb2,
@@ -13898,6 +13936,11 @@
 /obj/structure/scrap/medical/large,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
+"ZR" = (
+/obj/structure/table/reinforced,
+/obj/random/credits/c5000,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "ZT" = (
 /obj/structure/salvageable/console_os{
 	dir = 1
@@ -72242,13 +72285,13 @@ gf
 gf
 gf
 vL
-Ap
-MB
+sO
+le
 vL
 MP
 vL
-kl
-kl
+Rr
+BC
 Bd
 vL
 fF
@@ -72451,8 +72494,8 @@ gf
 gf
 gf
 vL
-ys
-Ts
+Gt
+BV
 za
 MP
 hf
@@ -72661,12 +72704,12 @@ gf
 gf
 vL
 Ap
-TE
+ZR
 vL
 MP
 vL
-UH
-Eb
+BC
+BC
 Il
 vL
 fF
@@ -72872,7 +72915,7 @@ vL
 vL
 vL
 vL
-MP
+BG
 vL
 vL
 vL
@@ -73285,11 +73328,11 @@ CC
 gf
 vL
 vy
-zM
+ci
 vL
 TW
-nC
-AY
+EK
+XM
 MP
 zU
 Xt
@@ -73494,12 +73537,12 @@ CC
 gf
 vL
 tt
-SI
+zG
 vL
 VJ
 Qm
-SQ
-MP
+VB
+nC
 zU
 Xt
 GD
@@ -73702,17 +73745,17 @@ Cp
 hA
 gf
 vL
-Co
-RA
-Gt
-BC
+DL
+If
+PZ
+SQ
 BC
 BC
 MP
 zU
 Xt
 GD
-DN
+vD
 vL
 fF
 "}
@@ -74120,14 +74163,14 @@ hA
 hA
 gf
 vL
-SC
+HI
 GD
 SB
 MP
 MP
-MP
+BG
 TT
-QZ
+MQ
 GD
 GD
 Xy
@@ -74336,7 +74379,7 @@ Mk
 Lv
 MP
 TT
-Wo
+NH
 Ar
 GD
 Xy
@@ -74961,7 +75004,7 @@ IU
 IU
 IU
 IU
-zv
+Mq
 IU
 IU
 IU
@@ -75796,7 +75839,7 @@ hA
 hA
 hA
 hA
-hW
+Ao
 gf
 gf
 fE
@@ -76836,13 +76879,13 @@ hW
 hW
 hW
 hW
-hW
 BJ
+hW
 hW
 BL
 CC
-hk
-fE
+Pt
+gf
 fE
 fE
 fE
@@ -77047,10 +77090,10 @@ hW
 vJ
 hW
 hW
-BJ
 hW
-WJ
-PV
+hW
+yF
+vJ
 gf
 fE
 fE
@@ -77256,7 +77299,7 @@ hW
 hW
 hW
 hW
-hW
+ir
 hW
 BL
 hA
@@ -77463,10 +77506,10 @@ hW
 hW
 hW
 hW
-hW
-hW
-hW
 BJ
+hW
+hW
+hW
 Cl
 hA
 gf
@@ -77674,7 +77717,7 @@ hW
 hW
 hW
 hW
-vJ
+dU
 hW
 hW
 hW

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -7273,14 +7273,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"zM" = (
-/obj/machinery/door/airlock/vault{
-	id_tag = "safehousebolts";
-	name = "Safehouse"
-	},
-/obj/structure/invislight,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/safehouse)
 "zN" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/big/bush2,
@@ -12583,6 +12575,11 @@
 /obj/item/stock_parts/console_screen,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"UH" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/invislight,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/meadow)
 "UJ" = (
 /obj/structure/table/onestar,
 /obj/structure/window/reinforced{
@@ -13781,6 +13778,13 @@
 /obj/item/ammo_casing/flare/prespawn,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
+"Zk" = (
+/obj/machinery/door/airlock/vault{
+	id_tag = "safehousebolts";
+	name = "Safehouse"
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "Zm" = (
 /obj/structure/table/onestar,
 /obj/random/tool_upgrade/low_chance,
@@ -74998,7 +75002,7 @@ IU
 IU
 IU
 IU
-zM
+Zk
 IU
 IU
 IU
@@ -75207,7 +75211,7 @@ hA
 DB
 zL
 Et
-vJ
+UH
 zL
 DB
 IU

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -7164,6 +7164,14 @@
 /obj/structure/morgue,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"zv" = (
+/obj/machinery/door/airlock/vault{
+	id_tag = "safehousebolts";
+	name = "Safehouse"
+	},
+/obj/structure/invislight,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "zw" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/meadow)
@@ -7227,6 +7235,10 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"zM" = (
+/obj/structure/reagent_dispensers/fueltank/huge/derelict,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "zN" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/big/bush2,
@@ -7274,10 +7286,6 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"zY" = (
-/obj/structure/reagent_dispensers/fueltank/huge/derelict,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/safehouse)
 "Aa" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/hypospray/autoinjector/drugs,
@@ -7505,6 +7513,11 @@
 /obj/random/gun_normal,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"AY" = (
+/obj/structure/table/onestar,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/carpet,
+/area/nadezhda/dungeon/outside/safehouse)
 "AZ" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/small/bushb2,
@@ -7709,13 +7722,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"BV" = (
-/obj/machinery/door/airlock/vault{
-	id_tag = "safehousebolts";
-	name = "Safehouse"
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/safehouse)
 "BW" = (
 /obj/structure/flora/small/grassb1,
 /obj/structure/flora/small/busha1,
@@ -7814,10 +7820,15 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
 "Co" = (
-/obj/machinery/door/airlock/sandstone{
-	name = "Generator Room"
-	},
-/turf/simulated/floor/wood/wild5,
+/obj/structure/table/rack/shelf,
+/obj/item/circuitboard/apc,
+/obj/item/stack/cable_coil,
+/obj/item/tool/multitool/improvised,
+/obj/item/clothing/gloves/insulated,
+/obj/item/frame/apc,
+/obj/random/powercell/large_safe,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/wood/wild3,
 /area/nadezhda/dungeon/outside/safehouse)
 "Cp" = (
 /obj/structure/flora/big/bush1,
@@ -8173,6 +8184,13 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
+"DN" = (
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/structure/table/marble,
+/obj/random/junkfood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "DO" = (
 /obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -8812,6 +8830,12 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"Gt" = (
+/obj/machinery/door/airlock/sandstone{
+	name = "Generator Room"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "Gu" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/big/bush2{
@@ -9148,9 +9172,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"HM" = (
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/safehouse)
 "HN" = (
 /obj/machinery/light/floor,
 /obj/structure/table/rack/shelf,
@@ -11005,12 +11026,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"OQ" = (
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/safehouse)
 "OR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11285,17 +11300,6 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
-"PU" = (
-/obj/structure/table/rack/shelf,
-/obj/item/circuitboard/apc,
-/obj/item/stack/cable_coil,
-/obj/item/tool/multitool/improvised,
-/obj/item/clothing/gloves/insulated,
-/obj/item/frame/apc,
-/obj/random/powercell/large_safe,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/safehouse)
 "PV" = (
 /obj/structure/grille,
 /obj/structure/barricade,
@@ -11568,6 +11572,11 @@
 /obj/random/common_oddities,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"QZ" = (
+/obj/structure/table/marble,
+/obj/random/junkfood,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "Ra" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/steel_reinforced,
@@ -11710,6 +11719,9 @@
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"RA" = (
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "RB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11945,11 +11957,6 @@
 /obj/random/firstaid,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
-"Sv" = (
-/obj/structure/table/standard,
-/obj/item/oddity/common/towel,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/dungeon/outside/safehouse)
 "Sw" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/material/shard,
@@ -11979,6 +11986,12 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
+"SC" = (
+/obj/structure/table/standard,
+/obj/item/oddity/common/towel,
+/obj/item/soap/nanotrasen,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/dungeon/outside/safehouse)
 "SD" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -12007,6 +12020,10 @@
 /obj/random/turret,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
+"SI" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/dungeon/outside/safehouse)
 "SJ" = (
 /obj/item/clothing/head/hairflower,
 /obj/structure/window/reinforced,
@@ -12239,6 +12256,14 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"TE" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/weapon/katana,
+/obj/item/toy/weapon/crossbow,
+/obj/item/toy/weapon/sword,
+/obj/random/credits/c100,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/dungeon/outside/safehouse)
 "TF" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/cafe,
@@ -12998,6 +13023,11 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"Wo" = (
+/obj/structure/table/marble,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/safehouse)
 "Wp" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/big/bush2,
@@ -13294,10 +13324,6 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"XD" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/safehouse)
 "XE" = (
 /obj/random/mob/vox/low_chance,
 /turf/simulated/mineral/planet,
@@ -72635,7 +72661,7 @@ gf
 gf
 vL
 Ap
-MB
+TE
 vL
 MP
 vL
@@ -73259,11 +73285,11 @@ CC
 gf
 vL
 vy
-zY
+zM
 vL
 TW
 nC
-SQ
+AY
 MP
 zU
 Xt
@@ -73468,7 +73494,7 @@ CC
 gf
 vL
 tt
-XD
+SI
 vL
 VJ
 Qm
@@ -73676,9 +73702,9 @@ Cp
 hA
 gf
 vL
-PU
-HM
 Co
+RA
+Gt
 BC
 BC
 BC
@@ -73686,7 +73712,7 @@ MP
 zU
 Xt
 GD
-OQ
+DN
 vL
 fF
 "}
@@ -74094,14 +74120,14 @@ hA
 hA
 gf
 vL
-Sv
+SC
 GD
 SB
 MP
 MP
 MP
 TT
-EP
+QZ
 GD
 GD
 Xy
@@ -74310,7 +74336,7 @@ Mk
 Lv
 MP
 TT
-EP
+Wo
 Ar
 GD
 Xy
@@ -74931,14 +74957,14 @@ hA
 gf
 vL
 vL
-vL
-vL
-vL
-vL
-BV
-vL
-vL
-vL
+IU
+IU
+IU
+IU
+zv
+IU
+IU
+IU
 vL
 Go
 vL
@@ -75147,7 +75173,7 @@ Et
 vJ
 zL
 DB
-vL
+IU
 WA
 GD
 vL
@@ -75356,7 +75382,7 @@ Da
 zL
 vJ
 Et
-vL
+IU
 WA
 TF
 vL

--- a/maps/__Nadezhda/area/_Nadezhda_areas.dm
+++ b/maps/__Nadezhda/area/_Nadezhda_areas.dm
@@ -214,6 +214,14 @@
 	icon_state = "erisblue"
 	requires_power = 1
 
+/area/nadezhda/dungeon/outside/safehouse
+	name = "Abandoned Safehouse"
+	icon_state = "nadezhdagreen"
+	dynamic_lighting = TRUE
+	is_dungeon_lootable = FALSE
+	ambience = list('sound/ambience/ambigen1.ogg','sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg','sound/ambience/ambigen14.ogg')
+	area_light_color = COLOR_LIGHTING_CREW_SOFT
+
 //This is put here because the floors are seperated by power needs, the reason being if not powering 1 floor lags the server to hell and back. -Kaz
 /area/nadezhda/dungeon/outside/prepper/vault/floor1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Converts the admin safehouse thing location for actual use.
</summary>
<hr>

Mostly just gets rid of the impassable terrain that was blocking it, add some loot, some void wolfs spawns, and boom.
	
<hr>
</details>

## Changelog
:cl:
tweak:Makes the deepforest safehouse a actual location. Can be used for RPs or what not, if cleared out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
