### PR TITLE
Adds Initial Starting Funds to Prospectors

### DIFF
--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -69,6 +69,7 @@
 	alt_titles = list("Sawbones", "Rookie Salvager")
 	alt_perks = list("Sawbones"=list(PERK_MEDICAL_EXPERT, PERK_STALKER), "Junk Technician"=list(PERK_JUNKBORN, PERK_ROBOTICS_EXPERT))
 	selection_color = "#a7bbc6"
+	initial_balance = 500	//Should be enough to get by with basic meds, tools, and food round-start.
 	wage = WAGE_NONE
 
 	disallow_species = list(FORM_BSSYNTH, FORM_NASHEF)
@@ -117,6 +118,7 @@
 	noob_name = "Rookie Prospector"
 	alt_titles = list("Rookie Prospector", "Hired Muscle")
 	selection_color = "#a7bbc6"
+	initial_balance = 500	//Should be enough to get by with basic meds, tools, and food round start.
 	wage = WAGE_NONE
 
 	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Their wage was set to 0 but, unlike colonists, did not receive starting money.

The starting money is 300 less than colonists, but to be fair, they start with bonus stats, bonus health, gear, and some baseline stuff like death alarms provided to them. So - seems fair to give them 500 credits vs the 800 colonists get.

## Changelog
:cl:
adds: Prospector starting money.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
