### PR TITLE
Erismed ports

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -250,7 +250,6 @@
 		"dermaline_amount" = H.reagents.get_reagent_amount("dermaline"),
 		"blood_amount" = round((H.vessel.get_reagent_amount("blood") / H.species.blood_volume)*100),
 		"disabilities" = H.sdisabilities,
-		"lung_ruptured" = H.is_lung_ruptured(),
 		"external_organs" = H.organs.Copy(),
 		"internal_organs" = H.internal_organs.Copy(),
 		"species_organs" = H.species.has_process, //Just pass a reference for this, it shouldn't ever be modified outside of the datum.
@@ -349,8 +348,6 @@
 				dat += "<td>[I.name],<br><i>[e.name]</i></td><td>[total_burn_damage]</td><td>[total_brute_and_misc_damage]</td><td>[internal_wounds_details ? internal_wounds_details : "None"]</td><td></td>"
 				dat += "</tr>"
 
-		if(e.organ_tag == BP_CHEST && occ["lung_ruptured"])
-			other_wounds += "Lung ruptured"
 		if(e.status & ORGAN_SPLINTED)
 			other_wounds += "Splinted"
 		if(e.status & ORGAN_BLEEDING)

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -112,20 +112,22 @@
 	var/tox_content = M.chem_effects[CE_TOXIN] + M.chem_effects[CE_ALCOHOL_TOXIC]
 	var/OX = M.getOxyLoss() > 50 	? 	"<b>[M.getOxyLoss()]</b>" 		: M.getOxyLoss()
 	var/TX = tox_content > 8		?	"<b>[tox_content]</b>"			: (tox_content ? tox_content : "0")
-	var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
 	var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getBruteLoss()]</b>" 	: M.getBruteLoss()
+	var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
+
 	// Values are rounded because of nerve efficiency and damage, backgrounds,
 	// VIV stat changes, chems, and other variables that affect max NSA threshold.
 	var/NSA = round(M.metabolism_effects.get_nsa(), 1)
 	var/NSA_MAX = round(M.metabolism_effects.nsa_threshold, 1)
+
 	if(M.status_flags & FAKEDEATH)
 		OX = fake_oxy > 50 			? 	"<b>[fake_oxy]</b>" 			: fake_oxy
 		dat += "<h2>Analyzing Results for [M]:</h2>"
 		dat += span("highlight", "Overall Status: dead")
 	else
 		dat += span("highlight", "Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "dead" : "[round(M.health/M.maxHealth*100)]% healthy"]")
-	dat += span("highlight", "    Key: <font color='#0080ff'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font>")
-	dat += span("highlight", "    Damage Specifics: <font color='#0080ff'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font>")
+	dat += span("highlight", "    Key: <font color='#0080ff'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='red'>Brute</font>/<font color='#FFA500'>Burns</font>")
+	dat += span("highlight", "    Damage Specifics: <font color='#0080ff'>[OX]</font> - <font color='green'>[TX]</font> - <font color='red'>[BR]</font> - <font color='#FFA500'>[BU]</font>")
 	if(M.bodytemperature >= 313.15) // 40º C / 104 F = fever
 		dat += span("highlight", "Body Temperature: <font color='red'>[M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)</font>")
 	else if(M.bodytemperature <= 283.222) // 10º C / 50 F = too cold, this is slowdown threshold too
@@ -144,26 +146,41 @@
 	if(ishuman(M) && mode == 1)
 		var/mob/living/carbon/human/H = M
 		var/list/damaged = H.get_damaged_organs(1, 1)
-		dat += span("highlight", "Localized Damage, Brute/Burn:")
+		dat += "<hr>"
+		dat += span("highlight", "Localized Damage:")
 		if(length(damaged) > 0)
 			for(var/obj/item/organ/external/org in damaged)
-				dat += text("<span class='highlight'>     [][]: [][] - []</span>",
+				var/brute_health = org.max_health - org.brute_dam
+				var/burn_health = org.max_health - org.burn_dam
+				var/internal_wound_severity = org.severity_internal_wounds
+
+				if(internal_wound_severity > 0)
+					if(internal_wound_severity < 5)
+						internal_wound_severity = "Light"
+					else if(internal_wound_severity < 8)
+						internal_wound_severity = "Moderate"
+					else
+						internal_wound_severity = "Severe"
+				else
+					internal_wound_severity = null
+
+				dat += text("<span class='highlight'>     [][]:  [] - [] - [] [] []</span>",
 				capitalize(org.name),
 				(BP_IS_ROBOTIC(org)) ? "(Cybernetic)" : "",
-				(org.brute_dam > 0) ? SPAN_WARNING("[org.brute_dam]") : 0,
-				(org.status & ORGAN_BLEEDING)?SPAN_DANGER(" \[Bleeding\]"):"",
-				(org.burn_dam > 0) ? "<font color='#FFA500'>[org.burn_dam]</font>" : 0)
+				"<font color='red'>[brute_health ? brute_health : "0"] / [org.max_health]</font>",
+				"<font color='#FFA500'>[burn_health ? burn_health : "0"] / [org.max_health]</font>",
+				(org.status & ORGAN_BLEEDING) ? "<font color='red'>\[Bleeding\]</font>" : "",
+				(org.status & ORGAN_BROKEN && !(org.status & ORGAN_SPLINTED)) ? "<font color='red'>\[Broken\]</font>" : "",
+				internal_wound_severity ? "<font color='red'>\[[internal_wound_severity] Organ Wounds\]</font>" : "")
 		else
