### PR TITLE
Psion Regen Increase

### DIFF
--- a/code/modules/psionics/psion.dm
+++ b/code/modules/psionics/psion.dm
@@ -78,13 +78,13 @@
 
 		max_psi_points = round(clamp((owner.stats.getStat(STAT_COG) * 0.1), 1, 30)) + psi_max_bonus
 
-		cognitive_potential = round(clamp((owner.stats.getStat(STAT_COG) * 0.2), 0, 5))
+		cognitive_potential = round(clamp((owner.stats.getStat(STAT_COG) * 0.5), 0, 3))
 
 
 		if(owner.stats.getPerk(PERK_PSI_GRACE))
-			addtimer(CALLBACK(src, .proc/regen_points), (10 MINUTES - cognitive_potential MINUTES) * 0.5)
+			addtimer(CALLBACK(src, .proc/regen_points), (5 MINUTES - cognitive_potential MINUTES) * 0.5)
 		else
-			addtimer(CALLBACK(src, .proc/regen_points), (10 MINUTES - cognitive_potential MINUTES))
+			addtimer(CALLBACK(src, .proc/regen_points), (5 MINUTES - cognitive_potential MINUTES))
 
 		if(psi_points < max_psi_points)
 			psi_points += 1


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
Increases Psion Regen
Tweak: Changes Psion Regen based on COG from 0.2 to 0.5, and lowers base Regen from 10 minutes to 5 minutes.  Formula has been changed to reflect, and will only allow up to a maximum of 3 minutes removed at high COG. e.g.
Small COG(10): Regen is 5-4.5 minutes per point with about 1-2 psi points Large COG(100): Regen is 2 minutes per point with about 10-12 psi points

QoL
These values can easily be tweaked.  Tested for speed and still feels slow, but more balanced to let a psionic recharge faster if they're focusing Cog.  Allows non-Soteria focused psions to have an easier time regen without Cerebrix.<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
