### PR TITLE
Removes Sec - Adds PMC

### DIFF
--- a/code/datums/setup_option/backgrounds/origin_chtmant.dm
+++ b/code/datums/setup_option/backgrounds/origin_chtmant.dm
@@ -45,7 +45,7 @@
 
 /datum/category_item/setup_option/background/ethnicity/chtmantra
 	name = "Ra Caste"
-	desc = "Ra are the warriors and sentries of the hives. Numbering in the hundreds they would tower over Ru’s and even \
+	desc = "Ra are the warriors and sentries of the hives. Numbering in the hundreds they would tower over Ruï¿½s and even \
 			most workers, the Ro. Their bodies were highly adapted for combat and they know only loyalty unto death for the good of \
 			the hive. Due to this, and the existence of the Ru, they often heavily lack any cognitive thinking skills and would \
 			rely on winning battles by sheer weight of numbers or pure attrition. The severe lack of intelligence they exhibit also bars them from most medical roles and all of science, engineering, and command roles."
@@ -53,7 +53,7 @@
 	restricted_to_species = list(FORM_CHTMANT)
 	allow_modifications = FALSE
 	restricted_depts = SCIENCE | ENGINEERING
-	restricted_jobs = list(/datum/job/cmo, /datum/job/rd, /datum/job/smc, /datum/job/swo, /datum/job/cmo, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/premier, /datum/job/pg, /datum/job/chief_engineer, /datum/job/chaplain, /datum/job/merchant)
+	restricted_jobs = list(/datum/job/cmo, /datum/job/rd, /datum/job/swo, /datum/job/cmo, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/premier, /datum/job/pg, /datum/job/chief_engineer, /datum/job/chaplain, /datum/job/merchant)
 
 	perks = list(PERK_CHITINARMOR)
 	racial_implants = (/obj/item/organ_module/active/simple/cht_mant_claws)

--- a/code/datums/setup_option/backgrounds/origin_chtmant.dm
+++ b/code/datums/setup_option/backgrounds/origin_chtmant.dm
@@ -45,7 +45,7 @@
 
 /datum/category_item/setup_option/background/ethnicity/chtmantra
 	name = "Ra Caste"
-	desc = "Ra are the warriors and sentries of the hives. Numbering in the hundreds they would tower over Ru�s and even \
+	desc = "Ra are the warriors and sentries of the hives. Numbering in the hundreds they would tower over Ru's and even \
 			most workers, the Ro. Their bodies were highly adapted for combat and they know only loyalty unto death for the good of \
 			the hive. Due to this, and the existence of the Ru, they often heavily lack any cognitive thinking skills and would \
 			rely on winning battles by sheer weight of numbers or pure attrition. The severe lack of intelligence they exhibit also bars them from most medical roles and all of science, engineering, and command roles."

--- a/code/datums/setup_option/backgrounds/origin_naramad.dm
+++ b/code/datums/setup_option/backgrounds/origin_naramad.dm
@@ -47,7 +47,7 @@
 	restricted_to_species = list(FORM_NARAMAD)
 
 	restricted_depts = SCIENCE | MEDICAL | ENGINEERING | COMMAND
