### PR TITLE
Reference moment

### DIFF
--- a/code/datums/uplink/void_wolf.dm
+++ b/code/datums/uplink/void_wolf.dm
@@ -2,7 +2,7 @@
 	category = /datum/uplink_category/void_wolf
 
 /datum/uplink_item/item/void_wolf/cog
-	name = "\"Cog\" lasgun"
+	name = "\"Cog\" laser carbine"
 	item_cost = 3
 	path = /obj/item/gun/energy/cog
 

--- a/code/game/machinery/vendor/weapon_kit_vendors.dm
+++ b/code/game/machinery/vendor/weapon_kit_vendors.dm
@@ -249,7 +249,7 @@
 					"Breacher-hammer Kit" = /obj/item/storage/box/m_kit/breacher,
 					"Operator Kit" = /obj/item/storage/box/m_kit/opshotkit,
 					"Mamba Kit" = /obj/item/storage/box/m_kit/mamba,
-					"Gear Lasgun Kit" = /obj/item/storage/box/m_kit/gear_lasgun)
+					"Gear Laser Carbine Kit" = /obj/item/storage/box/m_kit/gear_lasgun)
 	var/selection = items[input(redeemer, "Pick your primary weapon", "Marshal Voucher Redemption") as null|anything in items]
 	if(selection)
 		new selection(loc)
@@ -263,7 +263,7 @@
 					"Spec-Op Kit" = /obj/item/storage/box/m_kit/specop,
 					"State Auto-Shotgun Kit" = /obj/item/storage/box/m_kit/state_auto,
 					"Copperhead Kit" = /obj/item/storage/box/m_kit/copperhead,
-					"Gear Lasgun Kit" = /obj/item/storage/box/m_kit/gear_lasgun,
+					"Gear Laser Carbine Kit" = /obj/item/storage/box/m_kit/gear_lasgun,
 					"Sunrise Las-SMG Kit" = /obj/item/storage/box/m_kit/typewriter)
 	var/selection = items[input(redeemer, "Pick your primary weapon", "Marshal Voucher Redemption") as null|anything in items]
 	if(selection)

--- a/code/game/objects/items/weapons/autolathe_disk/absolute_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/absolute_disks.dm
@@ -233,7 +233,7 @@
 		/datum/design/autolathe/gun/ntpistol = 2,
 		/datum/design/autolathe/cell/small/high,
 	)
-	
+
 //for the EOTP
 /obj/item/computer_hardware/hard_drive/portable/design/nt/counselor
 	disk_name = "Absolute Armory - Counselor PDW E Plus"
@@ -244,7 +244,7 @@
 		/datum/design/autolathe/gun/taser,
 		/datum/design/autolathe/cell/medium/high,
 	)
-	
+
 /obj/item/computer_hardware/hard_drive/portable/design/nt/nt_counselor
 	disk_name = "Absolute Armory - NT LP \"Serenity\" Plus"
 	icon_state = "neotheology"
@@ -341,7 +341,7 @@ obj/item/computer_hardware/hard_drive/portable/design/nt/valkirye
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/guns/carpedie
-	disk_name = "Absolute Armory - Carpedie Lasgun Rifle"
+	disk_name = "Absolute Armory - Carpediem laser musket"
 	icon_state = "neotheology"
 
 	license = 8
@@ -352,7 +352,7 @@ obj/item/computer_hardware/hard_drive/portable/design/nt/valkirye
 
 //for the EOTP
 /obj/item/computer_hardware/hard_drive/portable/design/nt/carpedie
-	disk_name = "Absolute Armory - Carpedie Lasgun Rifle Plus"
+	disk_name = "Absolute Armory - Carpediem laser musket Plus"
 	icon_state = "neotheology"
 
 	license = 8
@@ -474,7 +474,7 @@ obj/item/computer_hardware/hard_drive/portable/design/nt/concillium
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/guns/antebellum
-	disk_name = "Absolute Armory - Antebellum Blunderbuss lasgun"
+	disk_name = "Absolute Armory - Antebellum laser blunderbuss"
 	icon_state = "neotheology"
 
 	license = 8
@@ -485,7 +485,7 @@ obj/item/computer_hardware/hard_drive/portable/design/nt/concillium
 
 //for the EOTP
 /obj/item/computer_hardware/hard_drive/portable/design/nt/antebellum
