### PR TITLE
Fixing 14.5x114mm

### DIFF
--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -637,8 +637,8 @@
 
 //// 14.5×114mm Anti-Materiel Rifle Rounds ////
 /obj/item/projectile/bullet/antim
-	damage_types = list(BRUTE = 60)
-	armor_penetration = 100
+	damage_types = list(BRUTE = 80)
+	armor_penetration = 200
 	nocap_structures = TRUE
 	//stun = 5
 	//weaken = 10
@@ -649,7 +649,7 @@
 	recoil = 40
 
 /obj/item/projectile/bullet/antim/lethal
-	damage_types = list(BRUTE = 45)
+	damage_types = list(BRUTE = 60)
 	embed = TRUE
 	armor_penetration = 60
 	agony = 100
@@ -671,7 +671,7 @@
 	recoil = 40
 
 /obj/item/projectile/bullet/antim/scrap
-	damage_types = list(BRUTE = 41.5)
+	damage_types = list(BRUTE = 45)
 	armor_penetration = 50
 	affective_damage_range = 8
 	affective_ap_range = 8


### PR DESCRIPTION
fixes one caliber being too weak compared to others. The 14.5x114 had very much decent armour piercing, but due to various changes around how PVE and PVP worked in the duration between when it was introduced and now, it's fallen a lot behind other weapons that were updated. This weapon is a single shot, meaning it's difficult to use in PVP effectively, making as much damage (Only around 50 brute without the scope) as two regular bullets from most higher end automatic rifles, which just does not cut it for what is supposed to be the best (or one of) possible ballistic precision rifle available. Not only that, but on the PVE side of things, it also was very bad due to the low damage. The AP made it possible to kill most pests easily, but it still lacked against heavier mobs, which normally would be the prime target of a rifle like that. So this PR fixes it with minor changes to the AP and damage values.

