### PR TITLE
Reduces crossbow bolt crafting cost

### DIFF
--- a/code/datums/craft/recipes/lodge.dm
+++ b/code/datums/craft/recipes/lodge.dm
@@ -7,10 +7,10 @@
 // Weaponry -----------------
 /datum/craft_recipe/lodge/crossbow_bolts
 	name = "Crossbow Bolts"
-	result = /obj/item/ammo_casing/crossbow_bolts
+	result = /obj/item/ammo_casing/crossbow_bolts/bulk
 	time = 0
 	steps = list(
-		list(/obj/item/stack/rods, 1)
+		list(/obj/item/stack/rods, 5)
 	)
 	flags = CRAFT_BATCH
 
@@ -18,7 +18,7 @@
 	name = "Fragment Crossbow Bolt"
 	result = /obj/item/ammo_casing/crossbow_bolts/fragment/bulk
 	steps = list(
-		list(/obj/item/stack/rods, 10),
+		list(/obj/item/stack/rods, 5),
 		list(/obj/item/stack/ore, 1)
 	)
 
@@ -27,7 +27,7 @@
 	result = /obj/item/ammo_casing/crossbow_bolts/speed/bulk
 	time = 0
 	steps = list(
-		list(/obj/item/stack/rods, 10),
+		list(/obj/item/stack/rods, 5),
 		list(CRAFT_MATERIAL, 1, MATERIAL_BONE, "time" = 1), //Takes a second
 		list(CRAFT_MATERIAL, 1, MATERIAL_LEATHER, "time" = 1) //Takes a second
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Reduces the bolt lance's bolt crafting cost
</summary>
<hr>

Makes the regular bolt's recipe a bulk one, and halves all three bolt types' metal rod cost, where previously it was 1 sheet = 1 bolt, now it's 1 sheet = 2 bolts

I feel like 1 sheet = 1 shot with the bolt lance is a bit steep and could be lowered so less time has to be spent gathering scrap metal objects to smelt.

This PR does not touch the makeshift crossbow at all.
	
<hr>
</details>

## Changelog
:cl:
balance: Reduces crossbow bolt crafting costs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