-			dat += span("highlight", "    Limbs are OK.")
+			dat += span("highlight", "Limbs are OK.")
+		dat += "<hr>"
 
 	OX = M.getOxyLoss() > 50 ? 	 "<font color='#0080ff'><b>Severe oxygen deprivation detected</b></font>" 		: 	"Subject bloodstream oxygen level normal"
-	TX = tox_content > 8 ? 	 "<font color='green'><b>Dangerous amount of toxins detected</b></font>" 	: 	"Subject bloodstream toxin level minimal"
-	BU = M.getFireLoss() > 50 ?  "<font color='#FFA500'><b>Severe burn damage detected</b></font>" 			:	"Subject burn injury status O.K"
-	BR = M.getBruteLoss() > 50 ? "<font color='red'><b>Severe anatomical damage detected</b></font>" 		: 	"Subject brute-force injury status O.K"
-	NSA = NSA >= NSA_MAX ? "<font color='#6533da'><b>Severe Neural System Accumulation detected!</b></font>" 	: 	"Subject Neural System Accumulation nominal"
+	TX = tox_content > 12 ? 	 "<font color='green'><b>Dangerous amount of toxins detected</b></font>" 	: 	"Subject bloodstream toxin level minimal"
 	if(M.status_flags & FAKEDEATH)
 		OX = fake_oxy > 50 ? SPAN_WARNING("Severe oxygen deprivation detected") : "Subject bloodstream oxygen level normal"
-	dat += "[OX] | [TX] | [BU] | [BR] | [NSA]"
+	dat += "[OX] | [TX] | [NSA]"
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
 		if(C.reagents.total_volume)
@@ -207,47 +224,15 @@
 		dat += SPAN_WARNING("Significant brain damage detected. Subject may have had a concussion.")
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		var/foundUnlocatedFracture = FALSE
-		for(var/name in H.organs_by_name)
-			var/obj/item/organ/external/E = H.organs_by_name[name]
-			if(!E)
-				continue
-			if(E.status & ORGAN_BROKEN)
-				if(!(E.status & ORGAN_SPLINTED))
-					if(E.organ_tag in list(BP_R_ARM, BP_L_ARM, BP_R_LEG, BP_L_LEG))
-						dat += SPAN_WARNING("Unsecured fracture in subject's [E.get_bone()]. Splinting recommended for transport.")
-					else if(E.organ_tag in list(BP_HEAD, BP_CHEST, BP_GROIN))
-						dat += SPAN_WARNING("Unsecured fracture in subject's [E.get_bone()]. Surgery recommended.")
-					else
-						foundUnlocatedFracture = TRUE
-
-		if(foundUnlocatedFracture) // Sanity check
-			dat += SPAN_WARNING("Bone fractures detected. Advanced scanner required for location.")
-
-		for(var/obj/item/organ/external/e in H.organs)
-			if(!e)
-				continue
-			for(var/datum/wound/W in e.wounds) if(W.internal)
-				dat += text(SPAN_WARNING("Internal trauma detected. Advanced scanner required for location."))
-				break
-			var/internal_wound_severity = e.severity_internal_wounds
-			if(!internal_wound_severity)
-				continue
-			if(internal_wound_severity < 5)
-				dat += text(SPAN_WARNING("Light internal damage detected in \the [e]. Advanced scanner required for location. Treatment recommended."))
-			else if(internal_wound_severity < 9)
-				dat += text(SPAN_WARNING("Moderate internal damage detected \the [e]. Advanced scanner required for location. Treatment recommended."))
-			else
-				dat += text(SPAN_WARNING("Severe internal damage detected \the [e]. Advanced scanner required for location. Immediate treatment recommended."))
 
 		if(H.vessel)
 			var/blood_volume = H.vessel.get_reagent_amount("blood")
 			var/blood_percent =  round((blood_volume / H.species.blood_volume)*100)
 			var/blood_type = H.dna.b_type
 			if((blood_percent <= H.total_blood_req + BLOOD_VOLUME_SAFE_MODIFIER) && (blood_percent > H.total_blood_req + BLOOD_VOLUME_BAD_MODIFIER))
-				dat += SPAN_DANGER("Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl.</span> <span class='highlight'>Type: [blood_type]")
+				dat += "<font color='red'>Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl.</font> <span class='highlight'>Type: [blood_type]</span>"
 			else if(blood_percent <= H.total_blood_req + BLOOD_VOLUME_BAD_MODIFIER)
-				dat += SPAN_DANGER("<i>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl.</i></span> <span class='highlight'>Type: [blood_type]")
+				dat += "<font color='red'><i>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl.</i></font> <span class='highlight'>Type: [blood_type]</span>"
 			else
 				dat += span("highlight", "Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]")
 		dat += "<span class='highlight'>Subject's pulse: <font color='[H.pulse() == PULSE_THREADY || H.pulse() == PULSE_NONE ? "red" : "#0080ff"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font></span>"

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -150,8 +150,8 @@
 		dat += span("highlight", "Localized Damage:")
 		if(length(damaged) > 0)
 			for(var/obj/item/organ/external/org in damaged)
