### PR TITLE
Merc space base update

### DIFF
--- a/maps/Centcom/map/centcom.dmm
+++ b/maps/Centcom/map/centcom.dmm
@@ -3090,6 +3090,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/tank/air,
+/obj/item/tank/air,
+/obj/item/tank/air,
+/obj/item/tank/air,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/centcom/merc_base)
 "iR" = (
@@ -3141,10 +3145,8 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/shuttle/mercshuttle_area)
 "iX" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
 /area/centcom/merc_base)
 "iY" = (
 /obj/structure/table/rack,
@@ -3459,6 +3461,7 @@
 /obj/structure/toilet{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/gibs,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/shuttle/mercshuttle_area)
 "jS" = (
@@ -3543,10 +3546,9 @@
 /turf/space,
 /area/space)
 "kb" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Suit Storage";
-	opacity = 1
-	},
+/obj/machinery/door/airlock/centcom,
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/floor_decal/industrial/caution,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/centcom/merc_base)
 "kc" = (
@@ -3826,11 +3828,13 @@
 /obj/item/tank/jetpack/oxygen,
 /obj/item/tank/jetpack/oxygen,
 /obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/centcom/merc_base)
 "kG" = (
@@ -3915,10 +3919,9 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/centcom/merc_base)
 "kO" = (
-/obj/machinery/light/floor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/random/mecha,
+/obj/effect/floor_decal/industrial/box,
+/turf/simulated/floor/tiled/dark/golden,
 /area/centcom/merc_base)
 "kP" = (
 /obj/machinery/door/airlock/centcom{
@@ -3929,7 +3932,11 @@
 /area/centcom/merc_base)
 "kQ" = (
 /obj/structure/table/rack,
-/obj/item/clothing/suit/space/void/SCAF,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/gloves/thick/combat,
+/obj/item/clothing/suit/space/void/SCAF/voidwolf,
+/obj/item/clothing/mask/gas/hox,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/centcom/merc_base)
 "kR" = (
@@ -5475,6 +5482,14 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/centcom/evac)
+"pj" = (
+/obj/structure/table/rack,
+/obj/item/storage/belt/webbing,
+/obj/item/storage/belt/webbing,
+/obj/item/storage/belt/webbing,
+/obj/item/storage/belt/webbing,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/centcom/merc_base)
 "pm" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin{
@@ -5556,6 +5571,10 @@
 /obj/structure/flora/pottedplant/smelly,
 /turf/simulated/floor/tiled/dark/golden,
 /area/centcom/evac)
+"qu" = (
+/obj/effect/floor_decal/industrial/stand_clear,
+/turf/simulated/floor/tiled/dark/golden,
+/area/centcom/merc_base)
 "qE" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/dark/golden,
@@ -5598,6 +5617,10 @@
 /obj/item/contraband/poster/placed/recruitment/rebels,
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/centcom/evac)
+"rp" = (
+/obj/machinery/computer/teleporter,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "rq" = (
 /mob/living/carbon/superior_animal/genetics/fratellis,
 /turf/simulated/floor/fixed/fgrass,
@@ -5635,6 +5658,11 @@
 	},
 /turf/space/transit/north/shuttlespace_ns6,
 /area/space)
+"rG" = (
+/obj/machinery/chemical_dispenser/industrial,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "rN" = (
 /obj/structure/table/steel,
 /obj/item/storage/deferred/crate/alcohol,
@@ -5676,6 +5704,12 @@
 /obj/structure/flora/small/grassb2,
 /turf/simulated/floor/fixed/fgrass,
 /area/centcom/evac)
+"sZ" = (
+/obj/structure/table/glass,
+/obj/item/stack/material/plasma/full,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "ti" = (
 /obj/machinery/light{
 	dir = 1
@@ -5709,6 +5743,15 @@
 	},
 /turf/simulated/floor/beach/sand,
 /area/centcom/evac)
+"ty" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers,
+/obj/item/storage/bag/chemistry,
+/obj/item/storage/bag/chemistry,
+/obj/item/clothing/glasses/powered/science,
+/obj/item/clothing/glasses/powered/science,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "tz" = (
 /turf/simulated/floor/carpet/turcarpet,
 /area/centcom/evac)
@@ -5737,6 +5780,15 @@
 /obj/structure/flora/small/grassa4,
 /turf/simulated/floor/fixed/fgrass,
 /area/centcom/evac)
+"uf" = (
+/obj/structure/table/rack,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/gloves/thick/combat,
+/obj/item/clothing/suit/space/void/SCAF/voidwolf,
+/obj/item/clothing/mask/gas/dal,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/centcom/merc_base)
 "ug" = (
 /turf/simulated/floor/carpet/turcarpet,
 /area/centcom/raider_base)
@@ -5758,6 +5810,11 @@
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/centcom/evac)
+"uv" = (
+/obj/structure/uplink/mercenary,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/dark/golden,
+/area/centcom/merc_base)
 "ux" = (
 /obj/machinery/suit_storage_unit/excelsior,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -5771,6 +5828,11 @@
 	},
 /turf/simulated/floor/beach/sand,
 /area/centcom/evac)
