### PR TITLE
Cash register: fix custom orders, make price changeable

### DIFF
--- a/code/modules/economy/cash_register.dm
+++ b/code/modules/economy/cash_register.dm
@@ -401,7 +401,7 @@
 	var/item_name
 	for(var/i=1, i<=item_list.len, i++)
 		item_name = item_list[i]
-		dat += "<tr><td class=\"tx-name-r\">[item_list[item_name] ? "<a href='?src=\ref[src];choice=subtract;item=\ref[item_name]'>-</a> <a href='?src=\ref[src];choice=set_amount;item=\ref[item_name]'>Set</a> <a href='?src=\ref[src];choice=add;item=\ref[item_name]'>+</a> [item_list[item_name]] ([price_list[item_name]] &thorn <a href='?src=\ref[src];choice=set_price;item=\ref[item_name]'>Change</a>) x " : ""][item_name] <a href='?src=\ref[src];choice=clear;item=\ref[item_name]'>Remove</a></td><td class=\"tx-data-r\" width=50>[price_list[item_name] * item_list[item_name]] &thorn</td></tr>"
+		dat += "<tr><td class=\"tx-name-r\">[item_list[item_name] ? "<a href='?src=\ref[src];choice=subtract;item=\ref[item_name]'>-</a> <a href='?src=\ref[src];choice=set_amount;item=\ref[item_name]'>Set</a> <a href='?src=\ref[src];choice=add;item=\ref[item_name]'>+</a> [item_list[item_name]] x " : ""][item_name] ([price_list[item_name]] &thorn <a href='?src=\ref[src];choice=set_price;item=\ref[item_name]'>Change</a>) <a href='?src=\ref[src];choice=clear;item=\ref[item_name]'>Remove</a></td><td class=\"tx-data-r\" width=50>[price_list[item_name] * item_list[item_name]] &thorn</td></tr>"
 	dat += "</table><table width=300>"
 	dat += "<tr><td class=\"tx-name-r\"><a href='?src=\ref[src];choice=clear'>Clear Entry</a></td><td class=\"tx-name-r\" style='text-align: right'><b>Total Amount: [transaction_amount] &thorn</b></td></tr>"
 	dat += "</table></html>"

--- a/code/modules/economy/cash_register.dm
+++ b/code/modules/economy/cash_register.dm
@@ -126,11 +126,11 @@
 				var/t_purpose = sanitize(input("Enter purpose", "New purpose") as text)
 				if (!t_purpose || !Adjacent(usr)) return
 				transaction_purpose = t_purpose
-				item_list += t_purpose
+				item_list[t_purpose] = 1
 				var/t_amount = round(input("Enter price", "New price") as num)
 				if (!t_amount || !Adjacent(usr)) return
 				transaction_amount += t_amount
-				price_list += t_amount
+				price_list[t_purpose] = t_amount
 				playsound(src, 'sound/machines/twobeep.ogg', 25)
 				visible_message("\icon[src][transaction_purpose]: [t_amount] Credit\s.")
 			if("set_amount")
@@ -144,6 +144,15 @@
 					price_list -= item_name
 				else
 					item_list[item_name] = n_amount
+			if("set_price")
+				var/item_name = locate(href_list["item"])
+				var/n_price = round(input("Enter price", "New price") as num)
+				if (!Adjacent(usr)) return
+				if (!n_price) return
+				if (!item_list[item_name]) return
+				transaction_amount -= item_list[item_name] * price_list[item_name]
+				price_list[item_name] = n_price
+				transaction_amount += item_list[item_name] * price_list[item_name]
 			if("subtract")
 				var/item_name = locate(href_list["item"])
 				if(item_name)
@@ -392,7 +401,7 @@
 	var/item_name
 	for(var/i=1, i<=item_list.len, i++)
 		item_name = item_list[i]
-		dat += "<tr><td class=\"tx-name-r\">[item_list[item_name] ? "<a href='?src=\ref[src];choice=subtract;item=\ref[item_name]'>-</a> <a href='?src=\ref[src];choice=set_amount;item=\ref[item_name]'>Set</a> <a href='?src=\ref[src];choice=add;item=\ref[item_name]'>+</a> [item_list[item_name]] x " : ""][item_name] <a href='?src=\ref[src];choice=clear;item=\ref[item_name]'>Remove</a></td><td class=\"tx-data-r\" width=50>[price_list[item_name] * item_list[item_name]] &thorn</td></tr>"
+		dat += "<tr><td class=\"tx-name-r\">[item_list[item_name] ? "<a href='?src=\ref[src];choice=subtract;item=\ref[item_name]'>-</a> <a href='?src=\ref[src];choice=set_amount;item=\ref[item_name]'>Set</a> <a href='?src=\ref[src];choice=add;item=\ref[item_name]'>+</a> [item_list[item_name]] ([price_list[item_name]] &thorn <a href='?src=\ref[src];choice=set_price;item=\ref[item_name]'>Change</a>) x " : ""][item_name] <a href='?src=\ref[src];choice=clear;item=\ref[item_name]'>Remove</a></td><td class=\"tx-data-r\" width=50>[price_list[item_name] * item_list[item_name]] &thorn</td></tr>"
 	dat += "</table><table width=300>"
 	dat += "<tr><td class=\"tx-name-r\"><a href='?src=\ref[src];choice=clear'>Clear Entry</a></td><td class=\"tx-name-r\" style='text-align: right'><b>Total Amount: [transaction_amount] &thorn</b></td></tr>"
 	dat += "</table></html>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	fix cash register custom orders
	add ability to change prices
</summary>
<hr>
Today's episode of "Things no one will ever notice":
When adding custom orders in the cash register, each item is shown with 0 Credits, although the total transaction amount will be updated. The code used two lists with named items, but the part about custom orders used them as simple lists. So instead of an item (item 1, name Apple, value 1) we had (item 1, Apple). Later calculations were doomed to fail (An apple costs 3 credits, so Apple times three is ... bullshit, to be honest. 1 times three works better). Same thing with the prices list.

By fixing the way items are added to these lists, another feature is working (again?): In one line, the amount of items to be bought can be changed. This only worked with scanned items before the change.

By testing whether the part about scanning items still works, I noticed that we are selling items with their actual worth. No way to change it. Boo! I've added this ability. Changing the value of a previously entered custom order works, too.

![image](https://user-images.githubusercontent.com/73559117/236000524-6e3749f1-a469-4bf5-9903-f35c08b1b9aa.png)
In this example image, I've created custom orders and changed their amount and price. The price per line and the total amount was updated correctly. Then I scanned some random bottle and updated its price as well. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl: dutop
fix: Custom orders in the cash register showing price
fix: Amount of individual items changeable
add: Prices of items can be changed, even with scanned items
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
