### PR TITLE
Survival box: Replace oxygen bottle and mask with bruise pack (gauze) and matches

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -92,9 +92,9 @@
 	qdel(src)
 
 /obj/item/storage/box/survival/populate_contents()
-	new /obj/item/clothing/mask/breath(src)
-	new /obj/item/tank/emergency_oxygen(src)
+	new /obj/item/stack/medical/bruise_pack(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/storage/box/matches(src)
 	if(prob(50))
 		new /obj/item/reagent_containers/food/snacks/openable/mre(src)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Changes the contents of the survival box; replaces oxygen bottle and mask with gauze and matches.
</summary>
<hr>
In the survival box everyone gets on spawn, there is an oxygen bottle and oxygen mask. (Also a syrette and ERP). Perfect for a space station, but less than useful on a land-based colony with breathable atmosphere (for humans. Let others breath their stupid dirt air, who cares about them anyway. Joking.) Sure, there are fires, but in my eyes, it doesn't make sense to carry everything around for that rather obscure case.
That's why I removed bottle and mask and replaced it with a bruise pack (roll of gauze) and a pack of matches, as a more sensible choice of survival equipment.
I did not touch the extended survival box which is used god-knows-where.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:dutop
tweak: In the survival box, switched out oxygen bottle and mask with gauze and matches
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