-				var/brute_health = org.max_health - org.brute_dam
-				var/burn_health = org.max_health - org.burn_dam
+				var/brute_health = org.max_damage - org.brute_dam
+				var/burn_health = org.max_damage - org.burn_dam
 				var/internal_wound_severity = org.severity_internal_wounds
 
 				if(internal_wound_severity > 0)
@@ -167,8 +167,8 @@
 				dat += text("<span class='highlight'>     [][]:  [] - [] - [] [] []</span>",
 				capitalize(org.name),
 				(BP_IS_ROBOTIC(org)) ? "(Cybernetic)" : "",
-				"<font color='red'>[brute_health ? brute_health : "0"] / [org.max_health]</font>",
-				"<font color='#FFA500'>[burn_health ? burn_health : "0"] / [org.max_health]</font>",
+				"<font color='red'>[brute_health ? brute_health : "0"] / [org.max_damage]</font>",
+				"<font color='#FFA500'>[burn_health ? burn_health : "0"] / [org.max_damage]</font>",
 				(org.status & ORGAN_BLEEDING) ? "<font color='red'>\[Bleeding\]</font>" : "",
 				(org.status & ORGAN_BROKEN && !(org.status & ORGAN_SPLINTED)) ? "<font color='red'>\[Broken\]</font>" : "",
 				internal_wound_severity ? "<font color='red'>\[[internal_wound_severity] Organ Wounds\]</font>" : "")

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -187,7 +187,7 @@
 
 							if(!(M.organ_list_by_process(OP_LUNGS).len) || M.losebreath)
 								sound += " and no respiration"
-							else if(M.is_lung_ruptured() || M.getOxyLoss() > 50)
+							else if(M.getOxyLoss() > 50)
 								sound += " and [pick("wheezing","gurgling")] sounds"
 							else
 								sound += " and healthy respiration"

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -53,6 +53,15 @@
 		health = 0
 		..(wound_damage, damage_type, wounding_multiplier, sharp, edge, silent)
 
