### PR TITLE
Enable spoons, forks and knives in lunchboxes

### DIFF
--- a/code/game/objects/items/weapons/storage/lunchbox.dm
+++ b/code/game/objects/items/weapons/storage/lunchbox.dm
@@ -14,7 +14,9 @@
 	attack_verb = "lunched"
 	price_tag = 5
 	can_hold = list(
-		/obj/item/reagent_containers/food
+		/obj/item/reagent_containers/food,
+		/obj/item/material/kitchen/utensil,
+		/obj/item/tool/knife
 		)
 
 /obj/item/storage/lunchbox/rainbow


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Enable spoons, forks and knives in lunchboxes
</summary>
<hr>
Spoons, forks and knives should fit in a lunchbox, so you don't have to eat your steak like an animal. As we don't have dinner knives / menu knives and _every_ knife is based on the kitchen knife, this means that every knife works. Other kitchen tools are not allowed.

![image](https://github.com/sojourn-13/sojourn-station/assets/73559117/c34edee0-0177-445b-9186-fda9dfe32cec)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl: dutop
add: Allow spoons, forks and knives in lunchboxes.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
