### PR TITLE
fix #4623 - Use created object instead of object type

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -331,8 +331,8 @@
 			for(var/i=1 to (slices_num-slices_lost))
 				var/obj/slice = new slice_path (src.loc)
 				reagents.trans_to_obj(slice, reagents_per_slice)
-				if(istype(slice_path, /obj/item/reagent_containers/food/snacks))
-					slice_path?:food_quality = src.food_quality
+				if(istype(slice, /obj/item/reagent_containers/food/snacks))
+					slice?:food_quality = src.food_quality
 			qdel(src)
 			return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Fixes slices of food not having the quality of the sliced food
</summary>
<hr>
Slice-able food has a variable slice_path. For example "/obj/item/reagent_containers/food/snacks/plaincakeslice" for "/obj/item/reagent_containers/food/snacks/sliceable/plaincake". When slicing, a new object of that given type is created for each slice. As I understand it, right after slicing, it was attempted to alter the food_quality variable of *the path* of the newly created object instead of the object itself.

Fixes #4623, thanks for finding the troublesome code lines! 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl: dutop
fix: Slices of slice-able food items get the same quality as the food item itself.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