-	disk_name = "Absolute Armory - Antebellum Blunderbuss lasgun Plus"
+	disk_name = "Absolute Armory - Antebellum laser blunderbuss Plus"
 	icon_state = "neotheology"
 
 	license = 8

--- a/code/game/objects/items/weapons/disc.dm
+++ b/code/game/objects/items/weapons/disc.dm
@@ -39,7 +39,7 @@
 // Subtypes
 
 /obj/item/disk/data/demo
-	name = "data disk - 'God Emperor of Mankind'"
+	name = "data disk - 'Demolition Man'"
 	read_only = TRUE
 
 /obj/item/disk/data/demo/New()
@@ -48,7 +48,7 @@
 	buf.types=DNA2_BUF_UE|DNA2_BUF_UI
 	//data = "066000033000000000AF00330660FF4DB002690"
 	//data = "0C80C80C80C80C80C8000000000000161FBDDEF" - Farmer Jeff
-	buf.dna.real_name="God Emperor of Mankind"
+	buf.dna.real_name="Demolition Man"
 	buf.dna.unique_enzymes = md5(buf.dna.real_name)
 	buf.dna.UI=list(0x066,0x000,0x033,0x000,0x000,0x000,0xAF0,0x033,0x066,0x0FF,0x4DB,0x002,0x690)
 	//buf.dna.UI=list(0x0C8,0x0C8,0x0C8,0x0C8,0x0C8,0x0C8,0x000,0x000,0x000,0x000,0x161,0xFBD,0xDEF) // Farmer Jeff

--- a/code/game/objects/items/weapons/storage/hardcases.dm
+++ b/code/game/objects/items/weapons/storage/hardcases.dm
@@ -550,7 +550,7 @@ obj/item/storage/hcases/attackby(obj/item/W, mob/user)
 		var/list/options = list()
 		// Keeping this in case any other "sensible" option for a primary weapon for Lifeline Techs arrives, just add them as an option here.
 		options["Bullpip SMG with HV ammo"] = list(/obj/item/gun/projectile/automatic/c20r/sci/preloaded,/obj/item/gun_upgrade/muzzle/silencer,/obj/item/ammo_magazine/smg_35/hv,/obj/item/ammo_magazine/smg_35/hv)
-		options["Soteria \"Sprocket\" lasgun"] = list(/obj/item/gun/energy/cog/sprocket/preloaded,/obj/item/cell/medium/moebius/high)
+		options["Soteria \"Sprocket\" laser carbine"] = list(/obj/item/gun/energy/cog/sprocket/preloaded,/obj/item/cell/medium/moebius/high)
 		var/choice = input(user,"Which gun will you take?") as null|anything in options
 		if(src && choice)
 			var/list/things_to_spawn = options[choice]

--- a/code/game/objects/items/weapons/storage/marshal_kits.dm
+++ b/code/game/objects/items/weapons/storage/marshal_kits.dm
@@ -37,8 +37,8 @@
 		new /obj/item/storage/pouch/ammo(src)
 
 /obj/item/storage/box/m_kit/gear_lasgun
-	name = "\improper Gear Lasgun Kit"
-	desc = "The standard Marshal box kit containing a modified Cog lasgun that also fires stun beams. For the economic officer."
+	name = "\improper Gear Laser Carbine Kit"
+	desc = "The standard Marshal box kit containing a modified Cog laser carbine that also fires stun beams. For the economic officer."
 
 	populate_contents()
 		new /obj/item/gun/energy/cog/gear(src)

--- a/code/game/objects/random/medicine.dm
+++ b/code/game/objects/random/medicine.dm
@@ -27,13 +27,13 @@
 				/obj/item/reagent_containers/hypospray/autoinjector/tricordrazine = 3,\
 				/obj/item/reagent_containers/hypospray/autoinjector/quickclot = 3,\
 				/obj/item/stack/nanopaste = 0.5,\
-				/obj/item/reagent_containers/syringe/stim/mbr = 0.5,\
+				/obj/item/reagent_containers/syringe/stim/greaser = 0.5,\
 				/obj/item/reagent_containers/syringe/stim/cherrydrops = 0.5,\
 				/obj/item/reagent_containers/syringe/stim/pro_surgeon = 0.5,\
 				/obj/item/reagent_containers/syringe/stim/violence = 0.5,\
 				/obj/item/reagent_containers/syringe/stim/bouncer = 0.5,\
 				/obj/item/reagent_containers/syringe/stim/steady = 0.5,\