+"uH" = (
+/obj/structure/closet/wardrobe/job/chemistry_white,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "uM" = (
 /obj/machinery/light{
 	dir = 4
@@ -5828,6 +5890,11 @@
 	},
 /turf/space/transit/north/shuttlespace_ns9,
 /area/space)
+"vF" = (
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "vR" = (
 /obj/structure/table/woodentable,
 /obj/item/tool/knife/neotritual{
@@ -5839,6 +5906,10 @@
 "vU" = (
 /turf/simulated/floor/carpet/gaycarpet,
 /area/centcom/raider_base)
+"vX" = (
+/obj/machinery/light/floor,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/centcom/merc_base)
 "wd" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -5887,6 +5958,12 @@
 /obj/item/contraband/poster/placed/advertisement/eat,
 /turf/simulated/wall/r_wall,
 /area/centcom/evac)
+"xG" = (
+/obj/effect/floor_decal/industrial/loading{
+	dir = 1
+	},
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "xI" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/coffee_master,
@@ -5906,6 +5983,13 @@
 /obj/item/contraband/poster/placed/recruitment/security,
 /turf/simulated/wall/r_wall,
 /area/centcom/evac)
+"yc" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/centcom/merc_base)
 "ye" = (
 /obj/effect/step_trigger/thrower{
 	affect_ghosts = 1;
@@ -5924,6 +6008,9 @@
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/centcom/raider_base)
+"yk" = (
+/turf/simulated/floor/tiled/dark/golden,
+/area/centcom/merc_base)
 "yl" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/beer,
@@ -5935,6 +6022,11 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/centcom/evac)
+"ys" = (
+/obj/structure/grille,
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/centcom/merc_base)
 "yw" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -5949,6 +6041,11 @@
 /obj/item/flame/candle,
 /turf/simulated/floor/wood/wild1,
 /area/centcom/evac)
+"yN" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/white/cargo,
+/area/centcom/merc_base)
 "yR" = (
 /obj/structure/sign/department/bar,
 /turf/simulated/wall/r_wall,
@@ -5985,6 +6082,10 @@
 /obj/structure/reagent_dispensers/cahorsbarrel,
 /turf/simulated/floor/tiled/cafe,
 /area/centcom/evac)
+"zN" = (
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/wood/wild2,
+/area/centcom/merc_base)
 "zP" = (
 /obj/structure/table/rack/shelf,
 /obj/item/circuitboard/excelsior_boombox,
@@ -6086,6 +6187,10 @@
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/centcom/evac)
+"Bu" = (
+/obj/structure/closet/crate/voidwolf/voidwolfdrugs,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/centcom/merc_base)
 "BJ" = (
 /obj/effect/step_trigger/thrower{
 	affect_ghosts = 1;
@@ -6156,7 +6261,15 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/centcom/evac)
 "Cr" = (
-/obj/machinery/suit_storage_unit/merc,
+/obj/structure/table/rack,
+/obj/item/clothing/mask/gas/tactical,
+/obj/item/clothing/mask/gas/tactical,
+/obj/item/clothing/mask/gas/tactical,
+/obj/item/clothing/mask/gas/tactical,
+/obj/item/clothing/mask/gas/opifex,
+/obj/item/clothing/mask/gas/opifex,
+/obj/item/clothing/mask/gas/opifex,
+/obj/item/clothing/mask/gas/opifex,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/centcom/merc_base)
 "Ct" = (
@@ -6172,6 +6285,12 @@
 	},
 /turf/space/transit/north/shuttlespace_ns2,
 /area/space)
+"CB" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/obj/structure/grille,
+/turf/space,
+/area/space)
 "CP" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
@@ -6182,6 +6301,15 @@
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/dark/panels,
 /area/centcom/raider_base)
