### PR TITLE
more sanity interactions

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -332,7 +332,6 @@ obj/item/scroll/attackby(obj/item/I, mob/living/carbon/human/M)
 					mage_candle.endless_burn = TRUE
 					B.remove_self(15)
 					M.sanity.changeLevel(-5)
-					mage_candle.lit_sanity_damage = 0.5 //Flips this to be a bad thing, its burning magically!!!
 					to_chat(M, "<span class='info'>A candle is lit by forces unknown...</span>")
 				candle_amount += 1
 

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -332,6 +332,7 @@ obj/item/scroll/attackby(obj/item/I, mob/living/carbon/human/M)
 					mage_candle.endless_burn = TRUE
 					B.remove_self(15)
 					M.sanity.changeLevel(-5)
+					mage_candle.lit_sanity_damage = 0.5 //Flips this to be a bad thing, its burning magically!!!
 					to_chat(M, "<span class='info'>A candle is lit by forces unknown...</span>")
 				candle_amount += 1
 

--- a/code/game/objects/items/weapons/candle.dm
+++ b/code/game/objects/items/weapons/candle.dm
@@ -8,6 +8,7 @@
 	light_color = COLOR_LIGHTING_ORANGE_DARK
 	var/wax = 2000
 	var/endless_burn = FALSE
+	var/lit_sanity_damage = -0.5
 
 /obj/item/flame/candle/New()
 	wax = rand(800, 1000) // Enough for 27-33 minutes. 30 minutes on average.
@@ -53,13 +54,14 @@
 
 
 /obj/item/flame/candle/proc/light(flavor_text = SPAN_NOTICE("\The [usr] lights the [name]."))
-	if(!src.lit)
-		src.lit = 1
+	if(!lit)
+		lit = 1
 		//src.damtype = "fire"
 		for(var/mob/O in viewers(usr, null))
 			O.show_message(flavor_text, 1)
 		set_light(CANDLE_LUM)
 		START_PROCESSING(SSobj, src)
+		sanity_damage = lit_sanity_damage
 
 
 /obj/item/flame/candle/Process()
@@ -82,6 +84,7 @@
 		lit = 0
 		update_icon()
 		set_light(0)
+		sanity_damage = 0
 
 /obj/item/flame/candle/eternal
 	name = "eternal candle"
@@ -89,6 +92,7 @@
 	icon_state = "candle_eternal"
 	light_color = COLOR_LIGHTING_CYAN_BRIGHT
 	endless_burn = TRUE
+	lit_sanity_damage = -1
 
 /obj/item/flame/candle/eternal/update_icon()
 	var/i

--- a/code/game/objects/structures/bluespace_crystal_structure.dm
+++ b/code/game/objects/structures/bluespace_crystal_structure.dm
@@ -25,6 +25,7 @@
 		/obj/item/seeds/bluespacetomatoseed
 	)
 	var/entropy_value = 8
+	sanity_damage = 1 //Looks nice!
 
 /obj/structure/bs_crystal_structure/New()
 	..()

--- a/code/game/objects/structures/diamond_gem.dm
+++ b/code/game/objects/structures/diamond_gem.dm
@@ -11,6 +11,7 @@
 	//Insainly rare materals, tho its impossable to brake down without some adv trickery
 	matter = list(MATERIAL_VOXALLOY = 5, MATERIAL_DURASTEEL = 30, MATERIAL_DIAMOND = 30, MATERIAL_TITANIUM = 10, MATERIAL_OSMIUM = 20, MATERIAL_MHYDROGEN = 20, MATERIAL_PLASMAGLASS = 60, MATERIAL_PLASMA = 100)
 	price_tag = 0 //We have no buyer
+	sanity_damage = 4 //Looks nice!
 
 /obj/structure/diamond/attackby(obj/item/I, mob/user)
 
@@ -33,3 +34,4 @@
 	icon_state = "weathyshovel"
 	matter = list(MATERIAL_DIAMOND = 30, MATERIAL_GOLD = 20)
 	price_tag = 200 //as much as tools used to be worth sold...
+	sanity_damage = 2 //Looks nice!

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -58,6 +58,7 @@
 			src.locked = FALSE
 			new /obj/item/material/shard( src.loc )
 			playsound(src, "shatter", 70, 1)
+			sanity_damage = 0.5 //Broken window theory
 			update_icon()
 	else
 		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -93,10 +93,13 @@
 		if(has_extinguisher)
 			if(istype(has_extinguisher, /obj/item/extinguisher/mini))
 				icon_state = "extinguisher_closed_mini"
+				sanity_damage = -0.1
 			else
 				icon_state = "extinguisher_closed_full"
+				sanity_damage = -0.2
 		else
 			icon_state = "extinguisher_closed"
