### PR TITLE
Visitor update.

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -5,7 +5,7 @@
 #define JOBS_MEDICAL "Chief Biolab Overseer","Soteria Doctor","Soteria Psychiatrist","Soteria Lifeline Technician"
 #define JOBS_SCIENCE "Chief Research Overseer","Soteria Scientist","Soteria Roboticist"
 #define JOBS_LSS "Chief Executive Officer","Cargo Technician","Lonestar Miner","Bartender","Chef","Gardener","Janitor","Artist"
-#define JOBS_CIVILIAN "Colonist"
+#define JOBS_CIVILIAN "Colonist", "Visitor"
 #define JOBS_CHURCH "Prime", "Vector"
 #define JOBS_PROSPECTOR "Foreman","Salvager","Prospector"
 #define JOBS_NONHUMAN "AI","Robot","pAI"
@@ -26,7 +26,7 @@
 #define DEPARTMENT_CIVILIAN	"Contractors"
 #define DEPARTMENT_CHURCH	"Church of Absolute"
 #define DEPARTMENT_PROSPECTOR "Prospectors"
-#define DEPARTMENT_INDEPENDENT "Contractors"
+#define DEPARTMENT_INDEPENDENT "Independant"
 
 #define DEPARTMENT_GREYSON "Greyson Positronic"
 

--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -3,6 +3,12 @@
 	suit = /obj/item/clothing/suit/storage/rank/ass_jacket
 	uniform = /obj/item/clothing/under/rank/assistant
 
+/decl/hierarchy/outfit/job/foreigner
+	name = OUTFIT_JOB_NAME("Visitor")
+	id_type = /obj/item/card/id/visitor
+	pda_type = null
+	uniform = /obj/item/clothing/under/genericw
+
 /decl/hierarchy/outfit/job/service
 	l_ear = /obj/item/device/radio/headset/headset_service
 	hierarchy_type = /decl/hierarchy/outfit/job/service

--- a/code/game/jobs/department.dm
+++ b/code/game/jobs/department.dm
@@ -131,7 +131,7 @@
 /datum/department/independent
 	name = "Independent Allied Factions"
 	id = DEPARTMENT_INDEPENDENT
-	jobs_in_department = list("/datum/job/off_colony_hunt_master","/datum/job/off_colony_hunter","/datum/job/off_colony_herbalist","/datum/job/outsider","/datum/job/assistant", "/datum/job/foreigner")
+	jobs_in_department = list("/datum/job/off_colony_hunt_master","/datum/job/off_colony_hunter","/datum/job/off_colony_herbalist","/datum/job/outsider","/datum/job/assistant","/datum/job/foreigner")
 
 /datum/department/greyson_positronic
 	name = "Greyson Positronic"

--- a/code/game/jobs/department.dm
+++ b/code/game/jobs/department.dm
@@ -54,7 +54,7 @@
 /*************
 	Retainers
 **************/
-//These departments are paid out of ship funding
+//These departments are paid out of colony funding
 /datum/department/ironhammer
 	name = "Marshal and Blackshield Division"
 	id = DEPARTMENT_SECURITY
@@ -131,7 +131,7 @@
 /datum/department/independent
 	name = "Independent Allied Factions"
 	id = DEPARTMENT_INDEPENDENT
-	jobs_in_department = list("/datum/job/off_colony_hunt_master","/datum/job/off_colony_hunter","/datum/job/off_colony_herbalist","/datum/job/outsider","/datum/job/assistant")
+	jobs_in_department = list("/datum/job/off_colony_hunt_master","/datum/job/off_colony_hunter","/datum/job/off_colony_herbalist","/datum/job/outsider","/datum/job/assistant", "/datum/job/foreigner")
 
 /datum/department/greyson_positronic
 	name = "Greyson Positronic"

--- a/code/game/jobs/job/avisitor.dm
+++ b/code/game/jobs/job/avisitor.dm
@@ -1,0 +1,37 @@
+/datum/job/foreigner
+	title = "Visitor"
+	flag = ASSISTANT
+	department = DEPARTMENT_CIVILIAN
+	department_flag = CIVILIAN
+	faction = MAP_FACTION
+	total_positions = -1
+	spawn_positions = -1
+	supervisors = "Your own desires."
+	difficulty = "Very Easy."
+	selection_color = "#dddddd"
+	initial_balance = 800
+	wage = WAGE_NONE //Get a job ya lazy bum
+
+	outfit_type = /decl/hierarchy/outfit/job/foreigner
+
+	stat_modifiers = list(
+		STAT_ROB = 8,
+		STAT_TGH = 8,
+		STAT_BIO = 8,
+		STAT_MEC = 8,
+		STAT_VIG = 8,
+		STAT_COG = 8
+	)
+
+	description = "The ideal role for new characters. You are not a member of the colony(yet) and as such do not require records, but as a foreigner who's been allowed in<br>\
+you're held to very different standards.Use this freedom to determine your place in the world; Have you come from space, hoping to make a home in this place?<br>\
+Are you a straggler from the woods, just looking for a few nights reprieve from the horrors of this planet?<br>\
+Perhaps your intent for the colony is less charitable, intent to take advantage of your hosts misplaced trust?<br>\
+<br>\
+Regardless of what your reasons may be, remember that you are a guest in this place. If you create issues the Marshals or Shield may simply show you the gate, or worse."
+
+/obj/landmark/join/start/foreigner
+	name = "Visitor"
+	icon_state = "player-grey"
+	join_tag = /datum/job/foreigner
+