-				/obj/item/reagent_containers/syringe/stim/machine_spirit = 0.1,\
+				/obj/item/reagent_containers/syringe/stim/greasy_lard = 0.1,\
 				/obj/item/reagent_containers/syringe/stim/grape_drops = 0.1,\
 				/obj/item/reagent_containers/syringe/stim/ultra_surgeon = 0.1,\
 				/obj/item/reagent_containers/syringe/stim/violence_ultra = 0.1,\

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -286,7 +286,7 @@
 
 /obj/item/clothing/accessory/cape/prospie
 	name = "prospector mantle"
-	desc = "A rough mantle of salvaged hydrophobic materials typically worn around one's shoulders. While some may wear it for style, others prefer its use as decent camouflage on the humid amethian jungle."
+	desc = "A rough mantle of salvaged hydrophobic materials typically worn around one's shoulders. While some may wear it for style, others prefer its use as decent camouflage in the humid amethian forest."
 	icon_state = "prospie_cape"
 
 // Head of Departments

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -71,7 +71,7 @@
 
 /obj/item/clothing/suit/armor/vest/ironhammer_wintercoat //pieced together thanks to Rebel's Supply spec coat - Dongels
 	name = "security armored coat"
-	desc = "An armored winter coat with vest that protects against some damage. This one has been done in marshal security colors. Not designed for serious operations. You're pretty sure the coat is just thick enough to keep warm, and that's all. Why you would want that on a sweaty jungle planet is beyond thought."
+	desc = "An armored winter coat with vest that protects against some damage. This one has been done in marshal security colors. Not designed for serious operations. You're pretty sure the coat is just thick enough to keep warm, and that's all. Why you would want that on a planet like Amethyn is beyond thought."
 	icon_state = "coatsecurity_long"
 
 /obj/item/clothing/suit/storage/vest/ironhammer

--- a/code/modules/clothing/suits/greatcoat.dm
+++ b/code/modules/clothing/suits/greatcoat.dm
@@ -80,7 +80,7 @@
 
 /obj/item/clothing/suit/greatcoat/nt_wintercoat //Sprite recolour from a Civ13 open github skyrim hidden piece with a few change ups to match our pallet -Dongels
 	name = "absolutist wintercoat"
-	desc = "A comfortably warm, and thick decorated wintercoat for the Absolutist faith and its supporters. Keeping the faithfull warm in the jungle heat since 2652."
+	desc = "A comfortably warm, and thick decorated wintercoat for the Absolutist faith and its supporters. Keeping the faithfull warm in the Amethyn heat since 2652."
 	icon_state = "nt_wintercoat"
 	item_state = "nt_wintercoat"
 	blood_overlay_type = "coat"
@@ -183,7 +183,7 @@
 
 /obj/item/clothing/suit/greatcoat/cossackcoat
 	name = "jaeger riding coat"
-	desc = "A traditional riding coat often worn by Jaegers, typically inherited or tailored as an expensive practical gift. The design is murder in the humid jungle, but is a time-honored and comfortable jacket for irregulars who served on Krios, where they dressed like woodsmen in their ambush patrols on Sol-Fed regulars in the cold forests and swamps of home."
+	desc = "A traditional riding coat often worn by Jaegers, typically inherited or tailored as an expensive practical gift. The design is murder in the humid Amethyn forests, but is a time-honored and comfortable jacket for irregulars who served on Krios, where they dressed like woodsmen in their ambush patrols on Sol-Fed regulars in the cold forests and swamps of home."
 	icon_state = "cossackcoat"
 	item_state = "cossackcoat"
 	blood_overlay_type = "coat"

--- a/code/modules/core_implant/cruciform/rituals/construction.dm
+++ b/code/modules/core_implant/cruciform/rituals/construction.dm
@@ -568,7 +568,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 /datum/nt_blueprint/weapons
 
 /datum/nt_blueprint/weapons/antebellum
