### PR TITLE
Excel armor stat change and mob tweaks

### DIFF
--- a/code/modules/clothing/spacesuits/void/excelsior.dm
+++ b/code/modules/clothing/spacesuits/void/excelsior.dm
@@ -7,20 +7,22 @@
 	//The excelsior armors cost small amounts of rare materials that they can teleport in.
 	//This means they can either build up materials over time, or make it go faster by scavenging rare mats
 	matter = list(
-		MATERIAL_PLASTIC = 20,
+		MATERIAL_PLASTIC = 5,
 		MATERIAL_GLASS = 10,
-		MATERIAL_PLASTEEL = 3
+		MATERIAL_PLASTEEL = 25,
+		MATERIAL_GOLD = 10
+		MATERIAL_SILVER = 10
 	)
 
 	armor_list = list(
-		melee = 60,
-		bullet = 60,
-		energy = 60,
-		bomb = 75,
-		bio = 100,
-		rad = 90
+		melee = 45, // Excel Not made for Close range combat, Melee armor reflects this
+		bullet = 55,
+		energy = 70,
+		bomb = 80,
+		bio = 90,
+		rad = 25
 	)
-	siemens_coefficient = 0
+	siemens_coefficient = 0 //Shockproof!
 	species_restricted = list("Human")
 	//camera_networks = list(NETWORK_EXCELSIOR) //Todo future: Excelsior camera network and monitoring console
 	light_overlay = "helmet_light_green"
@@ -35,19 +37,21 @@
 	flags_inv = HIDEGLOVES|HIDEJUMPSUIT|HIDETAIL
 	w_class = ITEM_SIZE_NORMAL
 	//Decent all around, but less ballistic resistance
-	stiffness = LIGHT_STIFFNESS
+	stiffness = MEDIUM_STIFFNESS
 	armor_list = list(
-		melee = 60,
-		bullet = 60,
-		energy = 60,
-		bomb = 75,
-		bio = 100,
-		rad = 90
+		melee = 45, // Excel Not made for Close range combat, Melee armor reflects this
+		bullet = 55,
+		energy = 70,
+		bomb = 80,
+		bio = 90,
+		rad = 25
 	)
 	siemens_coefficient = 0 //Shockproof!
 	matter = list(
-		MATERIAL_PLASTIC = 30,
-		MATERIAL_STEEL = 10,
-		MATERIAL_PLASTEEL = 5
+		MATERIAL_PLASTIC = 10,
+		MATERIAL_STEEL = 20,
+		MATERIAL_PLASTEEL = 50
+		MATERIAL_GOLD = 20,
+		MATERIAL_SILVER = 20
 	)
 	helmet = /obj/item/clothing/head/helmet/space/void/excelsior

--- a/code/modules/clothing/spacesuits/void/excelsior.dm
+++ b/code/modules/clothing/spacesuits/void/excelsior.dm
@@ -6,11 +6,12 @@
 
 	//The excelsior armors cost small amounts of rare materials that they can teleport in.
 	//This means they can either build up materials over time, or make it go faster by scavenging rare mats
+	//The general focus of the low ish armor stat is that they should rely more on their tools than strait up combat. They got the toys(shields/turrets/traps) to take the hits for 'em afterall
 	matter = list(
 		MATERIAL_PLASTIC = 5,
 		MATERIAL_GLASS = 10,
 		MATERIAL_PLASTEEL = 25,
-		MATERIAL_GOLD = 10
+		MATERIAL_GOLD = 10,
 		MATERIAL_SILVER = 10
 	)
 
@@ -50,7 +51,7 @@
 	matter = list(
 		MATERIAL_PLASTIC = 10,
 		MATERIAL_STEEL = 20,
-		MATERIAL_PLASTEEL = 50
+		MATERIAL_PLASTEEL = 50,
 		MATERIAL_GOLD = 20,
 		MATERIAL_SILVER = 20
 	)

--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/excelsior/excelsior.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/excelsior/excelsior.dm
@@ -9,7 +9,7 @@
 	maxHealth = 100
 	health = 100
 
-	armor = list(melee = 60, bullet = 60, energy = 60, bomb = 75, bio = 100, rad = 90) //Legitmently their armor
+	armor = list(melee = 55, bullet = 55, energy = 70, bomb = 80, bio = 90, rad = 25) //Legitmently their armor (melee is higher {45} to account for AI stupidness)
 
 	//range/ammo stuff
 	ranged = 1
@@ -45,7 +45,7 @@
 	min_bodytemperature = 0
 
 //Drops
-	meat_amount = 4
+	meat_amount = 1
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/human
 
 	inherent_mutations = list(MUTATION_HEART, MUTATION_LUNG, MUTATION_LIVER, MUTATION_BLOOD_VESSEL, MUTATION_MUSCLES, MUTATION_NERVES)
@@ -70,7 +70,7 @@
 	projectilesound = 'sound/weapons/guns/fire/grease_fire.ogg'
 	rounds_left = 71
 	mag_type = /obj/item/ammo_magazine/highcap_pistol_35/drum/empty
-	mags_left = 1 //1+1
+	mags_left = 2 //2+1
 
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak
 	icon_state = "excel_ak"


### PR DESCRIPTION
**-Changelog-**

Changed Excel void suit to reflect it's description and make it less of a juggernaut suit made by the gods.
(Requires additional material to craft /&/ Better energy protection, less melee and rad with average Ballistic; with added weight as it's a pretty beefy bomb suit for a full void suit)

Seems the experience i've seen is that even a lone Excel agent can 1v5 the colony with this armor, although it's expected that the excel agent is to be fighting an uphill battle. This will hopefully make them less reliant on going full "nuke-ops war mode" every time they play. Y'all got traps and other fun toys to play with before choosing a gun. After all a dead colonist is a terrible slave for implants of the glorious revolution!.

Reduced excel slave meat drop from 4 to 1 to reduce item lag, and made all mobs carry 3 mags worth of ammo (the ppsh for some reason only had 2 mags)