### PR TITLE
PROBABLY fixes certain deferred boxes being an obnoxious meme.

### DIFF
--- a/code/game/objects/items/weapons/storage/deferred.dm
+++ b/code/game/objects/items/weapons/storage/deferred.dm
@@ -58,6 +58,7 @@
 	item_state = "irp_box"
 	w_class = ITEM_SIZE_HUGE
 	desc = "A box of preserved, ready-to-eat food for soldiers and spacefarers on the go."
+	can_hold = list(/obj/item/storage/ration_pack)
 	initial_contents = list(/obj/item/storage/ration_pack = 7)
 
 
@@ -65,6 +66,7 @@
 	name = "tool modifications kit"
 	desc = "A sturdy container full of contraptions, bits of material, components and add-ons for modifying tools."
 	icon_state = "box_tools"
+	can_hold = list(/obj/random/tool_upgrade, /obj/random/tool_upgrade/rare)
 	initial_contents = list(/obj/random/tool_upgrade = 12,
 	/obj/random/tool_upgrade/rare = 3)
 
@@ -72,24 +74,29 @@
 /obj/item/storage/deferred/pouches
 	name = "uniform modification kit"
 	desc = "A box full of hard-wearing pouches designed for easy attachment to clothing and armor. Good for carrying extra ammo or tools in the field."
+	can_hold = list(/obj/random/pouch, /obj/item/storage/pouch/pistol_holster)
 	initial_contents = list(/obj/random/pouch = 8, /obj/item/storage/pouch/pistol_holster = 1)
 	//One guaranteed holster and plenty of randoms
 
 /obj/item/storage/deferred/comms
 	name = "communications kit"
 	desc = "A box full of radios and beacons"
+	can_hold = list(/obj/item/device/radio/beacon, /obj/item/device/radio)
 	initial_contents = list(/obj/item/device/radio/beacon = 6, /obj/item/device/radio = 6)
 
 /obj/item/storage/deferred/lights
 	name = "illumination kit"
 	desc = "A box of flares and flashlights"
+	can_hold = list(/obj/item/device/lighting/glowstick/flare, /obj/item/device/lighting/toggleable/flashlight/heavy)
 	initial_contents = list(/obj/item/device/lighting/glowstick/flare = 20, /obj/item/device/lighting/toggleable/flashlight/heavy = 6)
 
 /obj/item/storage/deferred/music
 	name = "morale kit"
 	desc = "All that's required to unite nation, compacted within single box."
 	icon_state = "box_serbian"
+	can_hold = list(/obj/item/device/synthesized_instrument/trumpet)
 	initial_contents = list(/obj/item/device/synthesized_instrument/trumpet = 1) //TODO: Add an accordian to this, sprites already made.
+
 
 //Medical
 /obj/item/storage/deferred/surgery


### PR DESCRIPTION
storage set their own inventory size/max itm size based on what's in them, cool right? Well, this means things like the tool-mods kit from lonestar is the most potent storage item ever because it comes with 12 normal size slots. They can now only hold the kinda items they come with, I'm very likely missing some stuff but oh well.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
