### PR TITLE
rebalancing bounty

### DIFF
--- a/code/modules/projectiles/guns/projectile/boltgun/mares_leg.dm
+++ b/code/modules/projectiles/guns/projectile/boltgun/mares_leg.dm
@@ -23,6 +23,8 @@
 	name = "\"Bounty\" repeating shotgun"
 	desc = "A training shotgun turned into a workhorse. The Bounty was a Blackshield training shotgun for their bolt cycling training, now modified and repurposed to fire slug and buckshot shells. When used in close quarters with Blackshield's training, a trooper can clear a whole room full of bugs in seconds."
 	icon = 'icons/obj/guns/projectile/bounty.dmi'
+	damage_multiplier = 1.1
+	penetration_multiplier = 0.7
 	icon_state = "bounty"
 	item_state = "bounty"
 	price_tag = 950


### PR DESCRIPTION
The bounty is a lever action rifle, made to fire 20mm shotgun rounds. But, despite being a quite costly, and supposedly mid-tier blackshield weapon, it's actually pretty bad. And that's because its stats are derived from a makeshift weapon that is purposefully bad, and I can't quite get why. This fixes it, and makes it a decent, but still not very good lever action that trades AP for some damage.
