### PR TITLE
Buffs psion point regen

### DIFF
--- a/code/modules/psionics/psion.dm
+++ b/code/modules/psionics/psion.dm
@@ -87,7 +87,7 @@
 			addtimer(CALLBACK(src, .proc/regen_points), (10 MINUTES - cognitive_potential MINUTES))
 
 		if(psi_points < max_psi_points)
-			psi_points += 1
+			psi_points = max_psi_points // Solvult said I could :)
 
 /obj/item/organ/internal/psionic_tumor/removed_mob(mob/living/user)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	>>:)
</summary>
<hr>
Made psions regenerate all of their points at once.
Endorsed by Solvult.

https://cdn.discordapp.com/attachments/387651131645362211/1125512591960178869/image.png
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: Psions now regenerate all their psi points at once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