-	restricted_jobs = list(/datum/job/salvager, /datum/job/supsec, /datum/job/serg, /datum/job/inspector, /datum/job/medspec, /datum/job/officer)
+	restricted_jobs = list(/datum/job/salvager, /datum/job/officer)
 
 	stat_modifiers = list(
 		STAT_ROB = 10,

--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -9,7 +9,6 @@
 		/datum/job/rd,
 		/datum/job/cmo,
 		/datum/job/chief_engineer,
-		/datum/job/smc,
 		/datum/job/outsider,
 		/datum/job/cyborg, //To stop people auto dropping these
 		/datum/job/ai
@@ -44,7 +43,6 @@
 		/datum/job/chief_engineer,
 		/datum/job/merchant,
 		/datum/job/rd,
-		/datum/job/smc,
 		/datum/job/swo,
 		/datum/job/cyborg, //To stop people auto dropping these
 		/datum/job/ai
@@ -76,7 +74,6 @@
 		/datum/job/cmo,
 		/datum/job/merchant,
 		/datum/job/rd,
-		/datum/job/smc,
 		/datum/job/swo,
 		/datum/job/cyborg, //To stop people auto dropping these
 		/datum/job/ai

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -1,77 +1,13 @@
-/datum/job/smc
-	title = "Blackshield Commander"
-	flag = SMC
-	head_position = 1
-	department = DEPARTMENT_SECURITY
-	department_flag = SECURITY | COMMAND
-	faction = MAP_FACTION
-	total_positions = 1
-	spawn_positions = 1
-	supervisors = "the Council"
-	difficulty = "Very Hard."
-	selection_color = "#97b0be"
-	req_admin_notify = 1
-	wage = WAGE_COMMAND
-	ideal_character_age = 40
-	minimum_character_age = 30
-	department_account_access = TRUE
-	playtimerequired = 2500
-	health_modifier = 25
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
-
-	outfit_type = /decl/hierarchy/outfit/job/security/smc
-
-	access = list(
-		access_security, access_eva, access_sec_doors, access_brig, access_armory, access_medspec,
-		access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
-		access_moebius, access_engine, access_mining, access_construction, access_mailsorting,
-		access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway,
-		access_external_airlocks, access_research_equipment, access_prospector, access_medical, access_kitchen, access_medical_suits
-	)
-
-	stat_modifiers = list(
-		STAT_ROB = 30,
-		STAT_TGH = 40,
-		STAT_VIG = 40,
-	)
-
-	perks = list(PERK_ASS_OF_CONCRETE,
-				 PERK_BLACKSHIELD_CONDITIONING,
-				 PERK_BOLT_REFLECT,
-				 PERK_CHEM_CONTRABAND)
-
-	software_on_spawn = list(/datum/computer_file/program/comm,
-							 /datum/computer_file/program/digitalwarrant,
-							 /datum/computer_file/program/camera_monitor,
-							 /datum/computer_file/program/reports)
-
-	description = "The Blackshield Commander serves as the commander of the local regiment of the Blackshield.<br>\
-	Contracted to protect and serve the colony, your faction serves as a voluntary first (and hopefully last) line of defense.<br>\
-	Your goal is to keep everyone living on the colony as safe as possible and to eliminate any threats to safety.<br>\
-	The Warrant Officer is your ally and you should work closely with them, they handle the upholding of the law."
-
-	duties = "Coordinate operatives in the field, assigning them to threats and distress calls as needed.<br>\
-		Work with the Warrant Officer to allocate funds to supply your teams with whatever munitions or equipment they need.<br>\
-		Plan assaults on entrenched threats, ensure each operative knows their roles and carries them out precisely.<br>\
-		Oversee performance of the operatives under your command and punish any that are insubordinate or incompetent.<br>\
-		Advise the council on threats to colony security and advise them towards choices that will minimise exposure to threats."
-
-/obj/landmark/join/start/smc
-	name = "Blackshield Commander"
-	icon_state = "player-blue-officer"
-	join_tag = /datum/job/smc
-
-
 /datum/job/swo
-	title = "Warrant Officer"
+	title = "Lonestar Thug-for-Hire Captain"
 	flag = SWO
 	head_position = 1
 	department = DEPARTMENT_SECURITY
-	department_flag = SECURITY | COMMAND
+	department_flag = SECURITY | COMMAND | LSS
 	faction = MAP_FACTION
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the Council"
+	supervisors = "the CEO"
 	difficulty = "Very Hard."
 	selection_color = "#97b0be"
 	req_admin_notify = 1
@@ -110,315 +46,32 @@
 							 /datum/computer_file/program/camera_monitor,
 							 /datum/computer_file/program/reports)
 
