### PR TITLE
Error in calculation of station time, fix #4666

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -19,7 +19,7 @@ var/station_date = ""
 var/next_station_date_change = 1 DAYS
 
 #define station_adjusted_time(time) time2text(time + station_time_in_ticks, "hh:mm")
-#define worldtime2stationtime(time) time2text(roundstart_hour HOURS + time, "hh:mm")
+#define worldtime2stationtime(time) time2text(roundstart_hour HOURS + time - round_start_time, "hh:mm")
 #define roundduration2text_in_ticks (round_start_time ? world.time - round_start_time : 0)
 #define station_time_in_ticks (roundstart_hour HOURS + roundduration2text_in_ticks)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Fix the display of the expiration time in guest passes
</summary>
<hr>
The variable expiration_time is set to world.time + the duration the guest pass is supposed to be valid. That is correct and the guest pass is valid for the given time. But when examining the guest pass, an incorrect expiration time is shown. This leads to "The guest pass expired at XXX", where XXX is two minutes in the future.
The reason is in the display method worldtime2stationtime. It does not consider that there's a difference between the world start time and the round start time. Subtracting the round start time (in round_start_time) fixes this issue.
This change also affects the autopsy scanner and a display at round end showing when an event started.
fixes #4666 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl: dutop
fix: Fix display of Guest Pass expiration time
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
