### PR TITLE
outsiders can now be FPBs

### DIFF
--- a/code/game/jobs/job/offcolony.dm
+++ b/code/game/jobs/job/offcolony.dm
@@ -138,7 +138,6 @@
 //	minimal_access = list(access_maint_tunnels)
 	outfit_type = /decl/hierarchy/outfit/job/outsider
 	difficulty = "Impossible!"
-	disallow_species = list(FORM_FBP, FORM_UNBRANDED, FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 	has_id = FALSE
 
 	stat_modifiers = list(


### PR DESCRIPTION
FBPs may now be allowed to be outsider, this rule has been set in a time where fear of them powergaming against the colony was common, but now that the rules of conflict between outsiders and colonists is more strict, this is not a problem anymore.

