### PR TITLE
dynamic xenoarch anomalies

### DIFF
--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -6,8 +6,8 @@ SUBSYSTEM_DEF(xenoarch)
 	var/const/xenoarch_spawn_chance = 0.5
 	var/const/digsite_size_lower = 4
 	var/const/digsite_size_upper = 12
-	var/const/artifact_spawnnum_lower = 6
-	var/const/artifact_spawnnum_upper = 12
+	var/artifact_spawnnum_lower = 1
+	var/artifact_spawnnum_upper = 2
 
 	var/list/artifact_spawning_turfs = list()
 	var/list/digsite_spawning_turfs = list()
@@ -76,9 +76,12 @@ SUBSYSTEM_DEF(xenoarch)
 			//have a chance for an artifact to spawn here, but not in animal or plant digsites
 			if(isnull(M.artifact_find) && digsite != 1 && digsite != 2)
 				artifact_spawning_turfs.Add(archeo_turf)
+				artifact_spawnnum_upper += 1
 
 	//create artifact machinery
-	var/num_artifacts_spawn = rand(artifact_spawnnum_lower, artifact_spawnnum_upper)
+	artifact_spawnnum_lower = artifact_spawnnum_upper / 2
+	var/num_artifacts_spawn = rand(artifact_spawnnum_lower * 0.1, artifact_spawnnum_upper * 0.1) // 0.1 makes it 10% potentially might have to be lowered more.
+	//log_and_message_admins("Xenoarch artifact spawn count is [num_artifacts_spawn].") //Used to test how many spawned at round start.
 	while(artifact_spawning_turfs.len > num_artifacts_spawn)
 		pick_n_take(artifact_spawning_turfs)
 


### PR DESCRIPTION
Makes anomalies spawn at a 5% - 10% of total non fossil digsites rate.
Might be tweaked down the line if to many are spawning.