### PR TITLE
experimental end round voting

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -264,6 +264,8 @@ SUBSYSTEM_DEF(ticker)
 	SEND_SOUND(world, sound('sound/AI/welcome.ogg')) // Skie
 	//Holiday Round-start stuff	~Carn
 	Holiday_Game_Start()
+	SSvote.start_restart_vote_loop()
+
 
 	for(var/mob/new_player/N in SSmobs.mob_list)
 		N.new_player_panel_proc()

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -44,6 +44,12 @@ SUBSYSTEM_DEF(vote)
 /datum/controller/subsystem/vote/proc/autostoryteller()
 	start_vote(/datum/poll/storyteller)
 
+/datum/controller/subsystem/vote/proc/start_restart_vote_loop()
+	addtimer(CALLBACK(src, /datum/controller/subsystem/vote/proc/recall_vote), 240 MINUTES)
+
+/datum/controller/subsystem/vote/proc/recall_vote()
+	start_vote(/datum/poll/restart)
+
 /datum/controller/subsystem/vote/proc/start_vote(newvote)
 	if(active_vote)
 		return FALSE

--- a/code/controllers/subsystems/voting/poll.dm
+++ b/code/controllers/subsystems/voting/poll.dm
@@ -1,6 +1,6 @@
 /datum/poll
 	var/name = "Voting"
-	var/question = "Voting, voting, candidates are faggots!"
+	var/question = "Voting, voting, candidates!"
 	var/description = ""
 	var/time = 60	//in seconds
 	var/list/choice_types = list(/datum/vote_choice)	//Choices will be initialized from this list

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -39,9 +39,13 @@
 
 /datum/poll/restart/admin
 	non_admin = FALSE
-	name = "ADMIN: End Round"
+	name = "Supper Majority: End Round"
 	question = "End Shift?"
 	choice_types = list(/datum/vote_choice/restart, /datum/vote_choice/countinue_round/admin)
+	minimum_win_percentage = 0.75
+	next_vote = 255 MINUTES //Minimum round length before it can be called for the first time
+	cooldown = 30 MINUTES //Cooldown is set to 30 mins as 1 hour is a bit much when things change so much in so little time + maxium 8 hour rounds means we should be a bit more forgiven.
+	only_admin = FALSE
 
 
 /*To prevent abuse and rule-by-salt, the evac vote weights each player's vote based on a few parameters

--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -3,6 +3,12 @@
 ///////////////////VOTES//////////////////////
 //////////////////////////////////////////////
 
+#define VOTE_WEIGHT_LOW	0.6
+#define VOTE_WEIGHT_NORMAL	1
+#define VOTE_WEIGHT_HIGH	1.2 //To tie 2 dead votes but not over-rule 2 living
+#define MINIMUM_VOTE_LIFETIME	15 MINUTES
+#define MIN_WIN_PERCENTAGE 0.6 //at the 4 hour round we need 60% Majority to end
+
 /datum/poll/restart
 	name = "End Round"
 	question = "End Shift?"
@@ -17,18 +23,32 @@
 	multiple_votes = TRUE //Duel votes are fun
 	can_revote = TRUE
 	can_unvote = TRUE //In case you heck up
+	only_admin = TRUE
 
 	see_votes = FALSE //No swaying
+	minimum_win_percentage = MIN_WIN_PERCENTAGE
+	var/non_admin = TRUE
+
+/datum/poll/restart/proc/lower_minium()
+	minimum_win_percentage -= 0.1
+
+	if(MIN_WIN_PERCENTAGE <= 0.2)
+		SSticker.shift_end(15 MINUTES)
+		for (var/mob/M as mob in SSmobs.mob_list)
+			to_chat(M, "<br><center><span class='danger'><b><font size=4>The round is ending do to exceeding 8 hours.</font></b><br></span></center><br>")
+
+/datum/poll/restart/admin
+	non_admin = FALSE
+	name = "ADMIN: End Round"
+	question = "End Shift?"
+	choice_types = list(/datum/vote_choice/restart, /datum/vote_choice/countinue_round/admin)
+
 
 /*To prevent abuse and rule-by-salt, the evac vote weights each player's vote based on a few parameters
 	If you are alive and have been for a while, then you have the normal 1 vote
 	If you are dead, or just spawned, you get only 0.6 votes
 	If you are an antag or a head of staff, you get 1.2 votes
 */
-#define VOTE_WEIGHT_LOW	0.6
-#define VOTE_WEIGHT_NORMAL	1
-#define VOTE_WEIGHT_HIGH	1.2 //To tie 2 dead votes but not over-rule 2 living
-#define MINIMUM_VOTE_LIFETIME	15 MINUTES
 
 /datum/poll/restart/get_vote_power(var/client/C)
 	if (!istype(C))
@@ -67,6 +87,18 @@
 	//If we get here, its just a normal player who's been playing for at least 15 minutes. Normal weight
 	return VOTE_WEIGHT_NORMAL
 
+/datum/poll/restart/on_end()
+	if(non_admin)
+		lower_minium()
+
+		addtimer(CALLBACK(src, /datum/poll/restart/proc/recall_vote), 60 MINUTES)
+	..()
+
+/datum/poll/restart/proc/recall_vote()
+	SSvote.start_vote(/datum/poll/restart)
+
+
+
 #undef VOTE_WEIGHT_LOW
 #undef VOTE_WEIGHT_NORMAL
 #undef VOTE_WEIGHT_HIGH
@@ -88,10 +120,8 @@
 /datum/vote_choice/countinue_round
 	text = "Continue Shift"
 
-
-
-
-
+/datum/vote_choice/countinue_round/admin
+	text = "Continue Shift"
 
 
 /*********************


### PR DESCRIPTION
Voting for round end now needs a 60% majority to be vaild
Every vote that fails lowers the needed majority by 10%
The end round vote is no longer callable
Round end now auto calls 4 hours in and then again every hour untill 8 hours into a round
Adds a supper majority end round, for people to call cooldown 30 mins to stop spaming