+"CU" = (
+/obj/structure/table/rack,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/gloves/thick/combat,
+/obj/item/clothing/suit/space/void/SCAF/voidwolf,
+/obj/item/clothing/mask/gas/cha,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/centcom/merc_base)
 "CW" = (
 /obj/item/flame/candle,
 /obj/item/flame/candle,
@@ -6230,10 +6358,21 @@
 /obj/machinery/door/airlock/glass_security,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/centcom/evac)
+"DM" = (
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "DW" = (
 /obj/machinery/vending/serbomat,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/centcom/evac)
+"Ev" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/centcom/merc_base)
 "Ew" = (
 /obj/item/contraband/poster/placed/recruitment/mercenary{
 	pixel_x = 5;
@@ -6264,6 +6403,13 @@
 "EP" = (
 /turf/simulated/floor/beach/sand,
 /area/centcom/evac)
+"ET" = (
+/obj/structure/table/glass,
+/obj/item/modular_computer/tablet/lease/preset/chemistry,
+/obj/item/modular_computer/tablet/lease/preset/chemistry,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "EU" = (
 /turf/simulated/floor/tiled/dark/panels,
 /area/centcom/raider_base)
@@ -6358,6 +6504,18 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/panels,
 /area/centcom/raider_base)
+"GS" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/item/handcuffs,
+/turf/simulated/floor/tiled/dark/cargo,
+/area/shuttle/mercshuttle_area)
+"GU" = (
+/obj/effect/window_lwall_spawn/plasma/reinforced,
+/turf/simulated/floor/wood/wild2,
+/area/centcom/merc_base)
 "GW" = (
 /obj/structure/table/rack/shelf,
 /obj/item/pizzabox/meat,
@@ -6397,12 +6555,8 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/centcom/evac)
 "HA" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/centcom/merc_base)
+/turf/simulated/floor/plating/under,
+/area/space)
 "HC" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/light{
@@ -6434,6 +6588,9 @@
 /obj/item/reagent_containers/food/snacks/tofu,
 /turf/simulated/floor/tiled/cafe,
 /area/centcom/evac)
+"In" = (
+/turf/simulated/floor/plating/under,
+/area/centcom/merc_base)
 "Ip" = (
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/fixed/fgrass,
@@ -6454,14 +6611,24 @@
 /obj/item/tool/knife,
 /turf/simulated/floor/tiled/cafe,
 /area/centcom/evac)
+"Iv" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/plating/under,
+/area/centcom/merc_base)
 "II" = (
 /obj/structure/sign/faction/neotheology_cross,
 /turf/simulated/wall/wood,
 /area/centcom/evac)
 "IK" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white/gray_perforated,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/centcom/merc_base)
+"IM" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Suit Storage";
+	opacity = 1
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/centcom/merc_base)
 "IS" = (
 /obj/structure/window/reinforced{
@@ -6501,6 +6668,10 @@
 /obj/machinery/biogenerator,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/shuttle/skipjack_area)
+"JI" = (
+/obj/structure/lattice,
+/turf/space,
+/area/centcom/merc_base)
 "JL" = (
 /turf/simulated/wall/wood,
 /area/centcom/evac)
@@ -6557,6 +6728,16 @@
 /obj/random/closet,
 /turf/simulated/floor/tiled/dark,
 /area/centcom/raider_base)
+"KQ" = (
+/obj/structure/table/rack,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/under/colorskirt/red,
+/obj/item/clothing/under/colorskirt/red,
+/obj/item/clothing/under/red,
+/obj/item/clothing/under/red,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/centcom/merc_base)
 "KR" = (
 /turf/unsimulated/wall,
 /area/centcom/evac)
@@ -6576,6 +6757,17 @@
 /obj/machinery/door/airlock/vault,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/centcom/evac)
+"Lm" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
+"Ls" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/sign/security/teleporter{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating/under,
+/area/centcom/merc_base)
 "LD" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/tiled/cafe,
@@ -6633,6 +6825,12 @@
 "MH" = (
 /turf/simulated/floor/wood/wild1,
 /area/centcom/evac)