-	description = "The Warrant Officer serves as the head officer of the local regiment of the Marshals.<br>\
-	Contracted to protect and serve the colony, your internal police force is dedicated to the fight against criminal elements.<br>\
-	Your main objective is to keep everyone safe by maintaining order, and upholding laws of all manner within the colony.<br>\
-	The Blackshield Commander is your ally and you should work closely with them - they provide the muscle and guns to defend the colony."
+	description = "The Lonestar Thug-for-Hire Captain serves as the head officer of the local regiment of the Lonestar Child Killers Inc.<br>\
+	Contracted to extort and enforce Lonestar brand corporate law on the colony, your internal police force is dedicated to the fight anti-Lonestar elements.<br>\
+	Your main objective is to kill anyone you don't like and act like real life Blackwater, Tri-Corp, Wagner Group, and other various other edgy organizations.<br>\
+	Really edgy 'people' in the Sojourn community will love and enjoy your role. Being 'based' to the terminally online incel behind his computer."
 
-	duties = "Coordinate officers around the colony, assigning them to tasks and distress calls as needed.<br>\
-		Work with the Blackshield Commander to allocate funds to supply your teams with whatever armor, supplies, weapons, munitions, or tools they need.<br>\
-		Keep the peace around the colony and ensure each officer knows their roles and carries them out precisely.<br>\
-		Oversee performance of the officers under your command and punish any that are insubordinate or incompetent.<br>\
-		Advise the council on threats to colony security and advise them towards choices that will uphold the public trust."
+	duties = "Kill women, children, and innocent 'people'.<br>\
+		Be a PMC. As is Cora, Alinar, and other brainrotted people's dream.<br>\
+		Uphold the McLaw of Lonestar(tm) brand."
 
 /obj/landmark/join/start/swo
-	name = "Warrant Officer"
+	name = "Lonestar Thug-for-Hire Captain"
 	icon_state = "player-blue-officer"
 	join_tag = /datum/job/swo
 