--- a/code/game/jobs/job/avisitor.dm
+++ b/code/game/jobs/job/avisitor.dm
@@ -1,6 +1,6 @@
 /datum/job/foreigner
 	title = "Visitor"
-	flag = ASSISTANT
+	flag = VISITOR
 	department = DEPARTMENT_CIVILIAN
 	department_flag = CIVILIAN
 	faction = MAP_FACTION

--- a/code/game/jobs/job/avisitor.dm
+++ b/code/game/jobs/job/avisitor.dm
@@ -34,4 +34,3 @@ Regardless of what your reasons may be, remember that you are a guest in this pl
 	name = "Visitor"
 	icon_state = "player-grey"
 	join_tag = /datum/job/foreigner
-

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -59,6 +59,7 @@ var/const/BOTANIST			=(1<<9)
 var/const/FOREMAN			=(1<<10)
 var/const/SALVAGER			=(1<<11)
 var/const/PROSPECTOR		=(1<<12)
+var/const/VISITOR			=(1<<13)
 
 
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -408,6 +408,10 @@ var/const/NO_EMAG_ACT = -50
 	icon_state = "id_lodge"
 	desc = "A bird skull hanging from a leather thong, carved by the hunting lodge and given to members to display name and rank. A small chip inside allows it to be used like any other access badge, encoded with the users biometrics."
 
+/obj/item/card/id/visitor
+	icon_state = "guest"
+	desc = "An official guest pass issued by the Nadehzda colony. This one bears the mark of Nadezhda customs and has no listed expiry date."
+
 //Keys
 /obj/item/keys
 	name = "skeleton key"

--- a/code/modules/multiz/map_data.dm
+++ b/code/modules/multiz/map_data.dm
@@ -117,7 +117,7 @@ ADMIN_VERB_ADD(/client/proc/test_MD, R_DEBUG, null)
 						/datum/job/chaplain, /datum/job/acolyte, /datum/job/janitor, /datum/job/hydro,
 						/datum/job/scientist, /datum/job/roboticist,
 						/datum/job/ai, /datum/job/cyborg,
-						/datum/job/assistant,
+						/datum/job/assistant, /datum/job/foreigner,
 						/datum/job/off_colony_hunt_master, /datum/job/off_colony_hunter, /datum/job/off_colony_herbalist, /datum/job/outsider
 						)
 

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -2996,6 +2996,7 @@
 /area/nadezhda/pros/prep)
 "aIM" = (
 /obj/item/stool/padded,
+/obj/landmark/join/start/foreigner,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "aIQ" = (
@@ -13864,6 +13865,12 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
+"dfV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/landmark/join/start/foreigner,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/crew_quarters/sleep/cryo2)
 "dgi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -18607,6 +18614,7 @@
 /area/nadezhda/command/fo)
 "egN" = (
 /obj/structure/bed/chair/comfy/brown,
+/obj/landmark/join/start/foreigner,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "egP" = (
@@ -23215,6 +23223,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/landmark/join/start/foreigner,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "fgl" = (
@@ -98412,6 +98421,7 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
+/obj/landmark/join/start/foreigner,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "vuO" = (
@@ -175411,7 +175421,7 @@ vMU
 oeR
 fgj
 rqF
-rqF
+dfV
 llJ
 kFn
 kFn

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -13865,12 +13865,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
-"dfV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/landmark/join/start/foreigner,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/crew_quarters/sleep/cryo2)
 "dgi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -23223,7 +23217,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/landmark/join/start/foreigner,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "fgl" = (
@@ -175421,7 +175414,7 @@ vMU
 oeR
 fgj
 rqF
-dfV
+rqF
 llJ
 kFn
 kFn

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -717,6 +717,7 @@
 #include "code\game\jobs\wages.dm"
 #include "code\game\jobs\whitelist.dm"
 #include "code\game\jobs\job\assistant.dm"
+#include "code\game\jobs\job\avisitor.dm"
 #include "code\game\jobs\job\captain.dm"
 #include "code\game\jobs\job\church.dm"
 #include "code\game\jobs\job\civilian.dm"


### PR DESCRIPTION
Visitor role is back, however this time it is not simply an alt-title for colonists. They spawn with a 0 access , 'official' guest pass that shows they have the right to be there. Mind you, they are STILL visitors they are STILL subject to all the usual rules for visitors. any crimes they commit can result in ejection and they generally should stick to main areas - but this should help the longtime issue of new players choosing outsider to introduce their 'foreigner' character and promptly dying dead-ly.

Also rename the dept for colonists/visitors from 'contractors' to 'Independents'.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
