### PR TITLE
Adds trays to Beacon (Tray revolution)

### DIFF
--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -6,6 +6,7 @@
 	anchored = 1
 	reagent_flags = OPENCONTAINER
 	volume = 100
+	price_tag = 150 //Mostly just to have a price for the beacon, but I guess you could sell them if you were REALLY desperate?
 
 	blue_ink_tk_blocker = TRUE //Removes bugs with teleportion
 

--- a/code/modules/trade/datums/trade_stations_presets/1-common/nt_cruisers.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/nt_cruisers.dm
@@ -54,7 +54,8 @@
 			/obj/item/tool/hatchet,
 			/obj/item/tool/minihoe,
 			/obj/item/device/scanner/plant,
-			/obj/item/clothing/gloves/botanic_leather
+			/obj/item/clothing/gloves/botanic_leather,
+			/obj/machinery/portable_atmospherics/hydroponics
 		),
 		"Custodial Supply" = list(
 			/obj/item/reagent_containers/glass/bucket,


### PR DESCRIPTION
The churchie stations get access to hydro-trays for purchase (150 base price, which means they're bought at 170 from the ship) They arrive bolted to the floor, mildly annoying, overall nonissue though Can only be sold when unwrenched, which makes sense

Tested it to make sure fruit can grow (grape) and be harvested (grape)

![image](https://user-images.githubusercontent.com/47806118/226913197-6b963237-7fb3-4fe8-a48c-7fc8e9b4562d.png)

![image](https://user-images.githubusercontent.com/47806118/226913216-812dcb8a-f0dd-42fb-b6f5-8a29650437a4.png)

![image](https://user-images.githubusercontent.com/47806118/226914602-22201995-a0a5-4b66-94a1-0ee8b5ddbc0d.png)