-
-/datum/job/supsec
-	title = "Supply Specialist"
-	flag = SUPSEC
-	department = DEPARTMENT_SECURITY
-	department_flag = SECURITY
-	faction = MAP_FACTION
-	total_positions = 1
-	spawn_positions = 1
-	supervisors = "the Warrant Officer"
-	difficulty = "Hard."
-	selection_color = "#a7bbc6"
-	department_account_access = TRUE
-	wage = WAGE_LABOUR_HAZARD
-	minimum_character_age = 25
-	playtimerequired = 1200
-	health_modifier = 20
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_NASHEF)
-
-	outfit_type = /decl/hierarchy/outfit/job/security/gunserg
-
-	access = list(
-		access_security, access_moebius, access_medspec, access_engine, access_mailsorting,
-		access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_morgue,
-		access_external_airlocks, access_research_equipment, access_prospector,
-		access_hydroponics, access_bar, access_kitchen, access_medical_suits, access_sec_shop, access_forensics_lockers
-	)
-
-	stat_modifiers = list(
-		STAT_ROB = 25,
-		STAT_TGH = 25,
-		STAT_VIG = 25,
-	)
-
-	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
-							 /datum/computer_file/program/camera_monitor)
-
-	perks = list(PERK_MARKET_PROF,
-				 /datum/perk/codespeak,
-				 /datum/perk/chem_contraband,
-				 /datum/perk/gunsmith)
-
-	description = "The Supply Specialist is the right hand of the warrant officer and the defacto controller of the armory and armory shop. <br>\
-	Your role is mainly a desk job - with duties rarely taking you outside of the colony or even the armory.<br>\
-	You will often be called to sell weaponry and armory to colonists, maintaining the stock of the equipment and tracking who has what.<br>\
-	You will also be often asked to watch or process prisoners. Perform regular checkups on anyone locked in the brig - breakouts are intolerable.<br>\
-	In quieter times, you serve as the on-site weapons instructor. Take the initiative to offer a variety of training drills, especially to junior operatives.<br>\
-	Remember that any Warrant Officer duties may be delegated to you if they wish and internal tasks will fall to you at times."
-
-	duties = "Manage a good balance of armory stock, and dispense responsibly with a paper trail and fair price.<br>\
-	Monitor prisoners in the brig to ensure their health and safety.<br>\
-	Perform training drills and other exercises to bring the Marshals up to standard."
-
-/obj/landmark/join/start/supsec
-	name = "Supply Specialist"
-	icon_state = "player-blue"
-	join_tag = /datum/job/supsec
-
-
-/datum/job/serg
-	title = "Sergeant"
-	flag = SERG
-	department = DEPARTMENT_SECURITY
-	department_flag = SECURITY
-	faction = MAP_FACTION
-	total_positions = 1
-	spawn_positions = 1
-	supervisors = "the Blackshield Commander"
-	difficulty = "Hard."
-	selection_color = "#a7bbc6"
-	department_account_access = TRUE
-	wage = WAGE_LABOUR_HAZARD
-	minimum_character_age = 25
-	playtimerequired = 1200
-	health_modifier = 20
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_NASHEF)
-
-	outfit_type = /decl/hierarchy/outfit/job/security/serg
-
-	access = list(
-		access_security, access_medspec, access_engine, access_mailsorting,
-		access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_morgue,
-		access_external_airlocks, access_research_equipment, access_prospector, access_kitchen
-	)
-
-	stat_modifiers = list(
-		STAT_ROB = 25,
-		STAT_TGH = 25,
-		STAT_VIG = 25,
-	)
-
-	perks = list(PERK_BLACKSHIELD_CONDITIONING, PERK_BOLT_REFLECT, PERK_CHEM_CONTRABAND)
-
-	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
-							 /datum/computer_file/program/camera_monitor)
-
-	description = "The Sergeant is the second-in-command of the Blackshield and the de-facto commanding officer if the Blackshield commander isn't around or injured. <br>\
-	Your role is mainly keeping order among the Blackshield troopers and corpsman and ensuring they do not act like a pack of thugs.<br>\
-	You will often be maintaining discipline and order within the ranks and fulfilling orders from the Blackshield commander.<br>\
-	You will also the secondary squad leader during conflicts, often times leading troopers independent of the Blackshield commander, but usually under his explicit orders.<br>\
-	In quieter times, you serve as a form of military police and drill instructor. Take the initiative to offer a variety of training drills, especially to junior operatives and report behavior that should have a member of security removed from their post.<br>\
-	Remember that any Blackshield Commander duties may be delegated to you if they wish, and will automatically be given if they are not present."
-
-	duties = "Manage good ethics among security, including the blackshield and marshals with a record of everything responsibly and recorded.<br>\
-	Give training and instruction to troopers. Run drills and ensure they are prepared for firing lines, kill zones, and breach tactics.<br>\
-	Follow the orders of the Blackshield Commander and in his absence keep security in line."
-
-/obj/landmark/join/start/serg
-	name = "Sergeant"
-	icon_state = "player-blue"
-	join_tag = /datum/job/serg
-
-
-/datum/job/inspector
-	title = "Ranger"
-	flag = INSPECTOR
-	department = DEPARTMENT_SECURITY
-	department_flag = SECURITY
-	faction = MAP_FACTION
-	total_positions = 2
-	spawn_positions = 2
-	supervisors = "the Warrant Officer"
-	difficulty = "Hard."
-	noob_name = "Junior Ranger"
-	alt_titles = list("Junior Ranger","Detective","Forensics Specialist")
-	selection_color = "#a7bbc6"
-	wage = WAGE_PROFESSIONAL
-	playtimerequired = 1200
-	health_modifier = 5
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_NASHEF)
-
-	outfit_type = /decl/hierarchy/outfit/job/security/inspector
-
-	access = list(
-		access_security, access_moebius, access_medspec, access_engine, access_mailsorting,
-		access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels,
-		access_external_airlocks, access_prospector, access_brig, access_hydroponics, access_bar, access_kitchen,
-		access_medical_suits
-	)
-
-	perks = list(PERK_EAR_OF_QUICKSILVER,
-				 PERK_CODESPEAK,
-				 PERK_CHEM_CONTRABAND)
-
-	stat_modifiers = list(
-		STAT_BIO = 15,
-		STAT_ROB = 15,
-		STAT_TGH = 15,
-		STAT_VIG = 25,
-	)
-
-	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
-							 /datum/computer_file/program/audio,
-							 /datum/computer_file/program/camera_monitor)
-
-	description = "The Ranger is the colony detective and field agent, taking on cases and suspects that aren't always what they seem.<br>\
-	Your job is to interrogate suspects, gather witness statements,  harvest evidence and reach a conclusion about the nature and culprit of a crime.<br>\
-	You are a higher ranking position than officers and operatives and can determine if charges are valid and may release individuals for lack of evidence. <br>\
-	However, you cannot give orders outside those pertaining to charges and arrests. The warrant officer still outranks you - bring all conflicts to them.<br>\
-	When there are no outstanding cases, look for them. Mingle with civilians, interact and converse, sniff out leads about potential criminal activity."
-
-	duties = "Interview suspects and witnesses after a crime. Record important details of their statements, and look for inconsistencies.<br>\
-		Gather evidence and bring it back for processing.<br>\
-		Send out officers to bring suspects in for questioning.<br>\
-		Interact with civilians and be on the lookout for criminal activity."
-
-/obj/landmark/join/start/inspector
-	name = "Ranger"
-	icon_state = "player-blue"
-	join_tag = /datum/job/inspector
-
-
-/datum/job/medspec
-	title = "Corpsman"
-	flag = MEDSPEC
-	department = DEPARTMENT_SECURITY
-	department_flag = SECURITY
-	faction = MAP_FACTION
-	total_positions = 2
-	spawn_positions = 2
-	supervisors = "the Blackshield Commander"
-	difficulty = "Hard."
-	noob_name = "Corpsman Cadet"
-	alt_titles = list("Corpsman Cadet", "Combat Medic")
-	selection_color = "#a7bbc6"
-	wage = WAGE_PROFESSIONAL
-	health_modifier = 5
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_NASHEF)
-
-	outfit_type = /decl/hierarchy/outfit/job/security/medspec
-
-	access = list(
-		access_security, access_sec_doors, access_medspec, access_morgue, access_maint_tunnels,
-		access_medical_equip, access_eva, access_brig, access_external_airlocks, access_surgery, access_medical_suits
-	)
-
-	stat_modifiers = list(
-		STAT_BIO = 25,
-		STAT_TGH = 10,
-		STAT_VIG = 15,
-		STAT_ROB = 10,
-	)
-
-	perks = list(PERK_MEDICAL_EXPERT, PERK_BLACKSHIELD_CONDITIONING)
-				// /datum/perk/chemist -Thanos Voice: "I'm sorry little one..."
-
-	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
-							 /datum/computer_file/program/suit_sensors,
-							 /datum/computer_file/program/chem_catalog,
-							 /datum/computer_file/program/camera_monitor)
-
-	description = "The Corpsman is a highly trained medical specialist within the Blackshield - a mixture of combatant and doctor.<br>\
-	Your first duty is that of a field medic. Serve on the back line of any combat situations, treating the wounded and evacuating the critical.<br>\
-	Your second duty is to treat any prisoners and suspects in custody. Wounds from escape and suicide attempts will test your surgical skills.<br>\
-	Your third duty, when faced with strange crimes, is to serve as a scientific analyst - scanning traces and conducting autopsies.<br>\
-	Remember that although you can be armed, the combat is better left to your colleagues. Focus on the tasks only you can do."
-
-	duties = "Minimize casualties in combat situations and treat all related wounds.<br>\
-	Treat any prisoners and suspects, and thoroughly monitor their health.<br>\
-	Work with the Ranger to solve crimes through collecting forensic evidence and conducting autopsies.<br>\
-	<b>While you are sufficiently medically trained, you are not a replacement doctor for Soteria Medical. You are a more personal combat medic under Blackshield and Marshals jurisdiction.</b>"
-
-/obj/landmark/join/start/medspec
-	name = "Corpsman"
-	icon_state = "player-blue"
-	join_tag = /datum/job/medspec
-
-
-/datum/job/trooper
-	title = "Blackshield Trooper"
-	flag = TROOPER
-	department = DEPARTMENT_SECURITY
-	department_flag = SECURITY
-	faction = MAP_FACTION
-	total_positions = 4
-	spawn_positions = 4
-	supervisors = "the Blackshield Commander"
-	difficulty = "Hard."
-	noob_name = "Blackshield Cadet"
-	alt_titles = list("Blackshield Cadet")
-	selection_color = "#a7bbc6"
-	wage = WAGE_LABOUR_HAZARD
-	health_modifier = 10
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_NASHEF)
-
-	outfit_type = /decl/hierarchy/outfit/job/security/troop
-
-	perks = list(PERK_BLACKSHIELD_CONDITIONING, PERK_BOLT_REFLECT, PERK_CHEM_CONTRABAND)
-
-	access = list(
-		access_security, access_eva,
-		access_sec_doors, access_brig, access_maint_tunnels, access_external_airlocks
-	)
-
-	stat_modifiers = list(
-		STAT_ROB = 25,
-		STAT_TGH = 20,
-		STAT_VIG = 25,
-	)
-
-	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
-							 /datum/computer_file/program/camera_monitor)
-
-	description = "The Trooper forms the base of the Blackshield, the front line against pirates, terrorists, and xenos.<br>\
-	You are the closest thing to a professional soldier the colony has. Employ your talents to bring an end to threats and conflict situations.<br>\
-	Tactics and teamwork are vital. You are paid to follow orders, not to think. Remember your focus on external threats - leave otherwise to Marshals.<br>\
-	When there are no standing orders, your ongoing task is to patrol and be on the lookout for threats or problems. Help the Marshals if explicitly asked. <br>\
-	Watch the main gate and perimeter. You have access to most places to help with your duties - do not abuse this."
-
-	duties = "Patrol the colony, provide a security presence, and look for trouble.<br>\
-		Deal with external threats to the colony such as pirates, hostile xenos, and anything that endangers colonists.<br>\
-		Exterminate monsters, giant vermin and hostile machines.<br>\
-		Follow orders from the chain of command.<br>\
-		Obey the law. You are not above it."
-
-/obj/landmark/join/start/trooper
-	name = "Blackshield Trooper"
-	icon_state = "player-blue"
-	join_tag = /datum/job/trooper
-
-
 /datum/job/officer