+"MK" = (
+/obj/structure/sign/directions/medical{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/centcom/merc_base)
 "MM" = (
 /obj/machinery/autolathe/excelsior,
 /obj/machinery/light{
@@ -6651,6 +6849,14 @@
 /obj/machinery/chemical_dispenser/soda,
 /turf/simulated/floor/tiled/cafe,
 /area/centcom/raider_base)
+"MW" = (
+/obj/machinery/chem_heater,
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "Nf" = (
 /obj/structure/sink/basion/crayon,
 /turf/simulated/floor/wood/wild1,
@@ -6671,6 +6877,11 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/dark/golden,
 /area/centcom/evac)
+"NB" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/white/cargo,
+/area/centcom/merc_base)
 "NK" = (
 /obj/structure/filingcabinet/medical,
 /obj/machinery/light{
@@ -6700,6 +6911,13 @@
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/white/cargo,
 /area/centcom/raider_base)
+"NY" = (
+/obj/structure/catwalk,
+/obj/machinery/teleport/station{
+	desc = "A bluespace teleporter, an advanced if unreliable bit of technology. Bluespace being what it is after the crash, these teleporters can still reliably work if used in the same star system, but every use has a chance of leaving you lost in space or worse."
+	},
+/turf/simulated/floor/plating/under,
+/area/centcom/merc_base)
 "Oc" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/food/snacks/cutlet,
@@ -6748,6 +6966,10 @@
 /obj/item/toy/figure/character/bobblehead/excelsior,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/centcom/evac)
+"OE" = (
+/obj/structure/sign/departmentold/medical1,
+/turf/simulated/wall/r_wall,
+/area/centcom/merc_base)
 "OH" = (
 /obj/structure/filingcabinet/employment,
 /turf/simulated/floor/tiled/dark/golden,
@@ -6759,8 +6981,16 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/centcom/merc_base)
+"OO" = (
+/obj/structure/table/rack,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/gloves/thick/combat,
+/obj/item/clothing/suit/space/void/SCAF/voidwolf,
+/obj/item/clothing/mask/gas/wolf,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/centcom/merc_base)
 "OU" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/centcom/merc_base)
 "OW" = (
@@ -6785,6 +7015,9 @@
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/white/cargo,
 /area/centcom/raider_base)
+"Pt" = (
+/turf/simulated/mineral,
+/area/centcom/merc_base)
 "Pw" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -6816,6 +7049,11 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/dark/golden,
 /area/centcom/evac)
+"PO" = (
+/obj/machinery/reagentgrinder/industrial,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "PQ" = (
 /obj/machinery/vending/weapon_machine,
 /turf/simulated/floor/tiled/dark/golden,
@@ -6850,6 +7088,14 @@
 	},
 /turf/space/transit/north/shuttlespace_ns13,
 /area/space)
+"Qj" = (
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots/merc,
+/obj/item/clothing/shoes/magboots/merc,
+/obj/item/clothing/shoes/magboots/merc,
+/obj/item/clothing/shoes/magboots/merc,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/centcom/merc_base)
 "Qp" = (
 /obj/structure/railing{
 	dir = 8
@@ -6877,6 +7123,11 @@
 /obj/item/computer_hardware/hard_drive/portable/design/excelsior_weapons,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/centcom/evac)
+"QD" = (
+/obj/structure/catwalk,
+/obj/machinery/teleport/hub,
+/turf/simulated/floor/plating/under,
+/area/centcom/merc_base)
 "QI" = (
 /obj/structure/table/woodentable,
 /obj/item/implant/core_implant/cruciform,
@@ -6942,6 +7193,11 @@
 	},
 /turf/simulated/floor/beach/sand,
 /area/centcom/evac)
+"RO" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "RU" = (
 /obj/machinery/teleport/hub,
 /obj/effect/floor_decal/industrial/outline,
@@ -6952,6 +7208,10 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/wild1,
 /area/centcom/evac)
+"Si" = (
+/obj/structure/catwalk,
+/turf/space,
+/area/space)
 "Sl" = (
 /obj/machinery/vending/security,
 /turf/simulated/floor/tiled/dark/golden,
@@ -6997,6 +7257,10 @@
 /obj/item/storage/fancy/candle_box,
 /turf/simulated/floor/wood/wild1,
 /area/centcom/evac)
