### PR TITLE
Add linen bin to Janitor closet

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -283,18 +283,28 @@ LINEN BINS
 	var/amount = 20
 	var/list/sheets = list()
 	var/obj/item/hidden
+	var/double = FALSE
 
 
 /obj/structure/bedsheetbin/examine(mob/user)
 	..(user)
 
 	if(amount < 1)
-		to_chat(user, "There are no bed sheets in the bin.")
+		if (double)
+			to_chat(user, "There are no double bed sheets in the bin.")
+		else
+			to_chat(user, "There are no bed sheets in the bin.")
 		return
 	if(amount == 1)
-		to_chat(user, "There is one bed sheet in the bin.")
+		if (double)
+			to_chat(user, "There is one double bed sheet in the bin.")
+		else
+			to_chat(user, "There is one bed sheet in the bin.")
 		return
-	to_chat(user, "There are [amount] bed sheets in the bin.")
+	if (double)
+		to_chat(user, "There are [amount] double bed sheets in the bin.")
+	else
+		to_chat(user, "There are [amount] bed sheets in the bin.")
 
 
 /obj/structure/bedsheetbin/update_icon()
@@ -327,6 +337,8 @@ LINEN BINS
 			B = sheets[sheets.len]
 			sheets.Remove(B)
 
+		else if (double)
+			B = new /obj/item/bedsheet/double(loc, TRUE)
 		else
 			B = new /obj/item/bedsheet(loc, TRUE)
 
@@ -351,6 +363,8 @@ LINEN BINS
 			B = sheets[sheets.len]
 			sheets.Remove(B)
 
+		else if (double)
+			B = new /obj/item/bedsheet/double(loc, TRUE)
 		else
 			B = new /obj/item/bedsheet(loc, TRUE)
 

--- a/code/modules/clothing/underwear/base.dm
+++ b/code/modules/clothing/underwear/base.dm
@@ -98,6 +98,12 @@
 
 	return TRUE
 
+/obj/item/underwear/attackby(var/obj/item/I, var/mob/U)
+	if(istype(I, /obj/item/flame/lighter))
+		burnclothing(I, U)
+	else
+		return ..()
+
 /obj/item/underwear/proc/RemoveUnderwear(var/mob/user, var/mob/living/carbon/human/H)
 	if(!CanRemoveUnderwear(user, H))
 		return FALSE
@@ -108,6 +114,30 @@
 	H.update_underwear()
 
 	return TRUE
+
+/obj/item/underwear/proc/burnclothing(obj/item/flame/P, mob/user)
+	var/class = "warning"
+
+	if(P.lit && !user.restrained())
+		if(istype(P, /obj/item/flame/lighter/zippo))
+			class = "rose"
+
+		user.visible_message("<span class='[class]'>[user] holds \the [P] up to \the [src], it looks like \he's trying to burn it!</span>", \
+		"<span class='[class]'>You hold \the [P] up to \the [src], burning it slowly.</span>")
+
+		spawn(20)
+			if(get_dist(src, user) < 2 && user.get_active_hand() == P && P.lit)
+				user.visible_message("<span class='[class]'>[user] burns right through \the [src], turning it to ash. It settles on the floor in a heap.</span>", \
+				"<span class='[class]'>You burn right through \the [src], turning it to ash. It settles on the floor in a heap.</span>")
+
+				if(user.get_inactive_hand() == src)
+					user.drop_from_inventory(src)
+
+				new /obj/effect/decal/cleanable/ash(src.loc)
+				qdel(src)
+
+			else
+				to_chat(user, "\red You must hold \the [P] steady to burn \the [src].")
 
 /obj/item/underwear/verb/RemoveSocks()
 	set name = "Remove Underwear"

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -5452,7 +5452,7 @@
 	name = "Mixed Air Supply Control";
 	output_tag = "air_out";
 	pressure_setting = 2000;
-	sensors = list("air_sensor"="Tank")
+	sensors = list("air_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -12560,7 +12560,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor"="Tank")
+	sensors = list("o2_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -29762,7 +29762,7 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
-	sensors = list("n2_sensor"="Tank")
+	sensors = list("n2_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -49793,7 +49793,7 @@
 	dir = 1;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon  Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous  Oxide","waste_sensor"="Gas  Mix  Tank")
+	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon  Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous  Oxide", "waste_sensor" = "Gas  Mix  Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
@@ -50228,7 +50228,7 @@
 	dir = 8;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon  Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous  Oxide","waste_sensor"="Gas  Mix  Tank")
+	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon  Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous  Oxide", "waste_sensor" = "Gas  Mix  Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
@@ -59355,6 +59355,9 @@
 /area/nadezhda/absolutism/bioreactor)
 "nfk" = (
 /obj/structure/table/rack/shelf,
+/obj/structure/bedsheetbin{
+	double = 1
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/janitor)
 "nfp" = (
@@ -67525,7 +67528,7 @@
 	input_tag = "tox_in";
 	name = "Plasma Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor"="Tank")
+	sensors = list("tox_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -72890,7 +72893,7 @@
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 1;
 	pixel_y = 3;
-	preloaded_reagents = list("plasma"=30)
+	preloaded_reagents = list("plasma" = 30)
 	},
 /obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -88900,7 +88903,7 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensors = list("n2o_sensor"="Tank")
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -90053,7 +90056,7 @@
 	input_tag = "waste_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "waste_out";
-	sensors = list("waste_sensor"="Tank")
+	sensors = list("waste_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -98481,7 +98484,7 @@
 /obj/machinery/reagentgrinder/portable,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/glass/beaker{
-	preloaded_reagents = list("plasma"=30)
+	preloaded_reagents = list("plasma" = 30)
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
@@ -107961,7 +107964,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensors = list("co2_sensor"="Tank")
+	sensors = list("co2_sensor" = "Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Adds a linen bin (bedsheetbin in code) to the Janitor closet. Enables the linen bin to contain double-sized bedsheets
</summary>
<hr>
I simply wanted to add a linen bin to the Janitor closet, to be able to change the bed sheets in Dorms. Collecting all sheets, washing them and returning them is just not great, as it leaves the beds uncovered! Having no spares sucks, as well, because maybe someone needed a bedsheet to cover up a shivering friend somewhere.
Problem: The linen bin does only provide single bed sheets, while the beds in the dorms are double-sized. So I simply added a var "double" that defines the bin as a bin for double-sized bedsheets. Default is FALSE. Var can be set in map. Description of linen bin shows if it's loaded with double sheets or not. Tested on local server.
Note: You COULD click on a double linen bin with a single-size bedsheet and load it into it. Examining would say there are 21 double bedsheets. Don't do that. You'd look stupid.

![image](https://github.com/sojourn-13/sojourn-station/assets/73559117/4124596d-87d8-47a7-8979-fb4594e482f2)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl: dutop
add: Double-sized linen bin to Janitor closet.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