+/// Brain blood oxygenation is handled via oxyloss
+/obj/item/organ/internal/brain/handle_blood()
+	if(BP_IS_ROBOTIC(src) || !owner)
+		return
+	if(!blood_req)
+		return
+
+	current_blood = max_blood_storage
+
 /obj/item/organ/internal/brain/proc/clear_hud()
 	if(brainmob && brainmob.client)
 		brainmob.client.screen.len = null //clear the hud

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -932,22 +932,8 @@ var/list/rank_prefix = list(\
 
 	..()
 
-/mob/living/carbon/human/proc/is_lung_ruptured()
-	var/obj/item/organ/internal/lungs/L = random_organ_by_process(OP_LUNGS)
-	return L && L.is_bruised()
-
-/mob/living/carbon/human/proc/rupture_lung()
-	var/obj/item/organ/internal/lungs/L = random_organ_by_process(OP_LUNGS)
-
-	if(L && !L.is_bruised())
-		src.custom_pain("You feel a stabbing pain in your chest!", 1)
-		L.bruise()
-
-
-//returns 1 if made bloody, returns 0 otherwise
-
-/mob/living/carbon/human/add_blood(mob/living/carbon/human/M as mob)
-	if (!..())
+/mob/living/carbon/human/add_blood(mob/living/carbon/human/M)
+	if(!..())0e08cb51 (removed legacy lung rupture, pulse fix)
 		return 0
 	//if this blood isn't already in the list, add it
 	if(istype(M))
@@ -1513,7 +1499,7 @@ var/list/rank_prefix = list(\
 //			output for machines^	^^^^^^^output for people^^^^^^^^^
 
 /mob/living/carbon/human/proc/pulse()
-	if(!(organ_list_by_process(OP_HEART).len))
+	if(stat == DEAD || !(organ_list_by_process(OP_HEART).len))
 		return PULSE_NONE
 	else
 		return pulse

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -933,7 +933,7 @@ var/list/rank_prefix = list(\
 	..()
 
 /mob/living/carbon/human/add_blood(mob/living/carbon/human/M)
-	if(!..())0e08cb51 (removed legacy lung rupture, pulse fix)
+	if(!..())
 		return 0
 	//if this blood isn't already in the list, add it
 	if(istype(M))

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -167,6 +167,8 @@
 	return ..()
 
 /mob/living/carbon/human/adjustOxyLoss(amount)
+	if(in_stasis && amount > 0)		// Stasis prevents oxy loss
+		return
 	if(species.flags & NO_BREATHE)
 		oxyloss = 0
 	else

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -1,16 +1,24 @@
 //Updates the mob's health from organs and mob damage variables
 /mob/living/carbon/human/updatehealth()
-
 	if(status_flags & GODMODE)
 		health = maxHealth
 		stat = CONSCIOUS
 		return
 
-	var/brain_damage = getBrainLoss()
-	var/oxygen_level = (species.flags & NO_BREATHE) ? 0 : oxyloss
-	var/lethal_damage = max(brain_damage, oxygen_level)
+	var/total_burn  = 0
+	var/total_brute = 0
+	var/total_internal = 0
 
-	health = maxHealth - lethal_damage
+	for(var/obj/item/organ/external/O in organs)
+		if(O.vital)
+			total_brute += O.brute_dam
+			total_burn  += O.burn_dam
+			total_internal += O.severity_internal_wounds
+
+
+	var/oxy_l = ((species.flags & NO_BREATHE) ? 0 : getOxyLoss())
+
+	health = maxHealth - oxy_l - total_burn - total_brute - total_internal
 	LEGACY_SEND_SIGNAL(src, COMSIG_HUMAN_HEALTH, health)
 	return
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -989,8 +989,24 @@
 		var/image/holder = hud_list[HEALTH_HUD]
 		if(stat == DEAD)
 			holder.icon_state = "hudhealth-100" 	// X_X
-		else
-			var/percentage_health = RoundHealth((health-HEALTH_THRESHOLD_CRIT)/(maxHealth-HEALTH_THRESHOLD_CRIT)*100)
+		else	
+			var/organ_health
+			var/organ_damage
+			var/limb_health
+			var/limb_damage
+
+			for(var/obj/item/organ/external/E in organs)
+				organ_health += E.total_internal_health
+				organ_damage += E.severity_internal_wounds
+				limb_health += E.max_health
+				limb_damage += max(E.brute_dam, E.burn_dam)
+
+			var/crit_health = (health / maxHealth) * 100
+			var/external_health = (1 - (limb_health ? limb_damage / limb_health : 0)) * 100
+			var/internal_health = (1 - (organ_health ? organ_damage / organ_health : 0)) * 100
+
+			var/percentage_health = RoundHealth(min(crit_health, external_health, internal_health))	// Old: RoundHealth((health-HEALTH_THRESHOLD_CRIT)/(maxHealth-HEALTH_THRESHOLD_CRIT)*100)
+
 			holder.icon_state = "hud[percentage_health]"
 		hud_list[HEALTH_HUD] = holder
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -989,7 +989,7 @@
 		var/image/holder = hud_list[HEALTH_HUD]
 		if(stat == DEAD)
 			holder.icon_state = "hudhealth-100" 	// X_X
-		else	
+		else
 			var/organ_health
 			var/organ_damage
 			var/limb_health
@@ -998,7 +998,7 @@
 			for(var/obj/item/organ/external/E in organs)
 				organ_health += E.total_internal_health
 				organ_damage += E.severity_internal_wounds
-				limb_health += E.max_health
+				limb_health += E.max_damage
 				limb_damage += max(E.brute_dam, E.burn_dam)
 
 			var/crit_health = (health / maxHealth) * 100

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -28,7 +28,7 @@
 	if(stats.getPerk(PERK_BALLS_OF_PLASTEEL))
 		hard_crit_threshold += 20
 
-	. = 0.9	* get_limb_damage() + 0.6 * oxyloss
+	. = get_limb_damage()
 
 	//Constant Pain above 80% of the crit treshold gets converted to dynamic pain (hallos)
 	//Damage from the last tick gets saved as last_tick_pain and compared to current pain, if the current pain is larger hallos gets applied again

--- a/code/modules/mob/living/carbon/superior_animal/roach/roach_spits.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach_spits.dm
@@ -25,7 +25,7 @@
 	icon = 'icons/obj/hivemind.dmi'
 	icon_state = "goo_proj"
 	damage_types = list()
-	irradiate = 80
+	irradiate = 20
 	check_armour = ARMOR_BIO
 	step_delay = 2
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -171,9 +171,9 @@ default behaviour is:
 
 /mob/living/verb/succumb()
 	set hidden = TRUE
-	if ((src.health < 0 && src.health > (5-src.maxHealth))) // Health below Zero but above 5-away-from-death, as before, but variable
-		src.adjustOxyLoss(src.health + src.maxHealth * 2) // Deal 2x health in OxyLoss damage, as before but variable.
-		src.health = src.maxHealth - src.getOxyLoss() - src.getToxLoss() - src.getFireLoss() - src.getBruteLoss()
+	if (health < 0) // Health below Zero but above 5-away-from-death, as before, but variable
+		adjustOxyLoss(health + maxHealth * 2) // Deal 2x health in OxyLoss damage, as before but variable.
+		health = -maxHealth
 		to_chat(src, "\blue You have given up life and succumbed to death.")
 
 

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -15,10 +15,10 @@
 		if(BURN)
 			amount = round(amount * burn_mod, 0.1)
 
-	// Damage is transferred to internal organs. Chest and head must be broken before transferring.
+	// Damage is transferred to internal organs. Chest and head must be broken before transferring unless they're slime limbs.
 	if(LAZYLEN(internal_organs))
 		var/can_transfer = FALSE	// Only applies to brute and burn
-		if((organ_tag != BP_CHEST && organ_tag != BP_HEAD) || status & ORGAN_BROKEN)
+		if((organ_tag != BP_CHEST && organ_tag != BP_HEAD) || status & ORGAN_BROKEN || cannot_break)
 			can_transfer = TRUE
 		var/obj/item/organ/internal/I = pick(internal_organs)
 		var/transferred_damage_amount

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -34,8 +34,8 @@
 				transferred_damage_amount = amount
 
 		if(transferred_damage_amount > 0)
-			I.take_damage(transferred_damage_amount, damage_type, wounding_multiplier, sharp, edge, FALSE)
-			amount = round(max(amount / 2, amount - transferred_damage_amount), 0.1)
+			if(I.take_damage(transferred_damage_amount, damage_type, wounding_multiplier, sharp, edge, FALSE))
+				amount = round(max(amount / 2, amount - transferred_damage_amount), 0.1)
 
 	if(amount <= 0)
 		return FALSE

--- a/code/modules/organs/external/damage.dm
+++ b/code/modules/organs/external/damage.dm
@@ -26,7 +26,8 @@
 			if(BRUTE)
 				transferred_damage_amount = can_transfer ? (amount - (max_damage - brute_dam) / armor_divisor) / 2 : 0
 			if(BURN)
-				transferred_damage_amount = can_transfer ? (amount - (max_damage - burn_dam) / armor_divisor) / 2 : 0
+				var/damage_divisor = can_transfer ? 2 : 4
+				transferred_damage_amount = (amount - (max_damage - burn_dam) / armor_divisor) / damage_divisor
 			if(HALLOSS)
 				transferred_damage_amount = 0
 			else

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -171,10 +171,14 @@
 					break
 			if(BV)
 				BV.current_blood = max(BV.current_blood - blood_req, 0)
-			if(BV?.current_blood == 0)	//When all blood from the organ and blood vessel is lost,
+			if(!damage && BV?.current_blood == 0)	//When all blood from the organ and blood vessel is lost,
 				add_wound(/datum/component/internal_wound/organic/oxy/blood_loss)
 
 		return
+
+	// If the bleedout status is removed, remove blood loss wound
+	if(damage)
+		remove_wound(GetComponent(/datum/component/internal_wound/organic/oxy/blood_loss))
 
 	current_blood = min(current_blood + blood_req, max_blood_storage)
 

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -421,6 +421,8 @@
 	SEND_SIGNAL(src, COMSIG_APPVAL, src)
 	SEND_SIGNAL(src, COMSIG_IWOUND_FLAGS_ADD)
 
+	refresh_damage()
+
 	for(var/prefix in prefixes)
 		name = "[prefix] [name]"
 

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -86,12 +86,12 @@
 
 /obj/item/organ/internal/take_damage(amount, damage_type = BRUTE, wounding_multiplier = 1, sharp = FALSE, edge = FALSE, silent = FALSE)	//Deals damage to the organ itself
 	if(!damage_type || status & ORGAN_DEAD)
-		return
+		return FALSE
 
 	var/wound_count = max(0, round((amount * wounding_multiplier) / 8))	// At base values, every 8 points of damage is 1 wound
 
 	if(!wound_count)
-		return
+		return FALSE
 
 	var/list/possible_wounds = get_possible_wounds(damage_type, sharp, edge)
 
@@ -104,6 +104,9 @@
 				break
 
 		owner.custom_pain("Something inside your [parent.name] hurts a lot.", 0)		// Let em know they're hurting
+
+		return TRUE
+	return FALSE
 
 /obj/item/organ/internal/proc/get_possible_wounds(damage_type, sharp, edge)
 	var/list/possible_wounds = list()

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -72,6 +72,8 @@
 	owner = null //overrides removed() call
 	. = ..()
 
+/obj/item/organ/internal/carrion/core/take_damage(amount, damage_type = BRUTE, wounding_multiplier = 1, sharp = FALSE, edge = FALSE, silent = FALSE)
+	return
 
 /obj/item/organ/internal/carrion/core/proc/make_spider()
 	set category = "Carrion"

--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -161,12 +161,12 @@
 			to_chat(src, SPAN_WARNING("You feel extremely [pick("dizzy","woosey","faint")]"))
 	else if(blood_volume < blood_bad)
 		eye_blurry = max(eye_blurry,6)
-		adjustOxyLoss(6)
+		adjustOxyLoss(2)
 		if(prob(15))
 			to_chat(src, SPAN_WARNING("You feel very [pick("dizzy","woosey","faint")]"))
 	else if(blood_volume < blood_okay)
 		eye_blurry = max(eye_blurry,6)
-		adjustOxyLoss(4)
+		adjustOxyLoss(1.5)
 		if(prob(15))
 			Weaken(rand(1,3))
 			to_chat(src, SPAN_WARNING("You feel very [pick("dizzy","woosey","faint")]"))
@@ -174,7 +174,7 @@
 		if(prob(1))
 			to_chat(src, SPAN_WARNING("You feel [pick("dizzy","woosey","faint")]"))
 		if(getOxyLoss() < 10)
-			adjustOxyLoss(2)
+			adjustOxyLoss(1)
 
 	// Blood loss or heart damage make you lose nutriments
 	if(blood_volume < blood_safe || heart_efficiency < BRUISED_2_EFFICIENCY)
@@ -212,7 +212,7 @@
 			to_chat(src, SPAN_WARNING("Your [heavy_spot] feels too heavy for your body"))
 
 	if(lung_efficiency < BROKEN_2_EFFICIENCY)
-		adjustOxyLoss(2)
+		adjustOxyLoss(1)
 
 /mob/living/carbon/human/proc/stomach_process()
 	var/stomach_efficiency = get_organ_efficiency(OP_STOMACH)

--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -59,10 +59,9 @@
 	var/obj/item/organ/internal/kidney = random_organ_by_process(OP_KIDNEYS)
 	var/chem_toxicity = chem_effects[CE_ANTITOX] + chem_effects[CE_BLOODCLOT] + chem_effects[CE_SPEEDBOOST]
 	var/toxin_strength = chem_effects[CE_TOXIN] * IORGAN_KIDNEY_TOX_RATIO + chem_toxicity
-	var/toxin_damage = 0
 
 	// Existing damage is subtracted to prevent weaker toxins from maxing out tox wounds on the organ
-	toxin_damage = (toxin_strength / (stats.getPerk(PERK_BLOOD_OF_LEAD) ? 2 : 1)) - (kidneys_efficiency / 100) - kidney.damage
+	var/toxin_damage = kidney ? (toxin_strength / (stats.getPerk(PERK_BLOOD_OF_LEAD) ? 2 : 1)) - (kidneys_efficiency / 100) - kidney.damage : 0
 
 	// Organ functions
 	// Blood regeneration if there is some space
@@ -81,12 +80,9 @@
 	var/obj/item/organ/internal/liver = random_organ_by_process(OP_LIVER)
 	var/alcohol_strength = chem_effects[CE_ALCOHOL]
 	var/toxin_strength = chem_effects[CE_TOXIN] * IORGAN_LIVER_TOX_RATIO + chem_effects[CE_ALCOHOL_TOXIC]
-	var/toxin_damage = 0
 
 	// Existing damage is subtracted to prevent weaker toxins from maxing out tox wounds on the organ
-	toxin_damage = (toxin_strength / (stats.getPerk(PERK_BLOOD_OF_LEAD) ? 2 : 1)) - (liver_efficiency / 100) - liver.damage
-
-	// Organ functions
+	var/toxin_damage = liver ? (toxin_strength / (stats.getPerk(PERK_BLOOD_OF_LEAD) ? 2 : 1)) - (liver_efficiency / 100) - liver.damage : 0
 
 	// Bad stuff
 	// If you're not filtering well, you're in trouble. Ammonia buildup to toxic levels and damage from alcohol
@@ -115,13 +111,14 @@
 /mob/living/carbon/human/proc/handle_pulse()
 	var/roboheartcheck = TRUE //Check if all hearts are robotic
 	for(var/obj/item/organ/internal/heart in organ_list_by_process(OP_HEART))
-		if(!(heart.nature == MODIFICATION_SILICON || heart.nature == MODIFICATION_LIFELIKE))
+		if(!BP_IS_ROBOTIC(heart))
 			roboheartcheck = FALSE
 			break
 
 	if(stat == DEAD || roboheartcheck)
 		pulse = PULSE_NONE	//that's it, you're dead (or your metal heart is), nothing can influence your pulse
 		return
+
 	if(life_tick % 5 == 0)//update pulse every 5 life ticks (~1 tick/sec, depending on server load)
 		pulse = PULSE_NORM
 
@@ -135,17 +132,15 @@
 
 /mob/living/carbon/human/proc/handle_heart_blood()
 	var/heart_efficiency = get_organ_efficiency(OP_HEART)
-	if(stat == DEAD || bodytemperature <= 170)	//Dead or cryosleep people do not pump the blood.
-		return
-
+	var/blood_oxygenation = 0.4 * chem_effects[CE_OXYGENATED] - 0.2 * chem_effects[CE_BLOODCLOT]
 	var/blood_volume_raw = vessel.get_reagent_amount("blood")
 	var/blood_volume = round((blood_volume_raw/species.blood_volume)*100) // Percentage.
 
 	// Damaged heart virtually reduces the blood volume, as the blood isn't being pumped properly anymore.
 	if(heart_efficiency <= 100)	//flat scaling up to 100
-		blood_volume *= heart_efficiency / 100
+		blood_volume *= (heart_efficiency / 100) + blood_oxygenation
 	else	//half scaling at over 100
-		blood_volume *= 1 + ((heart_efficiency - 100) / 200)
+		blood_volume *= 1 + ((heart_efficiency - 100) / 200) + blood_oxygenation
 
 	//Effects of bloodloss
 	var/blood_safe = total_blood_req + BLOOD_VOLUME_SAFE_MODIFIER

--- a/code/modules/organs/internal/internal_wounds/_internal_wound.dm
+++ b/code/modules/organs/internal/internal_wounds/_internal_wound.dm
@@ -149,6 +149,8 @@
 
 /datum/component/internal_wound/proc/apply_tool(obj/item/I, mob/user)
 	var/success = FALSE
+	var/obj/item/organ/internal/organ = parent
+	var/obj/item/organ/limb = organ.parent
 
 	if(istype(I, /obj/item/reagent_containers/syringe))
 		var/obj/item/reagent_containers/syringe/S = I
@@ -161,14 +163,25 @@
 			to_chat(user, SPAN_WARNING("You cannot draw blood like this."))
 
 	if(!I.tool_qualities || !LAZYLEN(I.tool_qualities))
-		var/charges_needed = LAZYACCESS(treatments_item, I.type)
-		var/can_treat = TRUE
+		var/charges_needed
+		for(var/path in treatments_item)
+			if(istype(I, path))
+				charges_needed = treatments_item[path]
+		var/is_treated = FALSE
+		var/free_use = FALSE
+		var/user_stat_level = user.stats.getStat(diagnosis_stat)
 		if(charges_needed)
 			if(istype(I, /obj/item/stack))
 				var/obj/item/stack/S = I
-				if(!S.use(charges_needed))
-					can_treat = FALSE
-			if(can_treat && do_after(user, WORKTIME_NORMAL - user.stats.getStat(diagnosis_stat), parent))
+				if(do_after(user, WORKTIME_NORMAL - user_stat_level, parent))
+					if(prob(10 + user_stat_level))
+						free_use = TRUE
+						is_treated = TRUE
+					else
+						is_treated = S.use(charges_needed)
+			if(is_treated)
+				if(free_use)
+					to_chat(user, SPAN_NOTICE("You have managed to waste less [I.name]."))
 				success = TRUE
 	else
 		for(var/tool_quality in treatments_tool)
@@ -182,6 +195,8 @@
 	if(user)
 		if(success)
 			to_chat(user, SPAN_NOTICE("You treat the [name] with \the [I]."))
+			if(limb)
+				SSnano.update_user_uis(user, limb)
 		else
 			to_chat(user, SPAN_WARNING("You cannot treat the [name] with \the [I]."))
 

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -187,7 +187,6 @@
 
 /datum/component/internal_wound/organic/radiation/malignant
 	name = "malignant tumor"
-	treatments_tool = list()
 	treatments_chem = list(CE_ONCOCIDAL = 2)
 	characteristic_flag = IWOUND_CAN_DAMAGE|IWOUND_PROGRESS|IWOUND_SPREAD
 	severity = 0

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -214,7 +214,7 @@
 	treatments_chem = list(CE_OXYGENATED = 2, CE_BLOODRESTORE = 1)	// Dex+ treats, but it will come back if you don't get blood
 	severity = 0
 	severity_max = IORGAN_MAX_HEALTH
-	progression_threshold = 9	// Kills the organ in approx. 3 minutes
+	progression_threshold = IWOUND_1_MINUTE	// Kills small organs in 7 minutes, normal in 14
 
 /datum/component/internal_wound/organic/oxy/blood_loss
 	name = "blood loss"

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -213,9 +213,6 @@
 		if(owner && parent && amount > 0 && !silent)
 			owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
 
-/obj/item/organ/proc/bruise()
-	damage = max(damage, min_bruised_damage)
-
 /obj/item/organ/emp_act(severity)
 	if(!BP_IS_ROBOTIC(src))
 		return

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -215,8 +215,10 @@
 	if(M.species?.reagent_tag == IS_CHTMANT)
 		return
 	M.adjustOxyLoss(-1.5 * effect_multiplier)
-	M.add_chemical_effect(CE_OXYGENATED, 1)
 	holder.remove_reagent("lexorin", 0.2 * effect_multiplier)
+	var/ce_to_add = 1 - M.chem_effects[CE_OXYGENATED]
+	if(ce_to_add > 0)
+		M.add_chemical_effect(CE_OXYGENATED, ce_to_add)
 
 /datum/reagent/medicine/dexalinp
 	name = "Dexalin Plus"
@@ -231,8 +233,10 @@
 
 /datum/reagent/medicine/dexalinp/affect_blood(mob/living/carbon/M, alien, effect_multiplier, var/removed = REM)
 	M.adjustOxyLoss(-30 * effect_multiplier)
-	M.add_chemical_effect(CE_OXYGENATED, 2)
 	holder.remove_reagent("lexorin", 0.3 * effect_multiplier)
+	var/ce_to_add = 2 - M.chem_effects[CE_OXYGENATED]
+	if(ce_to_add > 0)
+		M.add_chemical_effect(CE_OXYGENATED, ce_to_add)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		//G for GUNS

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -513,7 +513,7 @@
 	addiction_chance = 0.01 //Will STILL likely always be addicting
 	nerve_system_accumulations = 15
 	metabolism = REM * 0.2 //but processes much faster than other toxins
-	strength = 8 //Rather lethal
+	strength = 2
 	heating_point = 523
 	heating_products = list("toxin")
 

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -17,7 +17,7 @@
 
 /datum/reagent/toxin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(strength)
-		var/multi = effect_multiplier
+		//var/multi = effect_multiplier
 		/*if(issmall(M))  // Small bodymass, more effect from lower volume.
 			multi *= 2
 		M.adjustToxLoss(strength * multi)

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -25,8 +25,7 @@
 			var/mob/living/carbon/human/H = M
 			H.sanity.onToxin(src, effect_multiplier)
 			M.sanity.onToxin(src, multi)*/
-		M.add_chemical_effect(CE_TOXIN, multi * strength)
-
+		M.add_chemical_effect(CE_TOXIN, strength)
 
 /datum/reagent/toxin/affect_ingest(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(ishuman(M))

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -297,6 +297,7 @@
 	taste_description = "acid"
 	reagent_state = LIQUID
 	color = "#C8A5DC"
+	metabolism = REM * 2.5
 	overdose = REAGENTS_OVERDOSE
 	nerve_system_accumulations = 30
 
@@ -534,14 +535,18 @@
 	nerve_system_accumulations = 15
 	strength = 1
 
+/datum/reagent/toxin/aranecolmin/on_mob_add(mob/living/L)
+	. = ..()
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		if(LAZYLEN(C.internal_organs) && C.bloodstr && C.bloodstr.has_reagent("pararein"))
+			var/obj/item/organ/internal/I = pick(C.internal_organs)
+			to_chat(C, "Something burns inside your [I.parent.name]...")
+			create_overdose_wound(I, C, /datum/component/internal_wound/organic/heavy_poisoning, "rot", TRUE)
+
 /datum/reagent/toxin/aranecolmin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	..()
 	M.add_chemical_effect(CE_PAINKILLER, 15)
-	if(M.bloodstr && M.bloodstr.has_reagent("pararein"))
-		if(prob(5))
-			to_chat(M, SPAN_WARNING("The blood in your veins burns beneath your flesh!"))
-			if(LAZYLEN(M.internal_organs))	// Check needed because spiders can inject this into roaches
-				create_overdose_wound(pick(M.internal_organs), M, /datum/component/internal_wound/organic/heavy_poisoning, "rot", TRUE)
 
 /datum/reagent/toxin/diplopterum
 	name = "Diplopterum"

--- a/modular_sojourn/Borers/borer_powers.dm
+++ b/modular_sojourn/Borers/borer_powers.dm
@@ -711,7 +711,6 @@
 		"dermaline_amount" = H.reagents.get_reagent_amount("dermaline"),
 		"blood_amount" = round((H.vessel.get_reagent_amount("blood") / H.species.blood_volume)*100),
 		"disabilities" = H.sdisabilities,
-		"lung_ruptured" = H.is_lung_ruptured(),
 		"external_organs" = H.organs.Copy(),
 		"internal_organs" = H.internal_organs.Copy(),
 		"species_organs" = H.species.has_process, //Just pass a reference for this, it shouldn't ever be modified outside of the datum.
@@ -772,8 +771,6 @@
 		for(var/datum/wound/W in e.wounds) if(W.internal)
 			other_wounds += "Internal bleeding"
 			break
-		if(e.organ_tag == BP_CHEST && occ["lung_ruptured"])
-			other_wounds += "Lung ruptured"
 		if(e.status & ORGAN_SPLINTED)
 			other_wounds += "Splinted"
 		if(e.status & ORGAN_BLEEDING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
### Adjustments
- Mob health checks vital limb brute and burn damage again.
- Burn damage will always transfer at least 25% damage to internal organs.
- Damage to limbs will only be deducted when the transferred damage creates/progresses a wound.
- Oxy damage doesn't contribute to pain. Organ wounds cause pain as a side effect and organ damage to certain organs can causes oxy damage. It doesn't make sense to make organ wounds apply pain from two sources.
- Unbreakable type bones don't break. Slime people are the only ones that use these bones and this change is needed to allow them to die.
- Blood loss organ wounds progression time increased to 1 minute per level instead of 18 seconds.
- Oxy damage from damaged organs reduced by 50% to 75% depending on the case.
- Oxygenation effect from Dexalin and Dexalin Plus don't stack with other effects.
- Gestrahlte bile projectile radiation damage reduced to 5 from 15.
- Malignant tumors can be removed with a cutting tool.
- Lexorin duration significantly reduced. 0.5u is consumed per tick instead of 0.01u.
- Stasis prevents suffocation/oxy damage.
- Toxins don't use the effect multiplier for their base toxin effect.
- Aranecolmin only applies rot wound once.
- Pararein strength reduced to 2 from 8.
- Created blood oxygenation modifier for heart processes. Previously, the chemical effect of Dexalin and Dexalin Plus were unused. This allows them to be used to aid in preventing the negative effects of blood loss. The new blood volume calculation in heart processing is:
  - `(current blood / species blood max) * ((heart efficiency / 100) + 0.4 * oxygenation effect - 0.2 * blood clotting effect)`

### Fixes
- Carrion core won't take damage while inside a human.
- Blood loss wounds won't stack and restoring blood levels will treat them.
- Brains don't suffer blood loss. Oxy loss already handles that behavior. Also, this may handle the issue where resuscitator wouldn't revive a body that should otherwise be revivable.
- Removed legacy lung rupture wound.
- Humans should no longer have a pulse when dead.
- Fixed runtime related to liver and kidney processes.
- Organ wound treatment does the progress bar and stat check before consuming charges. UI will update on a successful treatment.
- Fixed an issue where still live organs wouldn't heal after a wound was treated.
- Fixed an issue where succumb wouldn't let you die if you were too close to death.


![image](https://user-images.githubusercontent.com/95178278/225781910-6d6735eb-1b26-4660-a209-9479d8543d94.png)

## Changelog
:cl:
tweak: Burn damage will always transfer at least 25% damage to internal organs
tweak: Damage to limbs will only be deducted when the transferred damage creates/progresses a wound
tweak: Oxy loss doesn't contribute to pain
tweak: Unbreakable type bones don't break
tweak: Blood loss organ wounds progression time increased to 1 minute per level instead of 18 seconds
tweak: Oxy damage from damaged organs reduced by 50% to 75% depending on the case
tweak: Oxygenation effect from Dexalin and Dexalin Plus don't stack with other effects
tweak: Stasis prevents suffocation/oxy damage
tweak: Aranecolmin only applies rot wound once
tweak: Created blood oxygenation modifier for heart processes
tweak: Malignant tumors can be removed with a cutting tool
tweak: Toxins don't use effect multiplier for base toxin effect
balance: Gestrahlte bile projectile radiation damage reduced to 5 from 15
balance: Lexorin duration significantly reduced, 0.5u is consumed per tick instead of 0.01u
balance: Pararein strength reduced to 2 from 8
fix: Carrion core won't take damage while inside a human
fix: Blood loss wounds won't stack and restoring blood levels will treat them
fix: Brains don't suffer blood loss
fix: Humans should no longer have a pulse when dead
fix: Fixed runtime related to liver and kidney processes
fix: Organ wound treatment does the progress bar and stat check before consuming charges, UI will update on a successful treatment
fix: Fixed an issue where still live organs wouldn't heal after a wound was treated
fix: Fixed an issue where succumb wouldn't let you die if you were too close to death
del: Removed legacy lung rupture wound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