+"SZ" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "Tf" = (
 /obj/structure/table/woodentable,
 /obj/item/clothing/accessory/badge/marshal{
@@ -7009,6 +7273,16 @@
 /obj/structure/medical_stand/anesthetic,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/centcom/evac)
+"Tj" = (
+/obj/structure/table/glass,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
+"To" = (
+/obj/machinery/chemical_dispenser,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "Tr" = (
 /obj/structure/table/reinforced,
 /obj/random/booze,
@@ -7086,6 +7360,11 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/shuttle/skipjack_area)
+"Ux" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/under,
+/area/centcom/merc_base)
 "UC" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/cafe,
@@ -7186,6 +7465,10 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/turcarpet,
 /area/centcom/evac)
+"WR" = (
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "Xc" = (
 /obj/structure/flora/pottedplant/minitree{
 	pixel_y = 21
@@ -7198,6 +7481,11 @@
 "Xq" = (
 /obj/effect/shuttle_landmark/transit/rocinante_transit,
 /turf/space/transit/north/shuttlespace_ns2,
+/area/space)
+"Xs" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/simulated/wall/r_wall,
 /area/space)
 "XC" = (
 /obj/structure/railing{
@@ -7268,6 +7556,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/tank/emergency_nitgen,
+/obj/item/tank/emergency_nitgen,
+/obj/item/tank/emergency_nitgen,
+/obj/item/tank/emergency_nitgen,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/centcom/merc_base)
 "Ys" = (
@@ -7300,6 +7592,11 @@
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/white/cargo,
 /area/centcom/raider_base)
+"YN" = (
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/turf/space,
+/area/space)
 "YQ" = (
 /turf/simulated/floor/tiled/white/cargo,
 /area/centcom/merc_base)
@@ -7337,6 +7634,17 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/centcom/evac)
+"ZF" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/sign/security/teleporter/right{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating/under,
+/area/centcom/merc_base)
+"ZJ" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/wood/wild3,
+/area/centcom/merc_base)
 "ZK" = (
 /obj/machinery/light{
 	dir = 1
@@ -27259,7 +27567,7 @@ hl
 hl
 hl
 hl
-hl
+yg
 qH
 qH
 qH
@@ -27457,16 +27765,16 @@ qH
 qH
 qH
 qH
+yg
 hl
 hl
 hl
 hl
-hl
-hl
-qH
-qH
-qH
-qH
+yg
+hC
+hC
+hC
+hn
 qH
 qH
 qH
@@ -27659,29 +27967,29 @@ qH
 qH
 qH
 qH
-qH
+Xs
 hl
 hl
 hl
 hl
 hl
-hl
+yg
+HA
+HA
+hn
+hC
+hn
 qH
 qH
 qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-hl
-hl
 hl
 hl
 hl
+hl
+yg
 qH
 qH
 qH
@@ -27860,25 +28168,9 @@ qH
 qH
 qH
 qH
-qH
-qH
-hl
-hl
-hl
-hl
-hl
-hl
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-hl
-hl
+hC
+hn
+yg
 hl
 hl
 hl
@@ -27886,6 +28178,22 @@ hl
 hl
 qH
 qH
+qH
+qH
+hn
+hC
+hC
+hC
+hn
+yg
+hl
+hl
+hl
+hl
+hl
+yg
+hC
+hC
 qH
 qH
 qH
@@ -28062,26 +28370,10 @@ qH
 qH
 qH
 qH
+hC
+HA
 qH
-qH
-qH
-hl
-hl
-hl
-hl
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-hl
-hl
-hl
-hl
+yg
 hl
 hl
 hl
@@ -28089,6 +28381,22 @@ qH
 qH
 qH
 qH
+qH
+qH
+qH
+qH
+HA
+yg
+hl
+hl
+hl
+hl
+hl
+yg
+HA
+qH
+hn
+hC
 qH
 qH
 qH
@@ -28263,8 +28571,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+hn
+HA
 qH
 qH
 qH
@@ -28286,6 +28594,18 @@ hl
 hl
 hl
 hl
+HA
+qH
+qH
+qH
+hn
+hn
+hC
+hC
+yg
+hl
+HA
+qH
 qH
 qH
 qH
@@ -28296,21 +28616,9 @@ qH
 qH
 hl
 hl
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
 qH
 qH
 qH
@@ -28464,8 +28772,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+hC
+hn
 qH
 qH
 qH
@@ -28499,20 +28807,20 @@ qH
 hl
 hl
 hl
+HA
 qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+HA
+yg
+hl
+hl
+hl
+hl
+hl
+hl
+hl
 qH
 qH
 qH
@@ -28665,6 +28973,8 @@ qH
 qH
 qH
 qH
+hC
+hn
 qH
 qH
 qH
@@ -28696,25 +29006,23 @@ qH
 qH
 qH
 qH
+HA
+hl
+yg
+hC
 qH
 qH
 qH
+HA
+yg
 hl
 hl
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hl
+hl
+hl
 qH
 qH
 qH
@@ -28866,6 +29174,9 @@ qH
 qH
 qH
 qH
+hC
+hC
+HA
 qH
 qH
 qH
@@ -28899,24 +29210,21 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+HA
+hC
+hn
+hn
+hC
+hC
+yg
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
 qH
 qH
 qH
@@ -29067,60 +29375,60 @@ qH
 qH
 qH
 qH
+yg
+yg
+yg
+yg
+hl
+hl
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+qH
+hn
+yg
 hl
 hl
 hl
 hl
 hl
 hl
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hl
+hl
 qH
 qH
 hk
@@ -29311,18 +29619,18 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
 qH
 qH
 hk
@@ -29513,18 +29821,18 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
 qH
 qH
 hk
@@ -29693,7 +30001,7 @@ qH
 jk
 ir
 jR
-ko
+GS
 ir
 kJ
 kU
@@ -29715,18 +30023,18 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
 qH
 qH
 hk
@@ -29917,17 +30225,17 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
 qH
 qH
 qH
@@ -30120,16 +30428,16 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
 qH
 qH
 qH
@@ -30273,9 +30581,9 @@ qH
 qH
 qH
 qH
+yg
 hl
-hl
-hl
+yg
 hl
 hl
 hl
@@ -30322,16 +30630,16 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
 qH
 qH
 qH
@@ -30475,10 +30783,10 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-hl
+hn
+hC
+HA
+yg
 hl
 hl
 hl
@@ -30525,14 +30833,14 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hl
+hl
+hl
+hl
+hl
 qH
 qH
 qH
@@ -30678,7 +30986,7 @@ qH
 qH
 qH
 qH
-qH
+hC
 qH
 qH
 qH
@@ -30727,13 +31035,13 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hl
+hl
+hl
+yg
 qH
 qH
 qH
@@ -30879,8 +31187,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+hn
+hn
 qH
 qH
 qH
@@ -30929,13 +31237,13 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hl
+yg
+hl
+yg
 qH
 qH
 qH
@@ -31081,8 +31389,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+hC
+HA
 qH
 qH
 qH
@@ -31133,10 +31441,10 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
+hl
+hl
+hl
+hn
 qH
 qH
 qH
@@ -31282,9 +31590,9 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
+hn
+hn
+HA
 qH
 qH
 qH
@@ -31336,10 +31644,10 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
+hl
+yg
+hn
+hC
 qH
 qH
 qH
@@ -31484,8 +31792,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+hC
+HA
 qH
 qH
 qH
@@ -31539,9 +31847,9 @@ qH
 qH
 qH
 qH
+HA
 qH
-qH
-qH
+hC
 qH
 qH
 qH
@@ -31686,6 +31994,7 @@ qH
 qH
 qH
 qH
+hC
 qH
 qH
 qH
@@ -31693,16 +32002,15 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+hC
+hC
+hE
+hC
+hC
+hE
+hn
+hC
+hC
 bP
 bP
 bP
@@ -31742,8 +32050,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+HA
+hC
 qH
 qH
 qH
@@ -31888,10 +32196,10 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
+hn
+hC
+hE
+hE
 hm
 hm
 hm
@@ -31901,16 +32209,16 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+Si
+vF
+Si
+Si
+Si
+Si
+hn
+Si
+Si
+hn
 ir
 ir
 ir
@@ -31944,8 +32252,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+HA
+hC
 qH
 qH
 qH
@@ -32090,21 +32398,21 @@ qH
 qH
 qH
 hl
-hl
-hl
-qH
-qH
-qH
+yg
+yg
 hn
-qH
+YN
+YN
+YN
 hn
-qH
-qH
-qH
-qH
-qH
-qH
-qH
+YN
+hn
+YN
+YN
+YN
+hn
+hn
+HA
 hf
 hf
 hf
@@ -32112,7 +32420,7 @@ hf
 hf
 hf
 hf
-qH
+hm
 qH
 ir
 ir
@@ -32146,8 +32454,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+HA
+hn
 qH
 qH
 qH
@@ -32294,27 +32602,27 @@ qH
 hl
 hl
 hl
+bJ
+bJ
+ys
+bJ
+Pt
 hl
-hl
-hn
-hl
-hl
-hl
-hn
+HA
 qH
 qH
 qH
 qH
-qH
-qH
+Si
+hC
 hf
-iN
-iN
-iN
-iN
-iN
+Tj
+Tj
+Tj
+Tj
+Tj
 hf
-qH
+hn
 qH
 hE
 ir
@@ -32348,8 +32656,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+hn
+hn
 qH
 qH
 qH
@@ -32496,19 +32804,19 @@ qH
 qH
 hl
 hl
+bJ
+bJ
+ys
+bJ
+bJ
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-qH
-qH
-qH
-qH
-qH
-qH
+YN
+YN
+YN
+YN
+Si
+hC
 hf
 iN
 iN
@@ -32516,7 +32824,7 @@ iE
 iN
 iN
 hf
-qH
+hn
 qH
 hC
 kh
@@ -32549,8 +32857,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+HA
+hC
 qH
 qH
 qH
@@ -32698,11 +33006,11 @@ qH
 qH
 hl
 hl
-hl
-hl
-hl
-hl
-hl
+bJ
+iX
+yk
+yk
+bJ
 hl
 hl
 bJ
@@ -32710,7 +33018,7 @@ hf
 hf
 hf
 bJ
-qH
+hC
 hf
 iN
 ck
@@ -32718,7 +33026,7 @@ iF
 gZ
 iN
 hf
-qH
+hE
 qH
 ka
 bJ
@@ -32750,10 +33058,10 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
+HA
+hn
+CB
+yg
 qH
 qH
 qH
@@ -32900,11 +33208,11 @@ qH
 qH
 qH
 hl
-hl
-hl
-hl
-hl
-hl
+bJ
+iX
+uv
+In
+bJ
 hl
 bJ
 bJ
@@ -32952,9 +33260,9 @@ qH
 qH
 qH
 qH
-qH
-qH
-hl
+yg
+hC
+yg
 hl
 hl
 qH
@@ -33102,11 +33410,11 @@ qH
 qH
 qH
 hl
-hl
-hl
-hl
-hl
-hl
+ys
+yk
+In
+yk
+bJ
 hl
 bJ
 hc
@@ -33121,7 +33429,7 @@ iN
 cn
 iN
 iN
-jq
+GU
 jq
 jq
 lI
@@ -33154,7 +33462,7 @@ qH
 qH
 qH
 hl
-hl
+yg
 hl
 hl
 hl
@@ -33303,12 +33611,12 @@ qH
 qH
 qH
 qH
-qH
-hl
-hl
-hl
-hl
-hl
+hC
+JI
+ys
+bJ
+bJ
+bJ
 hl
 bJ
 bL
@@ -33323,7 +33631,7 @@ iN
 iN
 iN
 iN
-jq
+zN
 jq
 jq
 jq
@@ -33332,7 +33640,7 @@ jq
 jq
 hf
 qH
-qH
+hC
 qH
 qH
 qH
@@ -33505,12 +33813,12 @@ qH
 qH
 qH
 qH
-qH
-qH
-hl
-hl
-hl
-hl
+RO
+JI
+bJ
+Pt
+Pt
+Pt
 hl
 bJ
 he
@@ -33525,7 +33833,7 @@ iN
 iN
 ja
 jn
-jq
+GU
 jq
 jq
 jq
@@ -33534,7 +33842,7 @@ jq
 jq
 hf
 qH
-qH
+hC
 qH
 qH
 qH
@@ -33708,7 +34016,7 @@ qH
 qH
 qH
 qH
-qH
+hC
 hl
 hl
 hl
@@ -33735,8 +34043,8 @@ SJ
 jq
 SJ
 bJ
-qH
-qH
+hn
+hC
 qH
 hm
 hm
@@ -33938,7 +34246,7 @@ ku
 bJ
 bJ
 hl
-qH
+hC
 qH
 qH
 hn
@@ -33959,7 +34267,7 @@ qH
 qH
 qH
 qH
-qH
+hC
 hl
 hl
 hl
@@ -34160,10 +34468,10 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
-qH
+HA
+hC
+yg
+yg
 hl
 hl
 hl
@@ -34361,13 +34669,13 @@ qH
 qH
 qH
 qH
+HA
+hn
+hn
+HA
 qH
 qH
-qH
-qH
-qH
-qH
-hl
+yg
 hl
 hl
 hl
@@ -34525,10 +34833,10 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
+Pt
+bJ
+bJ
+Pt
 bJ
 iy
 iC
@@ -34562,9 +34870,9 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
+HA
+hC
+hC
 qH
 qH
 qH
@@ -34725,12 +35033,12 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
+Pt
+Pt
+bJ
+Pt
+Iv
+iN
 bJ
 bJ
 bJ
@@ -34751,7 +35059,7 @@ bJ
 bJ
 bJ
 bJ
-hl
+bJ
 hl
 hl
 hl
@@ -34763,9 +35071,9 @@ qH
 qH
 qH
 qH
-qH
-qH
-qH
+HA
+hn
+hC
 qH
 qH
 qH
@@ -34927,20 +35235,20 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+Pt
 bJ
-kN
-lS
-jo
-jE
-jN
+bJ
+rp
+Iv
+iX
+iX
+In
+MK
+iX
+iX
+yc
+iX
+iX
 kX
 Fu
 Fu
@@ -34949,10 +35257,10 @@ Fu
 Fu
 kX
 kQ
-kQ
-kQ
-Cr
-bJ
+OO
+Bu
+pj
+KQ
 bJ
 hl
 hl
@@ -34965,8 +35273,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+hC
+hn
 qH
 qH
 qH
@@ -35129,20 +35437,20 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+Pt
 bJ
+Pt
+NY
 iX
-kw
+iX
+bJ
+Ls
+iX
+iX
+qu
 kO
-kw
-kw
+qu
+iX
 kb
 kw
 kw
@@ -35167,8 +35475,8 @@ qH
 qH
 qH
 qH
-qH
-qH
+hC
+HA
 qH
 qH
 qH
@@ -35331,20 +35639,20 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+Pt
+Pt
+Iv
+QD
+xG
+Ux
 bJ
-iY
-jm
-jp
-jF
-jT
+ZF
+bJ
+iX
+iX
+iX
+iX
+iX
 kX
 Fu
 Fu
@@ -35352,12 +35660,12 @@ kw
 Fu
 Fu
 kX
-kQ
-kQ
-kQ
+CU
+uf
+Bu
 Cr
+Qj
 bJ
-bJ
 hl
 hl
 hl
@@ -35369,7 +35677,7 @@ qH
 qH
 qH
 qH
-qH
+hC
 qH
 qH
 qH
@@ -35533,32 +35841,33 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+Pt
+Pt
+ys
+iX
+iX
+iX
+iN
+iN
 bJ
 bJ
+ZJ
+WR
+ZJ
 bJ
-bJ
-bJ
-bJ
-bJ
-YQ
+OE
+yN
 Fu
 kw
 Fu
-YQ
+NB
 bJ
 bJ
 bJ
 bJ
 bJ
 bJ
+bJ
 hl
 hl
 hl
@@ -35569,9 +35878,8 @@ hl
 hl
 hl
 hl
-hl
-hl
-qH
+yg
+hC
 qH
 qH
 qH
@@ -35735,20 +36043,20 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+Pt
+Pt
+bJ
+iN
+iN
+iX
+iX
+Pt
+bJ
+sZ
+iN
+iN
+iN
+uH
 bJ
 iQ
 YQ
@@ -35773,7 +36081,7 @@ hl
 hl
 hl
 hl
-hl
+yg
 qH
 qH
 qH
@@ -35938,23 +36246,23 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+Pt
+bJ
+bJ
+Pt
+bJ
+bJ
+bJ
+bJ
+PO
+iN
+iN
+iN
+ET
 bJ
 bJ
 OU
-HA
+kw
 OU
 bJ
 bJ
@@ -36140,26 +36448,26 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+Pt
+Pt
+Pt
+Pt
+Pt
+Pt
+Pt
+bJ
+DM
+iN
+Lm
+iN
+DM
 bJ
 bJ
+kX
+IM
+kX
 bJ
-bJ
-bJ
-hl
+Pt
 hl
 hl
 hl
@@ -36349,19 +36657,19 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+bJ
+To
+SZ
+ty
+SZ
+To
+bJ
+bJ
+jN
+kw
+jT
+bJ
+Pt
 hl
 hl
 hl
@@ -36551,19 +36859,19 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+bJ
+rG
+iN
+MW
+iN
+rG
+bJ
+bJ
+jE
+kw
+jF
+bJ
+Pt
 hl
 hl
 hl
@@ -36753,19 +37061,19 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+bJ
+bJ
+bJ
+bJ
+bJ
+bJ
+bJ
+bJ
+jo
+vX
+jp
+bJ
+Pt
 hl
 hl
 hl
@@ -36961,13 +37269,13 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+Pt
+bJ
+lS
+kw
+jm
+bJ
+Pt
 hl
 hl
 hl
@@ -37163,13 +37471,13 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+Pt
+bJ
+kN
+Ev
+iY
+bJ
+Pt
 hl
 hl
 hl
@@ -37365,13 +37673,13 @@ hl
 hl
 hl
 hl
-hl
-hl
-hl
-hl
-hl
-hl
-hl
+Pt
+bJ
+bJ
+bJ
+bJ
+bJ
+Pt
 hl
 hl
 hl


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Decided that the space base needed a few small changes to spice it up a bit for anyone that ever wanted to use the "Merc" antag slot. Made it more voidwolf like and added in a few small rooms with useful machines for event runners.
	
<hr>
</details>

## Changelog
:cl:
fixes up the merc compound at centcom map for antag use. Adds in some voiddwolf scaf suits along with RNG mech and a chem lab. Secret-ish uplink for funs add as well.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
