### PR TITLE
Stat cap

### DIFF
--- a/code/__DEFINES/mob_stats.dm
+++ b/code/__DEFINES/mob_stats.dm
@@ -1,4 +1,5 @@
 #define STAT_VALUE_DEFAULT	0
+#define STAT_VALUE_MAXIMUM 150
 
 #define STAT_MEC			"Mechanical"
 #define STAT_COG			"Cognition"

--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -58,6 +58,12 @@
 	S.changeValue(Value)
 	LEGACY_SEND_SIGNAL(holder, COMSIG_STAT, S.name, S.getValue(), S.getValue(TRUE))
 
+/datum/stat_holder/proc/changeStat_withcap(statName, Value)
+	var/datum/stat/S = stat_list[statName]
+	S.changeValue_withcap(Value)
+	LEGACY_SEND_SIGNAL(holder, COMSIG_STAT, S.name, S.getValue(), S.getValue(TRUE))
+
+
 /datum/stat_holder/proc/setStat(statName, Value)
 	var/datum/stat/S = stat_list[statName]
 	S.setValue(Value)
@@ -196,10 +202,17 @@
 			return SM
 
 /datum/stat/proc/changeValue(affect)
+	value = value + affect
+
+/datum/stat/proc/changeValue_withcap(affect)
+	if(value > STAT_VALUE_MAXIMUM)
+		return
+
 	if(value + affect > STAT_VALUE_MAXIMUM)
 		value = STAT_VALUE_MAXIMUM
 	else
 		value = value + affect
+
 
 /datum/stat/proc/getValue(pure = FALSE)
 	if(pure)
@@ -215,6 +228,10 @@
 			. += SM.value
 
 /datum/stat/proc/setValue(value)
+	src.value = value
+
+//Unused but might be good for later additions
+/datum/stat/proc/setValue_withcap(value)
 	if(value > STAT_VALUE_MAXIMUM)
 		src.value = STAT_VALUE_MAXIMUM
 	else

--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -196,7 +196,10 @@
 			return SM
 
 /datum/stat/proc/changeValue(affect)
-	value = value + affect
+	if(value + affect > STAT_VALUE_MAXIMUM)
+		value = STAT_VALUE_MAXIMUM
+	else
+		value = value + affect
 
 /datum/stat/proc/getValue(pure = FALSE)
 	if(pure)
@@ -212,7 +215,10 @@
 			. += SM.value
 
 /datum/stat/proc/setValue(value)
-	src.value = value
+	if(value > STAT_VALUE_MAXIMUM)
+		src.value = STAT_VALUE_MAXIMUM
+	else
+		src.value = value
 
 /datum/stat/productivity
 	name = STAT_MEC

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -361,7 +361,7 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 					var/stat_up = L[stat] * 2 * resting_times
 					if((owner.stats.getStat(stat)) >= STAT_VALUE_MAXIMUM)
 						stat_up = 0
-						to_chat(owner, SPAN_NOTICE("Your [stat] can not be raised any higher with simple trinkets..."))
+						to_chat(owner, SPAN_NOTICE("You feel that you can't grow anymore better for today in [stat] with oddities"))
 					else
 						to_chat(owner, SPAN_NOTICE("Your [stat] stat goes up by [stat_up]"))
 						owner.stats.changeStat_withcap(stat, stat_up)

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -359,8 +359,12 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 					resting_times = 1
 				for(var/stat in L)
 					var/stat_up = L[stat] * 2 * resting_times
-					to_chat(owner, SPAN_NOTICE("Your [stat] stat goes up by [stat_up]"))
-					owner.stats.changeStat(stat, stat_up)
+					if((owner.stats.getStat(stat)) >= STAT_VALUE_MAXIMUM)
+						stat_up = 0
+						to_chat(owner, SPAN_NOTICE("Your [stat] can not be raised any higher with simple trinkets..."))
+					else
+						to_chat(owner, SPAN_NOTICE("Your [stat] stat goes up by [stat_up]"))
+						owner.stats.changeStat_withcap(stat, stat_up)
 
 				if(I.perk)
 					if(owner.stats.addPerk(I.perk))
@@ -390,7 +394,11 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 				LAZYAPLUS(stat_change, pick(ALL_STATS_FOR_LEVEL_UP), 3)
 
 			for(var/stat in stat_change)
-				owner.stats.changeStat(stat, stat_change[stat])
+				if((owner.stats.getStat(stat)) >= STAT_VALUE_MAXIMUM)
+					to_chat(owner, SPAN_NOTICE("You can not increase [stat] anymore with simple resting."))
+				else
+					to_chat(owner, SPAN_NOTICE("Your [stat] stat goes up by [stat_change[stat]]"))
+					owner.stats.changeStat_withcap(stat, stat_change[stat])
 
 	owner.pick_individual_objective()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Ports from Eris
https://github.com/discordia-space/CEV-Eris/pull/7938

This should finally prevent another Yawet situation of grinding stats so hard you oneshot people with your fists and before the usual 'Why are you balancing after Eris' another Eris based server already had this long before and I was going to port it but it was part of another PR which got canned that's why it's standalone now.

By Trilby, allows you to bypass the caps using alternative means just not by resting / oddities
<hr>
</details>

## Changelog
:cl:
add: Stat cap
/:cl:
