### PR TITLE
Im so sick of bugs.

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/belt.dm
+++ b/code/modules/client/preference_setup/loadout/lists/belt.dm
@@ -29,11 +29,17 @@
 
 
 /datum/gear/belt/medbelt
-	display_name = "Medical belt, Selection EMT / Doctor"
+	display_name = "Medical belt Selection"
 	path = /obj/item/storage/belt/medical
 	allowed_roles = list("Soteria Doctor","Soteria Biolab Officer","Soteria Lifeline Technician")
 	cost = 1
-	flags = GEAR_HAS_TYPE_SELECTION
 
+/datum/gear/belt/medbelt/New()
+	..()
+	var/belts = list(
+		"Medical Belt"				=	/obj/item/storage/belt/medical,
+		"EMT Belt"			=	/obj/item/storage/belt/medical/emt,
+	)
+	gear_tweaks += new /datum/gear_tweak/path(belts)
 
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -41,28 +41,6 @@
 		rad = 0
 	)
 
-/obj/item/clothing/suit/armor/vest/verb/toggle_style()
-	set name = "Adjust Style"
-	set category = "Object"
-	set src in usr
-
-	if(!isliving(loc))
-		return
-
-	var/mob/M = usr
-	var/list/options = list()
-	options["Baseline"] = "armor"
-	options["Security"] = "armor_security"
-
-	var/choice = input(M,"What kind of style do you want?","Adjust Style") as null|anything in options
-
-	if(src && choice && !M.incapacitated() && Adjacent(M))
-		icon_state = options[choice]
-		to_chat(M, "You adjusted your attire's style into [choice] mode.")
-		update_icon()
-		update_wear_icon()
-		usr.update_action_buttons()
-		return 1
 
 /obj/item/clothing/suit/armor/vest/full
 	name = "full body armor"
@@ -73,7 +51,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	stiffness = LIGHT_STIFFNESS
 
-/obj/item/clothing/suit/armor/vest/full/toggle_style()
+/obj/item/clothing/suit/armor/vest/full/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -110,7 +88,7 @@
 	)
 	price_tag = 150
 
-/obj/item/clothing/suit/armor/vest/handmade/toggle_style()
+/obj/item/clothing/suit/armor/vest/handmade/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -212,7 +190,7 @@
 	armor_list = list(melee = 30, bullet = 30, energy = 25, bomb = 20, bio = 100, rad = 80)
 	flags_inv = HIDEJUMPSUIT
 
-/obj/item/clothing/suit/armor/vest/botanist/toggle_style()
+/obj/item/clothing/suit/armor/vest/botanist/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -244,7 +222,7 @@
 	armor_list = list(melee = 30, bullet = 30, energy = 25, bomb = 25, bio = 100, rad = 80)
 	flags_inv = HIDEJUMPSUIT
 
-/obj/item/clothing/suit/armor/vest/acolyte/toggle_style()
+/obj/item/clothing/suit/armor/vest/acolyte/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -291,7 +269,7 @@
 	desc = "The armour of the church arms forces of old - coming from the now extinct military of New Byzantine. The inner layers has plates of biomatter-infused steel and chainmail, together with shoulder protection that elevates to protect the neck and fix it with the helmet of the same design."
 	icon_state = "divisor_guardsmen_armor"
 
-/obj/item/clothing/suit/armor/vest/path/divisor/toggle_style()
+/obj/item/clothing/suit/armor/vest/path/divisor/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -319,7 +297,7 @@
 	desc = "The Tessellate Habit is an mixture of an well protective, efficient gambeson with inner chainmail that ensures the protection of it's user."
 	icon_state = "tessellate_riding_habit"
 
-/obj/item/clothing/suit/armor/vest/path/tessallate/toggle_style()
+/obj/item/clothing/suit/armor/vest/path/tessallate/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -347,7 +325,7 @@
 	desc = "The well suited lemniscates garbs of new, made for the highest quality ceremonies by looking absurdly fancy.  It's protective values are quite close to the design of an pourpoint with inner chainmail with golden ridges and lines that only reinforces it's fanciness value."
 	icon_state = "lemniscate_garbs"
 
-/obj/item/clothing/suit/armor/vest/path/lemniscate/toggle_style()
+/obj/item/clothing/suit/armor/vest/path/lemniscate/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -375,7 +353,7 @@
 	desc = "An old design of armor, often repainted, pieced together with minor plates overlapping on the shoulders, waist and legs, with an large plate protecting the chest and belly."
 	icon_state = "monomial_kasaya"
 
-/obj/item/clothing/suit/armor/vest/path/monomial/toggle_style()
+/obj/item/clothing/suit/armor/vest/path/monomial/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -403,7 +381,7 @@
 	desc = "A Factorial's best protection well working their duties on the colony and back in its day on New Byzantine, tends to have different attachments for a more personalized garb."
 	icon_state = "factorial_powergarb"
 
-/obj/item/clothing/suit/armor/vest/path/factorial/toggle_style()
+/obj/item/clothing/suit/armor/vest/path/factorial/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -436,7 +414,7 @@
 	flags_inv = HIDEJUMPSUIT
 	matter = list(MATERIAL_PLASTEEL = 60, MATERIAL_PLASTIC = 8, MATERIAL_SILVER = 5, MATERIAL_GOLD = 5)
 
-/obj/item/clothing/suit/armor/vest/rosaria/toggle_style()
+/obj/item/clothing/suit/armor/vest/rosaria/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -469,7 +447,7 @@
 	armor_list = list(melee = 30, bullet = 30, energy = 25, bomb = 25, bio = 100, rad = 80)
 	flags_inv = HIDEJUMPSUIT
 
-/obj/item/clothing/suit/armor/vest/custodian/toggle_style()
+/obj/item/clothing/suit/armor/vest/custodian/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -502,7 +480,7 @@
 	flags_inv = HIDEJUMPSUIT
 	matter = list(MATERIAL_PLASTEEL = 60, MATERIAL_PLASTIC = 8, MATERIAL_SILVER = 5, MATERIAL_GOLD = 5)
 
-/obj/item/clothing/suit/armor/vest/prime/toggle_style()
+/obj/item/clothing/suit/armor/vest/prime/verb/toggle_style()
 	set name = "Adjust Style"
 	set category = "Object"
 	set src in usr
@@ -859,6 +837,29 @@
 	blood_overlay_type = "armor"
 	slowdown = 0.2
 	armor_list = list(melee = 45, bullet = 50, energy = 30, bomb = 50, bio = 0, rad = 0)
+
+
+/obj/item/clothing/suit/armor/flakvest/commander/toggle_style()
+	set name = "Adjust Style"
+	set category = "Object"
+	set src in usr
+
+	if(!isliving(loc))
+		return
+
+	var/mob/M = usr
+	var/list/options = list()
+
+	var/choice = input(M,"What kind of style do you want?","Adjust Style") as null|anything in options
+
+	if(src && choice && !M.incapacitated() && Adjacent(M))
+		icon_state = options[choice]
+		item_state = options[choice]
+		to_chat(M, "You adjusted your attire's style into [choice] mode.")
+		update_icon()
+		update_wear_icon()
+		usr.update_action_buttons()
+		return 1
 
 /obj/item/clothing/suit/armor/flakvest/commander/full
 	name = "commander's full body flak vest"
@@ -1263,12 +1264,66 @@
 	slowdown = 0.15
 	armor_list = list(melee = 50, bullet = 50, energy = 30, bomb = 10, bio = 0, rad = 0)
 
+/obj/item/clothing/suit/armor/platecarrier/hos/toggle_style()
+	set name = "Adjust Style"
+	set category = "Object"
+	set src in usr
+
+	if(!isliving(loc))
+		return
+
+	var/mob/M = usr
+	var/list/options = list()
+	options["Baseline"] = "platecarrier"
+	options["Security"] = "platecarrier_ih"
+	options["Green"] = "platecarrier_green"
+	options["Tan"] = "platecarrier_tan"
+
+	var/choice = input(M,"What kind of style do you want?","Adjust Style") as null|anything in options
+
+	if(src && choice && !M.incapacitated() && Adjacent(M))
+		icon_state = options[choice]
+		item_state = options[choice]
+		to_chat(M, "You adjusted your attire's style into [choice] mode.")
+		update_icon()
+		update_wear_icon()
+		usr.update_action_buttons()
+		return 1
+
+
 /obj/item/clothing/suit/armor/platecarrier/hos/full
 	name = "advanced plate carrier"
 	desc = "An armored vest carrying military grade trauma plates and advanced ballistic meshes.This set has a set of equally advanced arm and leg-guards added for increased overall protection."
 	icon_state = "platecarrier_ih_fullbody"
 	item_state = "platecarrier_ih_fullbody"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
+
+
+/obj/item/clothing/suit/armor/platecarrier/hos/full/toggle_style()
+	set name = "Adjust Style"
+	set category = "Object"
+	set src in usr
+
+	if(!isliving(loc))
+		return
+
+	var/mob/M = usr
+	var/list/options = list()
+	options["Baseline"] = "platecarrier_fullbody"
+	options["Security"] = "platecarrier_ih_fullbody"
+	options["Green"] = "platecarrier_green_fullbody"
+	options["Tan"] = "platecarrier_tan_fullbody"
+
+	var/choice = input(M,"What kind of style do you want?","Adjust Style") as null|anything in options
+
+	if(src && choice && !M.incapacitated() && Adjacent(M))
+		icon_state = options[choice]
+		item_state = options[choice]
+		to_chat(M, "You adjusted your attire's style into [choice] mode.")
+		update_icon()
+		update_wear_icon()
+		usr.update_action_buttons()
+		return 1
 
 /*
 // Coats

--- a/code/modules/psionics/psionic_items/psi_Larmor.dm
+++ b/code/modules/psionics/psionic_items/psi_Larmor.dm
@@ -14,7 +14,7 @@
 	slot_flags = SLOT_OCLOTHING
 	matter = list()
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS //It has gloves, hood, and shoes for the rest of them
-	slowdown = -0.375 //3,75% speed up!
+	slowdown = 0 //3,75% speed up! //No! Don't put it on every single item
 	armor_list = list(
 		melee = 30,
 		bullet = 25,
@@ -55,10 +55,8 @@
 	icon_override = 'icons/obj/psionic/occLmob.dmi'
 	desc = "This is a hard hood made of dark fabric material. It is decorated with bronze slabs and has a strange ribbed texture. The crystal on its front part pulsates unusually as soon as the object is on the psion's head. A haze of hidden knowledge covers your face from unnecessary glances."
 	slot_flags = SLOT_HEAD
-	flags_inv = BLOCKHAIR|BLOCKHEADHAIR|FLEXIBLEMATERIAL
-	item_flags = BLOCKHAIR|BLOCKHEADHAIR|FLEXIBLEMATERIAL
 	matter = list()
-	slowdown = -0.375 //3,75% speed up!
+	//slowdown = -0.375 //3,75% speed up!
 	armor_list = list(
 		melee = 30,
 		bullet = 25,
@@ -148,7 +146,7 @@
 	icon_override = 'icons/obj/psionic/occLmob.dmi'
 	slot_flags = SLOT_FEET
 	matter = list()
-	slowdown = -0.375 //3,75% speed up!
+	slowdown = -1.375 //3,75% speed up! No! Wrong! no shoes is slowdown 1, 0.375 is slower than having shoes on! You need to use -1 plus whatever arbitrary amount of extra speed, and only on shoes.
 	can_hold_knife = 1
 	armor_list = list(
 		melee = 25,

--- a/code/modules/psionics/psionic_items/psi_Larmor.dm
+++ b/code/modules/psionics/psionic_items/psi_Larmor.dm
@@ -14,7 +14,7 @@
 	slot_flags = SLOT_OCLOTHING
 	matter = list()
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS //It has gloves, hood, and shoes for the rest of them
-	slowdown = 0 //3,75% speed up! //No! Don't put it on every single item
+	slowdown = -0.09 //with all three pieces figures out to 1.36 speed bonus, which is fairly high but also this shit is rare.
 	armor_list = list(
 		melee = 30,
 		bullet = 25,
@@ -56,7 +56,7 @@
 	desc = "This is a hard hood made of dark fabric material. It is decorated with bronze slabs and has a strange ribbed texture. The crystal on its front part pulsates unusually as soon as the object is on the psion's head. A haze of hidden knowledge covers your face from unnecessary glances."
 	slot_flags = SLOT_HEAD
 	matter = list()
-	//slowdown = -0.375 //3,75% speed up!
+	slowdown = -0.09
 	armor_list = list(
 		melee = 30,
 		bullet = 25,
@@ -101,6 +101,7 @@
 	item_state = "gloves"
 	icon_state = "gloves"
 	icon_override = 'icons/obj/psionic/occLmob.dmi'
+	slowdown = -0.09
 	slot_flags = SLOT_GLOVES
 	item_flags = THICKMATERIAL
 	siemens_coefficient = 1 //Insulated!
@@ -146,7 +147,7 @@
 	icon_override = 'icons/obj/psionic/occLmob.dmi'
 	slot_flags = SLOT_FEET
 	matter = list()
-	slowdown = -1.375 //3,75% speed up! No! Wrong! no shoes is slowdown 1, 0.375 is slower than having shoes on! You need to use -1 plus whatever arbitrary amount of extra speed, and only on shoes.
+	slowdown = -1.09 //3,75% speed up! No! Wrong! Humans are +1 slowdown by default so that you are slower without shoes, this is why shoes have -1 slowdown. Needs to have -1 slowdown as BASE
 	can_hold_knife = 1
 	armor_list = list(
 		melee = 25,

--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -1,5 +1,6 @@
 /* Drugs */
 /datum/reagent/drug
