### PR TITLE
Frontier Psychiatrist - Two new psionic abilities to help with sanity

### DIFF
--- a/code/modules/organs/internal/psionic.dm
+++ b/code/modules/organs/internal/psionic.dm
@@ -31,6 +31,7 @@
 
 	owner_verbs = list(
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_healing,
+		/obj/item/organ/internal/psionic_tumor/proc/meditative_focus,
 		/obj/item/organ/internal/psionic_tumor/proc/psychosomatictransfer,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_telepathy,
 		/obj/item/organ/internal/psionic_tumor/proc/telekineticprowress,
@@ -53,6 +54,7 @@
 	name = "cultured flesh"
 	owner_verbs = list(
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_healing,
+		/obj/item/organ/internal/psionic_tumor/proc/meditative_focus,
 		/obj/item/organ/internal/psionic_tumor/proc/psychosomatictransfer,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_telepathy,
 		/obj/item/organ/internal/psionic_tumor/proc/telekineticprowress,
@@ -71,6 +73,7 @@
 		/obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster,
 		// Psych unique powers just for them. Do not add these to other lists. -Kaz
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_heal_other,
+		/obj/item/organ/internal/psionic_tumor/proc/meditative_focus_other,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_heal_brain,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_gift
 	)

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -81,7 +81,7 @@
 
 	if(pay_power_cost(psi_point_cost))
 		if(owner.sanity.level >= (owner.sanity.max_level - 10))
-			psi_points = psi_point_cost
+			psi_points += psi_point_cost
 			owner.visible_message(
 			"[owner] fidgets uncomfortably.",
 			"Your mind is assured."

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -71,3 +71,30 @@
 			to_chat(owner, SPAN_NOTICE("You don't crave for [R.name] anymore."))
 			owner.metabolism_effects.addiction_list.Remove(R)
 			qdel(R)
+
+// Heals sanity
+/obj/item/organ/internal/psionic_tumor/proc/meditative_focus()
+	set category = "Psionic powers"
+	set name = "Meditative Focus (2)"
+	set desc = "Expend two psi points of your psi essence to focus your mind and increase your sanity."
+	psi_point_cost = 2
+
+	if(pay_power_cost(psi_point_cost))
+		if(owner.sanity.level >= (owner.sanity.max_level - 10))
+			psi_points = psi_points + 2
+			owner.visible_message(
+			"[owner] fidgets uncomfortably.",
+			"Your mind is assured."
+			)
+			return
+		else if(owner.sanity.level < (owner.sanity.max_level - 10))
+			owner.sanity.level = owner.sanity.level + 5 + (owner.stats.getStat(STAT_COG)/2)
+			if(owner.stats.getPerk(PERK_PSI_ATTUNEMENT))
+				owner.sanity.level = owner.sanity.level + 10
+			if(owner.stats.getPerk(PERK_PSI_MANIA))
+				owner.sanity.level = owner.sanity.level + 5
+			playsound(owner.loc,'sound/effects/telesci_ping.ogg', 25, 1)
+			owner.visible_message(
+				"[owner]'s head lowers for a concentrated moment.",
+				"A second turns to eternity, your mind assures its place in the universe"
+				)

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -81,18 +81,18 @@
 
 	if(pay_power_cost(psi_point_cost))
 		if(owner.sanity.level >= (owner.sanity.max_level - 10))
-			psi_points = psi_points + 2
+			psi_points = psi_point_cost
 			owner.visible_message(
 			"[owner] fidgets uncomfortably.",
 			"Your mind is assured."
 			)
 			return
 		else if(owner.sanity.level < (owner.sanity.max_level - 10))
-			owner.sanity.level = owner.sanity.level + 5 + (owner.stats.getStat(STAT_COG)/2)
+			owner.sanity.changeLevel(5 + (owner.stats.getStat(STAT_COG)/2))
 			if(owner.stats.getPerk(PERK_PSI_ATTUNEMENT))
-				owner.sanity.level = owner.sanity.level + 10
+				owner.sanity.changeLevel(10)
 			if(owner.stats.getPerk(PERK_PSI_MANIA))
-				owner.sanity.level = owner.sanity.level + 5
+				owner.sanity.changeLevel(5)
 			playsound(owner.loc,'sound/effects/telesci_ping.ogg', 25, 1)
 			owner.visible_message(
 				"[owner]'s head lowers for a concentrated moment.",

--- a/code/modules/psionics/psion_powers/pyschiatrist_powers.dm
+++ b/code/modules/psionics/psion_powers/pyschiatrist_powers.dm
@@ -28,6 +28,43 @@
 		else
 			usr.show_message("\blue You are not holding someone you can use this power on.")
 
+
+/obj/item/organ/internal/psionic_tumor/proc/meditative_focus_other()
+	set category = "Psionic powers"
+	set name = "Psionic Tranquility (2)"
+	set desc = "Expend two psi points of your psi essence to calm the mind of another person you are grappling and restore their sanity."
+	psi_point_cost = 2
+
+	var/mob/living/carbon/human/L = get_grabbed_mob(owner)
+
+	if(L.psi_blocking >= 10)
+		owner.stun_effect_act(0, L.psi_blocking * 5, BP_HEAD)
+		owner.weakened = L.psi_blocking
+		usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
+		return
+
+	if(pay_power_cost(psi_point_cost))
+		if(L && isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC && L.sanity.level >= (L.sanity.max_level - 10))
+			psi_points = psi_points + 2
+			usr.visible_message(
+					"[usr] places a hand on [L], a soft hum raidates around them and quickly fades away",
+					"You place your hand upon [L], concentrating [L]'s thoughts... but their mind is already calm."
+					)
+			return
+		else if(L && isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC && L.sanity.level < (L.sanity.max_level - 10))
+			usr.visible_message(
+					"[usr] places a hand on [L], a soft hum raidates around them",
+					"You place your hand upon [L], calming [L]'s thoughts!"
+					)
+			playsound(src.loc,'sound/effects/telesci_ping.ogg', 25, 3)
+			L.sanity.level = L.sanity.level + 10 + (owner.stats.getStat(STAT_COG)/2)
+			if(owner.stats.getPerk(PERK_PSI_ATTUNEMENT))
+				L.sanity.level = L.sanity.level + 20
+			if(owner.stats.getPerk(PERK_PSI_MANIA))
+				L.sanity.level = L.sanity.level + 10
+		else
+			usr.show_message("\blue You are not holding someone you can use this power on.")
+
 /obj/item/organ/internal/psionic_tumor/proc/psionic_heal_brain()
 	set category = "Psionic powers"
 	set name = "Cerebral Regeneration (3)"

--- a/code/modules/psionics/psion_powers/pyschiatrist_powers.dm
+++ b/code/modules/psionics/psion_powers/pyschiatrist_powers.dm
@@ -37,6 +37,10 @@
 
 	var/mob/living/carbon/human/L = get_grabbed_mob(owner)
 
+	if(!L)
+		usr.show_message("\blue You are not holding someone you can use this power on.")
+		return
+
 	if(L.psi_blocking >= 10)
 		owner.stun_effect_act(0, L.psi_blocking * 5, BP_HEAD)
 		owner.weakened = L.psi_blocking
@@ -44,24 +48,24 @@
 		return
 
 	if(pay_power_cost(psi_point_cost))
-		if(L && isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC && L.sanity.level >= (L.sanity.max_level - 10))
-			psi_points = psi_points + 2
+		if(isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC && L.sanity.level >= (L.sanity.max_level - 10))
+			psi_points += psi_point_cost //Refunds?
 			usr.visible_message(
 					"[usr] places a hand on [L], a soft hum raidates around them and quickly fades away",
 					"You place your hand upon [L], concentrating [L]'s thoughts... but their mind is already calm."
 					)
 			return
-		else if(L && isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC && L.sanity.level < (L.sanity.max_level - 10))
+		else if(isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC && L.sanity.level < (L.sanity.max_level - 10))
 			usr.visible_message(
 					"[usr] places a hand on [L], a soft hum raidates around them",
 					"You place your hand upon [L], calming [L]'s thoughts!"
 					)
 			playsound(src.loc,'sound/effects/telesci_ping.ogg', 25, 3)
-			L.sanity.level = L.sanity.level + 10 + (owner.stats.getStat(STAT_COG)/2)
+			L.sanity.changeLevel(10 + (owner.stats.getStat(STAT_COG)/2))
 			if(owner.stats.getPerk(PERK_PSI_ATTUNEMENT))
-				L.sanity.level = L.sanity.level + 20
+				L.sanity.changeLevel(20)
 			if(owner.stats.getPerk(PERK_PSI_MANIA))
-				L.sanity.level = L.sanity.level + 10
+				L.sanity.changeLevel(10)
 		else
 			usr.show_message("\blue You are not holding someone you can use this power on.")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Adds two new psionic abilities

For all psionics:
Meditative Focus - Expend two psi points of your psi essence to focus your mind and increase your sanity, scales off your Cog stat and Psi focused Background perks ( Scholar / Bedlam )

For psychiatrist/enhanced psion:
Psionic Tranquility - Expend two psi points of your psi essence to calm the mind of another person you are grappling and restore their sanity, scales off your Cog stat and Psi focused Background perks ( Scholar / Bedlam )

Dev note: This has been tested and balanced with LongSleeves/Landen to not cause issues with inspiration system and is capped to (max sanity level - 10) and costing 2 psi points to curb Power gaming abuse.  If issues arrise, a timer will be coded in to prevent inspiration abuse
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
