### PR TITLE
Minor map fixes

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -80,7 +80,7 @@
 /obj/item/maneki_neko,
 /obj/structure/table/onestar,
 /turf/simulated/floor/wood,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "aaZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -5560,7 +5560,7 @@
 /obj/structure/table/onestar,
 /obj/item/device/radio/random_radio,
 /turf/simulated/floor/wood,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "boT" = (
 /mob/living/simple_animal/hostile/bear/excelsior,
 /obj/effect/decal/cleanable/dirt,
@@ -8108,7 +8108,7 @@
 "bUs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "bUu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/mineral,
@@ -9616,7 +9616,7 @@
 "clN" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/wood/wild3,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "clQ" = (
 /obj/machinery/door_timer{
 	id = "Cell 2";
@@ -12484,8 +12484,13 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "cSM" = (
-/turf/simulated/wall/r_wall,
-/area/nadezhda/quartermaster/pods)
+/obj/effect/floor_decal/spline/wood,
+/obj/structure/closet/wall_mounted/emcloset{
+	pixel_x = -1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/crew_quarters)
 "cSP" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -12886,6 +12891,10 @@
 /obj/random/booze,
 /obj/random/junkfood,
 /obj/structure/window/reinforced,
+/obj/machinery/power/wall_obelisk{
+	pixel_x = -32;
+	pixel_y = -10
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm3)
 "cXl" = (
@@ -13199,7 +13208,7 @@
 /obj/item/soap,
 /obj/item/towel,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "dbo" = (
 /obj/random/mob/spiders/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -13234,11 +13243,6 @@
 /obj/machinery/gibber,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
-"dbH" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/wall/r_wall,
-/turf/simulated/floor/rock,
-/area/nadezhda/crew_quarters/pool)
 "dcf" = (
 /obj/structure/table/standard,
 /obj/random/medical_lowcost/low_chance,
@@ -13282,7 +13286,7 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "dcY" = (
-/obj/structure/sign/directions/room2,
+/obj/structure/sign/directions/room3,
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm3)
 "dda" = (
@@ -14493,7 +14497,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "dqC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15702,10 +15706,6 @@
 	name = "murky water"
 	},
 /area/asteroid/cave)
-"dEh" = (
-/turf/simulated/wall/r_wall,
-/turf/simulated/floor/rock,
-/area/nadezhda/crew_quarters/pool)
 "dEn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -20130,7 +20130,7 @@
 	name = "Bathroom"
 	},
 /turf/simulated/floor/tiled/derelict/red_white_edges,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "eAH" = (
 /obj/structure/bed/chair/wood{
 	dir = 4
@@ -22125,10 +22125,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
-/obj/structure/closet/wall_mounted/emcloset{
-	pixel_x = -1;
-	pixel_y = -32
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
@@ -23942,7 +23938,7 @@
 	})
 "frb" = (
 /turf/simulated/floor/wood/wild3,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "frd" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
@@ -26119,11 +26115,6 @@
 	icon_state = "2-8"
 	},
 /obj/structure/closet/secure_closet/reinforced/quartermaster,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
 "fTa" = (
@@ -28987,7 +28978,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "gyZ" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/tablet/lease/preset/chemistry,
@@ -29189,7 +29180,7 @@
 /obj/random/junkfood,
 /obj/random/junkfood,
 /turf/simulated/floor/wood/wild3,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "gBA" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid,
@@ -32452,14 +32443,6 @@
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
-"hqj" = (
-/obj/structure/cable/green{
-	d1 = 32;
-	d2 = 2;
-	icon_state = "32-1"
-	},
-/turf/simulated/open,
-/area/nadezhda/command/merchant)
 "hqp" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/ifak,
@@ -34037,6 +34020,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 32
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm3)
@@ -36511,7 +36498,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/wood/wild3,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "ihB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -39238,7 +39225,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "iOg" = (
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -41543,7 +41530,7 @@
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/yellowdouble,
 /turf/simulated/floor/wood/wild3,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "joh" = (
 /obj/structure/boulder,
 /obj/structure/barricade,
@@ -43259,7 +43246,7 @@
 "jIg" = (
 /obj/structure/toilet,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "jIi" = (
 /obj/machinery/conveyor/west{
 	id = "QMLoad2"
@@ -47807,7 +47794,7 @@
 /area/asteroid/cave)
 "kJV" = (
 /turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "kJX" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -51253,7 +51240,7 @@
 	pixel_y = 16
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "lCh" = (
 /obj/machinery/optable{
 	name = "Xenobiology Operating Table"
@@ -52241,7 +52228,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "lMN" = (
 /obj/structure/flora/small/rock2,
 /turf/simulated/floor/asteroid/grass,
@@ -54915,6 +54902,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 32
+	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm2)
 "mqE" = (
@@ -56926,6 +56917,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 32
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/dorm4)
@@ -59310,7 +59305,7 @@
 "nnp" = (
 /obj/structure/multiz/ladder/up,
 /turf/simulated/floor/wood,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "nnt" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "15,5";
@@ -59888,18 +59883,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
-	},
+/obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
 "ntV" = (
@@ -59981,7 +59965,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "nuQ" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -62985,7 +62969,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood/wild3,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "oay" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /turf/simulated/open,
@@ -64572,7 +64556,7 @@
 	},
 /obj/effect/floor_decal/corner_techfloor_grid,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "osn" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -66570,7 +66554,7 @@
 "oOA" = (
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/crew_quarters)
 "oOD" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/door/blast/regular/open{
@@ -67671,7 +67655,7 @@
 "paa" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/floor/wood,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "pab" = (
 /obj/random/cluster/roaches,
 /obj/effect/decal/cleanable/dirt,
@@ -68127,7 +68111,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood/wild3,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "pgg" = (
 /obj/machinery/smartfridge/drying_rack,
 /obj/machinery/camera/network/research{
@@ -69142,13 +69126,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "prZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/blast/shutters/glass{
+	name = "Fireplace  Cover"
 	},
-/turf/simulated/wall/r_wall,
-/area/nadezhda/command/merchant)
+/obj/structure/bonfire/permanent,
+/obj/machinery/power/wall_obelisk{
+	pixel_y = 22
+	},
+/turf/simulated/floor/rock,
+/area/nadezhda/crew_quarters)
 "psc" = (
 /obj/structure/table/standard,
 /obj/random/ammo_lowcost/low_chance,
@@ -70571,7 +70557,7 @@
 "pHP" = (
 /obj/structure/mirror,
 /turf/simulated/wall/r_wall,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "pHW" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -72762,7 +72748,7 @@
 "qfw" = (
 /obj/machinery/light_switch,
 /turf/simulated/wall/r_wall,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "qfx" = (
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology/xenoflora)
@@ -74464,6 +74450,10 @@
 /obj/random/booze,
 /obj/random/junkfood,
 /obj/structure/window/reinforced,
+/obj/machinery/power/wall_obelisk{
+	pixel_x = -32;
+	pixel_y = -10
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm2)
 "qyM" = (
@@ -76946,7 +76936,7 @@
 "rcE" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/wall/r_wall,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "rcI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80608,7 +80598,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "rSY" = (
 /obj/structure/table/marble,
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/board,
@@ -84176,6 +84166,10 @@
 /obj/random/booze,
 /obj/random/junkfood,
 /obj/structure/window/reinforced,
+/obj/machinery/power/wall_obelisk{
+	pixel_x = -32;
+	pixel_y = -10
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm4)
 "sGj" = (
@@ -85426,7 +85420,7 @@
 "sWd" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/wild3,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "sWe" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
@@ -95270,7 +95264,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "uZI" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -96664,7 +96658,7 @@
 /obj/structure/table/marble,
 /obj/machinery/microwave,
 /turf/simulated/floor/wood/wild3,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "vpq" = (
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/command/courtroom)
@@ -98454,7 +98448,7 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "vKy" = (
-/obj/structure/sign/directions/room1,
+/obj/structure/sign/directions/room2,
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm2)
 "vKz" = (
@@ -102301,13 +102295,9 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
 "wAd" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/command/merchant)
+/obj/structure/sign/directions/room1,
+/turf/simulated/wall,
+/area/nadezhda/crew_quarters/dorm1)
 "wAh" = (
 /obj/structure/table/standard,
 /obj/machinery/holoposter{
@@ -103637,7 +103627,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/crew_quarters)
 "wRI" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -103881,21 +103871,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "wUv" = (
-/obj/structure/cable/green{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/obj/machinery/power/apc{
-	locked = 0;
-	name = "South APC";
-	operating = 0;
-	pixel_y = -28
-	},
-/obj/structure/cable/green,
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "wUx" = (
 /obj/machinery/suit_storage_unit,
 /turf/simulated/floor/plating/under,
@@ -105793,7 +105771,7 @@
 /obj/random/booze,
 /obj/random/junkfood/onlycake,
 /turf/simulated/floor/wood/wild3,
-/area/nadezhda/quartermaster/pods)
+/area/nadezhda/command/merchant)
 "xrT" = (
 /obj/structure/flora/small/bushc1,
 /turf/simulated/floor/asteroid/dirt,
@@ -106476,7 +106454,6 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/human/monkey/punpun,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/servist)
 "xzr" = (
@@ -107739,7 +107716,7 @@
 /area/nadezhda/crew_quarters/bar)
 "xMH" = (
 /obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
 "xMK" = (
 /obj/structure/toilet,
@@ -136195,16 +136172,16 @@ uyF
 uyF
 uyF
 fgl
-cSM
-cSM
-cSM
-cSM
-cSM
-cSM
-cSM
-cSM
-cSM
-cSM
+ieZ
+ieZ
+ieZ
+ieZ
+ieZ
+ieZ
+ieZ
+ieZ
+ieZ
+ieZ
 iBY
 iBY
 mcl
@@ -136397,7 +136374,7 @@ cZb
 cZb
 cZb
 hLL
-cSM
+ieZ
 jIg
 kJV
 eAy
@@ -136406,7 +136383,7 @@ frb
 clN
 gBw
 vpm
-cSM
+ieZ
 rJR
 iBY
 mcl
@@ -136608,7 +136585,7 @@ frb
 frb
 frb
 xrN
-cSM
+ieZ
 iBY
 iBY
 mcl
@@ -136804,13 +136781,13 @@ hLL
 rcE
 lMM
 dbi
-cSM
+ieZ
 jof
 ihy
 frb
 frb
 sWd
-cSM
+ieZ
 iBY
 iBY
 mcl
@@ -137003,16 +136980,16 @@ cZb
 cZb
 cZb
 hLL
-cSM
+ieZ
 gyY
 osm
-cSM
-cSM
+ieZ
+ieZ
 aaV
 boR
 pgd
 pgd
-cSM
+ieZ
 iBY
 dxY
 mcl
@@ -137205,11 +137182,11 @@ mvG
 cZb
 cZb
 hLL
-cSM
-cSM
-cSM
-cSM
-cSM
+ieZ
+ieZ
+ieZ
+ieZ
+ieZ
 nnp
 paa
 nuP
@@ -137411,12 +137388,12 @@ hLL
 hLL
 hLL
 hLL
-cSM
+ieZ
 rSQ
 dqy
 iOe
 wUv
-cSM
+ieZ
 ryI
 iBY
 mcl
@@ -137613,12 +137590,12 @@ cyC
 cZb
 cZb
 cZb
-cSM
-cSM
-cSM
-cSM
-cSM
-cSM
+ieZ
+ieZ
+ieZ
+ieZ
+ieZ
+ieZ
 iBY
 oSn
 kGl
@@ -160866,14 +160843,14 @@ toi
 toi
 oOA
 wRG
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
+htd
+htd
+htd
+htd
+htd
+htd
+htd
+htd
 toi
 toi
 toi
@@ -163481,7 +163458,7 @@ gWg
 eYt
 xhw
 kal
-ptP
+prZ
 oxd
 jkx
 rgi
@@ -165898,7 +165875,7 @@ ybf
 ozQ
 qVN
 eup
-onp
+wAd
 vxO
 hVt
 jTG
@@ -167518,7 +167495,7 @@ tlh
 scK
 mwC
 eXs
-atw
+cSM
 sqp
 sqp
 sqp
@@ -170559,8 +170536,8 @@ sOi
 sOi
 sOi
 sOi
-dEh
-dbH
+sOi
+sOi
 sOi
 sOi
 cZb
@@ -172173,8 +172150,8 @@ cUl
 rWi
 cZb
 cZb
-ghg
-ghg
+cZb
+cZb
 cZb
 rWi
 awx
@@ -177613,7 +177590,7 @@ ieZ
 cNR
 xFh
 ieZ
-prZ
+ieZ
 ieZ
 ieZ
 ieZ
@@ -177815,8 +177792,8 @@ ieZ
 ieZ
 ieZ
 ieZ
-wAd
-hqj
+jLX
+jLX
 jLX
 ieZ
 aGu


### PR DESCRIPTION
**Removed extra PunPun
Set CEO bedroom to same area as CEO office.
Fixed Dorm signs
fixed vent Issue in Guildmaster office and removed extra wall tile.
Fixed Sauna's wall issue
Added light switches to dorms missing them
Maint doors by dorms are now powered
Added in protection obelisks to other dorms and above fireplace**
(my previous map PR fixed #4615 and fixed #4611  )