+			sanity_damage = 0
 		return
 	if(has_extinguisher)
 		if(istype(has_extinguisher, /obj/item/extinguisher/mini))
@@ -105,3 +108,4 @@
 			icon_state = "extinguisher_full"
 	else
 		icon_state = "extinguisher_empty"
+		sanity_damage = 0.1

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -24,6 +24,7 @@
 	shattered = TRUE
 	unlocked = TRUE
 	open = TRUE
+	sanity_damage = 0.1 //Broken window theory
 	playsound(user, 'sound/effects/Glassbr3.ogg', 100, 1)
 	update_icon()
 

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -23,19 +23,19 @@
 	if(needs_to_maintain)
 		if(prob(25))
 			needs_to_be_deweeded = TRUE
-			sanity_damage = 0.01
+			sanity_damage += 0.004
 		if(prob(25))
 			needs_to_be_pest_b_goned = TRUE
-			sanity_damage = 0.01
+			sanity_damage += 0.004
 		if(prob(25))
 			needs_to_be_watered = TRUE
-			sanity_damage = 0.01
+			sanity_damage += 0.004
 		if(prob(10))
 			remove_dead_weeds = TRUE
-			sanity_damage = 0.01
+			sanity_damage += 0.004
 		if(prob(10))
 			remove_dead_pets = TRUE
-			sanity_damage = 0.01
+			sanity_damage += 0.004
 
 /obj/structure/flora/examine(mob/user)
 	..()
@@ -59,7 +59,7 @@
 			to_chat(user, "<span class='info'>The invasive weeds wilt away.</span>")
 			needs_to_be_deweeded = FALSE
 			remove_dead_weeds = TRUE
-			sanity_damage -= -0.01
+			sanity_damage -= 0.004
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 2, learner = H)
@@ -67,7 +67,7 @@
 		if(istype(I, /obj/item/tool/minihoe))
 			to_chat(user, "<span class='info'>You remove the invasive plants.</span>")
 			needs_to_be_deweeded = FALSE
-			sanity_damage -= -0.01
+			sanity_damage -= 0.004
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 1, learner = H)
@@ -76,7 +76,7 @@
 		if(istype(I, /obj/item/tool/minihoe)  || istype(I, /obj/item/tool/scythe))
 			to_chat(user, "<span class='info'>The weeds are no more.</span>")
 			remove_dead_weeds = FALSE
-			sanity_damage -= -0.01
+			sanity_damage -= 0.004
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 1, learner = H)
@@ -86,7 +86,7 @@
 			to_chat(user, "<span class='info'>The harmful pests slowly die out.</span>")
 			needs_to_be_pest_b_goned = FALSE
 			remove_dead_pets = TRUE
-			sanity_damage -= -0.01
+			sanity_damage -= 0.004
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 1, learner = H)
@@ -95,7 +95,7 @@
 		if(istype(I, /obj/item/tool/shovel))
 			to_chat(user, "<span class='info'>The dead pests are no more.</span>")
 			remove_dead_pets = FALSE
-			sanity_damage -= -0.01
+			sanity_damage -= 0.004
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 1, learner = H)
@@ -104,7 +104,7 @@
 		if(istype(I, /obj/item/plantspray/water))
 			to_chat(user, "<span class='info'>The water rejuvenates the plants.</span>")
 			needs_to_be_watered = FALSE
-			sanity_damage -= -0.01
+			sanity_damage -= 0.004
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 3, learner = H)

--- a/code/game/objects/structures/flora/flora.dm
+++ b/code/game/objects/structures/flora/flora.dm
@@ -23,14 +23,19 @@
 	if(needs_to_maintain)
 		if(prob(25))
 			needs_to_be_deweeded = TRUE
+			sanity_damage = 0.01
 		if(prob(25))
 			needs_to_be_pest_b_goned = TRUE
+			sanity_damage = 0.01
 		if(prob(25))
 			needs_to_be_watered = TRUE
+			sanity_damage = 0.01
 		if(prob(10))
 			remove_dead_weeds = TRUE
+			sanity_damage = 0.01
 		if(prob(10))
 			remove_dead_pets = TRUE
+			sanity_damage = 0.01
 
 /obj/structure/flora/examine(mob/user)
 	..()
@@ -54,6 +59,7 @@
 			to_chat(user, "<span class='info'>The invasive weeds wilt away.</span>")
 			needs_to_be_deweeded = FALSE
 			remove_dead_weeds = TRUE
+			sanity_damage -= -0.01
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 2, learner = H)
@@ -61,6 +67,7 @@
 		if(istype(I, /obj/item/tool/minihoe))
 			to_chat(user, "<span class='info'>You remove the invasive plants.</span>")
 			needs_to_be_deweeded = FALSE
