### PR TITLE
Update standard.dm

### DIFF
--- a/code/modules/organs/external/subtypes/standard.dm
+++ b/code/modules/organs/external/subtypes/standard.dm
@@ -22,12 +22,12 @@
 /obj/item/organ/external/head/take_damage(amount, damage_type, armor_divisor = 1, wounding_multiplier = 1, sharp, edge, used_weapon = null, list/forbidden_limbs = list(), silent)
 	. = ..()
 	if(. && !disfigured)
-		if(amount > 40)
+		if(amount > 25)
 			if(damage_type == BRUTE && prob(50))
 				disfigure("brute")
-		else
-			if (damage_type == BURN)
-				disfigure("burn")
+			else
+				if (damage_type == BURN)
+					disfigure("burn")
 
 /obj/item/organ/external/head/get_conditions()
 	var/list/conditions_list = ..()


### PR DESCRIPTION
fixes a longstanding bug where any amount of burn damage to the head would result in disfiguring whereas no amount of brute(more or less) would.

damage of at least 25 points(in one hit) will now disfigure a head that it hits. For brute this will be on a coin toss, whereas burn will always proc(use high powered lasers to melt faces off.)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