+
 	reagent_type = "Drug"
 	scannable = TRUE
 
@@ -324,16 +325,16 @@
 	M.add_chemical_effect(CE_PULSE, 1) //If you inject it into your blood
 	M.add_chemical_effect(CE_PAINKILLER, 5)
 	if(M.stats.getPerk(PERK_CHAINGUN_SMOKER))
-		M.add_chemical_effect(CE_ANTITOX, 5)
-		M.heal_organ_damage(0.1, 0.1)
-		M.add_chemical_effect(CE_ONCOCIDAL, 0.5)	// STALKER reference
+		M.add_chemical_effect(CE_ANTITOX, 5 * effect_multiplier)
+		M.heal_organ_damage(0.1 * effect_multiplier, 0.1 * effect_multiplier)
+		M.add_chemical_effect(CE_ONCOCIDAL, 0.5)	// STALKER reference	// STALKER reference
 
 /datum/reagent/drug/nicotine/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
 	..()
 	M.add_chemical_effect(CE_PAINKILLER, 5)
 	if(M.stats.getPerk(PERK_CHAINGUN_SMOKER))
 		M.add_chemical_effect(CE_ANTITOX, 5)
-		M.heal_organ_damage(0.1, 0.1)
+		M.heal_organ_damage(0.1 * effect_multiplier, 0.1 * effect_multiplier)
 
 /datum/reagent/drug/nicotine/overdose(var/mob/living/carbon/M, var/alien)
 	M.add_side_effect("Headache", 11)


### PR DESCRIPTION
Cigarettes no longer(seem to) cause kidney damage to people with unclean living.

psion void armor has correct slowdown Additionally, no longer allows ears to flop outside of it. It's a fucking space suit, why would they be out?

Opifex medbelt no longer selectable, sorry powergamers.

Removes change_appearance from baseline armor vest. Why? It is the parent to MANY MANY MANY fucking items and thus caused MANY MANY MANY items to have erronious change_appearance procs that only had two options for the base parent item. This is why we don't put fucking procs on BASE PARENT items that affect DOZENS of other items. Fixes a few others, WO plate has no unique sprite and now has a proper working change appearance. CO does have a unique sprite, it is gone.

Fixes #4732
Fixes #4734
fixes #4724

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