+			sanity_damage -= -0.01
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 1, learner = H)
@@ -69,6 +76,7 @@
 		if(istype(I, /obj/item/tool/minihoe)  || istype(I, /obj/item/tool/scythe))
 			to_chat(user, "<span class='info'>The weeds are no more.</span>")
 			remove_dead_weeds = FALSE
+			sanity_damage -= -0.01
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 1, learner = H)
@@ -78,6 +86,7 @@
 			to_chat(user, "<span class='info'>The harmful pests slowly die out.</span>")
 			needs_to_be_pest_b_goned = FALSE
 			remove_dead_pets = TRUE
+			sanity_damage -= -0.01
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 1, learner = H)
@@ -86,6 +95,7 @@
 		if(istype(I, /obj/item/tool/shovel))
 			to_chat(user, "<span class='info'>The dead pests are no more.</span>")
 			remove_dead_pets = FALSE
+			sanity_damage -= -0.01
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 1, learner = H)
@@ -94,6 +104,7 @@
 		if(istype(I, /obj/item/plantspray/water))
 			to_chat(user, "<span class='info'>The water rejuvenates the plants.</span>")
 			needs_to_be_watered = FALSE
+			sanity_damage -= -0.01
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
 				H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/clay_thumb, "CLAY_THUMB_CONISOUR", skill_gained = 3, learner = H)

--- a/code/game/objects/structures/flora/flora_potted.dm
+++ b/code/game/objects/structures/flora/flora_potted.dm
@@ -5,6 +5,7 @@
 	icon_state = "plant-26"
 	layer = PROJECTILE_HIT_THRESHHOLD_LAYER
 	needs_to_maintain = TRUE
+	sanity_damage = -0.05
 
 /obj/structure/flora/pottedplant
 	name = "potted plant"
@@ -12,6 +13,7 @@
 	icon = 'icons/obj/plants.dmi'
 	icon_state = "plant-01"
 	needs_to_maintain = TRUE
+	sanity_damage = -0.05
 
 /obj/structure/flora/pottedplant/large
 	name = "large potted plant"
@@ -255,6 +257,7 @@
 	light_power = 0.6
 	light_color = "#B5A642" //Brass-y
 	needs_to_maintain = FALSE
+	sanity_damage = -0.06 //Rare and looks nice
 
 /obj/structure/flora/pottedplant/bush_ball
 	name = "potted bush ball"

--- a/code/game/objects/structures/flora/flora_potted.dm
+++ b/code/game/objects/structures/flora/flora_potted.dm
@@ -5,7 +5,7 @@
 	icon_state = "plant-26"
 	layer = PROJECTILE_HIT_THRESHHOLD_LAYER
 	needs_to_maintain = TRUE
-	sanity_damage = -0.05
+	sanity_damage = -0.02
 
 /obj/structure/flora/pottedplant
 	name = "potted plant"
@@ -13,7 +13,7 @@
 	icon = 'icons/obj/plants.dmi'
 	icon_state = "plant-01"
 	needs_to_maintain = TRUE
-	sanity_damage = -0.05
+	sanity_damage = -0.02
 
 /obj/structure/flora/pottedplant/large
 	name = "large potted plant"
@@ -257,7 +257,7 @@
 	light_power = 0.6
 	light_color = "#B5A642" //Brass-y
 	needs_to_maintain = FALSE
-	sanity_damage = -0.06 //Rare and looks nice
+	sanity_damage = -0.03 //Rare and looks nice
 
 /obj/structure/flora/pottedplant/bush_ball
 	name = "potted bush ball"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -252,6 +252,7 @@
 	starting_reagent = "water"
 	var/cups = 20
 	var/cup_type = /obj/item/reagent_containers/food/drinks/sillycup
+	sanity_damage = 0.1 //Talk around these RP!
 
 /obj/structure/reagent_dispensers/water_cooler/attack_hand(var/mob/user)
 	if(cups > 0)

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -53,7 +53,7 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 	var/sanity_passive_gain_multiplier = 1
 	var/sanity_invulnerability = 0
 	var/level
-	var/max_level = 100
+	var/max_level = 150 //Soj change to give a bit more breathing room
 	var/level_change = 0
 
 	var/insight


### PR DESCRIPTION
Adds more instigations of sanity
Potted plants now regen small amount of sanity, everything it needs to be maintained lowers its sanity regen
Broken fire axe cases and display cases lower sanity
Water coolers increase sanity
extinguisher cases now increase sanity based on being stocked (Mini gives smaller then full stock), having a empty  on open deals sanity damage
Bluespace cystal stuckers now give sanity
Both the golden shovel and LSS big gem now give sanity

Increases max sanity storage by 20 to give a bit more of breathing room