### PR TITLE
Hivemind - per emojiocracy vote.

### DIFF
--- a/code/game/gamemodes/events/blob.dm
+++ b/code/game/gamemodes/events/blob.dm
@@ -41,8 +41,8 @@
 
 	log_and_message_admins("Active Blob combative players number is [active_players].")
 	if(GLOB.hive_data_bool["pop_lock"])
-		if(active_players <= 7)
-			log_and_message_admins("Blob failed to spawn as their was less then 7 active players exspected to combat the blob.")
+		if(active_players <= 4)
+			log_and_message_admins("Blob failed to spawn as their was less then 4 active players exspected to combat the blob.")
 			kill()
 			return
 

--- a/code/game/gamemodes/events/hivemind_invasion.dm
+++ b/code/game/gamemodes/events/hivemind_invasion.dm
@@ -46,8 +46,8 @@
 
 	log_and_message_admins("Active Hivemind combative players number is [active_players].")
 	if(GLOB.hive_data_bool["pop_lock"])
-		if(active_players < 15)
-			log_and_message_admins("Hivemind failed to spawn as their was less then 15 active players exspected to combat the hivemind.")
+		if(active_players < 7)
+			log_and_message_admins("Hivemind failed to spawn as their was less then 7 active players exspected to combat the hivemind.")
 			kill()
 			return
 


### PR DESCRIPTION
Reduces total 'combat related' players required to spawn either blob or Hivemind.

Hiveminds now require 7 players.
Blob now requires 4 players.

See below for the list of jobs that count for this requirement. Why does Premier count??

``#define JOBS_ANTI_HIVEMIND "Blackshield Commander","Warrant Officer","Supply Specialist","Ranger","Corpsman","Blackshield Trooper","Marshal Officer","Sergeant","Prime","Vector","Foreman","Salvager","Prospector","Premier","Steward","AI","Janitor","Soteria Lifeline Technician","Soteria Roboticist","Lonestar Miner" ``

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
