### PR TITLE
Oddity double barrel now holds two shells instead of a single one

### DIFF
--- a/code/modules/projectiles/guns/oddity_items.dm
+++ b/code/modules/projectiles/guns/oddity_items.dm
@@ -39,7 +39,7 @@
 	slot_flags = SLOT_BACK
 	caliber = CAL_SHOTGUN
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_STEEL = 10)
-	max_shells = 1
+	max_shells = 2
 	damage_multiplier = 2
 	penetration_multiplier = 2
 	init_recoil = RIFLE_RECOIL(4)


### PR DESCRIPTION
This double barrel shotgun, that could fire two shells at once, had only a capacity of a single shell. Wtf? Anyway, this change is so that this gun makes sense at all.
