### PR TITLE
Changes One Star Vendor to Greyson Positronic Vendor

### DIFF
--- a/code/game/machinery/vendor/one_star_vending.dm
+++ b/code/game/machinery/vendor/one_star_vending.dm
@@ -1,6 +1,6 @@
 /obj/machinery/vending/one_star
-	name = "One Star Vendor"
-	desc = "A vendor of the One Star variety typical made by GP."
+	name = "Greyson Positronic Vendor"
+	desc = "A holographic vendor made by Greyson Positronic."
 	icon = 'icons/obj/machines/one_star/vending.dmi'
 	icon_state = "vendor_guns"
 	icon_vend = "vendor_printing"
@@ -31,7 +31,7 @@
 		)
 
 /obj/machinery/vending/one_star/food
-	desc = "A vendor of the One Star variety typical made by GP. This one sells food variety."
+	desc = "A holographic vendor made by Greyson Positronic. This one sells a variety of food."
 	product_slogans = "It's a Vending Machine!;We all eat lunch from a Vending Machine!"
 	product_ads = "You must be the new guy!;Hows is your child doing?;Real Meals!;Some people say its not real food but many quite like and many think you will to!"
 
@@ -64,5 +64,5 @@
 		)
 
 /obj/machinery/vending/one_star/health
-	desc = "A vendor of the One Star variety typical made by GP. This one sells medical paraphernalia of the GP variety."
+	desc = "A holographic vendor made by Greyson Positronic. This one sells medical paraphernalia of the GP variety."
 	icon_state = "vendor_health"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Changes the "One Star Vendor" name to "Greyson Positronic Vendor" to match with our lore. The name "One Star" is what is used by Eris. Also altered the description to match, and minorly altered the wording
	
<hr>
</details>

## Changelog
:cl:
fix: Changed One Star Vendor to Greyson Positronic Vendor to match with Sojourn's lore 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