-	name = "\"Antebellum\" Blunderbuss lasgun"
+	name = "\"Antebellum\" laser blunderbuss"
 	build_path = /obj/item/gun/energy/plasma/antebellum
 	materials = list(
 		/obj/item/stack/material/plasteel = 10,
@@ -580,7 +580,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 	build_time = 3 SECONDS
 
 /datum/nt_blueprint/weapons/carpediem
-	name = "\"Carpediem\" lasgun"
+	name = "\"Carpediem\" laser musket"
 	build_path = /obj/item/gun/energy/carpediem
 	materials = list(
 		/obj/item/stack/material/plasteel = 5,

--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/colony/colony.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/colony/colony.dm
@@ -64,7 +64,7 @@
 
 /mob/living/carbon/superior_animal/human/colony_allie/ship_breaker_marks
 	name = "Shipbreaker Marksman"
-	desc = "A Prospector Shipbreaker Scout Armed with a Cog lasgun, The gun seems modified to shoot on burst mode to deal the double of hits to the Enemy, he seems to be an Veteran Vatgrown Fighter."
+	desc = "A Prospector Shipbreaker Scout Armed with a Cog laser carbine, The gun seems modified to shoot on burst mode to deal the double of hits to the Enemy, he seems to be an Veteran Vatgrown Fighter."
 	icon_state = "Shipbreakercg"
 	icon_dead = "Shipbreakercg_dead"
 	rapid = 1

--- a/code/modules/projectiles/guns/energy/laser/antebellum.dm
+++ b/code/modules/projectiles/guns/energy/laser/antebellum.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/plasma/antebellum
-	name = "\"Antebellum\" Blunderbuss lasgun"
+	name = "\"Antebellum\" laser blunderbuss"
 	icon = 'icons/obj/guns/energy/antebellum.dmi'
 	icon_state = "antebellum"
 	item_state = null	//so the human update icon uses the icon_state instead.

--- a/code/modules/projectiles/guns/energy/laser/carpediem.dm
+++ b/code/modules/projectiles/guns/energy/laser/carpediem.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/carpediem
-	name = "\"Carpediem\" lasgun"
+	name = "\"Carpediem\" laser musket"
 	icon = 'icons/obj/guns/energy/carpediem.dmi'
 	icon_state = "carpediem"
 	item_state = null	//so the human update icon uses the icon_state instead.

--- a/code/modules/projectiles/guns/energy/laser/cog.dm
+++ b/code/modules/projectiles/guns/energy/laser/cog.dm
@@ -104,9 +104,9 @@
 	update_icon()
 
 /obj/item/gun/energy/cog/sawn
-	name = " \"Pinion\" laser carbine"
+	name = " \"Pinion\" laser pistol"
 	icon = 'icons/obj/guns/energy/obrez_retro.dmi'
-	desc = "Nicknamed the 'Coglet', The \"Pinion\" laser carbine is the result of advanced AI conforming the Cog to meet the demand of mercurial gun laws. Concessions have been made, but by excluding the stock and much of the focusing lens, the weapon just barely squeezes into a standard-issue holster."
+	desc = "Nicknamed the 'Coglet', The \"Pinion\" laser pistol is the result of advanced AI conforming the Cog to meet the demand of mercurial gun laws. Concessions have been made, but by excluding the stock and much of the focusing lens, the weapon just barely squeezes into a standard-issue holster."
 	icon_state = "shorty"
 	item_state = "shorty"
 	fire_sound = 'sound/weapons/energy/laser_pistol.ogg'

--- a/code/modules/projectiles/guns/energy/laser/cog.dm
+++ b/code/modules/projectiles/guns/energy/laser/cog.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/cog
-	name = "\"Cog\" lasgun"
+	name = "\"Cog\" laser carbine"
 	icon = 'icons/obj/guns/energy/cog.dmi'
 	icon_state = "cog"
 	item_state = null	//so the human update icon uses the icon_state instead.
@@ -26,7 +26,7 @@
 	allow_greyson_mods = TRUE
 
 /obj/item/gun/energy/cog/gear
-	name = "\"Gear\" lasgun"
+	name = "\"Gear\" police laser carbine"
 	desc = "A Greyson Positronic design, cheap and widely produced. In the distant past - this was the main weapon of low-rank police forces, billions of copies of this gun were made. They are ubiquitous. \
 	This model has been modified by the Marshals to allow for non-lethal electrodes to be discharged as well as lasers, but at the cost of its cell-usage efficiency."
 	icon = 'icons/obj/guns/energy/cog_alt.dmi' // Using their proper sprite now
@@ -43,7 +43,7 @@
 	allow_greyson_mods = FALSE
 
 /obj/item/gun/energy/cog/sprocket
-	name = "Soteria \"Sprocket\" lasgun"
+	name = "Soteria \"Sprocket\" laser carbine"
 	desc = "Originally a Greyson Positronic design, tinkered by Marshals to allow nonlethal reduction of rowdy personnel, this gun has been further modified by Soteria to include a foldable stock, \
 			making it lightweight and easy to operate by non-trained personnel. The main disabler laser can neutralize the rowdiest patients at the cost of heavy cell usage."
 	icon = 'icons/obj/guns/energy/sprocket.dmi'
@@ -104,9 +104,9 @@
 	update_icon()
 
 /obj/item/gun/energy/cog/sawn
-	name = " \"Pinion\" lasgun"
+	name = " \"Pinion\" laser carbine"
 	icon = 'icons/obj/guns/energy/obrez_retro.dmi'
-	desc = "Nicknamed the 'Coglet', The \"Pinion\" lasgun is the result of advanced AI conforming the Cog to meet the demand of mercurial gun laws. Concessions have been made, but by excluding the stock and much of the focusing lens, the weapon just barely squeezes into a standard-issue holster."
+	desc = "Nicknamed the 'Coglet', The \"Pinion\" laser carbine is the result of advanced AI conforming the Cog to meet the demand of mercurial gun laws. Concessions have been made, but by excluding the stock and much of the focusing lens, the weapon just barely squeezes into a standard-issue holster."
 	icon_state = "shorty"
 	item_state = "shorty"
 	fire_sound = 'sound/weapons/energy/laser_pistol.ogg'

--- a/code/modules/projectiles/guns/energy/laser/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser/laser.dm
@@ -46,7 +46,7 @@
 	allow_greyson_mods = TRUE
 
 /obj/item/gun/energy/laser/mounted/cyborg
-	name = "integrated \"Cog\" lasgun"
+	name = "integrated \"Cog\" laser carbine"
 	desc = "A Greyson Positronic design, cheap and widely produced. In the distant past - this was the main weapon of low-rank police forces, billions of copies of this gun were made."
 	icon = 'icons/obj/guns/energy/cog.dmi'
 	icon_state = "cog"

--- a/code/modules/projectiles/guns/projectile/pistol/gyropistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/gyropistol.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/gyropistol
-	name = "SA GP \"Emperor \""
+	name = "SA GP \"Novichok\""
 	desc = "A bulky pistol designed to fire 19mm self-propelled explosive rockets. Commonly referred to as the 'man-opener' by Void Wolves."
 	icon = 'icons/obj/guns/projectile/gyropistol.dmi'
 	icon_state = "gyropistol"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1460,7 +1460,7 @@
 
 /obj/item/reagent_containers/food/snacks/icecream
 	name = "icecream"
-	desc = "A luxurious yet simple iced cream, the most refreshing dessert after a trip through the humid Amethian jungle."
+	desc = "A luxurious yet simple iced cream, the most refreshing dessert after a trip through the humid Amethian forest."
 	icon_state = "vanillaicecream"
 	trash = /obj/item/trash/icecreambowl
 	bitesize = 3

--- a/code/modules/reagents/reagent_containers/food/snacks/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/sandwich.dm
@@ -149,7 +149,7 @@
 	center_of_mass = list("x"=16, "y"=4)
 	nutriment_desc = list("toasted bread" = 3, "cheese" = 3, "delux toasted sandwich" = 5)
 	nutriment_amt = 3
-	preloaded_reagents = list("protein" = 3, "machine binding ritual" = 3, "glucose" = 2)
+	preloaded_reagents = list("protein" = 3, "greaser" = 3, "glucose" = 2)
 	cooked = TRUE
 	matter = list(MATERIAL_BIOMATTER = 23)
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -387,10 +387,10 @@
 /obj/item/reagent_containers/syringe/stim
 	name = "syringe (stim)"
 
-/obj/item/reagent_containers/syringe/stim/mbr
-	name = "syringe (Machine binding ritual)"
-	desc = "A syringe containing an ethanol based stimulator. Often used as a ritual drink by machine cults or engineering groups to enhance initiates who lack experience."
-	preloaded_reagents = list("machine binding ritual" = 15)
+/obj/item/reagent_containers/syringe/stim/greaser
+	name = "syringe (Greaser)"
+	desc = "A syringe containing an ethanol based stimulator. Often used by engineering groups to enhance initiates who lack experience."
+	preloaded_reagents = list("greaser" = 15)
 
 /obj/item/reagent_containers/syringe/stim/cherrydrops
 	name = "syringe (Cherry Drops)"
@@ -417,10 +417,10 @@
 	desc = "A syringe containing a dose of steady, a stimulant favored by mercenaries for enhancing reaction time."
 	preloaded_reagents = list("steady" = 15)
 
-/obj/item/reagent_containers/syringe/stim/machine_spirit
-	name = "syringe (Machine Spirit)"
-	desc = "A syringe containing the ethanol based stimulant machine spirit. A favored chemical used by the Artificer's Guild to make even the lowliest adept a machine master."
-	preloaded_reagents = list("machine spirit" = 15)
+/obj/item/reagent_containers/syringe/stim/greasy_lard
+	name = "syringe (Greasy Lard)"
+	desc = "A syringe containing the ethanol based stimulant Greaser. A favored chemical used by the Artificer's Guild to make even the lowliest adept a machine master."
+	preloaded_reagents = list("greasy lard" = 15)
 
 /obj/item/reagent_containers/syringe/stim/grape_drops
 	name = "syringe (Grape Drops)"

--- a/code/modules/reagents/reagents/stims.dm
+++ b/code/modules/reagents/reagents/stims.dm
@@ -4,9 +4,9 @@
 	constant_metabolism = TRUE
 	reagent_type = "Stimulator"
 
-/datum/reagent/stim/mbr
-	name = "Machine binding ritual"
-	id = "machine binding ritual"
+/datum/reagent/stim/greaser
+	name = "Greaser"
+	id = "greaser"
 	description = "A ethanol based stimulator. Used as pick me up for engineers and technicians."
 	taste_description = "bitterness"
 	reagent_state = LIQUID
@@ -15,15 +15,15 @@
 	addiction_chance = 20
 	nerve_system_accumulations = 15
 
-/datum/reagent/stim/mbr/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_BASIC, STIM_TIME, "mbr")
-	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC, STIM_TIME, "mbr")
+/datum/reagent/stim/greaser/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_BASIC, STIM_TIME, "greaser")
+	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC, STIM_TIME, "greaser")
 
-/datum/reagent/stim/mbr/withdrawal_act(mob/living/carbon/M)
-	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "mbr_w")
-	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "mbr_w")
+/datum/reagent/stim/greaser/withdrawal_act(mob/living/carbon/M)
+	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "greaser_w")
+	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "greaser_w")
 
-/datum/reagent/stim/mbr/overdose(mob/living/carbon/M, alien)
+/datum/reagent/stim/greaser/overdose(mob/living/carbon/M, alien)
 	if(prob(5))
 		M.vomit()
 	if(ishuman(M) && prob(80 - (60 * (1 - M.stats.getMult(STAT_TGH)))))
@@ -197,9 +197,9 @@
 		create_overdose_wound(I, M, /datum/component/internal_wound/organic/heavy_poisoning)
 	M.add_chemical_effect(CE_SLOWDOWN, 1)
 
-/datum/reagent/stim/machine_spirit
-	name = "Machine Spirit"
-	id = "machine spirit"
+/datum/reagent/stim/greasy_lard
+	name = "Greasy Lard"
+	id = "greasy lard"
 	description = "Potent ethanol based stimulator. Used by engineers and technicians to gain an edge when working with machines."
 	taste_description = "bitterness"
 	reagent_state = LIQUID
@@ -208,17 +208,17 @@
 	nerve_system_accumulations = 30
 	addiction_chance = 30
 
