### PR TITLE
Add option to disable the farmbot speaker

### DIFF
--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -19,6 +19,7 @@
 	var/replaces_nutriment = 0
 	var/collects_produce = 0
 	var/removes_dead = 0
+	var/speaker_on = 1
 
 	var/obj/structure/reagent_dispensers/watertank/tank
 
@@ -57,6 +58,8 @@
 		dat += "<br>Plant controls:<br>"
 		dat += "Collect produce: <A href='?src=\ref[src];collect=1'>[collects_produce ? "Yes" : "No"]</A><BR>"
 		dat += "Remove dead plants: <A href='?src=\ref[src];removedead=1'>[removes_dead ? "Yes" : "No"]</A><BR>"
+		dat += "<br>Speaker controls:<br>"
+		dat += "Enable speaker: <A href='?src=\ref[src];speakeron=1'>[speaker_on ? "Yes" : "No"]</A><BR>"
 		dat += "</TT>"
 
 	user << browse("<HEAD><TITLE>Farmbot v1.0 controls</TITLE></HEAD>[dat]", "window=autofarm")
@@ -99,7 +102,9 @@
 	else if(href_list["collect"])
 		collects_produce = !collects_produce
 	else if(href_list["removedead"])
-		removes_dead = !removes_dead
+		removes_dead = !removes_dead	
+	else if(href_list["speakeron"])
+		speaker_on = !speaker_on
 
 	attack_hand(usr)
 	return
@@ -176,9 +181,10 @@
 				action = "collect"
 				update_icons()
 				visible_message("<span class='notice'>[src] starts [T.dead? "removing the plant from" : "harvesting"] \the [A].</span>")
-				playsound(loc, "robot_talk_heavy", 10, 0, 0)
-				var/message = pick("I will gather.", "Time for harvesting.", "This one is ready.")
-				say(message)
+				if (speaker_on)
+					playsound(loc, "robot_talk_heavy", 10, 0, 0)
+					var/message = pick("I will gather.", "Time for harvesting.", "This one is ready.")
+					say(message)
 				attacking = 1
 				if(do_after(src, 30, A))
 					visible_message("<span class='notice'>[src] [T.dead? "removes the plant from" : "harvests"] \the [A].</span>")
@@ -187,9 +193,10 @@
 				action = "water"
 				update_icons()
 				visible_message(SPAN_NOTICE("[src] starts watering \the [A]."))
-				playsound(loc, "robot_talk_heavy", 10, 0, 0)
-				var/message = pick("Waters of life.", "Giving this one water.")
-				say(message)
+				if (speaker_on)
+					playsound(loc, "robot_talk_heavy", 10, 0, 0)
+					var/message = pick("Waters of life.", "Giving this one water.")
+					say(message)
 				attacking = 1
 				if(do_after(src, 30, A))
 					playsound(loc, 'sound/effects/slosh.ogg', 10, 1)
@@ -200,9 +207,10 @@
 				action = "hoe"
 				update_icons()
 				visible_message(SPAN_NOTICE("[src] starts uprooting the weeds in \the [A]."))
-				playsound(loc, "robot_talk_heavy", 10, 0, 0)
-				var/message = pick("I will purge this.", "This plant is dead, removing now.")
-				say(message)
+				if (speaker_on)
+					playsound(loc, "robot_talk_heavy", 10, 0, 0)
+					var/message = pick("I will purge this.", "This plant is dead, removing now.")
+					say(message)
 				attacking = 1
 				if(do_after(src, 30, A))
 					visible_message(SPAN_NOTICE("[src] uproots the weeds in \the [A]."))
@@ -212,9 +220,10 @@
 				action = "fertile"
 				update_icons()
 				visible_message(SPAN_NOTICE("[src] starts fertilizing \the [A]."))
-				playsound(loc, "robot_talk_heavy", 10, 0, 0)
-				var/message = pick("Replacing fertilizer.", "Restoring the mulch here.")
-				say(message)
+				if (speaker_on)
+					playsound(loc, "robot_talk_heavy", 10, 0, 0)
+					var/message = pick("Replacing fertilizer.", "Restoring the mulch here.")
+					say(message)
 				attacking = 1
 				if(do_after(src, 30, A))
 					visible_message(SPAN_NOTICE("[src] waters \the [A]."))
@@ -256,9 +265,10 @@
 					return
 				var/t = pick("slashed", "sliced", "cut", "clawed")
 				A.attack_generic(src, 5, t)
-				playsound(loc, "robot_talk_heavy", 10, 0, 0)
-				var/message = pick("Removing weeds.", "Purging parasitic plant life.")
-				say(message)
+				if (speaker_on)
+					playsound(loc, "robot_talk_heavy", 10, 0, 0)
+					var/message = pick("Removing weeds.", "Purging parasitic plant life.")
+					say(message)
 			if("water")
 				flick("farmbot_water", src)
 				visible_message(SPAN_DANGER("[src] splashes [A] with water!")) // That's it. RP effect.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Add option to disable the farmbot speaker
</summary>
<hr>
The options menu that can be accessed by pulling your ID through the farmbot, gets a new option to disable the speaker. No sound is played, no text is spoken. The texts describing the actions (...starts to harvest, ... harvested) stay. But the text spam stops. This is comparable to the vendors who can get their speaker disabled.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl: dutop
tweak: Add option to disable the farmbot speaker
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