-	title = "Marshal Officer"
+	title = "Lonestar Thug-for-Hire"
 	flag = OFFICER
 	department = DEPARTMENT_SECURITY
-	department_flag = SECURITY
+	department_flag = SECURITY | LSS
 	faction = MAP_FACTION
 	total_positions = 4
 	spawn_positions = 4
-	supervisors = "the Warrant Officer"
+	supervisors = "the Thug-for-Hire Captain"
 	difficulty = "Hard."
-	noob_name = "Junior Marshal Officer"
-	alt_titles = list("Junior Marshal Officer", "Marshal Civil Servant")
+	noob_name = "McLonestar Child Soldier"
+	alt_titles = list("McLonestar Child Soldier", "LARPers Wet Dream")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
 	health_modifier = 10
@@ -442,19 +95,14 @@
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/camera_monitor)
 
-	description = "The Marshal Officer forms the brunt of the Marshals, internally enforcing law and keeping the peace.<br>\
-	You are expected to be a problem solver who can descalate situations, reach peaceful agreements, and maintain public trust.<br>\
-	Keep your weapons holstered unless the situation demands otherwise - exercise good judgment and follow Blackshield orders.<br>\
-	When there are no standing orders, your ongoing task is to patrol the colony and be on the lookout for threats or problems. <br>\
-	Check in at departments and watch the main gate. You have access to most places to help with your duties  - do not abuse this."
+	description = "The Lonestar Thug-for-Hire forms the brunt of Lonestar, internally enforcing McLaw and extorting the public.<br>\
+	You are expected to be a problem solver who can descalate situations - such as shooting whoever you like.<br>\
+	Keep your weapons unholster, target innocent people, and follow the Lonestar CEO's plans.<br>\
+	Edgy larpers who contribute the worst, most putrid ideas - given usually by 15 year old HOI4 players - will love and look up to you."
 