-/datum/reagent/stim/machine_spirit/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_ADEPT, STIM_TIME, "machine_spirit")
-	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC, STIM_TIME, "machine_spirit")
-	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, STIM_TIME, "machine_spirit")
+/datum/reagent/stim/greasy_lard/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.stats.addTempStat(STAT_MEC, STAT_LEVEL_ADEPT, STIM_TIME, "greasy_lard")
+	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC, STIM_TIME, "greasy_lard")
+	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, STIM_TIME, "greasy_lard")
 
-/datum/reagent/stim/machine_spirit/withdrawal_act(mob/living/carbon/M)
-	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "machineSpirit_w")
-	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC, STIM_TIME, "machineSpirit_w")
-	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, STIM_TIME, "machineSpirit_w")
+/datum/reagent/stim/greasy_lard/withdrawal_act(mob/living/carbon/M)
+	M.stats.addTempStat(STAT_MEC, -STAT_LEVEL_BASIC, STIM_TIME, "greasy_lard_w")
+	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_BASIC, STIM_TIME, "greasy_lard_w")
+	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_BASIC, STIM_TIME, "greasy_lard_w")
 
-/datum/reagent/stim/machine_spirit/overdose(mob/living/carbon/M, alien)
+/datum/reagent/stim/greasy_lard/overdose(mob/living/carbon/M, alien)
 	if(prob(5))
 		M.vomit()
 	if(ishuman(M) && prob(80 - (60 * (1 - M.stats.getMult(STAT_TGH)))))

