### PR TITLE
Enable removing other's underwear, comparable to other clothing items.

### DIFF
--- a/code/modules/clothing/underwear/base.dm
+++ b/code/modules/clothing/underwear/base.dm
@@ -60,7 +60,7 @@
 		return
 	if(user != H)
 		visible_message("<span class='danger'>\The [user] is trying to remove \the [H]'s [name]!</span>")
-		if(!do_after(user, HUMAN_STRIP_DELAY, H, progress = 0))
+		if(!do_after(user, HUMAN_STRIP_DELAY, H, progress = 1))
 			return FALSE
 	. = RemoveUnderwear(user, H)
 	if(. && user != H)
@@ -72,7 +72,7 @@
 		return
 	if(user != H)
 		user.visible_message("<span class='warning'>\The [user] has begun putting on \a [src] on \the [H].</span>", "<span class='notice'>You begin putting on \the [src] on \the [H].</span>")
-		if(!do_after(user, HUMAN_STRIP_DELAY, H, progress = FALSE))
+		if(!do_after(user, HUMAN_STRIP_DELAY, H, progress = 1))
 			return FALSE
 	. = EquipUnderwear(user, H)
 	if(. && user != H)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -242,6 +242,10 @@
 	if(legcuffed)
 		dat += "<BR><A href='?src=\ref[src];item=[slot_legcuffed]'>Legcuffed</A>"
 
+	for(var/entry in worn_underwear)
+		var/obj/item/underwear/UW = entry
+		dat += "<BR><a href='?src=\ref[src];item=\ref[UW]'>Remove \the [UW]</a>"
+
 	if(suit && suit.accessories.len)
 		dat += "<BR><A href='?src=\ref[src];item=tie'>Remove accessory</A>"
 	dat += "<BR><A href='?src=\ref[src];item=splints'>Remove splints</A>"

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -52,6 +52,18 @@
 			suit.accessories -= A
 			update_inv_w_uniform()
 			return
+		else
+			var/obj/item/located_item = locate(slot_to_strip) in src
+			if (istype(located_item, /obj/item/underwear))
+				var/obj/item/underwear/UW = located_item
+				visible_message(
+					SPAN_DANGER("\The [user] starts trying to remove \the [src]'s [UW.name]!"),
+					SPAN_WARNING("You start trying to remove \the [src]'s [UW.name]!")
+				)
+				if (UW.DelayedRemoveUnderwear(user, src))
+					admin_attack_log(user, src, "Stripped \an [UW] from \the [src].", "Was stripped of \an [UW] from \the [src].", "stripped \an [UW] from \the [src] of")
+					user.put_in_active_hand(UW)
+				return
 
 	// Are we placing or stripping?
 	var/stripping


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Enable removing other's underwear, comparable to other clothing items.
</summary>
<hr>
This is not an ERP mechanics change! Possible correlations to my own presumed fetishes are coincidental and not intended! That made it worse, didn't it? My intentions for this change were:
- you can add underwear to another (appropriate) naked mob by just clicking on it. But there is no way to get it back.
- Performing an autopsy (or a full-body-surgery) on a player who will continue wearing their underwear seems unrealistic to me (immershionnn!)
- All clothing can be removed, but not underwear. Seems inconsistent to me.

Yes, it can be used for ERP and non-con RP, but this mechanic won't change anything about IC or OOC laws/rules. An admin-attack-log entry is performed.

In the stripping dialog (drag and drop from other mob to your mob) there are additional entries at the bottom, one for each underwear item, like it is done on Vesta.Bay and probably even Baystation.
![image](https://github.com/sojourn-13/sojourn-station/assets/73559117/ffce1e4e-12e9-4b90-840b-d36f6d777949)
The process of removing these items has been added. Existing code has been changed, so that a progress is shown, comparable to the removal of other items.
Checks for items preventing the removal are (already) in place, for example uniform and jackboots.

Based on VestaOfOrion/Vesta.Bay (because I already had a branch of that, I expect that Baystation12 would have worked as well). Revision mentioned in commit message.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl: dutop
add: Enable removing other's underwear, comparable to other clothing items.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