-	duties = "Patrol the colony, provide a security presence, and look for trouble.<br>\
-		Deal with internal threats to the colony such as criminals, saboteurs, and anything that endangers colonists.<br>\
-		Ensure that people follow the law and SoP to maintain order.<br>\
-		Follow orders from the chain of command.<br>\
-		Obey the law. You are not above it."
+	duties = "Kill."
 
 /obj/landmark/join/start/officer
-	name = "Marshal Officer"
+	name = "Lonestar Thug-for-Hire"
 	icon_state = "player-blue"
 	join_tag = /datum/job/officer

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -107,8 +107,7 @@ ADMIN_VERB_ADD(/client/proc/test_MD, R_DEBUG, null)
 
 	var/default_spawn = "Cryogenic Storage"
 
-	var/allowed_jobs = list(/datum/job/premier, /datum/job/rd, /datum/job/pg, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/smc, /datum/job/swo, /datum/job/foreman,
-						/datum/job/supsec, /datum/job/inspector, /datum/job/medspec, /datum/job/trooper, /datum/job/officer, /datum/job/serg,
+	var/allowed_jobs = list(/datum/job/premier, /datum/job/rd, /datum/job/pg, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/swo, /datum/job/foreman, /datum/job/officer,
 						/datum/job/doctor, /datum/job/recovery_team, /datum/job/psychiatrist,
 						/datum/job/technomancer,
 						/datum/job/cargo_tech, /datum/job/mining, /datum/job/merchant,

--- a/code/modules/tips_and_tricks/jobs.dm
+++ b/code/modules/tips_and_tricks/jobs.dm
@@ -8,7 +8,7 @@
     tipText = "As a premier, you function as an internal affairs agent, lawyer, and mediator."
 
 /tipsAndTricks/jobs/ironhammer_theft
-    jobs_list = list(/datum/job/smc, /datum/job/swo, /datum/job/supsec, /datum/job/inspector, /datum/job/medspec, /datum/job/trooper, /datum/job/officer, /datum/job/serg)
+    jobs_list = list(/datum/job/swo, /datum/job/officer)
     tipText = "As a member of security, you have broad access to chase criminals. This does not mean you can take anything you have access to. Taking things from other departments is theft!"
 
 /tipsAndTricks/jobs/plants_are_dieing_gardener
@@ -247,7 +247,7 @@
     tipText = "As an AI you can remotely control drone shells."
 
 /tipsAndTricks/jobs/pda_paper_scanner
-    jobs_list = list(/datum/job/premier, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/smc, /datum/job/pg, /datum/job/rd)
+    jobs_list = list(/datum/job/premier, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/pg, /datum/job/rd)
     tipText = "Your PDA has an integrated paper scanner and printer."
 
 /tipsAndTricks/jobs/aiCanBeMoved


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Since we are a server full of ideas and amazing forethought and totally no hypocrisy on the end of many people involved in its development / staff / 'ideas' - I will be standardizing all our ideas here.

Marshals and Blackshield have been **removed**!

They have been since replaced with Lonestar brand McMercenaries - since this server has a strange, quirky habit of fetishizing the idea of PMCs while sitting behind their computer.

This shall work as the Creative Director's approved Lonestar McMercs content **MERGED** with the Blackshield PMC rework promised to players for ages.

As such, here you go! I've added the asked for PR. It will be adjusted to be inline with the following McMercs path. Following the pathing:
- /mob/living/superior_animal/human/colony_allie/ship_breaker_marks
- /mob/living/superior_animal/human/colony_allie/ship_breaker_marks/sword

![image](https://user-images.githubusercontent.com/47883419/225472754-5e5d21d6-64d0-4cf5-9577-c3b4451495d0.png)
^ Will be redoing all the gear soon to look like this. ^

## "Rebel, is this a meme?"

No, honestly. It's not anymore. This is a PR for the braindead people who have asked for this, and the staff who just hypocritically DMed me to complain about code shit 'not fitting their lore idea' but approved this shit without much thought in their empty head.

## Changelog
:cl:
removes: Blackshield & Marshals
Adds: McChildkiller Mercenaries (Wagner Group is SS13)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