--- a/code/modules/reagents/recipes/recipes.dm
+++ b/code/modules/reagents/recipes/recipes.dm
@@ -631,23 +631,23 @@
 	required_reagents = list("hydrazine" = 2, "carbon" = 2, "ammonia" = 2)
 	result_amount = 6
 
-/datum/chemical_reaction/mbr
-	result = "machine binding ritual"
+/datum/chemical_reaction/greaser
+	result = "greaser"
 	required_reagents = list("coffee" = 2, "diplopterum" = 1, "sugar" = 1, "ethanol" = 1)
 	result_amount = 5
 	maximum_temperature = 343
 	minimum_temperature = 323
 
-/datum/chemical_reaction/machine_spirit
-	result = "machine spirit"
-	required_reagents = list("machine binding ritual" = 1, "tramadol" = 1, "blattedin" = 1)
+/datum/chemical_reaction/lard
+	result = "greasy lard"
+	required_reagents = list("greaser" = 1, "tramadol" = 1, "blattedin" = 1)
 	result_amount = 3
 	maximum_temperature = 318
 	minimum_temperature = 308
 
 /datum/chemical_reaction/party_drops
 	result = "party drops"
-	required_reagents = list("grape drops" = 1, "machine spirit" = 1, "ultrasurgeon" = 1)
+	required_reagents = list("grape drops" = 1, "greasy lard" = 1, "ultrasurgeon" = 1)
 	catalysts = list("honey" = 1)
 	result_amount = 3
 
@@ -935,7 +935,7 @@
 	result_amount = 2
 	maximum_temperature = 12.7
 	minimum_temperature = 7.7
- 
+
 /datum/chemical_reaction/mindwipe
 	result = "mindwipe"
 	required_reagents = list("mindbreaker" = 1, "psilocybin" = 1, "sanguinum" = 1 , "anti_toxin" = 1, "ethanol" = 1)

--- a/code/modules/research/designs/greyson.dm
+++ b/code/modules/research/designs/greyson.dm
@@ -1,22 +1,22 @@
 /datum/design/research/item/greyson/cog
-	name = "GP \"Cog\" lasgun"
+	name = "GP \"Cog\" laser carbine"
 	build_path = /obj/item/gun/energy/cog
 	category = CAT_WEAPON
 
 /datum/design/research/item/greyson/cog_sawn
-	name = "GP \"Pinion\" lasgun"
+	name = "GP \"Pinion\" laser carbine"
 	build_path = /obj/item/gun/energy/cog/sawn
 	category = CAT_WEAPON
 
 /*	// Unneeded with the introduction of the Sprocket, keeps this variant as Marshal exclusive
 /datum/design/research/item/greyson/cog_gear
-	name = "GP \"Gear\" lasgun"
+	name = "GP \"Gear\" police laser carbine"
 	build_path = /obj/item/gun/energy/cog/gear
 	category = CAT_WEAPON
 */
 
 /datum/design/research/item/greyson/cog_sprocket
-	name = "Soteria \"Sprocket\" lasgun"
+	name = "Soteria \"Sprocket\" laser carbine"
 	build_path = /obj/item/gun/energy/cog/sprocket
 	category = CAT_WEAPON
 

--- a/code/modules/research/designs/greyson.dm
+++ b/code/modules/research/designs/greyson.dm
@@ -4,7 +4,7 @@
 	category = CAT_WEAPON
 
 /datum/design/research/item/greyson/cog_sawn
-	name = "GP \"Pinion\" laser carbine"
+	name = "GP \"Pinion\" laser pistol"
 	build_path = /obj/item/gun/energy/cog/sawn
 	category = CAT_WEAPON
 

--- a/code/modules/research/nodes/greyson.dm
+++ b/code/modules/research/nodes/greyson.dm
@@ -14,7 +14,7 @@
 	unlocks_designs = list(/datum/design/research/item/greyson/cog)
 
 /datum/technology/GP_Cog_alt
-	name = "Greyson Positronic Alternative Lasgun Designs"
+	name = "Greyson Positronic Alternative Laser Carbine Designs"
 	desc = "Further changes made to the already successful Cog design."
 	tech_type = RESEARCH_GREYSON
 

--- a/maps/__Nadezhda/map/Underground_Old.dmm
+++ b/maps/__Nadezhda/map/Underground_Old.dmm
@@ -11496,10 +11496,10 @@
 /obj/item/reagent_containers/syringe/stim/ultra_surgeon{
 	pixel_x = 0
 	},
-/obj/item/reagent_containers/syringe/stim/machine_spirit{
+/obj/item/reagent_containers/syringe/stim/greasy_lard{
 	pixel_x = 5
 	},
-/obj/item/reagent_containers/syringe/stim/machine_spirit{
+/obj/item/reagent_containers/syringe/stim/greasy_lard{
 	pixel_x = 10
 	},
 /turf/simulated/floor/tiled/white,

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -38680,10 +38680,10 @@
 /obj/random/medical/low_chance,
 /obj/random/medical/low_chance,
 /obj/effect/floor_decal/industrial/warningred,
-/obj/item/reagent_containers/syringe/stim/machine_spirit{
+/obj/item/reagent_containers/syringe/stim/greasy_lard{
 	pixel_x = 10
 	},
-/obj/item/reagent_containers/syringe/stim/machine_spirit{
+/obj/item/reagent_containers/syringe/stim/greasy_lard{
 	pixel_x = 10
 	},
 /obj/item/reagent_containers/syringe/stim/ultra_surgeon,

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Omni_STU.dmm
@@ -57319,10 +57319,10 @@
 /obj/random/medical/low_chance,
 /obj/random/medical/low_chance,
 /obj/effect/floor_decal/industrial/warningred,
-/obj/item/reagent_containers/syringe/stim/machine_spirit{
+/obj/item/reagent_containers/syringe/stim/greasy_lard{
 	pixel_x = 10
 	},
-/obj/item/reagent_containers/syringe/stim/machine_spirit{
+/obj/item/reagent_containers/syringe/stim/greasy_lard{
 	pixel_x = 10
 	},
 /obj/item/reagent_containers/syringe/stim/ultra_surgeon,

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_Underground.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_Underground.dmm
@@ -11294,10 +11294,10 @@
 /obj/item/reagent_containers/syringe/stim/ultra_surgeon{
 	pixel_x = 0
 	},
-/obj/item/reagent_containers/syringe/stim/machine_spirit{
+/obj/item/reagent_containers/syringe/stim/greasy_lard{
 	pixel_x = 5
 	},
-/obj/item/reagent_containers/syringe/stim/machine_spirit{
+/obj/item/reagent_containers/syringe/stim/greasy_lard{
 	pixel_x = 10
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{

--- a/modular_sojourn/Borers/borer.dm
+++ b/modular_sojourn/Borers/borer.dm
@@ -371,7 +371,7 @@
 			to_chat(host, SPAN_NOTICE("Congratulations! You've reached Evolution Level 5, new abilities are now available."))
 		else
 			to_chat(src, SPAN_NOTICE("Congratulations! You've reached Evolution Level 5, new abilities are now available."))
-		produced_reagents |= list("violence", "steady", "bouncer", "prosurgeon", "cherry drops", "machine binding ritual")
+		produced_reagents |= list("violence", "steady", "bouncer", "prosurgeon", "cherry drops", "greaser")
 		abilities_in_host |= list(/mob/living/simple_animal/borer/proc/jumpstart)
 		if(host && !controlling)
 			verbs += /mob/living/simple_animal/borer/proc/jumpstart


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Removes several on the nose references from code - Lasguns (yes it is a generic term used by more than that one universe but for sake of consistency) now all of them are either laser carbines or in case of church weapons laser musket / blunderbuss
Machine Binding Ritual and Machine spirit renamed to Greaser and Greasy Lard to not be 1 to 1 reference.
"God Emperor of Mankind" is now "Demolition Man", yes still a reference but one less people will get and it can be considered generic.
"Emperor" Gyrojet pistol is now "Novichok" (hopefully that actually does mean manopener in russian) to be more in line with serbian guns.
Clothing referencing nonexistant jungle according to lore now refer to it as Amethyn or Amethyn forest
	
<hr>
</details>

## Changelog
:cl:
tweak: References
/:cl:
