### PR TITLE
Addon - Excel Fortress (Fixed maybe)

### DIFF
--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -35,6 +35,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
+"abV" = (
+/obj/structure/flora/small/grassb4,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "aca" = (
 /obj/structure/curtain/open,
 /obj/random/junk/nondense,
@@ -110,6 +114,11 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"agL" = (
+/obj/structure/table/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ahb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -125,6 +134,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"aiG" = (
+/obj/structure/table/standard,
+/obj/random/surgery_tool/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aiR" = (
 /obj/random/cluster/spiders/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -238,6 +252,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"apK" = (
+/mob/living/carbon/superior_animal/xenomorph{
+	name = "Greg";
+	desc = "Fuck you, Greg."
+	},
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "apW" = (
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/tiled/white,
@@ -269,6 +290,10 @@
 /obj/structure/table/onestar,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"ars" = (
+/mob/living/simple_animal/hostile/scarybat,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "arB" = (
 /obj/structure/sink/puddle,
 /obj/item/toy/desk/dippingbird,
@@ -341,6 +366,10 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"avd" = (
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "avx" = (
 /obj/structure/table/standard,
 /obj/item/stack/cable_coil/yellow,
@@ -367,6 +396,10 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"axm" = (
+/obj/machinery/cooking_with_jane/oven,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "axE" = (
 /obj/structure/medical_stand,
 /turf/simulated/floor/wood/wild4,
@@ -402,6 +435,13 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/prepper)
+"azd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "azq" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/cloth/suit,
@@ -413,6 +453,11 @@
 /obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"azN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/dense_weighted,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "azU" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/standard,
@@ -545,6 +590,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
+"aGx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank/huge/derelict,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aGT" = (
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
@@ -658,6 +709,16 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
+"aNA" = (
+/obj/structure/closet/crate/excelsior,
+/obj/random/surgery_tool/low_chance,
+/obj/item/tool/saw/circular/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"aNB" = (
+/obj/item/trash/mre,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aNF" = (
 /obj/machinery/light{
 	dir = 8;
@@ -686,6 +747,11 @@
 /obj/structure/flora/small/lavarock1,
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt,
+/area/asteroid/rogue)
+"aOz" = (
+/obj/item/implantcase/excelsior/broken,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "aOA" = (
 /obj/structure/girder/displaced,
@@ -726,6 +792,11 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"aQb" = (
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aSc" = (
 /turf/simulated/shuttle/floor/mining,
 /area/colony/exposedsun/crashed_shop/outsider)
@@ -737,6 +808,10 @@
 /obj/item/remains/mummy2,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"aSG" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aSK" = (
 /obj/structure/sink{
 	dir = 4;
@@ -790,6 +865,11 @@
 /obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/meadow)
+"aWN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aXb" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/random/mob/vox/low_chance,
@@ -841,6 +921,11 @@
 /obj/random/powercell/low_chance,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"baj" = (
+/obj/random/scrap/dense_weighted,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "baH" = (
 /obj/structure/cable/yellow,
 /obj/machinery/light/small,
@@ -916,6 +1001,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"beO" = (
+/obj/item/trash/grease,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "beQ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood/wild5,
@@ -957,6 +1046,10 @@
 /obj/item/stack/material/plasma/random,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"bif" = (
+/obj/item/trash/mre_candy,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bip" = (
 /obj/item/frame/apc,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -1016,6 +1109,10 @@
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"bkW" = (
+/obj/item/trash/cheesie,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "blc" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
@@ -1040,6 +1137,10 @@
 /obj/structure/reagent_dispensers/watertank/derelict,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper)
+"bmA" = (
+/obj/item/trash/material/circuit,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bmI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1126,6 +1227,12 @@
 /obj/structure/table/bench,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/zoo)
+"bpS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bpZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/food/large,
@@ -1175,6 +1282,10 @@
 "bsz" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"bsE" = (
+/obj/item/gun/projectile/automatic/thompson,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "bsX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -1283,6 +1394,11 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"bxt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bxF" = (
 /obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
@@ -1307,6 +1423,10 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"bAs" = (
+/obj/random/oddity_guns,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bAD" = (
 /obj/item/trash/raisins,
 /turf/simulated/floor/wood/wild4,
@@ -1333,6 +1453,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"bCC" = (
+/obj/random/scrap/dense_weighted,
+/obj/random/scrap/dense_weighted,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bDO" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -1526,6 +1651,10 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
+"bPk" = (
+/obj/structure/salvageable/computer_os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bPn" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood/wild5,
@@ -1607,10 +1736,8 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "bRP" = (
-/obj/machinery/porta_turret/prepper{
-	check_access = 0
-	},
-/turf/simulated/floor/rock/dark,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "bSg" = (
 /obj/structure/table/standard,
@@ -1622,6 +1749,10 @@
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"bSF" = (
+/obj/item/trash/os_coco_wrapper,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bTm" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/asteroid/rogue)
@@ -1681,6 +1812,11 @@
 /obj/structure/scrap/vehicle,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"bVT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mopbucket,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bWf" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/remains/unathi,
@@ -1721,8 +1857,8 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "bZw" = (
-/obj/structure/bookcase,
-/turf/simulated/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "bZE" = (
 /obj/structure/window/reinforced{
@@ -1821,6 +1957,11 @@
 /obj/structure/flora/small/grassb5,
 /turf/simulated/wall/wood_old,
 /area/colony/exposedsun/pastgate)
+"cfH" = (
+/obj/structure/table/standard,
+/obj/random/surgery_tool,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cfS" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/secure/briefcase,
@@ -1857,6 +1998,10 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"chH" = (
+/obj/item/trash/syndi_cakes,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "chJ" = (
 /obj/structure/table/rack,
 /obj/random/gun_normal,
@@ -1876,6 +2021,10 @@
 	tag = "icon-cargoshwall7"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"ciL" = (
+/obj/item/trash/cigbutt/brouzouf,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "cjr" = (
 /obj/structure/table/onestar,
 /obj/structure/window/reinforced,
@@ -1999,6 +2148,11 @@
 "coU" = (
 /turf/unsimulated/mineral,
 /area/asteroid/rogue)
+"cpf" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "cpm" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/enzyme,
@@ -2023,6 +2177,11 @@
 /obj/machinery/vending/sovietsoda,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"cpO" = (
+/obj/effect/decal/cleanable/filth,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cpP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/drone_fabricator/derelict{
@@ -2072,10 +2231,19 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"crI" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/tray,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "crM" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"crR" = (
+/obj/item/mine/excelsior,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "crS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -2090,6 +2258,10 @@
 /obj/machinery/cryopod/dormitory,
 /turf/simulated/floor/wood_old,
 /area/colony/exposedsun/crashed_shop/outsider)
+"cse" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "csg" = (
 /obj/structure/table/onestar,
 /obj/structure/window/reinforced,
@@ -2223,6 +2395,11 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"cvN" = (
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/mre,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cwm" = (
 /obj/structure/flora/small/busha1,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -2241,6 +2418,13 @@
 /obj/random/junk/nondense,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"cxf" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/random/medical,
+/obj/item/storage/firstaid,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cxi" = (
 /obj/item/ammo_casing/shotgun/spent,
 /turf/simulated/floor/wood/wild5,
@@ -2277,6 +2461,11 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"czK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "czR" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/big/bush3,
@@ -2469,6 +2658,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"cKn" = (
+/obj/structure/curtain/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cKr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -2788,6 +2981,11 @@
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"cZt" = (
+/obj/item/mine/excelsior,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cZD" = (
 /obj/machinery/door/airlock/multi_tile/metal,
 /obj/random/traps/low_chance,
@@ -2813,6 +3011,11 @@
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"daH" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/obj/structure/curtain/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "daI" = (
 /turf/simulated/mineral/random/rogue,
 /area/colony/exposedsun/crashed_shop/outsider)
@@ -2894,6 +3097,12 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"dgI" = (
+/obj/effect/decal/cleanable/cobweb{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dhy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -2961,14 +3170,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "dnC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/dark/bluecorner,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "dnH" = (
 /obj/structure/bed/double/padded,
@@ -2995,7 +3198,8 @@
 /turf/simulated/floor/rock/dark,
 /area/asteroid/rogue)
 "dpI" = (
-/turf/simulated/floor/tiled/dark/bluecorner,
+/obj/machinery/shieldwallgen/excelsior,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "dpK" = (
 /obj/structure/morgue,
@@ -3168,6 +3372,10 @@
 /obj/item/gun/projectile/boltgun/flare_gun,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
+"dyd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "dyi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/small/busha2,
@@ -3315,6 +3523,10 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"dEf" = (
+/obj/random/traps/low_chance,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "dEA" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
@@ -3352,6 +3564,11 @@
 	tag = "icon-cargoshwall28"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"dGf" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dGh" = (
 /obj/random/mat_katana,
 /obj/structure/table/rack/shelf,
@@ -3425,6 +3642,11 @@
 /obj/structure/closet/crate/serbcrate,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
+"dIZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dJV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/engineering,
@@ -3458,6 +3680,10 @@
 /obj/random/tool,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"dLa" = (
+/obj/machinery/autodoc,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dLt" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/vault)
@@ -3478,6 +3704,11 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
+"dMj" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/projectile/boltgun,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dMv" = (
 /obj/machinery/porta_turret/prepper{
 	check_access = 0;
@@ -3595,6 +3826,11 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"dVw" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dWh" = (
 /obj/structure/flora/big/bush1,
 /turf/unsimulated/wall/jungle,
@@ -3609,6 +3845,10 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"dYA" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dYN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
@@ -4078,6 +4318,10 @@
 "euc" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"euk" = (
+/obj/structure/sign/warning/armory/small,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "euG" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -4121,6 +4365,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"evX" = (
+/obj/structure/flora/small/grassb2,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "ewd" = (
 /obj/structure/flora/small/busha2,
 /mob/living/carbon/superior_animal/vox/ashen,
@@ -4159,6 +4407,11 @@
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"exQ" = (
+/obj/random/lowkeyrandom,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eyw" = (
 /obj/structure/table/onestar,
 /obj/structure/flora/pottedplant/dead{
@@ -4245,6 +4498,10 @@
 /obj/random/ammo_lowcost/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
+"eHj" = (
+/obj/structure/sign/faction/excelsior_old,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "eHE" = (
 /obj/structure/boulder,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -4362,6 +4619,11 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"ePc" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ePq" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -4412,6 +4674,18 @@
 /obj/random/booze,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"eSZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"eUu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eUV" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushb3,
@@ -4661,6 +4935,12 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
+"fgg" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/item/computer_hardware/hard_drive/portable/design/medical/advanced,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fgw" = (
 /obj/structure/closet/random_medsupply,
 /obj/item/storage/firstaid/ifak,
@@ -4899,6 +5179,10 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
+"fvq" = (
+/obj/structure/salvageable/data_os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fvS" = (
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/asteroid/rogue)
@@ -5047,6 +5331,10 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"fEy" = (
+/obj/structure/sign/warning/nosmoking,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "fFb" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark,
@@ -5132,6 +5420,11 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
+"fIY" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fJf" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/asteroid/dirt,
@@ -5300,6 +5593,13 @@
 /obj/structure/closet/random_hostilemobs,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"fTr" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "fTI" = (
 /obj/structure/target_stake,
 /obj/item/target/syndicate,
@@ -5396,6 +5696,11 @@
 /obj/random/pouch,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"fXm" = (
+/obj/effect/decal/cleanable/filth,
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fXI" = (
 /obj/structure/railing/grey,
 /obj/effect/step_trigger/vault_bunker_2F,
@@ -5435,6 +5740,16 @@
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/dungeon/outside/zoo)
+"gaK" = (
+/obj/random/lowkeyrandom/low_chance,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"gbh" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gbx" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
@@ -5621,6 +5936,16 @@
 /obj/random/cluster/spiders/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"glM" = (
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo/low_chance,
+/obj/random/ammo/low_chance,
+/obj/item/ammo_magazine/ammobox/antim_small,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gmm" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -5670,6 +5995,11 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"goL" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre/alt,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "goO" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/decal/cleanable/generic,
@@ -5884,6 +6214,17 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"gxY" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/filth,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gys" = (
 /obj/item/tool/broken_bottle,
 /obj/effect/decal/cleanable/generic,
@@ -5990,6 +6331,10 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"gCX" = (
+/obj/random/dungeon_gun_energy/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gDf" = (
 /obj/structure/closet/secure_closet/bar,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -6018,6 +6363,10 @@
 /obj/random/junkfood,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"gDT" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gEm" = (
 /obj/structure/flora/big/rocks2,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -6051,6 +6400,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"gID" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gIP" = (
 /obj/machinery/door/airlock/freezer,
 /turf/simulated/floor/tiled/cafe,
@@ -6067,6 +6421,11 @@
 /obj/structure/invislight,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/prepper)
+"gKn" = (
+/obj/structure/table/standard,
+/obj/random/medical/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gKF" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/wild3,
@@ -6110,6 +6469,10 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"gNQ" = (
+/obj/structure/salvageable/autolathe,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gNT" = (
 /obj/landmark/join/start/outsider,
 /turf/simulated/shuttle/floor/mining{
@@ -6145,6 +6508,12 @@
 /obj/random/traps,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"gPe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/mine/excelsior,
+/obj/item/trash/candy/proteinbar,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gPn" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light,
@@ -6184,6 +6553,11 @@
 /obj/item/storage/box/matches,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"gRv" = (
+/obj/effect/decal/cleanable/filth,
+/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gRw" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
@@ -6340,6 +6714,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"gXV" = (
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gYu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
@@ -6426,6 +6804,11 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"hdM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/makarov/preloaded,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hdO" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -6467,8 +6850,9 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
 "hgL" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/rock/dark,
+/obj/item/trash/cigbutt/fortress,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "hhc" = (
 /obj/structure/table/steel_reinforced,
@@ -6515,6 +6899,11 @@
 /obj/item/stack/material/glass/random,
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
+"hjE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hjQ" = (
 /obj/random/lathe_disk/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -6675,6 +7064,9 @@
 /obj/random/pouch,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"hoR" = (
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "hpb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/stack/medical/bruise_pack/handmade,
@@ -6752,6 +7144,11 @@
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"htl" = (
+/obj/machinery/suit_storage_unit/excelsior,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "htO" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 4
@@ -6838,6 +7235,10 @@
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
+"hzz" = (
+/obj/structure/reagent_dispensers/fueltank/derelict,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hzS" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 4
@@ -6959,6 +7360,11 @@
 /obj/random/boxes,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"hHA" = (
+/obj/machinery/door/airlock/centcom,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hHJ" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/random/mob/prepper,
@@ -6978,6 +7384,14 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
+"hJv" = (
+/obj/structure/medical_stand,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"hJx" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hJC" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -7019,6 +7433,18 @@
 /obj/effect/step_trigger/ironcompound_to_abandonedfortress_1_A,
 /turf/unsimulated/mineral,
 /area/colony)
+"hMw" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/random/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"hNy" = (
+/obj/structure/table/rack,
+/obj/effect/decal/cleanable/filth,
+/obj/item/gun_upgrade/trigger/boom,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hNJ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -7202,6 +7628,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
+"hWp" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hWt" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/trash/pistachios,
@@ -7313,6 +7744,13 @@
 /obj/item/tool/scythe,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"ida" = (
+/obj/structure/bed/psych{
+	desc = "It can be a bit noisy, but still serves well.";
+	name = "old bed"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "idi" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -7434,6 +7872,13 @@
 /obj/random/scrap,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"ijN" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ijO" = (
 /obj/effect/step_trigger/vault_bunker_2E,
 /turf/simulated/floor/tiled/dark,
@@ -7518,6 +7963,11 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"iow" = (
+/obj/item/flame/lighter/zippo/excelsior,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ioB" = (
 /obj/structure/flora/small/bushc2,
 /turf/unsimulated/wall/jungle,
@@ -7762,6 +8212,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"izb" = (
+/turf/simulated/wall/wood,
+/area/asteroid/rogue)
+"izz" = (
+/obj/structure/bed/chair/comfy,
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "izY" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/firstaid,
@@ -7959,6 +8416,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
+"iIL" = (
+/obj/structure/flora/small/grassa2,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "iIR" = (
 /turf/simulated/wall,
 /area/nadezhda/outside/meadow)
@@ -8071,6 +8532,13 @@
 /obj/random/tank/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"iRt" = (
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "spiderling";
+	name = "dead spider"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "iRv" = (
 /obj/machinery/light/floor{
 	pixel_y = -7
@@ -8293,6 +8761,10 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"jcQ" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jcV" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/hatton/moebius,
@@ -8358,6 +8830,19 @@
 /obj/structure/bed/chair/sofa/black,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/safehouse)
+"jeV" = (
+/obj/item/stock_parts/manipulator/excelsior,
+/obj/item/stock_parts/manipulator/excelsior,
+/obj/item/stock_parts/manipulator/excelsior,
+/obj/item/stock_parts/capacitor/excelsior,
+/obj/item/stock_parts/matter_bin/excelsior,
+/obj/item/stock_parts/micro_laser/excelsior,
+/obj/item/stock_parts/micro_laser/excelsior,
+/obj/item/stock_parts/scanning_module/excelsior,
+/obj/structure/table/standard,
+/obj/item/computer_hardware/hard_drive/portable/design/guns/ex_vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jeZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -8571,8 +9056,8 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/zoo)
 "jnq" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/dark/bluecorner,
+/obj/machinery/door/unpowered/simple/wood,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "jnw" = (
 /obj/structure/invislight,
@@ -8646,6 +9131,11 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"jrM" = (
+/obj/machinery/door/airlock/centcom,
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jrV" = (
 /obj/random/cluster/spiders,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -8743,6 +9233,14 @@
 /obj/machinery/vending/medical,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
+"jzZ" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/port_gen/pacman/diesel/anchored,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jBj" = (
 /obj/structure/multiz/stairs/active/bottom{
 	dir = 4
@@ -8756,6 +9254,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/dungeon/outside/zoo)
+"jBP" = (
+/obj/item/gun/projectile/colt,
+/obj/item/ammo_kit,
+/obj/random/scrap,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "jCe" = (
 /obj/effect/gibspawner/human,
 /turf/simulated/floor/asteroid/dirt,
@@ -8786,6 +9290,15 @@
 /obj/structure/flora/small/busha3,
 /turf/unsimulated/wall/jungle,
 /area/colony/exposedsun/pastgate)
+"jDh" = (
+/obj/structure/sign/departmentold/medical2,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
+"jEp" = (
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "jEI" = (
 /obj/structure/flora/small/grassb5,
 /obj/random/scrap/dense_even,
@@ -8810,6 +9323,14 @@
 /obj/item/mine_old,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"jFc" = (
+/obj/structure/safe/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "cobweb1"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jFP" = (
 /obj/structure/flora/small/busha2,
 /obj/random/flora/small_jungle_tree,
@@ -8857,11 +9378,30 @@
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"jHe" = (
+/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/revolver/deacon,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"jHE" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/trash/icecreambowl,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "jHF" = (
 /obj/structure/catwalk,
 /mob/living/carbon/superior_animal/human/voidwolf/captain,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"jHP" = (
+/obj/machinery/autolathe,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"jHS" = (
+/obj/structure/bookcase/manuals/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jIL" = (
 /obj/structure/closet/crate/solar,
 /turf/simulated/floor/tiled,
@@ -8978,6 +9518,15 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"jNk" = (
+/obj/structure/flora/small/grassa5,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
+"jNA" = (
+/mob/living/simple_animal/hostile/diyaab,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jND" = (
 /obj/structure/closet/crate/serbcrate,
 /obj/item/rig_module/device/drill,
@@ -9045,6 +9594,11 @@
 /obj/random/cloth/masks,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"jQO" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jQP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9064,6 +9618,18 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"jRU" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"jRZ" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/gun/projectile/rpg,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jSh" = (
 /obj/structure/showcase/sign2{
 	desc = "A warning sign depicting a small gun and a hazard symbol.";
@@ -9080,6 +9646,16 @@
 /obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"jSI" = (
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "spiderling";
+	name = "dead spider"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jTE" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light/small{
@@ -9169,6 +9745,10 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/item/ammo_magazine/maxim_75,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"jXU" = (
+/obj/structure/sign/warning/lethal_turrets,
+/turf/simulated/wall,
 /area/asteroid/rogue)
 "jYj" = (
 /obj/structure/shuttle_part/cargo{
@@ -9469,6 +10049,11 @@
 /obj/machinery/door/window/westright,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"knN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank/huge/derelict,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "knU" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -9535,6 +10120,11 @@
 /obj/item/noslipmodule,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"kro" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "krI" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/busha2,
@@ -9547,12 +10137,23 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"ksx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/gun_cheap/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ksF" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"ksL" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/plate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ksS" = (
 /obj/structure/flora/small/grassb3,
 /obj/structure/flora/small/busha2,
@@ -9580,6 +10181,10 @@
 /obj/random/science,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"kuJ" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kuK" = (
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -9621,6 +10226,11 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"kwB" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kxe" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plating/under,
@@ -9697,6 +10307,11 @@
 "kBn" = (
 /obj/item/ammo_magazine/light_rifle_257/empty,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"kBA" = (
+/obj/structure/bookcase,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "kBQ" = (
 /obj/random/junk/cigbutt,
@@ -9844,6 +10459,10 @@
 	},
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"kKj" = (
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kKF" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/simulated/floor/asteroid/dirt,
@@ -9902,6 +10521,12 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"kNY" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/mine/excelsior,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "kOq" = (
 /obj/structure/flora/small/bushb2,
 /turf/simulated/floor/asteroid/dirt,
@@ -9954,6 +10579,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"kRS" = (
+/obj/item/gun/projectile/makarov/preloaded,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kSg" = (
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -9968,6 +10597,10 @@
 /obj/random/claymore,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"kSP" = (
+/obj/random/scrap/dense_weighted,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kST" = (
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /turf/simulated/floor/wood/wild3,
@@ -10096,6 +10729,10 @@
 "laY" = (
 /turf/simulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"lbn" = (
+/obj/machinery/door/airlock,
+/turf/space,
+/area/asteroid/rogue)
 "lbt" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush1,
@@ -10108,6 +10745,11 @@
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"lcz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/autoinjector/drugs,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lcK" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/small/bushb2,
@@ -10135,6 +10777,11 @@
 /obj/structure/bed/chair/custom/onestar,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"lej" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre_shokoladka,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "lep" = (
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -10158,6 +10805,11 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"lgl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lgw" = (
 /obj/structure/table/standard,
 /obj/item/clothing/accessory/stethoscope,
@@ -10288,10 +10940,19 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"llD" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "llJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
+"llR" = (
+/obj/structure/sign/directions/medical,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "llS" = (
 /obj/structure/barricade,
 /obj/structure/cable{
@@ -10353,6 +11014,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
+"lrL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lrY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -10456,6 +11122,11 @@
 /obj/machinery/door/airlock/freezer,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/nadezhda/dungeon/outside/zoo)
+"lyh" = (
+/obj/machinery/cooking_with_jane/grill,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lyG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -10523,6 +11194,10 @@
 	},
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"lCt" = (
+/obj/item/mine/excelsior,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "lCx" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/big/bush2,
@@ -10568,8 +11243,9 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "lEJ" = (
-/obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall,
+/obj/item/mine/excelsior,
+/obj/landmark/corpse/excelsior,
+/turf/simulated/floor/rock/dark,
 /area/asteroid/rogue)
 "lEN" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -10603,6 +11279,11 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"lGh" = (
+/obj/random/lowkeyrandom/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lGl" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/tool,
@@ -10750,6 +11431,10 @@
 /obj/random/mob/undergroundmob/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"lPa" = (
+/obj/structure/coatrack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lPc" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -10841,6 +11526,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"lUB" = (
+/obj/structure/cable,
+/obj/item/circuitboard/apc,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "West APC";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plating/under,
+/area/asteroid/rogue)
 "lUD" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -10982,6 +11677,10 @@
 /obj/structure/reagent_dispensers/bidon,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"maX" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mbB" = (
 /obj/random/closet_wardrobe,
 /turf/simulated/floor/wood_old,
@@ -10995,6 +11694,10 @@
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/nadezhda/dungeon/outside/zoo)
+"mch" = (
+/obj/structure/sign/painting/russianstalin,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "mey" = (
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -11171,6 +11874,16 @@
 /obj/structure/curtain/medical,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
+"mny" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mnY" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark,
@@ -11301,6 +12014,11 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
+"msM" = (
+/obj/structure/table/marble,
+/obj/item/storage/pouch/ammo,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "msY" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/item/clothing/head/hairflower/blue,
@@ -11353,6 +12071,10 @@
 /obj/structure/bed/chair/custom/onestar/red,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"mvg" = (
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mvp" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/material_ore,
@@ -11427,6 +12149,11 @@
 /obj/random/surgery_tool/low_chance,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"mBg" = (
+/obj/structure/table/woodentable,
+/obj/item/implanter/excelsior/broken,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mBi" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -11536,6 +12263,10 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"mEl" = (
+/obj/item/storage/fancy/mre_cracker,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mEu" = (
 /obj/random/closet/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -11583,6 +12314,11 @@
 /obj/random/techpart,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"mFx" = (
+/obj/structure/scrap_cube,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mFJ" = (
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -11615,6 +12351,10 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"mHd" = (
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mHA" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -11727,6 +12467,12 @@
 /obj/structure/flora/small/grassb5,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
+"mLR" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "mMt" = (
 /obj/structure/table/woodentable,
 /obj/random/contraband,
@@ -11903,6 +12649,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"mTI" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mTJ" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -11911,6 +12662,11 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"mTK" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre_candy,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mTP" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/random/lowkeyrandom/low_chance,
@@ -12091,6 +12847,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"ncv" = (
+/obj/effect/decal/cleanable/rubble,
+/mob/living/simple_animal/hostile/scarybat,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "ncG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/circuitboard,
@@ -12114,6 +12875,20 @@
 /obj/structure/flora/big/bush1,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"ndn" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/firstaid/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"ndt" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/tool/sword/saber,
+/obj/effect/decal/cleanable/blood,
+/obj/landmark/corpse/chef,
+/mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ndw" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -12145,6 +12920,12 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"neP" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "neV" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/hypospray/autoinjector/drugs,
@@ -12211,6 +12992,15 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"njg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/fiction{
+	name = "Communist Manifesto"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nji" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -12232,6 +13022,14 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper)
+"nkh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/psych{
+	desc = "It can be a bit noisy, but still serves well.";
+	name = "old bed"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nkk" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -12268,6 +13066,11 @@
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"nlF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/plate,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nlG" = (
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -12417,7 +13220,9 @@
 /obj/structure/bookcase/metal,
 /obj/item/book/manual/fiction/warandpeace,
 /obj/item/book/manual/fiction/waroftheworlds,
-/obj/item/book/manual/fiction/achristmascarol,
+/obj/item/book/manual/fiction/achristmascarol{
+	icon = s
+	},
 /obj/item/book/manual/fiction/journeytothecenter,
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
@@ -12641,6 +13446,15 @@
 /obj/random/rig_module,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"nFy" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"nGF" = (
+/obj/machinery/cooking_with_jane/stove,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nGI" = (
 /obj/effect/decal/cleanable/rubble,
 /mob/living/carbon/superior_animal/wurm/osmium,
@@ -12728,6 +13542,11 @@
 /obj/item/computer_hardware/hard_drive/portable/design/excelsior,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"nOD" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nOF" = (
 /obj/effect/overlay/wallrot,
 /turf/simulated/wall,
@@ -12742,6 +13561,12 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"nPA" = (
+/obj/item/mine/excelsior,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nPK" = (
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/asteroid/dirt,
@@ -12752,6 +13577,15 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"nPV" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"nQa" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nQC" = (
 /obj/structure/table/standard,
 /obj/item/tool/tape_roll/flextape,
@@ -12785,6 +13619,19 @@
 /obj/structure/invislight,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"nSj" = (
+/obj/effect/dummy,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"nSk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/ammo/shotgun,
+/obj/random/ammo/shotgun/low_chance,
+/obj/random/ammo/shotgun/low_chance,
+/obj/random/ammo_fancy,
+/obj/random/ammo_fancy,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nTA" = (
 /turf/simulated/floor/asteroid/grass/colonialjungle4,
 /area/nadezhda/outside/meadow)
@@ -12948,6 +13795,12 @@
 /obj/effect/step_trigger/vault_bunker_1C,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"ocM" = (
+/obj/random/lowkeyrandom/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ocU" = (
 /obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -13092,6 +13945,10 @@
 /obj/item/oddity/common/old_money,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"oiJ" = (
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oiQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/knife,
@@ -13320,8 +14177,8 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
 "ouu" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/tiled/dark/bluecorner,
+/obj/item/trash/semki,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "ovb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13453,6 +14310,10 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
+"oBN" = (
+/obj/item/trash/mre,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "oBT" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -13464,6 +14325,9 @@
 /obj/structure/table,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"oCe" = (
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "oCm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13557,6 +14421,11 @@
 /obj/random/pack/cloth,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"oFf" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/material/device,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oFC" = (
 /obj/random/lathe_disk/advanced,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -13747,6 +14616,15 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/mineral/random/rogue,
 /area/colony/exposedsun/crashed_shop/outsider)
+"oNp" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oNq" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -13842,9 +14720,8 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "oSA" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/black,
-/turf/simulated/floor/tiled/dark/bluecorner,
+/obj/random/lowkeyrandom,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "oSD" = (
 /obj/random/pack/junk_machine,
@@ -13943,6 +14820,11 @@
 /obj/machinery/door/airlock,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"oVG" = (
+/obj/structure/table/rack,
+/obj/item/gun/energy/stunrevolver,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oVH" = (
 /obj/structure/table/rack,
 /obj/random/gun_normal,
@@ -13964,6 +14846,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"oXa" = (
+/obj/item/implant/excelsior/broken,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oXm" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -14033,10 +14919,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"pbc" = (
+/obj/item/bedsheet,
+/obj/structure/bed,
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "pbd" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"pbj" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
+"pbT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/mre/alt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pbZ" = (
 /obj/structure/table/rack/shelf,
 /obj/random/dungeon_gun_mods/low_chance,
@@ -14079,6 +14979,12 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"pft" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pgh" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	name = "General Containment"
@@ -14224,6 +15130,12 @@
 /obj/item/stack/material/wood/random,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"pmd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pmi" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood/wild4,
@@ -14346,6 +15258,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"ptd" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pty" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -14544,6 +15460,11 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"pEI" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pEQ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/mine_old,
@@ -14853,6 +15774,11 @@
 	},
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"pRk" = (
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pRE" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -14948,6 +15874,13 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper)
+"pVA" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pVL" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
@@ -14980,6 +15913,15 @@
 /obj/effect/step_trigger/monster_to_beast_1_A,
 /turf/simulated/floor/asteroid/dirt,
 /area/colony/exposedsun/pastgate)
+"pXo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pYa" = (
 /obj/structure/flora/rock,
 /turf/simulated/floor/asteroid/grass,
@@ -15058,6 +16000,15 @@
 	},
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"pZU" = (
+/obj/random/dungeon_gun_ballistic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"qai" = (
+/obj/item/trash/popcorn,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qaj" = (
 /obj/structure/closet/l3closet,
 /turf/simulated/floor/tiled/white/panels,
@@ -15079,6 +16030,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"qaJ" = (
+/obj/random/mecha/damaged/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mech_recharger,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qbx" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	locked = 1;
@@ -15187,8 +16144,8 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "qhe" = (
-/obj/machinery/door/airlock,
-/turf/simulated/wall/r_wall,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "qhr" = (
 /obj/structure/bed/chair/shuttle{
@@ -15530,6 +16487,10 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/meadow)
+"qzI" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qzP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -15540,6 +16501,15 @@
 /obj/structure/flora/small/bushc1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"qAh" = (
+/obj/random/scrap,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"qAA" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/stack/medical/bruise_pack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qAS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -15632,6 +16602,10 @@
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"qDV" = (
+/obj/item/trash/mre_paste,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qEm" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 2
@@ -15801,6 +16775,11 @@
 /obj/machinery/cryopod/dormitory,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
+"qNB" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/candle,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qNO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/molten_item,
@@ -16156,6 +17135,11 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/zoo)
+"rec" = (
+/obj/structure/table/rack,
+/obj/item/gun/projectile/automatic/vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rel" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/mineral/random/rogue,
@@ -16186,6 +17170,14 @@
 "rgE" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"rgN" = (
+/obj/item/book/manualshield_generator_guide,
+/obj/item/cell/large/excelsior,
+/obj/item/cell/large/excelsior,
+/obj/structure/table/standard,
+/obj/item/part/gun/frame/basilisk,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rgX" = (
 /obj/random/techpart/low_chance,
 /obj/random/closet_maintloot,
@@ -16246,11 +17238,21 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"rlf" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rli" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap_cube,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"rlq" = (
+/obj/item/trash/broken_robot_part,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rlt" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -16413,6 +17415,12 @@
 /obj/random/closet/low_chance,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"rti" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/gun/projectile/automatic/ak47/saiga,
+/obj/item/gun/projectile/automatic/ak47/saiga,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rtr" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/asteroid/dirt,
@@ -16463,6 +17471,11 @@
 	tag = "icon-cargoshwall30"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"rvu" = (
+/obj/structure/table/rack,
+/obj/random/gun_parts,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rvx" = (
 /obj/machinery/door/airlock/glass{
 	locked = 1;
@@ -16503,6 +17516,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"rwZ" = (
+/obj/landmark/corpse/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rxy" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -16695,6 +17712,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"rHH" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "rHY" = (
 /turf/unsimulated/mineral,
 /area/colony/exposedsun/pastgate)
@@ -16735,6 +17756,11 @@
 /obj/structure/flora/small/lavarock1,
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
+/area/asteroid/rogue)
+"rKx" = (
+/obj/item/storage/hcases/ammo/excel,
+/obj/structure/closet/crate/excelsior,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "rKz" = (
 /turf/simulated/wall/r_wall,
@@ -16805,6 +17831,11 @@
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"rQE" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre/alt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rQF" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/wood/wild4,
@@ -16824,6 +17855,18 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"rQU" = (
+/obj/structure/sign/departmentold/janitorial,
+/turf/simulated/wall,
+/area/asteroid/rogue)
+"rQX" = (
+/obj/item/trash/peachcan,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"rRc" = (
+/obj/item/trash/gamerchips,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rRg" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -16849,6 +17892,10 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"rSf" = (
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rSp" = (
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -16885,6 +17932,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"rUc" = (
+/obj/item/trash/mre_shokoladka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rUt" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -16893,6 +17944,12 @@
 /obj/structure/medical_stand,
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/crashed_shop/outsider)
+"rVQ" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rVT" = (
 /obj/machinery/door/blast/regular{
 	id = "prepper room A"
@@ -16915,6 +17972,11 @@
 /mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"rWT" = (
+/obj/effect/decal/cleanable/filth,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rXh" = (
 /obj/structure/catwalk,
 /obj/structure/railing/grey{
@@ -16932,6 +17994,14 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"rXS" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rYj" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/tool/shovel/improvised,
@@ -17093,6 +18163,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
+"sgs" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "sgz" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -17151,6 +18225,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"siV" = (
+/mob/living/simple_animal/hostile/bear/excelsior,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "sjc" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/big/bush3,
@@ -17189,6 +18267,11 @@
 	},
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"skU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "skV" = (
 /obj/structure/salvageable/console_os{
 	dir = 8
@@ -17200,6 +18283,10 @@
 /obj/structure/salvageable/personal,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"slv" = (
+/obj/structure/sign/faction/excelsior_old,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "slw" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -17223,6 +18310,11 @@
 /obj/item/oddity/common/paper_omega,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"smC" = (
+/obj/random/lowkeyrandom,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "smK" = (
 /obj/structure/table/rack/shelf,
 /obj/random/junkfood,
@@ -17261,6 +18353,11 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"spk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/firstaid/regular/empty,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "spm" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/stack/material/diamond/random,
@@ -17314,6 +18411,12 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/undergroundmob/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"ssg" = (
+/obj/structure/janitorialcart,
+/obj/item/keys/janitor,
+/obj/item/mop,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "ssJ" = (
 /obj/structure/bed/chair/custom/onestar/red{
@@ -17441,6 +18544,10 @@
 /obj/structure/scrap/large,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"szd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "sze" = (
 /obj/structure/flora/small/rock2,
 /turf/simulated/floor/asteroid/grass,
@@ -17535,6 +18642,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
+"sFp" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sFD" = (
 /obj/random/mob/prepper,
 /turf/simulated/floor/carpet/bcarpet,
@@ -17735,6 +18848,12 @@
 /obj/item/oddity/common/old_radio,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"sQu" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sQy" = (
 /obj/structure/table/rack/shelf,
 /obj/effect/decal/cleanable/dirt,
@@ -17785,6 +18904,10 @@
 /obj/item/stack/tile/carpet/gaycarpet,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"sSp" = (
+/obj/landmark/corpse/excelsior,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "sTa" = (
 /obj/structure/multiz/stairs/active{
 	dir = 4
@@ -17803,6 +18926,11 @@
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"sVt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sVx" = (
 /obj/structure/railing/grey{
 	dir = 1;
@@ -17830,6 +18958,12 @@
 /obj/item/storage/firstaid/surgery/combat,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"sYe" = (
+/obj/machinery/door/airlock/centcom,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/mine/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sYB" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/glowstick/flare/torch,
@@ -17872,6 +19006,15 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"tao" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"tau" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "taJ" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
@@ -17974,11 +19117,9 @@
 /turf/simulated/floor/rock/manmade/concrete,
 /area/nadezhda/outside/meadow)
 "tgr" = (
-/obj/machinery/door/airlock/highsecurity{
-	id_tag = "prepperrad_door_one";
-	locked = 1
-	},
-/turf/simulated/floor/tiled/dark/bluecorner,
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/trash,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "tgL" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -18089,6 +19230,10 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"tlG" = (
+/obj/structure/salvageable/implant_container_os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tlO" = (
 /obj/structure/closet/onestar/tier3/special,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -18101,6 +19246,10 @@
 "tml" = (
 /turf/simulated/mineral/planet,
 /area/colony/exposedsun/pastgate)
+"tmt" = (
+/obj/item/trash/cigbutt/fortressblue,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tmw" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha3,
@@ -18122,6 +19271,10 @@
 /obj/item/frame/apc,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"tmW" = (
+/obj/item/mine/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tnY" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/wood/wild5,
@@ -18159,11 +19312,27 @@
 /obj/random/tool_upgrade/rare,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"tpL" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/rcd/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tqA" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/claymore,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"tqU" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/tool/baton/excelbaton,
+/obj/item/tool/baton/excelbaton,
+/obj/item/clothing/suit/space/void/excelsior,
+/obj/item/clothing/head/helmet/space/void/excelsior,
+/obj/random/melee/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/boltgun/heavysniper,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "trl" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -18199,6 +19368,10 @@
 /obj/random/oddity_guns,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"ttl" = (
+/obj/structure/salvageable/console_broken_os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ttx" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/wood/wild3,
@@ -18276,6 +19449,10 @@
 	},
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/meadow)
+"tyl" = (
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tyI" = (
 /obj/structure/closet/random_medsupply,
 /obj/item/storage/firstaid,
@@ -18417,6 +19594,11 @@
 /obj/structure/salvageable/bliss,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/dungeon/outside/prepper)
+"tFp" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tFU" = (
 /obj/structure/flora/small/busha2,
 /obj/item/mine/armed,
@@ -18446,6 +19628,11 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"tIU" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tIV" = (
 /obj/asteroid_spawner/rogue_teleporter,
 /obj/rogue/teleporter,
@@ -18455,6 +19642,11 @@
 /mob/living/simple_animal/hostile/republicon/range,
 /turf/unsimulated/mineral,
 /area/colony)
+"tJe" = (
+/obj/structure/table/gamblingtable,
+/obj/item/gun/projectile/makarov/preloaded,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tJh" = (
 /obj/structure/salvageable/console_os{
 	dir = 4
@@ -18549,6 +19741,10 @@
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"tNG" = (
+/obj/item/part/gun/frame/vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tNR" = (
 /obj/structure/table/standard,
 /obj/random/surgery_tool/low_chance,
@@ -18567,6 +19763,11 @@
 /obj/structure/closet/secure_closet/rare_loot,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"tOp" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tOG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/remains/human,
@@ -18587,6 +19788,12 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
+"tPT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tQf" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/small/busha3,
@@ -18622,6 +19829,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
+"tSz" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tSB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -18695,6 +19907,10 @@
 "tVT" = (
 /obj/random/cluster/spiders/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"tWN" = (
+/obj/structure/scrap/medical/large,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "tWP" = (
 /obj/machinery/porta_turret/prepper,
@@ -18847,6 +20063,12 @@
 /mob/living/carbon/superior_animal/robot/greyson/synthetic,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"udE" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/rubble,
+/obj/item/bedsheet,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "udZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -18939,10 +20161,24 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"uhz" = (
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uih" = (
 /obj/machinery/power/smes/buildable,
 /turf/simulated/shuttle/floor/mining,
 /area/colony/exposedsun/crashed_shop/outsider)
+"uiu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/clothing/shoes/jackboots/janitor,
+/obj/structure/closet/l3closet/janitor,
+/obj/item/toy/figure/character/civilian/janitor,
+/obj/item/clothing/under/rank/janitor,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ujb" = (
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -19014,6 +20250,17 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"unn" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/tool/baton/excelbaton,
+/obj/item/tool/baton/excelbaton,
+/obj/item/clothing/suit/space/void/excelsior,
+/obj/item/clothing/head/helmet/space/void/excelsior,
+/obj/random/melee/low_chance,
+/obj/item/gun/projectile/automatic/drozd,
+/obj/item/gun/projectile/automatic/drozd,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "unD" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
@@ -19160,6 +20407,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"uvF" = (
+/obj/item/storage/fancy/vials,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uvO" = (
 /obj/structure/flora/small/grassb3,
 /obj/structure/flora/small/busha1,
@@ -19400,6 +20651,13 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"uId" = (
+/obj/structure/table/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/gun_parts,
+/obj/item/gun_upgrade/barrel/faulty,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uIf" = (
 /obj/structure/railing/grey,
 /obj/effect/step_trigger/vault_bunker_1F,
@@ -19434,9 +20692,7 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "uIZ" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/turf/simulated/floor/tiled/dark/bluecorner,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "uJw" = (
 /turf/simulated/wall/wood_old,
@@ -19454,6 +20710,11 @@
 /obj/structure/flora/small/busha3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"uKB" = (
+/obj/structure/table/marble,
+/obj/item/gun/projectile/automatic/ak47,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uKY" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/wood/wild4,
@@ -19486,6 +20747,10 @@
 /obj/item/oddity/common/old_id,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/dungeon/outside/zoo)
+"uMg" = (
+/obj/random/traps/low_chance,
+/turf/simulated/floor/rock/grey,
+/area/asteroid/rogue)
 "uMr" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Bathroom"
@@ -19538,6 +20803,11 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"uOL" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "uON" = (
 /obj/machinery/gym,
@@ -19650,6 +20920,11 @@
 /obj/machinery/cryopod/dormitory,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"uTB" = (
+/obj/machinery/door/airlock,
+/obj/item/mine/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uTO" = (
 /obj/structure/flora/small/bushb3,
 /obj/random/scrap/dense_even,
@@ -19700,6 +20975,11 @@
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"uVz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/peachcan,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uVU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -19879,6 +21159,12 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"vfH" = (
+/obj/structure/table/woodentable,
+/obj/item/clothing/under/excelsior/officer,
+/obj/item/clothing/head/exceslior/excelsior_officer,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vfL" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
@@ -20115,11 +21401,22 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"vqz" = (
+/obj/machinery/vending/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vqP" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"vtc" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "vto" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/plating/under,
@@ -20147,6 +21444,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"vtG" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vuc" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 4;
@@ -20367,6 +21670,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/colony/exposedsun/crashed_shop/outsider)
+"vHg" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/random/traps/low_chance,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "vHF" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -20491,6 +21799,11 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"vOl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/mre/os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vOF" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -20693,6 +22006,10 @@
 /obj/structure/flora/small/busha2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"vWE" = (
+/obj/structure/scrap_cube,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vWH" = (
 /obj/structure/toilet{
 	dir = 8
@@ -20712,6 +22029,10 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
+"vXA" = (
+/obj/machinery/suit_storage_unit/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vXM" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/asteroid/grass,
@@ -20727,6 +22048,12 @@
 /obj/random/scrap,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"vZn" = (
+/obj/item/paper/crumpled{
+	text = "You are on your own. Serve to your best extents and do not let our fortress fall!   - Skeinstovitch"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vZs" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -20781,6 +22108,10 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"wcf" = (
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wcv" = (
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/plating/under,
@@ -20790,6 +22121,12 @@
 /obj/item/clothing/head/hairflower,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"wcW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wcZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -20831,6 +22168,18 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"wfR" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wfX" = (
 /obj/item/remains/lizard,
 /obj/effect/decal/cleanable/blood,
@@ -21072,6 +22421,10 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
+"wun" = (
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wuv" = (
 /obj/structure/low_wall,
 /obj/item/material/shard,
@@ -21198,6 +22551,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"wBI" = (
+/obj/structure/sign/warning/high_voltage,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
+"wBR" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/item/storage/firstaid/combat,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wBS" = (
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/wood/wild4,
@@ -21324,11 +22687,22 @@
 /obj/item/clothing/mask/gas/old,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"wKG" = (
+/obj/item/mine/excelsior,
+/obj/effect/decal/cleanable/generic,
+/obj/random/scrap/sparse_even/low_chance,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "wKN" = (
 /obj/item/stool,
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"wKQ" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wKR" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall14";
@@ -21364,6 +22738,10 @@
 "wLJ" = (
 /obj/structure/closet/secure_closet/freezer/blood,
 /turf/simulated/floor/wood/wild4,
+/area/asteroid/rogue)
+"wLQ" = (
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "wLV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21452,6 +22830,12 @@
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"wPa" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/obj/item/trash/popcorn,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wPb" = (
 /obj/structure/closet/secure_closet/freezer/blood,
 /turf/simulated/floor/wood/wild4,
@@ -21492,6 +22876,10 @@
 /obj/item/beartrap/armed,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"wRY" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "wRZ" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -21547,6 +22935,12 @@
 /obj/random/ammo_lowcost/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/meadow)
+"wVF" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre_candy,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wVS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21610,6 +23004,10 @@
 /obj/random/cloth/armor,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"wZg" = (
+/obj/item/gun/projectile/boltgun,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wZn" = (
 /obj/machinery/light/floor{
 	pixel_y = -7
@@ -21632,8 +23030,8 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/asteroid/rogue)
 "wZW" = (
-/obj/structure/bed/chair/custom/onestar/red,
-/turf/simulated/floor/tiled/dark/bluecorner,
+/mob/living/carbon/superior_animal/human/excelsior,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "xai" = (
 /obj/effect/decal/cleanable/rubble,
@@ -21644,6 +23042,10 @@
 /obj/random/lathe_disk,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"xbH" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xbS" = (
 /obj/structure/table/rack/shelf,
 /obj/random/lowkeyrandom,
@@ -21678,6 +23080,11 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"xcU" = (
+/obj/effect/decal/cleanable/filth,
+/obj/item/trash/mre_can,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xdH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mat_katana,
@@ -21703,6 +23110,10 @@
 /obj/random/material_resources,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"xee" = (
+/obj/structure/cardboardbox,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xen" = (
 /obj/random/oddity_guns,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -21732,6 +23143,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"xfn" = (
+/obj/machinery/vending/engineering,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xfo" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -21782,6 +23197,11 @@
 /obj/random/mat_katana,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"xgt" = (
+/obj/machinery/door/airlock/centcom,
+/obj/item/mine/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xgx" = (
 /obj/structure/bed/chair/custom/onestar,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -21858,6 +23278,11 @@
 /obj/item/stack/cable_coil/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"xki" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/sosjerky,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xkq" = (
 /obj/item/stack/material/wood/random,
 /obj/effect/decal/cleanable/dirt,
@@ -21935,6 +23360,12 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"xoW" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/item/gun/projectile/boltgun,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xpA" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -21976,6 +23407,14 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"xrf" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xri" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
@@ -22089,6 +23528,11 @@
 /obj/item/tool/weldingtool,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"xxv" = (
+/obj/item/mine/excelsior,
+/obj/random/scrap/sparse_even/low_chance,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "xyD" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -22179,6 +23623,16 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
+"xEl" = (
+/obj/item/implanter/excelsior/broken,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"xEv" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "xEO" = (
 /obj/structure/table/bench/wooden,
 /obj/item/trash/broken_robot_part,
@@ -22195,6 +23649,10 @@
 /obj/random/furniture/bedsheetdouble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"xFy" = (
+/obj/random/scrap/moderate_weighted,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "xFG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -22488,6 +23946,12 @@
 /obj/item/rig/merc,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"xUz" = (
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "cobweb1"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xUP" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -22561,6 +24025,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"yaB" = (
+/obj/random/lowkeyrandom,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "yaD" = (
 /obj/structure/bed/chair/custom/onestar{
 	dir = 1
@@ -22733,6 +24202,15 @@
 /obj/structure/barricade,
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/crashed_shop/outsider)
+"yks" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/semki,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"ykG" = (
+/mob/living/simple_animal/hostile/megafauna/excelsior_cosmonaught,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ykI" = (
 /obj/structure/table/woodentable,
 /obj/random/firstaid,
@@ -38658,7 +40136,7 @@ qbU
 qbU
 qbU
 qbU
-euc
+dEf
 euc
 qbU
 euc
@@ -39071,7 +40549,7 @@ qbU
 qbU
 qbU
 qbU
-ugY
+vHg
 ugY
 ugY
 ugY
@@ -40133,7 +41611,7 @@ qbU
 qbU
 qbU
 qbU
-euc
+dEf
 qbU
 qbU
 qbU
@@ -40332,10 +41810,10 @@ qbU
 qbU
 euc
 euc
-euc
+dEf
 euc
 ugY
-euc
+dEf
 qbU
 qbU
 qbU
@@ -40537,9 +42015,9 @@ euc
 ugY
 ugY
 ugY
+dEf
 euc
-euc
-euc
+ars
 euc
 euc
 qbU
@@ -40742,7 +42220,7 @@ nxY
 qbU
 qbU
 qbU
-ugY
+vHg
 qbU
 qbU
 qbU
@@ -40964,7 +42442,7 @@ qbU
 qbU
 qbU
 euc
-euc
+dEf
 euc
 euc
 euc
@@ -41786,7 +43264,7 @@ nxY
 nxY
 qbU
 qbU
-ugY
+vHg
 qbU
 qbU
 qbU
@@ -41801,7 +43279,7 @@ qbU
 qbU
 qbU
 qbU
-euc
+ars
 euc
 ugY
 qbU
@@ -42204,7 +43682,7 @@ nxY
 nxY
 qbU
 qbU
-ugY
+ncv
 qbU
 qbU
 qbU
@@ -42217,12 +43695,12 @@ euc
 qbU
 qbU
 euc
-euc
+nSj
 euc
 qbU
 rel
 qkQ
-ugY
+vHg
 ugY
 ugY
 ugY
@@ -42420,7 +43898,7 @@ qbU
 qbU
 qbU
 euc
-ugY
+vHg
 euc
 qbU
 qbU
@@ -42854,7 +44332,7 @@ qbU
 qbU
 qbU
 qbU
-ugY
+vHg
 qbU
 qbU
 qbU
@@ -43054,7 +44532,7 @@ qbU
 qbU
 qbU
 euc
-euc
+ars
 euc
 qbU
 qbU
@@ -43249,6 +44727,7 @@ nxY
 nxY
 qbU
 eCR
+uMg
 eCR
 eCR
 eCR
@@ -43259,13 +44738,12 @@ eCR
 eCR
 eCR
 eCR
-eCR
-eCR
+uMg
 euc
 euc
 qbU
 euc
-euc
+dEf
 euc
 euc
 ugY
@@ -43464,7 +44942,7 @@ qbU
 eCR
 qbU
 qbU
-eCR
+uMg
 eCR
 qbU
 qbU
@@ -43670,7 +45148,7 @@ qbU
 qbU
 qbU
 qbU
-uVX
+crR
 qbU
 qbU
 qbU
@@ -43884,7 +45362,7 @@ qbU
 qbU
 qbU
 uVX
-uVX
+xxv
 uVX
 qbU
 uVX
@@ -44090,14 +45568,14 @@ qbU
 qbU
 uVX
 uVX
-uVX
+goL
 uVX
 uVX
 qbU
 qbU
 qbU
 uVX
-uVX
+lej
 uVX
 uVX
 dpk
@@ -44314,15 +45792,15 @@ qbU
 qbU
 euc
 euc
+dEf
 euc
-euc
-euc
+ars
 euc
 euc
 euc
 qbU
 qbU
-euc
+dEf
 qbU
 qbU
 qbU
@@ -44727,13 +46205,13 @@ qbU
 qbU
 qbU
 uVX
-uVX
+crR
 qbU
 qbU
 qbU
 qbU
 qbU
-euc
+xFy
 euc
 euc
 euc
@@ -45140,24 +46618,24 @@ qbU
 dpk
 dpk
 uVX
-uVX
+crR
+xEv
 dpk
 dpk
-dpk
+qbU
+qbU
+qbU
+qbU
+qbU
+sSp
+euc
 qbU
 qbU
 qbU
 qbU
 qbU
 euc
-euc
-qbU
-qbU
-qbU
-qbU
-qbU
-euc
-euc
+qAh
 euc
 qbU
 qbU
@@ -45347,7 +46825,7 @@ qbU
 uVX
 dpk
 uVX
-uVX
+lEJ
 qbU
 qbU
 qbU
@@ -45364,7 +46842,7 @@ qbU
 qbU
 qbU
 qbU
-euc
+qAh
 euc
 qbU
 qbU
@@ -45568,10 +47046,10 @@ qbU
 qbU
 qbU
 euc
+qAh
 euc
-euc
-euc
-euc
+jBP
+qAh
 euc
 qbU
 qbU
@@ -45761,7 +47239,7 @@ qbU
 qbU
 qbU
 uVX
-uVX
+cpf
 qbU
 qbU
 qbU
@@ -45975,8 +47453,8 @@ qbU
 qbU
 qbU
 qbU
-qbU
-qbU
+coU
+coU
 coU
 coU
 coU
@@ -46178,28 +47656,28 @@ qbU
 qbU
 qbU
 qbU
+jHE
 dpk
+wRY
+wRY
 dpk
 uVX
-uVX
-dpk
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 coU
@@ -46392,27 +47870,27 @@ qbU
 qbU
 qbU
 cKr
-dpk
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+kNY
+uVX
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -46601,27 +48079,27 @@ qbU
 qbU
 uVX
 dpk
+pbj
 uVX
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -46800,37 +48278,37 @@ nxY
 nxY
 nxY
 nxY
-coU
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-lEJ
-dpk
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+qbU
+mNA
+wKG
+ciL
 uVX
 lEJ
-rKz
-rKz
-rKz
-rKz
-rKz
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+mNA
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -47010,36 +48488,36 @@ nxY
 nxY
 nxY
 coU
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+eHj
 uVX
-dpI
-dpI
+pbj
 uVX
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+uVX
+eHj
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -47219,37 +48697,37 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-uVX
-dpI
-dpI
-uVX
-uVX
-uVX
-uVX
-uVX
+coU
 rKz
 rKz
 rKz
 rKz
-uVX
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+rKz
+mNA
+jXU
+xgt
+kKj
+jXU
+mNA
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
 qbU
 qbU
 qbU
@@ -47428,36 +48906,36 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-uVX
-dpI
-dpI
-dpI
-dpI
-dpI
-uVX
-uVX
-hgL
-bRP
+coU
 rKz
+ePc
+uIZ
+uIZ
+uIZ
+dpI
+wcf
+gDT
+uIZ
+uIZ
+dpI
+uIZ
+vOl
+bZw
+rSf
 rKz
-uVX
-uVX
-uVX
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+siV
+oCe
+iIL
+oCe
+oCe
+siV
+oCe
+rKz
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -47637,37 +49115,37 @@ nxY
 nxY
 nxY
 coU
+coU
 qbU
-qbU
-qbU
-qbU
-qbU
-bRP
-hgL
-uVX
-dpI
-dpI
-dpI
-dpI
-dpI
-uVX
-uVX
-hgL
-hgL
+oiJ
+bxt
+rRc
+uIZ
+uIZ
+uIZ
+uIZ
+skU
+bZw
+uIZ
+uIZ
+uIZ
+bZw
+uIZ
 rKz
+jNk
+oCe
+siV
+oCe
+iIL
+abV
+oCe
 rKz
-uVX
-uVX
-uVX
-uVX
-uVX
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
 qbU
 qbU
 qbU
@@ -47846,37 +49324,37 @@ nxY
 nxY
 nxY
 coU
+coU
 qbU
 qbU
-qbU
-qbU
-qbU
+tau
+bZw
+uIZ
 hgL
-hgL
-uVX
-uVX
-uVX
-dpI
-dpI
-dpI
-uVX
-uVX
-hgL
-bRP
+uIZ
+skU
+uIZ
+bZw
+tOp
+uIZ
+wZW
+uIZ
+uIZ
 rKz
+oCe
+siV
+oCe
+bsE
+siV
+oCe
+oCe
 rKz
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
 qbU
 qbU
 qbU
@@ -48055,37 +49533,37 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-bRP
-hgL
-uVX
-uVX
-uVX
-dpI
-dpI
-dpI
-uVX
-uVX
-hgL
-hgL
+coU
 rKz
+oiJ
+tao
+beO
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
 rKz
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-qbU
-qbU
-qbU
+oCe
+oCe
+jNk
+oCe
+oCe
+oCe
+siV
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
 qbU
 qbU
 qbU
@@ -48264,37 +49742,37 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
 rKz
-hgL
-hgL
-hgL
-hgL
-dpI
-dpI
-dpI
-hgL
-hgL
-hgL
+uIZ
+uIZ
+uIZ
+tmW
+uIZ
+xrf
+uIZ
+uIZ
 bRP
+uIZ
+uIZ
+uIZ
+uIZ
+bmA
 rKz
+evX
+oCe
+oCe
+siV
+siV
+jNk
+oCe
 rKz
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
 qbU
 qbU
 qbU
@@ -48473,36 +49951,36 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
+coU
 rKz
-rKz
-rKz
-rKz
+rKx
+qhe
+jcQ
+qzI
 bRP
 bRP
-dpI
-dpI
-dpI
 bRP
 bRP
+qNB
+dMj
+uIZ
+jcQ
+uIZ
+uIZ
 rKz
+oCe
+mLR
+fTr
+mLR
+mLR
+mLR
+fTr
 rKz
-rKz
-rKz
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -48682,36 +50160,36 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-rKz
+coU
+slv
+rKx
+uIZ
+uIZ
+uIZ
 bZw
+ndn
+uIZ
+uIZ
+tgr
+uIZ
+uIZ
+uIZ
+skU
 bZw
+slv
+uIZ
+uIZ
+avd
+uIZ
+bZw
+uIZ
+uIZ
 rKz
-rKz
-lEJ
-tgr
-tgr
-tgr
-lEJ
-rKz
-rKz
-rKz
-rKz
-rKz
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -48890,37 +50368,37 @@ nxY
 nxY
 nxY
 nxY
+coU
+coU
 rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-dpI
-dpI
-dpI
+uIZ
+wcf
+bZw
+bZw
+uIZ
+bZw
 wZW
-dnC
-dpI
-dpI
-dpI
-hgL
-bRP
+wZW
+uIZ
+uIZ
+qhe
+uIZ
+wcf
+uIZ
 rKz
+uIZ
+gDT
+uIZ
+uIZ
+wVF
+uIZ
+tao
 rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-uVX
-uVX
-uVX
-uVX
-uVX
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -49099,37 +50577,37 @@ nxY
 nxY
 nxY
 nxY
+coU
+coU
 rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-dpI
 uIZ
-oSA
-ouu
-dpI
-dpI
-dpI
-hgL
-bRP
+bZw
+bZw
+skU
+dIZ
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+wcf
+uIZ
+bZw
+uIZ
 rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-uVX
-uVX
-uVX
-uVX
-uVX
+jQO
+uIZ
+bZw
+bZw
+qhe
+rwZ
+tFp
+qbU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -49308,37 +50786,37 @@ nxY
 nxY
 nxY
 nxY
+coU
+coU
 rKz
-dpI
-dpI
-dpI
-dpI
-dpI
+mNA
+nFy
+nFy
+mNA
+mNA
+mNA
+mNA
+mNA
+mNA
+mNA
+mNA
+nFy
+nFy
+mNA
 rKz
-jnq
-rKz
-rKz
-rKz
-tgr
-tgr
-tgr
-rKz
-rKz
-rKz
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-rKz
-rKz
-uVX
-uVX
-uVX
-uVX
-uVX
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+tao
+qbU
+qbU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -49517,37 +50995,37 @@ nxY
 nxY
 nxY
 nxY
+coU
+coU
 rKz
-dpI
-dpI
-dpI
+uIZ
+uIZ
+uIZ
+uIZ
+bkW
+uIZ
+mHd
+bZw
+azN
+kSP
+uIZ
+uIZ
+uIZ
+uIZ
 rKz
-dpI
-rKz
-dpI
-dpI
-dpI
-rKz
-dpI
-dpI
-dpI
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-rKz
-rKz
-uVX
-uVX
-uVX
-uVX
-uVX
+uIZ
+qhe
+aNB
+uIZ
+tao
+tao
+tFp
+qbU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -49726,37 +51204,37 @@ nxY
 nxY
 nxY
 nxY
+coU
+coU
 rKz
-dpI
-dpI
-dpI
+bZw
+rlq
+uIZ
+uIZ
+uIZ
+uIZ
+qhe
+bZw
+uIZ
+kSP
+uIZ
+pbT
+uIZ
+wZW
 rKz
-dpI
-dpI
-dpI
-dpI
-dpI
-rKz
-dpI
-dpI
-dpI
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-rKz
-rKz
-uVX
-uVX
-uVX
-uVX
-uVX
+rUc
+tmW
+uIZ
+uIZ
+uIZ
+uIZ
+tFp
+qbU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -49935,38 +51413,38 @@ nxY
 nxY
 nxY
 nxY
+coU
+coU
 rKz
-dpI
-dpI
-dpI
+bZw
+uIZ
+rlq
+kSP
+ptd
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+tmt
+uIZ
+bZw
+uIZ
 rKz
-dpI
+gXV
+bZw
+bZw
+uIZ
+tOp
+bZw
+mTI
 rKz
-dpI
-dpI
-dpI
-rKz
-dpI
-dpI
-dpI
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-rKz
-rKz
-uVX
-uVX
-uVX
-uVX
-uVX
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -50144,38 +51622,38 @@ nxY
 nxY
 nxY
 nxY
+coU
+coU
 rKz
-dpI
-dpI
-dpI
+uIZ
+uIZ
+uIZ
+kSP
+uIZ
+spk
+uIZ
+gPe
+tyl
+qhe
+wZW
+bZw
+bZw
+qhe
 rKz
-dpI
+gXV
+sVt
+uIZ
+uIZ
+wcf
+uIZ
+bZw
 rKz
-dpI
-dpI
-dpI
-rKz
-dpI
-dpI
-dpI
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-rKz
-rKz
-uVX
-uVX
-uVX
-uVX
-uVX
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -50353,38 +51831,38 @@ nxY
 nxY
 nxY
 nxY
+coU
+coU
 rKz
-dpI
-dpI
-dpI
-rKz
-dpI
-rKz
-dpI
-dpI
-dpI
-qhe
-dpI
-dpI
-dpI
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
+mNA
+mNA
+mNA
+mNA
+mNA
+mNA
+uIZ
+uIZ
+mNA
+mNA
+mNA
+mNA
+mNA
+mNA
+mNA
 rKz
 rKz
-uVX
-uVX
-uVX
-uVX
-uVX
-qbU
+rKz
+rKz
+rKz
+jrM
+rHH
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -50562,38 +52040,38 @@ nxY
 nxY
 nxY
 nxY
+coU
+coU
 rKz
-dpI
-dpI
-dpI
+oiJ
+pEI
+hdM
+rVQ
+gXV
+mNA
+uIZ
+uIZ
+mNA
+rVQ
+uIZ
+pEI
+kRS
+pEI
+dgI
+mNA
+rvu
+uId
+cse
+cse
+tmW
+wcf
 rKz
-dpI
-rKz
-rKz
-rKz
-rKz
-rKz
-dpI
-dpI
-dpI
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-rKz
-rKz
-uVX
-uVX
-uVX
-uVX
-uVX
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -50771,38 +52249,38 @@ nxY
 nxY
 nxY
 nxY
+coU
+coU
+slv
+qbU
+udE
+uIZ
+ijN
+gXV
+mNA
+bZw
+uIZ
+eHj
+pEI
+uIZ
+rVQ
+uIZ
+pEI
+uIZ
+mNA
+uIZ
+qhe
+bZw
+wcf
+uIZ
+wcf
 rKz
-rKz
-rKz
-rKz
-rKz
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -50981,36 +52459,36 @@ nxY
 nxY
 nxY
 coU
+coU
 qbU
 qbU
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+tao
+uIZ
+uIZ
+mNA
+bZw
+uIZ
+mNA
+uIZ
+aWN
+uIZ
+bZw
+uIZ
+uIZ
+mNA
+kSP
+uIZ
+uIZ
+uIZ
+bZw
+uIZ
+rKz
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -51190,34 +52668,34 @@ nxY
 nxY
 nxY
 coU
+coU
 qbU
 qbU
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+oiJ
+pEI
+uIZ
+mNA
+tmW
+bZw
+mNA
+wBR
+uIZ
+pEI
+bZw
+rVQ
+uIZ
+mNA
+bCC
+uIZ
+wZW
+gDT
+aWN
+uIZ
+rKz
+coU
+coU
+coU
 coU
 coU
 qbU
@@ -51399,33 +52877,33 @@ nxY
 nxY
 nxY
 coU
+coU
+rKz
+oiJ
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+oiJ
+xoW
+bZw
+mNA
+uIZ
+bZw
+mNA
+pEI
+uIZ
+pEI
+uIZ
+pEI
+bZw
+mNA
+uIZ
+uIZ
+qhe
+uIZ
+qhe
+uIZ
+rKz
+coU
+coU
 coU
 coU
 qbU
@@ -51608,32 +53086,32 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+rKz
+ndt
+oiJ
+qAA
+bZw
+bZw
+nFy
+bif
+qzI
+mNA
+bZw
+uIZ
+uIZ
+qhe
+uIZ
+ksx
+mNA
+bZw
+bZw
+hNy
+oVG
+rec
+agL
+rKz
+coU
 coU
 coU
 coU
@@ -51817,35 +53295,35 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
 coU
-coU
-coU
+rKz
+mNA
+mNA
+mNA
+mNA
+mNA
+mNA
+uIZ
+ptd
+mNA
+mNA
+nFy
+mNA
+mNA
+mNA
+mNA
+mNA
+sYe
+hHA
+mNA
+mNA
+mNA
+dyd
+rKz
+qbU
+qbU
+qbU
+qbU
 uJw
 oRI
 kAs
@@ -52026,37 +53504,37 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
 coU
-coU
-coU
-uJw
-kAs
+rKz
+wKQ
+uIZ
+qhe
+bZw
+uIZ
+nFy
+uIZ
+uIZ
+uIZ
+gDT
+uIZ
+ksL
+bZw
+uIZ
+uIZ
+nFy
+uIZ
+gXV
+mNA
+ssg
+aWN
+uIZ
+rKz
+ugY
+lCt
+jkn
+jkn
+qbU
+iII
 kAs
 kAs
 xBq
@@ -52235,35 +53713,35 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
 coU
-coU
-coU
+rKz
+lyh
+uIZ
+aWN
+bZw
+uIZ
+mNA
+maX
+uIZ
+uIZ
+gXV
+gXV
+uIZ
+qhe
+qai
+tmW
+nFy
+uIZ
+bZw
+mNA
+uIZ
+uIZ
+uIZ
+slv
+qbU
+qbU
+qbU
+qbU
 uJw
 qNA
 ubR
@@ -52444,31 +53922,31 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+rKz
+axm
+bZw
+jRU
+pft
+bZw
+mNA
+jnq
+mNA
+llR
+mNA
+mNA
+jnq
+mNA
+mNA
+mNA
+mNA
+uIZ
+bZw
+mNA
+wZg
+aWN
+bZw
+rKz
 coU
 coU
 coU
@@ -52653,31 +54131,31 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+rKz
+mny
+uIZ
+msM
+uKB
+bZw
+mNA
+uIZ
+uIZ
+uIZ
+bZw
+mNA
+uIZ
+xbH
+chH
+bZw
+mNA
+qzI
+bZw
+mNA
+uiu
+uIZ
+uIZ
+rKz
 coU
 coU
 coU
@@ -52862,33 +54340,33 @@ nxY
 nxY
 nxY
 coU
+coU
+rKz
+wfR
+uIZ
+wLQ
+hjE
+uIZ
+eHj
+bZw
+aSG
+uIZ
+aWN
+mNA
+uIZ
+jNA
+uIZ
+uIZ
+eHj
+uIZ
+uIZ
+mNA
+dyd
+rQU
+jnq
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
 coU
 coU
 qbU
@@ -53071,34 +54549,34 @@ nxY
 nxY
 nxY
 coU
+coU
+rKz
+nGF
+uIZ
+uIZ
+bZw
+fXm
+mNA
+tSz
+rXS
+sgs
+sFp
+mNA
+lcz
+pVA
+dyd
+sFp
+mNA
+bZw
+wPa
+gXV
+cpO
+uIZ
+uIZ
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
 coU
 coU
 qbU
@@ -53280,35 +54758,35 @@ nxY
 nxY
 nxY
 coU
+coU
+rKz
+rKz
+rKz
+rKz
+szd
+szd
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+szd
+rKz
+rKz
+rKz
+rKz
+uIZ
+bZw
+gXV
+uIZ
+llD
+uIZ
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -53489,35 +54967,35 @@ nxY
 nxY
 nxY
 coU
+coU
+rKz
+jHS
+uIZ
+fgg
+cxf
+hMw
+tIU
+qzI
+gKn
+gKn
+gKn
+jDh
+xUz
+uIZ
+uIZ
+uIZ
+nFy
+sVt
+bZw
+uIZ
+uIZ
+uIZ
+gXV
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
 coU
 coU
 qbU
@@ -53698,36 +55176,36 @@ nxY
 nxY
 nxY
 coU
+coU
+fEy
+vqz
+uIZ
+bZw
+uIZ
+uIZ
+qhe
+bZw
+bZw
+uIZ
+uIZ
+nFy
+uIZ
+crI
+uIZ
+tmW
+lbn
+uIZ
+uIZ
+uIZ
+uIZ
+bZw
+gXV
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
 coU
 coU
 qbU
@@ -53907,37 +55385,37 @@ nxY
 nxY
 nxY
 coU
+coU
+rKz
+aiG
+uIZ
+dVw
+uIZ
+uIZ
+uIZ
+mEl
+uIZ
+lrL
+uIZ
+nFy
+bZw
+bZw
+uIZ
+bZw
+rKz
+wZW
+uIZ
+uIZ
+nPV
+bZw
+aWN
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -54116,37 +55594,37 @@ nxY
 nxY
 nxY
 coU
+coU
+rKz
+cfH
+uIZ
+bZw
+uIZ
+uIZ
+uIZ
+jcQ
+uIZ
+uIZ
+xbH
+rKz
+qhe
+uIZ
+bZw
+baj
+rKz
+uIZ
+uIZ
+kuJ
+tJe
+czK
+bVT
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 qbU
@@ -54325,38 +55803,38 @@ nxY
 nxY
 nxY
 coU
+coU
+slv
+cfH
+uIZ
+uvF
+qhe
+uIZ
+uIZ
+uIZ
+uIZ
+xbH
+uIZ
+slv
+gXV
+hJx
+bZw
+kSP
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -54534,38 +56012,38 @@ nxY
 nxY
 nxY
 coU
+coU
+rKz
+aNA
+uIZ
+cKn
+cKn
+cKn
+uhz
+cKn
+daH
+cKn
+uhz
+rKz
+gXV
+bZw
+nQa
+uIZ
+rKz
+bZw
+gbh
+gXV
+gXV
+lrL
+qaJ
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 qbU
@@ -54743,39 +56221,39 @@ nxY
 nxY
 nxY
 coU
+coU
+rKz
+uIZ
+bZw
+cKn
+xbH
+xbH
+xbH
+cKn
+uIZ
+xbH
+xbH
+rKz
+uIZ
+bZw
+uIZ
+qhe
+uTB
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+nSk
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -54952,39 +56430,39 @@ nxY
 nxY
 nxY
 coU
+coU
+rKz
+dLa
+bZw
+cKn
+ptd
+xbH
+xbH
+cKn
+uIZ
+uIZ
+uIZ
+rKz
+uIZ
+uIZ
+wZW
+bZw
+euk
+vXA
+uIZ
+uIZ
+llD
+uIZ
+glM
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 qbU
@@ -55161,40 +56639,40 @@ nxY
 nxY
 nxY
 coU
+coU
+rKz
+gNQ
+gbh
+aQb
+hJv
+nkh
+tWN
+cKn
+hJv
+ida
+jSI
+rKz
+qzI
+uIZ
+uIZ
+oNp
+rKz
+htl
+bZw
+tqU
+unn
+uIZ
+qzI
+rKz
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -55370,40 +56848,40 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+uIZ
+uIZ
+rKz
+rKz
+szd
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -55579,41 +57057,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+uIZ
+lrL
+uIZ
+uIZ
+rKz
+uIZ
+uIZ
+bZw
+aGx
+knN
+rKz
+uIZ
+cZt
+rKz
+jFc
+bZw
+uIZ
+uIZ
+uIZ
+uIZ
+vfH
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -55788,41 +57266,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+slv
+rwZ
+uIZ
+bZw
+oXa
+rKz
+uIZ
+kro
+rQX
+bZw
+bZw
+rKz
+uIZ
+uIZ
+mch
+uIZ
+bZw
+uIZ
+vZn
+bZw
+uIZ
+mBg
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -55997,41 +57475,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+xEl
+jcQ
+uIZ
+uIZ
+slv
+uIZ
+qhe
+uIZ
+uIZ
+uIZ
+rKz
+uIZ
+uIZ
+rKz
+dYA
+uIZ
+uIZ
+bZw
+bZw
+bZw
+jHe
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -56206,41 +57684,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+xEl
+uIZ
+uIZ
+tmW
+rKz
+uIZ
+uIZ
+gXV
+uIZ
+uIZ
+rKz
+uIZ
+uIZ
+slv
+nOD
+uIZ
+iow
+lPa
+uIZ
+xee
+kBA
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -56415,41 +57893,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+aOz
+uIZ
+bZw
+uIZ
+rKz
+bSF
+uIZ
+uIZ
+uIZ
+bZw
+rKz
+uTB
+nFy
+rKz
+rKz
+rKz
+rKz
+rKz
+jnq
+rKz
+rKz
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -56624,41 +58102,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+jeV
+uIZ
+uIZ
+bZw
+uTB
+uIZ
+uIZ
+uIZ
+kro
+bZw
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+wZW
+gID
+uIZ
+uIZ
+uIZ
+qzI
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -56833,41 +58311,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+jHP
+wLQ
+tmW
+gbh
+rKz
+uIZ
+qzI
+uIZ
+uIZ
+gXV
+sVt
+bZw
+uVz
+sVt
+gXV
+qhe
+uIZ
+uIZ
+uIZ
+xki
+gRv
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -57042,41 +58520,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+szd
+uIZ
+uIZ
+gXV
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -57251,41 +58729,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+jzZ
+pXo
+gxY
+pXo
+pXo
+lUB
+rKz
+uIZ
+bZw
+uIZ
+gXV
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+uIZ
+slv
+uIZ
+uIZ
+uIZ
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 qbU
@@ -57460,42 +58938,42 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+tlG
+bZw
+bZw
+bZw
+oFf
+uIZ
+rKz
+uIZ
+hJx
+uIZ
+gDT
+bZw
+qDV
+uIZ
+ptd
+uIZ
+tPT
+rKz
+uIZ
+nPV
+uIZ
+rKz
+izb
+izb
+izb
+izb
+izb
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -57669,43 +59147,43 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+slv
+rgN
+mHd
+uIZ
+bZw
+bZw
+uIZ
+wBI
+maX
+aNB
+uIZ
+bZw
+bZw
+uIZ
+uIZ
+uIZ
+uIZ
+sVt
+rKz
+uIZ
+eSZ
+uIZ
+rKz
+izb
+izz
+jEp
+hoR
+izb
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 qbU
 qbU
 qbU
@@ -57878,42 +59356,42 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+bPk
+uIZ
+uIZ
+wZW
+uIZ
+uIZ
+rKz
+uTB
+uTB
+rKz
+uIZ
+lrL
+rKz
+uIZ
+mTK
+uIZ
+uIZ
+bZw
+lrL
+bZw
+bZw
+rKz
+izb
+hoR
+hoR
+hoR
+izb
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -58087,42 +59565,42 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+fEy
+fvq
+wLQ
+uIZ
+qhe
+aWN
+uIZ
+yks
+uIZ
+uIZ
+oBN
+rUc
+uIZ
+rKz
+gXV
+uIZ
+uIZ
+gDT
+bZw
+gXV
+qhe
+bZw
+rKz
+izb
+hoR
+apK
+hoR
+izb
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -58296,42 +59774,42 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+ttl
+uIZ
+uIZ
+tmW
+bZw
+bZw
+aWN
+uIZ
+uIZ
+rKz
+bZw
+bZw
+rKz
+uIZ
+uIZ
+hWp
+tNG
+uIZ
+gXV
+nPA
+uIZ
+rKz
+izb
+pbc
+hoR
+hoR
+izb
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -58505,42 +59983,42 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+xfn
+uIZ
+uIZ
+uIZ
+qzI
+bZw
+uIZ
+iRt
+uIZ
+rKz
+uIZ
+uIZ
+slv
+vtG
+bZw
+bZw
+uIZ
+uIZ
+gDT
+uIZ
+uIZ
+rKz
+izb
+izb
+izb
+izb
+izb
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -58714,42 +60192,42 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+xgt
+kKj
+rKz
+vtc
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -58923,42 +60401,42 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+bZw
+lgl
+rti
+bZw
+bZw
+jRZ
+tpL
+dGf
+uIZ
+bZw
+dIZ
+bZw
+gDT
+wun
+uIZ
+hJx
+qhe
+uIZ
+uIZ
+rwZ
+oiJ
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -59131,43 +60609,43 @@ nxY
 nxY
 nxY
 nxY
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+rKz
+maX
+bZw
+uIZ
+xcU
+uIZ
+uIZ
+wun
+wZW
+uIZ
+bZw
+uIZ
+uIZ
+cZt
+uIZ
+sVt
+bZw
+azd
+uIZ
+uIZ
+oiJ
+tFp
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -59341,42 +60819,42 @@ nxY
 nxY
 nxY
 coU
+coU
+coU
+rKz
+uIZ
+uIZ
+uIZ
+uIZ
+bZw
+bpS
+gXV
+uIZ
+uIZ
+bZw
+uIZ
+rQE
+uIZ
+uIZ
+uIZ
+ouu
+tPT
+uIZ
+gDT
+tao
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -59550,42 +61028,42 @@ nxY
 nxY
 nxY
 coU
+coU
+coU
+rKz
+uIZ
+uIZ
+qhe
+uIZ
+pZU
+jQO
+uIZ
+aWN
+ptd
+uIZ
+neP
+cvN
+qhe
+mvg
+wZW
+uIZ
+gXV
+uIZ
+bAs
+oiJ
 qbU
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -59759,41 +61237,41 @@ nxY
 nxY
 nxY
 coU
+coU
+coU
+szd
+bZw
+uIZ
+uIZ
+jcQ
+uIZ
+uIZ
+uIZ
+eUu
+gDT
+gXV
+uIZ
+uIZ
+bZw
+wcW
+uIZ
+uIZ
+qhe
+wun
+maX
+tao
+oiJ
 qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 qbU
@@ -59968,41 +61446,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+vWE
+dnC
+mFx
+yaB
+oSA
+vWE
+oSA
+uOL
+oSA
+uIZ
+dIZ
+ykG
+uIZ
+rlf
+exQ
+dnC
+dnC
+vWE
+oSA
+vWE
+oSA
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -60177,41 +61655,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+vWE
+vWE
+exQ
+exQ
+uOL
+oSA
+dnC
+gaK
+lGh
+bZw
+njg
+nlF
+uIZ
+exQ
+uOL
+vWE
+oSA
+oSA
+ocM
+uOL
+vWE
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -60386,41 +61864,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+qhe
+uIZ
+bZw
+wun
+qhe
+bZw
+fIY
+bZw
+cZt
+aWN
+rWT
+wZW
+wZW
+uIZ
+pZU
+pRk
+uIZ
+bZw
+pmd
+lrL
+hzz
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -60595,41 +62073,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+uOL
+uOL
+oSA
+dnC
+dnC
+oSA
+sQu
+uIZ
+gaK
+gaK
+exQ
+uOL
+oSA
+dnC
+dnC
+oSA
+vWE
+smC
+vWE
+vWE
+dnC
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -60804,41 +62282,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+uOL
+kwB
+dnC
+dnC
+oSA
+oSA
+oSA
+bAs
+gCX
+oSA
+vWE
+vWE
+uOL
+exQ
+dnC
+oSA
+exQ
+dnC
+oSA
+dnC
+oSA
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -61013,41 +62491,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+slv
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+rKz
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -61222,41 +62700,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 qbU
 qbU
@@ -61431,41 +62909,41 @@ nxY
 nxY
 nxY
 coU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
-qbU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
+coU
 coU
 coU
 qbU

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -82,7 +82,7 @@
 /area/colony/exposedsun/pastgate)
 "afk" = (
 /obj/structure/flora/pottedplant/rotwood,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "afB" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -125,7 +125,7 @@
 /area/colony/exposedsun/crashed_shop/outsider)
 "aho" = (
 /obj/item/storage/fancy/mre_cracker,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ahW" = (
 /obj/random/junk,
@@ -197,7 +197,10 @@
 "amr" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "amG" = (
 /obj/machinery/gym/toughness,
@@ -264,7 +267,7 @@
 /area/nadezhda/outside/one_star)
 "aqy" = (
 /obj/machinery/suit_storage_unit/excelsior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "aqA" = (
 /obj/machinery/floodlight,
@@ -360,7 +363,7 @@
 /area/nadezhda/outside/meadow)
 "avp" = (
 /obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "avx" = (
 /obj/structure/table/standard,
@@ -394,7 +397,7 @@
 /area/asteroid/rogue)
 "axL" = (
 /obj/structure/table/bench/wooden,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "axM" = (
 /obj/effect/overlay/water,
@@ -404,7 +407,7 @@
 "axV" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "ayt" = (
 /obj/item/bedsheet,
@@ -441,7 +444,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "azq" = (
 /obj/structure/table/steel_reinforced,
@@ -546,7 +549,7 @@
 /area/nadezhda/outside/one_star)
 "aDy" = (
 /obj/item/trash/broken_robot_part,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "aDz" = (
 /obj/effect/decal/cleanable/rubble,
@@ -583,14 +586,14 @@
 "aFi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "aFP" = (
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
 "aGn" = (
 /obj/effect/decal/cleanable/ash,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "aGo" = (
 /obj/structure/railing/grey{
@@ -609,7 +612,7 @@
 "aHK" = (
 /obj/item/storage/hcases/ammo/excel,
 /obj/structure/closet/crate/excelsior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "aIu" = (
 /obj/machinery/light/floor,
@@ -714,7 +717,7 @@
 /obj/random/ammo/low_chance,
 /obj/random/ammo/low_chance,
 /obj/item/ammo_magazine/ammobox/antim_small,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "aMH" = (
 /obj/item/remains,
@@ -801,7 +804,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "aQr" = (
 /obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "aSc" = (
 /turf/simulated/shuttle/floor/mining,
@@ -861,9 +864,14 @@
 /obj/random/junkfood,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"aVm" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/clothing/glasses/welding/superior/shades,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "aWi" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "aWp" = (
 /obj/structure/flora/big/bush2,
@@ -922,6 +930,15 @@
 /obj/random/powercell/low_chance,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"bam" = (
+/obj/machinery/recharger,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
+"baC" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock/manmade/ruin2,
+/area/asteroid/rogue)
 "baH" = (
 /obj/structure/cable/yellow,
 /obj/machinery/light/small,
@@ -1000,7 +1017,7 @@
 "beH" = (
 /mob/living/simple_animal/hostile/diyaab,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "beQ" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -1119,7 +1136,7 @@
 "blx" = (
 /obj/item/mine/excelsior,
 /obj/item/trash/semki,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "blY" = (
 /obj/machinery/door/airlock/sandstone{
@@ -1130,7 +1147,7 @@
 "bmh" = (
 /obj/item/mine/excelsior,
 /obj/item/trash/mre/alt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "bmp" = (
 /obj/structure/reagent_dispensers/watertank/derelict,
@@ -1236,7 +1253,7 @@
 /area/nadezhda/dungeon/outside/zoo)
 "bqC" = (
 /obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "bqX" = (
 /obj/random/pack/tech_loot,
@@ -1275,6 +1292,11 @@
 "bsz" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"bsR" = (
+/obj/effect/decal/cleanable/filth,
+/obj/random/dungeon_gun_ballistic,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "bsX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -1342,7 +1364,7 @@
 	dir = 8
 	},
 /obj/structure/flora/pottedplant/rotwood_green,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "bvC" = (
 /obj/structure/table/standard,
@@ -1407,7 +1429,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "byy" = (
 /obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "bzc" = (
 /obj/random/scrap,
@@ -1419,7 +1441,7 @@
 "bAa" = (
 /obj/item/mine/excelsior,
 /obj/landmark/corpse/excelsior,
-/turf/simulated/floor/rock/dark,
+/turf/simulated/floor/rock/manmade/ruin2,
 /area/asteroid/rogue)
 "bAm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1461,11 +1483,11 @@
 /obj/structure/closet/l3closet/janitor,
 /obj/item/toy/figure/character/civilian/janitor,
 /obj/item/clothing/under/rank/janitor,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "bCY" = (
 /obj/item/trash/mre_candy,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "bDO" = (
 /obj/random/closet_tech,
@@ -1538,7 +1560,7 @@
 "bHO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_weighted,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "bHZ" = (
 /obj/machinery/light/small{
@@ -1644,7 +1666,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/port_gen/pacman/diesel/anchored,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "bNM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1762,7 +1784,7 @@
 /area/nadezhda/outside/meadow)
 "bRP" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "bRR" = (
 /obj/random/scrap/moderate_weighted,
@@ -1791,7 +1813,7 @@
 	armed = 1
 	},
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/rock/dark,
+/turf/simulated/floor/rock/manmade/ruin2,
 /area/asteroid/rogue)
 "bTH" = (
 /obj/structure/closet/firecloset,
@@ -1910,7 +1932,7 @@
 /area/nadezhda/outside/meadow)
 "cam" = (
 /obj/item/trash/mre_shokoladka,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "caq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1980,10 +2002,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"ces" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "ceR" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "cfa" = (
 /obj/effect/decal/cleanable/rubble,
@@ -2019,7 +2046,7 @@
 "chw" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "chC" = (
 /obj/effect/step_trigger/surface_to_forest_2_B,
@@ -2095,6 +2122,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"ckM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "clb" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/cloth/armor/low_chance,
@@ -2257,7 +2289,7 @@
 	armed = 1
 	},
 /obj/item/trash/mre,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "crC" = (
 /obj/item/remains/tajaran,
@@ -2269,7 +2301,7 @@
 /obj/item/mine/excelsior{
 	armed = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "crM" = (
 /obj/effect/decal/cleanable/blood,
@@ -2359,7 +2391,7 @@
 /obj/structure/table/standard,
 /obj/random/medical,
 /obj/random/medical,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "cty" = (
 /obj/structure/window/reinforced{
@@ -2430,7 +2462,7 @@
 /area/nadezhda/outside/meadow)
 "cvA" = (
 /obj/item/trash/cigbutt/fortressblue,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "cwm" = (
 /obj/structure/flora/small/busha1,
@@ -2488,7 +2520,7 @@
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "czs" = (
 /obj/machinery/vending/engineering,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "czR" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -2600,11 +2632,15 @@
 "cEw" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"cEx" = (
+/obj/machinery/gibber,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "cEA" = (
 /obj/structure/toilet{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "cEB" = (
 /obj/machinery/light/small{
@@ -2620,6 +2656,11 @@
 /obj/structure/flora/small/bushc2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
+"cEZ" = (
+/obj/structure/table/standard,
+/obj/random/medical/low_chance,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "cFd" = (
 /obj/structure/flora/small/grassa4,
 /obj/structure/flora/big/bush3,
@@ -2628,7 +2669,7 @@
 "cFk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/mre/alt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "cFy" = (
 /obj/item/gun/projectile/automatic/lmg/pk,
@@ -2644,7 +2685,7 @@
 	dir = 4
 	},
 /obj/machinery/porta_turret/excelsior/preloaded,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "cGz" = (
 /obj/structure/flora/small/bushb3,
@@ -2703,7 +2744,7 @@
 "cKr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/rock/dark,
+/turf/simulated/floor/rock/manmade/ruin2,
 /area/asteroid/rogue)
 "cKv" = (
 /obj/structure/medical_stand/anesthetic,
@@ -2741,12 +2782,13 @@
 "cLU" = (
 /obj/item/mine/excelsior,
 /obj/item/trash/material/device,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "cLV" = (
 /obj/structure/table/standard,
 /obj/random/medical/low_chance,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "cLY" = (
 /obj/machinery/autolathe,
@@ -2769,7 +2811,7 @@
 /obj/structure/table/standard,
 /obj/random/medical,
 /obj/item/computer_hardware/hard_drive/portable/design/medical/advanced,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "cNa" = (
 /obj/item/remains/ribcage,
@@ -2954,7 +2996,7 @@
 "cUA" = (
 /obj/structure/table/rack,
 /obj/random/gun_parts,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "cUK" = (
 /obj/random/material,
@@ -3012,7 +3054,7 @@
 "cYh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/mre/os,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "cYn" = (
 /obj/machinery/door/blast/shutters/glass,
@@ -3097,7 +3139,7 @@
 /obj/random/medical,
 /obj/random/medical,
 /obj/item/storage/firstaid,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "dbn" = (
 /obj/random/common_oddities,
@@ -3106,7 +3148,7 @@
 "dbE" = (
 /mob/living/carbon/superior_animal/human/excelsior,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "dbO" = (
 /obj/structure/table/onestar,
@@ -3144,7 +3186,7 @@
 	dir = 1
 	},
 /obj/structure/flora/pottedplant/drooping,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "ddO" = (
 /obj/structure/reagent_dispensers/watertank/huge,
@@ -3158,6 +3200,10 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"dez" = (
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "deS" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -3189,7 +3235,7 @@
 /obj/item/book/manual/fiction{
 	name = "Communist Manifesto"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "dhy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3206,6 +3252,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"dhV" = (
+/obj/random/common_oddities,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "djk" = (
 /obj/structure/table/rack/shelf,
 /obj/random/junkfood,
@@ -3266,11 +3316,11 @@
 "dnv" = (
 /obj/effect/decal/cleanable/filth,
 /obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "dnC" = (
 /mob/living/carbon/superior_animal/human/excelsior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "dnH" = (
 /obj/structure/bed/double/padded,
@@ -3298,7 +3348,7 @@
 /area/asteroid/rogue)
 "dpI" = (
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "dpK" = (
 /obj/structure/morgue,
@@ -3383,6 +3433,10 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"dup" = (
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "duC" = (
 /obj/random/junk/nondense,
 /turf/simulated/floor/tiled/dark,
@@ -3496,11 +3550,11 @@
 "dyP" = (
 /obj/machinery/cooking_with_jane/grill,
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "dzj" = (
 /obj/structure/scrap/medical/large,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "dzp" = (
 /obj/structure/flora/big/bush1,
@@ -3709,7 +3763,7 @@
 "dHR" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "dIw" = (
 /obj/structure/flora/small/bushb2,
@@ -3778,7 +3832,8 @@
 "dKT" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "dLt" = (
 /turf/unsimulated/mineral,
@@ -3921,7 +3976,7 @@
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "dUH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3929,6 +3984,13 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"dVv" = (
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "dWh" = (
 /obj/structure/flora/big/bush1,
 /turf/unsimulated/wall/jungle,
@@ -3936,7 +3998,7 @@
 "dWp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/gun_cheap/low_chance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "dXH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3999,7 +4061,7 @@
 "ebi" = (
 /obj/machinery/cooking_with_jane/stove,
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ebz" = (
 /obj/structure/scrap/food/large,
@@ -4038,7 +4100,7 @@
 "edP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/firstaid/regular/empty,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "edQ" = (
 /obj/structure/boulder,
@@ -4349,7 +4411,7 @@
 /area/nadezhda/dungeon/outside/zoo)
 "epY" = (
 /obj/item/trash/syndi_cakes,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "eqk" = (
 /obj/random/structures,
@@ -4441,7 +4503,7 @@
 /area/asteroid/rogue)
 "eut" = (
 /obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "euG" = (
 /obj/structure/cable{
@@ -4516,7 +4578,7 @@
 "exc" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "exl" = (
 /obj/structure/table/glass,
@@ -4577,7 +4639,7 @@
 /obj/structure/table/rack,
 /obj/effect/decal/cleanable/filth,
 /obj/item/gun_upgrade/trigger/boom,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "eCK" = (
 /obj/structure/closet/random_hostilemobs,
@@ -4619,6 +4681,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
+"eGQ" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "eGW" = (
 /obj/effect/decal/cleanable/filth,
 /obj/structure/table/rack/shelf,
@@ -4633,7 +4700,7 @@
 /obj/effect/decal/cleanable/cobweb2{
 	icon_state = "cobweb1"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "eHE" = (
 /obj/structure/boulder,
@@ -4694,7 +4761,7 @@
 "eLL" = (
 /obj/random/lowkeyrandom,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "eMv" = (
 /obj/random/closet_tech,
@@ -4820,7 +4887,7 @@
 /obj/item/mine/excelsior{
 	armed = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "eVM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4980,7 +5047,8 @@
 /area/colony/exposedsun/pastgate)
 "fcB" = (
 /obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "fcC" = (
 /obj/machinery/light/floor,
@@ -4991,7 +5059,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "fdz" = (
 /obj/machinery/porta_turret/prepper,
@@ -5161,7 +5229,7 @@
 "fkD" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "fkH" = (
 /obj/structure/flora/small/busha1,
@@ -5269,7 +5337,7 @@
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "fqQ" = (
 /obj/item/trash/mre,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "fqU" = (
 /obj/random/junk/cigbutt,
@@ -5290,7 +5358,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "fsT" = (
 /obj/structure/closet/crate/trashcart,
@@ -5303,6 +5371,11 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
+"ftz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/firedoor_assembly,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "ftE" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -5315,6 +5388,14 @@
 /obj/structure/closet/secure_closet/rare_loot,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"fuq" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "fuB" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -5397,7 +5478,7 @@
 /area/nadezhda/outside/one_star)
 "fyp" = (
 /obj/item/trash/peachcan,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "fyx" = (
 /obj/random/mob/undergroundmob,
@@ -5405,7 +5486,7 @@
 /area/colony/exposedsun/crashed_shop/outsider)
 "fyX" = (
 /obj/machinery/complant_teleporter,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "fze" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -5474,7 +5555,8 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/closet_tech/low_chance,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "fDS" = (
 /obj/machinery/light{
@@ -5500,6 +5582,11 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"fET" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "fFb" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark,
@@ -5557,13 +5644,18 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "fGF" = (
 /obj/structure/cardboardbox,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "fGQ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"fHd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "fHi" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/junk,
@@ -5725,7 +5817,7 @@
 /area/nadezhda/outside/meadow)
 "fQG" = (
 /obj/item/trash/os_coco_wrapper,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "fRg" = (
 /obj/structure/table/steel_reinforced,
@@ -5773,7 +5865,7 @@
 "fTh" = (
 /obj/effect/decal/cleanable/filth,
 /obj/structure/flora/pottedplant/minitree,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "fTI" = (
 /obj/structure/target_stake,
@@ -5834,7 +5926,7 @@
 /obj/item/reagent_containers/food/snacks/toastedsandwich,
 /obj/item/reagent_containers/food/snacks/toastedsandwich,
 /obj/item/reagent_containers/food/snacks/toastedsandwich,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "fVI" = (
 /obj/structure/bed/chair/custom/onestar/red{
@@ -5879,7 +5971,7 @@
 "fWQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mopbucket,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "fXe" = (
 /obj/structure/window/reinforced{
@@ -5896,7 +5988,7 @@
 	icon_state = "cobweb1"
 	},
 /obj/structure/flora/pottedplant/rotwood_blue,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "fXI" = (
 /obj/structure/railing/grey,
@@ -5936,7 +6028,7 @@
 "fZu" = (
 /obj/machinery/porta_turret/excelsior/preloaded,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "gab" = (
 /obj/machinery/vending/hydronutrients,
@@ -6034,7 +6126,7 @@
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "ggb" = (
 /obj/item/trash/grease,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "ggM" = (
 /obj/random/scrap/dense_weighted,
@@ -6082,7 +6174,11 @@
 /area/nadezhda/outside/one_star)
 "gia" = (
 /obj/machinery/cooking_with_jane/oven,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
+"gid" = (
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "gim" = (
 /obj/random/junk/cigbutt,
@@ -6100,6 +6196,10 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"gjj" = (
+/obj/item/trash/mre_shokoladka,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "gjt" = (
 /obj/structure/flora/small/trailrockb3,
 /turf/simulated/floor/asteroid/dirt,
@@ -6121,7 +6221,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "gkh" = (
 /obj/machinery/light,
-/turf/simulated/floor/rock/dark,
+/turf/simulated/floor/rock/manmade/ruin2,
 /area/asteroid/rogue)
 "gkM" = (
 /obj/structure/sign/neon/beer,
@@ -6246,7 +6346,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/firstaid/low_chance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "grf" = (
 /obj/structure/cable/yellow{
@@ -6421,7 +6521,7 @@
 /area/nadezhda/dungeon/outside/prepper)
 "gyo" = (
 /obj/random/dungeon_gun_energy/low_chance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "gys" = (
 /obj/item/tool/broken_bottle,
@@ -6437,7 +6537,7 @@
 	name = "West APC";
 	pixel_x = -28
 	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "gyZ" = (
 /obj/effect/overlay/water/top,
@@ -6467,7 +6567,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "gAk" = (
 /obj/structure/flora/pottedplant/mysterious,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "gAr" = (
 /obj/machinery/seed_storage/random,
@@ -6596,12 +6696,12 @@
 /area/nadezhda/outside/meadow)
 "gFS" = (
 /obj/structure/salvageable/data_os,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "gGm" = (
 /obj/random/lowkeyrandom,
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "gGH" = (
 /obj/item/remains/ribcage,
@@ -6615,7 +6715,7 @@
 /area/colony/exposedsun/crashed_shop/outsider)
 "gHH" = (
 /obj/structure/scrap_cube,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "gIP" = (
 /obj/machinery/door/airlock/freezer,
@@ -6739,8 +6839,8 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "gQn" = (
 /obj/structure/table/woodentable,
-/obj/item/implanter/excelsior/broken,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/chemical_dispenser/coffee_master,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "gQq" = (
 /obj/effect/decal/cleanable/rubble,
@@ -6861,7 +6961,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "gUl" = (
 /obj/structure/cryofeed{
@@ -6991,7 +7091,7 @@
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "hcG" = (
 /obj/structure/shuttle_part/cargo{
@@ -7058,7 +7158,7 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
 "hgL" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "hhc" = (
 /obj/structure/table/steel_reinforced,
@@ -7241,7 +7341,10 @@
 /area/nadezhda/dungeon/outside/monster_cave)
 "hnP" = (
 /obj/structure/bookcase/manuals/medical,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "hnQ" = (
 /obj/structure/table/rack/shelf,
@@ -7275,7 +7378,7 @@
 /area/nadezhda/outside/one_star)
 "hox" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "hpb" = (
 /obj/effect/decal/cleanable/generic,
@@ -7440,6 +7543,10 @@
 /obj/random/gun_cheap/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"hyA" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "hyZ" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/wild5,
@@ -7465,13 +7572,13 @@
 "hAV" = (
 /obj/structure/table/standard,
 /obj/random/medical,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "hBa" = (
 /obj/item/mine/excelsior{
 	armed = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "hBX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7500,6 +7607,10 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"hDc" = (
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "hEU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/lathe_disk,
@@ -7609,7 +7720,7 @@
 /obj/structure/scrap_cube,
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "hJY" = (
 /obj/structure/table/steel_reinforced,
@@ -7678,7 +7789,7 @@
 "hOg" = (
 /obj/structure/table/standard,
 /obj/random/surgery_tool/low_chance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "hOt" = (
 /obj/structure/salvageable/machine,
@@ -7689,7 +7800,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "hPm" = (
 /obj/structure/salvageable/data_os,
@@ -7724,12 +7835,12 @@
 "hQJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "hQX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "hRb" = (
 /turf/simulated/wall/r_wall,
@@ -7876,7 +7987,7 @@
 /area/nadezhda/outside/one_star)
 "hYL" = (
 /obj/item/implant/excelsior/broken,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "hYM" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -7939,8 +8050,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "ice" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/random/dungeon_ammo/really_low_chance,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "icq" = (
 /obj/random/mob/prepper_ranged,
@@ -8006,6 +8124,11 @@
 /obj/structure/flora/small/busha2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"iey" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/gym/robustness,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "ieY" = (
 /obj/structure/flora/small/rock4,
 /obj/random/mob/vox/low_chance,
@@ -8058,7 +8181,7 @@
 "igW" = (
 /obj/structure/table/gamblingtable,
 /obj/item/gun/projectile/makarov/preloaded,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ihc" = (
 /obj/random/mob/voidwolf/low_chance,
@@ -8083,7 +8206,7 @@
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "iip" = (
 /obj/item/trash/cheesie,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "iiE" = (
 /obj/structure/table/steel_reinforced,
@@ -8093,7 +8216,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mine/excelsior,
 /obj/item/trash/candy/proteinbar,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "iji" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8110,6 +8233,12 @@
 /obj/effect/step_trigger/vault_bunker_2E,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
+"ika" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "ikb" = (
 /obj/structure/table/rack/shelf,
 /obj/random/firstaid/low_chance,
@@ -8128,7 +8257,7 @@
 /area/nadezhda/dungeon/outside/zoo)
 "ikF" = (
 /obj/item/trash/semki,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "ikO" = (
 /obj/structure/catwalk,
@@ -8440,7 +8569,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "izA" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "izY" = (
 /obj/structure/table/steel_reinforced,
@@ -8456,7 +8585,7 @@
 "iAz" = (
 /obj/random/scrap/dense_weighted,
 /obj/random/scrap/dense_weighted,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "iAE" = (
 /obj/structure/table/steel_reinforced,
@@ -8514,7 +8643,7 @@
 "iDM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "iEa" = (
 /obj/machinery/light{
@@ -8567,6 +8696,9 @@
 /obj/random/rig_module,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"iFU" = (
+/turf/simulated/floor/rock/manmade/ruin2,
+/area/asteroid/rogue)
 "iGf" = (
 /obj/machinery/computer/aiupload{
 	dir = 4
@@ -8602,7 +8734,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/item/gun/projectile/boltgun,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "iHc" = (
 /obj/structure/flora/ausbushes/pointybush,
@@ -8900,6 +9032,11 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
+"iYP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/dungeon_gun_ballistic,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "iYS" = (
 /mob/living/simple_animal/hostile/hivebot,
 /turf/unsimulated/mineral,
@@ -8971,6 +9108,13 @@
 /obj/machinery/door/airlock/vault,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/safehouse)
+"jcD" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "jcH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9080,7 +9224,7 @@
 /area/nadezhda/dungeon/outside/safehouse)
 "jfz" = (
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "jfW" = (
 /obj/machinery/gym/robustness,
@@ -9092,6 +9236,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"jgj" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "jgr" = (
 /mob/living/simple_animal/schlorgo,
 /turf/simulated/floor/asteroid/grass,
@@ -9160,6 +9308,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"jio" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "jiM" = (
 /obj/random/science,
 /turf/simulated/floor/tiled/dark,
@@ -9193,7 +9346,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "jjD" = (
 /obj/structure/boulder,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "jjE" = (
 /obj/random/flora/jungle_tree,
@@ -9261,7 +9414,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "jkv" = (
 /obj/machinery/autolathe,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "jkG" = (
 /obj/structure/table/rack,
@@ -9276,18 +9429,30 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"jlf" = (
+/obj/effect/decal/cleanable/filth,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "jlK" = (
 /obj/structure/cable/yellow,
 /obj/structure/salvageable/machine,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"jlL" = (
+/obj/effect/window_lwall_spawn/reinforced/polarized,
+/turf/space,
+/area/asteroid/rogue)
 "jmu" = (
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper)
 "jmx" = (
 /obj/item/gun/projectile/makarov/preloaded,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/closet/gimmick,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "jnj" = (
 /mob/living/simple_animal/hostile/bear/brown,
@@ -9297,11 +9462,11 @@
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/revolver/deacon,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "jnq" = (
 /mob/living/simple_animal/hostile/bear/excelsior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "jnw" = (
 /obj/structure/invislight,
@@ -9377,11 +9542,16 @@
 /area/nadezhda/outside/one_star)
 "jrF" = (
 /obj/structure/medical_stand,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "jrV" = (
 /obj/random/cluster/spiders,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"jsO" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "jsR" = (
 /obj/structure/cable/yellow{
@@ -9404,7 +9574,7 @@
 "jva" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "jvH" = (
 /obj/structure/flora/rock/variant1,
@@ -9642,7 +9812,7 @@
 "jJO" = (
 /obj/effect/decal/cleanable/filth,
 /obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "jJQ" = (
 /obj/structure/table/steel_reinforced,
@@ -9798,6 +9968,10 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"jQS" = (
+/obj/random/scrap/dense_weighted,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "jQU" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/small/busha1,
@@ -9970,7 +10144,7 @@
 /area/nadezhda/dungeon/outside/safehouse)
 "kaq" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "kbC" = (
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -10005,7 +10179,7 @@
 /area/nadezhda/outside/one_star)
 "kcL" = (
 /obj/item/trash/cigbutt/brouzouf,
-/turf/simulated/floor/rock/dark,
+/turf/simulated/floor/rock/manmade/ruin2,
 /area/asteroid/rogue)
 "kcN" = (
 /obj/structure/table/rack,
@@ -10013,6 +10187,12 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"kdd" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "kdx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -10101,6 +10281,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"kfS" = (
+/obj/structure/closet/body_bag,
+/obj/landmark/corpse/excelsior,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "kgn" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10140,7 +10325,7 @@
 "kjp" = (
 /obj/item/implanter/excelsior/broken,
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "kjs" = (
 /obj/structure/table/steel_reinforced,
@@ -10216,6 +10401,11 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"knp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "knq" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -10310,7 +10500,7 @@
 "ksu" = (
 /obj/structure/table/marble,
 /obj/item/storage/pouch/ammo,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ksF" = (
 /obj/structure/multiz/stairs/enter/bottom{
@@ -10336,7 +10526,7 @@
 /obj/effect/decal/cleanable/cobweb2{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ktF" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -10454,7 +10644,7 @@
 /obj/item/mine/excelsior{
 	armed = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "kzF" = (
 /obj/machinery/light/small{
@@ -10479,6 +10669,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
 /area/asteroid/rogue)
+"kBi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "kBn" = (
 /obj/item/ammo_magazine/light_rifle_257/empty,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -10496,7 +10693,7 @@
 /area/nadezhda/outside/one_star)
 "kBY" = (
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "kCa" = (
 /obj/machinery/recharge_station,
@@ -10675,6 +10872,11 @@
 /obj/structure/flora/small/grassb2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"kNe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "kNj" = (
 /obj/structure/table/woodentable,
 /obj/random/oddity_guns,
@@ -10737,7 +10939,7 @@
 "kQA" = (
 /obj/structure/scrap_cube,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "kQG" = (
 /obj/structure/closet/onestar/tier1/mineral,
@@ -10755,13 +10957,18 @@
 "kSt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "kSw" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
+"kSE" = (
+/obj/machinery/light,
+/obj/structure/closet/random_medsupply,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "kSO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/claymore,
@@ -10774,7 +10981,7 @@
 "kUs" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "kUx" = (
 /obj/structure/table/steel,
@@ -10821,7 +11028,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/item/reagent_containers/food/drinks/drinkingglass/mug,
+/obj/item/reagent_containers/food/drinks/drinkingglass/mug,
+/obj/item/reagent_containers/food/drinks/drinkingglass/mug,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "kVE" = (
 /mob/living/carbon/superior_animal/xenomorph{
@@ -10878,7 +11088,7 @@
 "kXX" = (
 /obj/effect/decal/cleanable/filth,
 /obj/random/scrap/dense_even,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "kYd" = (
 /obj/structure/table/rack/shelf,
@@ -10896,6 +11106,13 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"kZp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fireaxecabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "kZv" = (
 /obj/structure/table/onestar,
 /obj/random/common_oddities/low_chance,
@@ -10918,7 +11135,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "laj" = (
 /obj/structure/table/marble,
@@ -11011,7 +11228,7 @@
 /obj/item/stock_parts/scanning_module/excelsior,
 /obj/structure/table/standard,
 /obj/item/computer_hardware/hard_drive/portable/design/guns/ex_vintorez,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "lgw" = (
 /obj/structure/table/standard,
@@ -11095,7 +11312,7 @@
 /area/nadezhda/dungeon/outside/monster_cave)
 "ljm" = (
 /obj/structure/salvageable/autolathe,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ljt" = (
 /obj/structure/table/steel_reinforced,
@@ -11149,7 +11366,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "llF" = (
 /mob/living/simple_animal/hostile/megafauna/excelsior_cosmonaught,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "llJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11190,7 +11407,7 @@
 "lpc" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "lpp" = (
 /obj/structure/flora/small/grassb2,
@@ -11221,6 +11438,11 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"lrx" = (
+/obj/machinery/door/airlock,
+/obj/item/mine/excelsior,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "lrE" = (
 /obj/machinery/door/airlock/multi_tile/metal,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -11231,7 +11453,7 @@
 "lrL" = (
 /obj/random/scrap/dense_even,
 /obj/random/scrap/dense_even,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "lrY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11451,7 +11673,7 @@
 /obj/item/mine/excelsior,
 /obj/effect/decal/cleanable/generic,
 /obj/random/scrap/sparse_even/low_chance,
-/turf/simulated/floor/rock/dark,
+/turf/simulated/floor/rock/manmade/ruin2,
 /area/asteroid/rogue)
 "lEN" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -11554,7 +11776,7 @@
 "lIh" = (
 /obj/effect/decal/cleanable/filth,
 /mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "lIk" = (
 /obj/structure/grille/broken,
@@ -11565,6 +11787,10 @@
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
+"lJy" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "lJE" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/mineral/planet,
@@ -11633,12 +11859,12 @@
 /obj/item/paper/crumpled{
 	text = "You are on your own. Serve to your best extents and do not let our fortress fall!   - Skeinstovitch"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "lNk" = (
 /obj/machinery/suit_storage_unit/excelsior,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "lNE" = (
 /obj/random/structures/os,
@@ -11650,12 +11876,12 @@
 /area/colony/exposedsun/crashed_shop/outsider)
 "lOU" = (
 /obj/structure/flora/pottedplant/star_root,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "lPa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/bench/wooden,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "lPc" = (
 /obj/structure/cable/yellow{
@@ -11675,7 +11901,6 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "lQj" = (
-/obj/structure/closet/crate/excelsior,
 /obj/item/tool/baton/excelbaton,
 /obj/item/tool/baton/excelbaton,
 /obj/item/clothing/suit/space/void/excelsior,
@@ -11683,7 +11908,8 @@
 /obj/random/melee/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/boltgun/heavysniper,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "lQk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11744,7 +11970,7 @@
 "lTl" = (
 /mob/living/carbon/superior_animal/human/excelsior,
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "lTC" = (
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -12017,12 +12243,12 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "mjb" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/stack/medical/bruise_pack,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "mjo" = (
 /obj/structure/table/standard,
@@ -12105,6 +12331,10 @@
 /obj/structure/curtain/medical,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
+"mng" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "mnY" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark,
@@ -12336,6 +12566,13 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"myt" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/random_milsupply,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "myJ" = (
 /turf/simulated/shuttle/wall/cargo{
 	icon_state = "cargoshwall31";
@@ -12718,7 +12955,7 @@
 /obj/item/gun/projectile/automatic/ak47/saiga,
 /obj/item/gun/projectile/automatic/ak47/saiga,
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "mNN" = (
 /obj/effect/decal/cleanable/generic,
@@ -12729,6 +12966,10 @@
 /obj/item/target/alien,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/dungeon/outside/prepper)
+"mOu" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "mOL" = (
 /obj/structure/boulder,
 /obj/structure/barricade,
@@ -12889,7 +13130,7 @@
 "mUI" = (
 /obj/item/trash/popcorn,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "mVa" = (
 /obj/random/material_rare,
@@ -13120,6 +13361,13 @@
 /obj/structure/flora/rock,
 /turf/simulated/floor/beach/sand/desert,
 /area/nadezhda/dungeon/outside/zoo)
+"ngB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/largecrate/animal/cat,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "ngF" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall36";
@@ -13198,9 +13446,13 @@
 /obj/item/plastique,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"nld" = (
+/obj/structure/scrap,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "nle" = (
 /obj/structure/salvageable/implant_container_os,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "nlq" = (
 /obj/structure/cable{
@@ -13354,7 +13606,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "nrW" = (
 /obj/structure/salvageable/computer_os,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "nsg" = (
 /obj/structure/salvageable/console_os,
@@ -13393,16 +13645,16 @@
 "nuB" = (
 /obj/effect/decal/cleanable/filth,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "nuE" = (
 /obj/item/trash/gamerchips,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "nuW" = (
 /obj/structure/table/marble,
 /obj/item/gun/projectile/automatic/ak47,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "nvl" = (
 /obj/structure/sign/warning/caution{
@@ -13532,7 +13784,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/showcase/television,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "nBY" = (
 /obj/machinery/light/small{
@@ -13551,6 +13804,13 @@
 /obj/effect/decal/cleanable/blood/oil/streak,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"nCC" = (
+/obj/effect/decal/cleanable/filth,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "nCJ" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/glass/bottle/aluminum,
@@ -13625,7 +13885,11 @@
 "nGT" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/human/excelsior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
+"nGW" = (
+/obj/machinery/door/unpowered/simple/wood,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "nHb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13672,7 +13936,7 @@
 "nJu" = (
 /obj/effect/decal/cleanable/filth,
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "nJw" = (
 /obj/effect/decal/cleanable/rubble,
@@ -13702,7 +13966,7 @@
 /obj/structure/janitorialcart,
 /obj/item/keys/janitor,
 /obj/item/mop,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "nMX" = (
 /obj/machinery/vending/cola,
@@ -13738,7 +14002,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "nPq" = (
 /obj/structure/flora/small/busha2,
@@ -13748,7 +14012,7 @@
 "nPJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/makarov/preloaded,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "nPK" = (
 /obj/structure/flora/rock/variant1,
@@ -13773,6 +14037,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"nQY" = (
+/obj/structure/computerframe,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "nRe" = (
 /obj/random/contraband,
 /obj/effect/decal/cleanable/dirt,
@@ -13908,7 +14176,7 @@
 /area/nadezhda/dungeon/outside/zoo)
 "nZp" = (
 /obj/item/gun/projectile/boltgun,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "nZr" = (
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -13918,7 +14186,8 @@
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "nZN" = (
 /obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "oab" = (
 /obj/structure/closet/secure_closet/freezer,
@@ -13951,7 +14220,7 @@
 /area/nadezhda/outside/meadow)
 "obJ" = (
 /obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "oco" = (
 /obj/item/part/gun/frame/kalash,
@@ -13999,6 +14268,10 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"oel" = (
+/obj/machinery/gym/robustness,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "oes" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/cafe,
@@ -14038,7 +14311,7 @@
 "ofK" = (
 /obj/machinery/door/airlock/centcom,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ofO" = (
 /obj/structure/flora/small/bushb3,
@@ -14146,7 +14419,7 @@
 /area/nadezhda/dungeon/outside/prepper)
 "ojC" = (
 /obj/item/mine/excelsior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "ojS" = (
 /obj/item/emp_mine/armed,
@@ -14191,7 +14464,7 @@
 /area/nadezhda/outside/one_star)
 "olN" = (
 /obj/item/part/gun/frame/vintorez,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "omd" = (
 /obj/structure/flora/small/busha1,
@@ -14240,6 +14513,10 @@
 "oph" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"opq" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "opC" = (
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -14309,7 +14586,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "osM" = (
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/wall,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "osT" = (
 /obj/structure/railing/grey,
@@ -14358,7 +14635,7 @@
 /area/nadezhda/outside/one_star)
 "ouu" = (
 /obj/random/dungeon_gun_ballistic,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "ovb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14402,9 +14679,8 @@
 /obj/item/mine/excelsior{
 	armed = 1
 	},
-/obj/item/trash/mre_candy,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "owF" = (
 /obj/random/flora/jungle_tree,
@@ -14567,7 +14843,7 @@
 "oDU" = (
 /mob/living/carbon/superior_animal/human/excelsior,
 /obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "oEv" = (
 /obj/machinery/button/remote/airlock{
@@ -14609,7 +14885,7 @@
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "oFk" = (
 /obj/random/scrap/dense_weighted,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "oFC" = (
 /obj/random/lathe_disk/advanced,
@@ -14806,11 +15082,7 @@
 /turf/simulated/mineral/random/rogue,
 /area/colony/exposedsun/crashed_shop/outsider)
 "oNj" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/porta_turret/excelsior/preloaded,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "oNq" = (
 /obj/structure/railing/grey{
@@ -14910,7 +15182,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/rock/dark,
+/turf/simulated/floor/rock/manmade/ruin2,
 /area/asteroid/rogue)
 "oSD" = (
 /obj/random/pack/junk_machine,
@@ -14953,7 +15225,7 @@
 /area/colony/exposedsun/pastgate)
 "oTT" = (
 /obj/structure/flora/pottedplant/redshoot,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "oUc" = (
 /obj/structure/boulder,
@@ -15033,7 +15305,7 @@
 /obj/random/mecha/damaged/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mech_recharger,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "oWV" = (
 /obj/effect/decal/cleanable/rubble,
@@ -15051,7 +15323,7 @@
 "oXO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/autoinjector/drugs,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "oYe" = (
 /obj/machinery/light{
@@ -15167,7 +15439,7 @@
 "pfV" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/bear/excelsior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "pgh" = (
 /obj/machinery/door/airlock/multi_tile/metal{
@@ -15187,7 +15459,11 @@
 /area/nadezhda/outside/meadow)
 "phk" = (
 /obj/structure/coatrack,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/wild1,
+/area/asteroid/rogue)
+"phC" = (
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/steel/brown_platform,
 /area/asteroid/rogue)
 "pit" = (
 /obj/structure/multiz/ladder,
@@ -15313,11 +15589,8 @@
 /area/asteroid/rogue)
 "plG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/psych{
-	desc = "It can be a bit noisy, but still serves well.";
-	name = "old bed"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "plK" = (
 /turf/simulated/floor/carpet/turcarpet,
@@ -15330,6 +15603,16 @@
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"pmY" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/random/dungeon_ammo/really_low_chance,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "pnn" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -15371,7 +15654,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
 /obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "pnV" = (
 /obj/structure/closet/crate/trashcart,
@@ -15403,6 +15686,17 @@
 /obj/structure/flora/small/bushc1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"ppl" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/random/dungeon_ammo/really_low_chance,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "ppo" = (
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -15579,13 +15873,16 @@
 /obj/item/spacecash/bundle/c10,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"pzz" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "pzW" = (
 /obj/structure/flora/small/busha2,
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "pAv" = (
-/obj/structure/closet/crate/excelsior,
 /obj/item/tool/baton/excelbaton,
 /obj/item/tool/baton/excelbaton,
 /obj/item/clothing/suit/space/void/excelsior,
@@ -15593,7 +15890,9 @@
 /obj/random/melee/low_chance,
 /obj/item/gun/projectile/automatic/drozd,
 /obj/item/gun/projectile/automatic/drozd,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/standard,
+/obj/item/clothing/glasses/eyepatch/secpatch,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "pAx" = (
 /obj/machinery/door/unpowered/simple/wood,
@@ -15608,7 +15907,7 @@
 /obj/machinery/door/airlock/centcom,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mine/excelsior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "pBb" = (
 /obj/structure/table/onestar,
@@ -15617,7 +15916,7 @@
 /area/nadezhda/outside/one_star)
 "pBg" = (
 /obj/random/scrap/dense_even,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "pBC" = (
 /obj/structure/flora/small/busha2,
@@ -15689,7 +15988,7 @@
 "pFf" = (
 /obj/item/mine/excelsior,
 /obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "pFJ" = (
 /obj/machinery/power/solar_control,
@@ -15735,11 +16034,8 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "pHI" = (
-/obj/item/mine/excelsior{
-	armed = 1
-	},
-/obj/item/trash/mre_candy,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "pHN" = (
 /obj/random/mob/vox/low_chance,
@@ -15808,7 +16104,7 @@
 "pJu" = (
 /obj/effect/decal/cleanable/filth,
 /obj/item/trash/mre_can,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "pJz" = (
 /obj/effect/decal/cleanable/rubble,
@@ -15838,7 +16134,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "pKQ" = (
 /turf/simulated/shuttle/wall/cargo{
@@ -15893,7 +16189,7 @@
 /obj/structure/bed,
 /obj/effect/decal/cleanable/rubble,
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "pMY" = (
 /obj/item/contraband/poster/placed/generic/fruit_bowl{
@@ -15917,7 +16213,7 @@
 "pNG" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
 /obj/structure/curtain/medical,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "pNN" = (
 /obj/structure/cable/yellow{
@@ -16142,7 +16438,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "pXi" = (
 /obj/structure/curtain/medical,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "pXj" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -16222,6 +16518,11 @@
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"pZG" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "pZH" = (
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -16273,7 +16574,7 @@
 /obj/item/mine/excelsior,
 /obj/item/trash/plate,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "qdm" = (
 /obj/structure/closet/cabinet,
@@ -16374,7 +16675,7 @@
 /obj/random/ammo/shotgun/low_chance,
 /obj/random/ammo_fancy,
 /obj/random/ammo_fancy,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "qhr" = (
 /obj/structure/bed/chair/shuttle{
@@ -16413,6 +16714,11 @@
 /obj/random/gun_normal/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"qio" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/random_medsupply,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "qiC" = (
 /obj/machinery/light/floor{
 	dir = 4;
@@ -16423,6 +16729,10 @@
 "qiU" = (
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
+"qjc" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "qjg" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -16502,7 +16812,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "qmN" = (
 /obj/machinery/shieldwallgen/excelsior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "qmO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16631,7 +16941,7 @@
 "qvg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "qvn" = (
 /obj/structure/closet/crate/bin,
@@ -16647,7 +16957,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "qwo" = (
 /obj/effect/decal/cleanable/rubble,
@@ -16744,7 +17054,7 @@
 /area/nadezhda/outside/meadow)
 "qzT" = (
 /obj/machinery/vending/medical,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "qAS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16897,7 +17207,7 @@
 /mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
 /obj/item/trash/popcorn,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "qGS" = (
 /obj/structure/flora/small/bushc2,
@@ -16910,7 +17220,7 @@
 "qHe" = (
 /obj/structure/table/standard,
 /obj/random/surgery_tool,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "qHh" = (
 /obj/random/cluster/roaches,
@@ -17077,7 +17387,7 @@
 /area/nadezhda/dungeon/outside/zoo)
 "qPt" = (
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "qPO" = (
 /obj/structure/table/rack/shelf,
@@ -17386,6 +17696,10 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"rdH" = (
+/obj/item/trash/mre,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "rdN" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -17402,7 +17716,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "rfd" = (
 /obj/random/junk/cigbutt,
@@ -17429,13 +17743,20 @@
 "rgT" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "rgX" = (
 /obj/random/techpart/low_chance,
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"rhr" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "rhw" = (
 /mob/living/carbon/superior_animal/robot/greyson/custodian/engineer,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
@@ -17465,7 +17786,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "riv" = (
 /obj/item/storage/fancy/vials,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "riD" = (
 /obj/machinery/light/small{
@@ -17754,7 +18075,8 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "rww" = (
 /obj/structure/reagent_dispensers/fueltank/derelict,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "rxy" = (
 /obj/structure/cable/yellow{
@@ -17803,7 +18125,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/pistachios,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "rAV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17835,6 +18157,13 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"rBT" = (
+/obj/random/lowkeyrandom,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "rBW" = (
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
@@ -17872,6 +18201,10 @@
 /obj/random/mecha/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"rCV" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "rDf" = (
 /obj/structure/sign/warning/caution/small2,
 /turf/simulated/wall/r_wall,
@@ -17901,8 +18234,8 @@
 /obj/item/cell/large/excelsior,
 /obj/item/cell/large/excelsior,
 /obj/structure/table/standard,
-/obj/item/part/gun/frame/basilisk,
-/turf/simulated/floor/tiled/dark,
+/obj/random/dungeon_gun_ballistic/low_chance,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "rEO" = (
 /obj/machinery/door/airlock/highsecurity{
@@ -18007,6 +18340,11 @@
 /area/asteroid/rogue)
 "rKz" = (
 /turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
+"rLO" = (
+/obj/machinery/light,
+/obj/structure/firedoor_assembly,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "rMe" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -18123,7 +18461,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/gun_parts,
 /obj/item/gun_upgrade/barrel/faulty,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "rSp" = (
 /obj/random/mob/render/low_chance,
@@ -18179,7 +18517,8 @@
 "rVZ" = (
 /obj/item/mine/excelsior,
 /obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "rWz" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -18283,7 +18622,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "scK" = (
 /obj/item/tank/onestar_regenerator,
@@ -18348,6 +18687,10 @@
 /obj/item/bee_pack,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"sfb" = (
+/obj/effect/floor_decal/industrial/road/warning3,
+/turf/simulated/floor/rock/grey,
+/area/asteroid/rogue)
 "sfr" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/syndie_kit/chameleon,
@@ -18401,6 +18744,16 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/zoo)
+"shr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/random/closet_tech/low_chance,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "shv" = (
 /obj/structure/table/onestar,
 /obj/random/pack/tech_loot/onestar,
@@ -18528,11 +18881,11 @@
 "snc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/peachcan,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "snd" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "sns" = (
 /turf/simulated/floor/tiled/dark,
@@ -18615,12 +18968,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_even,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "srx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/pottedplant/green_rock,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "srB" = (
 /obj/effect/decal/cleanable/rubble,
@@ -18636,11 +18989,11 @@
 "ssO" = (
 /obj/structure/table/rack,
 /obj/item/gun/projectile/automatic/vintorez,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "ssP" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "stb" = (
 /obj/effect/decal/cleanable/rubble,
@@ -18693,7 +19046,7 @@
 /obj/item/ammo_casing/rocket,
 /obj/item/ammo_casing/rocket,
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "suZ" = (
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
@@ -18765,9 +19118,15 @@
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"syk" = (
+/obj/machinery/door/airlock,
+/obj/item/mine/excelsior,
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/asteroid/rogue)
 "syp" = (
 /obj/structure/flora/pottedplant/stoutbush,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "syE" = (
 /obj/structure/table/marble,
@@ -18781,6 +19140,10 @@
 /obj/structure/flora/small/rock2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"szl" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "sAP" = (
 /obj/structure/flora/small/bushc1,
 /obj/structure/flora/big/bush3,
@@ -18860,7 +19223,7 @@
 /area/nadezhda/outside/meadow)
 "sEk" = (
 /obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "sEK" = (
 /obj/structure/bed/chair{
@@ -19008,7 +19371,7 @@
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "sNe" = (
 /obj/machinery/porta_turret/excelsior/preloaded,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "sNA" = (
 /obj/structure/bed/chair,
@@ -19155,7 +19518,7 @@
 	pixel_x = -8;
 	pixel_y = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "sUP" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -19183,6 +19546,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"sXz" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "sXB" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/standard,
@@ -19224,7 +19591,7 @@
 	armed = 1
 	},
 /obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "sZV" = (
 /obj/effect/decal/cleanable/rubble,
@@ -19342,7 +19709,7 @@
 "tgr" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/trash,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "tgL" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -19361,6 +19728,10 @@
 /obj/random/tool_upgrade/low_chance,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"thh" = (
+/mob/living/simple_animal/hostile/bear/excelsior,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "thS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -19390,6 +19761,10 @@
 /mob/living/simple_animal/hostile/panther,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
+"tiB" = (
+/obj/structure/synthesized_instrument/synthesizer/piano,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "tji" = (
 /obj/random/junk,
 /obj/random/junk,
@@ -19456,7 +19831,7 @@
 "tlD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "tlO" = (
 /obj/structure/closet/onestar/tier3/special,
@@ -19534,9 +19909,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
 "tqb" = (
-/obj/item/flame/lighter/zippo/excelsior,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/curtain,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "tqA" = (
 /obj/structure/table/steel_reinforced,
@@ -19588,7 +19962,7 @@
 /area/nadezhda/dungeon/outside/zoo)
 "ttU" = (
 /obj/machinery/autodoc,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "tuo" = (
 /obj/item/folder/red,
@@ -19649,7 +20023,7 @@
 "tyf" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/trash/mre,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "tyi" = (
 /obj/effect/overlay/water/top{
@@ -19673,7 +20047,7 @@
 /obj/structure/closet/crate/excelsior,
 /obj/random/surgery_tool/low_chance,
 /obj/item/tool/saw/circular/medical,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "tyW" = (
 /obj/machinery/light{
@@ -19714,6 +20088,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"tAf" = (
+/obj/structure/noticeboard/medical,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "tAp" = (
 /turf/simulated/wall,
 /area/nadezhda/dungeon/outside/zoo)
@@ -19725,6 +20103,14 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"tAF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "tBk" = (
 /obj/structure/table/rack/shelf,
 /obj/random/gun_energy_cheap,
@@ -19738,7 +20124,7 @@
 "tBs" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/projectile/boltgun,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "tCf" = (
 /obj/structure/table/standard,
@@ -19820,6 +20206,11 @@
 /obj/structure/salvageable/bliss,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/dungeon/outside/prepper)
+"tFv" = (
+/obj/structure/dogbed,
+/obj/structure/flora/pumpkin,
+/turf/simulated/floor/wood/wild1,
+/area/asteroid/rogue)
 "tFU" = (
 /obj/structure/flora/small/busha2,
 /obj/item/mine/armed,
@@ -19835,12 +20226,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "tIm" = (
-/obj/structure/scrap_cube,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "tIC" = (
 /obj/item/paper_bin,
@@ -20074,7 +20461,7 @@
 "tTP" = (
 /obj/machinery/porta_turret/excelsior/preloaded,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "tUH" = (
 /obj/machinery/power/port_gen/pacman,
@@ -20123,7 +20510,7 @@
 "tWQ" = (
 /obj/item/implantcase/excelsior/broken,
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "tWY" = (
 /obj/structure/table/onestar,
@@ -20214,7 +20601,7 @@
 "ubp" = (
 /obj/random/scrap/dense_weighted,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ubu" = (
 /obj/random/mob/voidwolf,
@@ -20259,7 +20646,7 @@
 "ucC" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "udc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20291,7 +20678,7 @@
 "uea" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/lapvend,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "uec" = (
 /obj/structure/flora/tree/dead,
@@ -20303,7 +20690,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/landmark/corpse/chef,
 /mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ueX" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -20316,6 +20703,9 @@
 /obj/item/reagent_containers/food/drinks/milk,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
+"ufe" = (
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/asteroid/rogue)
 "ufg" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -20354,12 +20744,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"ugr" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "ugx" = (
 /obj/structure/table,
 /obj/item/stack/material/wood/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"ugC" = (
+/obj/structure/fireaxecabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "ugY" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -20387,6 +20787,10 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"uhF" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "uih" = (
 /obj/machinery/power/smes/buildable,
 /turf/simulated/shuttle/floor/mining,
@@ -20449,7 +20853,7 @@
 /area/nadezhda/outside/one_star)
 "umz" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "umG" = (
 /obj/machinery/light,
@@ -20590,7 +20994,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "utC" = (
 /obj/structure/barricade,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "utY" = (
 /mob/living/simple_animal/penguin/baby,
@@ -20677,7 +21081,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/papershredder,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "uzt" = (
 /obj/effect/decal/cleanable/blood,
@@ -20761,6 +21165,10 @@
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"uCV" = (
+/obj/machinery/door/window/holowindoor,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "uDa" = (
 /obj/structure/closet/random_hostilemobs,
 /obj/effect/decal/cleanable/dirt,
@@ -20785,7 +21193,7 @@
 "uDS" = (
 /obj/structure/scrap_cube,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "uDY" = (
 /obj/structure/girder,
@@ -20795,7 +21203,7 @@
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "uEq" = (
 /obj/structure/boulder,
@@ -21027,7 +21435,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/item/storage/firstaid/combat,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "uON" = (
 /obj/machinery/gym,
@@ -21221,7 +21629,7 @@
 /area/asteroid/rogue)
 "uWM" = (
 /obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "uXk" = (
 /obj/structure/flora/small/busha3,
@@ -21270,6 +21678,10 @@
 "vaO" = (
 /turf/simulated/mineral/planet,
 /area/nadezhda/dungeon/outside/monster_cave)
+"vbn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild1,
+/area/asteroid/rogue)
 "vbq" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -21489,7 +21901,7 @@
 	icon_state = "spiderling";
 	name = "dead spider"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "vkQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21563,7 +21975,7 @@
 	icon_state = "spiderling";
 	name = "dead spider"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "vom" = (
 /obj/structure/table/plasmaglass,
@@ -21644,7 +22056,13 @@
 "vqZ" = (
 /obj/machinery/door/airlock/centcom,
 /obj/item/mine/excelsior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
+"vsV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "vto" = (
 /obj/structure/closet/crate/bin,
@@ -21783,7 +22201,7 @@
 "vBH" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "vBO" = (
 /obj/random/junk/nondense,
@@ -21866,7 +22284,7 @@
 "vEb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_even,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "vEk" = (
 /obj/structure/table/bench/wooden,
@@ -21905,7 +22323,7 @@
 /area/colony/exposedsun/crashed_shop/outsider)
 "vHs" = (
 /obj/landmark/corpse/excelsior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "vHF" = (
 /obj/machinery/computer/arcade/orion_trail,
@@ -21919,7 +22337,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/curtain,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "vIA" = (
 /obj/structure/flora/small/bushc2,
@@ -21951,7 +22370,7 @@
 /area/colony/exposedsun/pastgate)
 "vJM" = (
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "vJQ" = (
 /obj/structure/bed/chair/comfy/black{
@@ -21985,10 +22404,8 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "vLG" = (
-/obj/item/mine/excelsior{
-	armed = 1
-	},
 /obj/item/trash/mre/alt,
+/obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock/dark,
 /area/asteroid/rogue)
 "vLX" = (
@@ -22073,6 +22490,10 @@
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"vPo" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "vPG" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
@@ -22292,7 +22713,7 @@
 "vZw" = (
 /obj/item/rcd/excelsior,
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "vZC" = (
 /obj/random/scrap/sparse_even,
@@ -22517,7 +22938,8 @@
 "wmo" = (
 /obj/structure/table/rack,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/item/clothing/glasses/powered/night,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "wmE" = (
 /obj/machinery/papershredder,
@@ -22530,7 +22952,8 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "wnh" = (
 /obj/random/lowkeyrandom,
-/turf/simulated/floor/tiled/dark,
+/obj/random/dungeon_gun_ballistic,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "wnI" = (
 /obj/machinery/recharge_station,
@@ -22558,11 +22981,8 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
 "woR" = (
-/obj/structure/bed/psych{
-	desc = "It can be a bit noisy, but still serves well.";
-	name = "old bed"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "wpR" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -22582,6 +23002,9 @@
 "wqu" = (
 /obj/structure/bed/chair/comfy,
 /turf/simulated/floor/wood,
+/area/asteroid/rogue)
+"wqX" = (
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "wre" = (
 /turf/simulated/shuttle/floor/mining{
@@ -22634,7 +23057,7 @@
 "wsW" = (
 /obj/structure/table/reinforced,
 /obj/item/trash/candle,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "wsZ" = (
 /obj/machinery/door/airlock/vault/bolted{
@@ -22653,12 +23076,14 @@
 /obj/structure/flora/small/bushc3,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"wtz" = (
+/obj/random/dungeon_gun_ballistic,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "wtC" = (
-/obj/item/mine/excelsior{
-	armed = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "wtL" = (
 /obj/structure/flora/small/grassb1,
@@ -22682,11 +23107,11 @@
 "wvi" = (
 /obj/structure/table/rack,
 /obj/item/gun/energy/stunrevolver,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "wvJ" = (
 /obj/item/trash/material/circuit,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "wvW" = (
 /obj/structure/table,
@@ -22844,7 +23269,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "wEV" = (
 /obj/item/trash/mre_paste,
@@ -22914,6 +23339,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"wJm" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/asteroid/rogue)
 "wJr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/nightmare/low_chance,
@@ -23112,7 +23543,7 @@
 /area/nadezhda/outside/meadow)
 "wRP" = (
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/rock/dark,
+/turf/simulated/floor/rock/manmade/ruin2,
 /area/asteroid/rogue)
 "wRZ" = (
 /obj/machinery/power/terminal{
@@ -23273,7 +23704,7 @@
 "xav" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "xbq" = (
 /obj/random/lathe_disk,
@@ -23315,7 +23746,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
 "xcF" = (
 /obj/item/trash/mre_paste,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "xdH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23447,12 +23878,16 @@
 /obj/structure/table/woodentable,
 /obj/item/clothing/under/excelsior/officer,
 /obj/item/clothing/head/exceslior/excelsior_officer,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "xhY" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"xiC" = (
+/obj/random/lowkeyrandom,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "xiH" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/contraband,
@@ -23572,7 +24007,7 @@
 "xmM" = (
 /obj/structure/curtain/medical,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "xnX" = (
 /obj/structure/flora/big/rocks1,
@@ -23658,7 +24093,15 @@
 "xty" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
+"xtL" = (
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "xtX" = (
 /obj/structure/bed/chair{
@@ -23686,7 +24129,7 @@
 /area/colony/exposedsun/crashed_shop/outsider)
 "xvh" = (
 /obj/random/oddity_guns,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "xvi" = (
 /obj/item/pizzabox/vegetable,
@@ -23805,7 +24248,7 @@
 /obj/structure/scrap_cube,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "xBx" = (
 /obj/machinery/door/airlock/multi_tile/metal{
@@ -23827,7 +24270,11 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
+"xCX" = (
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "xDd" = (
 /obj/effect/step_trigger/vault_bunker_2B,
@@ -23853,6 +24300,11 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
+"xEH" = (
+/obj/machinery/door/airlock,
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/asteroid/rogue)
 "xEO" = (
 /obj/structure/table/bench/wooden,
 /obj/item/trash/broken_robot_part,
@@ -24038,7 +24490,7 @@
 "xNJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "xOk" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -24097,7 +24549,7 @@
 "xQf" = (
 /obj/item/trash/cigbutt/fortress,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "xQu" = (
 /obj/structure/flora/small/busha2,
@@ -24110,8 +24562,11 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "xRl" = (
-/mob/living/simple_animal/hostile/bear/excelsior,
-/turf/simulated/mineral/random/rogue,
+/obj/random/junk,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "xRs" = (
 /obj/structure/table/steel_reinforced,
@@ -24132,7 +24587,7 @@
 "xSJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/sosjerky,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "xSP" = (
 /obj/structure/target_stake,
@@ -24148,7 +24603,7 @@
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "xTu" = (
 /obj/structure/sign/departmentold/medical1,
@@ -24173,7 +24628,7 @@
 "xTT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/complant_teleporter,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "xUd" = (
 /obj/structure/sign/warning/armory{
@@ -24241,7 +24696,7 @@
 "xZn" = (
 /obj/structure/curtain/medical,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "xZx" = (
 /obj/structure/table/standard,
@@ -24307,7 +24762,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
 /obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ybU" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -24409,7 +24864,7 @@
 /area/nadezhda/dungeon/outside/prepper)
 "yhY" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "yiT" = (
 /obj/structure/table/steel_reinforced,
@@ -45185,7 +45640,7 @@ qbU
 qbU
 qbU
 qbU
-eCR
+sfb
 qbU
 qbU
 wzO
@@ -45401,7 +45856,7 @@ qbU
 qbU
 qbU
 uVX
-uVX
+dpk
 uVX
 qbU
 qbU
@@ -45603,15 +46058,15 @@ qbU
 qbU
 qbU
 qbU
-uVX
+dpk
+rel
 qbU
 qbU
-qbU
-uVX
+dpk
 ldM
 uVX
 qbU
-uVX
+dpk
 qbU
 qbU
 qbU
@@ -45813,7 +46268,7 @@ qbU
 qbU
 qbU
 uVX
-uVX
+dpk
 vLG
 uVX
 uVX
@@ -46654,7 +47109,7 @@ qbU
 qbU
 qbU
 qbU
-xRl
+qbU
 qbU
 qbU
 qbU
@@ -46864,7 +47319,7 @@ qbU
 dpk
 dpk
 iET
-djA
+uVX
 uCn
 dpk
 dpk
@@ -47073,7 +47528,7 @@ dpk
 uVX
 loq
 qbU
-xRl
+qbU
 qbU
 qbU
 qbU
@@ -47275,7 +47730,7 @@ qbU
 qbU
 qbU
 qbU
-qbU
+dpk
 dpk
 dpk
 qbU
@@ -47906,8 +48361,8 @@ tnz
 dpk
 ptw
 ptw
-dpk
-uVX
+baC
+iFU
 qbU
 coU
 coU
@@ -48117,7 +48572,7 @@ qbU
 qbU
 cKr
 bTz
-uVX
+iFU
 coU
 coU
 coU
@@ -48323,10 +48778,10 @@ qbU
 qbU
 qbU
 qbU
-uVX
-dpk
+iFU
+baC
 wRP
-uVX
+iFU
 coU
 coU
 coU
@@ -48534,7 +48989,7 @@ qbU
 mNA
 lEJ
 kcL
-uVX
+iFU
 bAa
 mNA
 coU
@@ -48743,7 +49198,7 @@ coU
 hwy
 oSA
 wRP
-uVX
+iFU
 gkh
 hwy
 coU
@@ -49160,17 +49615,17 @@ hgL
 hgL
 qmN
 utC
-jfz
+qjc
 hgL
 hgL
 qmN
 hgL
 cYh
-aFi
+wtC
 fcB
 rKz
 aLI
-wSZ
+wtz
 eas
 wSZ
 wSZ
@@ -49371,11 +49826,11 @@ hgL
 hgL
 hgL
 jva
-bRP
+pHI
 hgL
 hgL
 hgL
-bRP
+pHI
 hgL
 rKz
 hNR
@@ -49574,13 +50029,13 @@ coU
 qbU
 qbU
 lTl
-bRP
+pHI
 hgL
 xQf
 hgL
 jva
 hgL
-bRP
+pHI
 pFf
 hgL
 dnC
@@ -49990,7 +50445,7 @@ nxY
 coU
 coU
 rKz
-laf
+hgL
 hgL
 hgL
 ojC
@@ -49998,7 +50453,7 @@ hgL
 sUx
 hgL
 hgL
-nZN
+vPo
 hgL
 hgL
 hgL
@@ -50202,11 +50657,11 @@ rKz
 aHK
 fTh
 hox
-sNe
+hyA
 nZN
-nZN
-nZN
-nZN
+vPo
+vPo
+vPo
 wsW
 tBs
 hgL
@@ -50214,7 +50669,7 @@ hox
 hgL
 gAk
 rKz
-wSZ
+uCV
 glZ
 cOt
 glZ
@@ -50412,7 +50867,7 @@ aHK
 hgL
 hgL
 hgL
-bRP
+pHI
 gqN
 hgL
 hgL
@@ -50421,13 +50876,13 @@ hgL
 hgL
 hgL
 jva
-bRP
+pHI
 tCZ
 hgL
 hgL
 avp
-snd
-bRP
+jgj
+pHI
 hgL
 yhY
 rKz
@@ -50619,10 +51074,10 @@ coU
 rKz
 hgL
 utC
-bRP
-bRP
+pHI
+pHI
 hgL
-bRP
+pHI
 dnC
 dnC
 hgL
@@ -50632,8 +51087,8 @@ hgL
 utC
 hgL
 rKz
-snd
-jfz
+jgj
+qjc
 hgL
 hgL
 owt
@@ -50826,25 +51281,25 @@ nxY
 coU
 coU
 rKz
-hgL
-bRP
-bRP
+vsV
+pHI
+pHI
 jva
 xty
 hgL
 hgL
 hgL
 hgL
-hgL
+jcD
 utC
 hgL
-bRP
-yhY
+pHI
+rLO
 rKz
-rVZ
+eGQ
 hgL
-bRP
-bRP
+wtC
+pHI
 dpI
 vHs
 axV
@@ -51036,8 +51491,8 @@ coU
 coU
 rKz
 mNA
-tQp
-tQp
+szl
+szl
 mNA
 mNA
 mNA
@@ -51046,15 +51501,15 @@ mNA
 mNA
 mNA
 mNA
-tQp
-tQp
+szl
+szl
 mNA
 rKz
 lOU
 hgL
 hgL
 hgL
-hgL
+jgj
 vJM
 qbU
 qbU
@@ -51244,22 +51699,22 @@ nxY
 coU
 coU
 rKz
-hgL
-hgL
-hgL
-hgL
+oNj
+oNj
+oNj
+oNj
 iip
-hgL
-aGn
+tiB
+dez
 bRP
 bHO
-oFk
-hgL
-hgL
-hgL
-hgL
+jQS
+nQY
+oNj
+oNj
+oNj
 rKz
-hgL
+cEx
 dpI
 fqQ
 hgL
@@ -51455,23 +51910,23 @@ coU
 rKz
 hOw
 aDy
-jnq
-hgL
-hgL
-hgL
-dpI
+thh
+oNj
+oNj
+axL
+xCX
 bRP
-hgL
-oFk
-hgL
+oNj
+jQS
+oNj
 cFk
-hgL
-dnC
+oNj
+jio
 rKz
-cam
-hBa
+gjj
+kdd
 hgL
-hgL
+jgj
 hgL
 hgL
 axV
@@ -51663,26 +52118,26 @@ coU
 coU
 rKz
 bRP
-hgL
+oNj
 aDy
-oFk
+jQS
 aWi
-hgL
-hgL
-hgL
-hgL
-hgL
+oNj
+oNj
+oNj
+oNj
+oNj
 cvA
-hgL
+oNj
 bRP
-hgL
+oNj
 rKz
 sEk
-bRP
-bRP
+pHI
+pHI
 hgL
 sZH
-bRP
+pHI
 chw
 rKz
 coU
@@ -51871,17 +52326,17 @@ nxY
 coU
 coU
 rKz
-hgL
-hgL
-hgL
-oFk
-hgL
+oNj
+oNj
+oNj
+jQS
+oNj
 edP
-jnq
+thh
 iiZ
 kBY
-dpI
-dnC
+xCX
+uhF
 bRP
 aFi
 nJu
@@ -51892,7 +52347,7 @@ hgL
 hgL
 utC
 hgL
-bRP
+pHI
 rKz
 coU
 coU
@@ -52087,7 +52542,7 @@ mNA
 mNA
 mNA
 oTT
-hgL
+oNj
 mNA
 mNA
 mNA
@@ -52289,14 +52744,14 @@ nxY
 coU
 coU
 rKz
-jjD
-rgT
+tIm
+nld
 nPJ
 azg
-sEk
+dup
 mNA
-hgL
-yhY
+oNj
+opq
 mNA
 azg
 fyX
@@ -52309,7 +52764,7 @@ cUA
 rRO
 qPt
 qPt
-hBa
+kdd
 utC
 rKz
 coU
@@ -52500,23 +52955,23 @@ coU
 tCZ
 qbU
 pMT
-hgL
+oNj
 xTs
-sEk
+dup
 mNA
-bRP
-hgL
+kZp
+oNj
 hwy
 rgT
-hgL
+oNj
 azg
-hgL
+oNj
 rgT
-hgL
+oNj
 mNA
 hgL
 dpI
-bRP
+pHI
 utC
 hgL
 utC
@@ -52709,26 +53164,26 @@ coU
 qbU
 qbU
 qbU
-vJM
-hgL
-hgL
+pzz
+oNj
+oNj
 mNA
 hOw
-jnq
+thh
 mNA
-laf
-iDM
-hgL
+myt
+fHd
+oNj
 bRP
-hgL
-hgL
+oNj
+oNj
 mNA
 oFk
 hgL
 hgL
 hgL
-bRP
-hgL
+pHI
+hyA
 rKz
 coU
 coU
@@ -52918,24 +53373,24 @@ coU
 qbU
 qbU
 qbU
-jjD
+tIm
 rgT
-hgL
+oNj
 mNA
 hBa
 bRP
 mNA
 uOI
-hgL
+oNj
 rgT
 bRP
 azg
-yhY
+kSE
 mNA
 iAz
 hgL
 dnC
-jfz
+qjc
 iDM
 hgL
 rKz
@@ -53125,23 +53580,23 @@ nxY
 coU
 coU
 rKz
-jjD
+tIm
 qbU
-jjD
+tIm
 iHb
-bRP
+qvg
 mNA
-hgL
+oNj
 bRP
 mNA
 rgT
-hgL
+oNj
 rgT
-hgL
+oNj
 rgT
-bRP
+qio
 mNA
-laf
+vsV
 hgL
 dpI
 hgL
@@ -53335,7 +53790,7 @@ coU
 coU
 rKz
 uep
-jjD
+tIm
 mjb
 bRP
 bRP
@@ -53343,15 +53798,15 @@ tQp
 bCY
 sNe
 mNA
-bRP
-hgL
-hgL
-dpI
-hgL
+ftz
+oNj
+oNj
+xCX
+oNj
 dWp
 mNA
-bRP
-bRP
+pHI
+pHI
 eCv
 wvi
 ssO
@@ -53549,11 +54004,11 @@ mNA
 mNA
 mNA
 mNA
-hgL
+oNj
 aWi
 mNA
 mNA
-tQp
+szl
 mNA
 mNA
 mNA
@@ -53753,23 +54208,23 @@ coU
 coU
 rKz
 dKT
-hgL
+oNj
 nJu
 aFi
-hgL
-tQp
-hgL
-hgL
-hgL
+oNj
+szl
+oNj
+oNj
+oNj
 jfz
-hgL
+oNj
 qcp
 bvs
-hgL
-hgL
-tQp
-hgL
-sEk
+oNj
+oNj
+szl
+oNj
+dup
 mNA
 nMq
 iDM
@@ -53962,25 +54417,25 @@ coU
 coU
 rKz
 dyP
-hgL
-iDM
+oNj
+fHd
 bRP
-hgL
+oNj
 mNA
-umz
-hgL
-hgL
-sEk
-sEk
-hgL
-dpI
+mng
+oNj
+oNj
+dup
+dup
+oNj
+xCX
 mUI
 hBa
-tQp
-hgL
+szl
+oNj
 bRP
 mNA
-laf
+vsV
 hgL
 hgL
 tCZ
@@ -54186,12 +54641,12 @@ mNA
 mNA
 mNA
 mNA
-hgL
+oNj
 qvg
 mNA
 nZp
 iDM
-bRP
+pHI
 rKz
 coU
 coU
@@ -54380,20 +54835,20 @@ coU
 coU
 rKz
 fVt
-hgL
+oNj
 ksu
 nuW
 qvg
 mNA
-hgL
-hgL
-hgL
-bRP
+oNj
+pmY
+oNj
+ice
 mNA
-hgL
-izA
+oNj
+ppl
 epY
-bRP
+ice
 mNA
 sNe
 bRP
@@ -54589,23 +55044,23 @@ coU
 coU
 rKz
 kVt
-hgL
+oNj
 aQr
 hQX
-hgL
+oNj
 hwy
 hOw
-ice
-hgL
-iDM
+osM
+oNj
+fHd
 mNA
 laf
 beH
-laf
-hgL
+oNj
+oNj
 hwy
-hgL
-hgL
+oNj
+oNj
 mNA
 kAK
 vjc
@@ -54798,8 +55253,8 @@ coU
 coU
 rKz
 ebi
-hgL
-hgL
+oNj
+oNj
 bRP
 dnv
 mNA
@@ -54810,15 +55265,15 @@ cEA
 mNA
 oXO
 qvM
-kAK
+bRP
 cEA
 mNA
-bRP
+iey
 qGH
-sEk
+dup
 jJO
-hgL
-hgL
+oNj
+oNj
 rKz
 qbU
 coU
@@ -55022,10 +55477,10 @@ rKz
 rKz
 rKz
 rKz
-hgL
+oel
 bRP
-sEk
-hgL
+dup
+oNj
 vBH
 afk
 rKz
@@ -55216,27 +55671,27 @@ coU
 coU
 rKz
 hnP
-hgL
+oNj
 cMR
 dbi
 ctv
 hAV
 sNe
-cLV
-cLV
+cEZ
+cEZ
 cLV
 oKr
 fXg
-hgL
-jnq
-hgL
+oNj
+thh
+oNj
 tQp
-xNJ
+kNe
 bRP
-hgL
-hgL
-hgL
-sEk
+oNj
+oNj
+oNj
+dup
 rKz
 qbU
 coU
@@ -55425,27 +55880,27 @@ coU
 coU
 eci
 qzT
-hgL
+kfS
 bRP
-hgL
-hgL
-dpI
+oNj
+oNj
+xCX
 bRP
 eVr
-hgL
-hgL
-tQp
-hgL
+oNj
+oNj
+szl
+oNj
 crF
-hgL
+oNj
 hBa
 tQp
-hgL
-hgL
-jnq
-hgL
+oNj
+oNj
+thh
+oNj
 bRP
-sEk
+dup
 rKz
 qbU
 coU
@@ -55634,24 +56089,24 @@ coU
 coU
 rKz
 hOg
-hgL
+kfS
 ceR
-hgL
-hgL
-hgL
+oNj
+oNj
+oNj
 aho
-hgL
+oNj
 xav
-hgL
-tQp
+oNj
+szl
 bRP
 bRP
-hgL
+oNj
 qvg
 rKz
-dnC
-hgL
-hgL
+uhF
+oNj
+oNj
 dbE
 bRP
 nBK
@@ -55843,22 +56298,22 @@ coU
 coU
 rKz
 qHe
-hgL
+kfS
 bRP
-hgL
-hgL
-hgL
-hox
-hgL
-hgL
+oNj
+oNj
+oNj
+rCV
+oNj
+oNj
 izA
 rKz
-dpI
-hgL
+jlf
+oNj
 bRP
 ubp
 rKz
-snd
+xRl
 snd
 axL
 igW
@@ -56052,17 +56507,17 @@ coU
 coU
 tCZ
 qHe
-hgL
+oNj
 riv
-dpI
-hgL
-hgL
-hgL
-hgL
+xCX
+oNj
+oNj
+oNj
+oNj
 izA
-hgL
+oNj
 tCZ
-sEk
+dup
 kaq
 bRP
 kzu
@@ -56259,9 +56714,9 @@ nxY
 nxY
 coU
 coU
-rKz
+tAf
 tyL
-hgL
+oNj
 pXi
 pXi
 pXi
@@ -56271,16 +56726,16 @@ pNG
 pXi
 xZn
 rKz
-sEk
+dup
 pfV
 uWM
-hgL
+oNj
 rKz
-hOw
-lpc
+kBi
+pZG
 sEk
 sEk
-xav
+ckM
 oWB
 rKz
 qbU
@@ -56469,21 +56924,21 @@ nxY
 coU
 coU
 rKz
-oNj
+laf
 bRP
 pXi
 izA
 izA
 izA
 pXi
-hgL
+oNj
 izA
-izA
+jsO
 rKz
 laf
 bRP
-hgL
-dpI
+oNj
+xCX
 cTi
 hgL
 hgL
@@ -56685,19 +57140,19 @@ aWi
 izA
 izA
 pXi
-hgL
-hgL
-hgL
+oNj
+oNj
+oNj
 rKz
-hgL
-hgL
-dnC
+oNj
+oNj
+uhF
 bRP
 qJt
 aqy
 hgL
 hgL
-vBH
+ces
 hgL
 aME
 rKz
@@ -56899,12 +57354,12 @@ woR
 vnE
 rKz
 sNe
-hgL
-hgL
+oNj
+oNj
 kts
 rKz
 lNk
-bRP
+pHI
 lQj
 pAv
 hgL
@@ -57108,8 +57563,8 @@ rKz
 rKz
 rKz
 rKz
-hgL
-hgL
+oNj
+oNj
 rKz
 rKz
 mED
@@ -57307,25 +57762,25 @@ coU
 coU
 rKz
 ddc
-xav
+ckM
 hgL
 hgL
 rKz
-snd
-hgL
+jgj
+lJy
 xTT
 uyY
 uea
 rKz
-hgL
-hgL
+oNj
+oNj
 rKz
 eHy
-bRP
+vbn
 vHY
-hgL
-hgL
-hgL
+wqX
+wqX
+wqX
 xhW
 rKz
 coU
@@ -57515,26 +57970,26 @@ coU
 coU
 coU
 tCZ
-vHs
+dhV
 hgL
-bRP
+pHI
 hYL
 rKz
-snd
+jgj
 dHR
 fyp
-bRP
-bRP
+pHI
+pHI
 rKz
-hgL
-hgL
+oNj
+oNj
 wZW
-hgL
-bRP
-hgL
+tFv
+vbn
+tqb
 lMF
-bRP
-hgL
+vbn
+wqX
 gQn
 rKz
 coU
@@ -57736,14 +58191,14 @@ hgL
 hgL
 rKz
 snd
-hgL
+oNj
 rKz
 eut
-hgL
-hgL
-bRP
-bRP
-bRP
+wqX
+tqb
+vbn
+vbn
+vbn
 jnl
 rKz
 coU
@@ -57936,22 +58391,22 @@ rKz
 kjp
 hgL
 hgL
-hBa
+kdd
 rKz
-hgL
+ugC
 hgL
 sEk
 hgL
 hgL
 rKz
-laf
-hgL
+wJm
+phC
 tCZ
 kUs
-hgL
+wqX
 tqb
 phk
-hgL
+wqX
 fGF
 fkD
 rKz
@@ -58144,23 +58599,23 @@ coU
 rKz
 tWQ
 hgL
-bRP
+pHI
 hgL
 rKz
 fQG
 jnq
 hgL
 hgL
-bRP
+pHI
 rKz
-cTi
-tQp
-rKz
-rKz
+syk
+xEH
 rKz
 rKz
 rKz
-obJ
+rKz
+rKz
+nGW
 rKz
 rKz
 rKz
@@ -58354,23 +58809,23 @@ rKz
 lgv
 hgL
 hgL
+pHI
+lrx
+oNj
+oNj
+oNj
+fET
 bRP
-cTi
-hgL
-hgL
-hgL
-dHR
-bRP
-hgL
-hgL
-hgL
-hgL
-hgL
-dnC
+hDc
+ufe
+ufe
+oNj
+oNj
+uhF
 cqX
-hgL
-hgL
-hgL
+oNj
+oNj
+oNj
 sNe
 rKz
 coU
@@ -58561,24 +59016,24 @@ coU
 coU
 rKz
 jkv
-aQr
-hBa
-lpc
+gid
+kdd
+pZG
 rKz
 laf
 sNe
-hgL
-hgL
-sEk
-xNJ
+oNj
+oNj
+dup
+kNe
 bRP
 snc
-xNJ
-sEk
-dpI
-hgL
-jnq
-hgL
+kNe
+dup
+xCX
+oNj
+thh
+oNj
 xSJ
 lIh
 rKz
@@ -58787,9 +59242,9 @@ rKz
 rKz
 rKz
 mED
-hgL
-hgL
-sEk
+oNj
+oNj
+dup
 rKz
 coU
 coU
@@ -58981,24 +59436,24 @@ rKz
 bMw
 xCH
 fDD
-xCH
-xCH
+shr
+shr
 gyS
 rKz
-hgL
+oNj
 srx
-hgL
-sEk
+oNj
+dup
 sNe
-hgL
-hgL
-hgL
-hgL
+oNj
+oNj
+oNj
+oNj
 syp
-tCZ
-hgL
-hgL
-hgL
+jlL
+oNj
+oNj
+dez
 rKz
 coU
 coU
@@ -59188,26 +59643,26 @@ coU
 coU
 rKz
 nle
-bRP
-bRP
-bRP
+pHI
+pHI
+pHI
 cLU
 hgL
 rKz
-hgL
+oNj
 kaq
-hgL
+oNj
 jfz
 bRP
 xcF
-hgL
+oNj
 aWi
-hgL
+oNj
 pKF
-rKz
-hgL
+jlL
+oNj
 dbE
-hgL
+rhr
 rKz
 bZw
 bZw
@@ -59399,24 +59854,24 @@ tCZ
 rEF
 aGn
 hgL
-bRP
-bRP
+pHI
+pHI
 hgL
 cjK
-umz
-fqQ
-hgL
+mng
+rdH
+oNj
 bRP
 bRP
-hgL
-hgL
-hgL
-hgL
-xNJ
-rKz
+oNj
+dez
+oNj
+oNj
+kNe
+jlL
 laf
 fsF
-hgL
+oNj
 rKz
 bZw
 wqu
@@ -59615,13 +60070,13 @@ rKz
 gIS
 qTm
 rKz
-hgL
+oNj
 nPm
 rKz
-hgL
-pHI
-hgL
-hgL
+oNj
+hBa
+oNj
+oNj
 bRP
 xav
 bRP
@@ -59815,7 +60270,7 @@ coU
 coU
 eci
 gFS
-aQr
+gid
 hgL
 dpI
 iDM
@@ -59827,13 +60282,13 @@ uJW
 cam
 snd
 rKz
-sEk
-hgL
-hgL
+dup
+oNj
+oNj
 jfz
 bRP
-sEk
-dpI
+dup
+xCX
 bRP
 rKz
 bZw
@@ -60026,9 +60481,9 @@ rKz
 wEw
 hgL
 hgL
-hBa
-bRP
-bRP
+kdd
+pHI
+pHI
 iDM
 hgL
 hgL
@@ -60036,14 +60491,14 @@ rKz
 hOw
 bRP
 rKz
-laf
-hgL
+ngB
+oNj
 ucC
 olN
-hgL
-sEk
+oNj
+dup
 rAJ
-hgL
+oNj
 rKz
 bZw
 ayt
@@ -60234,25 +60689,25 @@ coU
 rKz
 czs
 hgL
-hgL
-hgL
-sNe
-bRP
+bam
+aVm
+hyA
+pHI
 hgL
 vkM
 hgL
 rKz
-hgL
-hgL
+oNj
+oNj
 tCZ
 uEi
 bRP
 bRP
-hgL
-hgL
+oNj
+oNj
 jfz
-hgL
-hgL
+oNj
+oNj
 rKz
 bZw
 bZw
@@ -60452,7 +60907,7 @@ rKz
 rKz
 rKz
 vqZ
-kfA
+xtL
 rKz
 uIZ
 rKz
@@ -60650,23 +61105,23 @@ coU
 coU
 coU
 rKz
-bRP
+iYP
 kSt
 mNF
-aFi
-aFi
+wtC
+wtC
 suV
 vZw
 fZu
 hgL
-bRP
-xty
-bRP
-jfz
+tAF
+knp
+pHI
+dVv
 ssP
-sNe
-kaq
-dpI
+hyA
+mOu
+bsR
 hgL
 hgL
 vHs
@@ -60860,7 +61315,7 @@ coU
 coU
 rKz
 umz
-bRP
+pHI
 hgL
 pJu
 hgL
@@ -60868,13 +61323,13 @@ hgL
 ssP
 dnC
 hgL
-bRP
+pHI
 jnq
 hgL
-wtC
+owt
 hgL
 xNJ
-bRP
+pHI
 gUa
 hgL
 hgL
@@ -61068,27 +61523,27 @@ coU
 coU
 coU
 rKz
+vsV
 hgL
 hgL
 hgL
-hgL
-bRP
+pHI
 pnU
 sEk
 hgL
-hgL
-bRP
+aGn
+pHI
 hgL
 bmh
 hgL
 hgL
 hgL
 ikF
-pKF
+ika
 hgL
-jfz
+qjc
 vJM
-qbU
+yhY
 rKz
 coU
 coU
@@ -61277,7 +61732,7 @@ coU
 coU
 coU
 rKz
-laf
+hgL
 jnq
 dpI
 hgL
@@ -61285,7 +61740,7 @@ ouu
 rVZ
 hgL
 iDM
-aWi
+sXz
 hgL
 hcu
 tyf
@@ -61297,7 +61752,7 @@ sEk
 hgL
 xvh
 jjD
-qbU
+hgL
 qbU
 coU
 coU
@@ -61486,19 +61941,19 @@ coU
 coU
 coU
 mED
-bRP
+pHI
 hgL
 hgL
 hox
 hgL
-hgL
+ugr
 jnq
 reX
-jfz
+qjc
 sEk
 hgL
 hgL
-bRP
+pHI
 fcX
 jnq
 hgL
@@ -61703,9 +62158,9 @@ pBg
 gHH
 wnh
 kQA
-wnh
+xiC
 pBg
-xty
+knp
 llF
 pBg
 xBs
@@ -61715,7 +62170,7 @@ bqC
 gHH
 pBg
 gHH
-wnh
+xiC
 rKz
 coU
 coU
@@ -62113,15 +62568,15 @@ coU
 coU
 coU
 rKz
-dpI
+nCC
 hgL
-bRP
+pHI
 ssP
 dpI
-bRP
+pHI
 nGT
-bRP
-wtC
+pHI
+owt
 iDM
 nuB
 dnC
@@ -62130,9 +62585,9 @@ hgL
 ouu
 exc
 jnq
-bRP
+pHI
 scg
-xav
+ckM
 rww
 rKz
 coU
@@ -62334,7 +62789,7 @@ kXX
 kXX
 eLL
 kQA
-wnh
+xiC
 pBg
 pBg
 pBg
@@ -62535,15 +62990,15 @@ kQA
 uDS
 bqC
 pBg
-wnh
+xiC
 pBg
 pBg
 xvh
 gyo
-wnh
+rBT
 gHH
-tIm
-kQA
+gHH
+fuq
 vEb
 pBg
 pBg

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -35,10 +35,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
-"abV" = (
-/obj/structure/flora/small/grassb4,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "aca" = (
 /obj/structure/curtain/open,
 /obj/random/junk/nondense,
@@ -114,11 +110,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"agL" = (
-/obj/structure/table/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ahb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -128,15 +119,23 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"ahF" = (
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ahW" = (
 /obj/random/junk,
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"aiG" = (
-/obj/structure/table/standard,
-/obj/random/surgery_tool/low_chance,
+"aii" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"ail" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/mre/alt,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "aiR" = (
@@ -252,13 +251,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"apK" = (
-/mob/living/carbon/superior_animal/xenomorph{
-	name = "Greg";
-	desc = "Fuck you, Greg."
-	},
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "apW" = (
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/tiled/white,
@@ -290,10 +282,6 @@
 /obj/structure/table/onestar,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"ars" = (
-/mob/living/simple_animal/hostile/scarybat,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "arB" = (
 /obj/structure/sink/puddle,
 /obj/item/toy/desk/dippingbird,
@@ -317,6 +305,10 @@
 /mob/living/simple_animal/frog,
 /turf/simulated/floor/beach/water/swamp,
 /area/nadezhda/dungeon/outside/zoo)
+"asz" = (
+/obj/random/traps/low_chance,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "asH" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/ammo_magazine/maxim_75,
@@ -366,10 +358,6 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"avd" = (
-/obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "avx" = (
 /obj/structure/table/standard,
 /obj/item/stack/cable_coil/yellow,
@@ -396,10 +384,6 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"axm" = (
-/obj/machinery/cooking_with_jane/oven,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "axE" = (
 /obj/structure/medical_stand,
 /turf/simulated/floor/wood/wild4,
@@ -435,13 +419,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/prepper)
-"azd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "azq" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/cloth/suit,
@@ -453,11 +430,6 @@
 /obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"azN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap/dense_weighted,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "azU" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/standard,
@@ -518,6 +490,10 @@
 /obj/structure/scrap/guns/large,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"aBs" = (
+/obj/item/storage/fancy/mre_cracker,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aBB" = (
 /obj/structure/closet/random_miscellaneous,
 /turf/simulated/floor/tiled/dark,
@@ -548,6 +524,16 @@
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"aCI" = (
+/obj/item/trash/material/circuit,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"aCP" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/item/computer_hardware/hard_drive/portable/design/medical/advanced,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aDz" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
@@ -580,6 +566,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/safehouse)
+"aEX" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aFP" = (
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
@@ -590,12 +582,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
-"aGx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank/huge/derelict,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "aGT" = (
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
@@ -673,6 +659,14 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"aLp" = (
+/obj/item/book/manualshield_generator_guide,
+/obj/item/cell/large/excelsior,
+/obj/item/cell/large/excelsior,
+/obj/structure/table/standard,
+/obj/item/part/gun/frame/basilisk,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aLU" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/small/busha3,
@@ -709,16 +703,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
-"aNA" = (
-/obj/structure/closet/crate/excelsior,
-/obj/random/surgery_tool/low_chance,
-/obj/item/tool/saw/circular/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"aNB" = (
-/obj/item/trash/mre,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "aNF" = (
 /obj/machinery/light{
 	dir = 8;
@@ -747,11 +731,6 @@
 /obj/structure/flora/small/lavarock1,
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt,
-/area/asteroid/rogue)
-"aOz" = (
-/obj/item/implantcase/excelsior/broken,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "aOA" = (
 /obj/structure/girder/displaced,
@@ -792,9 +771,16 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"aQb" = (
-/obj/structure/curtain/medical,
-/obj/effect/decal/cleanable/dirt,
+"aQJ" = (
+/obj/random/dungeon_gun_ballistic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"aRi" = (
+/obj/structure/sign/painting/russianstalin,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
+"aRI" = (
+/obj/item/gun/projectile/boltgun,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "aSc" = (
@@ -808,10 +794,6 @@
 /obj/item/remains/mummy2,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"aSG" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "aSK" = (
 /obj/structure/sink{
 	dir = 4;
@@ -859,17 +841,19 @@
 /obj/random/junkfood,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"aVF" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/gun/projectile/rpg,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aWp" = (
 /obj/structure/flora/big/bush2,
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/meadow)
-"aWN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "aXb" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/random/mob/vox/low_chance,
@@ -921,11 +905,6 @@
 /obj/random/powercell/low_chance,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"baj" = (
-/obj/random/scrap/dense_weighted,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "baH" = (
 /obj/structure/cable/yellow,
 /obj/machinery/light/small,
@@ -970,6 +949,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"bcq" = (
+/obj/item/trash/semki,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bcs" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/storage/bag/produce,
@@ -985,6 +968,12 @@
 /obj/machinery/electrolyzer,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"bdY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bec" = (
 /obj/structure/table/rack/shelf,
 /obj/item/oddity/common/towel{
@@ -1001,10 +990,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"beO" = (
-/obj/item/trash/grease,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "beQ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood/wild5,
@@ -1046,10 +1031,6 @@
 /obj/item/stack/material/plasma/random,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"bif" = (
-/obj/item/trash/mre_candy,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bip" = (
 /obj/item/frame/apc,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -1109,10 +1090,6 @@
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"bkW" = (
-/obj/item/trash/cheesie,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "blc" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
@@ -1121,6 +1098,12 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"bls" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/plate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "blu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1137,10 +1120,6 @@
 /obj/structure/reagent_dispensers/watertank/derelict,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper)
-"bmA" = (
-/obj/item/trash/material/circuit,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bmI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1227,12 +1206,6 @@
 /obj/structure/table/bench,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/zoo)
-"bpS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bpZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/food/large,
@@ -1282,10 +1255,6 @@
 "bsz" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"bsE" = (
-/obj/item/gun/projectile/automatic/thompson,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "bsX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -1347,11 +1316,20 @@
 	icon_state = "3,7"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"bvw" = (
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bvC" = (
 /obj/structure/table/standard,
 /obj/random/powercell/medium_safe,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"bvH" = (
+/obj/effect/decal/cleanable/filth,
+/obj/item/trash/mre_can,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bvP" = (
 /obj/machinery/power/terminal{
 	dir = 1;
@@ -1394,11 +1372,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"bxt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bxF" = (
 /obj/random/mob/roomba/range,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
@@ -1423,10 +1396,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"bAs" = (
-/obj/random/oddity_guns,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bAD" = (
 /obj/item/trash/raisins,
 /turf/simulated/floor/wood/wild4,
@@ -1453,11 +1422,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
-"bCC" = (
-/obj/random/scrap/dense_weighted,
-/obj/random/scrap/dense_weighted,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bDO" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -1473,6 +1437,10 @@
 /obj/random/material_rare/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"bFc" = (
+/obj/item/trash/gamerchips,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bFd" = (
 /obj/machinery/door/blast/regular{
 	id = "prepperblastdoors"
@@ -1493,6 +1461,10 @@
 /obj/item/ammo_magazine/rifle_75/empty,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
+"bFy" = (
+/obj/machinery/door/airlock,
+/turf/space,
+/area/asteroid/rogue)
 "bFW" = (
 /obj/item/stool,
 /turf/simulated/floor/carpet/turcarpet,
@@ -1519,6 +1491,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"bHO" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/item/gun/projectile/boltgun,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bHZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1651,10 +1629,6 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
-"bPk" = (
-/obj/structure/salvageable/computer_os,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bPn" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood/wild5,
@@ -1736,7 +1710,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "bRP" = (
-/obj/structure/table/reinforced,
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "bSg" = (
@@ -1744,14 +1718,32 @@
 /obj/item/trash/plate,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"bSn" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/filth,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bSC" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"bSF" = (
-/obj/item/trash/os_coco_wrapper,
-/turf/simulated/floor/tiled/dark,
+"bSX" = (
+/mob/living/carbon/superior_animal/xenomorph{
+	name = "Greg";
+	desc = "Fuck you, Greg."
+	},
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
+"bTh" = (
+/obj/landmark/corpse/excelsior,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
 "bTm" = (
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -1812,11 +1804,6 @@
 /obj/structure/scrap/vehicle,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"bVT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/mopbucket,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bWf" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/remains/unathi,
@@ -1842,6 +1829,11 @@
 /obj/structure/flora/small/grassb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"bXE" = (
+/obj/machinery/door/airlock/centcom,
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bXS" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/wood/wild5,
@@ -1852,12 +1844,16 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"bYn" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bYv" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "bZw" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "bZE" = (
@@ -1935,6 +1931,16 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"ccg" = (
+/obj/structure/table/woodentable,
+/obj/item/implanter/excelsior/broken,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"cct" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre_shokoladka,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "ccK" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/cafe,
@@ -1949,6 +1955,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"cdz" = (
+/obj/item/trash/mre,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cfa" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -1957,9 +1967,9 @@
 /obj/structure/flora/small/grassb5,
 /turf/simulated/wall/wood_old,
 /area/colony/exposedsun/pastgate)
-"cfH" = (
-/obj/structure/table/standard,
-/obj/random/surgery_tool,
+"cfn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/peachcan,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "cfS" = (
@@ -1998,10 +2008,6 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"chH" = (
-/obj/item/trash/syndi_cakes,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "chJ" = (
 /obj/structure/table/rack,
 /obj/random/gun_normal,
@@ -2021,10 +2027,6 @@
 	tag = "icon-cargoshwall7"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"ciL" = (
-/obj/item/trash/cigbutt/brouzouf,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "cjr" = (
 /obj/structure/table/onestar,
 /obj/structure/window/reinforced,
@@ -2077,6 +2079,11 @@
 /obj/structure/flora/big/bush1,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"cmu" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cmA" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/effect/decal/cleanable/dirt,
@@ -2114,6 +2121,12 @@
 "coa" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/zoo)
+"cof" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cog" = (
 /obj/item/tool/fireaxe,
 /obj/item/storage/firstaid/fire,
@@ -2148,11 +2161,6 @@
 "coU" = (
 /turf/unsimulated/mineral,
 /area/asteroid/rogue)
-"cpf" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/pistachios,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "cpm" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/enzyme,
@@ -2177,11 +2185,6 @@
 /obj/machinery/vending/sovietsoda,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"cpO" = (
-/obj/effect/decal/cleanable/filth,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cpP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/drone_fabricator/derelict{
@@ -2226,24 +2229,19 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"crv" = (
+/obj/structure/sign/departmentold/janitorial,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "crC" = (
 /obj/item/remains/tajaran,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"crI" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/tray,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "crM" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"crR" = (
-/obj/item/mine/excelsior,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "crS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -2258,10 +2256,6 @@
 /obj/machinery/cryopod/dormitory,
 /turf/simulated/floor/wood_old,
 /area/colony/exposedsun/crashed_shop/outsider)
-"cse" = (
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "csg" = (
 /obj/structure/table/onestar,
 /obj/structure/window/reinforced,
@@ -2395,11 +2389,6 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"cvN" = (
-/obj/effect/decal/cleanable/generic,
-/obj/item/trash/mre,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cwm" = (
 /obj/structure/flora/small/busha1,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -2418,13 +2407,6 @@
 /obj/random/junk/nondense,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"cxf" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/obj/random/medical,
-/obj/item/storage/firstaid,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cxi" = (
 /obj/item/ammo_casing/shotgun/spent,
 /turf/simulated/floor/wood/wild5,
@@ -2461,11 +2443,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"czK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "czR" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/big/bush3,
@@ -2573,6 +2550,11 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"cEe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cEw" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
@@ -2658,10 +2640,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"cKn" = (
-/obj/structure/curtain/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cKr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -2799,6 +2777,12 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"cQZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "cRG" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/smuggler_zone)
@@ -2898,6 +2882,11 @@
 /obj/random/closet_wardrobe/low_chance,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
+"cVj" = (
+/obj/machinery/cooking_with_jane/stove,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cVk" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/defib_kit/compact/combat/loaded,
@@ -2923,6 +2912,19 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"cXn" = (
+/obj/item/trash/peachcan,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"cXq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/ammo/shotgun,
+/obj/random/ammo/shotgun/low_chance,
+/obj/random/ammo/shotgun/low_chance,
+/obj/random/ammo_fancy,
+/obj/random/ammo_fancy,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cXz" = (
 /obj/structure/table/rack/shelf,
 /obj/item/trash/mre/os,
@@ -2949,6 +2951,10 @@
 /obj/random/junkfood/low_chance,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/safehouse)
+"cYA" = (
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cYL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/traps/low_chance,
@@ -2981,11 +2987,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"cZt" = (
-/obj/item/mine/excelsior,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cZD" = (
 /obj/machinery/door/airlock/multi_tile/metal,
 /obj/random/traps/low_chance,
@@ -3011,11 +3012,6 @@
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"daH" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/obj/structure/curtain/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "daI" = (
 /turf/simulated/mineral/random/rogue,
 /area/colony/exposedsun/crashed_shop/outsider)
@@ -3061,6 +3057,11 @@
 	icon_state = "5,20"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"ddv" = (
+/obj/item/trash/cigbutt/fortress,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ddO" = (
 /obj/structure/reagent_dispensers/watertank/huge,
 /obj/machinery/light/small{
@@ -3086,6 +3087,11 @@
 "dfC" = (
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"dgd" = (
+/obj/item/bedsheet,
+/obj/structure/bed,
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "dge" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -3097,12 +3103,6 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"dgI" = (
-/obj/effect/decal/cleanable/cobweb{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dhy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -3170,7 +3170,7 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "dnC" = (
-/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "dnH" = (
@@ -3198,17 +3198,25 @@
 /turf/simulated/floor/rock/dark,
 /area/asteroid/rogue)
 "dpI" = (
-/obj/machinery/shieldwallgen/excelsior,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "dpK" = (
 /obj/structure/morgue,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"dqf" = (
+/obj/structure/sign/directions/medical,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "dqw" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"dqC" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "dqH" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -3344,6 +3352,11 @@
 /obj/structure/salvageable/autolathe,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"dwY" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre_candy,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dxt" = (
 /obj/random/boxes,
 /turf/simulated/floor/tiled/dark,
@@ -3372,10 +3385,6 @@
 /obj/item/gun/projectile/boltgun/flare_gun,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
-"dyd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/asteroid/rogue)
 "dyi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/small/busha2,
@@ -3416,6 +3425,12 @@
 /obj/random/powercell,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"dzT" = (
+/obj/structure/janitorialcart,
+/obj/item/keys/janitor,
+/obj/item/mop,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dAl" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -3490,6 +3505,10 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/zoo)
+"dCu" = (
+/obj/effect/dummy,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "dCT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/prepper,
@@ -3523,10 +3542,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"dEf" = (
-/obj/random/traps/low_chance,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "dEA" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
@@ -3558,17 +3573,17 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"dFO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/firstaid/regular/empty,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dFT" = (
 /turf/simulated/shuttle/wall/cargo{
 	icon_state = "cargoshwall28";
 	tag = "icon-cargoshwall28"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"dGf" = (
-/obj/machinery/porta_turret/excelsior/preloaded,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dGh" = (
 /obj/random/mat_katana,
 /obj/structure/table/rack/shelf,
@@ -3590,6 +3605,10 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"dHc" = (
+/obj/item/trash/grease,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dHh" = (
 /obj/structure/table/standard,
 /obj/item/roller,
@@ -3642,9 +3661,10 @@
 /obj/structure/closet/crate/serbcrate,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
-"dIZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/metal,
+"dJQ" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/rubble,
+/obj/item/bedsheet,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "dJV" = (
@@ -3680,13 +3700,17 @@
 /obj/random/tool,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"dLa" = (
-/obj/machinery/autodoc,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dLt" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/vault)
+"dLJ" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/tool/sword/saber,
+/obj/effect/decal/cleanable/blood,
+/obj/landmark/corpse/chef,
+/mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dLT" = (
 /obj/structure/table/standard,
 /obj/structure/window/reinforced{
@@ -3704,11 +3728,6 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
-"dMj" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/projectile/boltgun,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dMv" = (
 /obj/machinery/porta_turret/prepper{
 	check_access = 0;
@@ -3729,6 +3748,12 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"dOw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dOM" = (
 /obj/item/bee_pack,
 /obj/structure/table/standard,
@@ -3755,6 +3780,10 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"dQe" = (
+/obj/structure/scrap_cube,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dQt" = (
 /obj/structure/table/onestar,
 /obj/random/powercell/low_chance,
@@ -3826,11 +3855,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
-"dVw" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dWh" = (
 /obj/structure/flora/big/bush1,
 /turf/unsimulated/wall/jungle,
@@ -3845,10 +3869,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"dYA" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dYN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
@@ -3893,6 +3913,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"ebq" = (
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ebz" = (
 /obj/structure/scrap/food/large,
 /turf/simulated/floor/tiled/dark,
@@ -3977,6 +4001,11 @@
 /obj/random/cluster/spiders,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
+"egt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "egw" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -3987,6 +4016,10 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"egT" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eha" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/steel_reinforced,
@@ -4051,6 +4084,10 @@
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"eiY" = (
+/obj/item/trash/broken_robot_part,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ejs" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -4162,6 +4199,10 @@
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"emV" = (
+/obj/item/trash/cheesie,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eno" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
@@ -4254,6 +4295,10 @@
 /obj/structure/curtain/open,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"erh" = (
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "esi" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/big/bush3,
@@ -4318,10 +4363,6 @@
 "euc" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"euk" = (
-/obj/structure/sign/warning/armory/small,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "euG" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -4365,10 +4406,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"evX" = (
-/obj/structure/flora/small/grassb2,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "ewd" = (
 /obj/structure/flora/small/busha2,
 /mob/living/carbon/superior_animal/vox/ashen,
@@ -4382,6 +4419,10 @@
 /obj/random/dungeon_gun_mods,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"ewx" = (
+/obj/item/implant/excelsior/broken,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ewC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/random/flora/jungle_tree,
@@ -4407,11 +4448,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"exQ" = (
-/obj/random/lowkeyrandom,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "eyw" = (
 /obj/structure/table/onestar,
 /obj/structure/flora/pottedplant/dead{
@@ -4438,6 +4474,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"ezZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/gun_cheap/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eAm" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white/panels,
@@ -4450,6 +4491,16 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"eCz" = (
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"eCA" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/firstaid/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eCK" = (
 /obj/structure/closet/random_hostilemobs,
 /turf/simulated/floor/tiled/dark,
@@ -4484,6 +4535,20 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"eGa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/fiction{
+	name = "Communist Manifesto"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"eGw" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "eGG" = (
 /obj/machinery/door/airlock/multi_tile/metal,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -4498,10 +4563,6 @@
 /obj/random/ammo_lowcost/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
-"eHj" = (
-/obj/structure/sign/faction/excelsior_old,
-/turf/simulated/wall,
-/area/asteroid/rogue)
 "eHE" = (
 /obj/structure/boulder,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -4619,11 +4680,6 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"ePc" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ePq" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -4669,23 +4725,16 @@
 /obj/random/mob/roaches,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"eSB" = (
+/obj/effect/decal/cleanable/filth,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eSN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/booze,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"eSZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"eUu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "eUV" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushb3,
@@ -4713,6 +4762,19 @@
 /obj/machinery/centrifuge,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/dungeon/outside/zoo)
+"eWn" = (
+/obj/item/stock_parts/manipulator/excelsior,
+/obj/item/stock_parts/manipulator/excelsior,
+/obj/item/stock_parts/manipulator/excelsior,
+/obj/item/stock_parts/capacitor/excelsior,
+/obj/item/stock_parts/matter_bin/excelsior,
+/obj/item/stock_parts/micro_laser/excelsior,
+/obj/item/stock_parts/micro_laser/excelsior,
+/obj/item/stock_parts/scanning_module/excelsior,
+/obj/structure/table/standard,
+/obj/item/computer_hardware/hard_drive/portable/design/guns/ex_vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eXs" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/derelict,
@@ -4746,6 +4808,11 @@
 	},
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"eXK" = (
+/obj/item/storage/hcases/ammo/excel,
+/obj/structure/closet/crate/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eYw" = (
 /obj/landmark/join/start/outsider,
 /turf/simulated/shuttle/floor/mining{
@@ -4770,6 +4837,13 @@
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"eZt" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eZx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -4855,6 +4929,12 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"fcU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fdz" = (
 /obj/machinery/porta_turret/prepper,
 /turf/simulated/floor/tiled/dark,
@@ -4935,10 +5015,8 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
-"fgg" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/obj/item/computer_hardware/hard_drive/portable/design/medical/advanced,
+"ffP" = (
+/obj/machinery/autodoc,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "fgw" = (
@@ -4980,6 +5058,10 @@
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"fin" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fit" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/asteroid/grass,
@@ -5005,6 +5087,18 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"fjG" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fjK" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt,
@@ -5058,6 +5152,11 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
+"fmy" = (
+/obj/structure/table/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fmI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/traps/low_chance,
@@ -5088,6 +5187,10 @@
 /obj/machinery/chemical_dispenser,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"foK" = (
+/obj/random/scrap/moderate_weighted,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "foM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5179,12 +5282,13 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
-"fvq" = (
-/obj/structure/salvageable/data_os,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "fvS" = (
 /turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/asteroid/rogue)
+"fvU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/makarov/preloaded,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "fwb" = (
 /obj/structure/table/steel,
@@ -5249,6 +5353,11 @@
 /obj/random/mob/undergroundmob,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"fyT" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fze" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt,
@@ -5263,6 +5372,12 @@
 /obj/random/mob/tengolo/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
+"fBe" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/random/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fBr" = (
 /obj/structure/flora/small/busha3,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -5331,10 +5446,6 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"fEy" = (
-/obj/structure/sign/warning/nosmoking,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "fFb" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark,
@@ -5420,11 +5531,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
-"fIY" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/human/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "fJf" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/asteroid/dirt,
@@ -5464,6 +5570,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"fKU" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"fLR" = (
+/obj/item/trash/cigbutt/fortressblue,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fLW" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushc2,
@@ -5593,12 +5708,11 @@
 /obj/structure/closet/random_hostilemobs,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"fTr" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/grass,
+"fTH" = (
+/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/revolver/deacon,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "fTI" = (
 /obj/structure/target_stake,
@@ -5609,6 +5723,12 @@
 /obj/random/firstaid,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
+"fTZ" = (
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "cobweb1"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fUg" = (
 /obj/machinery/portable_atmospherics/hydroponics{
 	pixel_y = 4
@@ -5651,6 +5771,10 @@
 /obj/random/lathe_disk/advanced,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"fVi" = (
+/obj/structure/sign/faction/excelsior_old,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "fVI" = (
 /obj/structure/bed/chair/custom/onestar/red{
 	dir = 4
@@ -5696,11 +5820,6 @@
 /obj/random/pouch,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"fXm" = (
-/obj/effect/decal/cleanable/filth,
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "fXI" = (
 /obj/structure/railing/grey,
 /obj/effect/step_trigger/vault_bunker_2F,
@@ -5740,16 +5859,6 @@
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/dungeon/outside/zoo)
-"gaK" = (
-/obj/random/lowkeyrandom/low_chance,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"gbh" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gbx" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
@@ -5936,16 +6045,6 @@
 /obj/random/cluster/spiders/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"glM" = (
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo/low_chance,
-/obj/random/ammo/low_chance,
-/obj/item/ammo_magazine/ammobox/antim_small,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gmm" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -5995,11 +6094,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"goL" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre/alt,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "goO" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/decal/cleanable/generic,
@@ -6092,6 +6186,10 @@
 /obj/item/oddity/common/coin,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"gtS" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gtY" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -6146,6 +6244,9 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"gvv" = (
+/turf/simulated/wall/wood,
+/area/asteroid/rogue)
 "gvB" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/microwave,
@@ -6214,17 +6315,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"gxY" = (
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/filth,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gys" = (
 /obj/item/tool/broken_bottle,
 /obj/effect/decal/cleanable/generic,
@@ -6265,6 +6355,10 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"gAY" = (
+/obj/item/part/gun/frame/vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gBg" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/bed/chair{
@@ -6320,6 +6414,10 @@
 /obj/random/junkfood/onlypizza,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
+"gCI" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gCP" = (
 /obj/structure/railing{
 	dir = 1
@@ -6331,14 +6429,17 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"gCX" = (
-/obj/random/dungeon_gun_energy/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gDf" = (
 /obj/structure/closet/secure_closet/bar,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"gDl" = (
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "spiderling";
+	name = "dead spider"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gDz" = (
 /obj/machinery/light{
 	dir = 1
@@ -6363,10 +6464,6 @@
 /obj/random/junkfood,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"gDT" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gEm" = (
 /obj/structure/flora/big/rocks2,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -6390,6 +6487,10 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"gGp" = (
+/obj/item/mine/excelsior,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "gGH" = (
 /obj/item/remains/ribcage,
 /obj/effect/decal/cleanable/blood,
@@ -6400,11 +6501,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
-"gID" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gIP" = (
 /obj/machinery/door/airlock/freezer,
 /turf/simulated/floor/tiled/cafe,
@@ -6421,11 +6517,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/prepper)
-"gKn" = (
-/obj/structure/table/standard,
-/obj/random/medical/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gKF" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/wild3,
@@ -6435,6 +6526,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"gKO" = (
+/obj/item/gun/projectile/automatic/thompson,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "gLJ" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/bucket,
@@ -6469,10 +6564,6 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
-"gNQ" = (
-/obj/structure/salvageable/autolathe,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gNT" = (
 /obj/landmark/join/start/outsider,
 /turf/simulated/shuttle/floor/mining{
@@ -6508,12 +6599,6 @@
 /obj/random/traps,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"gPe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/mine/excelsior,
-/obj/item/trash/candy/proteinbar,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gPn" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light,
@@ -6523,6 +6608,10 @@
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"gQc" = (
+/obj/structure/sign/warning/lethal_turrets,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "gQi" = (
 /obj/structure/table/onestar,
 /obj/random/junkfood,
@@ -6553,9 +6642,9 @@
 /obj/item/storage/box/matches,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"gRv" = (
-/obj/effect/decal/cleanable/filth,
-/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
+"gRr" = (
+/obj/structure/table/standard,
+/obj/random/surgery_tool/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "gRw" = (
@@ -6714,15 +6803,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"gXV" = (
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gYu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"gYz" = (
+/obj/structure/flora/small/grassb4,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "gZa" = (
 /obj/structure/table/rack/shelf,
 /obj/item/folder/black,
@@ -6735,6 +6824,11 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"gZo" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gZu" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -6780,6 +6874,14 @@
 /obj/structure/scrap/food/large,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"hcs" = (
+/obj/structure/safe/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "cobweb1"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hcG" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall19";
@@ -6804,11 +6906,6 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"hdM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/makarov/preloaded,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hdO" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -6849,9 +6946,17 @@
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"hfN" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre/alt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hgL" = (
-/obj/item/trash/cigbutt/fortress,
-/obj/effect/decal/cleanable/filth,
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid{
+	pixel_x = -8;
+	pixel_y = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "hhc" = (
@@ -6877,6 +6982,11 @@
 /obj/item/remains/mummy2,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"hih" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hiu" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -6899,11 +7009,6 @@
 /obj/item/stack/material/glass/random,
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
-"hjE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hjQ" = (
 /obj/random/lathe_disk/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -7064,9 +7169,6 @@
 /obj/random/pouch,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"hoR" = (
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "hpb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/stack/medical/bruise_pack/handmade,
@@ -7076,6 +7178,11 @@
 /obj/structure/flora/small/busha2,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"hpp" = (
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hpr" = (
 /obj/machinery/door/blast/shutters/glass,
 /obj/random/junkfood/rotten/low_chance,
@@ -7131,6 +7238,11 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"hrI" = (
+/obj/structure/table/gamblingtable,
+/obj/item/gun/projectile/makarov/preloaded,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hsp" = (
 /obj/structure/sink{
 	dir = 8;
@@ -7144,9 +7256,13 @@
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"htl" = (
-/obj/machinery/suit_storage_unit/excelsior,
-/obj/effect/decal/cleanable/cobweb2,
+"hsJ" = (
+/obj/structure/flora/small/grassa2,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
+"hsZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "htO" = (
@@ -7157,6 +7273,11 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"huf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "huO" = (
 /mob/living/simple_animal/hostile/render,
 /turf/simulated/floor/asteroid/dirt,
@@ -7204,6 +7325,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"hxa" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "hxm" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/big/bush2,
@@ -7235,10 +7360,6 @@
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
-"hzz" = (
-/obj/structure/reagent_dispensers/fueltank/derelict,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hzS" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 4
@@ -7257,6 +7378,20 @@
 /obj/item/storage/box/frag_grenade_shells,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
+"hAx" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"hAN" = (
+/obj/structure/sign/departmentold/medical2,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
+"hAS" = (
+/obj/effect/decal/cleanable/rubble,
+/mob/living/simple_animal/hostile/scarybat,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "hBX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -7284,6 +7419,11 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"hDl" = (
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/mre,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hEU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/lathe_disk,
@@ -7360,11 +7500,6 @@
 /obj/random/boxes,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"hHA" = (
-/obj/machinery/door/airlock/centcom,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hHJ" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/random/mob/prepper,
@@ -7384,14 +7519,6 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
-"hJv" = (
-/obj/structure/medical_stand,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"hJx" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hJC" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -7433,18 +7560,6 @@
 /obj/effect/step_trigger/ironcompound_to_abandonedfortress_1_A,
 /turf/unsimulated/mineral,
 /area/colony)
-"hMw" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/obj/random/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"hNy" = (
-/obj/structure/table/rack,
-/obj/effect/decal/cleanable/filth,
-/obj/item/gun_upgrade/trigger/boom,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hNJ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -7474,6 +7589,17 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"hOk" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/tool/baton/excelbaton,
+/obj/item/tool/baton/excelbaton,
+/obj/item/clothing/suit/space/void/excelsior,
+/obj/item/clothing/head/helmet/space/void/excelsior,
+/obj/random/melee/low_chance,
+/obj/item/gun/projectile/automatic/drozd,
+/obj/item/gun/projectile/automatic/drozd,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hOt" = (
 /obj/structure/salvageable/machine,
 /turf/simulated/floor/tiled/dark,
@@ -7491,6 +7617,10 @@
 /obj/structure/salvageable/server_os,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"hQd" = (
+/mob/living/simple_animal/hostile/bear/excelsior,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "hQn" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/material_resources,
@@ -7628,11 +7758,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
-"hWp" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hWt" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/trash/pistachios,
@@ -7744,13 +7869,6 @@
 /obj/item/tool/scythe,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"ida" = (
-/obj/structure/bed/psych{
-	desc = "It can be a bit noisy, but still serves well.";
-	name = "old bed"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "idi" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -7872,13 +7990,6 @@
 /obj/random/scrap,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"ijN" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ijO" = (
 /obj/effect/step_trigger/vault_bunker_2E,
 /turf/simulated/floor/tiled/dark,
@@ -7947,6 +8058,11 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/zoo)
+"inN" = (
+/obj/structure/table/standard,
+/obj/random/medical/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ioc" = (
 /obj/machinery/door/window,
 /turf/simulated/floor/tiled/cafe,
@@ -7963,9 +8079,8 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"iow" = (
-/obj/item/flame/lighter/zippo/excelsior,
-/obj/structure/table/woodentable,
+"ior" = (
+/obj/structure/salvageable/autolathe,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "ioB" = (
@@ -8034,6 +8149,13 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"irF" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "irR" = (
 /obj/item/modular_computer/console/preset/civilian/professional{
 	dir = 4
@@ -8124,6 +8246,10 @@
 /obj/machinery/door/window,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/zoo)
+"ivS" = (
+/obj/random/dungeon_gun_energy/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ivZ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
@@ -8166,6 +8292,15 @@
 /obj/structure/multiz/ladder,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"ixB" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ixC" = (
 /obj/structure/table/steel,
 /obj/effect/decal/cleanable/dirt,
@@ -8212,13 +8347,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"izb" = (
-/turf/simulated/wall/wood,
-/area/asteroid/rogue)
-"izz" = (
-/obj/structure/bed/chair/comfy,
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "izY" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/firstaid,
@@ -8255,6 +8383,16 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"iBF" = (
+/obj/random/scrap/dense_weighted,
+/obj/random/scrap/dense_weighted,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"iBG" = (
+/obj/item/mine/excelsior,
+/obj/random/scrap/sparse_even/low_chance,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "iCz" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/big/bush2,
@@ -8416,10 +8554,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
-"iIL" = (
-/obj/structure/flora/small/grassa2,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "iIR" = (
 /turf/simulated/wall,
 /area/nadezhda/outside/meadow)
@@ -8528,17 +8662,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/safehouse)
+"iQf" = (
+/obj/random/traps/low_chance,
+/turf/simulated/floor/rock/grey,
+/area/asteroid/rogue)
 "iQR" = (
 /obj/random/tank/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"iRt" = (
-/obj/effect/decal/cleanable/cobweb2{
-	icon_state = "spiderling";
-	name = "dead spider"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "iRv" = (
 /obj/machinery/light/floor{
 	pixel_y = -7
@@ -8558,6 +8689,11 @@
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"iSq" = (
+/obj/item/implanter/excelsior/broken,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "iSv" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/small/busha2,
@@ -8580,6 +8716,11 @@
 /obj/random/closet/low_chance,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"iTd" = (
+/obj/effect/decal/cleanable/filth,
+/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "iTq" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/briefcase,
@@ -8699,6 +8840,14 @@
 /mob/living/carbon/superior_animal/robot/greyson/roomba/slayer,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
+"jaE" = (
+/obj/item/storage/fancy/vials,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"jaJ" = (
+/obj/structure/salvageable/console_broken_os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jaO" = (
 /obj/item/stash_spawner,
 /turf/simulated/floor/wood/wild4,
@@ -8732,6 +8881,11 @@
 /obj/machinery/door/airlock/vault,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/safehouse)
+"jcF" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/obj/structure/curtain/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jcH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -8761,10 +8915,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"jcQ" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jcV" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/hatton/moebius,
@@ -8830,19 +8980,6 @@
 /obj/structure/bed/chair/sofa/black,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/safehouse)
-"jeV" = (
-/obj/item/stock_parts/manipulator/excelsior,
-/obj/item/stock_parts/manipulator/excelsior,
-/obj/item/stock_parts/manipulator/excelsior,
-/obj/item/stock_parts/capacitor/excelsior,
-/obj/item/stock_parts/matter_bin/excelsior,
-/obj/item/stock_parts/micro_laser/excelsior,
-/obj/item/stock_parts/micro_laser/excelsior,
-/obj/item/stock_parts/scanning_module/excelsior,
-/obj/structure/table/standard,
-/obj/item/computer_hardware/hard_drive/portable/design/guns/ex_vintorez,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jeZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -9087,6 +9224,10 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"jnY" = (
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jos" = (
 /obj/structure/table/onestar,
 /obj/random/tool/advanced/onestar/low_chance,
@@ -9107,6 +9248,16 @@
 /obj/machinery/power/port_gen/pacman/scrap,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"jpE" = (
+/obj/machinery/autolathe,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"jqA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jqD" = (
 /obj/structure/table/standard,
 /obj/item/oddity/common/old_radio,
@@ -9131,11 +9282,6 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"jrM" = (
-/obj/machinery/door/airlock/centcom,
-/obj/structure/barricade,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jrV" = (
 /obj/random/cluster/spiders,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -9166,6 +9312,11 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"jvX" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jwg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/prepper,
@@ -9207,6 +9358,11 @@
 /obj/item/oddity/common/book_bible,
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/prepper)
+"jyP" = (
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "jyY" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/tool/shovel/spade,
@@ -9233,14 +9389,6 @@
 /obj/machinery/vending/medical,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
-"jzZ" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/port_gen/pacman/diesel/anchored,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jBj" = (
 /obj/structure/multiz/stairs/active/bottom{
 	dir = 4
@@ -9254,12 +9402,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/dungeon/outside/zoo)
-"jBP" = (
-/obj/item/gun/projectile/colt,
-/obj/item/ammo_kit,
-/obj/random/scrap,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "jCe" = (
 /obj/effect/gibspawner/human,
 /turf/simulated/floor/asteroid/dirt,
@@ -9290,15 +9432,6 @@
 /obj/structure/flora/small/busha3,
 /turf/unsimulated/wall/jungle,
 /area/colony/exposedsun/pastgate)
-"jDh" = (
-/obj/structure/sign/departmentold/medical2,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
-"jEp" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "jEI" = (
 /obj/structure/flora/small/grassb5,
 /obj/random/scrap/dense_even,
@@ -9323,12 +9456,9 @@
 /obj/item/mine_old,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"jFc" = (
-/obj/structure/safe/floor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb2{
-	icon_state = "cobweb1"
-	},
+"jFi" = (
+/obj/machinery/door/airlock,
+/obj/item/mine/excelsior,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "jFP" = (
@@ -9378,30 +9508,11 @@
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"jHe" = (
-/obj/structure/table/woodentable,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/revolver/deacon,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"jHE" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/item/trash/icecreambowl,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "jHF" = (
 /obj/structure/catwalk,
 /mob/living/carbon/superior_animal/human/voidwolf/captain,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"jHP" = (
-/obj/machinery/autolathe,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"jHS" = (
-/obj/structure/bookcase/manuals/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jIL" = (
 /obj/structure/closet/crate/solar,
 /turf/simulated/floor/tiled,
@@ -9503,6 +9614,10 @@
 /obj/structure/salvageable/autolathe,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"jMF" = (
+/obj/item/trash/mre,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "jMG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit,
@@ -9518,15 +9633,6 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"jNk" = (
-/obj/structure/flora/small/grassa5,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
-"jNA" = (
-/mob/living/simple_animal/hostile/diyaab,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jND" = (
 /obj/structure/closet/crate/serbcrate,
 /obj/item/rig_module/device/drill,
@@ -9561,6 +9667,11 @@
 /obj/item/solar_assembly,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"jOp" = (
+/obj/structure/table/rack,
+/obj/item/gun/projectile/automatic/vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jOw" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/material_rare,
@@ -9594,11 +9705,6 @@
 /obj/random/cloth/masks,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"jQO" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jQP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9618,16 +9724,12 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"jRU" = (
-/mob/living/carbon/superior_animal/human/excelsior,
-/obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"jRZ" = (
-/obj/structure/closet/crate/excelsior,
-/obj/item/gun/projectile/rpg,
-/obj/item/ammo_casing/rocket,
-/obj/item/ammo_casing/rocket,
+"jRN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/psych{
+	desc = "It can be a bit noisy, but still serves well.";
+	name = "old bed"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "jSh" = (
@@ -9646,14 +9748,15 @@
 /obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"jSI" = (
-/obj/effect/decal/cleanable/cobweb2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb2{
-	icon_state = "spiderling";
-	name = "dead spider"
-	},
+"jSR" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/tool/baton/excelbaton,
+/obj/item/tool/baton/excelbaton,
+/obj/item/clothing/suit/space/void/excelsior,
+/obj/item/clothing/head/helmet/space/void/excelsior,
+/obj/random/melee/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/boltgun/heavysniper,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "jTE" = (
@@ -9746,10 +9849,6 @@
 /obj/item/ammo_magazine/maxim_75,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"jXU" = (
-/obj/structure/sign/warning/lethal_turrets,
-/turf/simulated/wall,
-/area/asteroid/rogue)
 "jYj" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall35";
@@ -9817,6 +9916,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
+"kbI" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kcq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
@@ -9860,6 +9963,10 @@
 /mob/living/carbon/superior_animal/human/voidwolf/fieldtech/ranged,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"kem" = (
+/obj/structure/cardboardbox,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kep" = (
 /obj/structure/invislight,
 /obj/machinery/door/airlock/multi_tile/metal{
@@ -9926,6 +10033,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"kgi" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/stack/medical/bruise_pack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kgn" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/bcarpet,
@@ -9949,6 +10061,12 @@
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"khM" = (
+/obj/effect/decal/cleanable/cobweb{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kii" = (
 /obj/random/mob/prepper,
 /turf/simulated/floor/plating/under,
@@ -10031,6 +10149,11 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"kne" = (
+/obj/structure/bookcase,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "knh" = (
 /obj/random/scrap/dense_weighted,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -10049,11 +10172,6 @@
 /obj/machinery/door/window/westright,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"knN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank/huge/derelict,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "knU" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -10114,22 +10232,26 @@
 /obj/random/toolbox,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"kqO" = (
+/obj/structure/sign/warning/high_voltage,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "krh" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/noslipmodule,
 /obj/item/noslipmodule,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"kro" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "krI" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"krP" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/candle,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ksr" = (
 /obj/structure/railing/grey,
 /obj/structure/multiz/stairs/active/bottom{
@@ -10137,23 +10259,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"ksx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/gun_cheap/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ksF" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"ksL" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/plate,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ksS" = (
 /obj/structure/flora/small/grassb3,
 /obj/structure/flora/small/busha2,
@@ -10165,6 +10276,11 @@
 /obj/item/clothing/gloves/thick/ablasive/iron_lock_security,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"ktB" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ktF" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
@@ -10177,18 +10293,23 @@
 /obj/random/tool_upgrade/rare/low_chance,
 /turf/simulated/floor/tiled/dark/orangecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"kud" = (
+/obj/random/lowkeyrandom,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kur" = (
 /obj/random/science,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"kuJ" = (
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kuK" = (
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"kuV" = (
+/obj/item/trash/mre_shokoladka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kva" = (
 /obj/structure/salvageable/data_os,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10226,9 +10347,9 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"kwB" = (
-/obj/structure/scrap_cube,
-/obj/effect/decal/cleanable/filth,
+"kwf" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "kxe" = (
@@ -10308,9 +10429,9 @@
 /obj/item/ammo_magazine/light_rifle_257/empty,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"kBA" = (
-/obj/structure/bookcase,
-/obj/effect/decal/cleanable/dirt,
+"kBF" = (
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/material/metal,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "kBQ" = (
@@ -10366,6 +10487,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"kEz" = (
+/mob/living/simple_animal/hostile/scarybat,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "kFl" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/grass,
@@ -10459,10 +10584,6 @@
 	},
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"kKj" = (
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kKF" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/simulated/floor/asteroid/dirt,
@@ -10496,6 +10617,12 @@
 /obj/structure/flora/small/bushc2,
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/meadow)
+"kMy" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/item/storage/firstaid/combat,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kMK" = (
 /obj/random/structures,
 /obj/machinery/light/small,
@@ -10521,12 +10648,6 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"kNY" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/item/mine/excelsior,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "kOq" = (
 /obj/structure/flora/small/bushb2,
 /turf/simulated/floor/asteroid/dirt,
@@ -10579,10 +10700,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"kRS" = (
-/obj/item/gun/projectile/makarov/preloaded,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kSg" = (
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -10597,14 +10714,16 @@
 /obj/random/claymore,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
-"kSP" = (
-/obj/random/scrap/dense_weighted,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kST" = (
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/dungeon/outside/safehouse)
+"kUl" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/obj/item/trash/popcorn,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kUx" = (
 /obj/structure/table/steel,
 /obj/random/science,
@@ -10729,10 +10848,6 @@
 "laY" = (
 /turf/simulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"lbn" = (
-/obj/machinery/door/airlock,
-/turf/space,
-/area/asteroid/rogue)
 "lbt" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush1,
@@ -10745,9 +10860,10 @@
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"lcz" = (
+"lcd" = (
+/obj/random/lowkeyrandom/low_chance,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/autoinjector/drugs,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "lcK" = (
@@ -10777,11 +10893,6 @@
 /obj/structure/bed/chair/custom/onestar,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"lej" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre_shokoladka,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "lep" = (
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -10805,11 +10916,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
-"lgl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lgw" = (
 /obj/structure/table/standard,
 /obj/item/clothing/accessory/stethoscope,
@@ -10890,6 +10996,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/mineral/planet,
 /area/nadezhda/dungeon/outside/monster_cave)
+"liS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mopbucket,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ljt" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/science,
@@ -10940,19 +11051,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"llD" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "llJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
-"llR" = (
-/obj/structure/sign/directions/medical,
-/turf/simulated/wall,
-/area/asteroid/rogue)
 "llS" = (
 /obj/structure/barricade,
 /obj/structure/cable{
@@ -10968,10 +11070,25 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"lmY" = (
+/obj/structure/cable,
+/obj/item/circuitboard/apc,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "West APC";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plating/under,
+/area/asteroid/rogue)
 "loD" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"loP" = (
+/obj/item/trash/popcorn,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "loV" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 1
@@ -10995,6 +11112,11 @@
 /obj/random/pack/gun_loot,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"lqA" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "lqU" = (
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/beach/water/jungle,
@@ -11014,11 +11136,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
-"lrL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lrY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -11045,6 +11162,10 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"ltq" = (
+/obj/item/mine/excelsior,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "ltt" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/wood/wild1,
@@ -11060,12 +11181,23 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
+"luh" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/semki,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lur" = (
 /obj/item/trash/semki,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"luv" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/mine/excelsior,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "luy" = (
 /obj/random/closet_tech/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -11122,11 +11254,6 @@
 /obj/machinery/door/airlock/freezer,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/nadezhda/dungeon/outside/zoo)
-"lyh" = (
-/obj/machinery/cooking_with_jane/grill,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lyG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -11194,10 +11321,6 @@
 	},
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"lCt" = (
-/obj/item/mine/excelsior,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "lCx" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/big/bush2,
@@ -11242,6 +11365,12 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"lEE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/mine/excelsior,
+/obj/item/trash/candy/proteinbar,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lEJ" = (
 /obj/item/mine/excelsior,
 /obj/landmark/corpse/excelsior,
@@ -11279,11 +11408,6 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"lGh" = (
-/obj/random/lowkeyrandom/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lGl" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/tool,
@@ -11330,6 +11454,9 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"lHQ" = (
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "lHV" = (
 /obj/effect/step_trigger/vault_bunker_2C,
 /turf/simulated/floor/tiled/dark,
@@ -11354,6 +11481,11 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"lIR" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lJc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/render/low_chance,
@@ -11394,6 +11526,11 @@
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/asteroid/rogue)
+"lLd" = (
+/obj/structure/scrap_cube,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lLf" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/small/busha2,
@@ -11403,6 +11540,10 @@
 /obj/item/trash/cigbutt/fortressblue,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"lLv" = (
+/obj/item/trash/os_coco_wrapper,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lLH" = (
 /obj/structure/bed,
 /turf/simulated/floor/wood/wild5,
@@ -11431,10 +11572,6 @@
 /obj/random/mob/undergroundmob/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
-"lPa" = (
-/obj/structure/coatrack,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lPc" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -11526,16 +11663,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"lUB" = (
-/obj/structure/cable,
-/obj/item/circuitboard/apc,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28
-	},
-/turf/simulated/floor/plating/under,
-/area/asteroid/rogue)
 "lUD" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -11645,6 +11772,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"lZR" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lZZ" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -11677,10 +11808,6 @@
 /obj/structure/reagent_dispensers/bidon,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"maX" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mbB" = (
 /obj/random/closet_wardrobe,
 /turf/simulated/floor/wood_old,
@@ -11694,9 +11821,11 @@
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/nadezhda/dungeon/outside/zoo)
-"mch" = (
-/obj/structure/sign/painting/russianstalin,
-/turf/simulated/wall/r_wall,
+"mda" = (
+/obj/item/paper/crumpled{
+	text = "You are on your own. Serve to your best extents and do not let our fortress fall!   - Skeinstovitch"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "mey" = (
 /obj/random/scrap/sparse_even,
@@ -11707,6 +11836,12 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"meX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mff" = (
 /obj/structure/multiz/stairs{
 	dir = 1
@@ -11859,6 +11994,16 @@
 /obj/structure/flora/small/busha2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"mmx" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"mmF" = (
+/obj/machinery/shieldwallgen/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mmN" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/invislight,
@@ -11874,16 +12019,6 @@
 /obj/structure/curtain/medical,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
-"mny" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mnY" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark,
@@ -12014,11 +12149,6 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
-"msM" = (
-/obj/structure/table/marble,
-/obj/item/storage/pouch/ammo,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "msY" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/item/clothing/head/hairflower/blue,
@@ -12071,9 +12201,9 @@
 /obj/structure/bed/chair/custom/onestar/red,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"mvg" = (
-/obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark,
+"mvh" = (
+/obj/structure/sign/warning/armory/small,
+/turf/simulated/wall/r_wall,
 /area/asteroid/rogue)
 "mvp" = (
 /obj/structure/table/steel_reinforced,
@@ -12110,6 +12240,10 @@
 "mxn" = (
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/nadezhda/outside/one_star)
+"mxx" = (
+/obj/item/trash/mre_candy,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mxA" = (
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
@@ -12149,10 +12283,12 @@
 /obj/random/surgery_tool/low_chance,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"mBg" = (
-/obj/structure/table/woodentable,
-/obj/item/implanter/excelsior/broken,
-/turf/simulated/floor/tiled/dark,
+"mAP" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/wall/r_wall,
 /area/asteroid/rogue)
 "mBi" = (
 /obj/effect/window_lwall_spawn/reinforced,
@@ -12263,10 +12399,6 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"mEl" = (
-/obj/item/storage/fancy/mre_cracker,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mEu" = (
 /obj/random/closet/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -12314,11 +12446,6 @@
 /obj/random/techpart,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"mFx" = (
-/obj/structure/scrap_cube,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mFJ" = (
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -12351,10 +12478,6 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"mHd" = (
-/obj/effect/decal/cleanable/ash,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mHA" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -12467,12 +12590,6 @@
 /obj/structure/flora/small/grassb5,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
-"mLR" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "mMt" = (
 /obj/structure/table/woodentable,
 /obj/random/contraband,
@@ -12649,11 +12766,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"mTI" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mTJ" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -12662,11 +12774,6 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"mTK" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre_candy,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mTP" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/random/lowkeyrandom/low_chance,
@@ -12778,6 +12885,17 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/one_star)
+"mYJ" = (
+/obj/structure/bed/psych{
+	desc = "It can be a bit noisy, but still serves well.";
+	name = "old bed"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"mZc" = (
+/obj/machinery/vending/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mZe" = (
 /obj/structure/flora/small/busha1,
 /obj/item/trash/mre_candy,
@@ -12847,11 +12965,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"ncv" = (
-/obj/effect/decal/cleanable/rubble,
-/mob/living/simple_animal/hostile/scarybat,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "ncG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/circuitboard,
@@ -12875,20 +12988,6 @@
 /obj/structure/flora/big/bush1,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"ndn" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/firstaid/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"ndt" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/item/tool/sword/saber,
-/obj/effect/decal/cleanable/blood,
-/obj/landmark/corpse/chef,
-/mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ndw" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -12920,12 +13019,6 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"neP" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "neV" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/hypospray/autoinjector/drugs,
@@ -12988,24 +13081,24 @@
 /obj/random/junkfood/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
+"niQ" = (
+/obj/structure/table/rack,
+/obj/random/gun_parts,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nja" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
-"njg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/manual/fiction{
-	name = "Communist Manifesto"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nji" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"njB" = (
+/obj/item/trash/cigbutt/brouzouf,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "njD" = (
 /obj/item/mine_old{
 	layer = 2.6
@@ -13022,14 +13115,6 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper)
-"nkh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/psych{
-	desc = "It can be a bit noisy, but still serves well.";
-	name = "old bed"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nkk" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -13066,11 +13151,6 @@
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"nlF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/plate,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nlG" = (
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -13220,9 +13300,6 @@
 /obj/structure/bookcase/metal,
 /obj/item/book/manual/fiction/warandpeace,
 /obj/item/book/manual/fiction/waroftheworlds,
-/obj/item/book/manual/fiction/achristmascarol{
-	icon = s
-	},
 /obj/item/book/manual/fiction/journeytothecenter,
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
@@ -13239,6 +13316,10 @@
 "nuk" = (
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/meadow)
+"nuz" = (
+/obj/machinery/cooking_with_jane/oven,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nvl" = (
 /obj/structure/sign/warning/caution{
 	pixel_x = -30
@@ -13301,6 +13382,10 @@
 /obj/item/folder/yellow,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"nxb" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "nxv" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/small/busha1,
@@ -13359,6 +13444,10 @@
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"nBe" = (
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nBv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
@@ -13446,15 +13535,6 @@
 /obj/random/rig_module,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"nFy" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"nGF" = (
-/obj/machinery/cooking_with_jane/stove,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nGI" = (
 /obj/effect/decal/cleanable/rubble,
 /mob/living/carbon/superior_animal/wurm/osmium,
@@ -13489,6 +13569,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"nHN" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/material/device,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nIx" = (
 /obj/structure/barricade,
 /obj/structure/boulder,
@@ -13512,10 +13597,21 @@
 /obj/structure/boulder,
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"nKW" = (
+/obj/structure/sign/warning/nosmoking,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "nLJ" = (
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"nLN" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nMn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13542,9 +13638,14 @@
 /obj/item/computer_hardware/hard_drive/portable/design/excelsior,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"nOD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
+"nOv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"nOx" = (
+/obj/effect/decal/cleanable/filth,
+/obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "nOF" = (
@@ -13561,10 +13662,9 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"nPA" = (
-/obj/item/mine/excelsior,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/pistachios,
+"nPz" = (
+/obj/structure/table/marble,
+/obj/item/gun/projectile/automatic/ak47,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "nPK" = (
@@ -13577,15 +13677,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"nPV" = (
-/mob/living/carbon/superior_animal/human/excelsior,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"nQa" = (
-/obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nQC" = (
 /obj/structure/table/standard,
 /obj/item/tool/tape_roll/flextape,
@@ -13609,6 +13700,20 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"nRo" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"nRq" = (
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "spiderling";
+	name = "dead spider"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nRv" = (
 /obj/structure/bed/chair/custom/wood{
 	dir = 8
@@ -13619,19 +13724,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"nSj" = (
-/obj/effect/dummy,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
-"nSk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/ammo/shotgun,
-/obj/random/ammo/shotgun/low_chance,
-/obj/random/ammo/shotgun/low_chance,
-/obj/random/ammo_fancy,
-/obj/random/ammo_fancy,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nTA" = (
 /turf/simulated/floor/asteroid/grass/colonialjungle4,
 /area/nadezhda/outside/meadow)
@@ -13795,16 +13887,14 @@
 /obj/effect/step_trigger/vault_bunker_1C,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"ocM" = (
-/obj/random/lowkeyrandom/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ocU" = (
 /obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"odl" = (
+/obj/structure/bed/chair/comfy,
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "odw" = (
 /obj/structure/flora/small/busha1,
 /obj/random/traps,
@@ -13945,10 +14035,6 @@
 /obj/item/oddity/common/old_money,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"oiJ" = (
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "oiQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/knife,
@@ -14061,6 +14147,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"ooY" = (
+/obj/structure/salvageable/implant_container_os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oph" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
@@ -14177,7 +14267,8 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
 "ouu" = (
-/obj/item/trash/semki,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/liquidfood,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "ovb" = (
@@ -14249,6 +14340,10 @@
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"oxW" = (
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oxY" = (
 /obj/structure/table/rack/shelf,
 /obj/random/gun_cheap,
@@ -14299,6 +14394,10 @@
 /obj/structure/flora/big/bush1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"oAi" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oAK" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
@@ -14310,10 +14409,6 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
-"oBN" = (
-/obj/item/trash/mre,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "oBT" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -14325,9 +14420,6 @@
 /obj/structure/table,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"oCe" = (
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "oCm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14421,11 +14513,6 @@
 /obj/random/pack/cloth,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"oFf" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/material/device,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "oFC" = (
 /obj/random/lathe_disk/advanced,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -14616,15 +14703,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/mineral/random/rogue,
 /area/colony/exposedsun/crashed_shop/outsider)
-"oNp" = (
-/obj/machinery/porta_turret/excelsior/preloaded,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/cobweb2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "oNq" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -14708,6 +14786,11 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
+"oRO" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oSf" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha1,
@@ -14720,7 +14803,7 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "oSA" = (
-/obj/random/lowkeyrandom,
+/obj/random/scrap,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "oSD" = (
@@ -14820,11 +14903,6 @@
 /obj/machinery/door/airlock,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"oVG" = (
-/obj/structure/table/rack,
-/obj/item/gun/energy/stunrevolver,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "oVH" = (
 /obj/structure/table/rack,
 /obj/random/gun_normal,
@@ -14846,10 +14924,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"oXa" = (
-/obj/item/implant/excelsior/broken,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "oXm" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -14919,22 +14993,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"pbc" = (
-/obj/item/bedsheet,
-/obj/structure/bed,
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "pbd" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"pbj" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "pbT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/mre/alt,
+/obj/machinery/suit_storage_unit/excelsior,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "pbZ" = (
@@ -14954,6 +15018,16 @@
 /obj/structure/flora/small/bushc1,
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"pdb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/asteroid/rogue)
+"pdI" = (
+/obj/structure/closet/crate/excelsior,
+/obj/random/surgery_tool/low_chance,
+/obj/item/tool/saw/circular/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "peq" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/carpet/turcarpet,
@@ -14979,18 +15053,16 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"pft" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pgh" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	name = "General Containment"
 	},
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/nadezhda/dungeon/outside/zoo)
+"pgp" = (
+/obj/structure/reagent_dispensers/fueltank/derelict,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pgD" = (
 /obj/structure/bed/double/padded,
 /obj/random/furniture/bedsheetdouble,
@@ -15130,12 +15202,6 @@
 /obj/item/stack/material/wood/random,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"pmd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pmi" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood/wild4,
@@ -15240,6 +15306,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"prj" = (
+/obj/structure/coatrack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "prT" = (
 /obj/structure/multiz/ladder,
 /obj/structure/flora/small/bushb2,
@@ -15258,10 +15328,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"ptd" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pty" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -15384,6 +15450,11 @@
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"pAw" = (
+/obj/item/implantcase/excelsior/broken,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pAx" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/wild5,
@@ -15460,11 +15531,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
-"pEI" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pEQ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/mine_old,
@@ -15496,6 +15562,11 @@
 /obj/structure/railing,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"pGB" = (
+/obj/random/lowkeyrandom/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pGH" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -15534,6 +15605,12 @@
 	icon_state = "3,7"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"pHY" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/gun/projectile/automatic/ak47/saiga,
+/obj/item/gun/projectile/automatic/ak47/saiga,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pIe" = (
 /obj/effect/decal/mecha_wreckage/ripley,
 /obj/item/material/shard/shrapnel/scrap,
@@ -15757,6 +15834,16 @@
 /obj/item/secbot_assembly/ed209_assembly,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"pQJ" = (
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo/low_chance,
+/obj/random/ammo/low_chance,
+/obj/item/ammo_magazine/ammobox/antim_small,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pRb" = (
 /obj/random/junk,
 /obj/item/mine_old,
@@ -15774,11 +15861,6 @@
 	},
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"pRk" = (
-/obj/effect/decal/cleanable/generic,
-/obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pRE" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15874,13 +15956,6 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper)
-"pVA" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pVL" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
@@ -15913,15 +15988,6 @@
 /obj/effect/step_trigger/monster_to_beast_1_A,
 /turf/simulated/floor/asteroid/dirt,
 /area/colony/exposedsun/pastgate)
-"pXo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pYa" = (
 /obj/structure/flora/rock,
 /turf/simulated/floor/asteroid/grass,
@@ -16000,15 +16066,6 @@
 	},
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"pZU" = (
-/obj/random/dungeon_gun_ballistic,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"qai" = (
-/obj/item/trash/popcorn,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "qaj" = (
 /obj/structure/closet/l3closet,
 /turf/simulated/floor/tiled/white/panels,
@@ -16030,12 +16087,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"qaJ" = (
-/obj/random/mecha/damaged/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mech_recharger,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "qbx" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	locked = 1;
@@ -16144,7 +16195,7 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "qhe" = (
-/obj/effect/decal/cleanable/filth,
+/obj/item/mine/excelsior,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "qhr" = (
@@ -16158,6 +16209,11 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"qhz" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qhG" = (
 /obj/structure/table/woodentable,
 /obj/random/knife,
@@ -16260,6 +16316,10 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"qms" = (
+/obj/landmark/corpse/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qmu" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -16399,6 +16459,10 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
+"qvx" = (
+/obj/machinery/vending/engineering,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qvJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/pack/junk_machine,
@@ -16487,29 +16551,19 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/meadow)
-"qzI" = (
-/obj/machinery/porta_turret/excelsior/preloaded,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "qzP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"qzQ" = (
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "qzS" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/small/bushc1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"qAh" = (
-/obj/random/scrap,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
-"qAA" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/item/stack/medical/bruise_pack,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "qAS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -16586,6 +16640,11 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"qDw" = (
+/obj/machinery/door/airlock/centcom,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qDA" = (
 /turf/simulated/floor/asteroid/grass/sif,
 /area/nadezhda/dungeon/outside/zoo)
@@ -16602,8 +16661,8 @@
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"qDV" = (
-/obj/item/trash/mre_paste,
+"qDZ" = (
+/obj/item/trash/syndi_cakes,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "qEm" = (
@@ -16673,6 +16732,16 @@
 /obj/random/cluster/roaches,
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
+"qHi" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qHj" = (
 /obj/structure/closet/crate/serbcrate,
 /obj/random/powercell/medium_safe,
@@ -16775,11 +16844,6 @@
 /obj/machinery/cryopod/dormitory,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
-"qNB" = (
-/obj/structure/table/reinforced,
-/obj/item/trash/candle,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "qNO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/molten_item,
@@ -17135,11 +17199,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/zoo)
-"rec" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/automatic/vintorez,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rel" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/mineral/random/rogue,
@@ -17170,14 +17229,6 @@
 "rgE" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"rgN" = (
-/obj/item/book/manualshield_generator_guide,
-/obj/item/cell/large/excelsior,
-/obj/item/cell/large/excelsior,
-/obj/structure/table/standard,
-/obj/item/part/gun/frame/basilisk,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rgX" = (
 /obj/random/techpart/low_chance,
 /obj/random/closet_maintloot,
@@ -17238,19 +17289,15 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"rlf" = (
-/obj/structure/scrap_cube,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rli" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap_cube,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"rlq" = (
-/obj/item/trash/broken_robot_part,
+"rlk" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre_candy,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "rlt" = (
@@ -17380,6 +17427,11 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"rrt" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rrP" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 24
@@ -17415,12 +17467,6 @@
 /obj/random/closet/low_chance,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"rti" = (
-/obj/structure/closet/crate/excelsior,
-/obj/item/gun/projectile/automatic/ak47/saiga,
-/obj/item/gun/projectile/automatic/ak47/saiga,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rtr" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/asteroid/dirt,
@@ -17471,11 +17517,6 @@
 	tag = "icon-cargoshwall30"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"rvu" = (
-/obj/structure/table/rack,
-/obj/random/gun_parts,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rvx" = (
 /obj/machinery/door/airlock/glass{
 	locked = 1;
@@ -17516,10 +17557,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"rwZ" = (
-/obj/landmark/corpse/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rxy" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -17712,10 +17749,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"rHH" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "rHY" = (
 /turf/unsimulated/mineral,
 /area/colony/exposedsun/pastgate)
@@ -17757,11 +17790,6 @@
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/asteroid/rogue)
-"rKx" = (
-/obj/item/storage/hcases/ammo/excel,
-/obj/structure/closet/crate/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rKz" = (
 /turf/simulated/wall/r_wall,
 /area/asteroid/rogue)
@@ -17794,6 +17822,12 @@
 /obj/structure/salvageable/data,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"rOh" = (
+/obj/machinery/door/airlock/centcom,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/mine/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rOo" = (
 /obj/random/cluster/roaches,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -17809,6 +17843,10 @@
 /obj/item/implant/excelsior/broken,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"rPh" = (
+/obj/random/oddity_guns,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rPB" = (
 /obj/random/mob/hakhma/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -17831,11 +17869,6 @@
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"rQE" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre/alt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rQF" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/wood/wild4,
@@ -17855,18 +17888,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"rQU" = (
-/obj/structure/sign/departmentold/janitorial,
-/turf/simulated/wall,
-/area/asteroid/rogue)
-"rQX" = (
-/obj/item/trash/peachcan,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"rRc" = (
-/obj/item/trash/gamerchips,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rRg" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -17892,10 +17913,6 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"rSf" = (
-/obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rSp" = (
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -17932,8 +17949,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"rUc" = (
-/obj/item/trash/mre_shokoladka,
+"rUp" = (
+/obj/structure/table/woodentable,
+/obj/item/clothing/under/excelsior/officer,
+/obj/item/clothing/head/exceslior/excelsior_officer,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "rUt" = (
@@ -17944,12 +17963,6 @@
 /obj/structure/medical_stand,
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/crashed_shop/outsider)
-"rVQ" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rVT" = (
 /obj/machinery/door/blast/regular{
 	id = "prepper room A"
@@ -17957,6 +17970,11 @@
 /obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"rWt" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rWz" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/small/busha2,
@@ -17972,9 +17990,9 @@
 /mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"rWT" = (
-/obj/effect/decal/cleanable/filth,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
+"rWN" = (
+/mob/living/simple_animal/hostile/diyaab,
+/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "rXh" = (
@@ -17994,12 +18012,9 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
-"rXS" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/effect/decal/cleanable/dirt,
+"rXG" = (
+/obj/random/lowkeyrandom,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "rYj" = (
@@ -18045,6 +18060,10 @@
 /obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"saF" = (
+/obj/random/scrap,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "saY" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/beakers,
@@ -18163,10 +18182,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
-"sgs" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/wall,
-/area/asteroid/rogue)
 "sgz" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -18225,10 +18240,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"siV" = (
-/mob/living/simple_animal/hostile/bear/excelsior,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "sjc" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/big/bush3,
@@ -18249,6 +18260,11 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"sjT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/sosjerky,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "skv" = (
 /obj/random/scrap/sparse_weighted,
 /obj/effect/decal/cleanable/dirt,
@@ -18267,11 +18283,6 @@
 	},
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"skU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "skV" = (
 /obj/structure/salvageable/console_os{
 	dir = 8
@@ -18283,10 +18294,6 @@
 /obj/structure/salvageable/personal,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"slv" = (
-/obj/structure/sign/faction/excelsior_old,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "slw" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -18310,11 +18317,6 @@
 /obj/item/oddity/common/paper_omega,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"smC" = (
-/obj/random/lowkeyrandom,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "smK" = (
 /obj/structure/table/rack/shelf,
 /obj/random/junkfood,
@@ -18353,11 +18355,6 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"spk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/firstaid/regular/empty,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "spm" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/stack/material/diamond/random,
@@ -18370,6 +18367,15 @@
 /obj/structure/salvageable/implant_container_os,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"spr" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"spJ" = (
+/obj/structure/bookcase/manuals/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sqo" = (
 /turf/simulated/shuttle/wall/cargo{
 	icon_state = "cargoshwall33";
@@ -18412,12 +18418,6 @@
 /obj/random/mob/undergroundmob/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"ssg" = (
-/obj/structure/janitorialcart,
-/obj/item/keys/janitor,
-/obj/item/mop,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ssJ" = (
 /obj/structure/bed/chair/custom/onestar/red{
 	dir = 1
@@ -18443,6 +18443,10 @@
 	tag = "icon-cargoshwall18"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"sub" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sur" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -18530,6 +18534,14 @@
 "sxn" = (
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/zoo)
+"sxM" = (
+/obj/item/trash/mre_paste,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"sxQ" = (
+/obj/structure/flora/small/grassa5,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "sxS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -18544,10 +18556,6 @@
 /obj/structure/scrap/large,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"szd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "sze" = (
 /obj/structure/flora/small/rock2,
 /turf/simulated/floor/asteroid/grass,
@@ -18626,6 +18634,11 @@
 /obj/random/traps,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"sDY" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sEK" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -18642,12 +18655,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
-"sFp" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "sFD" = (
 /obj/random/mob/prepper,
 /turf/simulated/floor/carpet/bcarpet,
@@ -18819,6 +18826,11 @@
 "sPa" = (
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
+"sPh" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/trash/icecreambowl,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "sPt" = (
 /obj/structure/table/rack,
 /obj/item/stack/ore/plasma,
@@ -18836,6 +18848,11 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"sQl" = (
+/obj/structure/table/rack,
+/obj/item/gun/energy/stunrevolver,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sQm" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
@@ -18848,12 +18865,6 @@
 /obj/item/oddity/common/old_radio,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"sQu" = (
-/obj/structure/scrap_cube,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "sQy" = (
 /obj/structure/table/rack/shelf,
 /obj/effect/decal/cleanable/dirt,
@@ -18904,10 +18915,6 @@
 /obj/item/stack/tile/carpet/gaycarpet,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"sSp" = (
-/obj/landmark/corpse/excelsior,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "sTa" = (
 /obj/structure/multiz/stairs/active{
 	dir = 4
@@ -18926,11 +18933,6 @@
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"sVt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "sVx" = (
 /obj/structure/railing/grey{
 	dir = 1;
@@ -18958,12 +18960,6 @@
 /obj/item/storage/firstaid/surgery/combat,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"sYe" = (
-/obj/machinery/door/airlock/centcom,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/mine/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "sYB" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/glowstick/flare/torch,
@@ -19006,15 +19002,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"tao" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"tau" = (
-/mob/living/carbon/superior_animal/human/excelsior,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "taJ" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
@@ -19116,6 +19103,11 @@
 "tgh" = (
 /turf/simulated/floor/rock/manmade/concrete,
 /area/nadezhda/outside/meadow)
+"tgk" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tgr" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/trash,
@@ -19195,6 +19187,12 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"tjF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank/huge/derelict,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tjP" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/big/bush3,
@@ -19204,6 +19202,16 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"tkq" = (
+/obj/structure/table/rack,
+/obj/effect/decal/cleanable/filth,
+/obj/item/gun_upgrade/trigger/boom,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"tkE" = (
+/obj/structure/scrap/medical/large,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tkN" = (
 /obj/structure/table/standard,
 /obj/structure/window/reinforced{
@@ -19230,10 +19238,6 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"tlG" = (
-/obj/structure/salvageable/implant_container_os,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tlO" = (
 /obj/structure/closet/onestar/tier3/special,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -19246,10 +19250,6 @@
 "tml" = (
 /turf/simulated/mineral/planet,
 /area/colony/exposedsun/pastgate)
-"tmt" = (
-/obj/item/trash/cigbutt/fortressblue,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tmw" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha3,
@@ -19271,10 +19271,6 @@
 /obj/item/frame/apc,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"tmW" = (
-/obj/item/mine/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tnY" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/wood/wild5,
@@ -19312,27 +19308,11 @@
 /obj/random/tool_upgrade/rare,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"tpL" = (
-/obj/structure/closet/crate/excelsior,
-/obj/item/rcd/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tqA" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/claymore,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"tqU" = (
-/obj/structure/closet/crate/excelsior,
-/obj/item/tool/baton/excelbaton,
-/obj/item/tool/baton/excelbaton,
-/obj/item/clothing/suit/space/void/excelsior,
-/obj/item/clothing/head/helmet/space/void/excelsior,
-/obj/random/melee/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/boltgun/heavysniper,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "trl" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -19368,10 +19348,6 @@
 /obj/random/oddity_guns,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"ttl" = (
-/obj/structure/salvageable/console_broken_os,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ttx" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/wood/wild3,
@@ -19430,12 +19406,21 @@
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
+"txA" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "txD" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/simulated/floor/wood_old,
 /area/colony/exposedsun/crashed_shop/outsider)
+"txM" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tyi" = (
 /obj/effect/overlay/water/top{
 	pixel_y = -9
@@ -19449,10 +19434,6 @@
 	},
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/meadow)
-"tyl" = (
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tyI" = (
 /obj/structure/closet/random_medsupply,
 /obj/item/storage/firstaid,
@@ -19465,6 +19446,13 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"tyY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tzf" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall14";
@@ -19492,11 +19480,24 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"tzP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tzX" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"tAb" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/random/medical,
+/obj/item/storage/firstaid,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tAp" = (
 /turf/simulated/wall,
 /area/nadezhda/dungeon/outside/zoo)
@@ -19594,11 +19595,6 @@
 /obj/structure/salvageable/bliss,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/dungeon/outside/prepper)
-"tFp" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tFU" = (
 /obj/structure/flora/small/busha2,
 /obj/item/mine/armed,
@@ -19613,6 +19609,12 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"tIh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tIC" = (
 /obj/item/paper_bin,
 /obj/item/paper_bin,
@@ -19628,11 +19630,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"tIU" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tIV" = (
 /obj/asteroid_spawner/rogue_teleporter,
 /obj/rogue/teleporter,
@@ -19642,17 +19639,17 @@
 /mob/living/simple_animal/hostile/republicon/range,
 /turf/unsimulated/mineral,
 /area/colony)
-"tJe" = (
-/obj/structure/table/gamblingtable,
-/obj/item/gun/projectile/makarov/preloaded,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tJh" = (
 /obj/structure/salvageable/console_os{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"tJo" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tJR" = (
 /obj/item/folder,
 /obj/item/folder,
@@ -19741,10 +19738,6 @@
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"tNG" = (
-/obj/item/part/gun/frame/vintorez,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tNR" = (
 /obj/structure/table/standard,
 /obj/random/surgery_tool/low_chance,
@@ -19763,16 +19756,15 @@
 /obj/structure/closet/secure_closet/rare_loot,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"tOp" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tOG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/remains/human,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"tOK" = (
+/obj/structure/sign/faction/excelsior_old,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "tPs" = (
 /obj/item/material/shard,
 /turf/simulated/floor/tiled/white,
@@ -19788,12 +19780,6 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
-"tPT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tQf" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/small/busha3,
@@ -19829,11 +19815,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
-"tSz" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tSB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -19868,11 +19849,24 @@
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"tUw" = (
+/obj/item/gun/projectile/makarov/preloaded,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tUH" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"tUM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/clothing/shoes/jackboots/janitor,
+/obj/structure/closet/l3closet/janitor,
+/obj/item/toy/figure/character/civilian/janitor,
+/obj/item/clothing/under/rank/janitor,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tUY" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/food/condiment/sugar,
@@ -19908,10 +19902,6 @@
 /obj/random/cluster/spiders/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"tWN" = (
-/obj/structure/scrap/medical/large,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tWP" = (
 /obj/machinery/porta_turret/prepper,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -19921,6 +19911,11 @@
 /obj/item/stock_parts/manipulator/one_star,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"tXl" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre/alt,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "tXm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/multi_tile/metal{
@@ -19955,6 +19950,11 @@
 /obj/structure/scrap/guns/large,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"tYx" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tZg" = (
 /obj/random/mob/vox,
 /turf/simulated/floor/asteroid/grass,
@@ -19994,6 +19994,11 @@
 /obj/random/rations,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"uau" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/random/traps/low_chance,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "uaW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20063,12 +20068,6 @@
 /mob/living/carbon/superior_animal/robot/greyson/synthetic,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"udE" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/rubble,
-/obj/item/bedsheet,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "udZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -20161,24 +20160,10 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
-"uhz" = (
-/obj/structure/curtain/medical,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "uih" = (
 /obj/machinery/power/smes/buildable,
 /turf/simulated/shuttle/floor/mining,
 /area/colony/exposedsun/crashed_shop/outsider)
-"uiu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/clothing/shoes/jackboots/janitor,
-/obj/structure/closet/l3closet/janitor,
-/obj/item/toy/figure/character/civilian/janitor,
-/obj/item/clothing/under/rank/janitor,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ujb" = (
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -20191,6 +20176,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/safehouse)
+"ule" = (
+/obj/random/lowkeyrandom,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ulg" = (
 /obj/structure/table/onestar,
 /obj/structure/window/reinforced{
@@ -20250,15 +20240,9 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"unn" = (
-/obj/structure/closet/crate/excelsior,
-/obj/item/tool/baton/excelbaton,
-/obj/item/tool/baton/excelbaton,
-/obj/item/clothing/suit/space/void/excelsior,
-/obj/item/clothing/head/helmet/space/void/excelsior,
-/obj/random/melee/low_chance,
-/obj/item/gun/projectile/automatic/drozd,
-/obj/item/gun/projectile/automatic/drozd,
+"umT" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "unD" = (
@@ -20383,6 +20367,11 @@
 /obj/structure/reagent_dispensers/fueltank/huge,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"utQ" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "utY" = (
 /mob/living/simple_animal/penguin/baby,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -20407,10 +20396,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"uvF" = (
-/obj/item/storage/fancy/vials,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "uvO" = (
 /obj/structure/flora/small/grassb3,
 /obj/structure/flora/small/busha1,
@@ -20526,6 +20511,11 @@
 /mob/living/simple_animal/hostile/samak,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
+"uBC" = (
+/obj/structure/table/standard,
+/obj/random/surgery_tool,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uBW" = (
 /obj/structure/railing/grey{
 	dir = 1;
@@ -20651,13 +20641,6 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
-"uId" = (
-/obj/structure/table/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/gun_parts,
-/obj/item/gun_upgrade/barrel/faulty,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "uIf" = (
 /obj/structure/railing/grey,
 /obj/effect/step_trigger/vault_bunker_1F,
@@ -20692,6 +20675,8 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "uIZ" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/projectile/boltgun,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "uJw" = (
@@ -20710,11 +20695,6 @@
 /obj/structure/flora/small/busha3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"uKB" = (
-/obj/structure/table/marble,
-/obj/item/gun/projectile/automatic/ak47,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "uKY" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/wood/wild4,
@@ -20747,10 +20727,6 @@
 /obj/item/oddity/common/old_id,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/dungeon/outside/zoo)
-"uMg" = (
-/obj/random/traps/low_chance,
-/turf/simulated/floor/rock/grey,
-/area/asteroid/rogue)
 "uMr" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Bathroom"
@@ -20773,6 +20749,15 @@
 /obj/random/lathe_disk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"uMy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uMB" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/cafe,
@@ -20803,11 +20788,6 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
-"uOL" = (
-/obj/structure/scrap_cube,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "uON" = (
 /obj/machinery/gym,
@@ -20920,11 +20900,6 @@
 /obj/machinery/cryopod/dormitory,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"uTB" = (
-/obj/machinery/door/airlock,
-/obj/item/mine/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "uTO" = (
 /obj/structure/flora/small/bushb3,
 /obj/random/scrap/dense_even,
@@ -20975,11 +20950,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"uVz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/peachcan,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "uVU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -21024,6 +20994,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"uYg" = (
+/mob/living/simple_animal/hostile/megafauna/excelsior_cosmonaught,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vag" = (
 /obj/structure/flora/small/grassa4,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -21096,6 +21070,10 @@
 /obj/random/cloth/helmet,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"vdu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "vdy" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/asteroid/grass,
@@ -21159,12 +21137,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
-"vfH" = (
-/obj/structure/table/woodentable,
-/obj/item/clothing/under/excelsior/officer,
-/obj/item/clothing/head/exceslior/excelsior_officer,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vfL" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
@@ -21175,6 +21147,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"vgl" = (
+/obj/random/scrap/dense_weighted,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vgW" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -21203,6 +21179,12 @@
 /obj/item/oddity/common/old_money,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"vhQ" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vhR" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
@@ -21266,6 +21248,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
+"vkJ" = (
+/obj/machinery/suit_storage_unit/excelsior,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vkQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -21330,6 +21317,11 @@
 /obj/item/material/shard/shrapnel,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"vnV" = (
+/obj/structure/table/marble,
+/obj/item/storage/pouch/ammo,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vom" = (
 /obj/structure/table/plasmaglass,
 /obj/item/ammo_casing/flare/blue/prespawn,
@@ -21340,6 +21332,11 @@
 /obj/item/ammo_casing/flare/prespawn,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
+"voR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "voT" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -21401,22 +21398,11 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"vqz" = (
-/obj/machinery/vending/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vqP" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"vtc" = (
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "vto" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/plating/under,
@@ -21444,12 +21430,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"vtG" = (
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vuc" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 4;
@@ -21491,6 +21471,10 @@
 /obj/machinery/door/airlock/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"vxP" = (
+/obj/structure/salvageable/computer_os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vyy" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/contraband/low_chance,
@@ -21498,6 +21482,12 @@
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
+"vyI" = (
+/obj/item/mine/excelsior,
+/obj/effect/decal/cleanable/generic,
+/obj/random/scrap/sparse_even/low_chance,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "vyL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -21528,6 +21518,10 @@
 /obj/item/device/synthesized_instrument/trumpet,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"vAm" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vAu" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/steel/danger,
@@ -21569,6 +21563,10 @@
 /obj/item/mine_old,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"vBX" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vCx" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/medical,
@@ -21670,11 +21668,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/colony/exposedsun/crashed_shop/outsider)
-"vHg" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/random/traps/low_chance,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "vHF" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -21761,6 +21754,12 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"vMv" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vMR" = (
 /obj/structure/cable/ender{
 	id = "preppergrid"
@@ -21799,11 +21798,6 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"vOl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/mre/os,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vOF" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -22006,10 +22000,6 @@
 /obj/structure/flora/small/busha2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"vWE" = (
-/obj/structure/scrap_cube,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vWH" = (
 /obj/structure/toilet{
 	dir = 8
@@ -22029,10 +22019,6 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
-"vXA" = (
-/obj/machinery/suit_storage_unit/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vXM" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/asteroid/grass,
@@ -22048,12 +22034,6 @@
 /obj/random/scrap,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"vZn" = (
-/obj/item/paper/crumpled{
-	text = "You are on your own. Serve to your best extents and do not let our fortress fall!   - Skeinstovitch"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vZs" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -22073,6 +22053,10 @@
 /obj/item/mine_old,
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
+"vZU" = (
+/obj/structure/flora/small/grassb2,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "vZZ" = (
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/wood/wild5,
@@ -22090,6 +22074,10 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"waE" = (
+/obj/structure/medical_stand,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wbq" = (
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
@@ -22098,6 +22086,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"wbG" = (
+/obj/item/mine/excelsior,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wbJ" = (
 /obj/landmark/join/start/outsider,
 /obj/structure/bed/chair,
@@ -22108,25 +22102,25 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"wcf" = (
-/obj/structure/barricade,
+"wcn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/plate,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "wcv" = (
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"wcB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/dense_weighted,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wcP" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/item/clothing/head/hairflower,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
-"wcW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wcZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22168,18 +22162,6 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"wfR" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wfX" = (
 /obj/item/remains/lizard,
 /obj/effect/decal/cleanable/blood,
@@ -22275,6 +22257,11 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"wlq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/mre/os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wlE" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/railing,
@@ -22338,6 +22325,13 @@
 "wpR" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/zoo)
+"wpT" = (
+/obj/structure/table/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/gun_parts,
+/obj/item/gun_upgrade/barrel/faulty,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wqj" = (
 /obj/structure/table/standard,
 /obj/machinery/centrifuge,
@@ -22410,6 +22404,11 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"wti" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wtv" = (
 /obj/structure/flora/small/bushc3,
 /obj/structure/flora/small/bushc3,
@@ -22421,15 +22420,16 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
-"wun" = (
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wuv" = (
 /obj/structure/low_wall,
 /obj/item/material/shard,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/zoo)
+"wuG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wuT" = (
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/techmaint_cargo,
@@ -22438,6 +22438,12 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"wvG" = (
+/obj/item/gun/projectile/colt,
+/obj/item/ammo_kit,
+/obj/random/scrap,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "wvW" = (
 /obj/structure/table,
 /turf/simulated/floor/tiled/white/panels,
@@ -22490,6 +22496,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"wxX" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/tray,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wyk" = (
 /obj/item/material/shard/shrapnel/scrap,
 /obj/random/junk,
@@ -22551,16 +22562,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"wBI" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
-"wBR" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/item/storage/firstaid/combat,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wBS" = (
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/wood/wild4,
@@ -22642,6 +22643,10 @@
 /obj/item/material/shard,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
+"wGs" = (
+/obj/structure/curtain/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wGX" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
@@ -22687,22 +22692,11 @@
 /obj/item/clothing/mask/gas/old,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"wKG" = (
-/obj/item/mine/excelsior,
-/obj/effect/decal/cleanable/generic,
-/obj/random/scrap/sparse_even/low_chance,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "wKN" = (
 /obj/item/stool,
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"wKQ" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wKR" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall14";
@@ -22738,10 +22732,6 @@
 "wLJ" = (
 /obj/structure/closet/secure_closet/freezer/blood,
 /turf/simulated/floor/wood/wild4,
-/area/asteroid/rogue)
-"wLQ" = (
-/obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "wLV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22830,12 +22820,6 @@
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"wPa" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/obj/item/trash/popcorn,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wPb" = (
 /obj/structure/closet/secure_closet/freezer/blood,
 /turf/simulated/floor/wood/wild4,
@@ -22876,10 +22860,6 @@
 /obj/item/beartrap/armed,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"wRY" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "wRZ" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -22935,12 +22915,6 @@
 /obj/random/ammo_lowcost/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/meadow)
-"wVF" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre_candy,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wVS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22971,6 +22945,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"wXp" = (
+/obj/item/flame/lighter/zippo/excelsior,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wXx" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -22985,6 +22964,11 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"wYh" = (
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wYx" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushb2,
@@ -23004,8 +22988,9 @@
 /obj/random/cloth/armor,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"wZg" = (
-/obj/item/gun/projectile/boltgun,
+"wZi" = (
+/obj/machinery/cooking_with_jane/grill,
+/obj/structure/table/marble,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "wZn" = (
@@ -23042,10 +23027,6 @@
 /obj/random/lathe_disk,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"xbH" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xbS" = (
 /obj/structure/table/rack/shelf,
 /obj/random/lowkeyrandom,
@@ -23080,11 +23061,6 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"xcU" = (
-/obj/effect/decal/cleanable/filth,
-/obj/item/trash/mre_can,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xdH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mat_katana,
@@ -23110,8 +23086,9 @@
 /obj/random/material_resources,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"xee" = (
-/obj/structure/cardboardbox,
+"xem" = (
+/obj/machinery/door/airlock/centcom,
+/obj/item/mine/excelsior,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "xen" = (
@@ -23143,10 +23120,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"xfn" = (
-/obj/machinery/vending/engineering,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xfo" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -23181,6 +23154,12 @@
 /obj/machinery/power/port_gen/pacman/diesel/anchored,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"xfH" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xgb" = (
 /obj/structure/flora/big/bush2,
 /turf/unsimulated/wall/jungle,
@@ -23197,11 +23176,6 @@
 /obj/random/mat_katana,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"xgt" = (
-/obj/machinery/door/airlock/centcom,
-/obj/item/mine/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xgx" = (
 /obj/structure/bed/chair/custom/onestar,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -23278,11 +23252,6 @@
 /obj/item/stack/cable_coil/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"xki" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/sosjerky,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xkq" = (
 /obj/item/stack/material/wood/random,
 /obj/effect/decal/cleanable/dirt,
@@ -23326,6 +23295,12 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
+"xlQ" = (
+/obj/random/mecha/damaged/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mech_recharger,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xmn" = (
 /obj/structure/table/standard,
 /obj/random/medical,
@@ -23360,10 +23335,9 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
-"xoW" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/item/gun/projectile/boltgun,
+"xoD" = (
+/obj/random/lowkeyrandom/low_chance,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "xpA" = (
@@ -23407,14 +23381,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"xrf" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xri" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
@@ -23425,6 +23391,10 @@
 /obj/random/pack/tech_loot,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"xrw" = (
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xrG" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark/danger,
@@ -23444,6 +23414,19 @@
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"xtu" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/rcd/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"xtS" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/port_gen/pacman/diesel/anchored,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xtX" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -23528,11 +23511,6 @@
 /obj/item/tool/weldingtool,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"xxv" = (
-/obj/item/mine/excelsior,
-/obj/random/scrap/sparse_even/low_chance,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "xyD" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -23566,6 +23544,11 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"xzo" = (
+/obj/item/mine/excelsior,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xzW" = (
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
@@ -23623,16 +23606,6 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
-"xEl" = (
-/obj/item/implanter/excelsior/broken,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"xEv" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "xEO" = (
 /obj/structure/table/bench/wooden,
 /obj/item/trash/broken_robot_part,
@@ -23649,10 +23622,6 @@
 /obj/random/furniture/bedsheetdouble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"xFy" = (
-/obj/random/scrap/moderate_weighted,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "xFG" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -23684,6 +23653,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"xHj" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xHm" = (
 /obj/item/remains/deer,
 /turf/simulated/floor/asteroid/dirt,
@@ -23748,6 +23722,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"xKz" = (
+/obj/effect/decal/cleanable/filth,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xKB" = (
 /obj/item/stack/rods/random,
 /obj/item/stack/rods/random,
@@ -23801,6 +23780,11 @@
 /obj/random/junkfood,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"xNo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/autoinjector/drugs,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xNp" = (
 /obj/structure/table/rack/shelf,
 /obj/random/pouch/low_chance,
@@ -23854,6 +23838,11 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"xPI" = (
+/obj/random/scrap/dense_weighted,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xPO" = (
 /obj/structure/table/standard,
 /obj/item/oddity/common/towel,
@@ -23873,6 +23862,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/safehouse)
+"xQs" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xQu" = (
 /obj/structure/flora/small/busha2,
 /obj/effect/overlay/water,
@@ -23893,6 +23886,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
+"xSq" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xSt" = (
 /obj/structure/curtain/open,
 /obj/effect/decal/cleanable/dirt,
@@ -23946,12 +23943,6 @@
 /obj/item/rig/merc,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"xUz" = (
-/obj/effect/decal/cleanable/cobweb2{
-	icon_state = "cobweb1"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xUP" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -24025,11 +24016,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"yaB" = (
-/obj/random/lowkeyrandom,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "yaD" = (
 /obj/structure/bed/chair/custom/onestar{
 	dir = 1
@@ -24122,6 +24108,10 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"yga" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ygc" = (
 /obj/item/tool/pickaxe,
 /obj/item/clothing/head/hardhat,
@@ -24202,13 +24192,16 @@
 /obj/structure/barricade,
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/crashed_shop/outsider)
-"yks" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/semki,
+"ykj" = (
+/obj/structure/salvageable/data_os,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
-"ykG" = (
-/mob/living/simple_animal/hostile/megafauna/excelsior_cosmonaught,
+"ykv" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "ykI" = (
@@ -24217,6 +24210,10 @@
 /obj/random/scrap,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"ylk" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "ylq" = (
 /obj/structure/table/steel,
 /obj/item/toy/figure/character/bobblehead/excelsior,
@@ -40136,7 +40133,7 @@ qbU
 qbU
 qbU
 qbU
-dEf
+asz
 euc
 qbU
 euc
@@ -40549,7 +40546,7 @@ qbU
 qbU
 qbU
 qbU
-vHg
+uau
 ugY
 ugY
 ugY
@@ -41611,7 +41608,7 @@ qbU
 qbU
 qbU
 qbU
-dEf
+asz
 qbU
 qbU
 qbU
@@ -41810,10 +41807,10 @@ qbU
 qbU
 euc
 euc
-dEf
+asz
 euc
 ugY
-dEf
+asz
 qbU
 qbU
 qbU
@@ -42015,9 +42012,9 @@ euc
 ugY
 ugY
 ugY
-dEf
+asz
 euc
-ars
+kEz
 euc
 euc
 qbU
@@ -42220,7 +42217,7 @@ nxY
 qbU
 qbU
 qbU
-vHg
+uau
 qbU
 qbU
 qbU
@@ -42442,7 +42439,7 @@ qbU
 qbU
 qbU
 euc
-dEf
+asz
 euc
 euc
 euc
@@ -43264,7 +43261,7 @@ nxY
 nxY
 qbU
 qbU
-vHg
+uau
 qbU
 qbU
 qbU
@@ -43279,7 +43276,7 @@ qbU
 qbU
 qbU
 qbU
-ars
+kEz
 euc
 ugY
 qbU
@@ -43682,7 +43679,7 @@ nxY
 nxY
 qbU
 qbU
-ncv
+hAS
 qbU
 qbU
 qbU
@@ -43695,12 +43692,12 @@ euc
 qbU
 qbU
 euc
-nSj
+dCu
 euc
 qbU
 rel
 qkQ
-vHg
+uau
 ugY
 ugY
 ugY
@@ -43898,7 +43895,7 @@ qbU
 qbU
 qbU
 euc
-vHg
+uau
 euc
 qbU
 qbU
@@ -44332,7 +44329,7 @@ qbU
 qbU
 qbU
 qbU
-vHg
+uau
 qbU
 qbU
 qbU
@@ -44532,7 +44529,7 @@ qbU
 qbU
 qbU
 euc
-ars
+kEz
 euc
 qbU
 qbU
@@ -44727,7 +44724,7 @@ nxY
 nxY
 qbU
 eCR
-uMg
+iQf
 eCR
 eCR
 eCR
@@ -44738,12 +44735,12 @@ eCR
 eCR
 eCR
 eCR
-uMg
+iQf
 euc
 euc
 qbU
 euc
-dEf
+asz
 euc
 euc
 ugY
@@ -44942,7 +44939,7 @@ qbU
 eCR
 qbU
 qbU
-uMg
+iQf
 eCR
 qbU
 qbU
@@ -45148,7 +45145,7 @@ qbU
 qbU
 qbU
 qbU
-crR
+gGp
 qbU
 qbU
 qbU
@@ -45362,7 +45359,7 @@ qbU
 qbU
 qbU
 uVX
-xxv
+iBG
 uVX
 qbU
 uVX
@@ -45568,14 +45565,14 @@ qbU
 qbU
 uVX
 uVX
-goL
+tXl
 uVX
 uVX
 qbU
 qbU
 qbU
 uVX
-lej
+cct
 uVX
 uVX
 dpk
@@ -45792,15 +45789,15 @@ qbU
 qbU
 euc
 euc
-dEf
+asz
 euc
-ars
+kEz
 euc
 euc
 euc
 qbU
 qbU
-dEf
+asz
 qbU
 qbU
 qbU
@@ -46205,13 +46202,13 @@ qbU
 qbU
 qbU
 uVX
-crR
+gGp
 qbU
 qbU
 qbU
 qbU
 qbU
-xFy
+foK
 euc
 euc
 euc
@@ -46618,8 +46615,8 @@ qbU
 dpk
 dpk
 uVX
-crR
-xEv
+gGp
+lqA
 dpk
 dpk
 qbU
@@ -46627,7 +46624,7 @@ qbU
 qbU
 qbU
 qbU
-sSp
+bTh
 euc
 qbU
 qbU
@@ -46635,7 +46632,7 @@ qbU
 qbU
 qbU
 euc
-qAh
+saF
 euc
 qbU
 qbU
@@ -46842,7 +46839,7 @@ qbU
 qbU
 qbU
 qbU
-qAh
+saF
 euc
 qbU
 qbU
@@ -47046,10 +47043,10 @@ qbU
 qbU
 qbU
 euc
-qAh
+saF
 euc
-jBP
-qAh
+wvG
+saF
 euc
 qbU
 qbU
@@ -47239,7 +47236,7 @@ qbU
 qbU
 qbU
 uVX
-cpf
+eGw
 qbU
 qbU
 qbU
@@ -47656,10 +47653,10 @@ qbU
 qbU
 qbU
 qbU
-jHE
+sPh
 dpk
-wRY
-wRY
+nxb
+nxb
 dpk
 uVX
 qbU
@@ -47870,7 +47867,7 @@ qbU
 qbU
 qbU
 cKr
-kNY
+luv
 uVX
 coU
 coU
@@ -48079,7 +48076,7 @@ qbU
 qbU
 uVX
 dpk
-pbj
+dqC
 uVX
 coU
 coU
@@ -48286,8 +48283,8 @@ qbU
 qbU
 qbU
 mNA
-wKG
-ciL
+vyI
+njB
 uVX
 lEJ
 mNA
@@ -48494,12 +48491,12 @@ coU
 coU
 coU
 coU
-eHj
+tOK
 uVX
-pbj
+dqC
 uVX
 uVX
-eHj
+tOK
 coU
 coU
 coU
@@ -48704,10 +48701,10 @@ rKz
 rKz
 rKz
 mNA
-jXU
-xgt
-kKj
-jXU
+gQc
+xem
+nBe
+gQc
 mNA
 rKz
 rKz
@@ -48908,28 +48905,28 @@ nxY
 coU
 coU
 rKz
-ePc
-uIZ
-uIZ
-uIZ
-dpI
-wcf
-gDT
-uIZ
-uIZ
-dpI
-uIZ
-vOl
+sDY
 bZw
-rSf
+bZw
+bZw
+mmF
+bRP
+gCI
+bZw
+bZw
+mmF
+bZw
+wlq
+aii
+erh
 rKz
-siV
-oCe
-iIL
-oCe
-oCe
-siV
-oCe
+hQd
+qzQ
+hsJ
+qzQ
+qzQ
+hQd
+qzQ
 rKz
 coU
 coU
@@ -49117,28 +49114,28 @@ nxY
 coU
 coU
 qbU
-oiJ
-bxt
-rRc
-uIZ
-uIZ
-uIZ
-uIZ
-skU
+cYA
+voR
+bFc
 bZw
-uIZ
-uIZ
-uIZ
 bZw
-uIZ
+bZw
+bZw
+wuG
+aii
+bZw
+bZw
+bZw
+aii
+bZw
 rKz
-jNk
-oCe
-siV
-oCe
-iIL
-abV
-oCe
+sxQ
+qzQ
+hQd
+qzQ
+hsJ
+gYz
+qzQ
 rKz
 coU
 coU
@@ -49327,27 +49324,27 @@ coU
 coU
 qbU
 qbU
-tau
+utQ
+aii
 bZw
-uIZ
-hgL
-uIZ
-skU
-uIZ
+ddv
 bZw
-tOp
-uIZ
+wuG
+bZw
+aii
+oRO
+bZw
 wZW
-uIZ
-uIZ
+bZw
+bZw
 rKz
-oCe
-siV
-oCe
-bsE
-siV
-oCe
-oCe
+qzQ
+hQd
+qzQ
+gKO
+hQd
+qzQ
+qzQ
 rKz
 coU
 coU
@@ -49535,28 +49532,28 @@ nxY
 coU
 coU
 rKz
-oiJ
-tao
-beO
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
+cYA
+xQs
+dHc
+bZw
+bZw
+bZw
+bZw
+bZw
+bZw
+bZw
+bZw
+bZw
+bZw
+bZw
 rKz
-oCe
-oCe
-jNk
-oCe
-oCe
-oCe
-siV
+qzQ
+qzQ
+sxQ
+qzQ
+qzQ
+qzQ
+hQd
 rKz
 coU
 coU
@@ -49744,28 +49741,28 @@ nxY
 coU
 coU
 rKz
-uIZ
-uIZ
-uIZ
-tmW
-uIZ
-xrf
-uIZ
-uIZ
-bRP
-uIZ
-uIZ
-uIZ
-uIZ
-bmA
+bZw
+bZw
+bZw
+qhe
+bZw
+hgL
+bZw
+bZw
+vAm
+bZw
+bZw
+bZw
+bZw
+aCI
 rKz
-evX
-oCe
-oCe
-siV
-siV
-jNk
-oCe
+vZU
+qzQ
+qzQ
+hQd
+hQd
+sxQ
+qzQ
 rKz
 coU
 coU
@@ -49953,28 +49950,28 @@ nxY
 coU
 coU
 rKz
-rKx
-qhe
-jcQ
-qzI
-bRP
-bRP
-bRP
-bRP
-qNB
-dMj
+eXK
+dpI
+yga
+txM
+vAm
+vAm
+vAm
+vAm
+krP
 uIZ
-jcQ
-uIZ
-uIZ
+bZw
+yga
+bZw
+bZw
 rKz
-oCe
-mLR
-fTr
-mLR
-mLR
-mLR
-fTr
+qzQ
+cQZ
+irF
+cQZ
+cQZ
+cQZ
+irF
 rKz
 coU
 coU
@@ -50161,29 +50158,29 @@ nxY
 nxY
 coU
 coU
-slv
-rKx
-uIZ
-uIZ
-uIZ
+fVi
+eXK
 bZw
-ndn
-uIZ
-uIZ
+bZw
+bZw
+aii
+eCA
+bZw
+bZw
 tgr
-uIZ
-uIZ
-uIZ
-skU
 bZw
-slv
-uIZ
-uIZ
-avd
-uIZ
 bZw
-uIZ
-uIZ
+bZw
+wuG
+aii
+fVi
+bZw
+bZw
+ahF
+bZw
+aii
+bZw
+bZw
 rKz
 coU
 coU
@@ -50371,28 +50368,28 @@ nxY
 coU
 coU
 rKz
-uIZ
-wcf
 bZw
+bRP
+aii
+aii
 bZw
-uIZ
-bZw
+aii
 wZW
 wZW
-uIZ
-uIZ
-qhe
-uIZ
-wcf
-uIZ
+bZw
+bZw
+dpI
+bZw
+bRP
+bZw
 rKz
-uIZ
-gDT
-uIZ
-uIZ
-wVF
-uIZ
-tao
+bZw
+gCI
+bZw
+bZw
+rlk
+bZw
+xQs
 rKz
 coU
 coU
@@ -50580,28 +50577,28 @@ nxY
 coU
 coU
 rKz
-uIZ
+bZw
+aii
+aii
+wuG
+nOv
 bZw
 bZw
-skU
-dIZ
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-wcf
-uIZ
 bZw
-uIZ
+bZw
+bZw
+bRP
+bZw
+aii
+bZw
 rKz
-jQO
-uIZ
+qhz
 bZw
-bZw
-qhe
-rwZ
-tFp
+aii
+aii
+dpI
+qms
+gZo
 qbU
 coU
 coU
@@ -50790,8 +50787,8 @@ coU
 coU
 rKz
 mNA
-nFy
-nFy
+oAi
+oAi
 mNA
 mNA
 mNA
@@ -50800,16 +50797,16 @@ mNA
 mNA
 mNA
 mNA
-nFy
-nFy
+oAi
+oAi
 mNA
 rKz
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-tao
+bZw
+bZw
+bZw
+bZw
+bZw
+xQs
 qbU
 qbU
 coU
@@ -50998,28 +50995,28 @@ nxY
 coU
 coU
 rKz
-uIZ
-uIZ
-uIZ
-uIZ
-bkW
-uIZ
-mHd
 bZw
-azN
-kSP
-uIZ
-uIZ
-uIZ
-uIZ
+bZw
+bZw
+bZw
+emV
+bZw
+eCz
+aii
+wcB
+vgl
+bZw
+bZw
+bZw
+bZw
 rKz
-uIZ
-qhe
-aNB
-uIZ
-tao
-tao
-tFp
+bZw
+dpI
+cdz
+bZw
+xQs
+xQs
+gZo
 qbU
 coU
 coU
@@ -51207,28 +51204,28 @@ nxY
 coU
 coU
 rKz
+aii
+eiY
 bZw
-rlq
-uIZ
-uIZ
-uIZ
-uIZ
-qhe
 bZw
-uIZ
-kSP
-uIZ
-pbT
-uIZ
+bZw
+bZw
+dpI
+aii
+bZw
+vgl
+bZw
+ail
+bZw
 wZW
 rKz
-rUc
-tmW
-uIZ
-uIZ
-uIZ
-uIZ
-tFp
+kuV
+qhe
+bZw
+bZw
+bZw
+bZw
+gZo
 qbU
 coU
 coU
@@ -51416,28 +51413,28 @@ nxY
 coU
 coU
 rKz
+aii
 bZw
-uIZ
-rlq
-kSP
-ptd
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-tmt
-uIZ
+eiY
+vgl
+vBX
 bZw
-uIZ
+bZw
+bZw
+bZw
+bZw
+fLR
+bZw
+aii
+bZw
 rKz
-gXV
+oSA
+aii
+aii
 bZw
-bZw
-uIZ
-tOp
-bZw
-mTI
+oRO
+aii
+hAx
 rKz
 coU
 coU
@@ -51625,28 +51622,28 @@ nxY
 coU
 coU
 rKz
-uIZ
-uIZ
-uIZ
-kSP
-uIZ
-spk
-uIZ
-gPe
-tyl
-qhe
+bZw
+bZw
+bZw
+vgl
+bZw
+dFO
+bZw
+lEE
+xrw
+dpI
 wZW
-bZw
-bZw
-qhe
+aii
+aii
+dpI
 rKz
-gXV
-sVt
-uIZ
-uIZ
-wcf
-uIZ
+oSA
+hih
 bZw
+bZw
+bRP
+bZw
+aii
 rKz
 coU
 coU
@@ -51840,8 +51837,8 @@ mNA
 mNA
 mNA
 mNA
-uIZ
-uIZ
+bZw
+bZw
 mNA
 mNA
 mNA
@@ -51854,8 +51851,8 @@ rKz
 rKz
 rKz
 rKz
-jrM
-rHH
+bXE
+ylk
 rKz
 coU
 coU
@@ -52043,28 +52040,28 @@ nxY
 coU
 coU
 rKz
-oiJ
-pEI
-hdM
-rVQ
-gXV
+cYA
+cmu
+fvU
+xfH
+oSA
 mNA
-uIZ
-uIZ
+bZw
+bZw
 mNA
-rVQ
-uIZ
-pEI
-kRS
-pEI
-dgI
+xfH
+bZw
+cmu
+tUw
+cmu
+khM
 mNA
-rvu
-uId
-cse
-cse
-tmW
-wcf
+niQ
+wpT
+kbI
+kbI
+qhe
+bRP
 rKz
 coU
 coU
@@ -52251,29 +52248,29 @@ nxY
 nxY
 coU
 coU
-slv
+fVi
 qbU
-udE
-uIZ
-ijN
-gXV
+dJQ
+bZw
+eZt
+oSA
+mNA
+aii
+bZw
+tOK
+cmu
+bZw
+xfH
+bZw
+cmu
+bZw
 mNA
 bZw
-uIZ
-eHj
-pEI
-uIZ
-rVQ
-uIZ
-pEI
-uIZ
-mNA
-uIZ
-qhe
+dpI
+aii
+bRP
 bZw
-wcf
-uIZ
-wcf
+bRP
 rKz
 coU
 coU
@@ -52463,26 +52460,26 @@ coU
 qbU
 qbU
 qbU
-tao
-uIZ
-uIZ
+xQs
+bZw
+bZw
+mNA
+aii
+bZw
 mNA
 bZw
-uIZ
-mNA
-uIZ
-aWN
-uIZ
+egt
 bZw
-uIZ
-uIZ
-mNA
-kSP
-uIZ
-uIZ
-uIZ
+aii
 bZw
-uIZ
+bZw
+mNA
+vgl
+bZw
+bZw
+bZw
+aii
+bZw
 rKz
 coU
 coU
@@ -52672,26 +52669,26 @@ coU
 qbU
 qbU
 qbU
-oiJ
-pEI
-uIZ
-mNA
-tmW
+cYA
+cmu
 bZw
 mNA
-wBR
-uIZ
-pEI
-bZw
-rVQ
-uIZ
+qhe
+aii
 mNA
-bCC
-uIZ
+kMy
+bZw
+cmu
+aii
+xfH
+bZw
+mNA
+iBF
+bZw
 wZW
-gDT
-aWN
-uIZ
+gCI
+egt
+bZw
 rKz
 coU
 coU
@@ -52879,28 +52876,28 @@ nxY
 coU
 coU
 rKz
-oiJ
+cYA
 qbU
-oiJ
-xoW
-bZw
+cYA
+bHO
+aii
 mNA
-uIZ
 bZw
+aii
 mNA
-pEI
-uIZ
-pEI
-uIZ
-pEI
+cmu
 bZw
+cmu
+bZw
+cmu
+aii
 mNA
-uIZ
-uIZ
-qhe
-uIZ
-qhe
-uIZ
+bZw
+bZw
+dpI
+bZw
+dpI
+bZw
 rKz
 coU
 coU
@@ -53088,28 +53085,28 @@ nxY
 coU
 coU
 rKz
-ndt
-oiJ
-qAA
-bZw
-bZw
-nFy
-bif
-qzI
+dLJ
+cYA
+kgi
+aii
+aii
+oAi
+mxx
+txM
 mNA
+aii
 bZw
-uIZ
-uIZ
-qhe
-uIZ
-ksx
+bZw
+dpI
+bZw
+ezZ
 mNA
-bZw
-bZw
-hNy
-oVG
-rec
-agL
+aii
+aii
+tkq
+sQl
+jOp
+fmy
 rKz
 coU
 coU
@@ -53303,22 +53300,22 @@ mNA
 mNA
 mNA
 mNA
-uIZ
-ptd
+bZw
+vBX
 mNA
 mNA
-nFy
-mNA
-mNA
-mNA
-mNA
-mNA
-sYe
-hHA
+oAi
 mNA
 mNA
 mNA
-dyd
+mNA
+mNA
+rOh
+qDw
+mNA
+mNA
+mNA
+pdb
 rKz
 qbU
 qbU
@@ -53506,31 +53503,31 @@ nxY
 coU
 coU
 rKz
-wKQ
-uIZ
-qhe
+rWt
 bZw
-uIZ
-nFy
-uIZ
-uIZ
-uIZ
-gDT
-uIZ
-ksL
+dpI
+aii
 bZw
-uIZ
-uIZ
-nFy
-uIZ
-gXV
+oAi
+bZw
+bZw
+bZw
+gCI
+bZw
+bls
+aii
+bZw
+bZw
+oAi
+bZw
+oSA
 mNA
-ssg
-aWN
-uIZ
+dzT
+egt
+bZw
 rKz
 ugY
-lCt
+ltq
 jkn
 jkn
 qbU
@@ -53715,29 +53712,29 @@ nxY
 coU
 coU
 rKz
-lyh
-uIZ
-aWN
+wZi
 bZw
-uIZ
+egt
+aii
+bZw
 mNA
-maX
-uIZ
-uIZ
-gXV
-gXV
-uIZ
+egT
+bZw
+bZw
+oSA
+oSA
+bZw
+dpI
+loP
 qhe
-qai
-tmW
-nFy
-uIZ
+oAi
 bZw
+aii
 mNA
-uIZ
-uIZ
-uIZ
-slv
+bZw
+bZw
+bZw
+fVi
 qbU
 qbU
 qbU
@@ -53924,15 +53921,15 @@ nxY
 coU
 coU
 rKz
-axm
-bZw
-jRU
-pft
-bZw
+nuz
+aii
+fyT
+tIh
+aii
 mNA
 jnq
 mNA
-llR
+dqf
 mNA
 mNA
 jnq
@@ -53940,12 +53937,12 @@ mNA
 mNA
 mNA
 mNA
-uIZ
 bZw
+aii
 mNA
-wZg
-aWN
-bZw
+aRI
+egt
+aii
 rKz
 coU
 coU
@@ -54133,28 +54130,28 @@ nxY
 coU
 coU
 rKz
-mny
-uIZ
-msM
-uKB
+qHi
 bZw
+vnV
+nPz
+aii
 mNA
-uIZ
-uIZ
-uIZ
 bZw
-mNA
-uIZ
-xbH
-chH
 bZw
-mNA
-qzI
 bZw
+aii
 mNA
-uiu
-uIZ
-uIZ
+bZw
+xSq
+qDZ
+aii
+mNA
+txM
+aii
+mNA
+tUM
+bZw
+bZw
 rKz
 coU
 coU
@@ -54342,27 +54339,27 @@ nxY
 coU
 coU
 rKz
-wfR
-uIZ
-wLQ
-hjE
-uIZ
-eHj
+fjG
 bZw
-aSG
-uIZ
-aWN
+ebq
+cEe
+bZw
+tOK
+aii
+sub
+bZw
+egt
 mNA
-uIZ
-jNA
-uIZ
-uIZ
-eHj
-uIZ
-uIZ
+bZw
+rWN
+bZw
+bZw
+tOK
+bZw
+bZw
 mNA
-dyd
-rQU
+pdb
+crv
 jnq
 rKz
 qbU
@@ -54551,28 +54548,28 @@ nxY
 coU
 coU
 rKz
-nGF
-uIZ
-uIZ
+cVj
 bZw
-fXm
-mNA
-tSz
-rXS
-sgs
-sFp
-mNA
-lcz
-pVA
-dyd
-sFp
-mNA
 bZw
-wPa
-gXV
-cpO
-uIZ
-uIZ
+aii
+nOx
+mNA
+tJo
+ykv
+hxa
+aEX
+mNA
+xNo
+nLN
+pdb
+aEX
+mNA
+aii
+kUl
+oSA
+eSB
+bZw
+bZw
 rKz
 qbU
 coU
@@ -54763,25 +54760,25 @@ rKz
 rKz
 rKz
 rKz
-szd
-szd
+vdu
+vdu
 rKz
 rKz
 rKz
 rKz
 rKz
 rKz
-szd
+vdu
 rKz
 rKz
 rKz
 rKz
-uIZ
 bZw
-gXV
-uIZ
-llD
-uIZ
+aii
+oSA
+bZw
+kwf
+bZw
 rKz
 qbU
 coU
@@ -54969,28 +54966,28 @@ nxY
 coU
 coU
 rKz
-jHS
-uIZ
-fgg
-cxf
-hMw
-tIU
-qzI
-gKn
-gKn
-gKn
-jDh
-xUz
-uIZ
-uIZ
-uIZ
-nFy
-sVt
+spJ
 bZw
-uIZ
-uIZ
-uIZ
-gXV
+aCP
+tAb
+fBe
+txA
+txM
+inN
+inN
+inN
+hAN
+fTZ
+bZw
+bZw
+bZw
+oAi
+hih
+aii
+bZw
+bZw
+bZw
+oSA
 rKz
 qbU
 coU
@@ -55177,29 +55174,29 @@ nxY
 nxY
 coU
 coU
-fEy
-vqz
-uIZ
+nKW
+mZc
 bZw
-uIZ
-uIZ
+aii
+bZw
+bZw
+dpI
+aii
+aii
+bZw
+bZw
+oAi
+bZw
+wxX
+bZw
 qhe
+bFy
 bZw
 bZw
-uIZ
-uIZ
-nFy
-uIZ
-crI
-uIZ
-tmW
-lbn
-uIZ
-uIZ
-uIZ
-uIZ
 bZw
-gXV
+bZw
+aii
+oSA
 rKz
 qbU
 coU
@@ -55387,28 +55384,28 @@ nxY
 coU
 coU
 rKz
-aiG
-uIZ
-dVw
-uIZ
-uIZ
-uIZ
-mEl
-uIZ
-lrL
-uIZ
-nFy
+gRr
+bZw
+rrt
 bZw
 bZw
-uIZ
 bZw
+aBs
+bZw
+wti
+bZw
+oAi
+aii
+aii
+bZw
+aii
 rKz
 wZW
-uIZ
-uIZ
-nPV
 bZw
-aWN
+bZw
+tYx
+aii
+egt
 rKz
 qbU
 coU
@@ -55596,28 +55593,28 @@ nxY
 coU
 coU
 rKz
-cfH
-uIZ
+uBC
 bZw
-uIZ
-uIZ
-uIZ
-jcQ
-uIZ
-uIZ
-xbH
-rKz
-qhe
-uIZ
+aii
 bZw
-baj
+bZw
+bZw
+yga
+bZw
+bZw
+xSq
 rKz
-uIZ
-uIZ
-kuJ
-tJe
-czK
-bVT
+dpI
+bZw
+aii
+xPI
+rKz
+bZw
+bZw
+gtS
+hrI
+huf
+liS
 rKz
 qbU
 coU
@@ -55804,22 +55801,22 @@ nxY
 nxY
 coU
 coU
-slv
-cfH
-uIZ
-uvF
-qhe
-uIZ
-uIZ
-uIZ
-uIZ
-xbH
-uIZ
-slv
-gXV
-hJx
+fVi
+uBC
 bZw
-kSP
+jaE
+dpI
+bZw
+bZw
+bZw
+bZw
+xSq
+bZw
+fVi
+oSA
+fin
+aii
+vgl
 rKz
 rKz
 rKz
@@ -56014,28 +56011,28 @@ nxY
 coU
 coU
 rKz
-aNA
-uIZ
-cKn
-cKn
-cKn
-uhz
-cKn
-daH
-cKn
-uhz
-rKz
-gXV
+pdI
 bZw
-nQa
-uIZ
+wGs
+wGs
+wGs
+hpp
+wGs
+jcF
+wGs
+hpp
 rKz
+oSA
+aii
+lZR
 bZw
-gbh
-gXV
-gXV
-lrL
-qaJ
+rKz
+aii
+tgk
+oSA
+oSA
+wti
+xlQ
 rKz
 qbU
 coU
@@ -56223,28 +56220,28 @@ nxY
 coU
 coU
 rKz
-uIZ
 bZw
-cKn
-xbH
-xbH
-xbH
-cKn
-uIZ
-xbH
-xbH
+aii
+wGs
+xSq
+xSq
+xSq
+wGs
+bZw
+xSq
+xSq
 rKz
-uIZ
 bZw
-uIZ
-qhe
-uTB
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-nSk
+aii
+bZw
+dpI
+jFi
+bZw
+bZw
+bZw
+bZw
+bZw
+cXq
 rKz
 qbU
 coU
@@ -56432,28 +56429,28 @@ nxY
 coU
 coU
 rKz
-dLa
+ffP
+aii
+wGs
+vBX
+xSq
+xSq
+wGs
 bZw
-cKn
-ptd
-xbH
-xbH
-cKn
-uIZ
-uIZ
-uIZ
+bZw
+bZw
 rKz
-uIZ
-uIZ
-wZW
 bZw
-euk
-vXA
-uIZ
-uIZ
-llD
-uIZ
-glM
+bZw
+wZW
+aii
+mvh
+pbT
+bZw
+bZw
+kwf
+bZw
+pQJ
 rKz
 qbU
 coU
@@ -56641,28 +56638,28 @@ nxY
 coU
 coU
 rKz
-gNQ
-gbh
-aQb
-hJv
-nkh
-tWN
-cKn
-hJv
-ida
-jSI
+ior
+tgk
+wYh
+waE
+jRN
+tkE
+wGs
+waE
+mYJ
+nRq
 rKz
-qzI
-uIZ
-uIZ
-oNp
-rKz
-htl
+txM
 bZw
-tqU
-unn
-uIZ
-qzI
+bZw
+ixB
+rKz
+vkJ
+aii
+jSR
+hOk
+bZw
+txM
 rKz
 qbU
 coU
@@ -56862,11 +56859,11 @@ rKz
 rKz
 rKz
 rKz
-uIZ
-uIZ
+bZw
+bZw
 rKz
 rKz
-szd
+vdu
 rKz
 rKz
 rKz
@@ -57060,27 +57057,27 @@ coU
 coU
 coU
 rKz
-uIZ
-lrL
-uIZ
-uIZ
-rKz
-uIZ
-uIZ
 bZw
-aGx
-knN
-rKz
-uIZ
-cZt
-rKz
-jFc
+wti
 bZw
-uIZ
-uIZ
-uIZ
-uIZ
-vfH
+bZw
+rKz
+bZw
+bZw
+aii
+tjF
+hsZ
+rKz
+bZw
+xzo
+rKz
+hcs
+aii
+bZw
+bZw
+bZw
+bZw
+rUp
 rKz
 coU
 coU
@@ -57268,28 +57265,28 @@ nxY
 coU
 coU
 coU
-slv
-rwZ
-uIZ
+fVi
+qms
 bZw
-oXa
+aii
+ewx
 rKz
-uIZ
-kro
-rQX
 bZw
-bZw
+ktB
+cXn
+aii
+aii
 rKz
-uIZ
-uIZ
-mch
-uIZ
 bZw
-uIZ
-vZn
 bZw
-uIZ
-mBg
+aRi
+bZw
+aii
+bZw
+mda
+aii
+bZw
+ccg
 rKz
 coU
 coU
@@ -57478,27 +57475,27 @@ coU
 coU
 coU
 rKz
-xEl
-jcQ
-uIZ
-uIZ
-slv
-uIZ
-qhe
-uIZ
-uIZ
-uIZ
+iSq
+yga
+bZw
+bZw
+fVi
+bZw
+dpI
+bZw
+bZw
+bZw
 rKz
-uIZ
-uIZ
+bZw
+bZw
 rKz
-dYA
-uIZ
-uIZ
+nRo
 bZw
 bZw
-bZw
-jHe
+aii
+aii
+aii
+fTH
 rKz
 coU
 coU
@@ -57687,27 +57684,27 @@ coU
 coU
 coU
 rKz
-xEl
-uIZ
-uIZ
-tmW
+iSq
+bZw
+bZw
+qhe
 rKz
-uIZ
-uIZ
-gXV
-uIZ
-uIZ
+bZw
+bZw
+oSA
+bZw
+bZw
 rKz
-uIZ
-uIZ
-slv
-nOD
-uIZ
-iow
-lPa
-uIZ
-xee
-kBA
+bZw
+bZw
+fVi
+umT
+bZw
+wXp
+prj
+bZw
+kem
+kne
 rKz
 coU
 coU
@@ -57896,19 +57893,19 @@ coU
 coU
 coU
 rKz
-aOz
-uIZ
+pAw
 bZw
-uIZ
-rKz
-bSF
-uIZ
-uIZ
-uIZ
+aii
 bZw
 rKz
-uTB
-nFy
+lLv
+bZw
+bZw
+bZw
+aii
+rKz
+jFi
+oAi
 rKz
 rKz
 rKz
@@ -58105,27 +58102,27 @@ coU
 coU
 coU
 rKz
-jeV
-uIZ
-uIZ
+eWn
 bZw
-uTB
-uIZ
-uIZ
-uIZ
-kro
 bZw
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
+aii
+jFi
+bZw
+bZw
+bZw
+ktB
+aii
+bZw
+bZw
+bZw
+bZw
+bZw
 wZW
-gID
-uIZ
-uIZ
-uIZ
-qzI
+fKU
+bZw
+bZw
+bZw
+txM
 rKz
 coU
 coU
@@ -58314,27 +58311,27 @@ coU
 coU
 coU
 rKz
-jHP
-wLQ
-tmW
-gbh
-rKz
-uIZ
-qzI
-uIZ
-uIZ
-gXV
-sVt
-bZw
-uVz
-sVt
-gXV
+jpE
+ebq
 qhe
-uIZ
-uIZ
-uIZ
-xki
-gRv
+tgk
+rKz
+bZw
+txM
+bZw
+bZw
+oSA
+hih
+aii
+cfn
+hih
+oSA
+dpI
+bZw
+bZw
+bZw
+sjT
+iTd
 rKz
 coU
 coU
@@ -58540,10 +58537,10 @@ rKz
 rKz
 rKz
 rKz
-szd
-uIZ
-uIZ
-gXV
+vdu
+bZw
+bZw
+oSA
 rKz
 coU
 coU
@@ -58732,27 +58729,27 @@ coU
 coU
 coU
 rKz
-jzZ
-pXo
-gxY
-pXo
-pXo
-lUB
+xtS
+uMy
+bSn
+uMy
+uMy
+lmY
 rKz
-uIZ
 bZw
-uIZ
-gXV
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-uIZ
-slv
-uIZ
-uIZ
-uIZ
+aii
+bZw
+oSA
+bZw
+bZw
+bZw
+bZw
+bZw
+bZw
+fVi
+bZw
+bZw
+bZw
 rKz
 coU
 coU
@@ -58941,33 +58938,33 @@ coU
 coU
 coU
 rKz
-tlG
+ooY
+aii
+aii
+aii
+nHN
 bZw
-bZw
-bZw
-oFf
-uIZ
 rKz
-uIZ
-hJx
-uIZ
-gDT
 bZw
-qDV
-uIZ
-ptd
-uIZ
-tPT
+fin
+bZw
+gCI
+aii
+sxM
+bZw
+vBX
+bZw
+bdY
 rKz
-uIZ
-nPV
-uIZ
+bZw
+tYx
+bZw
 rKz
-izb
-izb
-izb
-izb
-izb
+gvv
+gvv
+gvv
+gvv
+gvv
 coU
 coU
 coU
@@ -59149,34 +59146,34 @@ nxY
 coU
 coU
 coU
-slv
-rgN
-mHd
-uIZ
+fVi
+aLp
+eCz
+bZw
+aii
+aii
+bZw
+kqO
+egT
+cdz
+bZw
+aii
+aii
 bZw
 bZw
-uIZ
-wBI
-maX
-aNB
-uIZ
 bZw
 bZw
-uIZ
-uIZ
-uIZ
-uIZ
-sVt
+hih
 rKz
-uIZ
-eSZ
-uIZ
+bZw
+tzP
+bZw
 rKz
-izb
-izz
-jEp
-hoR
-izb
+gvv
+odl
+jyP
+lHQ
+gvv
 coU
 coU
 coU
@@ -59359,33 +59356,33 @@ coU
 coU
 coU
 rKz
-bPk
-uIZ
-uIZ
+vxP
+bZw
+bZw
 wZW
-uIZ
-uIZ
-rKz
-uTB
-uTB
-rKz
-uIZ
-lrL
-rKz
-uIZ
-mTK
-uIZ
-uIZ
-bZw
-lrL
 bZw
 bZw
 rKz
-izb
-hoR
-hoR
-hoR
-izb
+jFi
+jFi
+rKz
+bZw
+wti
+rKz
+bZw
+dwY
+bZw
+bZw
+aii
+wti
+aii
+aii
+rKz
+gvv
+lHQ
+lHQ
+lHQ
+gvv
 coU
 coU
 coU
@@ -59567,34 +59564,34 @@ nxY
 coU
 coU
 coU
-fEy
-fvq
-wLQ
-uIZ
-qhe
-aWN
-uIZ
-yks
-uIZ
-uIZ
-oBN
-rUc
-uIZ
-rKz
-gXV
-uIZ
-uIZ
-gDT
+nKW
+ykj
+ebq
 bZw
-gXV
-qhe
+dpI
+egt
+bZw
+luh
+bZw
+bZw
+jMF
+kuV
 bZw
 rKz
-izb
-hoR
-apK
-hoR
-izb
+oSA
+bZw
+bZw
+gCI
+aii
+oSA
+dpI
+aii
+rKz
+gvv
+lHQ
+bSX
+lHQ
+gvv
 coU
 coU
 coU
@@ -59777,33 +59774,33 @@ coU
 coU
 coU
 rKz
-ttl
-uIZ
-uIZ
-tmW
+jaJ
 bZw
 bZw
-aWN
-uIZ
-uIZ
-rKz
+qhe
+aii
+aii
+egt
 bZw
 bZw
 rKz
-uIZ
-uIZ
-hWp
-tNG
-uIZ
-gXV
-nPA
-uIZ
+aii
+aii
 rKz
-izb
-pbc
-hoR
-hoR
-izb
+bZw
+bZw
+jvX
+gAY
+bZw
+oSA
+wbG
+bZw
+rKz
+gvv
+dgd
+lHQ
+lHQ
+gvv
 coU
 coU
 coU
@@ -59986,33 +59983,33 @@ coU
 coU
 coU
 rKz
-xfn
-uIZ
-uIZ
-uIZ
-qzI
+qvx
 bZw
-uIZ
-iRt
-uIZ
+bZw
+bZw
+txM
+aii
+bZw
+gDl
+bZw
 rKz
-uIZ
-uIZ
-slv
-vtG
 bZw
 bZw
-uIZ
-uIZ
-gDT
-uIZ
-uIZ
+fVi
+mmx
+aii
+aii
+bZw
+bZw
+gCI
+bZw
+bZw
 rKz
-izb
-izb
-izb
-izb
-izb
+gvv
+gvv
+gvv
+gvv
+gvv
 coU
 coU
 coU
@@ -60205,10 +60202,10 @@ rKz
 rKz
 rKz
 rKz
-xgt
-kKj
+xem
+nBe
 rKz
-vtc
+mAP
 rKz
 rKz
 rKz
@@ -60404,27 +60401,27 @@ coU
 coU
 coU
 rKz
+aii
+ouu
+pHY
+aii
+aii
+aVF
+xtu
+bYn
 bZw
-lgl
-rti
+aii
+nOv
+aii
+gCI
+bvw
+bZw
+fin
+dpI
 bZw
 bZw
-jRZ
-tpL
-dGf
-uIZ
-bZw
-dIZ
-bZw
-gDT
-wun
-uIZ
-hJx
-qhe
-uIZ
-uIZ
-rwZ
-oiJ
+qms
+cYA
 rKz
 coU
 coU
@@ -60613,27 +60610,27 @@ coU
 coU
 coU
 rKz
-maX
+egT
+aii
 bZw
-uIZ
-xcU
-uIZ
-uIZ
-wun
+bvH
+bZw
+bZw
+bvw
 wZW
-uIZ
 bZw
-uIZ
-uIZ
-cZt
-uIZ
-sVt
+aii
 bZw
-azd
-uIZ
-uIZ
-oiJ
-tFp
+bZw
+xzo
+bZw
+hih
+aii
+tyY
+bZw
+bZw
+cYA
+gZo
 rKz
 coU
 coU
@@ -60822,26 +60819,26 @@ coU
 coU
 coU
 rKz
-uIZ
-uIZ
-uIZ
-uIZ
 bZw
-bpS
-gXV
-uIZ
-uIZ
 bZw
-uIZ
-rQE
-uIZ
-uIZ
-uIZ
-ouu
-tPT
-uIZ
-gDT
-tao
+bZw
+bZw
+aii
+meX
+oSA
+bZw
+bZw
+aii
+bZw
+hfN
+bZw
+bZw
+bZw
+bcq
+bdY
+bZw
+gCI
+xQs
 qbU
 rKz
 coU
@@ -61031,26 +61028,26 @@ coU
 coU
 coU
 rKz
-uIZ
-uIZ
-qhe
-uIZ
-pZU
-jQO
-uIZ
-aWN
-ptd
-uIZ
-neP
-cvN
-qhe
-mvg
+bZw
+bZw
+dpI
+bZw
+aQJ
+qhz
+bZw
+egt
+vBX
+bZw
+cof
+hDl
+dpI
+jnY
 wZW
-uIZ
-gXV
-uIZ
-bAs
-oiJ
+bZw
+oSA
+bZw
+rPh
+cYA
 qbU
 qbU
 coU
@@ -61239,28 +61236,28 @@ nxY
 coU
 coU
 coU
-szd
+vdu
+aii
 bZw
-uIZ
-uIZ
-jcQ
-uIZ
-uIZ
-uIZ
-eUu
-gDT
-gXV
-uIZ
-uIZ
 bZw
-wcW
-uIZ
-uIZ
-qhe
-wun
-maX
-tao
-oiJ
+yga
+bZw
+bZw
+bZw
+dOw
+gCI
+oSA
+bZw
+bZw
+aii
+jqA
+bZw
+bZw
+dpI
+bvw
+egT
+xQs
+cYA
 qbU
 coU
 coU
@@ -61449,27 +61446,27 @@ coU
 coU
 coU
 rKz
-vWE
+dQe
+oxW
+lLd
+rXG
 dnC
-mFx
-yaB
-oSA
-vWE
-oSA
-uOL
-oSA
-uIZ
-dIZ
-ykG
-uIZ
-rlf
-exQ
+dQe
 dnC
+lIR
 dnC
-vWE
-oSA
-vWE
-oSA
+bZw
+nOv
+uYg
+bZw
+vMv
+ule
+oxW
+oxW
+dQe
+dnC
+dQe
+dnC
 rKz
 coU
 coU
@@ -61658,27 +61655,27 @@ coU
 coU
 coU
 rKz
-vWE
-vWE
-exQ
-exQ
-uOL
-oSA
+dQe
+dQe
+ule
+ule
+lIR
 dnC
-gaK
-lGh
+oxW
+xoD
+pGB
+aii
+eGa
+wcn
 bZw
-njg
-nlF
-uIZ
-exQ
-uOL
-vWE
-oSA
-oSA
-ocM
-uOL
-vWE
+ule
+lIR
+dQe
+dnC
+dnC
+lcd
+lIR
+dQe
 rKz
 coU
 coU
@@ -61867,27 +61864,27 @@ coU
 coU
 coU
 rKz
-qhe
-uIZ
+dpI
 bZw
-wun
-qhe
-bZw
-fIY
-bZw
-cZt
-aWN
-rWT
+aii
+bvw
+dpI
+aii
+xHj
+aii
+xzo
+egt
+xKz
 wZW
 wZW
-uIZ
-pZU
-pRk
-uIZ
 bZw
-pmd
-lrL
-hzz
+aQJ
+kBF
+bZw
+aii
+fcU
+wti
+pgp
 rKz
 coU
 coU
@@ -62076,27 +62073,27 @@ coU
 coU
 coU
 rKz
-uOL
-uOL
-oSA
+lIR
+lIR
 dnC
+oxW
+oxW
 dnC
-oSA
-sQu
-uIZ
-gaK
-gaK
-exQ
-uOL
-oSA
+vhQ
+bZw
+xoD
+xoD
+ule
+lIR
 dnC
+oxW
+oxW
 dnC
-oSA
-vWE
-smC
-vWE
-vWE
-dnC
+dQe
+kud
+dQe
+dQe
+oxW
 rKz
 coU
 coU
@@ -62285,27 +62282,27 @@ coU
 coU
 coU
 rKz
-uOL
-kwB
+lIR
+spr
+oxW
+oxW
 dnC
 dnC
-oSA
-oSA
-oSA
-bAs
-gCX
-oSA
-vWE
-vWE
-uOL
-exQ
 dnC
-oSA
-exQ
+rPh
+ivS
 dnC
-oSA
+dQe
+dQe
+lIR
+ule
+oxW
 dnC
-oSA
+ule
+oxW
+dnC
+oxW
+dnC
 rKz
 coU
 coU
@@ -62502,7 +62499,7 @@ rKz
 rKz
 rKz
 rKz
-slv
+fVi
 rKz
 rKz
 rKz

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -119,8 +119,8 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
-"ahF" = (
-/obj/item/trash/liquidfood,
+"aho" = (
+/obj/item/storage/fancy/mre_cracker,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "ahW" = (
@@ -129,15 +129,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"aii" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"ail" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/mre/alt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "aiR" = (
 /obj/random/cluster/spiders/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -198,6 +189,11 @@
 "aly" = (
 /obj/random/mob/undergroundmob/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
+/area/asteroid/rogue)
+"amr" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "amG" = (
 /obj/machinery/gym/toughness,
@@ -262,6 +258,10 @@
 /obj/item/reagent_containers/food/drinks/mug/teacup,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"aqy" = (
+/obj/machinery/suit_storage_unit/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aqA" = (
 /obj/machinery/floodlight,
 /turf/simulated/shuttle/floor/mining{
@@ -305,10 +305,6 @@
 /mob/living/simple_animal/frog,
 /turf/simulated/floor/beach/water/swamp,
 /area/nadezhda/dungeon/outside/zoo)
-"asz" = (
-/obj/random/traps/low_chance,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "asH" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/ammo_magazine/maxim_75,
@@ -358,6 +354,10 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"avp" = (
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "avx" = (
 /obj/structure/table/standard,
 /obj/item/stack/cable_coil/yellow,
@@ -388,11 +388,25 @@
 /obj/structure/medical_stand,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
+"axL" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "axM" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/meadow)
+"axV" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"ayt" = (
+/obj/item/bedsheet,
+/obj/structure/bed,
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "ayu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -419,6 +433,12 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/prepper)
+"azg" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "azq" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/cloth/suit,
@@ -490,10 +510,6 @@
 /obj/structure/scrap/guns/large,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"aBs" = (
-/obj/item/storage/fancy/mre_cracker,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "aBB" = (
 /obj/structure/closet/random_miscellaneous,
 /turf/simulated/floor/tiled/dark,
@@ -524,14 +540,8 @@
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"aCI" = (
-/obj/item/trash/material/circuit,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"aCP" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/obj/item/computer_hardware/hard_drive/portable/design/medical/advanced,
+"aDy" = (
+/obj/item/trash/broken_robot_part,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "aDz" = (
@@ -566,15 +576,18 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/safehouse)
-"aEX" = (
-/obj/structure/toilet{
-	dir = 8
-	},
+"aFi" = (
+/obj/random/lowkeyrandom,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "aFP" = (
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"aGn" = (
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aGo" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -589,6 +602,11 @@
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
+"aHK" = (
+/obj/item/storage/hcases/ammo/excel,
+/obj/structure/closet/crate/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aIu" = (
 /obj/machinery/light/floor,
 /obj/structure/reagent_dispensers/water_cooler,
@@ -659,13 +677,9 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"aLp" = (
-/obj/item/book/manualshield_generator_guide,
-/obj/item/cell/large/excelsior,
-/obj/item/cell/large/excelsior,
-/obj/structure/table/standard,
-/obj/item/part/gun/frame/basilisk,
-/turf/simulated/floor/tiled/dark,
+"aLI" = (
+/mob/living/simple_animal/hostile/bear/excelsior,
+/turf/simulated/floor/asteroid/grass,
 /area/asteroid/rogue)
 "aLU" = (
 /obj/structure/flora/big/bush3,
@@ -688,6 +702,16 @@
 /obj/item/clothing/suit/armor/heavy,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"aME" = (
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo/low_chance,
+/obj/random/ammo/low_chance,
+/obj/item/ammo_magazine/ammobox/antim_small,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "aMH" = (
 /obj/item/remains,
 /obj/random/gun_cheap,
@@ -771,16 +795,8 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"aQJ" = (
-/obj/random/dungeon_gun_ballistic,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"aRi" = (
-/obj/structure/sign/painting/russianstalin,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
-"aRI" = (
-/obj/item/gun/projectile/boltgun,
+"aQr" = (
+/obj/structure/table/bench/standard,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "aSc" = (
@@ -841,11 +857,8 @@
 /obj/random/junkfood,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"aVF" = (
-/obj/structure/closet/crate/excelsior,
-/obj/item/gun/projectile/rpg,
-/obj/item/ammo_casing/rocket,
-/obj/item/ammo_casing/rocket,
+"aWi" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "aWp" = (
@@ -949,10 +962,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"bcq" = (
-/obj/item/trash/semki,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bcs" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/storage/bag/produce,
@@ -968,12 +977,6 @@
 /obj/machinery/electrolyzer,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"bdY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bec" = (
 /obj/structure/table/rack/shelf,
 /obj/item/oddity/common/towel{
@@ -990,6 +993,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"beH" = (
+/mob/living/simple_animal/hostile/diyaab,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "beQ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood/wild5,
@@ -1098,24 +1106,28 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"bls" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/plate,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "blu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"blx" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/semki,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "blY" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Generator Room"
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/dungeon/outside/safehouse)
+"bmh" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/mre/alt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bmp" = (
 /obj/structure/reagent_dispensers/watertank/derelict,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -1218,6 +1230,10 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/zoo)
+"bqC" = (
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bqX" = (
 /obj/random/pack/tech_loot,
 /turf/simulated/floor/wood/wild5,
@@ -1316,20 +1332,11 @@
 	icon_state = "3,7"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"bvw" = (
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bvC" = (
 /obj/structure/table/standard,
 /obj/random/powercell/medium_safe,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"bvH" = (
-/obj/effect/decal/cleanable/filth,
-/obj/item/trash/mre_can,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bvP" = (
 /obj/machinery/power/terminal{
 	dir = 1;
@@ -1386,9 +1393,22 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"byy" = (
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"bzc" = (
+/obj/random/scrap,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "bzR" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"bAa" = (
+/obj/item/mine/excelsior,
+/obj/landmark/corpse/excelsior,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "bAm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1422,6 +1442,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"bCs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/clothing/shoes/jackboots/janitor,
+/obj/structure/closet/l3closet/janitor,
+/obj/item/toy/figure/character/civilian/janitor,
+/obj/item/clothing/under/rank/janitor,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"bCY" = (
+/obj/item/trash/mre_candy,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bDO" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -1437,10 +1470,6 @@
 /obj/random/material_rare/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"bFc" = (
-/obj/item/trash/gamerchips,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bFd" = (
 /obj/machinery/door/blast/regular{
 	id = "prepperblastdoors"
@@ -1461,9 +1490,12 @@
 /obj/item/ammo_magazine/rifle_75/empty,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
-"bFy" = (
-/obj/machinery/door/airlock,
-/turf/space,
+"bFR" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/item/trash/mre_shokoladka,
+/turf/simulated/floor/rock/dark,
 /area/asteroid/rogue)
 "bFW" = (
 /obj/item/stool,
@@ -1492,9 +1524,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "bHO" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/item/gun/projectile/boltgun,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/dense_weighted,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "bHZ" = (
@@ -1595,6 +1626,14 @@
 "bLQ" = (
 /turf/simulated/shuttle/wall/cargo,
 /area/colony/exposedsun/crashed_shop/outsider)
+"bMw" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/port_gen/pacman/diesel/anchored,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bNM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair{
@@ -1710,47 +1749,37 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
 "bRP" = (
-/obj/structure/barricade,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"bRR" = (
+/obj/random/scrap/moderate_weighted,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
 "bSg" = (
 /obj/structure/table/standard,
 /obj/item/trash/plate,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"bSn" = (
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/filth,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bSC" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"bSX" = (
-/mob/living/carbon/superior_animal/xenomorph{
-	name = "Greg";
-	desc = "Fuck you, Greg."
-	},
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
-"bTh" = (
-/obj/landmark/corpse/excelsior,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "bTm" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/asteroid/rogue)
 "bTs" = (
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/asteroid/dirt,
+/area/asteroid/rogue)
+"bTz" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock/dark,
 /area/asteroid/rogue)
 "bTH" = (
 /obj/structure/closet/firecloset,
@@ -1829,11 +1858,6 @@
 /obj/structure/flora/small/grassb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"bXE" = (
-/obj/machinery/door/airlock/centcom,
-/obj/structure/barricade,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bXS" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/wood/wild5,
@@ -1844,17 +1868,12 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"bYn" = (
-/obj/machinery/porta_turret/excelsior/preloaded,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "bYv" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "bZw" = (
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/wall/wood,
 /area/asteroid/rogue)
 "bZE" = (
 /obj/structure/window/reinforced{
@@ -1877,6 +1896,10 @@
 "bZQ" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/meadow)
+"cam" = (
+/obj/item/trash/mre_shokoladka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "caq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame,
@@ -1931,16 +1954,6 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"ccg" = (
-/obj/structure/table/woodentable,
-/obj/item/implanter/excelsior/broken,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"cct" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre_shokoladka,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "ccK" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/cafe,
@@ -1955,8 +1968,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"cdz" = (
-/obj/item/trash/mre,
+"ceR" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "cfa" = (
@@ -1967,11 +1981,6 @@
 /obj/structure/flora/small/grassb5,
 /turf/simulated/wall/wood_old,
 /area/colony/exposedsun/pastgate)
-"cfn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/peachcan,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cfS" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/secure/briefcase,
@@ -1995,6 +2004,11 @@
 "chp" = (
 /turf/simulated/wall/r_wall,
 /area/colony/exposedsun/pastgate)
+"chw" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "chC" = (
 /obj/effect/step_trigger/surface_to_forest_2_B,
 /turf/simulated/floor/asteroid/dirt,
@@ -2045,6 +2059,10 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"cjK" = (
+/obj/structure/sign/warning/high_voltage,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "cjV" = (
 /obj/structure/salvageable/personal,
 /turf/simulated/floor/tiled/dark/danger,
@@ -2079,11 +2097,6 @@
 /obj/structure/flora/big/bush1,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"cmu" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cmA" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/effect/decal/cleanable/dirt,
@@ -2121,12 +2134,6 @@
 "coa" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/zoo)
-"cof" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cog" = (
 /obj/item/tool/fireaxe,
 /obj/item/storage/firstaid/fire,
@@ -2158,6 +2165,10 @@
 	},
 /turf/simulated/mineral/random/rogue,
 /area/colony/exposedsun/crashed_shop/outsider)
+"coO" = (
+/obj/structure/flora/small/grassb4,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "coU" = (
 /turf/unsimulated/mineral,
 /area/asteroid/rogue)
@@ -2229,15 +2240,25 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"crv" = (
-/obj/structure/sign/departmentold/janitorial,
-/turf/simulated/wall,
+"cqX" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/item/trash/mre,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "crC" = (
 /obj/item/remains/tajaran,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"crF" = (
+/obj/item/trash/tray,
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "crM" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/cafe,
@@ -2322,6 +2343,12 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"ctv" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/random/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cty" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2389,6 +2416,10 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"cvA" = (
+/obj/item/trash/cigbutt/fortressblue,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cwm" = (
 /obj/structure/flora/small/busha1,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -2443,6 +2474,10 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"czs" = (
+/obj/machinery/vending/engineering,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "czR" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/big/bush3,
@@ -2550,14 +2585,15 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"cEe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cEw" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"cEA" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cEB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2577,6 +2613,11 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"cFk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/mre/alt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cFy" = (
 /obj/item/gun/projectile/automatic/lmg/pk,
 /obj/random/cloth/armor/low_chance,
@@ -2586,6 +2627,12 @@
 /mob/living/simple_animal/redpanda,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/zoo)
+"cGo" = (
+/obj/effect/decal/cleanable/cobweb{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cGz" = (
 /obj/structure/flora/small/bushb3,
 /obj/structure/flora/ausbushes/grassybush,
@@ -2678,6 +2725,16 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"cLU" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/material/device,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"cLV" = (
+/obj/structure/table/standard,
+/obj/random/medical/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cLY" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor/wood/wild5,
@@ -2695,6 +2752,12 @@
 /obj/random/furniture/bedsheetdouble,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/safehouse)
+"cMR" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/item/computer_hardware/hard_drive/portable/design/medical/advanced,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cNa" = (
 /obj/item/remains/ribcage,
 /turf/simulated/floor/tiled/cafe,
@@ -2720,6 +2783,13 @@
 /obj/random/closet_wardrobe/low_chance,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"cOt" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "cOO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/science,
@@ -2777,12 +2847,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"cQZ" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "cRG" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/smuggler_zone)
@@ -2840,6 +2904,11 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"cTi" = (
+/obj/machinery/door/airlock,
+/obj/item/mine/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cTM" = (
 /obj/structure/table/standard,
 /obj/random/common_oddities,
@@ -2869,6 +2938,11 @@
 	},
 /turf/simulated/shuttle/floor/mining,
 /area/colony/exposedsun/crashed_shop/outsider)
+"cUA" = (
+/obj/structure/table/rack,
+/obj/random/gun_parts,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cUK" = (
 /obj/random/material,
 /obj/random/material,
@@ -2882,11 +2956,6 @@
 /obj/random/closet_wardrobe/low_chance,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
-"cVj" = (
-/obj/machinery/cooking_with_jane/stove,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cVk" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/defib_kit/compact/combat/loaded,
@@ -2912,19 +2981,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"cXn" = (
-/obj/item/trash/peachcan,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"cXq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/ammo/shotgun,
-/obj/random/ammo/shotgun/low_chance,
-/obj/random/ammo/shotgun/low_chance,
-/obj/random/ammo_fancy,
-/obj/random/ammo_fancy,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cXz" = (
 /obj/structure/table/rack/shelf,
 /obj/item/trash/mre/os,
@@ -2940,6 +2996,11 @@
 /obj/random/rations,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"cYh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/mre/os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "cYn" = (
 /obj/machinery/door/blast/shutters/glass,
 /obj/random/junkfood/rotten/low_chance,
@@ -2951,10 +3012,6 @@
 /obj/random/junkfood/low_chance,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/safehouse)
-"cYA" = (
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "cYL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/traps/low_chance,
@@ -3022,10 +3079,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"dbi" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/random/medical,
+/obj/item/storage/firstaid,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dbn" = (
 /obj/random/common_oddities,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"dbE" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dbO" = (
 /obj/structure/table/onestar,
 /obj/structure/salvageable/console_os,
@@ -3057,11 +3126,6 @@
 	icon_state = "5,20"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"ddv" = (
-/obj/item/trash/cigbutt/fortress,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ddO" = (
 /obj/structure/reagent_dispensers/watertank/huge,
 /obj/machinery/light/small{
@@ -3087,11 +3151,6 @@
 "dfC" = (
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"dgd" = (
-/obj/item/bedsheet,
-/obj/structure/bed,
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "dge" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -3103,6 +3162,15 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"dgV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/fiction{
+	name = "Communist Manifesto"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dhy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -3130,6 +3198,12 @@
 /mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
+"djA" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "djP" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -3169,8 +3243,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"dnv" = (
+/obj/effect/decal/cleanable/filth,
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dnC" = (
-/obj/random/lowkeyrandom,
+/mob/living/carbon/superior_animal/human/excelsior,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "dnH" = (
@@ -3205,18 +3284,10 @@
 /obj/structure/morgue,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"dqf" = (
-/obj/structure/sign/directions/medical,
-/turf/simulated/wall,
-/area/asteroid/rogue)
 "dqw" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"dqC" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "dqH" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -3352,11 +3423,6 @@
 /obj/structure/salvageable/autolathe,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"dwY" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre_candy,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dxt" = (
 /obj/random/boxes,
 /turf/simulated/floor/tiled/dark,
@@ -3407,6 +3473,15 @@
 /obj/item/tank/anesthetic,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"dyP" = (
+/obj/machinery/cooking_with_jane/grill,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"dzj" = (
+/obj/structure/scrap/medical/large,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dzp" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -3425,12 +3500,6 @@
 /obj/random/powercell,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"dzT" = (
-/obj/structure/janitorialcart,
-/obj/item/keys/janitor,
-/obj/item/mop,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dAl" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -3505,10 +3574,6 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/zoo)
-"dCu" = (
-/obj/effect/dummy,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "dCT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/prepper,
@@ -3573,11 +3638,6 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"dFO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/firstaid/regular/empty,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dFT" = (
 /turf/simulated/shuttle/wall/cargo{
 	icon_state = "cargoshwall28";
@@ -3605,10 +3665,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"dHc" = (
-/obj/item/trash/grease,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dHh" = (
 /obj/structure/table/standard,
 /obj/item/roller,
@@ -3630,6 +3686,11 @@
 /obj/machinery/chemical_dispenser/beer,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
+"dHR" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dIw" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush3,
@@ -3660,12 +3721,6 @@
 "dIV" = (
 /obj/structure/closet/crate/serbcrate,
 /turf/simulated/floor/wood/wild4,
-/area/asteroid/rogue)
-"dJQ" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/rubble,
-/obj/item/bedsheet,
-/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "dJV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3700,16 +3755,17 @@
 /obj/random/tool,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"dKT" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dLt" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/vault)
-"dLJ" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/item/tool/sword/saber,
-/obj/effect/decal/cleanable/blood,
-/obj/landmark/corpse/chef,
-/mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing,
-/turf/simulated/floor/tiled/dark,
+"dLw" = (
+/obj/effect/dummy,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
 "dLT" = (
 /obj/structure/table/standard,
@@ -3748,12 +3804,6 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"dOw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dOM" = (
 /obj/item/bee_pack,
 /obj/structure/table/standard,
@@ -3780,10 +3830,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"dQe" = (
-/obj/structure/scrap_cube,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "dQt" = (
 /obj/structure/table/onestar,
 /obj/random/powercell/low_chance,
@@ -3849,6 +3895,14 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"dTV" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dUH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3859,6 +3913,11 @@
 /obj/structure/flora/big/bush1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"dWp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/gun_cheap/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "dXH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -3913,8 +3972,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"ebq" = (
-/obj/structure/table/bench/standard,
+"eas" = (
+/obj/structure/flora/small/grassa2,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
+"ebi" = (
+/obj/machinery/cooking_with_jane/stove,
+/obj/structure/table/marble,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "ebz" = (
@@ -3930,6 +3994,10 @@
 /obj/random/toolbox/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"eci" = (
+/obj/structure/sign/warning/nosmoking,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "ecz" = (
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
@@ -3947,6 +4015,11 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
+"edP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/firstaid/regular/empty,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "edQ" = (
 /obj/structure/boulder,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -4001,11 +4074,6 @@
 /obj/random/cluster/spiders,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
-"egt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "egw" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -4016,10 +4084,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"egT" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "eha" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/steel_reinforced,
@@ -4084,10 +4148,6 @@
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"eiY" = (
-/obj/item/trash/broken_robot_part,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ejs" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -4199,10 +4259,6 @@
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"emV" = (
-/obj/item/trash/cheesie,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "eno" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
@@ -4271,6 +4327,10 @@
 "epQ" = (
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/zoo)
+"epY" = (
+/obj/item/trash/syndi_cakes,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eqk" = (
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -4295,10 +4355,6 @@
 /obj/structure/curtain/open,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"erh" = (
-/obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "esi" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/big/bush3,
@@ -4363,6 +4419,10 @@
 "euc" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"eut" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "euG" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -4419,10 +4479,6 @@
 /obj/random/dungeon_gun_mods,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"ewx" = (
-/obj/item/implant/excelsior/broken,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ewC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/random/flora/jungle_tree,
@@ -4436,6 +4492,11 @@
 /obj/structure/flora/small/lavarock1,
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt,
+/area/asteroid/rogue)
+"exc" = (
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "exl" = (
 /obj/structure/table/glass,
@@ -4474,11 +4535,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"ezZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/gun_cheap/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "eAm" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white/panels,
@@ -4487,18 +4543,20 @@
 /obj/structure/flora/small/grassa2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"eBe" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "eBV" = (
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"eCz" = (
-/obj/effect/decal/cleanable/ash,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"eCA" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/firstaid/low_chance,
+"eCv" = (
+/obj/structure/table/rack,
+/obj/effect/decal/cleanable/filth,
+/obj/item/gun_upgrade/trigger/boom,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "eCK" = (
@@ -4535,20 +4593,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"eGa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/manual/fiction{
-	name = "Communist Manifesto"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"eGw" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/pistachios,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "eGG" = (
 /obj/machinery/door/airlock/multi_tile/metal,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -4563,6 +4607,14 @@
 /obj/random/ammo_lowcost/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
+"eHy" = (
+/obj/structure/safe/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "cobweb1"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eHE" = (
 /obj/structure/boulder,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -4619,6 +4671,11 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"eLL" = (
+/obj/random/lowkeyrandom,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eMv" = (
 /obj/random/closet_tech,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -4725,11 +4782,6 @@
 /obj/random/mob/roaches,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"eSB" = (
-/obj/effect/decal/cleanable/filth,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "eSN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/booze,
@@ -4743,6 +4795,13 @@
 "eUW" = (
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/outside/meadow)
+"eVr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "eVM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -4762,19 +4821,6 @@
 /obj/machinery/centrifuge,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/dungeon/outside/zoo)
-"eWn" = (
-/obj/item/stock_parts/manipulator/excelsior,
-/obj/item/stock_parts/manipulator/excelsior,
-/obj/item/stock_parts/manipulator/excelsior,
-/obj/item/stock_parts/capacitor/excelsior,
-/obj/item/stock_parts/matter_bin/excelsior,
-/obj/item/stock_parts/micro_laser/excelsior,
-/obj/item/stock_parts/micro_laser/excelsior,
-/obj/item/stock_parts/scanning_module/excelsior,
-/obj/structure/table/standard,
-/obj/item/computer_hardware/hard_drive/portable/design/guns/ex_vintorez,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "eXs" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/derelict,
@@ -4808,11 +4854,6 @@
 	},
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"eXK" = (
-/obj/item/storage/hcases/ammo/excel,
-/obj/structure/closet/crate/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "eYw" = (
 /obj/landmark/join/start/outsider,
 /turf/simulated/shuttle/floor/mining{
@@ -4837,13 +4878,6 @@
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"eZt" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "eZx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -4924,15 +4958,19 @@
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony/exposedsun/pastgate)
+"fcB" = (
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fcC" = (
 /obj/machinery/light/floor,
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"fcU" = (
+"fcX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "fdz" = (
@@ -5015,10 +5053,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
-"ffP" = (
-/obj/machinery/autodoc,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "fgw" = (
 /obj/structure/closet/random_medsupply,
 /obj/item/storage/firstaid/ifak,
@@ -5058,10 +5092,6 @@
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"fin" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "fit" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/asteroid/grass,
@@ -5087,18 +5117,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"fjG" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "fjK" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt,
@@ -5120,6 +5138,11 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"fkD" = (
+/obj/structure/bookcase,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fkH" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/big/bush3,
@@ -5152,11 +5175,6 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
-"fmy" = (
-/obj/structure/table/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "fmI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/traps/low_chance,
@@ -5187,10 +5205,6 @@
 /obj/machinery/chemical_dispenser,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"foK" = (
-/obj/random/scrap/moderate_weighted,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "foM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5233,14 +5247,31 @@
 /obj/random/ammo/shotgun,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"fqQ" = (
+/obj/item/trash/mre,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fqU" = (
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"fsd" = (
+/obj/machinery/door/airlock/centcom,
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fsf" = (
 /obj/effect/step_trigger/swampcaves_to_riverforest_2_B,
 /turf/simulated/floor/asteroid/dirt,
 /area/colony/exposedsun/pastgate)
+"fsF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fsT" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/reagent_containers/spray/cleaner,
@@ -5284,11 +5315,6 @@
 /area/nadezhda/outside/meadow)
 "fvS" = (
 /turf/simulated/floor/tiled/derelict/red_white_edges,
-/area/asteroid/rogue)
-"fvU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/makarov/preloaded,
-/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "fwb" = (
 /obj/structure/table/steel,
@@ -5349,15 +5375,14 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"fyp" = (
+/obj/item/trash/peachcan,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fyx" = (
 /obj/random/mob/undergroundmob,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
-"fyT" = (
-/mob/living/carbon/superior_animal/human/excelsior,
-/obj/structure/table/bench/standard,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "fze" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt,
@@ -5372,12 +5397,6 @@
 /obj/random/mob/tengolo/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/meadow)
-"fBe" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/obj/random/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "fBr" = (
 /obj/structure/flora/small/busha3,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -5422,6 +5441,17 @@
 /obj/random/gun_cheap,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/meadow)
+"fDD" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/filth,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fDS" = (
 /obj/machinery/light{
 	dir = 4;
@@ -5501,6 +5531,10 @@
 /obj/random/traps,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"fGF" = (
+/obj/structure/cardboardbox,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fGQ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -5570,13 +5604,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"fKU" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"fLR" = (
-/obj/item/trash/cigbutt/fortressblue,
+"fLF" = (
+/obj/machinery/door/airlock/centcom,
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "fLW" = (
@@ -5669,10 +5699,18 @@
 /obj/structure/flora/small/bushb2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"fQG" = (
+/obj/item/trash/os_coco_wrapper,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fRg" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"fRD" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "fRZ" = (
 /obj/structure/salvageable/data_os,
 /turf/simulated/floor/plating/under,
@@ -5708,12 +5746,6 @@
 /obj/structure/closet/random_hostilemobs,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"fTH" = (
-/obj/structure/table/woodentable,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/revolver/deacon,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "fTI" = (
 /obj/structure/target_stake,
 /obj/item/target/syndicate,
@@ -5723,12 +5755,6 @@
 /obj/random/firstaid,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
-"fTZ" = (
-/obj/effect/decal/cleanable/cobweb2{
-	icon_state = "cobweb1"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "fUg" = (
 /obj/machinery/portable_atmospherics/hydroponics{
 	pixel_y = 4
@@ -5771,9 +5797,15 @@
 /obj/random/lathe_disk/advanced,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"fVi" = (
-/obj/structure/sign/faction/excelsior_old,
-/turf/simulated/wall/r_wall,
+"fVt" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "fVI" = (
 /obj/structure/bed/chair/custom/onestar/red{
@@ -5799,6 +5831,11 @@
 /obj/random/junk,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"fWH" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/random/traps/low_chance,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "fWK" = (
 /obj/machinery/button/remote/airlock{
 	dir = 4;
@@ -5810,6 +5847,11 @@
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"fWQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mopbucket,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fXe" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -5820,6 +5862,12 @@
 /obj/random/pouch,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"fXg" = (
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "cobweb1"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fXI" = (
 /obj/structure/railing/grey,
 /obj/effect/step_trigger/vault_bunker_2F,
@@ -5855,6 +5903,11 @@
 "fYU" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"fZu" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gab" = (
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -5927,6 +5980,10 @@
 /obj/random/traps,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"gfM" = (
+/obj/item/gun/projectile/automatic/thompson,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "gfN" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -5945,6 +6002,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"ggb" = (
+/obj/item/trash/grease,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ggM" = (
 /obj/random/scrap/dense_weighted,
 /obj/random/scrap/dense_weighted,
@@ -5989,6 +6050,10 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"gia" = (
+/obj/machinery/cooking_with_jane/oven,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gim" = (
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -6024,6 +6089,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"gkh" = (
+/obj/machinery/light,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "gkM" = (
 /obj/structure/sign/neon/beer,
 /turf/simulated/wall/r_wall,
@@ -6044,6 +6113,12 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/random/cluster/spiders/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"glZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/asteroid/rogue)
 "gmm" = (
 /obj/structure/flora/small/busha1,
@@ -6137,6 +6212,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"gqN" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/firstaid/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "grf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -6186,10 +6267,6 @@
 /obj/item/oddity/common/coin,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"gtS" = (
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gtY" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -6244,9 +6321,6 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"gvv" = (
-/turf/simulated/wall/wood,
-/area/asteroid/rogue)
 "gvB" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/microwave,
@@ -6315,12 +6389,26 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"gyo" = (
+/obj/random/dungeon_gun_energy/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gys" = (
 /obj/item/tool/broken_bottle,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"gyS" = (
+/obj/structure/cable,
+/obj/item/circuitboard/apc,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "West APC";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plating/under,
+/area/asteroid/rogue)
 "gyZ" = (
 /obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/jungle,
@@ -6355,10 +6443,6 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"gAY" = (
-/obj/item/part/gun/frame/vintorez,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gBg" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/bed/chair{
@@ -6414,10 +6498,6 @@
 /obj/random/junkfood/onlypizza,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
-"gCI" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gCP" = (
 /obj/structure/railing{
 	dir = 1
@@ -6433,13 +6513,6 @@
 /obj/structure/closet/secure_closet/bar,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"gDl" = (
-/obj/effect/decal/cleanable/cobweb2{
-	icon_state = "spiderling";
-	name = "dead spider"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gDz" = (
 /obj/machinery/light{
 	dir = 1
@@ -6487,9 +6560,14 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"gGp" = (
-/obj/item/mine/excelsior,
-/turf/simulated/floor/rock/dark,
+"gFS" = (
+/obj/structure/salvageable/data_os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"gGm" = (
+/obj/random/lowkeyrandom,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "gGH" = (
 /obj/item/remains/ribcage,
@@ -6501,10 +6579,21 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"gHH" = (
+/obj/structure/scrap_cube,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gIP" = (
 /obj/machinery/door/airlock/freezer,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
+"gIS" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gJo" = (
 /obj/structure/flora/big/bush3,
 /turf/simulated/wall/wood_old,
@@ -6526,10 +6615,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"gKO" = (
-/obj/item/gun/projectile/automatic/thompson,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "gLJ" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/bucket,
@@ -6608,10 +6693,6 @@
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"gQc" = (
-/obj/structure/sign/warning/lethal_turrets,
-/turf/simulated/wall,
-/area/asteroid/rogue)
 "gQi" = (
 /obj/structure/table/onestar,
 /obj/random/junkfood,
@@ -6622,6 +6703,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"gQn" = (
+/obj/structure/table/woodentable,
+/obj/item/implanter/excelsior/broken,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gQq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -6642,11 +6728,6 @@
 /obj/item/storage/box/matches,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"gRr" = (
-/obj/structure/table/standard,
-/obj/random/surgery_tool/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gRw" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
@@ -6741,6 +6822,13 @@
 /obj/random/ammo_lowcost,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/dungeon/outside/prepper)
+"gUa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gUl" = (
 /obj/structure/cryofeed{
 	dir = 4;
@@ -6808,10 +6896,6 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"gYz" = (
-/obj/structure/flora/small/grassb4,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "gZa" = (
 /obj/structure/table/rack/shelf,
 /obj/item/folder/black,
@@ -6824,11 +6908,6 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"gZo" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "gZu" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -6874,12 +6953,10 @@
 /obj/structure/scrap/food/large,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"hcs" = (
-/obj/structure/safe/floor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb2{
-	icon_state = "cobweb1"
-	},
+"hcu" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "hcG" = (
@@ -6946,17 +7023,7 @@
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"hfN" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre/alt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hgL" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid{
-	pixel_x = -8;
-	pixel_y = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "hhc" = (
@@ -6982,11 +7049,6 @@
 /obj/item/remains/mummy2,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"hih" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hiu" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -7090,6 +7152,10 @@
 /obj/random/medical_lowcost/low_chance,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"hmx" = (
+/obj/structure/flora/small/grassb2,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "hmJ" = (
 /obj/item/trash/raisins,
 /obj/effect/decal/cleanable/dirt,
@@ -7139,6 +7205,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"hnP" = (
+/obj/structure/bookcase/manuals/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hnQ" = (
 /obj/structure/table/rack/shelf,
 /obj/item/paper_bin,
@@ -7169,6 +7239,10 @@
 /obj/random/pouch,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"hox" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hpb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/stack/medical/bruise_pack/handmade,
@@ -7178,11 +7252,6 @@
 /obj/structure/flora/small/busha2,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"hpp" = (
-/obj/structure/curtain/medical,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hpr" = (
 /obj/machinery/door/blast/shutters/glass,
 /obj/random/junkfood/rotten/low_chance,
@@ -7238,11 +7307,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"hrI" = (
-/obj/structure/table/gamblingtable,
-/obj/item/gun/projectile/makarov/preloaded,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hsp" = (
 /obj/structure/sink{
 	dir = 8;
@@ -7256,15 +7320,6 @@
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"hsJ" = (
-/obj/structure/flora/small/grassa2,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
-"hsZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank/huge/derelict,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "htO" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 4
@@ -7273,11 +7328,6 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"huf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "huO" = (
 /mob/living/simple_animal/hostile/render,
 /turf/simulated/floor/asteroid/dirt,
@@ -7294,6 +7344,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
+"hwy" = (
+/obj/structure/sign/faction/excelsior_old,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "hwD" = (
 /obj/item/trash/tray,
 /obj/random/traps,
@@ -7325,10 +7379,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"hxa" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/wall,
-/area/asteroid/rogue)
 "hxm" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/big/bush2,
@@ -7378,19 +7428,16 @@
 /obj/item/storage/box/frag_grenade_shells,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
-"hAx" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/decal/cleanable/dirt,
+"hAV" = (
+/obj/structure/table/standard,
+/obj/random/medical,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
-"hAN" = (
-/obj/structure/sign/departmentold/medical2,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
-"hAS" = (
-/obj/effect/decal/cleanable/rubble,
-/mob/living/simple_animal/hostile/scarybat,
-/turf/simulated/floor/asteroid/dirt/dark,
+"hBa" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "hBX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7419,11 +7466,6 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
-"hDl" = (
-/obj/effect/decal/cleanable/generic,
-/obj/item/trash/mre,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "hEU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/lathe_disk,
@@ -7529,6 +7571,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"hJW" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hJY" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/junkfood/rotten/low_chance,
@@ -7575,6 +7623,10 @@
 /obj/random/lathe_disk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"hNR" = (
+/obj/structure/flora/small/grassa5,
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "hNY" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha3,
@@ -7589,21 +7641,22 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"hOk" = (
-/obj/structure/closet/crate/excelsior,
-/obj/item/tool/baton/excelbaton,
-/obj/item/tool/baton/excelbaton,
-/obj/item/clothing/suit/space/void/excelsior,
-/obj/item/clothing/head/helmet/space/void/excelsior,
-/obj/random/melee/low_chance,
-/obj/item/gun/projectile/automatic/drozd,
-/obj/item/gun/projectile/automatic/drozd,
+"hOg" = (
+/obj/structure/table/standard,
+/obj/random/surgery_tool/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "hOt" = (
 /obj/structure/salvageable/machine,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"hOw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hPm" = (
 /obj/structure/salvageable/data_os,
 /turf/simulated/floor/plating/under,
@@ -7617,10 +7670,6 @@
 /obj/structure/salvageable/server_os,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
-"hQd" = (
-/mob/living/simple_animal/hostile/bear/excelsior,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "hQn" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/material_resources,
@@ -7638,6 +7687,16 @@
 	},
 /turf/simulated/floor/beach/water/ice,
 /area/nadezhda/dungeon/outside/zoo)
+"hQJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/plate,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"hQX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hRb" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/outside/meadow)
@@ -7781,6 +7840,10 @@
 /obj/random/junkfood/onlypizza,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"hYL" = (
+/obj/item/implant/excelsior/broken,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "hYM" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/railing,
@@ -7841,6 +7904,10 @@
 /obj/effect/damagedfloor/rust,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"ice" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "icq" = (
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark,
@@ -7954,6 +8021,11 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"igW" = (
+/obj/structure/table/gamblingtable,
+/obj/item/gun/projectile/makarov/preloaded,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ihc" = (
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/tiled/cafe,
@@ -7975,10 +8047,20 @@
 /obj/random/structures/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"iip" = (
+/obj/item/trash/cheesie,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "iiE" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"iiZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/mine/excelsior,
+/obj/item/trash/candy/proteinbar,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "iji" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap,
@@ -8010,6 +8092,10 @@
 /obj/item/modular_computer/laptop/preset/records,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/dungeon/outside/zoo)
+"ikF" = (
+/obj/item/trash/semki,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ikO" = (
 /obj/structure/catwalk,
 /obj/random/mob/prepper,
@@ -8058,11 +8144,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/zoo)
-"inN" = (
-/obj/structure/table/standard,
-/obj/random/medical/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ioc" = (
 /obj/machinery/door/window,
 /turf/simulated/floor/tiled/cafe,
@@ -8079,10 +8160,6 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"ior" = (
-/obj/structure/salvageable/autolathe,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ioB" = (
 /obj/structure/flora/small/bushc2,
 /turf/unsimulated/wall/jungle,
@@ -8149,13 +8226,6 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"irF" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "irR" = (
 /obj/item/modular_computer/console/preset/civilian/professional{
 	dir = 4
@@ -8246,10 +8316,6 @@
 /obj/machinery/door/window,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/zoo)
-"ivS" = (
-/obj/random/dungeon_gun_energy/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ivZ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt,
@@ -8292,15 +8358,6 @@
 /obj/structure/multiz/ladder,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"ixB" = (
-/obj/machinery/porta_turret/excelsior/preloaded,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/cobweb2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ixC" = (
 /obj/structure/table/steel,
 /obj/effect/decal/cleanable/dirt,
@@ -8347,6 +8404,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"izA" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "izY" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/firstaid,
@@ -8358,6 +8419,11 @@
 /obj/item/trash/cigbutt/ishimura,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"iAz" = (
+/obj/random/scrap/dense_weighted,
+/obj/random/scrap/dense_weighted,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "iAE" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/beakers,
@@ -8383,16 +8449,6 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
-"iBF" = (
-/obj/random/scrap/dense_weighted,
-/obj/random/scrap/dense_weighted,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"iBG" = (
-/obj/item/mine/excelsior,
-/obj/random/scrap/sparse_even/low_chance,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "iCz" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/big/bush2,
@@ -8421,6 +8477,11 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"iDM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "iEa" = (
 /obj/machinery/light{
 	dir = 1
@@ -8456,6 +8517,10 @@
 /obj/item/ammo_magazine/c10x24,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"iET" = (
+/mob/living/simple_animal/hostile/bear/excelsior,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "iFg" = (
 /obj/structure/invislight,
 /turf/simulated/floor/tiled/techmaint_cargo,
@@ -8499,6 +8564,12 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"iHb" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/item/gun/projectile/boltgun,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "iHc" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/asteroid/grass,
@@ -8662,10 +8733,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/safehouse)
-"iQf" = (
-/obj/random/traps/low_chance,
-/turf/simulated/floor/rock/grey,
-/area/asteroid/rogue)
 "iQR" = (
 /obj/random/tank/low_chance,
 /turf/simulated/floor/plating/under,
@@ -8689,11 +8756,6 @@
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"iSq" = (
-/obj/item/implanter/excelsior/broken,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "iSv" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/small/busha2,
@@ -8716,11 +8778,6 @@
 /obj/random/closet/low_chance,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"iTd" = (
-/obj/effect/decal/cleanable/filth,
-/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "iTq" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/briefcase,
@@ -8771,6 +8828,13 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"iWS" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/item/trash/pistachios,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "iXn" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -8840,14 +8904,6 @@
 /mob/living/carbon/superior_animal/robot/greyson/roomba/slayer,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
-"jaE" = (
-/obj/item/storage/fancy/vials,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"jaJ" = (
-/obj/structure/salvageable/console_broken_os,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jaO" = (
 /obj/item/stash_spawner,
 /turf/simulated/floor/wood/wild4,
@@ -8881,11 +8937,6 @@
 /obj/machinery/door/airlock/vault,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/safehouse)
-"jcF" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/obj/structure/curtain/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jcH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -8993,6 +9044,10 @@
 /obj/item/stool/custom/bar_special,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
+"jfz" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jfW" = (
 /obj/machinery/gym/robustness,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -9102,6 +9157,10 @@
 /obj/random/cluster/roaches,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"jjD" = (
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jjE" = (
 /obj/random/flora/jungle_tree,
 /turf/simulated/mineral/planet,
@@ -9166,6 +9225,10 @@
 /obj/structure/wire_splicing,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"jkv" = (
+/obj/machinery/autolathe,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jkG" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/plasma/random,
@@ -9188,12 +9251,22 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper)
+"jmx" = (
+/obj/item/gun/projectile/makarov/preloaded,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jnj" = (
 /mob/living/simple_animal/hostile/bear/brown,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/zoo)
+"jnl" = (
+/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/revolver/deacon,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jnq" = (
-/obj/machinery/door/unpowered/simple/wood,
+/mob/living/simple_animal/hostile/bear/excelsior,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "jnw" = (
@@ -9224,10 +9297,6 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"jnY" = (
-/obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jos" = (
 /obj/structure/table/onestar,
 /obj/random/tool/advanced/onestar/low_chance,
@@ -9248,16 +9317,6 @@
 /obj/machinery/power/port_gen/pacman/scrap,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"jpE" = (
-/obj/machinery/autolathe,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"jqA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jqD" = (
 /obj/structure/table/standard,
 /obj/item/oddity/common/old_radio,
@@ -9282,6 +9341,10 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"jrF" = (
+/obj/structure/medical_stand,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jrV" = (
 /obj/random/cluster/spiders,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -9304,6 +9367,11 @@
 /obj/item/stock_parts/micro_laser/one_star,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"jva" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jvH" = (
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/beach/sand/desert,
@@ -9312,11 +9380,6 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"jvX" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jwg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/prepper,
@@ -9358,11 +9421,6 @@
 /obj/item/oddity/common/book_bible,
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/prepper)
-"jyP" = (
-/obj/structure/table/woodentable,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "jyY" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/tool/shovel/spade,
@@ -9456,11 +9514,6 @@
 /obj/item/mine_old,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"jFi" = (
-/obj/machinery/door/airlock,
-/obj/item/mine/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jFP" = (
 /obj/structure/flora/small/busha2,
 /obj/random/flora/small_jungle_tree,
@@ -9552,6 +9605,11 @@
 /obj/item/clothing/suit/armor/vest/iron_lock_security,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"jJO" = (
+/obj/effect/decal/cleanable/filth,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "jJQ" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/science,
@@ -9614,10 +9672,6 @@
 /obj/structure/salvageable/autolathe,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"jMF" = (
-/obj/item/trash/mre,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "jMG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit,
@@ -9667,11 +9721,6 @@
 /obj/item/solar_assembly,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
-"jOp" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/automatic/vintorez,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jOw" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/material_rare,
@@ -9724,14 +9773,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"jRN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/psych{
-	desc = "It can be a bit noisy, but still serves well.";
-	name = "old bed"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jSh" = (
 /obj/structure/showcase/sign2{
 	desc = "A warning sign depicting a small gun and a hazard symbol.";
@@ -9748,17 +9789,6 @@
 /obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"jSR" = (
-/obj/structure/closet/crate/excelsior,
-/obj/item/tool/baton/excelbaton,
-/obj/item/tool/baton/excelbaton,
-/obj/item/clothing/suit/space/void/excelsior,
-/obj/item/clothing/head/helmet/space/void/excelsior,
-/obj/random/melee/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/boltgun/heavysniper,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "jTE" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light/small{
@@ -9904,6 +9934,10 @@
 /obj/item/soap/nanotrasen,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
+"kaq" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kbC" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/item/reagent_containers/glass/bottle/petrel,
@@ -9916,10 +9950,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
-"kbI" = (
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kcq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
@@ -9939,6 +9969,10 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"kcL" = (
+/obj/item/trash/cigbutt/brouzouf,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "kcN" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/uranium/random,
@@ -9963,10 +9997,6 @@
 /mob/living/carbon/superior_animal/human/voidwolf/fieldtech/ranged,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"kem" = (
-/obj/structure/cardboardbox,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kep" = (
 /obj/structure/invislight,
 /obj/machinery/door/airlock/multi_tile/metal{
@@ -10014,6 +10044,10 @@
 /obj/item/circuitboard/apc,
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
+"kfA" = (
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kfD" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/decal/cleanable/rubble,
@@ -10033,11 +10067,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"kgi" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/item/stack/medical/bruise_pack,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kgn" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10061,12 +10090,6 @@
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"khM" = (
-/obj/effect/decal/cleanable/cobweb{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kii" = (
 /obj/random/mob/prepper,
 /turf/simulated/floor/plating/under,
@@ -10080,6 +10103,11 @@
 /mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"kjp" = (
+/obj/item/implanter/excelsior/broken,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kjs" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/clothing/head/welding,
@@ -10149,11 +10177,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"kne" = (
-/obj/structure/bookcase,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "knh" = (
 /obj/random/scrap/dense_weighted,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -10232,10 +10255,6 @@
 /obj/random/toolbox,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"kqO" = (
-/obj/structure/sign/warning/high_voltage,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "krh" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/noslipmodule,
@@ -10247,11 +10266,6 @@
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"krP" = (
-/obj/structure/table/reinforced,
-/obj/item/trash/candle,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ksr" = (
 /obj/structure/railing/grey,
 /obj/structure/multiz/stairs/active/bottom{
@@ -10259,6 +10273,11 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"ksu" = (
+/obj/structure/table/marble,
+/obj/item/storage/pouch/ammo,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ksF" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -10276,9 +10295,13 @@
 /obj/item/clothing/gloves/thick/ablasive/iron_lock_security,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"ktB" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+"kts" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "ktF" = (
@@ -10293,11 +10316,6 @@
 /obj/random/tool_upgrade/rare/low_chance,
 /turf/simulated/floor/tiled/dark/orangecorner,
 /area/nadezhda/dungeon/outside/prepper)
-"kud" = (
-/obj/random/lowkeyrandom,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kur" = (
 /obj/random/science,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -10306,10 +10324,6 @@
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"kuV" = (
-/obj/item/trash/mre_shokoladka,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kva" = (
 /obj/structure/salvageable/data_os,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10347,11 +10361,6 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"kwf" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kxe" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plating/under,
@@ -10406,6 +10415,13 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"kzu" = (
+/obj/random/scrap/dense_weighted,
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kzF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -10425,14 +10441,13 @@
 "kAs" = (
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
+"kAK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "kBn" = (
 /obj/item/ammo_magazine/light_rifle_257/empty,
 /turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
-"kBF" = (
-/obj/effect/decal/cleanable/generic,
-/obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "kBQ" = (
 /obj/random/junk/cigbutt,
@@ -10445,6 +10460,10 @@
 	},
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"kBY" = (
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kCa" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/dark,
@@ -10487,10 +10506,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"kEz" = (
-/mob/living/simple_animal/hostile/scarybat,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "kFl" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/grass,
@@ -10617,12 +10632,6 @@
 /obj/structure/flora/small/bushc2,
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/meadow)
-"kMy" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/item/storage/firstaid/combat,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "kMK" = (
 /obj/random/structures,
 /obj/machinery/light/small,
@@ -10691,6 +10700,11 @@
 /mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"kQA" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kQG" = (
 /obj/structure/closet/onestar/tier1/mineral,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -10704,6 +10718,11 @@
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/meadow)
+"kSt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kSw" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
@@ -10718,10 +10737,9 @@
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/dungeon/outside/safehouse)
-"kUl" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/obj/item/trash/popcorn,
-/obj/effect/decal/cleanable/dirt,
+"kUs" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "kUx" = (
@@ -10755,6 +10773,28 @@
 	layer = 2.6
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"kVt" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/toastedsandwich,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"kVE" = (
+/mob/living/carbon/superior_animal/xenomorph{
+	name = "Greg";
+	desc = "Fuck you, Greg."
+	},
+/turf/simulated/floor/wood,
 /area/asteroid/rogue)
 "kVF" = (
 /obj/structure/flora/small/busha1,
@@ -10801,6 +10841,11 @@
 /obj/item/remains/tajaran,
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"kXX" = (
+/obj/random/lowkeyrandom/low_chance,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "kYd" = (
 /obj/structure/table/rack/shelf,
 /obj/random/tool/advanced/onestar/low_chance,
@@ -10835,6 +10880,12 @@
 /obj/effect/step_trigger/vault_bunker_1G,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
+"laf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "laj" = (
 /obj/structure/table/marble,
 /obj/random/medical,
@@ -10860,12 +10911,6 @@
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"lcd" = (
-/obj/random/lowkeyrandom/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lcK" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/small/bushb2,
@@ -10889,6 +10934,11 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"ldM" = (
+/obj/item/mine/excelsior,
+/obj/random/scrap/sparse_even/low_chance,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "leb" = (
 /obj/structure/bed/chair/custom/onestar,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -10916,6 +10966,19 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"lgv" = (
+/obj/item/stock_parts/manipulator/excelsior,
+/obj/item/stock_parts/manipulator/excelsior,
+/obj/item/stock_parts/manipulator/excelsior,
+/obj/item/stock_parts/capacitor/excelsior,
+/obj/item/stock_parts/matter_bin/excelsior,
+/obj/item/stock_parts/micro_laser/excelsior,
+/obj/item/stock_parts/micro_laser/excelsior,
+/obj/item/stock_parts/scanning_module/excelsior,
+/obj/structure/table/standard,
+/obj/item/computer_hardware/hard_drive/portable/design/guns/ex_vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lgw" = (
 /obj/structure/table/standard,
 /obj/item/clothing/accessory/stethoscope,
@@ -10996,9 +11059,8 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/mineral/planet,
 /area/nadezhda/dungeon/outside/monster_cave)
-"liS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/mopbucket,
+"ljm" = (
+/obj/structure/salvageable/autolathe,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "ljt" = (
@@ -11051,6 +11113,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"llF" = (
+/mob/living/simple_animal/hostile/megafauna/excelsior_cosmonaught,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "llJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -11070,31 +11136,28 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"lmY" = (
-/obj/structure/cable,
-/obj/item/circuitboard/apc,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28
+"loq" = (
+/obj/landmark/corpse/excelsior,
+/obj/item/mine/excelsior{
+	armed = 1
 	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/rock/dark,
 /area/asteroid/rogue)
 "loD" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"loP" = (
-/obj/item/trash/popcorn,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "loV" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 1
 	},
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"lpc" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lpp" = (
 /obj/structure/flora/small/grassb2,
 /obj/structure/flora/ausbushes/grassybush,
@@ -11112,11 +11175,6 @@
 /obj/random/pack/gun_loot,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"lqA" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "lqU" = (
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/beach/water/jungle,
@@ -11162,10 +11220,6 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"ltq" = (
-/obj/item/mine/excelsior,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "ltt" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/wood/wild1,
@@ -11181,23 +11235,12 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
-"luh" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/semki,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lur" = (
 /obj/item/trash/semki,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"luv" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/item/mine/excelsior,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "luy" = (
 /obj/random/closet_tech/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -11365,15 +11408,10 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"lEE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/mine/excelsior,
-/obj/item/trash/candy/proteinbar,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lEJ" = (
 /obj/item/mine/excelsior,
-/obj/landmark/corpse/excelsior,
+/obj/effect/decal/cleanable/generic,
+/obj/random/scrap/sparse_even/low_chance,
 /turf/simulated/floor/rock/dark,
 /area/asteroid/rogue)
 "lEN" = (
@@ -11454,9 +11492,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
-"lHQ" = (
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "lHV" = (
 /obj/effect/step_trigger/vault_bunker_2C,
 /turf/simulated/floor/tiled/dark,
@@ -11477,15 +11512,15 @@
 /obj/random/tool/advanced/onestar/low_chance,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/nadezhda/outside/one_star)
+"lIh" = (
+/obj/effect/decal/cleanable/filth,
+/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lIk" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
-"lIR" = (
-/obj/structure/scrap_cube,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lJc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/render/low_chance,
@@ -11526,11 +11561,6 @@
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/asteroid/rogue)
-"lLd" = (
-/obj/structure/scrap_cube,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lLf" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/small/busha2,
@@ -11540,10 +11570,6 @@
 /obj/item/trash/cigbutt/fortressblue,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"lLv" = (
-/obj/item/trash/os_coco_wrapper,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lLH" = (
 /obj/structure/bed,
 /turf/simulated/floor/wood/wild5,
@@ -11564,6 +11590,17 @@
 /obj/effect/step_trigger/prepper_to_vbunker_6_A,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"lMF" = (
+/obj/item/paper/crumpled{
+	text = "You are on your own. Serve to your best extents and do not let our fortress fall!   - Skeinstovitch"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"lNk" = (
+/obj/machinery/suit_storage_unit/excelsior,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lNE" = (
 /obj/random/structures/os,
 /turf/simulated/floor/tiled/white/panels,
@@ -11572,6 +11609,11 @@
 /obj/random/mob/undergroundmob/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"lPa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lPc" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -11589,6 +11631,17 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"lQj" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/tool/baton/excelbaton,
+/obj/item/tool/baton/excelbaton,
+/obj/item/clothing/suit/space/void/excelsior,
+/obj/item/clothing/head/helmet/space/void/excelsior,
+/obj/random/melee/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/boltgun/heavysniper,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lQk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -11645,6 +11698,11 @@
 	},
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/dungeon/outside/zoo)
+"lTl" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lTC" = (
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
@@ -11772,10 +11830,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"lZR" = (
-/obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "lZZ" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -11821,12 +11875,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/nadezhda/dungeon/outside/zoo)
-"mda" = (
-/obj/item/paper/crumpled{
-	text = "You are on your own. Serve to your best extents and do not let our fortress fall!   - Skeinstovitch"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mey" = (
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -11836,12 +11884,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"meX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mff" = (
 /obj/structure/multiz/stairs{
 	dir = 1
@@ -11928,6 +11970,16 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"miU" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"mjb" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/stack/medical/bruise_pack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mjo" = (
 /obj/structure/table/standard,
 /obj/random/gun_energy_cheap,
@@ -11994,16 +12046,6 @@
 /obj/structure/flora/small/busha2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"mmx" = (
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"mmF" = (
-/obj/machinery/shieldwallgen/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mmN" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/invislight,
@@ -12201,10 +12243,6 @@
 /obj/structure/bed/chair/custom/onestar/red,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"mvh" = (
-/obj/structure/sign/warning/armory/small,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "mvp" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/material_ore,
@@ -12240,10 +12278,6 @@
 "mxn" = (
 /turf/simulated/wall/untinted/onestar_reinforced,
 /area/nadezhda/outside/one_star)
-"mxx" = (
-/obj/item/trash/mre_candy,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mxA" = (
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
@@ -12283,13 +12317,6 @@
 /obj/random/surgery_tool/low_chance,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"mAP" = (
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "mBi" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -12403,6 +12430,10 @@
 /obj/random/closet/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"mED" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "mEL" = (
 /obj/structure/table/steel,
 /obj/random/tool_upgrade/low_chance,
@@ -12639,6 +12670,12 @@
 "mNA" = (
 /turf/simulated/wall,
 /area/asteroid/rogue)
+"mNF" = (
+/obj/item/gun/projectile/automatic/ak47/saiga,
+/obj/item/gun/projectile/automatic/ak47/saiga,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mNN" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
@@ -12805,6 +12842,11 @@
 	icon_state = "5,20"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"mUI" = (
+/obj/item/trash/popcorn,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "mVa" = (
 /obj/random/material_rare,
 /obj/random/material_rare,
@@ -12885,17 +12927,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/one_star)
-"mYJ" = (
-/obj/structure/bed/psych{
-	desc = "It can be a bit noisy, but still serves well.";
-	name = "old bed"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"mZc" = (
-/obj/machinery/vending/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "mZe" = (
 /obj/structure/flora/small/busha1,
 /obj/item/trash/mre_candy,
@@ -13081,11 +13112,6 @@
 /obj/random/junkfood/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/safehouse)
-"niQ" = (
-/obj/structure/table/rack,
-/obj/random/gun_parts,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nja" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -13095,10 +13121,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"njB" = (
-/obj/item/trash/cigbutt/brouzouf,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "njD" = (
 /obj/item/mine_old{
 	layer = 2.6
@@ -13131,6 +13153,10 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/item/plastique,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"nle" = (
+/obj/structure/salvageable/implant_container_os,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "nlq" = (
 /obj/structure/cable{
@@ -13282,6 +13308,10 @@
 "nrh" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"nrW" = (
+/obj/structure/salvageable/computer_os,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nsg" = (
 /obj/structure/salvageable/console_os,
 /turf/simulated/floor/tiled/derelict,
@@ -13316,8 +13346,18 @@
 "nuk" = (
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/outside/meadow)
-"nuz" = (
-/obj/machinery/cooking_with_jane/oven,
+"nuB" = (
+/obj/effect/decal/cleanable/filth,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"nuE" = (
+/obj/item/trash/gamerchips,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"nuW" = (
+/obj/structure/table/marble,
+/obj/item/gun/projectile/automatic/ak47,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "nvl" = (
@@ -13382,10 +13422,6 @@
 /obj/item/folder/yellow,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"nxb" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "nxv" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/small/busha1,
@@ -13444,14 +13480,16 @@
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"nBe" = (
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nBv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"nBK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nBY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -13540,6 +13578,11 @@
 /mob/living/carbon/superior_animal/wurm/osmium,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"nGT" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nHb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
@@ -13569,11 +13612,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"nHN" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/material/device,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nIx" = (
 /obj/structure/barricade,
 /obj/structure/boulder,
@@ -13587,6 +13625,11 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"nJw" = (
+/obj/effect/decal/cleanable/rubble,
+/mob/living/simple_animal/hostile/bear/excelsior,
+/turf/simulated/floor/rock/grey,
+/area/asteroid/rogue)
 "nJz" = (
 /obj/structure/multiz/stairs/active{
 	dir = 4
@@ -13597,26 +13640,21 @@
 /obj/structure/boulder,
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"nKW" = (
-/obj/structure/sign/warning/nosmoking,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "nLJ" = (
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"nLN" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nMn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
+"nMq" = (
+/obj/structure/janitorialcart,
+/obj/item/keys/janitor,
+/obj/item/mop,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nMX" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -13638,16 +13676,6 @@
 /obj/item/computer_hardware/hard_drive/portable/design/excelsior,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"nOv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"nOx" = (
-/obj/effect/decal/cleanable/filth,
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nOF" = (
 /obj/effect/overlay/wallrot,
 /turf/simulated/wall,
@@ -13662,9 +13690,9 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"nPz" = (
-/obj/structure/table/marble,
-/obj/item/gun/projectile/automatic/ak47,
+"nPJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/makarov/preloaded,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "nPK" = (
@@ -13700,20 +13728,6 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"nRo" = (
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"nRq" = (
-/obj/effect/decal/cleanable/cobweb2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/cobweb2{
-	icon_state = "spiderling";
-	name = "dead spider"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "nRv" = (
 /obj/structure/bed/chair/custom/wood{
 	dir = 8
@@ -13837,12 +13851,20 @@
 "nZb" = (
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/dungeon/outside/zoo)
+"nZp" = (
+/obj/item/gun/projectile/boltgun,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nZr" = (
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "nZK" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"nZN" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oab" = (
 /obj/structure/closet/secure_closet/freezer,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -13872,6 +13894,10 @@
 /obj/item/solar_assembly,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"obJ" = (
+/obj/machinery/door/unpowered/simple/wood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oco" = (
 /obj/item/part/gun/frame/kalash,
 /turf/simulated/floor/asteroid/grass,
@@ -13891,10 +13917,6 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"odl" = (
-/obj/structure/bed/chair/comfy,
-/turf/simulated/floor/wood,
-/area/asteroid/rogue)
 "odw" = (
 /obj/structure/flora/small/busha1,
 /obj/random/traps,
@@ -13958,6 +13980,11 @@
 /obj/structure/flora/small/bushc1,
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/meadow)
+"ofK" = (
+/obj/machinery/door/airlock/centcom,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ofO" = (
 /obj/structure/flora/small/bushb3,
 /obj/structure/flora/big/bush3,
@@ -14062,6 +14089,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"ojC" = (
+/obj/item/mine/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ojS" = (
 /obj/item/emp_mine/armed,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -14103,6 +14134,10 @@
 /obj/structure/salvageable/autolathe,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"olN" = (
+/obj/item/part/gun/frame/vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "omd" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/small/bushc2,
@@ -14147,10 +14182,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"ooY" = (
-/obj/structure/salvageable/implant_container_os,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "oph" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
@@ -14221,6 +14252,10 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"osM" = (
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "osT" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -14267,8 +14302,7 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
 "ouu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/liquidfood,
+/obj/random/dungeon_gun_ballistic,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "ovb" = (
@@ -14309,6 +14343,14 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"owt" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/item/trash/mre_candy,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "owF" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -14340,10 +14382,6 @@
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"oxW" = (
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "oxY" = (
 /obj/structure/table/rack/shelf,
 /obj/random/gun_cheap,
@@ -14394,10 +14432,6 @@
 /obj/structure/flora/big/bush1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"oAi" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "oAK" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
@@ -14475,6 +14509,11 @@
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"oDU" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oEv" = (
 /obj/machinery/button/remote/airlock{
 	dir = 8;
@@ -14513,6 +14552,10 @@
 /obj/random/pack/cloth,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"oFk" = (
+/obj/random/scrap/dense_weighted,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oFC" = (
 /obj/random/lathe_disk/advanced,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -14605,6 +14648,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"oKr" = (
+/obj/structure/sign/departmentold/medical2,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "oKx" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/white,
@@ -14786,11 +14833,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
-"oRO" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "oSf" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha1,
@@ -14803,8 +14845,10 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "oSA" = (
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/rock/dark,
 /area/asteroid/rogue)
 "oSD" = (
 /obj/random/pack/junk_machine,
@@ -14919,6 +14963,12 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"oWB" = (
+/obj/random/mecha/damaged/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mech_recharger,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oWV" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/reagent_dispensers/fueltank,
@@ -14932,6 +14982,11 @@
 /obj/structure/sign/levels/stairsdown,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
+"oXO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/hypospray/autoinjector/drugs,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oYe" = (
 /obj/machinery/light{
 	dir = 8;
@@ -14997,10 +15052,6 @@
 /obj/random/closet_tech,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"pbT" = (
-/obj/machinery/suit_storage_unit/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pbZ" = (
 /obj/structure/table/rack/shelf,
 /obj/random/dungeon_gun_mods/low_chance,
@@ -15018,15 +15069,9 @@
 /obj/structure/flora/small/bushc1,
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"pdb" = (
-/obj/effect/decal/cleanable/dirt,
+"pdh" = (
+/obj/structure/sign/warning/lethal_turrets,
 /turf/simulated/wall,
-/area/asteroid/rogue)
-"pdI" = (
-/obj/structure/closet/crate/excelsior,
-/obj/random/surgery_tool/low_chance,
-/obj/item/tool/saw/circular/medical,
-/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "peq" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
@@ -15053,16 +15098,17 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"pfV" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/bear/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pgh" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	name = "General Containment"
 	},
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/nadezhda/dungeon/outside/zoo)
-"pgp" = (
-/obj/structure/reagent_dispensers/fueltank/derelict,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pgD" = (
 /obj/structure/bed/double/padded,
 /obj/random/furniture/bedsheetdouble,
@@ -15073,6 +15119,10 @@
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"phk" = (
+/obj/structure/coatrack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pit" = (
 /obj/structure/multiz/ladder,
 /turf/simulated/floor/asteroid/grass,
@@ -15195,6 +15245,14 @@
 /obj/random/cluster/spiders/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"plG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/psych{
+	desc = "It can be a bit noisy, but still serves well.";
+	name = "old bed"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "plK" = (
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
@@ -15243,6 +15301,12 @@
 /obj/random/credits/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"pnU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pnV" = (
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -15306,10 +15370,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"prj" = (
-/obj/structure/coatrack,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "prT" = (
 /obj/structure/multiz/ladder,
 /obj/structure/flora/small/bushb2,
@@ -15328,6 +15388,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"ptw" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "pty" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -15358,6 +15422,10 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"pve" = (
+/obj/structure/sign/directions/medical,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "pvh" = (
 /obj/structure/table/rack,
 /obj/item/tool/hammer/dumbbell,
@@ -15450,9 +15518,15 @@
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"pAw" = (
-/obj/item/implantcase/excelsior/broken,
-/obj/structure/table/rack,
+"pAv" = (
+/obj/structure/closet/crate/excelsior,
+/obj/item/tool/baton/excelbaton,
+/obj/item/tool/baton/excelbaton,
+/obj/item/clothing/suit/space/void/excelsior,
+/obj/item/clothing/head/helmet/space/void/excelsior,
+/obj/random/melee/low_chance,
+/obj/item/gun/projectile/automatic/drozd,
+/obj/item/gun/projectile/automatic/drozd,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "pAx" = (
@@ -15464,11 +15538,22 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"pAW" = (
+/obj/machinery/door/airlock/centcom,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/mine/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pBb" = (
 /obj/structure/table/onestar,
 /obj/structure/salvageable/implant_container_os,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"pBg" = (
+/obj/structure/scrap_cube,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pBC" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/big/bush2,
@@ -15536,6 +15621,11 @@
 /obj/item/mine_old,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"pFf" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pFJ" = (
 /obj/machinery/power/solar_control,
 /obj/structure/cable{
@@ -15562,11 +15652,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"pGB" = (
-/obj/random/lowkeyrandom/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pGH" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -15584,6 +15669,13 @@
 /obj/machinery/vending/fitness,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"pHI" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/item/trash/mre_candy,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pHN" = (
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -15605,12 +15697,6 @@
 	icon_state = "3,7"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"pHY" = (
-/obj/structure/closet/crate/excelsior,
-/obj/item/gun/projectile/automatic/ak47/saiga,
-/obj/item/gun/projectile/automatic/ak47/saiga,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pIe" = (
 /obj/effect/decal/mecha_wreckage/ripley,
 /obj/item/material/shard/shrapnel/scrap,
@@ -15654,6 +15740,11 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"pJu" = (
+/obj/effect/decal/cleanable/filth,
+/obj/item/trash/mre_can,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pJz" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
@@ -15678,6 +15769,12 @@
 /obj/structure/flora/small/grassb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"pKF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pKQ" = (
 /turf/simulated/shuttle/wall/cargo{
 	icon_state = "cargoshwall27";
@@ -15727,6 +15824,12 @@
 /obj/random/pack/junk_machine,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"pMT" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/rubble,
+/obj/item/bedsheet,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pMY" = (
 /obj/item/contraband/poster/placed/generic/fruit_bowl{
 	pixel_y = 32
@@ -15746,6 +15849,11 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
+"pNG" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/obj/structure/curtain/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pNN" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -15834,16 +15942,6 @@
 /obj/item/secbot_assembly/ed209_assembly,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"pQJ" = (
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo,
-/obj/random/ammo/low_chance,
-/obj/random/ammo/low_chance,
-/obj/item/ammo_magazine/ammobox/antim_small,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "pRb" = (
 /obj/random/junk,
 /obj/item/mine_old,
@@ -15977,6 +16075,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"pXi" = (
+/obj/structure/curtain/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "pXj" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/random/gun_normal,
@@ -16102,6 +16204,12 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"qcp" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/plate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qdm" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/excelsior/mixed{
@@ -16195,7 +16303,12 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "qhe" = (
-/obj/item/mine/excelsior,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/ammo/shotgun,
+/obj/random/ammo/shotgun/low_chance,
+/obj/random/ammo/shotgun/low_chance,
+/obj/random/ammo_fancy,
+/obj/random/ammo_fancy,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "qhr" = (
@@ -16209,11 +16322,6 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"qhz" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "qhG" = (
 /obj/structure/table/woodentable,
 /obj/random/knife,
@@ -16316,10 +16424,6 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
-"qms" = (
-/obj/landmark/corpse/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "qmu" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -16331,6 +16435,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"qmN" = (
+/obj/machinery/shieldwallgen/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qmO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/drone_fabricator,
@@ -16455,19 +16563,27 @@
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"qvg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qvn" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
-"qvx" = (
-/obj/machinery/vending/engineering,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "qvJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/pack/junk_machine,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"qvM" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qwo" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
@@ -16556,14 +16672,15 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"qzQ" = (
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "qzS" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/small/bushc1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"qzT" = (
+/obj/machinery/vending/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qAS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -16640,11 +16757,6 @@
 	icon_state = "9,23"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"qDw" = (
-/obj/machinery/door/airlock/centcom,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "qDA" = (
 /turf/simulated/floor/asteroid/grass/sif,
 /area/nadezhda/dungeon/outside/zoo)
@@ -16661,10 +16773,6 @@
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"qDZ" = (
-/obj/item/trash/syndi_cakes,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "qEm" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 2
@@ -16720,6 +16828,12 @@
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"qGH" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/obj/item/trash/popcorn,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qGS" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/flora/small/bushc3,
@@ -16728,20 +16842,15 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"qHe" = (
+/obj/structure/table/standard,
+/obj/random/surgery_tool,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qHh" = (
 /obj/random/cluster/roaches,
 /turf/simulated/floor/tiled,
 /area/nadezhda/dungeon/outside/zoo)
-"qHi" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/obj/item/reagent_containers/food/snacks/toastedsandwich,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "qHj" = (
 /obj/structure/closet/crate/serbcrate,
 /obj/random/powercell/medium_safe,
@@ -16783,6 +16892,10 @@
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"qJt" = (
+/obj/structure/sign/warning/armory/small,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "qJD" = (
 /obj/random/junk,
 /obj/random/junk,
@@ -16897,6 +17010,10 @@
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/zoo)
+"qPt" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qPO" = (
 /obj/structure/table/rack/shelf,
 /obj/random/medical,
@@ -16971,6 +17088,15 @@
 "qTf" = (
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"qTm" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/item/mine/excelsior,
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "qTv" = (
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood/wild5,
@@ -17207,6 +17333,12 @@
 /obj/structure/reagent_dispensers/bidon/advanced,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper)
+"reX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rfd" = (
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -17229,6 +17361,11 @@
 "rgE" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"rgT" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rgX" = (
 /obj/random/techpart/low_chance,
 /obj/random/closet_maintloot,
@@ -17261,6 +17398,10 @@
 /obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"riv" = (
+/obj/item/storage/fancy/vials,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "riD" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17294,12 +17435,6 @@
 /obj/structure/scrap_cube,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"rlk" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre_candy,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rlt" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -17427,11 +17562,6 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
-"rrt" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rrP" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 24
@@ -17557,6 +17687,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"rww" = (
+/obj/structure/reagent_dispensers/fueltank/derelict,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rxy" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -17598,6 +17732,14 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"rAJ" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rAV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
@@ -17689,6 +17831,14 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"rEF" = (
+/obj/item/book/manualshield_generator_guide,
+/obj/item/cell/large/excelsior,
+/obj/item/cell/large/excelsior,
+/obj/structure/table/standard,
+/obj/item/part/gun/frame/basilisk,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rEO" = (
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "prepperdoorinternal";
@@ -17822,12 +17972,6 @@
 /obj/structure/salvageable/data,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"rOh" = (
-/obj/machinery/door/airlock/centcom,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/mine/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rOo" = (
 /obj/random/cluster/roaches,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -17843,10 +17987,6 @@
 /obj/item/implant/excelsior/broken,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"rPh" = (
-/obj/random/oddity_guns,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rPB" = (
 /obj/random/mob/hakhma/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -17913,6 +18053,13 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"rRO" = (
+/obj/structure/table/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/gun_parts,
+/obj/item/gun_upgrade/barrel/faulty,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "rSp" = (
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -17949,12 +18096,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"rUp" = (
-/obj/structure/table/woodentable,
-/obj/item/clothing/under/excelsior/officer,
-/obj/item/clothing/head/exceslior/excelsior_officer,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rUt" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -17970,9 +18111,9 @@
 /obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"rWt" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/table/marble,
+"rVZ" = (
+/obj/item/mine/excelsior,
+/obj/item/trash/material/metal,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "rWz" = (
@@ -17989,11 +18130,6 @@
 /obj/effect/decal/cleanable/rubble,
 /mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
-"rWN" = (
-/mob/living/simple_animal/hostile/diyaab,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "rXh" = (
 /obj/structure/catwalk,
@@ -18012,11 +18148,6 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
-"rXG" = (
-/obj/random/lowkeyrandom,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "rYj" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/tool/shovel/improvised,
@@ -18060,10 +18191,6 @@
 /obj/effect/window_lwall_spawn/smartspawn/onestar,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
-"saF" = (
-/obj/random/scrap,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "saY" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/beakers,
@@ -18087,6 +18214,12 @@
 /obj/random/turret,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
+"scg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "scK" = (
 /obj/item/tank/onestar_regenerator,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -18260,10 +18393,10 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"sjT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/sosjerky,
-/turf/simulated/floor/tiled/dark,
+"sjS" = (
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/wood,
 /area/asteroid/rogue)
 "skv" = (
 /obj/random/scrap/sparse_weighted,
@@ -18327,6 +18460,11 @@
 /obj/random/junkfood,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"snc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/peachcan,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sns" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
@@ -18367,15 +18505,6 @@
 /obj/structure/salvageable/implant_container_os,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"spr" = (
-/obj/structure/scrap_cube,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"spJ" = (
-/obj/structure/bookcase/manuals/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "sqo" = (
 /turf/simulated/shuttle/wall/cargo{
 	icon_state = "cargoshwall33";
@@ -18413,6 +18542,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"srt" = (
+/obj/random/lowkeyrandom/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "srB" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/undergroundmob/low_chance,
@@ -18424,6 +18559,15 @@
 	},
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"ssO" = (
+/obj/structure/table/rack,
+/obj/item/gun/projectile/automatic/vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"ssP" = (
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "stb" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable{
@@ -18433,6 +18577,10 @@
 /obj/machinery/power/port_gen/pacman/diesel/anchored,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
+"stv" = (
+/obj/item/mine/excelsior,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "stz" = (
 /obj/random/traps,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -18443,10 +18591,6 @@
 	tag = "icon-cargoshwall18"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
-"sub" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "sur" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -18470,6 +18614,13 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"suV" = (
+/obj/item/gun/projectile/rpg,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "suZ" = (
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -18534,14 +18685,6 @@
 "sxn" = (
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/zoo)
-"sxM" = (
-/obj/item/trash/mre_paste,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"sxQ" = (
-/obj/structure/flora/small/grassa5,
-/turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
 "sxS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -18583,6 +18726,9 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"sBI" = (
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "sBS" = (
 /obj/machinery/cryopod{
 	dir = 4;
@@ -18634,9 +18780,8 @@
 /obj/random/traps,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"sDY" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/rubble,
+"sEk" = (
+/obj/random/scrap,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "sEK" = (
@@ -18742,6 +18887,10 @@
 "sLf" = (
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"sLE" = (
+/mob/living/simple_animal/hostile/scarybat,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "sLV" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 2;
@@ -18779,6 +18928,10 @@
 /obj/random/closet_tech,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"sNe" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sNA" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -18826,11 +18979,6 @@
 "sPa" = (
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
-"sPh" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/item/trash/icecreambowl,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "sPt" = (
 /obj/structure/table/rack,
 /obj/item/stack/ore/plasma,
@@ -18848,11 +18996,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"sQl" = (
-/obj/structure/table/rack,
-/obj/item/gun/energy/stunrevolver,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "sQm" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/prepper)
@@ -18928,6 +19071,14 @@
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"sUx" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sUP" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/random/mob/voidwolf/low_chance,
@@ -18990,6 +19141,13 @@
 /obj/machinery/door/airlock/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"sZH" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sZV" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/wood/wild4,
@@ -19103,11 +19261,6 @@
 "tgh" = (
 /turf/simulated/floor/rock/manmade/concrete,
 /area/nadezhda/outside/meadow)
-"tgk" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tgr" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/trash,
@@ -19187,12 +19340,6 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"tjF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank/huge/derelict,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tjP" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/big/bush3,
@@ -19202,16 +19349,6 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
-"tkq" = (
-/obj/structure/table/rack,
-/obj/effect/decal/cleanable/filth,
-/obj/item/gun_upgrade/trigger/boom,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"tkE" = (
-/obj/structure/scrap/medical/large,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tkN" = (
 /obj/structure/table/standard,
 /obj/structure/window/reinforced{
@@ -19238,6 +19375,11 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"tlD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tlO" = (
 /obj/structure/closet/onestar/tier3/special,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -19271,6 +19413,11 @@
 /obj/item/frame/apc,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"tnz" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/trash/icecreambowl,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "tnY" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/wood/wild5,
@@ -19308,6 +19455,11 @@
 /obj/random/tool_upgrade/rare,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
+"tqb" = (
+/obj/item/flame/lighter/zippo/excelsior,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tqA" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/claymore,
@@ -19356,6 +19508,10 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/zoo)
+"ttU" = (
+/obj/machinery/autodoc,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tuo" = (
 /obj/item/folder/red,
 /obj/item/folder/red,
@@ -19406,19 +19562,15 @@
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
-"txA" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "txD" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/simulated/floor/wood_old,
 /area/colony/exposedsun/crashed_shop/outsider)
-"txM" = (
-/obj/machinery/porta_turret/excelsior/preloaded,
+"tyf" = (
+/obj/effect/decal/cleanable/generic,
+/obj/item/trash/mre,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "tyi" = (
@@ -19439,6 +19591,12 @@
 /obj/item/storage/firstaid,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
+"tyL" = (
+/obj/structure/closet/crate/excelsior,
+/obj/random/surgery_tool/low_chance,
+/obj/item/tool/saw/circular/medical,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tyW" = (
 /obj/machinery/light{
 	dir = 4;
@@ -19446,13 +19604,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"tyY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tzf" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall14";
@@ -19480,24 +19631,11 @@
 /obj/random/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"tzP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tzX" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"tAb" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/obj/random/medical,
-/obj/item/storage/firstaid,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tAp" = (
 /turf/simulated/wall,
 /area/nadezhda/dungeon/outside/zoo)
@@ -19519,6 +19657,11 @@
 /mob/living/simple_animal/tindalos,
 /turf/simulated/floor/asteroid/grass/colonialjungle1,
 /area/nadezhda/dungeon/outside/zoo)
+"tBs" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/projectile/boltgun,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tCf" = (
 /obj/structure/table/standard,
 /obj/random/gun_energy_cheap,
@@ -19528,6 +19671,10 @@
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"tCZ" = (
+/obj/structure/sign/faction/excelsior_old,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "tDb" = (
 /obj/random/mob/undergroundmob,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -19609,10 +19756,12 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"tIh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/structure/table/bench/standard,
+"tIm" = (
+/obj/structure/scrap_cube,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "tIC" = (
@@ -19645,11 +19794,6 @@
 	},
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
-"tJo" = (
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tJR" = (
 /obj/item/folder,
 /obj/item/folder,
@@ -19761,10 +19905,6 @@
 /obj/item/remains/human,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"tOK" = (
-/obj/structure/sign/faction/excelsior_old,
-/turf/simulated/wall,
-/area/asteroid/rogue)
 "tPs" = (
 /obj/item/material/shard,
 /turf/simulated/floor/tiled/white,
@@ -19785,6 +19925,10 @@
 /obj/structure/flora/small/busha3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"tQp" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tQt" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/carpet,
@@ -19849,8 +19993,9 @@
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"tUw" = (
-/obj/item/gun/projectile/makarov/preloaded,
+"tTP" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "tUH" = (
@@ -19858,15 +20003,6 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"tUM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/clothing/shoes/jackboots/janitor,
-/obj/structure/closet/l3closet/janitor,
-/obj/item/toy/figure/character/civilian/janitor,
-/obj/item/clothing/under/rank/janitor,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tUY" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/food/condiment/sugar,
@@ -19906,16 +20042,16 @@
 /obj/machinery/porta_turret/prepper,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"tWQ" = (
+/obj/item/implantcase/excelsior/broken,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "tWY" = (
 /obj/structure/table/onestar,
 /obj/item/stock_parts/manipulator/one_star,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"tXl" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/mre/alt,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "tXm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/multi_tile/metal{
@@ -19950,11 +20086,6 @@
 /obj/structure/scrap/guns/large,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"tYx" = (
-/mob/living/carbon/superior_animal/human/excelsior,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "tZg" = (
 /obj/random/mob/vox,
 /turf/simulated/floor/asteroid/grass,
@@ -19994,11 +20125,6 @@
 /obj/random/rations,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
-"uau" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/random/traps/low_chance,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/asteroid/rogue)
 "uaW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20007,6 +20133,11 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"ubp" = (
+/obj/random/scrap/dense_weighted,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ubu" = (
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood/wild5,
@@ -20047,6 +20178,11 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/zoo)
+"ucC" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "udc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/guns/large,
@@ -20074,10 +20210,23 @@
 /obj/item/ammo_casing/pistol_35/scrap/prespawned,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"uea" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank/huge/derelict,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uec" = (
 /obj/structure/flora/tree/dead,
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/one_star)
+"uep" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/item/tool/sword/saber,
+/obj/effect/decal/cleanable/blood,
+/obj/landmark/corpse/chef,
+/mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ueX" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/enzyme,
@@ -20176,11 +20325,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/safehouse)
-"ule" = (
-/obj/random/lowkeyrandom,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ulg" = (
 /obj/structure/table/onestar,
 /obj/structure/window/reinforced{
@@ -20225,6 +20369,10 @@
 /obj/structure/closet/onestar/tier3/medical,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
+"umz" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "umG" = (
 /obj/machinery/light,
 /turf/simulated/floor/asteroid/grass,
@@ -20240,11 +20388,6 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"umT" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "unD" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
@@ -20367,9 +20510,8 @@
 /obj/structure/reagent_dispensers/fueltank/huge,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"utQ" = (
-/mob/living/carbon/superior_animal/human/excelsior,
-/obj/effect/decal/cleanable/rubble,
+"utC" = (
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "utY" = (
@@ -20453,6 +20595,12 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/asteroid/rogue)
+"uyY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank/huge/derelict,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uzt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/remains/human,
@@ -20511,11 +20659,6 @@
 /mob/living/simple_animal/hostile/samak,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
-"uBC" = (
-/obj/structure/table/standard,
-/obj/random/surgery_tool,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "uBW" = (
 /obj/structure/railing/grey{
 	dir = 1;
@@ -20530,6 +20673,11 @@
 /obj/structure/railing/grey,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
+"uCn" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "uCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures,
@@ -20556,10 +20704,21 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/wood/wild5,
 /area/asteroid/rogue)
+"uDS" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uDY" = (
 /obj/structure/girder,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"uEi" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uEq" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
@@ -20675,9 +20834,11 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "uIZ" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/projectile/boltgun,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/wall/r_wall,
 /area/asteroid/rogue)
 "uJw" = (
 /turf/simulated/wall/wood_old,
@@ -20695,6 +20856,10 @@
 /obj/structure/flora/small/busha3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"uJW" = (
+/obj/item/trash/mre,
+/turf/simulated/wall/r_wall,
+/area/asteroid/rogue)
 "uKY" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/wood/wild4,
@@ -20749,15 +20914,6 @@
 /obj/random/lathe_disk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"uMy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "uMB" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/cafe,
@@ -20788,6 +20944,12 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"uOI" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/item/storage/firstaid/combat,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "uON" = (
 /obj/machinery/gym,
@@ -20973,6 +21135,16 @@
 /obj/random/common_oddities,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"uWs" = (
+/obj/item/gun/projectile/colt,
+/obj/item/ammo_kit,
+/obj/random/scrap,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"uWM" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "uXk" = (
 /obj/structure/flora/small/busha3,
 /obj/random/mob/vox/low_chance,
@@ -20994,10 +21166,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"uYg" = (
-/mob/living/simple_animal/hostile/megafauna/excelsior_cosmonaught,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vag" = (
 /obj/structure/flora/small/grassa4,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -21070,10 +21238,6 @@
 /obj/random/cloth/helmet,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"vdu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "vdy" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/asteroid/grass,
@@ -21147,10 +21311,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"vgl" = (
-/obj/random/scrap/dense_weighted,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vgW" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -21179,12 +21339,6 @@
 /obj/item/oddity/common/old_money,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
-"vhQ" = (
-/obj/structure/scrap_cube,
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vhR" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
@@ -21223,6 +21377,10 @@
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
+"vjc" = (
+/obj/structure/sign/departmentold/janitorial,
+/turf/simulated/wall,
+/area/asteroid/rogue)
 "vjy" = (
 /obj/structure/flora/small/bushb3,
 /obj/structure/flora/tree/jungle_small/variant3,
@@ -21248,9 +21406,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
-"vkJ" = (
-/obj/machinery/suit_storage_unit/excelsior,
-/obj/effect/decal/cleanable/cobweb2,
+"vkM" = (
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "spiderling";
+	name = "dead spider"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "vkQ" = (
@@ -21317,9 +21477,14 @@
 /obj/item/material/shard/shrapnel,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"vnV" = (
-/obj/structure/table/marble,
-/obj/item/storage/pouch/ammo,
+"vnE" = (
+/obj/effect/decal/cleanable/cobweb2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "spiderling";
+	name = "dead spider"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "vom" = (
@@ -21332,11 +21497,6 @@
 /obj/item/ammo_casing/flare/prespawn,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/dungeon/outside/prepper)
-"voR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "voT" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -21403,6 +21563,11 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"vqZ" = (
+/obj/machinery/door/airlock/centcom,
+/obj/item/mine/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vto" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/plating/under,
@@ -21471,10 +21636,6 @@
 /obj/machinery/door/airlock/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"vxP" = (
-/obj/structure/salvageable/computer_os,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vyy" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/contraband/low_chance,
@@ -21482,12 +21643,6 @@
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/zoo)
-"vyI" = (
-/obj/item/mine/excelsior,
-/obj/effect/decal/cleanable/generic,
-/obj/random/scrap/sparse_even/low_chance,
-/turf/simulated/floor/rock/dark,
-/area/asteroid/rogue)
 "vyL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -21518,10 +21673,6 @@
 /obj/item/device/synthesized_instrument/trumpet,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"vAm" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vAu" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/steel/danger,
@@ -21551,6 +21702,11 @@
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"vBH" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vBO" = (
 /obj/random/junk/nondense,
 /turf/simulated/floor/tiled/dark,
@@ -21563,10 +21719,6 @@
 /obj/item/mine_old,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"vBX" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vCx" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/medical,
@@ -21633,6 +21785,11 @@
 /obj/effect/step_trigger/vault_bunker_1H,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
+"vEb" = (
+/obj/random/lowkeyrandom/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vEk" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/asteroid/grass,
@@ -21668,6 +21825,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/colony/exposedsun/crashed_shop/outsider)
+"vHs" = (
+/obj/landmark/corpse/excelsior,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vHF" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -21676,6 +21837,10 @@
 /obj/structure/sign/department/operational,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper)
+"vHY" = (
+/obj/machinery/door/airlock,
+/turf/space,
+/area/asteroid/rogue)
 "vIA" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/flora/small/busha2,
@@ -21704,6 +21869,10 @@
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"vJM" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vJQ" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -21735,6 +21904,13 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"vLG" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/item/trash/mre/alt,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "vLX" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -21754,12 +21930,6 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"vMv" = (
-/obj/structure/scrap_cube,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "vMR" = (
 /obj/structure/cable/ender{
 	id = "preppergrid"
@@ -22039,6 +22209,11 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"vZw" = (
+/obj/item/rcd/excelsior,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "vZC" = (
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/dark,
@@ -22052,10 +22227,6 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/item/mine_old,
 /turf/simulated/floor/wood/wild5,
-/area/asteroid/rogue)
-"vZU" = (
-/obj/structure/flora/small/grassb2,
-/turf/simulated/floor/asteroid/grass,
 /area/asteroid/rogue)
 "vZZ" = (
 /obj/random/mob/voidwolf/low_chance,
@@ -22074,10 +22245,6 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
-"waE" = (
-/obj/structure/medical_stand,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wbq" = (
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
@@ -22086,12 +22253,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"wbG" = (
-/obj/item/mine/excelsior,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/pistachios,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wbJ" = (
 /obj/landmark/join/start/outsider,
 /obj/structure/bed/chair,
@@ -22102,20 +22263,10 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
-"wcn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/plate,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wcv" = (
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/one_star)
-"wcB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap/dense_weighted,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wcP" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/item/clothing/head/hairflower,
@@ -22257,11 +22408,6 @@
 /obj/random/traps/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"wlq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/mre/os,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wlE" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/railing,
@@ -22288,6 +22434,11 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"wmo" = (
+/obj/structure/table/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wmE" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -22297,6 +22448,10 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"wnh" = (
+/obj/random/lowkeyrandom,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wnI" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -22322,16 +22477,16 @@
 "woQ" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
+"woR" = (
+/obj/structure/bed/psych{
+	desc = "It can be a bit noisy, but still serves well.";
+	name = "old bed"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wpR" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/zoo)
-"wpT" = (
-/obj/structure/table/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/gun_parts,
-/obj/item/gun_upgrade/barrel/faulty,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wqj" = (
 /obj/structure/table/standard,
 /obj/machinery/centrifuge,
@@ -22344,6 +22499,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"wqu" = (
+/obj/structure/bed/chair/comfy,
+/turf/simulated/floor/wood,
+/area/asteroid/rogue)
 "wre" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "5,20"
@@ -22392,6 +22551,11 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"wsW" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/candle,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wsZ" = (
 /obj/machinery/door/airlock/vault/bolted{
 	req_access = list(999)
@@ -22404,16 +22568,18 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"wti" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wtv" = (
 /obj/structure/flora/small/bushc3,
 /obj/structure/flora/small/bushc3,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"wtC" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wtL" = (
 /obj/structure/flora/small/grassb1,
 /obj/structure/flora/small/busha1,
@@ -22425,11 +22591,6 @@
 /obj/item/material/shard,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/zoo)
-"wuG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wuT" = (
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/techmaint_cargo,
@@ -22438,11 +22599,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"wvG" = (
-/obj/item/gun/projectile/colt,
-/obj/item/ammo_kit,
-/obj/random/scrap,
-/turf/simulated/floor/asteroid/dirt/dark,
+"wvi" = (
+/obj/structure/table/rack,
+/obj/item/gun/energy/stunrevolver,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"wvJ" = (
+/obj/item/trash/material/circuit,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "wvW" = (
 /obj/structure/table,
@@ -22496,11 +22660,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"wxX" = (
-/obj/item/mine/excelsior,
-/obj/item/trash/tray,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wyk" = (
 /obj/item/material/shard/shrapnel/scrap,
 /obj/random/junk,
@@ -22509,11 +22668,19 @@
 "wyl" = (
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"wzc" = (
+/obj/landmark/corpse/excelsior,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "wzn" = (
 /obj/structure/table/onestar,
 /obj/item/storage/fancy/cigarettes/khi,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"wzO" = (
+/obj/random/traps/low_chance,
+/turf/simulated/floor/rock/grey,
+/area/asteroid/rogue)
 "wAd" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/big/bush2,
@@ -22592,6 +22759,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"wEw" = (
+/obj/structure/salvageable/console_broken_os,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "wEV" = (
 /obj/item/trash/mre_paste,
 /obj/effect/decal/cleanable/filth,
@@ -22643,10 +22817,6 @@
 /obj/item/material/shard,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
-"wGs" = (
-/obj/structure/curtain/medical,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wGX" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
@@ -22860,6 +23030,10 @@
 /obj/item/beartrap/armed,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"wRP" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/rock/dark,
+/area/asteroid/rogue)
 "wRZ" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -22875,6 +23049,9 @@
 /obj/item/tool/multitool,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"wSZ" = (
+/turf/simulated/floor/asteroid/grass,
+/area/asteroid/rogue)
 "wTe" = (
 /mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -22945,10 +23122,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
-"wXp" = (
-/obj/item/flame/lighter/zippo/excelsior,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/tiled/dark,
+"wXs" = (
+/obj/effect/decal/cleanable/rubble,
+/mob/living/simple_animal/hostile/scarybat,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
 "wXx" = (
 /obj/structure/cable{
@@ -22964,11 +23141,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"wYh" = (
-/obj/structure/curtain/medical,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wYx" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushb2,
@@ -22988,11 +23160,6 @@
 /obj/random/cloth/armor,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
-"wZi" = (
-/obj/machinery/cooking_with_jane/grill,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "wZn" = (
 /obj/machinery/light/floor{
 	pixel_y = -7
@@ -23015,14 +23182,19 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/asteroid/rogue)
 "wZW" = (
-/mob/living/carbon/superior_animal/human/excelsior,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/sign/painting/russianstalin,
+/turf/simulated/wall/r_wall,
 /area/asteroid/rogue)
 "xai" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/crashed_shop/outsider)
+"xav" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xbq" = (
 /obj/random/lathe_disk,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -23061,6 +23233,10 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"xcF" = (
+/obj/item/trash/mre_paste,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xdH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mat_katana,
@@ -23086,11 +23262,6 @@
 /obj/random/material_resources,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
-"xem" = (
-/obj/machinery/door/airlock/centcom,
-/obj/item/mine/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xen" = (
 /obj/random/oddity_guns,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -23154,12 +23325,6 @@
 /obj/machinery/power/port_gen/pacman/diesel/anchored,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
-"xfH" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xgb" = (
 /obj/structure/flora/big/bush2,
 /turf/unsimulated/wall/jungle,
@@ -23198,6 +23363,12 @@
 "xhC" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/colony/exposedsun/pastgate)
+"xhW" = (
+/obj/structure/table/woodentable,
+/obj/item/clothing/under/excelsior/officer,
+/obj/item/clothing/head/exceslior/excelsior_officer,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xhY" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -23295,12 +23466,6 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
-"xlQ" = (
-/obj/random/mecha/damaged/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mech_recharger,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xmn" = (
 /obj/structure/table/standard,
 /obj/random/medical,
@@ -23324,6 +23489,11 @@
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"xmM" = (
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xnX" = (
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/grass,
@@ -23335,11 +23505,6 @@
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
-"xoD" = (
-/obj/random/lowkeyrandom/low_chance,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xpA" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -23391,10 +23556,6 @@
 /obj/random/pack/tech_loot,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
-"xrw" = (
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xrG" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark/danger,
@@ -23414,17 +23575,9 @@
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"xtu" = (
-/obj/structure/closet/crate/excelsior,
-/obj/item/rcd/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"xtS" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/port_gen/pacman/diesel/anchored,
+"xty" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "xtX" = (
@@ -23451,6 +23604,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"xvh" = (
+/obj/random/oddity_guns,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xvi" = (
 /obj/item/pizzabox/vegetable,
 /obj/random/boxes,
@@ -23544,11 +23701,6 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
-"xzo" = (
-/obj/item/mine/excelsior,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xzW" = (
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
@@ -23569,6 +23721,12 @@
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
+"xBs" = (
+/obj/structure/scrap_cube,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xBx" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 2
@@ -23582,6 +23740,15 @@
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"xCH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xDd" = (
 /obj/effect/step_trigger/vault_bunker_2B,
 /turf/simulated/floor/tiled/dark/danger,
@@ -23653,11 +23820,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"xHj" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/human/excelsior,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xHm" = (
 /obj/item/remains/deer,
 /turf/simulated/floor/asteroid/dirt,
@@ -23722,11 +23884,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"xKz" = (
-/obj/effect/decal/cleanable/filth,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xKB" = (
 /obj/item/stack/rods/random,
 /obj/item/stack/rods/random,
@@ -23780,11 +23937,6 @@
 /obj/random/junkfood,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
-"xNo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/hypospray/autoinjector/drugs,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xNp" = (
 /obj/structure/table/rack/shelf,
 /obj/random/pouch/low_chance,
@@ -23803,6 +23955,11 @@
 /obj/item/stock_parts/capacitor/one_star,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"xNJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xOk" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/busha1,
@@ -23838,11 +23995,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
-"xPI" = (
-/obj/random/scrap/dense_weighted,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xPO" = (
 /obj/structure/table/standard,
 /obj/item/oddity/common/towel,
@@ -23862,8 +24014,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/safehouse)
-"xQs" = (
-/obj/effect/decal/cleanable/rubble,
+"xQf" = (
+/obj/item/trash/cigbutt/fortress,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "xQu" = (
@@ -23876,6 +24029,10 @@
 /obj/structure/salvageable/server_os,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"xRl" = (
+/mob/living/simple_animal/hostile/bear/excelsior,
+/turf/simulated/mineral/random/rogue,
+/area/asteroid/rogue)
 "xRs" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/paper_bin,
@@ -23886,16 +24043,17 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
-"xSq" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "xSt" = (
 /obj/structure/curtain/open,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"xSJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/sosjerky,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xSP" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -23905,6 +24063,13 @@
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"xTs" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xTu" = (
 /obj/structure/sign/departmentold/medical1,
 /obj/structure/window/reinforced{
@@ -23921,6 +24086,10 @@
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"xTR" = (
+/obj/random/traps/low_chance,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "xUd" = (
 /obj/structure/sign/warning/armory{
 	pixel_x = 30
@@ -23984,6 +24153,11 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"xZn" = (
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "xZx" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/condiment/peppermill,
@@ -24044,6 +24218,12 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
+"ybJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ybU" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/scrap/poor,
@@ -24108,10 +24288,6 @@
 /obj/random/mob/prepper,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"yga" = (
-/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ygc" = (
 /obj/item/tool/pickaxe,
 /obj/item/clothing/head/hardhat,
@@ -24146,6 +24322,10 @@
 /obj/random/surgery_tool,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"yhY" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "yiT" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/tool/advanced,
@@ -24192,28 +24372,12 @@
 /obj/structure/barricade,
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/crashed_shop/outsider)
-"ykj" = (
-/obj/structure/salvageable/data_os,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
-"ykv" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/liquid_fuel,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
 "ykI" = (
 /obj/structure/table/woodentable,
 /obj/random/firstaid,
 /obj/random/scrap,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
-"ylk" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
 "ylq" = (
 /obj/structure/table/steel,
 /obj/item/toy/figure/character/bobblehead/excelsior,
@@ -40133,7 +40297,7 @@ qbU
 qbU
 qbU
 qbU
-asz
+xTR
 euc
 qbU
 euc
@@ -40546,7 +40710,7 @@ qbU
 qbU
 qbU
 qbU
-uau
+fWH
 ugY
 ugY
 ugY
@@ -41608,7 +41772,7 @@ qbU
 qbU
 qbU
 qbU
-asz
+xTR
 qbU
 qbU
 qbU
@@ -41807,10 +41971,10 @@ qbU
 qbU
 euc
 euc
-asz
+xTR
 euc
 ugY
-asz
+xTR
 qbU
 qbU
 qbU
@@ -42012,9 +42176,9 @@ euc
 ugY
 ugY
 ugY
-asz
+xTR
 euc
-kEz
+sLE
 euc
 euc
 qbU
@@ -42217,7 +42381,7 @@ nxY
 qbU
 qbU
 qbU
-uau
+fWH
 qbU
 qbU
 qbU
@@ -42439,7 +42603,7 @@ qbU
 qbU
 qbU
 euc
-asz
+xTR
 euc
 euc
 euc
@@ -43261,7 +43425,7 @@ nxY
 nxY
 qbU
 qbU
-uau
+fWH
 qbU
 qbU
 qbU
@@ -43276,7 +43440,7 @@ qbU
 qbU
 qbU
 qbU
-kEz
+sLE
 euc
 ugY
 qbU
@@ -43679,7 +43843,7 @@ nxY
 nxY
 qbU
 qbU
-hAS
+wXs
 qbU
 qbU
 qbU
@@ -43692,12 +43856,12 @@ euc
 qbU
 qbU
 euc
-dCu
+dLw
 euc
 qbU
 rel
 qkQ
-uau
+fWH
 ugY
 ugY
 ugY
@@ -43895,7 +44059,7 @@ qbU
 qbU
 qbU
 euc
-uau
+fWH
 euc
 qbU
 qbU
@@ -44312,7 +44476,7 @@ qbU
 qbU
 ify
 ify
-ify
+nJw
 rel
 qbU
 qbU
@@ -44329,7 +44493,7 @@ qbU
 qbU
 qbU
 qbU
-uau
+fWH
 qbU
 qbU
 qbU
@@ -44529,7 +44693,7 @@ qbU
 qbU
 qbU
 euc
-kEz
+sLE
 euc
 qbU
 qbU
@@ -44724,7 +44888,7 @@ nxY
 nxY
 qbU
 eCR
-iQf
+wzO
 eCR
 eCR
 eCR
@@ -44735,12 +44899,12 @@ eCR
 eCR
 eCR
 eCR
-iQf
+wzO
 euc
 euc
 qbU
 euc
-asz
+xTR
 euc
 euc
 ugY
@@ -44939,7 +45103,7 @@ qbU
 eCR
 qbU
 qbU
-iQf
+wzO
 eCR
 qbU
 qbU
@@ -45145,7 +45309,7 @@ qbU
 qbU
 qbU
 qbU
-gGp
+djA
 qbU
 qbU
 qbU
@@ -45359,7 +45523,7 @@ qbU
 qbU
 qbU
 uVX
-iBG
+ldM
 uVX
 qbU
 uVX
@@ -45565,14 +45729,14 @@ qbU
 qbU
 uVX
 uVX
-tXl
+vLG
 uVX
 uVX
 qbU
 qbU
 qbU
 uVX
-cct
+bFR
 uVX
 uVX
 dpk
@@ -45789,15 +45953,15 @@ qbU
 qbU
 euc
 euc
-asz
+xTR
 euc
-kEz
+sLE
 euc
 euc
 euc
 qbU
 qbU
-asz
+xTR
 qbU
 qbU
 qbU
@@ -46202,13 +46366,13 @@ qbU
 qbU
 qbU
 uVX
-gGp
+djA
 qbU
 qbU
 qbU
 qbU
 qbU
-foK
+bRR
 euc
 euc
 euc
@@ -46405,7 +46569,7 @@ qbU
 qbU
 qbU
 qbU
-qbU
+xRl
 qbU
 qbU
 qbU
@@ -46614,9 +46778,9 @@ qbU
 qbU
 dpk
 dpk
-uVX
-gGp
-lqA
+iET
+djA
+uCn
 dpk
 dpk
 qbU
@@ -46624,7 +46788,7 @@ qbU
 qbU
 qbU
 qbU
-bTh
+wzc
 euc
 qbU
 qbU
@@ -46632,7 +46796,7 @@ qbU
 qbU
 qbU
 euc
-saF
+bzc
 euc
 qbU
 qbU
@@ -46822,9 +46986,9 @@ qbU
 uVX
 dpk
 uVX
-lEJ
+loq
 qbU
-qbU
+xRl
 qbU
 qbU
 qbU
@@ -46839,7 +47003,7 @@ qbU
 qbU
 qbU
 qbU
-saF
+bzc
 euc
 qbU
 qbU
@@ -47043,10 +47207,10 @@ qbU
 qbU
 qbU
 euc
-saF
+bzc
 euc
-wvG
-saF
+uWs
+bzc
 euc
 qbU
 qbU
@@ -47236,7 +47400,7 @@ qbU
 qbU
 qbU
 uVX
-eGw
+iWS
 qbU
 qbU
 qbU
@@ -47653,10 +47817,10 @@ qbU
 qbU
 qbU
 qbU
-sPh
+tnz
 dpk
-nxb
-nxb
+ptw
+ptw
 dpk
 uVX
 qbU
@@ -47867,7 +48031,7 @@ qbU
 qbU
 qbU
 cKr
-luv
+bTz
 uVX
 coU
 coU
@@ -48076,7 +48240,7 @@ qbU
 qbU
 uVX
 dpk
-dqC
+wRP
 uVX
 coU
 coU
@@ -48283,10 +48447,10 @@ qbU
 qbU
 qbU
 mNA
-vyI
-njB
-uVX
 lEJ
+kcL
+uVX
+bAa
 mNA
 coU
 coU
@@ -48491,12 +48655,12 @@ coU
 coU
 coU
 coU
-tOK
+hwy
+oSA
+wRP
 uVX
-dqC
-uVX
-uVX
-tOK
+gkh
+hwy
 coU
 coU
 coU
@@ -48701,10 +48865,10 @@ rKz
 rKz
 rKz
 mNA
-gQc
-xem
-nBe
-gQc
+pdh
+fsd
+kfA
+pdh
 mNA
 rKz
 rKz
@@ -48905,28 +49069,28 @@ nxY
 coU
 coU
 rKz
-sDY
-bZw
-bZw
-bZw
-mmF
+amr
+hgL
+hgL
+hgL
+qmN
+utC
+jfz
+hgL
+hgL
+qmN
+hgL
+cYh
 bRP
-gCI
-bZw
-bZw
-mmF
-bZw
-wlq
-aii
-erh
+fcB
 rKz
-hQd
-qzQ
-hsJ
-qzQ
-qzQ
-hQd
-qzQ
+aLI
+wSZ
+eas
+wSZ
+wSZ
+aLI
+wSZ
 rKz
 coU
 coU
@@ -49114,28 +49278,28 @@ nxY
 coU
 coU
 qbU
-cYA
-voR
-bFc
-bZw
-bZw
-bZw
-bZw
-wuG
-aii
-bZw
-bZw
-bZw
-aii
-bZw
+jjD
+tlD
+nuE
+hgL
+hgL
+hgL
+hgL
+jva
+bRP
+hgL
+hgL
+hgL
+bRP
+hgL
 rKz
-sxQ
-qzQ
-hQd
-qzQ
-hsJ
-gYz
-qzQ
+hNR
+wSZ
+aLI
+wSZ
+eas
+coO
+wSZ
 rKz
 coU
 coU
@@ -49324,27 +49488,27 @@ coU
 coU
 qbU
 qbU
-utQ
-aii
-bZw
-ddv
-bZw
-wuG
-bZw
-aii
-oRO
-bZw
-wZW
-bZw
-bZw
+lTl
+bRP
+hgL
+xQf
+hgL
+jva
+hgL
+bRP
+pFf
+hgL
+dnC
+hgL
+hgL
 rKz
-qzQ
-hQd
-qzQ
-gKO
-hQd
-qzQ
-qzQ
+eBe
+aLI
+wSZ
+gfM
+aLI
+wSZ
+wSZ
 rKz
 coU
 coU
@@ -49532,28 +49696,28 @@ nxY
 coU
 coU
 rKz
-cYA
-xQs
-dHc
-bZw
-bZw
-bZw
-bZw
-bZw
-bZw
-bZw
-bZw
-bZw
-bZw
-bZw
+jjD
+vJM
+ggb
+hgL
+jnq
+hgL
+hgL
+hgL
+hgL
+jnq
+hgL
+hgL
+hgL
+hgL
 rKz
-qzQ
-qzQ
-sxQ
-qzQ
-qzQ
-qzQ
-hQd
+wSZ
+wSZ
+hNR
+wSZ
+wSZ
+wSZ
+aLI
 rKz
 coU
 coU
@@ -49741,28 +49905,28 @@ nxY
 coU
 coU
 rKz
-bZw
-bZw
-bZw
-qhe
-bZw
+laf
 hgL
-bZw
-bZw
-vAm
-bZw
-bZw
-bZw
-bZw
-aCI
+hgL
+ojC
+hgL
+sUx
+hgL
+hgL
+nZN
+hgL
+hgL
+hgL
+hgL
+wvJ
 rKz
-vZU
-qzQ
-qzQ
-hQd
-hQd
-sxQ
-qzQ
+hmx
+wSZ
+wSZ
+aLI
+aLI
+hNR
+wSZ
 rKz
 coU
 coU
@@ -49950,28 +50114,28 @@ nxY
 coU
 coU
 rKz
-eXK
+aHK
 dpI
-yga
-txM
-vAm
-vAm
-vAm
-vAm
-krP
-uIZ
-bZw
-yga
-bZw
-bZw
+hox
+sNe
+nZN
+nZN
+nZN
+nZN
+wsW
+tBs
+hgL
+hox
+hgL
+hgL
 rKz
-qzQ
-cQZ
-irF
-cQZ
-cQZ
-cQZ
-irF
+wSZ
+glZ
+cOt
+glZ
+glZ
+glZ
+cOt
 rKz
 coU
 coU
@@ -50158,29 +50322,29 @@ nxY
 nxY
 coU
 coU
-fVi
-eXK
-bZw
-bZw
-bZw
-aii
-eCA
-bZw
-bZw
+tCZ
+aHK
+hgL
+hgL
+hgL
+bRP
+gqN
+hgL
+hgL
 tgr
-bZw
-bZw
-bZw
-wuG
-aii
-fVi
-bZw
-bZw
-ahF
-bZw
-aii
-bZw
-bZw
+hgL
+hgL
+hgL
+jva
+bRP
+tCZ
+hgL
+hgL
+avp
+hgL
+bRP
+hgL
+yhY
 rKz
 coU
 coU
@@ -50368,28 +50532,28 @@ nxY
 coU
 coU
 rKz
-bZw
+hgL
+utC
 bRP
-aii
-aii
-bZw
-aii
-wZW
-wZW
-bZw
-bZw
+bRP
+hgL
+bRP
+dnC
+dnC
+hgL
+hgL
 dpI
-bZw
-bRP
-bZw
+hgL
+utC
+hgL
 rKz
-bZw
-gCI
-bZw
-bZw
-rlk
-bZw
-xQs
+hgL
+jfz
+hgL
+hgL
+owt
+hgL
+vJM
 rKz
 coU
 coU
@@ -50577,28 +50741,28 @@ nxY
 coU
 coU
 rKz
-bZw
-aii
-aii
-wuG
-nOv
-bZw
-bZw
-bZw
-bZw
-bZw
+hgL
 bRP
-bZw
-aii
-bZw
+bRP
+jva
+xty
+hgL
+hgL
+hgL
+hgL
+hgL
+utC
+hgL
+bRP
+yhY
 rKz
-qhz
-bZw
-aii
-aii
+rVZ
+hgL
+bRP
+bRP
 dpI
-qms
-gZo
+vHs
+axV
 qbU
 coU
 coU
@@ -50787,8 +50951,8 @@ coU
 coU
 rKz
 mNA
-oAi
-oAi
+tQp
+tQp
 mNA
 mNA
 mNA
@@ -50797,16 +50961,16 @@ mNA
 mNA
 mNA
 mNA
-oAi
-oAi
+tQp
+tQp
 mNA
 rKz
-bZw
-bZw
-bZw
-bZw
-bZw
-xQs
+hgL
+hgL
+hgL
+hgL
+hgL
+vJM
 qbU
 qbU
 coU
@@ -50995,28 +51159,28 @@ nxY
 coU
 coU
 rKz
-bZw
-bZw
-bZw
-bZw
-emV
-bZw
-eCz
-aii
-wcB
-vgl
-bZw
-bZw
-bZw
-bZw
+hgL
+hgL
+hgL
+hgL
+iip
+hgL
+aGn
+bRP
+bHO
+oFk
+hgL
+hgL
+hgL
+hgL
 rKz
-bZw
+hgL
 dpI
-cdz
-bZw
-xQs
-xQs
-gZo
+fqQ
+hgL
+vJM
+vJM
+axV
 qbU
 coU
 coU
@@ -51204,28 +51368,28 @@ nxY
 coU
 coU
 rKz
-aii
-eiY
-bZw
-bZw
-bZw
-bZw
+hOw
+aDy
+jnq
+hgL
+hgL
+hgL
 dpI
-aii
-bZw
-vgl
-bZw
-ail
-bZw
-wZW
+bRP
+hgL
+oFk
+hgL
+cFk
+hgL
+dnC
 rKz
-kuV
-qhe
-bZw
-bZw
-bZw
-bZw
-gZo
+cam
+hBa
+hgL
+hgL
+hgL
+hgL
+axV
 qbU
 coU
 coU
@@ -51413,28 +51577,28 @@ nxY
 coU
 coU
 rKz
-aii
-bZw
-eiY
-vgl
-vBX
-bZw
-bZw
-bZw
-bZw
-bZw
-fLR
-bZw
-aii
-bZw
+bRP
+hgL
+aDy
+oFk
+aWi
+hgL
+hgL
+hgL
+hgL
+hgL
+cvA
+hgL
+bRP
+hgL
 rKz
-oSA
-aii
-aii
-bZw
-oRO
-aii
-hAx
+sEk
+bRP
+bRP
+hgL
+sZH
+bRP
+chw
 rKz
 coU
 coU
@@ -51622,28 +51786,28 @@ nxY
 coU
 coU
 rKz
-bZw
-bZw
-bZw
-vgl
-bZw
-dFO
-bZw
-lEE
-xrw
+hgL
+hgL
+hgL
+oFk
+hgL
+edP
+jnq
+iiZ
+kBY
 dpI
-wZW
-aii
-aii
+dnC
+bRP
+bRP
 dpI
 rKz
-oSA
-hih
-bZw
-bZw
+sEk
+xNJ
+hgL
+hgL
+utC
+hgL
 bRP
-bZw
-aii
 rKz
 coU
 coU
@@ -51837,8 +52001,8 @@ mNA
 mNA
 mNA
 mNA
-bZw
-bZw
+hgL
+hgL
 mNA
 mNA
 mNA
@@ -51851,8 +52015,8 @@ rKz
 rKz
 rKz
 rKz
-bXE
-ylk
+fLF
+fRD
 rKz
 coU
 coU
@@ -52040,28 +52204,28 @@ nxY
 coU
 coU
 rKz
-cYA
-cmu
-fvU
-xfH
-oSA
+jjD
+rgT
+nPJ
+azg
+sEk
 mNA
-bZw
-bZw
+hgL
+yhY
 mNA
-xfH
-bZw
-cmu
-tUw
-cmu
-khM
+azg
+hgL
+rgT
+jmx
+rgT
+cGo
 mNA
-niQ
-wpT
-kbI
-kbI
-qhe
-bRP
+cUA
+rRO
+qPt
+qPt
+hBa
+utC
 rKz
 coU
 coU
@@ -52248,29 +52412,29 @@ nxY
 nxY
 coU
 coU
-fVi
+tCZ
 qbU
-dJQ
-bZw
-eZt
-oSA
+pMT
+hgL
+xTs
+sEk
 mNA
-aii
-bZw
-tOK
-cmu
-bZw
-xfH
-bZw
-cmu
-bZw
+bRP
+hgL
+hwy
+rgT
+hgL
+azg
+hgL
+rgT
+hgL
 mNA
-bZw
+hgL
 dpI
-aii
 bRP
-bZw
-bRP
+utC
+hgL
+utC
 rKz
 coU
 coU
@@ -52460,26 +52624,26 @@ coU
 qbU
 qbU
 qbU
-xQs
-bZw
-bZw
+vJM
+hgL
+hgL
 mNA
-aii
-bZw
+hOw
+jnq
 mNA
-bZw
-egt
-bZw
-aii
-bZw
-bZw
+laf
+iDM
+hgL
+bRP
+hgL
+hgL
 mNA
-vgl
-bZw
-bZw
-bZw
-aii
-bZw
+oFk
+hgL
+hgL
+hgL
+bRP
+hgL
 rKz
 coU
 coU
@@ -52669,26 +52833,26 @@ coU
 qbU
 qbU
 qbU
-cYA
-cmu
-bZw
+jjD
+rgT
+hgL
 mNA
-qhe
-aii
+hBa
+bRP
 mNA
-kMy
-bZw
-cmu
-aii
-xfH
-bZw
+uOI
+hgL
+rgT
+bRP
+azg
+yhY
 mNA
-iBF
-bZw
-wZW
-gCI
-egt
-bZw
+iAz
+hgL
+dnC
+jfz
+iDM
+hgL
 rKz
 coU
 coU
@@ -52876,28 +53040,28 @@ nxY
 coU
 coU
 rKz
-cYA
+jjD
 qbU
-cYA
-bHO
-aii
+jjD
+iHb
+bRP
 mNA
-bZw
-aii
+hgL
+bRP
 mNA
-cmu
-bZw
-cmu
-bZw
-cmu
-aii
+rgT
+hgL
+rgT
+hgL
+rgT
+bRP
 mNA
-bZw
-bZw
+laf
+hgL
 dpI
-bZw
+hgL
 dpI
-bZw
+hgL
 rKz
 coU
 coU
@@ -53085,28 +53249,28 @@ nxY
 coU
 coU
 rKz
-dLJ
-cYA
-kgi
-aii
-aii
-oAi
-mxx
-txM
+uep
+jjD
+mjb
+bRP
+bRP
+tQp
+bCY
+sNe
 mNA
-aii
-bZw
-bZw
+bRP
+hgL
+hgL
 dpI
-bZw
-ezZ
+hgL
+dWp
 mNA
-aii
-aii
-tkq
-sQl
-jOp
-fmy
+bRP
+bRP
+eCv
+wvi
+ssO
+wmo
 rKz
 coU
 coU
@@ -53300,22 +53464,22 @@ mNA
 mNA
 mNA
 mNA
-bZw
-vBX
+hgL
+aWi
 mNA
 mNA
-oAi
-mNA
-mNA
-mNA
-mNA
-mNA
-rOh
-qDw
+tQp
 mNA
 mNA
 mNA
-pdb
+mNA
+mNA
+pAW
+ofK
+mNA
+mNA
+mNA
+kAK
 rKz
 qbU
 qbU
@@ -53503,31 +53667,31 @@ nxY
 coU
 coU
 rKz
-rWt
-bZw
+dKT
+hgL
 dpI
-aii
-bZw
-oAi
-bZw
-bZw
-bZw
-gCI
-bZw
-bls
-aii
-bZw
-bZw
-oAi
-bZw
-oSA
+bRP
+hgL
+tQp
+hgL
+hgL
+hgL
+jfz
+hgL
+qcp
+bRP
+hgL
+hgL
+tQp
+hgL
+sEk
 mNA
-dzT
-egt
-bZw
+nMq
+iDM
+hgL
 rKz
 ugY
-ltq
+stv
 jkn
 jkn
 qbU
@@ -53712,29 +53876,29 @@ nxY
 coU
 coU
 rKz
-wZi
-bZw
-egt
-aii
-bZw
+dyP
+hgL
+iDM
+bRP
+hgL
 mNA
-egT
-bZw
-bZw
-oSA
-oSA
-bZw
+umz
+hgL
+hgL
+sEk
+sEk
+hgL
 dpI
-loP
-qhe
-oAi
-bZw
-aii
+mUI
+ojC
+tQp
+hgL
+bRP
 mNA
-bZw
-bZw
-bZw
-fVi
+laf
+hgL
+hgL
+tCZ
 qbU
 qbU
 qbU
@@ -53921,28 +54085,28 @@ nxY
 coU
 coU
 rKz
-nuz
-aii
-fyT
-tIh
-aii
+gia
+bRP
+oDU
+ybJ
+bRP
 mNA
-jnq
+obJ
 mNA
-dqf
-mNA
-mNA
-jnq
+pve
 mNA
 mNA
+obJ
 mNA
 mNA
-bZw
-aii
 mNA
-aRI
-egt
-aii
+mNA
+hgL
+qvg
+mNA
+nZp
+iDM
+bRP
 rKz
 coU
 coU
@@ -54130,28 +54294,28 @@ nxY
 coU
 coU
 rKz
-qHi
-bZw
-vnV
-nPz
-aii
+fVt
+hgL
+ksu
+nuW
+qvg
 mNA
-bZw
-bZw
-bZw
-aii
+hgL
+hgL
+hgL
+bRP
 mNA
-bZw
-xSq
-qDZ
-aii
+hgL
+izA
+epY
+bRP
 mNA
-txM
-aii
+sNe
+bRP
 mNA
-tUM
-bZw
-bZw
+bCs
+hgL
+hgL
 rKz
 coU
 coU
@@ -54339,28 +54503,28 @@ nxY
 coU
 coU
 rKz
-fjG
-bZw
-ebq
-cEe
-bZw
-tOK
-aii
-sub
-bZw
-egt
+kVt
+hgL
+aQr
+hQX
+hgL
+hwy
+hOw
+ice
+hgL
+iDM
 mNA
-bZw
-rWN
-bZw
-bZw
-tOK
-bZw
-bZw
+laf
+beH
+laf
+hgL
+hwy
+hgL
+hgL
 mNA
-pdb
-crv
-jnq
+kAK
+vjc
+obJ
 rKz
 qbU
 coU
@@ -54548,28 +54712,28 @@ nxY
 coU
 coU
 rKz
-cVj
-bZw
-bZw
-aii
-nOx
+ebi
+hgL
+hgL
+bRP
+dnv
 mNA
-tJo
-ykv
-hxa
-aEX
+miU
+dTV
+osM
+cEA
 mNA
-xNo
-nLN
-pdb
-aEX
+oXO
+qvM
+kAK
+cEA
 mNA
-aii
-kUl
-oSA
-eSB
-bZw
-bZw
+bRP
+qGH
+sEk
+jJO
+hgL
+hgL
 rKz
 qbU
 coU
@@ -54760,25 +54924,25 @@ rKz
 rKz
 rKz
 rKz
-vdu
-vdu
+mED
+mED
 rKz
 rKz
 rKz
 rKz
 rKz
 rKz
-vdu
+mED
 rKz
 rKz
 rKz
 rKz
-bZw
-aii
-oSA
-bZw
-kwf
-bZw
+hgL
+bRP
+sEk
+hgL
+vBH
+hgL
 rKz
 qbU
 coU
@@ -54966,28 +55130,28 @@ nxY
 coU
 coU
 rKz
-spJ
-bZw
-aCP
-tAb
-fBe
-txA
-txM
-inN
-inN
-inN
-hAN
-fTZ
-bZw
-bZw
-bZw
-oAi
-hih
-aii
-bZw
-bZw
-bZw
-oSA
+hnP
+hgL
+cMR
+dbi
+ctv
+hAV
+sNe
+cLV
+cLV
+cLV
+oKr
+fXg
+hgL
+jnq
+hgL
+tQp
+xNJ
+bRP
+hgL
+hgL
+hgL
+sEk
 rKz
 qbU
 coU
@@ -55174,29 +55338,29 @@ nxY
 nxY
 coU
 coU
-nKW
-mZc
-bZw
-aii
-bZw
-bZw
+eci
+qzT
+hgL
+bRP
+hgL
+hgL
 dpI
-aii
-aii
-bZw
-bZw
-oAi
-bZw
-wxX
-bZw
-qhe
-bFy
-bZw
-bZw
-bZw
-bZw
-aii
-oSA
+bRP
+eVr
+hgL
+hgL
+tQp
+hgL
+crF
+hgL
+hBa
+vHY
+hgL
+hgL
+jnq
+hgL
+bRP
+sEk
 rKz
 qbU
 coU
@@ -55384,28 +55548,28 @@ nxY
 coU
 coU
 rKz
-gRr
-bZw
-rrt
-bZw
-bZw
-bZw
-aBs
-bZw
-wti
-bZw
-oAi
-aii
-aii
-bZw
-aii
+hOg
+hgL
+ceR
+hgL
+hgL
+hgL
+aho
+hgL
+xav
+hgL
+tQp
+bRP
+bRP
+hgL
+qvg
 rKz
-wZW
-bZw
-bZw
-tYx
-aii
-egt
+dnC
+hgL
+hgL
+dbE
+bRP
+nBK
 rKz
 qbU
 coU
@@ -55593,28 +55757,28 @@ nxY
 coU
 coU
 rKz
-uBC
-bZw
-aii
-bZw
-bZw
-bZw
-yga
-bZw
-bZw
-xSq
+qHe
+hgL
+bRP
+hgL
+hgL
+hgL
+hox
+hgL
+hgL
+izA
 rKz
 dpI
-bZw
-aii
-xPI
+hgL
+bRP
+ubp
 rKz
-bZw
-bZw
-gtS
-hrI
-huf
-liS
+hgL
+hgL
+axL
+igW
+lPa
+fWQ
 rKz
 qbU
 coU
@@ -55801,22 +55965,22 @@ nxY
 nxY
 coU
 coU
-fVi
-uBC
-bZw
-jaE
+tCZ
+qHe
+hgL
+riv
 dpI
-bZw
-bZw
-bZw
-bZw
-xSq
-bZw
-fVi
-oSA
-fin
-aii
-vgl
+hgL
+hgL
+hgL
+hgL
+izA
+hgL
+tCZ
+sEk
+kaq
+bRP
+kzu
 rKz
 rKz
 rKz
@@ -56011,28 +56175,28 @@ nxY
 coU
 coU
 rKz
-pdI
-bZw
-wGs
-wGs
-wGs
-hpp
-wGs
-jcF
-wGs
-hpp
+tyL
+hgL
+pXi
+pXi
+pXi
+xZn
+pXi
+pNG
+pXi
+xZn
 rKz
-oSA
-aii
-lZR
-bZw
+sEk
+pfV
+uWM
+hgL
 rKz
-aii
-tgk
-oSA
-oSA
-wti
-xlQ
+hOw
+lpc
+sEk
+sEk
+xav
+oWB
 rKz
 qbU
 coU
@@ -56220,28 +56384,28 @@ nxY
 coU
 coU
 rKz
-bZw
-aii
-wGs
-xSq
-xSq
-xSq
-wGs
-bZw
-xSq
-xSq
+laf
+bRP
+pXi
+izA
+izA
+izA
+pXi
+hgL
+izA
+izA
 rKz
-bZw
-aii
-bZw
+laf
+bRP
+hgL
 dpI
-jFi
-bZw
-bZw
-bZw
-bZw
-bZw
-cXq
+cTi
+hgL
+hgL
+jnq
+hgL
+hgL
+qhe
 rKz
 qbU
 coU
@@ -56429,28 +56593,28 @@ nxY
 coU
 coU
 rKz
-ffP
-aii
-wGs
-vBX
-xSq
-xSq
-wGs
-bZw
-bZw
-bZw
+ttU
+bRP
+pXi
+aWi
+izA
+izA
+pXi
+hgL
+hgL
+hgL
 rKz
-bZw
-bZw
-wZW
-aii
-mvh
-pbT
-bZw
-bZw
-kwf
-bZw
-pQJ
+hgL
+hgL
+dnC
+bRP
+qJt
+aqy
+hgL
+hgL
+vBH
+hgL
+aME
 rKz
 qbU
 coU
@@ -56638,28 +56802,28 @@ nxY
 coU
 coU
 rKz
-ior
-tgk
-wYh
-waE
-jRN
-tkE
-wGs
-waE
-mYJ
-nRq
+ljm
+lpc
+xmM
+jrF
+plG
+dzj
+pXi
+jrF
+woR
+vnE
 rKz
-txM
-bZw
-bZw
-ixB
+sNe
+hgL
+hgL
+kts
 rKz
-vkJ
-aii
-jSR
-hOk
-bZw
-txM
+lNk
+bRP
+lQj
+pAv
+hgL
+tTP
 rKz
 qbU
 coU
@@ -56859,11 +57023,11 @@ rKz
 rKz
 rKz
 rKz
-bZw
-bZw
+hgL
+hgL
 rKz
 rKz
-vdu
+mED
 rKz
 rKz
 rKz
@@ -57057,27 +57221,27 @@ coU
 coU
 coU
 rKz
-bZw
-wti
-bZw
-bZw
+laf
+xav
+hgL
+hgL
 rKz
-bZw
-bZw
-aii
-tjF
-hsZ
+hgL
+hgL
+bRP
+uyY
+uea
 rKz
-bZw
-xzo
+hgL
+hgL
 rKz
-hcs
-aii
-bZw
-bZw
-bZw
-bZw
-rUp
+eHy
+bRP
+hgL
+hgL
+hgL
+hgL
+xhW
 rKz
 coU
 coU
@@ -57265,28 +57429,28 @@ nxY
 coU
 coU
 coU
-fVi
-qms
-bZw
-aii
-ewx
+tCZ
+vHs
+hgL
+bRP
+hYL
 rKz
-bZw
-ktB
-cXn
-aii
-aii
+hgL
+dHR
+fyp
+bRP
+bRP
 rKz
-bZw
-bZw
-aRi
-bZw
-aii
-bZw
-mda
-aii
-bZw
-ccg
+hgL
+hgL
+wZW
+hgL
+bRP
+hgL
+lMF
+bRP
+hgL
+gQn
 rKz
 coU
 coU
@@ -57475,27 +57639,27 @@ coU
 coU
 coU
 rKz
-iSq
-yga
-bZw
-bZw
-fVi
-bZw
+kjp
+hox
+hgL
+hgL
+tCZ
+hgL
 dpI
-bZw
-bZw
-bZw
+hgL
+hgL
+hgL
 rKz
-bZw
-bZw
+hgL
+hgL
 rKz
-nRo
-bZw
-bZw
-aii
-aii
-aii
-fTH
+eut
+hgL
+hgL
+bRP
+bRP
+bRP
+jnl
 rKz
 coU
 coU
@@ -57684,27 +57848,27 @@ coU
 coU
 coU
 rKz
-iSq
-bZw
-bZw
-qhe
+kjp
+hgL
+hgL
+hBa
 rKz
-bZw
-bZw
-oSA
-bZw
-bZw
+hgL
+hgL
+sEk
+hgL
+hgL
 rKz
-bZw
-bZw
-fVi
-umT
-bZw
-wXp
-prj
-bZw
-kem
-kne
+laf
+hgL
+tCZ
+kUs
+hgL
+tqb
+phk
+hgL
+fGF
+fkD
 rKz
 coU
 coU
@@ -57893,25 +58057,25 @@ coU
 coU
 coU
 rKz
-pAw
-bZw
-aii
-bZw
+tWQ
+hgL
+bRP
+hgL
 rKz
-lLv
-bZw
-bZw
-bZw
-aii
-rKz
-jFi
-oAi
-rKz
-rKz
-rKz
-rKz
-rKz
+fQG
 jnq
+hgL
+hgL
+bRP
+rKz
+cTi
+tQp
+rKz
+rKz
+rKz
+rKz
+rKz
+obJ
 rKz
 rKz
 rKz
@@ -58102,27 +58266,27 @@ coU
 coU
 coU
 rKz
-eWn
-bZw
-bZw
-aii
-jFi
-bZw
-bZw
-bZw
-ktB
-aii
-bZw
-bZw
-bZw
-bZw
-bZw
-wZW
-fKU
-bZw
-bZw
-bZw
-txM
+lgv
+hgL
+hgL
+bRP
+cTi
+hgL
+hgL
+hgL
+dHR
+bRP
+hgL
+hgL
+hgL
+hgL
+hgL
+dnC
+cqX
+hgL
+hgL
+hgL
+sNe
 rKz
 coU
 coU
@@ -58311,27 +58475,27 @@ coU
 coU
 coU
 rKz
-jpE
-ebq
-qhe
-tgk
+jkv
+aQr
+hBa
+lpc
 rKz
-bZw
-txM
-bZw
-bZw
-oSA
-hih
-aii
-cfn
-hih
-oSA
+laf
+sNe
+hgL
+hgL
+sEk
+xNJ
+bRP
+snc
+xNJ
+sEk
 dpI
-bZw
-bZw
-bZw
-sjT
-iTd
+hgL
+jnq
+hgL
+xSJ
+lIh
 rKz
 coU
 coU
@@ -58537,10 +58701,10 @@ rKz
 rKz
 rKz
 rKz
-vdu
-bZw
-bZw
-oSA
+mED
+hgL
+hgL
+sEk
 rKz
 coU
 coU
@@ -58729,27 +58893,27 @@ coU
 coU
 coU
 rKz
-xtS
-uMy
-bSn
-uMy
-uMy
-lmY
+bMw
+xCH
+fDD
+xCH
+xCH
+gyS
 rKz
-bZw
-aii
-bZw
-oSA
-bZw
-bZw
-bZw
-bZw
-bZw
-bZw
-fVi
-bZw
-bZw
-bZw
+hgL
+bRP
+hgL
+sEk
+hgL
+hgL
+hgL
+hgL
+hgL
+hgL
+tCZ
+hgL
+hgL
+hgL
 rKz
 coU
 coU
@@ -58938,33 +59102,33 @@ coU
 coU
 coU
 rKz
-ooY
-aii
-aii
-aii
-nHN
-bZw
+nle
+bRP
+bRP
+bRP
+cLU
+hgL
+rKz
+hgL
+kaq
+hgL
+jfz
+bRP
+xcF
+hgL
+aWi
+hgL
+pKF
+rKz
+hgL
+dbE
+hgL
 rKz
 bZw
-fin
 bZw
-gCI
-aii
-sxM
 bZw
-vBX
 bZw
-bdY
-rKz
 bZw
-tYx
-bZw
-rKz
-gvv
-gvv
-gvv
-gvv
-gvv
 coU
 coU
 coU
@@ -59146,34 +59310,34 @@ nxY
 coU
 coU
 coU
-fVi
-aLp
-eCz
-bZw
-aii
-aii
-bZw
-kqO
-egT
-cdz
-bZw
-aii
-aii
-bZw
-bZw
-bZw
-bZw
-hih
+tCZ
+rEF
+aGn
+hgL
+bRP
+bRP
+hgL
+cjK
+umz
+fqQ
+hgL
+bRP
+bRP
+hgL
+hgL
+hgL
+hgL
+xNJ
+rKz
+laf
+fsF
+hgL
 rKz
 bZw
-tzP
+wqu
+sjS
+sBI
 bZw
-rKz
-gvv
-odl
-jyP
-lHQ
-gvv
 coU
 coU
 coU
@@ -59356,33 +59520,33 @@ coU
 coU
 coU
 rKz
-vxP
-bZw
-bZw
-wZW
-bZw
-bZw
+nrW
+hgL
+hgL
+dnC
+hgL
+hgL
 rKz
-jFi
-jFi
+gIS
+qTm
+rKz
+hgL
+xav
+rKz
+hgL
+pHI
+hgL
+hgL
+bRP
+xav
+bRP
+bRP
 rKz
 bZw
-wti
-rKz
+sBI
+sBI
+sBI
 bZw
-dwY
-bZw
-bZw
-aii
-wti
-aii
-aii
-rKz
-gvv
-lHQ
-lHQ
-lHQ
-gvv
 coU
 coU
 coU
@@ -59564,34 +59728,34 @@ nxY
 coU
 coU
 coU
-nKW
-ykj
-ebq
-bZw
+eci
+gFS
+aQr
+hgL
 dpI
-egt
-bZw
-luh
-bZw
-bZw
-jMF
-kuV
-bZw
+iDM
+hgL
+blx
+hgL
+hgL
+uJW
+cam
+hgL
 rKz
-oSA
-bZw
-bZw
-gCI
-aii
-oSA
+sEk
+hgL
+hgL
+jfz
+bRP
+sEk
 dpI
-aii
+bRP
 rKz
-gvv
-lHQ
-bSX
-lHQ
-gvv
+bZw
+sBI
+kVE
+sBI
+bZw
 coU
 coU
 coU
@@ -59774,33 +59938,33 @@ coU
 coU
 coU
 rKz
-jaJ
-bZw
-bZw
-qhe
-aii
-aii
-egt
-bZw
-bZw
+wEw
+hgL
+hgL
+hBa
+bRP
+bRP
+iDM
+hgL
+hgL
 rKz
-aii
-aii
+hOw
+bRP
+rKz
+laf
+hgL
+ucC
+olN
+hgL
+sEk
+rAJ
+hgL
 rKz
 bZw
+ayt
+sBI
+sBI
 bZw
-jvX
-gAY
-bZw
-oSA
-wbG
-bZw
-rKz
-gvv
-dgd
-lHQ
-lHQ
-gvv
 coU
 coU
 coU
@@ -59983,33 +60147,33 @@ coU
 coU
 coU
 rKz
-qvx
-bZw
-bZw
-bZw
-txM
-aii
-bZw
-gDl
-bZw
+czs
+hgL
+hgL
+hgL
+sNe
+bRP
+hgL
+vkM
+hgL
+rKz
+hgL
+hgL
+tCZ
+uEi
+bRP
+bRP
+hgL
+hgL
+jfz
+hgL
+hgL
 rKz
 bZw
 bZw
-fVi
-mmx
-aii
-aii
 bZw
 bZw
-gCI
 bZw
-bZw
-rKz
-gvv
-gvv
-gvv
-gvv
-gvv
 coU
 coU
 coU
@@ -60202,10 +60366,10 @@ rKz
 rKz
 rKz
 rKz
-xem
-nBe
+vqZ
+kfA
 rKz
-mAP
+uIZ
 rKz
 rKz
 rKz
@@ -60401,27 +60565,27 @@ coU
 coU
 coU
 rKz
-aii
-ouu
-pHY
-aii
-aii
-aVF
-xtu
-bYn
-bZw
-aii
-nOv
-aii
-gCI
-bvw
-bZw
-fin
+bRP
+kSt
+mNF
+bRP
+bRP
+suV
+vZw
+fZu
+hgL
+bRP
+xty
+bRP
+jfz
+ssP
+hgL
+kaq
 dpI
-bZw
-bZw
-qms
-cYA
+hgL
+hgL
+vHs
+jjD
 rKz
 coU
 coU
@@ -60610,27 +60774,27 @@ coU
 coU
 coU
 rKz
-egT
-aii
-bZw
-bvH
-bZw
-bZw
-bvw
-wZW
-bZw
-aii
-bZw
-bZw
-xzo
-bZw
-hih
-aii
-tyY
-bZw
-bZw
-cYA
-gZo
+umz
+bRP
+hgL
+pJu
+hgL
+hgL
+ssP
+dnC
+hgL
+bRP
+jnq
+hgL
+wtC
+hgL
+xNJ
+bRP
+gUa
+hgL
+hgL
+jjD
+axV
 rKz
 coU
 coU
@@ -60819,26 +60983,26 @@ coU
 coU
 coU
 rKz
-bZw
-bZw
-bZw
-bZw
-aii
-meX
-oSA
-bZw
-bZw
-aii
-bZw
-hfN
-bZw
-bZw
-bZw
-bcq
-bdY
-bZw
-gCI
-xQs
+hgL
+hgL
+hgL
+hgL
+bRP
+pnU
+sEk
+hgL
+hgL
+bRP
+hgL
+bmh
+hgL
+hgL
+hgL
+ikF
+pKF
+hgL
+jfz
+vJM
 qbU
 rKz
 coU
@@ -61028,26 +61192,26 @@ coU
 coU
 coU
 rKz
-bZw
-bZw
+laf
+jnq
 dpI
-bZw
-aQJ
-qhz
-bZw
-egt
-vBX
-bZw
-cof
-hDl
+hgL
+ouu
+rVZ
+hgL
+iDM
+aWi
+hgL
+hcu
+tyf
 dpI
-jnY
-wZW
-bZw
-oSA
-bZw
-rPh
-cYA
+byy
+dnC
+hgL
+sEk
+hgL
+xvh
+jjD
 qbU
 qbU
 coU
@@ -61236,28 +61400,28 @@ nxY
 coU
 coU
 coU
-vdu
-aii
-bZw
-bZw
-yga
-bZw
-bZw
-bZw
-dOw
-gCI
-oSA
-bZw
-bZw
-aii
-jqA
-bZw
-bZw
+mED
+bRP
+hgL
+hgL
+hox
+hgL
+hgL
+jnq
+reX
+jfz
+sEk
+hgL
+hgL
+bRP
+fcX
+jnq
+hgL
 dpI
-bvw
-egT
-xQs
-cYA
+ssP
+umz
+vJM
+jjD
 qbU
 coU
 coU
@@ -61446,27 +61610,27 @@ coU
 coU
 coU
 rKz
-dQe
-oxW
-lLd
-rXG
-dnC
-dQe
-dnC
-lIR
-dnC
-bZw
-nOv
-uYg
-bZw
-vMv
-ule
-oxW
-oxW
-dQe
-dnC
-dQe
-dnC
+gHH
+bqC
+pBg
+aFi
+wnh
+gHH
+wnh
+kQA
+wnh
+hgL
+xty
+llF
+hgL
+xBs
+eLL
+bqC
+bqC
+gHH
+wnh
+gHH
+wnh
 rKz
 coU
 coU
@@ -61655,27 +61819,27 @@ coU
 coU
 coU
 rKz
-dQe
-dQe
-ule
-ule
-lIR
-dnC
-oxW
-xoD
-pGB
-aii
-eGa
-wcn
-bZw
-ule
-lIR
-dQe
-dnC
-dnC
-lcd
-lIR
-dQe
+gHH
+gHH
+eLL
+eLL
+kQA
+wnh
+bqC
+kXX
+vEb
+bRP
+dgV
+hQJ
+hgL
+eLL
+kQA
+gHH
+wnh
+wnh
+srt
+kQA
+gHH
 rKz
 coU
 coU
@@ -61865,26 +62029,26 @@ coU
 coU
 rKz
 dpI
-bZw
-aii
-bvw
+hgL
+bRP
+ssP
 dpI
-aii
-xHj
-aii
-xzo
-egt
-xKz
-wZW
-wZW
-bZw
-aQJ
-kBF
-bZw
-aii
-fcU
-wti
-pgp
+bRP
+nGT
+bRP
+wtC
+iDM
+nuB
+dnC
+dnC
+hgL
+ouu
+exc
+jnq
+bRP
+scg
+xav
+rww
 rKz
 coU
 coU
@@ -62073,27 +62237,27 @@ coU
 coU
 coU
 rKz
-lIR
-lIR
-dnC
-oxW
-oxW
-dnC
-vhQ
-bZw
-xoD
-xoD
-ule
-lIR
-dnC
-oxW
-oxW
-dnC
-dQe
-kud
-dQe
-dQe
-oxW
+kQA
+kQA
+wnh
+bqC
+bqC
+wnh
+hJW
+hgL
+kXX
+kXX
+eLL
+kQA
+wnh
+bqC
+bqC
+wnh
+gHH
+gGm
+gHH
+gHH
+bqC
 rKz
 coU
 coU
@@ -62282,27 +62446,27 @@ coU
 coU
 coU
 rKz
-lIR
-spr
-oxW
-oxW
-dnC
-dnC
-dnC
-rPh
-ivS
-dnC
-dQe
-dQe
-lIR
-ule
-oxW
-dnC
-ule
-oxW
-dnC
-oxW
-dnC
+kQA
+uDS
+bqC
+bqC
+wnh
+wnh
+wnh
+xvh
+gyo
+wnh
+gHH
+tIm
+kQA
+eLL
+bqC
+wnh
+eLL
+bqC
+wnh
+bqC
+wnh
 rKz
 coU
 coU
@@ -62499,7 +62663,7 @@ rKz
 rKz
 rKz
 rKz
-fVi
+tCZ
 rKz
 rKz
 rKz

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -782,6 +782,11 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"aOF" = (
+/obj/machinery/porta_turret/excelsior/preloaded,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "aOP" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -893,6 +898,11 @@
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"aXQ" = (
+/obj/random/junk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "aYf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard{
@@ -942,6 +952,7 @@
 "bam" = (
 /obj/machinery/recharger,
 /obj/structure/table/standard,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "baC" = (
@@ -2642,6 +2653,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "cDT" = (
 /obj/random/dungeon_ammo/low_chance,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "cEk" = (
@@ -3129,6 +3141,11 @@
 /obj/structure/closet/secure_closet/anesthetics,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/zoo)
+"cZS" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "dae" = (
 /obj/random/mob/nightmare,
 /turf/simulated/floor/wood/wild5,
@@ -3461,6 +3478,7 @@
 	icon_state = "tube1";
 	pixel_y = 0
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "duC" = (
@@ -10119,6 +10137,12 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"jXa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "jXk" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/material/shard,
@@ -12916,6 +12940,11 @@
 /obj/item/stool/padded,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"mKd" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "mKm" = (
 /obj/effect/step_trigger/vault_bunker_1A,
 /turf/simulated/floor/tiled/dark,
@@ -13228,6 +13257,11 @@
 /obj/machinery/door/airlock,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"mWP" = (
+/obj/random/dungeon_gun_ballistic,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "mWT" = (
 /obj/structure/table/rack/shelf,
 /obj/random/booze/low_chance,
@@ -13806,6 +13840,7 @@
 /area/nadezhda/outside/one_star)
 "nxU" = (
 /obj/item/towel,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "nxY" = (
@@ -13855,6 +13890,11 @@
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"nAW" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "nBv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
@@ -14544,6 +14584,7 @@
 /area/nadezhda/outside/one_star)
 "olN" = (
 /obj/item/part/gun/frame/vintorez,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "omd" = (
@@ -14774,6 +14815,11 @@
 	},
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/colony/exposedsun/crashed_shop/outsider)
+"oxg" = (
+/obj/structure/barricade,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "oxj" = (
 /obj/machinery/light{
 	dir = 1
@@ -15062,6 +15108,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"oJL" = (
+/obj/structure/table/bench/standard,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "oKr" = (
 /obj/structure/sign/departmentold/medical2,
 /turf/simulated/wall/r_wall,
@@ -15223,6 +15274,11 @@
 /obj/structure/flora/rock/variant2,
 /turf/simulated/floor/beach/sand/desert,
 /area/nadezhda/dungeon/outside/zoo)
+"oRj" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "oRl" = (
 /obj/machinery/light/small,
 /obj/structure/table/standard,
@@ -15643,6 +15699,12 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/one_star)
+"pky" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "pkC" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/small/busha1,
@@ -17113,6 +17175,12 @@
 /obj/structure/barricade,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"qxH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/dungeon_ammo/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "qxJ" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -17650,6 +17718,11 @@
 "qVj" = (
 /turf/simulated/mineral/random/rogue,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"qVz" = (
+/mob/living/carbon/superior_animal/human/excelsior/excel_ak,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "qWt" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/asteroid/grass,
@@ -18644,6 +18717,7 @@
 /obj/item/mine/excelsior,
 /obj/item/trash/material/metal,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "rWf" = (
@@ -19018,6 +19092,7 @@
 "snc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/peachcan,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "snd" = (
@@ -19849,6 +19924,7 @@
 "tgr" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/trash,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "tgL" = (
@@ -20733,6 +20809,19 @@
 /obj/random/rations,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
+"uao" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/random/closet_tech/low_chance,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "uaW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20850,6 +20939,9 @@
 /area/nadezhda/dungeon/outside/safehouse)
 "ufe" = (
 /obj/machinery/clonepod,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "ufg" = (
@@ -20910,6 +21002,9 @@
 "ugC" = (
 /obj/structure/fireaxecabinet{
 	pixel_y = 30
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
@@ -22964,6 +23059,11 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"wdn" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "wdt" = (
 /obj/random/closet,
 /turf/simulated/floor/tiled/dark,
@@ -23927,6 +24027,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
 "xcF" = (
 /obj/item/trash/mre_paste,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "xdH" = (
@@ -49804,8 +49905,8 @@ coU
 rKz
 amr
 hgL
-jgj
-jgj
+aXQ
+aXQ
 qmN
 oFk
 qjc
@@ -50225,7 +50326,7 @@ lTl
 pHI
 hgL
 xQf
-hgL
+pHI
 jva
 hgL
 pHI
@@ -50434,13 +50535,13 @@ vJM
 ggb
 hgL
 jnq
-hgL
-hgL
-hgL
+pHI
+pHI
+pHI
 hgL
 jnq
 hgL
-hgL
+pHI
 hgL
 wvJ
 rKz
@@ -50645,10 +50746,10 @@ ojC
 hgL
 sUx
 hgL
-hgL
+pHI
 syk
 hgL
-hgL
+pHI
 hgL
 hgL
 wvJ
@@ -51065,7 +51166,7 @@ gqN
 hgL
 hgL
 tgr
-hgL
+pHI
 hgL
 hgL
 jva
@@ -51277,7 +51378,7 @@ hgL
 aNV
 dpI
 hgL
-utC
+oxg
 hgL
 rKz
 jgj
@@ -52319,7 +52420,7 @@ oNj
 oNj
 oNj
 oNj
-oNj
+bRP
 cvA
 oNj
 aFi
@@ -52528,7 +52629,7 @@ edP
 thh
 iiZ
 kBY
-xCX
+mKd
 uhF
 bRP
 aFi
@@ -53794,7 +53895,7 @@ jgj
 dpI
 hgL
 kzu
-hgL
+yhY
 rKz
 coU
 coU
@@ -54198,7 +54299,7 @@ mNA
 mNA
 mNA
 oNj
-aWi
+ucC
 mNA
 mNA
 szl
@@ -54406,11 +54507,11 @@ nJu
 aFi
 oNj
 szl
+bRP
+bRP
 oNj
-oNj
-oNj
-jfz
-oNj
+cZS
+bRP
 qcp
 bvs
 snd
@@ -54620,7 +54721,7 @@ oNj
 oNj
 oPF
 oNj
-oNj
+bRP
 nJu
 mUI
 hBa
@@ -55673,7 +55774,7 @@ rKz
 oel
 bRP
 snd
-oNj
+bRP
 vBH
 afk
 rKz
@@ -55882,7 +55983,7 @@ tQp
 bRP
 bRP
 oNj
-oNj
+bRP
 snd
 oNj
 rKz
@@ -57546,7 +57647,7 @@ jrF
 woR
 vnE
 rKz
-sNe
+aOF
 oNj
 oNj
 kts
@@ -57966,7 +58067,7 @@ uyY
 uea
 rKz
 oNj
-oNj
+bRP
 rKz
 eHy
 vbn
@@ -58168,13 +58269,13 @@ hgL
 pHI
 hYL
 rKz
-jgj
+aXQ
 dHR
 fyp
 pHI
 vQG
 rKz
-oNj
+bRP
 oNj
 wZW
 tFv
@@ -58378,7 +58479,7 @@ hgL
 hgL
 tCZ
 hgL
-dpI
+nAW
 hgL
 hgL
 ubp
@@ -58587,7 +58688,7 @@ hgL
 kdd
 rKz
 ugC
-hgL
+pHI
 cDT
 hgL
 ubp
@@ -58797,7 +58898,7 @@ yhY
 rKz
 fQG
 jnq
-hgL
+pHI
 hgL
 ima
 rKz
@@ -58806,7 +58907,7 @@ xEH
 rKz
 rKz
 rKz
-rKz
+mED
 rKz
 nGW
 rKz
@@ -59006,14 +59107,14 @@ pHI
 lrx
 oNj
 oNj
-oNj
+bRP
 fET
 bRP
 hDc
 oNj
 oNj
-oNj
-oNj
+bRP
+bRP
 uhF
 cqX
 oNj
@@ -59221,7 +59322,7 @@ oNj
 bRP
 bRP
 snc
-kNe
+qxH
 oNj
 xCX
 oNj
@@ -59630,14 +59731,14 @@ bMw
 xCH
 fDD
 shr
-shr
+uao
 gyS
 rKz
 bRR
 srx
-oNj
+bRP
 dup
-sNe
+aOF
 oNj
 lMF
 lMF
@@ -59846,7 +59947,7 @@ oNj
 kaq
 oNj
 jfz
-bRP
+xav
 xcF
 oNj
 aWi
@@ -60056,10 +60157,10 @@ rdH
 oNj
 bRP
 bRP
+bRP
+wdn
 oNj
-dez
-oNj
-oNj
+bRP
 bRP
 jlL
 laf
@@ -60265,10 +60366,10 @@ qTm
 rKz
 oNj
 nPm
-rKz
+mED
 sDd
 hBa
-oNj
+bRP
 oNj
 bRP
 xav
@@ -60463,7 +60564,7 @@ coU
 coU
 eci
 gFS
-gid
+oJL
 hgL
 dpI
 iDM
@@ -60475,8 +60576,8 @@ uJW
 cam
 snd
 rKz
-sDd
-oNj
+oRj
+bRP
 oNj
 jfz
 bRP
@@ -60672,8 +60773,8 @@ coU
 coU
 rKz
 wEw
-hgL
-hgL
+pHI
+pHI
 kdd
 pHI
 pHI
@@ -60685,11 +60786,11 @@ hOw
 qvg
 rKz
 ngB
-oNj
-ucC
+bRP
+pky
 olN
-oNj
-oNj
+bRP
+bRP
 rAJ
 lMF
 rKz
@@ -61929,10 +62030,10 @@ wvJ
 jnq
 dpI
 hgL
-ouu
+mWP
 rVZ
-hgL
-iDM
+pHI
+jXa
 sXz
 hgL
 hcu
@@ -62137,8 +62238,8 @@ mED
 jsO
 hgL
 hgL
-hox
-hgL
+qVz
+pHI
 ugr
 jnq
 reX

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -275,6 +275,14 @@
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"aqi" = (
+/obj/effect/decal/cleanable/generic,
+/mob/living/carbon/superior_animal/human/excelsior,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aqj" = (
 /obj/structure/table/onestar,
 /obj/item/reagent_containers/food/drinks/teapot,
@@ -1232,6 +1240,13 @@
 /obj/item/mine/excelsior,
 /obj/item/trash/semki,
 /turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
+"blC" = (
+/obj/item/bananapeel,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -2963,6 +2978,15 @@
 /obj/machinery/door/airlock/highsecurity,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
+"cLc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/mob/living/carbon/superior_animal/human/excelsior,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cLq" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/small/busha2,
@@ -4009,6 +4033,14 @@
 /obj/item/solar_assembly,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
+"dGD" = (
+/obj/structure/table/bench/wooden,
+/mob/living/carbon/superior_animal/human/excelsior,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dGE" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/invislight,
@@ -4372,6 +4404,13 @@
 /obj/random/toolbox/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"ech" = (
+/obj/item/gun/projectile/automatic/ak47/saiga,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "eci" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/wall/r_wall,
@@ -5706,6 +5745,13 @@
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"fqV" = (
+/obj/structure/reagent_dispensers/fueltank/derelict,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fsd" = (
 /obj/machinery/door/airlock/centcom,
 /obj/item/mine/excelsior{
@@ -6031,6 +6077,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "fGF" = (
 /obj/structure/cardboardbox,
+/obj/item/gun/projectile/revolver/wayfarer,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -6388,7 +6435,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
 "fWQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/mopbucket,
+/obj/structure/closet/random_milsupply,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -6986,6 +7033,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "gyS" = (
 /obj/structure/cable,
+/obj/machinery/power/port_gen/pacman/diesel/anchored,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -7679,6 +7727,16 @@
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"hjc" = (
+/obj/machinery/door/unpowered/simple/wood,
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hjh" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
@@ -7964,6 +8022,14 @@
 /mob/living/simple_animal/hostile/render,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"hva" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hvb" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/big/bush3,
@@ -8041,6 +8107,14 @@
 /obj/random/gun_cheap/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/monster_cave)
+"hyw" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hyA" = (
 /obj/machinery/porta_turret/excelsior/preloaded,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -8365,6 +8439,7 @@
 "hQX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/bench/standard,
+/mob/living/carbon/superior_animal/human/excelsior,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -8718,6 +8793,8 @@
 "igW" = (
 /obj/structure/table/gamblingtable,
 /obj/item/gun/projectile/makarov/preloaded,
+/obj/item/ammo_magazine/pistol_35/lethal,
+/obj/item/ammo_casing,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -9846,6 +9923,14 @@
 /obj/item/stool,
 /turf/simulated/floor/carpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"jgN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/bananapeel,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jgR" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -10933,8 +11018,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "kfS" = (
-/obj/structure/closet/body_bag,
 /obj/landmark/corpse/excelsior,
+/obj/structure/closet/coffin,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -11091,6 +11176,17 @@
 /obj/random/junk/nondense,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
+"koI" = (
+/obj/random/junk,
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/item/ammo_casing,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kpf" = (
 /mob/living/simple_animal/hostile/republicon,
 /turf/unsimulated/mineral,
@@ -11423,6 +11519,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"kEO" = (
+/obj/machinery/door/airlock,
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
+"kEX" = (
+/obj/structure/showcase/horrific_experiment_cloning,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kFl" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/grass,
@@ -11528,6 +11641,13 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/colony/exposedsun/pastgate)
+"kLe" = (
+/obj/structure/reagent_dispensers/fueltank/derelict,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kLn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
@@ -11611,6 +11731,15 @@
 /obj/structure/reagent_dispensers/watertank/huge/derelict,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"kPt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/salvageable/autolathe,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kQa" = (
 /obj/machinery/button/remote/airlock{
 	dir = 8;
@@ -12655,7 +12784,8 @@
 /obj/random/melee/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/boltgun/heavysniper,
-/obj/structure/table/standard,
+/obj/item/gun/projectile/automatic/vintorez/NM_colony,
+/obj/structure/closet/crate,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -12839,6 +12969,14 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/outside/meadow)
+"lXM" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/projectile/automatic/ak47,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lXT" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
@@ -14292,7 +14430,7 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
 "nlD" = (
-/obj/machinery/power/apc/inactive,
+/obj/machinery/power/apc/hyper,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -15031,6 +15169,14 @@
 /obj/machinery/portable_atmospherics/powered/scrubber/yggdrasil,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"nYl" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nYn" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -15065,7 +15211,6 @@
 /area/nadezhda/dungeon/outside/zoo)
 "nZp" = (
 /obj/item/gun/projectile/boltgun,
-/obj/structure/closet/custodial,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -16430,8 +16575,7 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "pfV" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/bear/excelsior,
+/obj/item/ammo_casing,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -16924,8 +17068,10 @@
 /obj/random/melee/low_chance,
 /obj/item/gun/projectile/automatic/drozd,
 /obj/item/gun/projectile/automatic/drozd,
-/obj/structure/table/standard,
 /obj/item/clothing/glasses/eyepatch/secpatch,
+/obj/item/gun/projectile/revolver/wayfarer,
+/obj/item/gun/projectile/revolver/wayfarer,
+/obj/structure/closet/crate,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -17752,6 +17898,15 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"qgn" = (
+/obj/structure/table/rack,
+/obj/item/gun/projectile/automatic/drozd/NM_colony,
+/obj/item/gun/projectile/automatic/drozd/NM_colony,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qgw" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -18531,6 +18686,7 @@
 /area/nadezhda/dungeon/outside/zoo)
 "qPt" = (
 /obj/structure/table/rack,
+/obj/item/gun/projectile/automatic/drozd/NM_colony,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -19729,6 +19885,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
 /obj/random/junk,
+/obj/item/mine/excelsior{
+	armed = 1
+	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -20584,6 +20743,16 @@
 /obj/structure/multiz/ladder,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/prepper)
+"sJY" = (
+/obj/random/junk,
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "sKv" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/closet/random_hostilemobs,
@@ -21848,6 +22017,7 @@
 "tWQ" = (
 /obj/item/implantcase/excelsior/broken,
 /obj/structure/table/rack,
+/obj/item/gun/projectile/automatic/ak47/NM_colony,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -26444,6 +26614,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"ydw" = (
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ydX" = (
 /obj/structure/sign/misc/techshop,
 /turf/simulated/wall/r_wall,
@@ -51886,8 +52063,8 @@ xtV
 jjD
 vJM
 ggb
+dnC
 hgL
-jnq
 pHI
 pHI
 pHI
@@ -52108,7 +52285,7 @@ hgL
 wvJ
 xtV
 hmx
-wSZ
+ech
 wSZ
 aLI
 aLI
@@ -52307,7 +52484,7 @@ hox
 hyA
 nZN
 vPo
-vPo
+lXM
 vPo
 wsW
 tBs
@@ -53560,10 +53737,10 @@ aDy
 thh
 oNj
 snd
-axL
+dGD
 nJu
 bRP
-oNj
+blC
 snd
 oNj
 cFk
@@ -53979,7 +54156,7 @@ snd
 oNj
 snd
 edP
-thh
+oNj
 iiZ
 kBY
 mKd
@@ -54395,9 +54572,9 @@ xrC
 nld
 nPJ
 azg
-oNj
+kLe
 aHN
-snd
+sJY
 opq
 aHN
 azg
@@ -54410,7 +54587,7 @@ aHN
 cUA
 rRO
 qPt
-qPt
+qgn
 kdd
 utC
 xtV
@@ -54607,7 +54784,7 @@ xTs
 oNj
 aHN
 kZp
-oNj
+blC
 hwy
 rgT
 oNj
@@ -54816,7 +54993,7 @@ oNj
 oNj
 aHN
 hOw
-thh
+oNj
 aHN
 myt
 fHd
@@ -55864,7 +56041,7 @@ bRP
 bRP
 oNj
 cZS
-bRP
+hva
 qcp
 bvs
 snd
@@ -55875,7 +56052,7 @@ oNj
 aHN
 nMq
 iDM
-ubp
+hgL
 xtV
 ugY
 stv
@@ -56071,10 +56248,10 @@ opq
 aHN
 mng
 oNj
-oNj
+pfV
 oPF
 oNj
-bRP
+hva
 nJu
 mUI
 hBa
@@ -56288,7 +56465,7 @@ aHN
 aHN
 aHN
 aHN
-snd
+sJY
 qvg
 aHN
 nZp
@@ -56502,7 +56679,7 @@ bRP
 aHN
 bCs
 hgL
-ubp
+hgL
 xtV
 coU
 coU
@@ -56711,7 +56888,7 @@ oNj
 aHN
 kAK
 vjc
-obJ
+hjc
 xtV
 qbU
 coU
@@ -57126,8 +57303,8 @@ xtV
 xtV
 oel
 bRP
-snd
-bRP
+sJY
+hva
 vBH
 afk
 xtV
@@ -57329,15 +57506,15 @@ cEZ
 cLV
 oKr
 fXg
+ydw
 oNj
-thh
 oNj
-tQp
+kEO
 bRP
-bRP
+hva
 oNj
 bRP
-snd
+koI
 oNj
 xtV
 qbU
@@ -58374,7 +58551,7 @@ pXi
 xZn
 xtV
 amQ
-pfV
+bRP
 uWM
 bRR
 xtV
@@ -58589,9 +58766,9 @@ sdu
 cTi
 hgL
 hgL
-jnq
 hgL
 hgL
+llF
 qhe
 xtV
 qbU
@@ -58791,7 +58968,7 @@ oNj
 oNj
 oNj
 xtV
-oNj
+uhF
 oNj
 pMm
 bRP
@@ -59006,7 +59183,7 @@ oNj
 kts
 xtV
 lNk
-pHI
+nYl
 lQj
 pAv
 hgL
@@ -59409,9 +59586,9 @@ coU
 coU
 xtV
 ddc
-ckM
-hgL
-hgL
+kPt
+kEX
+fqV
 xtV
 jgj
 lJy
@@ -59628,7 +59805,7 @@ fyp
 pHI
 vQG
 xtV
-bRP
+hyw
 oNj
 wZW
 tFv
@@ -60467,7 +60644,7 @@ hDc
 oNj
 oNj
 bRP
-bRP
+jgN
 uhF
 cqX
 oNj
@@ -60679,7 +60856,7 @@ qxH
 oNj
 xCX
 oNj
-thh
+oNj
 oNj
 xSJ
 lIh
@@ -61299,7 +61476,7 @@ xtV
 oNj
 kaq
 oNj
-jfz
+aqi
 xav
 xcF
 oNj
@@ -61933,7 +62110,7 @@ oRj
 bRP
 oNj
 jfz
-bRP
+jgN
 oNj
 xCX
 oRQ
@@ -62136,7 +62313,7 @@ hgL
 hgL
 xtV
 hOw
-qvg
+cLc
 xtV
 ngB
 bRP
@@ -62971,7 +63148,7 @@ ssP
 dnC
 hgL
 pHI
-jnq
+hgL
 hgL
 owt
 hgL
@@ -64231,7 +64408,7 @@ dnC
 hgL
 ouu
 exc
-jnq
+hgL
 pHI
 scg
 ckM

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -206,6 +206,11 @@
 /obj/machinery/gym/toughness,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"amQ" = (
+/obj/random/junk,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "amT" = (
 /obj/random/junk,
 /obj/random/junk,
@@ -752,6 +757,10 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"aNV" = (
+/obj/item/trash/broken_robot_part,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "aOd" = (
 /obj/structure/multiz/stairs/active/bottom{
 	dir = 4
@@ -1432,7 +1441,9 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "bzc" = (
-/obj/random/scrap,
+/obj/random/dungeon_ammo/low_chance,
+/obj/random/dungeon_ammo/low_chance,
+/obj/random/closet_maintloot,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
 "bzR" = (
@@ -1559,7 +1570,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "bHO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/random/scrap/dense_weighted,
+/obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "bHZ" = (
@@ -1787,8 +1798,8 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "bRR" = (
-/obj/random/scrap/moderate_weighted,
-/turf/simulated/floor/asteroid/dirt/dark,
+/obj/random/dungeon_ammo/low_chance,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "bSg" = (
 /obj/structure/table/standard,
@@ -2519,7 +2530,7 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "czs" = (
-/obj/machinery/vending/engineering,
+/obj/machinery/suit_storage_unit/engineering,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "czR" = (
@@ -2629,6 +2640,15 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"cDT" = (
+/obj/random/dungeon_ammo/low_chance,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
+"cEk" = (
+/obj/effect/decal/cleanable/generic,
+/obj/random/closet,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "cEw" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
@@ -3254,6 +3274,8 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "dhV" = (
 /obj/random/common_oddities,
+/obj/structure/table/standard,
+/obj/item/device/science_tool,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "djk" = (
@@ -3434,7 +3456,11 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
 "dup" = (
-/obj/random/scrap,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "duC" = (
@@ -3550,6 +3576,9 @@
 "dyP" = (
 /obj/machinery/cooking_with_jane/grill,
 /obj/structure/table/marble,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "dzj" = (
@@ -4533,6 +4562,13 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"euT" = (
+/obj/machinery/shieldwallgen/excelsior,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "evT" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -4695,11 +4731,11 @@
 /turf/simulated/floor/wood/wild5,
 /area/colony/exposedsun/pastgate)
 "eHy" = (
-/obj/structure/safe/floor,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2{
 	icon_state = "cobweb1"
 	},
+/obj/item/melee/energy/sword/red,
 /turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "eHE" = (
@@ -5336,8 +5372,10 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "fqQ" = (
-/obj/item/trash/mre,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/random/booze,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "fqU" = (
 /obj/random/junk/cigbutt,
@@ -5720,6 +5758,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"fLB" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/item/trash/mre,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "fLF" = (
 /obj/machinery/door/airlock/centcom,
 /obj/structure/barricade,
@@ -6198,6 +6243,7 @@
 /area/nadezhda/outside/one_star)
 "gjj" = (
 /obj/item/trash/mre_shokoladka,
+/obj/machinery/clonepod,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "gjt" = (
@@ -6520,7 +6566,7 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper)
 "gyo" = (
-/obj/random/dungeon_gun_energy/low_chance,
+/obj/random/dungeon_gun_energy,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "gys" = (
@@ -8206,6 +8252,7 @@
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "iip" = (
 /obj/item/trash/cheesie,
+/obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "iiE" = (
@@ -8295,6 +8342,11 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"ima" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "imx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -8583,8 +8635,7 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "iAz" = (
-/obj/random/scrap/dense_weighted,
-/obj/random/scrap/dense_weighted,
+/obj/structure/closet/random_milsupply,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "iAE" = (
@@ -9461,7 +9512,7 @@
 "jnl" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/revolver/deacon,
+/obj/random/dungeon_gun_ballistic,
 /turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "jnq" = (
@@ -9549,9 +9600,9 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
 "jsO" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/brown_platform,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet_maintloot,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "jsR" = (
 /obj/structure/cable/yellow{
@@ -9810,8 +9861,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "jJO" = (
-/obj/effect/decal/cleanable/filth,
-/obj/random/scrap,
+/obj/structure/closet/random_medsupply,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "jJQ" = (
@@ -9969,7 +10019,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
 "jQS" = (
-/obj/random/scrap/dense_weighted,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "jQU" = (
@@ -10267,6 +10319,12 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"kfH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "kfJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/prepper,
@@ -10500,6 +10558,7 @@
 "ksu" = (
 /obj/structure/table/marble,
 /obj/item/storage/pouch/ammo,
+/obj/random/contraband,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ksF" = (
@@ -10640,11 +10699,9 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
 "kzu" = (
-/obj/random/scrap/dense_weighted,
-/obj/item/mine/excelsior{
-	armed = 1
-	},
-/turf/simulated/floor/tiled/dark/brown_platform,
+/obj/effect/decal/cleanable/filth,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "kzF" = (
 /obj/machinery/light/small{
@@ -10674,6 +10731,15 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/ammo,
+/obj/random/dungeon_ammo/low_chance,
+/obj/random/dungeon_ammo/low_chance,
+/obj/random/dungeon_ammo/low_chance,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "kBn" = (
@@ -10874,7 +10940,7 @@
 /area/nadezhda/outside/meadow)
 "kNe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
+/obj/random/dungeon_ammo/low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "kNj" = (
@@ -11186,8 +11252,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
 "ldM" = (
-/obj/item/mine/excelsior,
-/obj/random/scrap/sparse_even/low_chance,
+/obj/random/junkfood,
 /turf/simulated/floor/rock/dark,
 /area/asteroid/rogue)
 "leb" = (
@@ -11228,6 +11293,7 @@
 /obj/item/stock_parts/scanning_module/excelsior,
 /obj/structure/table/standard,
 /obj/item/computer_hardware/hard_drive/portable/design/guns/ex_vintorez,
+/obj/item/book/manual/nonfiction/thescienceofright,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "lgw" = (
@@ -11311,8 +11377,9 @@
 /turf/simulated/mineral/planet,
 /area/nadezhda/dungeon/outside/monster_cave)
 "ljm" = (
-/obj/structure/salvageable/autolathe,
-/turf/simulated/floor/tiled/dark/brown_platform,
+/obj/effect/decal/cleanable/filth,
+/obj/random/closet_maintloot,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "ljt" = (
 /obj/structure/table/steel_reinforced,
@@ -11672,7 +11739,6 @@
 "lEJ" = (
 /obj/item/mine/excelsior,
 /obj/effect/decal/cleanable/generic,
-/obj/random/scrap/sparse_even/low_chance,
 /turf/simulated/floor/rock/manmade/ruin2,
 /area/asteroid/rogue)
 "lEN" = (
@@ -11856,10 +11922,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "lMF" = (
-/obj/item/paper/crumpled{
-	text = "You are on your own. Serve to your best extents and do not let our fortress fall!   - Skeinstovitch"
-	},
-/turf/simulated/floor/wood/wild1,
+/obj/random/closet,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "lNk" = (
 /obj/machinery/suit_storage_unit/excelsior,
@@ -13389,6 +13453,11 @@
 "nhc" = (
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/nadezhda/dungeon/outside/zoo)
+"nhe" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/storage/pouch/ammo,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "nhm" = (
 /obj/structure/table/onestar,
 /obj/item/paper_bin,
@@ -13535,6 +13604,11 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/colony/exposedsun/crashed_shop/outsider)
+"nob" = (
+/obj/structure/table/standard,
+/obj/random/booze,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "nod" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stack/material/cardboard/random,
@@ -13654,6 +13728,7 @@
 "nuW" = (
 /obj/structure/table/marble,
 /obj/item/gun/projectile/automatic/ak47,
+/obj/random/contraband,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "nvl" = (
@@ -13729,6 +13804,10 @@
 /obj/item/reagent_containers/food/drinks/cans/sodawater,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/outside/one_star)
+"nxU" = (
+/obj/item/towel,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "nxY" = (
 /turf/unsimulated/mineral,
 /area/colony)
@@ -14176,6 +14255,7 @@
 /area/nadezhda/dungeon/outside/zoo)
 "nZp" = (
 /obj/item/gun/projectile/boltgun,
+/obj/structure/closet/custodial,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "nZr" = (
@@ -14884,7 +14964,10 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
 "oFk" = (
-/obj/random/scrap/dense_weighted,
+/obj/structure/barricade,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "oFC" = (
@@ -15112,6 +15195,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"oPF" = (
+/obj/random/closet_maintloot,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "oPJ" = (
 /obj/machinery/botany,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -15166,6 +15253,11 @@
 /obj/item/device/lighting/toggleable/lantern,
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/wild5,
+/area/asteroid/rogue)
+"oRQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/boozeomat,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "oSf" = (
 /obj/random/flora/jungle_tree,
@@ -15462,8 +15554,9 @@
 /turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "phC" = (
-/obj/structure/barricade,
-/turf/simulated/floor/tiled/steel/brown_platform,
+/obj/effect/decal/cleanable/generic,
+/obj/random/closet_maintloot,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "pit" = (
 /obj/structure/multiz/ladder,
@@ -15590,6 +15683,10 @@
 "plG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/optable,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "plK" = (
@@ -16025,6 +16122,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"pGP" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/closet/random_medsupply,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "pHb" = (
 /obj/structure/medical_stand/anesthetic,
 /turf/simulated/floor/tiled/cafe,
@@ -16131,10 +16233,8 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
 "pKF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark/brown_platform,
+/obj/random/mob/xenomorphs,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
 "pKQ" = (
 /turf/simulated/shuttle/wall/cargo{
@@ -16167,6 +16267,11 @@
 /mob/living/simple_animal/lizard,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
+"pMm" = (
+/mob/living/carbon/superior_animal/human/excelsior,
+/obj/random/dungeon_ammo/low_chance,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "pMx" = (
 /obj/structure/bed/chair/custom/onestar/red{
 	dir = 1
@@ -16906,6 +17011,20 @@
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
+"qts" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/random/closet,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
+"qtD" = (
+/obj/random/dungeon_ammo/low_chance,
+/obj/random/dungeon_ammo/low_chance,
+/obj/random/cloth/armor,
+/obj/random/closet_maintloot,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "qtO" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -17399,6 +17518,11 @@
 /obj/random/medical,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"qPR" = (
+/obj/random/closet_maintloot,
+/obj/random/cloth/gloves,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
 "qQw" = (
 /mob/living/simple_animal/hostile/bear/polar,
 /turf/simulated/floor/asteroid/dirt,
@@ -17755,6 +17879,8 @@
 	pixel_x = 0;
 	pixel_y = -30
 	},
+/obj/structure/table/standard,
+/obj/random/booze,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "rhw" = (
@@ -18520,6 +18646,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
+"rWf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "rWz" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/small/busha2,
@@ -18660,6 +18792,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"sdu" = (
+/obj/effect/decal/cleanable/filth,
+/obj/random/dungeon_ammo/low_chance,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "sdT" = (
 /obj/machinery/autolathe/mechfab/loaded,
 /turf/simulated/floor/tiled/dark,
@@ -19119,10 +19256,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "syk" = (
-/obj/machinery/door/airlock,
-/obj/item/mine/excelsior,
-/obj/structure/barricade,
-/turf/simulated/floor/tiled/steel/brown_platform,
+/obj/structure/table/reinforced,
+/obj/random/credits/c100,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "syp" = (
 /obj/structure/flora/pottedplant/stoutbush,
@@ -19212,6 +19348,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
+"sDd" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "sDt" = (
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt,
@@ -19763,6 +19903,9 @@
 /area/nadezhda/dungeon/outside/zoo)
 "tiB" = (
 /obj/structure/synthesized_instrument/synthesizer/piano,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "tji" = (
@@ -19961,7 +20104,7 @@
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/zoo)
 "ttU" = (
-/obj/machinery/autodoc,
+/obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "tuo" = (
@@ -20044,9 +20187,9 @@
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/dungeon/outside/prepper)
 "tyL" = (
-/obj/structure/closet/crate/excelsior,
 /obj/random/surgery_tool/low_chance,
 /obj/item/tool/saw/circular/medical,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "tyW" = (
@@ -20599,9 +20742,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "ubp" = (
-/obj/random/scrap/dense_weighted,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/brown_platform,
+/obj/random/closet,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "ubu" = (
 /obj/random/mob/voidwolf,
@@ -20690,6 +20832,9 @@
 /obj/effect/decal/cleanable/blood,
 /obj/landmark/corpse/chef,
 /mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ueX" = (
@@ -20704,7 +20849,8 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/safehouse)
 "ufe" = (
-/turf/simulated/floor/tiled/steel/brown_platform,
+/obj/machinery/clonepod,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "ufg" = (
 /obj/structure/extinguisher_cabinet{
@@ -20733,6 +20879,13 @@
 "ufD" = (
 /obj/structure/multiz/ladder/up,
 /turf/simulated/floor/wood/wild4,
+/area/asteroid/rogue)
+"ufW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/random/closet,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "ugd" = (
 /obj/structure/table/onestar,
@@ -21203,6 +21356,7 @@
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/cobweb2,
+/obj/item/taperoll/police,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "uEq" = (
@@ -21624,7 +21778,9 @@
 "uWs" = (
 /obj/item/gun/projectile/colt,
 /obj/item/ammo_kit,
-/obj/random/scrap,
+/obj/random/dungeon_ammo/low_chance,
+/obj/random/dungeon_ammo/low_chance,
+/obj/random/closet_maintloot,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
 "uWM" = (
@@ -21897,10 +22053,7 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/dungeon/outside/zoo)
 "vkM" = (
-/obj/effect/decal/cleanable/cobweb2{
-	icon_state = "spiderling";
-	name = "dead spider"
-	},
+/obj/machinery/power/smes,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "vkQ" = (
@@ -22057,6 +22210,11 @@
 /obj/machinery/door/airlock/centcom,
 /obj/item/mine/excelsior,
 /turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
+"vss" = (
+/obj/structure/scrap_cube,
+/obj/random/closet_maintloot,
+/turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "vsV" = (
 /obj/machinery/light{
@@ -22309,6 +22467,13 @@
 /obj/item/tool/multitool/advanced/onestar,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"vFk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/bodyscanner,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "vGv" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/lathe_disk,
@@ -22536,6 +22701,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper)
+"vQG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/ammo,
+/obj/random/ammo,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/asteroid/rogue)
 "vQT" = (
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/pastgate)
@@ -22982,6 +23153,11 @@
 /area/nadezhda/dungeon/outside/safehouse)
 "woR" = (
 /obj/machinery/optable,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/item/gun/projectile/grenade,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "wpR" = (
@@ -23022,6 +23198,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"wsa" = (
+/obj/item/mine/excelsior{
+	armed = 1
+	},
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "wsg" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/big/bush3,
@@ -23110,7 +23293,7 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "wvJ" = (
-/obj/item/trash/material/circuit,
+/obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "wvW" = (
@@ -23340,10 +23523,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "wJm" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel/brown_platform,
+/obj/random/junk,
+/turf/simulated/floor/wood/wild1,
 /area/asteroid/rogue)
 "wJr" = (
 /obj/effect/decal/cleanable/rubble,
@@ -24071,6 +24252,13 @@
 /obj/random/pack/tech_loot,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
+"xrC" = (
+/obj/structure/boulder,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
 "xrG" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark/danger,
@@ -24303,7 +24491,7 @@
 "xEH" = (
 /obj/machinery/door/airlock,
 /obj/structure/barricade,
-/turf/simulated/floor/tiled/steel/brown_platform,
+/turf/simulated/floor/tiled/dark/brown_platform,
 /area/asteroid/rogue)
 "xEO" = (
 /obj/structure/table/bench/wooden,
@@ -24549,6 +24737,7 @@
 "xQf" = (
 /obj/item/trash/cigbutt/fortress,
 /obj/effect/decal/cleanable/filth,
+/obj/item/trash/broken_robot_part,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/asteroid/rogue)
 "xQu" = (
@@ -24567,6 +24756,10 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
+/area/asteroid/rogue)
+"xRr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/rock/dark,
 /area/asteroid/rogue)
 "xRs" = (
 /obj/structure/table/steel_reinforced,
@@ -45855,7 +46048,7 @@ qbU
 qbU
 qbU
 qbU
-uVX
+xRr
 dpk
 uVX
 qbU
@@ -46064,7 +46257,7 @@ qbU
 qbU
 dpk
 ldM
-uVX
+ldM
 qbU
 dpk
 qbU
@@ -46288,8 +46481,8 @@ qbU
 qbU
 qbU
 qbU
-euc
-euc
+qPR
+rUt
 qbU
 qbU
 euc
@@ -46710,7 +46903,7 @@ qbU
 euc
 qbU
 qbU
-euc
+rUt
 euc
 qbU
 qbU
@@ -46912,7 +47105,7 @@ qbU
 qbU
 qbU
 qbU
-bRR
+rUt
 euc
 euc
 euc
@@ -47121,7 +47314,7 @@ qbU
 qbU
 qbU
 euc
-euc
+pKF
 euc
 qbU
 qbU
@@ -47336,7 +47529,7 @@ qbU
 qbU
 qbU
 euc
-bzc
+euc
 euc
 qbU
 qbU
@@ -47543,7 +47736,7 @@ qbU
 qbU
 qbU
 qbU
-bzc
+euc
 euc
 qbU
 qbU
@@ -47747,8 +47940,8 @@ qbU
 qbU
 qbU
 euc
-bzc
 euc
+qtD
 uWs
 bzc
 euc
@@ -49611,15 +49804,15 @@ coU
 rKz
 amr
 hgL
-hgL
-hgL
+jgj
+jgj
 qmN
-utC
+oFk
 qjc
 hgL
 hgL
-qmN
-hgL
+euT
+wvJ
 cYh
 wtC
 fcB
@@ -50040,7 +50233,7 @@ pFf
 hgL
 dnC
 hgL
-hgL
+wvJ
 rKz
 eBe
 aLI
@@ -50249,7 +50442,7 @@ jnq
 hgL
 hgL
 hgL
-hgL
+wvJ
 rKz
 wSZ
 wSZ
@@ -50445,7 +50638,7 @@ nxY
 coU
 coU
 rKz
-hgL
+wvJ
 hgL
 hgL
 ojC
@@ -50453,7 +50646,7 @@ hgL
 sUx
 hgL
 hgL
-vPo
+syk
 hgL
 hgL
 hgL
@@ -51081,7 +51274,7 @@ pHI
 dnC
 dnC
 hgL
-hgL
+aNV
 dpI
 hgL
 utC
@@ -51700,13 +51893,13 @@ coU
 coU
 rKz
 oNj
-oNj
+snd
 oNj
 oNj
 iip
 tiB
 dez
-bRP
+bHO
 bHO
 jQS
 nQY
@@ -51716,7 +51909,7 @@ oNj
 rKz
 cEx
 dpI
-fqQ
+hgL
 hgL
 vJM
 vJM
@@ -51912,19 +52105,19 @@ hOw
 aDy
 thh
 oNj
-oNj
+snd
 axL
-xCX
+nJu
 bRP
 oNj
-jQS
+snd
 oNj
 cFk
-oNj
+snd
 jio
 rKz
 gjj
-kdd
+fLB
 hgL
 jgj
 hgL
@@ -52117,10 +52310,10 @@ nxY
 coU
 coU
 rKz
-bRP
+aFi
 oNj
 aDy
-jQS
+oNj
 aWi
 oNj
 oNj
@@ -52129,10 +52322,10 @@ oNj
 oNj
 cvA
 oNj
-bRP
-oNj
+aFi
+snd
 rKz
-sEk
+ufe
 pHI
 pHI
 hgL
@@ -52326,11 +52519,11 @@ nxY
 coU
 coU
 rKz
+snd
+snd
+snd
 oNj
-oNj
-oNj
-jQS
-oNj
+snd
 edP
 thh
 iiZ
@@ -52341,10 +52534,10 @@ bRP
 aFi
 nJu
 rKz
-sEk
-xNJ
-hgL
-hgL
+ubp
+ima
+ubp
+ubp
 utC
 hgL
 pHI
@@ -52542,7 +52735,7 @@ mNA
 mNA
 mNA
 oTT
-oNj
+snd
 mNA
 mNA
 mNA
@@ -52744,13 +52937,13 @@ nxY
 coU
 coU
 rKz
-tIm
+xrC
 nld
 nPJ
 azg
-dup
-mNA
 oNj
+mNA
+snd
 opq
 mNA
 azg
@@ -52957,7 +53150,7 @@ qbU
 pMT
 oNj
 xTs
-dup
+oNj
 mNA
 kZp
 oNj
@@ -52967,7 +53160,7 @@ oNj
 azg
 oNj
 rgT
-oNj
+snd
 mNA
 hgL
 dpI
@@ -53176,9 +53369,9 @@ fHd
 oNj
 bRP
 oNj
-oNj
+snd
 mNA
-oFk
+iAz
 hgL
 hgL
 hgL
@@ -53377,7 +53570,7 @@ tIm
 rgT
 oNj
 mNA
-hBa
+wsa
 bRP
 mNA
 uOI
@@ -53391,8 +53584,8 @@ iAz
 hgL
 dnC
 qjc
-iDM
-hgL
+rWf
+jgj
 rKz
 coU
 coU
@@ -53597,10 +53790,10 @@ rgT
 qio
 mNA
 vsV
-hgL
+jgj
 dpI
 hgL
-dpI
+kzu
 hgL
 rKz
 coU
@@ -54220,15 +54413,15 @@ jfz
 oNj
 qcp
 bvs
-oNj
+snd
 oNj
 szl
 oNj
-dup
+oNj
 mNA
 nMq
 iDM
-hgL
+ubp
 rKz
 ugY
 stv
@@ -54420,24 +54613,24 @@ dyP
 oNj
 fHd
 bRP
-oNj
+opq
 mNA
 mng
 oNj
 oNj
-dup
-dup
+oPF
 oNj
-xCX
+oNj
+nJu
 mUI
 hBa
 szl
-oNj
-bRP
+snd
+aFi
 mNA
-vsV
+qts
 hgL
-hgL
+ubp
 tCZ
 qbU
 qbU
@@ -54641,12 +54834,12 @@ mNA
 mNA
 mNA
 mNA
-oNj
+snd
 qvg
 mNA
 nZp
 iDM
-pHI
+ima
 rKz
 coU
 coU
@@ -54838,7 +55031,7 @@ fVt
 oNj
 ksu
 nuW
-qvg
+bRP
 mNA
 oNj
 pmY
@@ -54855,7 +55048,7 @@ bRP
 mNA
 bCs
 hgL
-hgL
+ubp
 rKz
 coU
 coU
@@ -55047,17 +55240,17 @@ kVt
 oNj
 aQr
 hQX
-oNj
+opq
 hwy
 hOw
 osM
 oNj
-fHd
+kfH
 mNA
 laf
 beH
 oNj
-oNj
+opq
 hwy
 oNj
 oNj
@@ -55270,8 +55463,8 @@ cEA
 mNA
 iey
 qGH
-dup
-jJO
+oNj
+xCX
 oNj
 oNj
 rKz
@@ -55479,7 +55672,7 @@ rKz
 rKz
 oel
 bRP
-dup
+snd
 oNj
 vBH
 afk
@@ -55686,12 +55879,12 @@ oNj
 thh
 oNj
 tQp
-kNe
+bRP
 bRP
 oNj
 oNj
+snd
 oNj
-dup
 rKz
 qbU
 coU
@@ -55895,12 +56088,12 @@ crF
 oNj
 hBa
 tQp
-oNj
+snd
 oNj
 thh
-oNj
+snd
 bRP
-dup
+amQ
 rKz
 qbU
 coU
@@ -56100,12 +56293,12 @@ xav
 oNj
 szl
 bRP
-bRP
+kNe
 oNj
 qvg
 rKz
 uhF
-oNj
+snd
 oNj
 dbE
 bRP
@@ -56300,18 +56493,18 @@ rKz
 qHe
 kfS
 bRP
-oNj
-oNj
-oNj
+jJO
+jJO
+jJO
 rCV
-oNj
-oNj
-izA
+jJO
+jJO
+pGP
 rKz
 jlf
 oNj
 bRP
-ubp
+bRP
 rKz
 xRl
 snd
@@ -56514,13 +56707,13 @@ oNj
 oNj
 oNj
 oNj
-izA
-oNj
+nhe
+opq
 tCZ
-dup
+snd
 kaq
 bRP
-kzu
+hBa
 rKz
 rKz
 rKz
@@ -56726,15 +56919,15 @@ pNG
 pXi
 xZn
 rKz
-dup
+amQ
 pfV
 uWM
-oNj
+bRR
 rKz
 kBi
 pZG
-sEk
-sEk
+jgj
+jgj
 ckM
 oWB
 rKz
@@ -56924,7 +57117,7 @@ nxY
 coU
 coU
 rKz
-laf
+vFk
 bRP
 pXi
 izA
@@ -56933,12 +57126,12 @@ izA
 pXi
 oNj
 izA
-jsO
+izA
 rKz
-laf
+ufW
 bRP
 oNj
-xCX
+sdu
 cTi
 hgL
 hgL
@@ -57146,7 +57339,7 @@ oNj
 rKz
 oNj
 oNj
-uhF
+pMm
 bRP
 qJt
 aqy
@@ -57342,7 +57535,7 @@ nxY
 coU
 coU
 rKz
-ljm
+oNj
 lpc
 xmM
 jrF
@@ -57564,7 +57757,7 @@ rKz
 rKz
 rKz
 oNj
-oNj
+nxU
 rKz
 rKz
 mED
@@ -57778,8 +57971,8 @@ rKz
 eHy
 vbn
 vHY
-wqX
-wqX
+wJm
+wJm
 wqX
 xhW
 rKz
@@ -57979,7 +58172,7 @@ jgj
 dHR
 fyp
 pHI
-pHI
+vQG
 rKz
 oNj
 oNj
@@ -57987,7 +58180,7 @@ wZW
 tFv
 vbn
 tqb
-lMF
+wqX
 vbn
 wqX
 gQn
@@ -58188,7 +58381,7 @@ hgL
 dpI
 hgL
 hgL
-hgL
+ubp
 rKz
 snd
 oNj
@@ -58395,12 +58588,12 @@ kdd
 rKz
 ugC
 hgL
-sEk
+cDT
 hgL
-hgL
+ubp
 rKz
-wJm
-phC
+laf
+hDc
 tCZ
 kUs
 wqX
@@ -58600,15 +58793,15 @@ rKz
 tWQ
 hgL
 pHI
-hgL
+yhY
 rKz
 fQG
 jnq
 hgL
 hgL
-pHI
+ima
 rKz
-syk
+lrx
 xEH
 rKz
 rKz
@@ -58817,8 +59010,8 @@ oNj
 fET
 bRP
 hDc
-ufe
-ufe
+oNj
+oNj
 oNj
 oNj
 uhF
@@ -59024,12 +59217,12 @@ laf
 sNe
 oNj
 oNj
-dup
-kNe
+oNj
+bRP
 bRP
 snc
 kNe
-dup
+oNj
 xCX
 oNj
 thh
@@ -59244,7 +59437,7 @@ rKz
 mED
 oNj
 oNj
-dup
+bRR
 rKz
 coU
 coU
@@ -59440,15 +59633,15 @@ shr
 shr
 gyS
 rKz
-oNj
+bRR
 srx
 oNj
 dup
 sNe
 oNj
-oNj
-oNj
-oNj
+lMF
+lMF
+lMF
 syp
 jlL
 oNj
@@ -59658,7 +59851,7 @@ xcF
 oNj
 aWi
 oNj
-pKF
+xav
 jlL
 oNj
 dbE
@@ -59867,11 +60060,11 @@ oNj
 dez
 oNj
 oNj
-kNe
+bRP
 jlL
 laf
 fsF
-oNj
+nob
 rKz
 bZw
 wqu
@@ -60073,14 +60266,14 @@ rKz
 oNj
 nPm
 rKz
-oNj
+sDd
 hBa
 oNj
 oNj
 bRP
 xav
 bRP
-bRP
+fqQ
 rKz
 bZw
 sBI
@@ -60282,14 +60475,14 @@ uJW
 cam
 snd
 rKz
-dup
+sDd
 oNj
 oNj
 jfz
 bRP
-dup
+oNj
 xCX
-bRP
+oRQ
 rKz
 bZw
 sBI
@@ -60489,16 +60682,16 @@ hgL
 hgL
 rKz
 hOw
-bRP
+qvg
 rKz
 ngB
 oNj
 ucC
 olN
 oNj
-dup
-rAJ
 oNj
+rAJ
+lMF
 rKz
 bZw
 ayt
@@ -60693,21 +60886,21 @@ bam
 aVm
 hyA
 pHI
-hgL
 vkM
-hgL
+vkM
+vkM
 rKz
 oNj
 oNj
 tCZ
 uEi
 bRP
-bRP
+kNe
 oNj
 oNj
-jfz
-oNj
-oNj
+cEk
+lMF
+lMF
 rKz
 bZw
 bZw
@@ -61113,7 +61306,7 @@ wtC
 suV
 vZw
 fZu
-hgL
+wvJ
 tAF
 knp
 pHI
@@ -61123,7 +61316,7 @@ hyA
 mOu
 bsR
 hgL
-hgL
+wvJ
 vHs
 jjD
 rKz
@@ -61332,7 +61525,7 @@ xNJ
 pHI
 gUa
 hgL
-hgL
+wvJ
 jjD
 axV
 rKz
@@ -61541,7 +61734,7 @@ hgL
 ikF
 ika
 hgL
-qjc
+phC
 vJM
 yhY
 rKz
@@ -61732,7 +61925,7 @@ coU
 coU
 coU
 rKz
-hgL
+wvJ
 jnq
 dpI
 hgL
@@ -61941,7 +62134,7 @@ coU
 coU
 coU
 mED
-pHI
+jsO
 hgL
 hgL
 hox
@@ -62151,10 +62344,10 @@ coU
 coU
 rKz
 gHH
-pBg
+wvJ
 gHH
-kXX
-pBg
+ljm
+wvJ
 gHH
 wnh
 kQA
@@ -62164,11 +62357,11 @@ knp
 llF
 pBg
 xBs
-vEb
-pBg
+jsO
+wvJ
 bqC
 gHH
-pBg
+wvJ
 gHH
 xiC
 rKz
@@ -62359,24 +62552,24 @@ coU
 coU
 coU
 rKz
-gHH
+vss
 gHH
 vEb
-vEb
+jsO
 kQA
 lrL
-pBg
-kXX
-vEb
-vEb
+wvJ
+ljm
+jsO
+jsO
 dgV
 hQJ
-pBg
+wvJ
 vEb
 kQA
 gHH
-pBg
-pBg
+wvJ
+wvJ
 srt
 kQA
 gHH
@@ -62779,25 +62972,25 @@ coU
 rKz
 kQA
 kQA
-pBg
+wvJ
 bqC
-pBg
-pBg
+wvJ
+wvJ
 hJW
 hgL
 kXX
-kXX
+ljm
 eLL
 kQA
 xiC
+wvJ
 pBg
-pBg
-pBg
+wvJ
 gHH
 gGm
 gHH
 gHH
-pBg
+wvJ
 rKz
 coU
 coU
@@ -62989,24 +63182,24 @@ rKz
 kQA
 uDS
 bqC
-pBg
-xiC
-pBg
-pBg
+wvJ
+wvJ
+wvJ
+wvJ
 xvh
 gyo
 rBT
 gHH
 gHH
 fuq
-vEb
-pBg
-pBg
-vEb
-pBg
-pBg
-pBg
-pBg
+jsO
+wvJ
+wvJ
+jsO
+wvJ
+wvJ
+wvJ
+wvJ
 rKz
 coU
 coU

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -83,7 +83,10 @@
 "afk" = (
 /obj/structure/flora/pottedplant/rotwood,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "afB" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
@@ -126,7 +129,10 @@
 "aho" = (
 /obj/item/storage/fancy/mre_cracker,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ahW" = (
 /obj/random/junk,
 /obj/random/junk,
@@ -201,7 +207,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "amG" = (
 /obj/machinery/gym/toughness,
 /turf/simulated/floor/wood/wild5,
@@ -210,7 +219,10 @@
 /obj/random/junk,
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "amT" = (
 /obj/random/junk,
 /obj/random/junk,
@@ -273,7 +285,10 @@
 "aqy" = (
 /obj/machinery/suit_storage_unit/excelsior,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aqA" = (
 /obj/machinery/floodlight,
 /turf/simulated/shuttle/floor/mining{
@@ -369,7 +384,10 @@
 "avp" = (
 /obj/item/trash/liquidfood,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "avx" = (
 /obj/structure/table/standard,
 /obj/item/stack/cable_coil/yellow,
@@ -403,7 +421,10 @@
 "axL" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "axM" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -413,7 +434,10 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ayt" = (
 /obj/item/bedsheet,
 /obj/structure/bed,
@@ -450,7 +474,10 @@
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "azq" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/cloth/suit,
@@ -555,7 +582,10 @@
 "aDy" = (
 /obj/item/trash/broken_robot_part,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aDz" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
@@ -592,14 +622,20 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aFP" = (
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
 "aGn" = (
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aGo" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -618,7 +654,16 @@
 /obj/item/storage/hcases/ammo/excel,
 /obj/structure/closet/crate/excelsior,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
+"aHN" = (
+/turf/simulated/wall,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aIu" = (
 /obj/machinery/light/floor,
 /obj/structure/reagent_dispensers/water_cooler,
@@ -692,7 +737,10 @@
 "aLI" = (
 /mob/living/simple_animal/hostile/bear/excelsior,
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aLU" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/small/busha3,
@@ -723,7 +771,10 @@
 /obj/random/ammo/low_chance,
 /obj/item/ammo_magazine/ammobox/antim_small,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aMH" = (
 /obj/item/remains,
 /obj/random/gun_cheap,
@@ -760,7 +811,10 @@
 "aNV" = (
 /obj/item/trash/broken_robot_part,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aOd" = (
 /obj/structure/multiz/stairs/active/bottom{
 	dir = 4
@@ -786,7 +840,10 @@
 /obj/machinery/porta_turret/excelsior/preloaded,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aOP" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -819,7 +876,10 @@
 "aQr" = (
 /obj/structure/table/bench/standard,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aSc" = (
 /turf/simulated/shuttle/floor/mining,
 /area/colony/exposedsun/crashed_shop/outsider)
@@ -882,11 +942,17 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/clothing/glasses/welding/superior/shades,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aWi" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aWp" = (
 /obj/structure/flora/big/bush2,
 /obj/effect/overlay/water,
@@ -902,7 +968,10 @@
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "aYf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard{
@@ -954,7 +1023,10 @@
 /obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "baC" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock/manmade/ruin2,
@@ -1038,7 +1110,10 @@
 /mob/living/simple_animal/hostile/diyaab,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "beQ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood/wild5,
@@ -1157,7 +1232,10 @@
 /obj/item/mine/excelsior,
 /obj/item/trash/semki,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "blY" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Generator Room"
@@ -1168,7 +1246,10 @@
 /obj/item/mine/excelsior,
 /obj/item/trash/mre/alt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "bmp" = (
 /obj/structure/reagent_dispensers/watertank/derelict,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -1274,7 +1355,10 @@
 "bqC" = (
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "bqX" = (
 /obj/random/pack/tech_loot,
 /turf/simulated/floor/wood/wild5,
@@ -1316,7 +1400,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/random/dungeon_gun_ballistic,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "bsX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -1385,7 +1472,10 @@
 	},
 /obj/structure/flora/pottedplant/rotwood_green,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "bvC" = (
 /obj/structure/table/standard,
 /obj/random/powercell/medium_safe,
@@ -1450,7 +1540,10 @@
 "byy" = (
 /obj/item/trash/material/metal,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "bzc" = (
 /obj/random/dungeon_ammo/low_chance,
 /obj/random/dungeon_ammo/low_chance,
@@ -1506,11 +1599,17 @@
 /obj/item/toy/figure/character/civilian/janitor,
 /obj/item/clothing/under/rank/janitor,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "bCY" = (
 /obj/item/trash/mre_candy,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "bDO" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -1583,7 +1682,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "bHZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1689,7 +1791,10 @@
 	},
 /obj/machinery/power/port_gen/pacman/diesel/anchored,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "bNM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair{
@@ -1807,11 +1912,17 @@
 "bRP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "bRR" = (
 /obj/random/dungeon_ammo/low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "bSg" = (
 /obj/structure/table/standard,
 /obj/item/trash/plate,
@@ -1955,7 +2066,10 @@
 "cam" = (
 /obj/item/trash/mre_shokoladka,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "caq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame,
@@ -2028,12 +2142,18 @@
 /mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ceR" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cfa" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -2069,7 +2189,10 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "chC" = (
 /obj/effect/step_trigger/surface_to_forest_2_B,
 /turf/simulated/floor/asteroid/dirt,
@@ -2123,7 +2246,10 @@
 "cjK" = (
 /obj/structure/sign/warning/high_voltage,
 /turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cjV" = (
 /obj/structure/salvageable/personal,
 /turf/simulated/floor/tiled/dark/danger,
@@ -2148,7 +2274,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "clb" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/cloth/armor/low_chance,
@@ -2234,7 +2363,10 @@
 "coO" = (
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "coU" = (
 /turf/unsimulated/mineral,
 /area/asteroid/rogue)
@@ -2312,7 +2444,10 @@
 	},
 /obj/item/trash/mre,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "crC" = (
 /obj/item/remains/tajaran,
 /obj/effect/decal/cleanable/blood,
@@ -2324,7 +2459,10 @@
 	armed = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "crM" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/cafe,
@@ -2414,7 +2552,10 @@
 /obj/random/medical,
 /obj/random/medical,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cty" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2485,7 +2626,10 @@
 "cvA" = (
 /obj/item/trash/cigbutt/fortressblue,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cwm" = (
 /obj/structure/flora/small/busha1,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -2543,7 +2687,10 @@
 "czs" = (
 /obj/machinery/suit_storage_unit/engineering,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "czR" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/big/bush3,
@@ -2655,25 +2802,37 @@
 /obj/random/dungeon_ammo/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cEk" = (
 /obj/effect/decal/cleanable/generic,
 /obj/random/closet,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cEw" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
 "cEx" = (
 /obj/machinery/gibber,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cEA" = (
 /obj/structure/toilet{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cEB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2692,7 +2851,10 @@
 /obj/structure/table/standard,
 /obj/random/medical/low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cFd" = (
 /obj/structure/flora/small/grassa4,
 /obj/structure/flora/big/bush3,
@@ -2702,7 +2864,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/mre/alt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cFy" = (
 /obj/item/gun/projectile/automatic/lmg/pk,
 /obj/random/cloth/armor/low_chance,
@@ -2718,7 +2883,10 @@
 	},
 /obj/machinery/porta_turret/excelsior/preloaded,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cGz" = (
 /obj/structure/flora/small/bushb3,
 /obj/structure/flora/ausbushes/grassybush,
@@ -2815,13 +2983,19 @@
 /obj/item/mine/excelsior,
 /obj/item/trash/material/device,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cLV" = (
 /obj/structure/table/standard,
 /obj/random/medical/low_chance,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cLY" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor/wood/wild5,
@@ -2844,7 +3018,10 @@
 /obj/random/medical,
 /obj/item/computer_hardware/hard_drive/portable/design/medical/advanced,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cNa" = (
 /obj/item/remains/ribcage,
 /turf/simulated/floor/tiled/cafe,
@@ -2876,7 +3053,10 @@
 	},
 /obj/structure/flora/small/grassa1,
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cOO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/science,
@@ -2995,7 +3175,10 @@
 /obj/machinery/door/airlock,
 /obj/item/mine/excelsior,
 /turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cTM" = (
 /obj/structure/table/standard,
 /obj/random/common_oddities,
@@ -3029,7 +3212,10 @@
 /obj/structure/table/rack,
 /obj/random/gun_parts,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cUK" = (
 /obj/random/material,
 /obj/random/material,
@@ -3087,7 +3273,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/mre/os,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "cYn" = (
 /obj/machinery/door/blast/shutters/glass,
 /obj/random/junkfood/rotten/low_chance,
@@ -3145,7 +3334,10 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dae" = (
 /obj/random/mob/nightmare,
 /turf/simulated/floor/wood/wild5,
@@ -3177,7 +3369,10 @@
 /obj/random/medical,
 /obj/item/storage/firstaid,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dbn" = (
 /obj/random/common_oddities,
 /turf/simulated/floor/tiled/dark,
@@ -3186,7 +3381,10 @@
 /mob/living/carbon/superior_animal/human/excelsior,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dbO" = (
 /obj/structure/table/onestar,
 /obj/structure/salvageable/console_os,
@@ -3224,7 +3422,10 @@
 	},
 /obj/structure/flora/pottedplant/drooping,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ddO" = (
 /obj/structure/reagent_dispensers/watertank/huge,
 /obj/machinery/light/small{
@@ -3240,7 +3441,10 @@
 "dez" = (
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "deS" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -3273,7 +3477,10 @@
 	name = "Communist Manifesto"
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dhy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -3294,7 +3501,10 @@
 /obj/structure/table/standard,
 /obj/item/device/science_tool,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "djk" = (
 /obj/structure/table/rack/shelf,
 /obj/random/junkfood,
@@ -3356,11 +3566,17 @@
 /obj/effect/decal/cleanable/filth,
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dnC" = (
 /mob/living/carbon/superior_animal/human/excelsior,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dnH" = (
 /obj/structure/bed/double/padded,
 /obj/random/furniture/bedsheetdouble,
@@ -3388,7 +3604,10 @@
 "dpI" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dpK" = (
 /obj/structure/morgue,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -3480,7 +3699,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "duC" = (
 /obj/random/junk/nondense,
 /turf/simulated/floor/tiled/dark,
@@ -3598,11 +3820,17 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dzj" = (
 /obj/structure/scrap/medical/large,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dzp" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -3811,7 +4039,10 @@
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dIw" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush3,
@@ -3881,7 +4112,10 @@
 /obj/structure/table/marble,
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dLt" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/prepper/vault)
@@ -4024,7 +4258,10 @@
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dUH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4037,7 +4274,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dWh" = (
 /obj/structure/flora/big/bush1,
 /turf/unsimulated/wall/jungle,
@@ -4046,7 +4286,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/gun_cheap/low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "dXH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -4104,12 +4347,18 @@
 "eas" = (
 /obj/structure/flora/small/grassa2,
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ebi" = (
 /obj/machinery/cooking_with_jane/stove,
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ebz" = (
 /obj/structure/scrap/food/large,
 /turf/simulated/floor/tiled/dark,
@@ -4126,7 +4375,10 @@
 "eci" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ecz" = (
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
@@ -4148,7 +4400,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/firstaid/regular/empty,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "edQ" = (
 /obj/structure/boulder,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -4459,7 +4714,10 @@
 "epY" = (
 /obj/item/trash/syndi_cakes,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "eqk" = (
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -4551,7 +4809,10 @@
 "eut" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "euG" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -4586,7 +4847,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "evT" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -4633,7 +4897,10 @@
 /obj/effect/decal/cleanable/generic,
 /obj/item/trash/material/metal,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "exl" = (
 /obj/structure/table/glass,
 /obj/random/firstaid,
@@ -4684,7 +4951,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "eBV" = (
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
@@ -4694,7 +4964,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/item/gun_upgrade/trigger/boom,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "eCK" = (
 /obj/structure/closet/random_hostilemobs,
 /turf/simulated/floor/tiled/dark,
@@ -4739,7 +5012,10 @@
 /obj/item/mine/excelsior,
 /obj/item/trash/material/metal,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "eGW" = (
 /obj/effect/decal/cleanable/filth,
 /obj/structure/table/rack/shelf,
@@ -4755,7 +5031,10 @@
 	},
 /obj/item/melee/energy/sword/red,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "eHE" = (
 /obj/structure/boulder,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -4816,7 +5095,10 @@
 /obj/random/lowkeyrandom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "eMv" = (
 /obj/random/closet_tech,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -4942,7 +5224,10 @@
 	armed = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "eVM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -5103,7 +5388,10 @@
 /obj/structure/closet/crate/trashcart,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fcC" = (
 /obj/machinery/light/floor,
 /obj/structure/closet/crate/bin,
@@ -5114,7 +5402,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fdz" = (
 /obj/machinery/porta_turret/prepper,
 /turf/simulated/floor/tiled/dark,
@@ -5284,7 +5575,10 @@
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fkH" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/big/bush3,
@@ -5394,7 +5688,10 @@
 /obj/structure/table/standard,
 /obj/random/booze,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fqU" = (
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark,
@@ -5405,7 +5702,10 @@
 	armed = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fsf" = (
 /obj/effect/step_trigger/swampcaves_to_riverforest_2_B,
 /turf/simulated/floor/asteroid/dirt,
@@ -5415,7 +5715,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fsT" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/reagent_containers/spray/cleaner,
@@ -5431,7 +5734,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/firedoor_assembly,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ftE" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -5451,7 +5757,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fuB" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -5535,7 +5844,10 @@
 "fyp" = (
 /obj/item/trash/peachcan,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fyx" = (
 /obj/random/mob/undergroundmob,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -5543,7 +5855,10 @@
 "fyX" = (
 /obj/machinery/complant_teleporter,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fze" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt,
@@ -5613,7 +5928,10 @@
 	},
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fDS" = (
 /obj/machinery/light{
 	dir = 4;
@@ -5642,7 +5960,10 @@
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fFb" = (
 /obj/random/closet_tech,
 /turf/simulated/floor/tiled/dark,
@@ -5701,7 +6022,10 @@
 "fGF" = (
 /obj/structure/cardboardbox,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fGQ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -5711,7 +6035,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fHi" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/junk,
@@ -5782,12 +6109,18 @@
 	},
 /obj/item/trash/mre,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fLF" = (
 /obj/machinery/door/airlock/centcom,
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fLW" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushc2,
@@ -5881,7 +6214,10 @@
 "fQG" = (
 /obj/item/trash/os_coco_wrapper,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fRg" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -5889,7 +6225,10 @@
 "fRD" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fRZ" = (
 /obj/structure/salvageable/data_os,
 /turf/simulated/floor/plating/under,
@@ -5929,7 +6268,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fTI" = (
 /obj/structure/target_stake,
 /obj/item/target/syndicate,
@@ -5990,7 +6332,10 @@
 /obj/item/reagent_containers/food/snacks/toastedsandwich,
 /obj/item/reagent_containers/food/snacks/toastedsandwich,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fVI" = (
 /obj/structure/bed/chair/custom/onestar/red{
 	dir = 4
@@ -6035,7 +6380,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mopbucket,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fXe" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -6052,7 +6400,10 @@
 	},
 /obj/structure/flora/pottedplant/rotwood_blue,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "fXI" = (
 /obj/structure/railing/grey,
 /obj/effect/step_trigger/vault_bunker_2F,
@@ -6092,7 +6443,10 @@
 /obj/machinery/porta_turret/excelsior/preloaded,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gab" = (
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -6168,7 +6522,10 @@
 "gfM" = (
 /obj/item/gun/projectile/automatic/thompson,
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gfN" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -6190,7 +6547,10 @@
 "ggb" = (
 /obj/item/trash/grease,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ggM" = (
 /obj/random/scrap/dense_weighted,
 /obj/random/scrap/dense_weighted,
@@ -6238,11 +6598,17 @@
 "gia" = (
 /obj/machinery/cooking_with_jane/oven,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gid" = (
 /obj/structure/table/bench/standard,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gim" = (
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
@@ -6263,7 +6629,10 @@
 /obj/item/trash/mre_shokoladka,
 /obj/machinery/clonepod,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gjt" = (
 /obj/structure/flora/small/trailrockb3,
 /turf/simulated/floor/asteroid/dirt,
@@ -6286,7 +6655,10 @@
 "gkh" = (
 /obj/machinery/light,
 /turf/simulated/floor/rock/manmade/ruin2,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gkM" = (
 /obj/structure/sign/neon/beer,
 /turf/simulated/wall/r_wall,
@@ -6313,7 +6685,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gmm" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -6411,7 +6786,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/firstaid/low_chance,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "grf" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -6586,7 +6964,10 @@
 "gyo" = (
 /obj/random/dungeon_gun_energy,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gys" = (
 /obj/item/tool/broken_bottle,
 /obj/effect/decal/cleanable/generic,
@@ -6602,7 +6983,10 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gyZ" = (
 /obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/jungle,
@@ -6632,7 +7016,10 @@
 "gAk" = (
 /obj/structure/flora/pottedplant/mysterious,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gAr" = (
 /obj/machinery/seed_storage/random,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -6652,6 +7039,13 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/meadow)
+"gBK" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/rock/manmade/ruin2,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gBX" = (
 /obj/machinery/porta_turret/prepper{
 	check_access = 0
@@ -6761,12 +7155,18 @@
 "gFS" = (
 /obj/structure/salvageable/data_os,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gGm" = (
 /obj/random/lowkeyrandom,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gGH" = (
 /obj/item/remains/ribcage,
 /obj/effect/decal/cleanable/blood,
@@ -6780,7 +7180,10 @@
 "gHH" = (
 /obj/structure/scrap_cube,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gIP" = (
 /obj/machinery/door/airlock/freezer,
 /turf/simulated/floor/tiled/cafe,
@@ -6791,7 +7194,10 @@
 	},
 /obj/machinery/door/airlock,
 /turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gJo" = (
 /obj/structure/flora/big/bush3,
 /turf/simulated/wall/wood_old,
@@ -6905,7 +7311,10 @@
 /obj/structure/table/woodentable,
 /obj/machinery/chemical_dispenser/coffee_master,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gQq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -7026,7 +7435,10 @@
 /obj/effect/decal/cleanable/generic,
 /obj/random/scrap,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "gUl" = (
 /obj/structure/cryofeed{
 	dir = 4;
@@ -7156,7 +7568,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hcG" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall19";
@@ -7223,7 +7638,10 @@
 /area/nadezhda/dungeon/outside/monster_cave)
 "hgL" = (
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hhc" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/stock_parts/console_screen,
@@ -7353,7 +7771,10 @@
 "hmx" = (
 /obj/structure/flora/small/grassb2,
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hmJ" = (
 /obj/item/trash/raisins,
 /obj/effect/decal/cleanable/dirt,
@@ -7409,7 +7830,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hnQ" = (
 /obj/structure/table/rack/shelf,
 /obj/item/paper_bin,
@@ -7443,7 +7867,10 @@
 "hox" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hpb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/stack/medical/bruise_pack/handmade,
@@ -7548,7 +7975,10 @@
 "hwy" = (
 /obj/structure/sign/faction/excelsior_old,
 /turf/simulated/wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hwD" = (
 /obj/item/trash/tray,
 /obj/random/traps,
@@ -7610,7 +8040,10 @@
 "hyA" = (
 /obj/machinery/porta_turret/excelsior/preloaded,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hyZ" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/wild5,
@@ -7637,13 +8070,19 @@
 /obj/structure/table/standard,
 /obj/random/medical,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hBa" = (
 /obj/item/mine/excelsior{
 	armed = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hBX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -7674,7 +8113,10 @@
 "hDc" = (
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hEU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/lathe_disk,
@@ -7785,7 +8227,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hJY" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/junkfood/rotten/low_chance,
@@ -7835,7 +8280,10 @@
 "hNR" = (
 /obj/structure/flora/small/grassa5,
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hNY" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha3,
@@ -7854,7 +8302,10 @@
 /obj/structure/table/standard,
 /obj/random/surgery_tool/low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hOt" = (
 /obj/structure/salvageable/machine,
 /turf/simulated/floor/tiled/dark,
@@ -7865,7 +8316,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hPm" = (
 /obj/structure/salvageable/data_os,
 /turf/simulated/floor/plating/under,
@@ -7900,12 +8354,18 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/plate,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hQX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/bench/standard,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hRb" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/outside/meadow)
@@ -8052,7 +8512,10 @@
 "hYL" = (
 /obj/item/implant/excelsior/broken,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "hYM" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/railing,
@@ -8123,7 +8586,10 @@
 	},
 /obj/random/dungeon_ammo/really_low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "icq" = (
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark,
@@ -8192,7 +8658,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/gym/robustness,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ieY" = (
 /obj/structure/flora/small/rock4,
 /obj/random/mob/vox/low_chance,
@@ -8246,7 +8715,10 @@
 /obj/structure/table/gamblingtable,
 /obj/item/gun/projectile/makarov/preloaded,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ihc" = (
 /obj/random/mob/voidwolf/low_chance,
 /turf/simulated/floor/tiled/cafe,
@@ -8272,7 +8744,10 @@
 /obj/item/trash/cheesie,
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "iiE" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/white/panels,
@@ -8282,7 +8757,10 @@
 /obj/item/mine/excelsior,
 /obj/item/trash/candy/proteinbar,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "iji" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap,
@@ -8303,7 +8781,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ikb" = (
 /obj/structure/table/rack/shelf,
 /obj/random/firstaid/low_chance,
@@ -8323,7 +8804,10 @@
 "ikF" = (
 /obj/item/trash/semki,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ikO" = (
 /obj/structure/catwalk,
 /obj/random/mob/prepper,
@@ -8364,7 +8848,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/closet,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "imx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -8640,7 +9127,10 @@
 "izA" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "izY" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/firstaid,
@@ -8655,7 +9145,10 @@
 "iAz" = (
 /obj/structure/closet/random_milsupply,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "iAE" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/beakers,
@@ -8713,7 +9206,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "iEa" = (
 /obj/machinery/light{
 	dir = 1
@@ -8804,7 +9300,10 @@
 /obj/item/bedsheet,
 /obj/item/gun/projectile/boltgun,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "iHc" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/asteroid/grass,
@@ -9105,7 +9604,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/dungeon_gun_ballistic,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "iYS" = (
 /mob/living/simple_animal/hostile/hivebot,
 /turf/unsimulated/mineral,
@@ -9183,7 +9685,10 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jcH" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9294,7 +9799,10 @@
 "jfz" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jfW" = (
 /obj/machinery/gym/robustness,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -9308,7 +9816,10 @@
 "jgj" = (
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jgr" = (
 /mob/living/simple_animal/schlorgo,
 /turf/simulated/floor/asteroid/grass,
@@ -9381,7 +9892,10 @@
 /mob/living/carbon/superior_animal/human/excelsior,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jiM" = (
 /obj/random/science,
 /turf/simulated/floor/tiled/dark,
@@ -9416,7 +9930,10 @@
 "jjD" = (
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jjE" = (
 /obj/random/flora/jungle_tree,
 /turf/simulated/mineral/planet,
@@ -9484,7 +10001,10 @@
 "jkv" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jkG" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/plasma/random,
@@ -9504,7 +10024,10 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jlK" = (
 /obj/structure/cable/yellow,
 /obj/structure/salvageable/machine,
@@ -9513,7 +10036,10 @@
 "jlL" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized,
 /turf/space,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jmu" = (
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/wall/r_wall,
@@ -9522,7 +10048,10 @@
 /obj/item/gun/projectile/makarov/preloaded,
 /obj/structure/closet/gimmick,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jnj" = (
 /mob/living/simple_animal/hostile/bear/brown,
 /turf/simulated/floor/asteroid/grass,
@@ -9532,11 +10061,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/dungeon_gun_ballistic,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jnq" = (
 /mob/living/simple_animal/hostile/bear/excelsior,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jnw" = (
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt,
@@ -9612,7 +10147,10 @@
 "jrF" = (
 /obj/structure/medical_stand,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jrV" = (
 /obj/random/cluster/spiders,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -9621,7 +10159,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jsR" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -9644,7 +10185,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jvH" = (
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/beach/sand/desert,
@@ -9881,7 +10425,10 @@
 "jJO" = (
 /obj/structure/closet/random_medsupply,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jJQ" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/science,
@@ -10041,7 +10588,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jQU" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/small/busha1,
@@ -10142,7 +10692,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "jXk" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/material/shard,
@@ -10221,7 +10774,10 @@
 "kaq" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kbC" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/item/reagent_containers/glass/bottle/petrel,
@@ -10268,7 +10824,10 @@
 	armed = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kdx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -10337,7 +10896,10 @@
 "kfA" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kfD" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/decal/cleanable/rubble,
@@ -10348,7 +10910,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kfJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/prepper,
@@ -10367,7 +10932,10 @@
 /obj/structure/closet/body_bag,
 /obj/landmark/corpse/excelsior,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kgn" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10408,7 +10976,10 @@
 /obj/item/implanter/excelsior/broken,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kjs" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/clothing/head/welding,
@@ -10487,7 +11058,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/material/metal,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "knq" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -10584,7 +11158,10 @@
 /obj/item/storage/pouch/ammo,
 /obj/random/contraband,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ksF" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -10610,7 +11187,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ktF" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/prepper/vault/floor5)
@@ -10726,7 +11306,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kzF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -10749,7 +11332,10 @@
 "kAK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kBi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -10765,7 +11351,10 @@
 /obj/random/dungeon_ammo/low_chance,
 /obj/random/dungeon_ammo/low_chance,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kBn" = (
 /obj/item/ammo_magazine/light_rifle_257/empty,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -10784,7 +11373,10 @@
 "kBY" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kCa" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/dark,
@@ -10966,7 +11558,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/dungeon_ammo/low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kNj" = (
 /obj/structure/table/woodentable,
 /obj/random/oddity_guns,
@@ -11030,7 +11625,10 @@
 /obj/structure/scrap_cube,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kQG" = (
 /obj/structure/closet/onestar/tier1/mineral,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -11048,7 +11646,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/liquidfood,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kSw" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
@@ -11058,7 +11659,10 @@
 /obj/machinery/light,
 /obj/structure/closet/random_medsupply,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kSO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/claymore,
@@ -11072,7 +11676,10 @@
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kUx" = (
 /obj/structure/table/steel,
 /obj/random/science,
@@ -11122,7 +11729,10 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/mug,
 /obj/item/reagent_containers/food/drinks/drinkingglass/mug,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kVE" = (
 /mob/living/carbon/superior_animal/xenomorph{
 	name = "Greg";
@@ -11179,7 +11789,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kYd" = (
 /obj/structure/table/rack/shelf,
 /obj/random/tool/advanced/onestar/low_chance,
@@ -11202,7 +11815,10 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "kZv" = (
 /obj/structure/table/onestar,
 /obj/random/common_oddities/low_chance,
@@ -11226,7 +11842,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "laj" = (
 /obj/structure/table/marble,
 /obj/random/medical,
@@ -11319,7 +11938,10 @@
 /obj/item/computer_hardware/hard_drive/portable/design/guns/ex_vintorez,
 /obj/item/book/manual/nonfiction/thescienceofright,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lgw" = (
 /obj/structure/table/standard,
 /obj/item/clothing/accessory/stethoscope,
@@ -11404,7 +12026,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ljt" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/science,
@@ -11458,7 +12083,10 @@
 "llF" = (
 /mob/living/simple_animal/hostile/megafauna/excelsior_cosmonaught,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "llJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -11499,7 +12127,10 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lpp" = (
 /obj/structure/flora/small/grassb2,
 /obj/structure/flora/ausbushes/grassybush,
@@ -11533,7 +12164,10 @@
 /obj/machinery/door/airlock,
 /obj/item/mine/excelsior,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lrE" = (
 /obj/machinery/door/airlock/multi_tile/metal,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -11545,7 +12179,10 @@
 /obj/random/scrap/dense_even,
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lrY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -11867,7 +12504,10 @@
 /obj/effect/decal/cleanable/filth,
 /mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lIk" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/under,
@@ -11880,7 +12520,10 @@
 "lJy" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lJE" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/mineral/planet,
@@ -11948,12 +12591,18 @@
 "lMF" = (
 /obj/random/closet,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lNk" = (
 /obj/machinery/suit_storage_unit/excelsior,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lNE" = (
 /obj/random/structures/os,
 /turf/simulated/floor/tiled/white/panels,
@@ -11965,12 +12614,18 @@
 "lOU" = (
 /obj/structure/flora/pottedplant/star_root,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lPa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lPc" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -11998,7 +12653,10 @@
 /obj/item/gun/projectile/boltgun/heavysniper,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lQk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_even,
@@ -12059,7 +12717,10 @@
 /mob/living/carbon/superior_animal/human/excelsior,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "lTC" = (
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/nadezhda/outside/one_star)
@@ -12332,12 +12993,18 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "mjb" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/stack/medical/bruise_pack,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "mjo" = (
 /obj/structure/table/standard,
 /obj/random/gun_energy_cheap,
@@ -12422,7 +13089,10 @@
 "mng" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "mnY" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark,
@@ -12660,7 +13330,10 @@
 	},
 /obj/structure/closet/random_milsupply,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "myJ" = (
 /turf/simulated/shuttle/wall/cargo{
 	icon_state = "cargoshwall31";
@@ -12802,7 +13475,10 @@
 "mED" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "mEL" = (
 /obj/structure/table/steel,
 /obj/random/tool_upgrade/low_chance,
@@ -12944,7 +13620,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "mKm" = (
 /obj/effect/step_trigger/vault_bunker_1A,
 /turf/simulated/floor/tiled/dark,
@@ -13049,7 +13728,10 @@
 /obj/item/gun/projectile/automatic/ak47/saiga,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "mNN" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
@@ -13062,7 +13744,10 @@
 "mOu" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "mOL" = (
 /obj/structure/boulder,
 /obj/structure/barricade,
@@ -13224,7 +13909,10 @@
 /obj/item/trash/popcorn,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "mVa" = (
 /obj/random/material_rare,
 /obj/random/material_rare,
@@ -13261,7 +13949,10 @@
 /obj/random/dungeon_gun_ballistic,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "mWT" = (
 /obj/structure/table/rack/shelf,
 /obj/random/booze/low_chance,
@@ -13465,7 +14156,10 @@
 	},
 /obj/structure/largecrate/animal/cat,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ngF" = (
 /obj/structure/shuttle_part/cargo{
 	icon_state = "cargoshwall36";
@@ -13491,7 +14185,10 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/storage/pouch/ammo,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nhm" = (
 /obj/structure/table/onestar,
 /obj/item/paper_bin,
@@ -13552,11 +14249,17 @@
 "nld" = (
 /obj/structure/scrap,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nle" = (
 /obj/structure/salvageable/implant_container_os,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nlq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13642,7 +14345,10 @@
 /obj/structure/table/standard,
 /obj/random/booze,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nod" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stack/material/cardboard/random,
@@ -13715,7 +14421,10 @@
 "nrW" = (
 /obj/structure/salvageable/computer_os,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nsg" = (
 /obj/structure/salvageable/console_os,
 /turf/simulated/floor/tiled/derelict,
@@ -13754,17 +14463,26 @@
 /obj/effect/decal/cleanable/filth,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nuE" = (
 /obj/item/trash/gamerchips,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nuW" = (
 /obj/structure/table/marble,
 /obj/item/gun/projectile/automatic/ak47,
 /obj/random/contraband,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nvl" = (
 /obj/structure/sign/warning/caution{
 	pixel_x = -30
@@ -13842,7 +14560,10 @@
 /obj/item/towel,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nxY" = (
 /turf/unsimulated/mineral,
 /area/colony)
@@ -13894,7 +14615,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nBv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
@@ -13905,7 +14629,10 @@
 /obj/machinery/light,
 /obj/structure/showcase/television,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nBY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -13929,7 +14656,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nCJ" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/glass/bottle/aluminum,
@@ -14005,11 +14735,17 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/human/excelsior,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nGW" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nHb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
@@ -14056,7 +14792,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nJw" = (
 /obj/effect/decal/cleanable/rubble,
 /mob/living/simple_animal/hostile/bear/excelsior,
@@ -14086,7 +14825,10 @@
 /obj/item/keys/janitor,
 /obj/item/mop,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nMX" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -14122,7 +14864,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nPq" = (
 /obj/structure/flora/small/busha2,
 /obj/random/flora/jungle_tree,
@@ -14132,7 +14877,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/projectile/makarov/preloaded,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nPK" = (
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/asteroid/dirt,
@@ -14159,7 +14907,10 @@
 "nQY" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nRe" = (
 /obj/random/contraband,
 /obj/effect/decal/cleanable/dirt,
@@ -14297,7 +15048,10 @@
 /obj/item/gun/projectile/boltgun,
 /obj/structure/closet/custodial,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nZr" = (
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/dungeon/outside/smuggler_zone_u)
@@ -14308,7 +15062,10 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oab" = (
 /obj/structure/closet/secure_closet/freezer,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -14341,7 +15098,10 @@
 "obJ" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oco" = (
 /obj/item/part/gun/frame/kalash,
 /turf/simulated/floor/asteroid/grass,
@@ -14391,7 +15151,10 @@
 "oel" = (
 /obj/machinery/gym/robustness,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oes" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/cafe,
@@ -14432,7 +15195,10 @@
 /obj/machinery/door/airlock/centcom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ofO" = (
 /obj/structure/flora/small/bushb3,
 /obj/structure/flora/big/bush3,
@@ -14540,7 +15306,10 @@
 "ojC" = (
 /obj/item/mine/excelsior,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ojS" = (
 /obj/item/emp_mine/armed,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -14586,7 +15355,10 @@
 /obj/item/part/gun/frame/vintorez,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "omd" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/small/bushc2,
@@ -14637,7 +15409,10 @@
 "opq" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "opC" = (
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -14708,7 +15483,10 @@
 "osM" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "osT" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -14757,7 +15535,10 @@
 "ouu" = (
 /obj/random/dungeon_gun_ballistic,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ovb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -14802,7 +15583,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "owF" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -14819,7 +15603,10 @@
 /obj/structure/barricade,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oxj" = (
 /obj/machinery/light{
 	dir = 1
@@ -14970,7 +15757,10 @@
 /mob/living/carbon/superior_animal/human/excelsior,
 /obj/structure/table/bench/standard,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oEv" = (
 /obj/machinery/button/remote/airlock{
 	dir = 8;
@@ -15015,7 +15805,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oFC" = (
 /obj/random/lathe_disk/advanced,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -15112,11 +15905,17 @@
 /obj/structure/table/bench/standard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oKr" = (
 /obj/structure/sign/departmentold/medical2,
 /turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oKx" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/white,
@@ -15217,7 +16016,10 @@
 /area/colony/exposedsun/crashed_shop/outsider)
 "oNj" = (
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oNq" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -15249,7 +16051,10 @@
 "oPF" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oPJ" = (
 /obj/machinery/botany,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -15278,7 +16083,10 @@
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oRl" = (
 /obj/machinery/light/small,
 /obj/structure/table/standard,
@@ -15314,7 +16122,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oSf" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha1,
@@ -15331,7 +16142,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/rock/manmade/ruin2,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oSD" = (
 /obj/random/pack/junk_machine,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -15374,7 +16188,10 @@
 "oTT" = (
 /obj/structure/flora/pottedplant/redshoot,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oUc" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -15454,7 +16271,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oWV" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/reagent_dispensers/fueltank,
@@ -15472,7 +16292,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/autoinjector/drugs,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "oYe" = (
 /obj/machinery/light{
 	dir = 8;
@@ -15558,7 +16381,10 @@
 "pdh" = (
 /obj/structure/sign/warning/lethal_turrets,
 /turf/simulated/wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "peq" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/carpet/turcarpet,
@@ -15588,7 +16414,10 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/bear/excelsior,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pgh" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	name = "General Containment"
@@ -15608,12 +16437,18 @@
 "phk" = (
 /obj/structure/coatrack,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "phC" = (
 /obj/effect/decal/cleanable/generic,
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pit" = (
 /obj/structure/multiz/ladder,
 /turf/simulated/floor/asteroid/grass,
@@ -15704,7 +16539,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pkC" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/small/busha1,
@@ -15750,7 +16588,10 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "plK" = (
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/dungeon/outside/smuggler_zone)
@@ -15771,7 +16612,10 @@
 	},
 /obj/random/dungeon_ammo/really_low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pnn" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -15814,7 +16658,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/random/scrap,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pnV" = (
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -15855,7 +16702,10 @@
 	},
 /obj/random/dungeon_ammo/really_low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ppo" = (
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -15944,7 +16794,10 @@
 "pve" = (
 /obj/structure/sign/directions/medical,
 /turf/simulated/wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pvh" = (
 /obj/structure/table/rack,
 /obj/item/tool/hammer/dumbbell,
@@ -16035,7 +16888,10 @@
 "pzz" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pzW" = (
 /obj/structure/flora/small/busha2,
 /obj/landmark/storyevent/midgame_stash_spawn,
@@ -16052,7 +16908,10 @@
 /obj/structure/table/standard,
 /obj/item/clothing/glasses/eyepatch/secpatch,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pAx" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/wild5,
@@ -16067,7 +16926,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mine/excelsior,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pBb" = (
 /obj/structure/table/onestar,
 /obj/structure/salvageable/implant_container_os,
@@ -16076,7 +16938,10 @@
 "pBg" = (
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pBC" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/big/bush2,
@@ -16148,7 +17013,10 @@
 /obj/item/mine/excelsior,
 /obj/item/trash/liquidfood,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pFJ" = (
 /obj/machinery/power/solar_control,
 /obj/structure/cable{
@@ -16188,7 +17056,10 @@
 /obj/effect/decal/cleanable/blood,
 /obj/structure/closet/random_medsupply,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pHb" = (
 /obj/structure/medical_stand/anesthetic,
 /turf/simulated/floor/tiled/cafe,
@@ -16200,7 +17071,10 @@
 "pHI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pHN" = (
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -16269,7 +17143,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/item/trash/mre_can,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pJz" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark,
@@ -16333,7 +17210,10 @@
 /mob/living/carbon/superior_animal/human/excelsior,
 /obj/random/dungeon_ammo/low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pMx" = (
 /obj/structure/bed/chair/custom/onestar/red{
 	dir = 1
@@ -16357,7 +17237,10 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/item/bedsheet,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pMY" = (
 /obj/item/contraband/poster/placed/generic/fruit_bowl{
 	pixel_y = 32
@@ -16381,7 +17264,10 @@
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
 /obj/structure/curtain/medical,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pNN" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16606,7 +17492,10 @@
 "pXi" = (
 /obj/structure/curtain/medical,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pXj" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/random/gun_normal,
@@ -16689,7 +17578,10 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pZH" = (
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -16742,7 +17634,10 @@
 /obj/item/trash/plate,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qdm" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/excelsior/mixed{
@@ -16843,7 +17738,10 @@
 /obj/random/ammo_fancy,
 /obj/random/ammo_fancy,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qhr" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8
@@ -16885,7 +17783,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/random_medsupply,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qiC" = (
 /obj/machinery/light/floor{
 	dir = 4;
@@ -16899,7 +17800,10 @@
 "qjc" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qjg" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -16980,7 +17884,10 @@
 "qmN" = (
 /obj/machinery/shieldwallgen/excelsior,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qmO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/drone_fabricator,
@@ -17079,7 +17986,10 @@
 	},
 /obj/random/closet,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qtD" = (
 /obj/random/dungeon_ammo/low_chance,
 /obj/random/dungeon_ammo/low_chance,
@@ -17123,7 +18033,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qvn" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/dark,
@@ -17139,7 +18052,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qwo" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
@@ -17180,7 +18096,10 @@
 /obj/random/dungeon_ammo/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qxJ" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -17242,7 +18161,10 @@
 "qzT" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qAS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -17395,7 +18317,10 @@
 /obj/item/trash/popcorn,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qGS" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/flora/small/bushc3,
@@ -17408,7 +18333,10 @@
 /obj/structure/table/standard,
 /obj/random/surgery_tool,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qHh" = (
 /obj/random/cluster/roaches,
 /turf/simulated/floor/tiled,
@@ -17457,7 +18385,10 @@
 "qJt" = (
 /obj/structure/sign/warning/armory/small,
 /turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qJD" = (
 /obj/random/junk,
 /obj/random/junk,
@@ -17575,7 +18506,10 @@
 "qPt" = (
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qPO" = (
 /obj/structure/table/rack/shelf,
 /obj/random/medical,
@@ -17663,7 +18597,10 @@
 /obj/item/mine/excelsior,
 /obj/machinery/door/airlock,
 /turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qTv" = (
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood/wild5,
@@ -17722,7 +18659,10 @@
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "qWt" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/asteroid/grass,
@@ -17896,7 +18836,10 @@
 "rdH" = (
 /obj/item/trash/mre,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rdN" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -17914,7 +18857,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rfd" = (
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -17941,7 +18887,10 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rgX" = (
 /obj/random/techpart/low_chance,
 /obj/random/closet_maintloot,
@@ -17955,7 +18904,10 @@
 /obj/structure/table/standard,
 /obj/random/booze,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rhw" = (
 /mob/living/carbon/superior_animal/robot/greyson/custodian/engineer,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
@@ -17986,7 +18938,10 @@
 "riv" = (
 /obj/item/storage/fancy/vials,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "riD" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18276,7 +19231,10 @@
 /obj/structure/reagent_dispensers/fueltank/derelict,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rxy" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -18325,7 +19283,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/pistachios,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rAV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
@@ -18362,7 +19323,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rBW" = (
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
@@ -18403,7 +19367,10 @@
 "rCV" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_ak,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rDf" = (
 /obj/structure/sign/warning/caution/small2,
 /turf/simulated/wall/r_wall,
@@ -18435,7 +19402,10 @@
 /obj/structure/table/standard,
 /obj/random/dungeon_gun_ballistic/low_chance,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rEO" = (
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "prepperdoorinternal";
@@ -18544,7 +19514,10 @@
 /obj/machinery/light,
 /obj/structure/firedoor_assembly,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rMe" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/asteroid/grass,
@@ -18661,7 +19634,10 @@
 /obj/random/gun_parts,
 /obj/item/gun_upgrade/barrel/faulty,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rSp" = (
 /obj/random/mob/render/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -18719,13 +19695,19 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rWf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "rWz" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/small/busha2,
@@ -18829,7 +19811,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "scK" = (
 /obj/item/tank/onestar_regenerator,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -18870,7 +19855,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/random/dungeon_ammo/low_chance,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "sdT" = (
 /obj/machinery/autolathe/mechfab/loaded,
 /turf/simulated/floor/tiled/dark,
@@ -18964,7 +19952,10 @@
 	},
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "shv" = (
 /obj/structure/table/onestar,
 /obj/random/pack/tech_loot/onestar,
@@ -19094,11 +20085,17 @@
 /obj/item/trash/peachcan,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "snd" = (
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "sns" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
@@ -19181,12 +20178,18 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "srx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/pottedplant/green_rock,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "srB" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/undergroundmob/low_chance,
@@ -19202,11 +20205,17 @@
 /obj/structure/table/rack,
 /obj/item/gun/projectile/automatic/vintorez,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ssP" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "stb" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable{
@@ -19259,7 +20268,10 @@
 /obj/item/ammo_casing/rocket,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "suZ" = (
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -19334,11 +20346,17 @@
 /obj/structure/table/reinforced,
 /obj/random/credits/c100,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "syp" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "syE" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood/wild5,
@@ -19354,7 +20372,10 @@
 "szl" = (
 /obj/machinery/door/airlock,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "sAP" = (
 /obj/structure/flora/small/bushc1,
 /obj/structure/flora/big/bush3,
@@ -19426,7 +20447,10 @@
 "sDd" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "sDt" = (
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt,
@@ -19439,7 +20463,10 @@
 "sEk" = (
 /obj/random/scrap,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "sEK" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -19587,7 +20614,10 @@
 "sNe" = (
 /obj/machinery/porta_turret/excelsior/preloaded,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "sNA" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -19734,7 +20764,10 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "sUP" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/random/mob/voidwolf/low_chance,
@@ -19764,7 +20797,10 @@
 "sXz" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "sXB" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/standard,
@@ -19807,7 +20843,10 @@
 	},
 /obj/item/trash/liquidfood,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "sZV" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/wood/wild4,
@@ -19926,7 +20965,10 @@
 /obj/item/storage/bag/trash,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tgL" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
@@ -19947,7 +20989,10 @@
 "thh" = (
 /mob/living/simple_animal/hostile/bear/excelsior,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "thS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -19983,7 +21028,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tji" = (
 /obj/random/junk,
 /obj/random/junk,
@@ -20051,7 +21099,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tlO" = (
 /obj/structure/closet/onestar/tier3/special,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -20130,7 +21181,10 @@
 "tqb" = (
 /obj/structure/curtain,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tqA" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/claymore,
@@ -20182,7 +21236,16 @@
 "ttU" = (
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
+"tun" = (
+/turf/simulated/floor/rock/manmade/ruin2,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tuo" = (
 /obj/item/folder/red,
 /obj/item/folder/red,
@@ -20243,7 +21306,10 @@
 /obj/effect/decal/cleanable/generic,
 /obj/item/trash/mre,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tyi" = (
 /obj/effect/overlay/water/top{
 	pixel_y = -9
@@ -20267,7 +21333,10 @@
 /obj/item/tool/saw/circular/medical,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tyW" = (
 /obj/machinery/light{
 	dir = 4;
@@ -20310,7 +21379,10 @@
 "tAf" = (
 /obj/structure/noticeboard/medical,
 /turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tAp" = (
 /turf/simulated/wall,
 /area/nadezhda/dungeon/outside/zoo)
@@ -20329,7 +21401,10 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tBk" = (
 /obj/structure/table/rack/shelf,
 /obj/random/gun_energy_cheap,
@@ -20344,7 +21419,10 @@
 /obj/structure/table/reinforced,
 /obj/item/gun/projectile/boltgun,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tCf" = (
 /obj/structure/table/standard,
 /obj/random/gun_energy_cheap,
@@ -20357,7 +21435,10 @@
 "tCZ" = (
 /obj/structure/sign/faction/excelsior_old,
 /turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tDb" = (
 /obj/random/mob/undergroundmob,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -20429,7 +21510,10 @@
 /obj/structure/dogbed,
 /obj/structure/flora/pumpkin,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tFU" = (
 /obj/structure/flora/small/busha2,
 /obj/item/mine/armed,
@@ -20447,7 +21531,10 @@
 "tIm" = (
 /obj/structure/boulder,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tIC" = (
 /obj/item/paper_bin,
 /obj/item/paper_bin,
@@ -20612,7 +21699,10 @@
 "tQp" = (
 /obj/machinery/door/airlock,
 /turf/simulated/floor/tiled/dark,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tQt" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/carpet,
@@ -20681,7 +21771,10 @@
 /obj/machinery/porta_turret/excelsior/preloaded,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tUH" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/yellow,
@@ -20730,7 +21823,10 @@
 /obj/item/implantcase/excelsior/broken,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "tWY" = (
 /obj/structure/table/onestar,
 /obj/item/stock_parts/manipulator/one_star,
@@ -20821,7 +21917,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uaW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20833,7 +21932,10 @@
 "ubp" = (
 /obj/random/closet,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ubu" = (
 /obj/random/mob/voidwolf,
 /turf/simulated/floor/wood/wild5,
@@ -20878,7 +21980,10 @@
 /mob/living/carbon/superior_animal/human/excelsior/excel_drozd,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "udc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/guns/large,
@@ -20910,7 +22015,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/lapvend,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uec" = (
 /obj/structure/flora/tree/dead,
 /turf/simulated/floor/beach/sand,
@@ -20925,7 +22033,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ueX" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/enzyme,
@@ -20943,7 +22054,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ufg" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -20978,7 +22092,10 @@
 	},
 /obj/random/closet,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ugd" = (
 /obj/structure/table/onestar,
 /obj/item/stock_parts/matter_bin/one_star,
@@ -20992,7 +22109,10 @@
 "ugr" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ugx" = (
 /obj/structure/table,
 /obj/item/stack/material/wood/random,
@@ -21007,7 +22127,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ugY" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -21038,7 +22161,10 @@
 "uhF" = (
 /mob/living/carbon/superior_animal/human/excelsior,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uih" = (
 /obj/machinery/power/smes/buildable,
 /turf/simulated/shuttle/floor/mining,
@@ -21102,7 +22228,10 @@
 "umz" = (
 /mob/living/carbon/superior_animal/human/excelsior/excel_vintorez,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "umG" = (
 /obj/machinery/light,
 /turf/simulated/floor/asteroid/grass,
@@ -21243,7 +22372,10 @@
 "utC" = (
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "utY" = (
 /mob/living/simple_animal/penguin/baby,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -21330,7 +22462,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uzt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/remains/human,
@@ -21416,7 +22551,10 @@
 "uCV" = (
 /obj/machinery/door/window/holowindoor,
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uDa" = (
 /obj/structure/closet/random_hostilemobs,
 /obj/effect/decal/cleanable/dirt,
@@ -21442,7 +22580,10 @@
 /obj/structure/scrap_cube,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uDY" = (
 /obj/structure/girder,
 /turf/simulated/floor/tiled/dark,
@@ -21453,7 +22594,10 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/taperoll/police,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uEq" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
@@ -21531,6 +22675,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/mineral/planet,
 /area/nadezhda/outside/meadow)
+"uHr" = (
+/turf/simulated/mineral/random/rogue,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uHE" = (
 /obj/random/mob/roomba/job,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -21574,7 +22724,10 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uJw" = (
 /turf/simulated/wall/wood_old,
 /area/asteroid/rogue)
@@ -21594,7 +22747,10 @@
 "uJW" = (
 /obj/item/trash/mre,
 /turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uKY" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/wood/wild4,
@@ -21685,7 +22841,10 @@
 /obj/item/bedsheet,
 /obj/item/storage/firstaid/combat,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uON" = (
 /obj/machinery/gym,
 /turf/simulated/floor/wood/wild5,
@@ -21881,7 +23040,10 @@
 "uWM" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "uXk" = (
 /obj/structure/flora/small/busha3,
 /obj/random/mob/vox/low_chance,
@@ -21932,7 +23094,10 @@
 "vbn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vbq" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -22121,7 +23286,10 @@
 "vjc" = (
 /obj/structure/sign/departmentold/janitorial,
 /turf/simulated/wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vjy" = (
 /obj/structure/flora/small/bushb3,
 /obj/structure/flora/tree/jungle_small/variant3,
@@ -22150,7 +23318,10 @@
 "vkM" = (
 /obj/machinery/power/smes,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vkQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -22224,7 +23395,10 @@
 	name = "dead spider"
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vom" = (
 /obj/structure/table/plasmaglass,
 /obj/item/ammo_casing/flare/blue/prespawn,
@@ -22305,18 +23479,27 @@
 /obj/machinery/door/airlock/centcom,
 /obj/item/mine/excelsior,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vss" = (
 /obj/structure/scrap_cube,
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vsV" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vto" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/plating/under,
@@ -22455,7 +23638,10 @@
 /mob/living/carbon/superior_animal/human/excelsior/excel_ppsh,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vBO" = (
 /obj/random/junk/nondense,
 /turf/simulated/floor/tiled/dark,
@@ -22538,7 +23724,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vEk" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/asteroid/grass,
@@ -22568,7 +23757,10 @@
 	},
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vGv" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/lathe_disk,
@@ -22584,7 +23776,10 @@
 "vHs" = (
 /obj/landmark/corpse/excelsior,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vHF" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -22599,7 +23794,10 @@
 	},
 /obj/structure/curtain,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vIA" = (
 /obj/structure/flora/small/bushc2,
 /obj/structure/flora/small/busha2,
@@ -22631,7 +23829,10 @@
 "vJM" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vJQ" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -22753,7 +23954,10 @@
 "vPo" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vPG" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
@@ -22801,7 +24005,10 @@
 /obj/random/ammo,
 /obj/random/ammo,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vQT" = (
 /turf/simulated/floor/wood/wild4,
 /area/colony/exposedsun/pastgate)
@@ -22980,7 +24187,10 @@
 /obj/item/rcd/excelsior,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "vZC" = (
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/dark,
@@ -23063,7 +24273,10 @@
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wdt" = (
 /obj/random/closet,
 /turf/simulated/floor/tiled/dark,
@@ -23211,7 +24424,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/powered/night,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wmE" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
@@ -23225,7 +24441,10 @@
 /obj/random/lowkeyrandom,
 /obj/random/dungeon_gun_ballistic,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wnI" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -23259,7 +24478,10 @@
 	},
 /obj/item/gun/projectile/grenade,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wpR" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/dungeon/outside/zoo)
@@ -23281,7 +24503,10 @@
 /area/asteroid/rogue)
 "wqX" = (
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wre" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "5,20"
@@ -23304,7 +24529,10 @@
 	},
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wsg" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/big/bush3,
@@ -23341,7 +24569,10 @@
 /obj/structure/table/reinforced,
 /obj/item/trash/candle,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wsZ" = (
 /obj/machinery/door/airlock/vault/bolted{
 	req_access = list(999)
@@ -23362,12 +24593,18 @@
 "wtz" = (
 /obj/random/dungeon_gun_ballistic,
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wtC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wtL" = (
 /obj/structure/flora/small/grassb1,
 /obj/structure/flora/small/busha1,
@@ -23391,11 +24628,17 @@
 /obj/structure/table/rack,
 /obj/item/gun/energy/stunrevolver,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wvJ" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wvW" = (
 /obj/structure/table,
 /turf/simulated/floor/tiled/white/panels,
@@ -23553,7 +24796,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wEV" = (
 /obj/item/trash/mre_paste,
 /obj/effect/decal/cleanable/filth,
@@ -23625,7 +24871,10 @@
 "wJm" = (
 /obj/random/junk,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wJr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/nightmare/low_chance,
@@ -23843,7 +25092,10 @@
 /area/nadezhda/outside/one_star)
 "wSZ" = (
 /turf/simulated/floor/asteroid/grass,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "wTe" = (
 /mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -23976,7 +25228,10 @@
 "wZW" = (
 /obj/structure/sign/painting/russianstalin,
 /turf/simulated/wall/r_wall,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xai" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -23986,7 +25241,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xbq" = (
 /obj/random/lathe_disk,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -24029,7 +25287,10 @@
 /obj/item/trash/mre_paste,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xdH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mat_katana,
@@ -24161,7 +25422,10 @@
 /obj/item/clothing/under/excelsior/officer,
 /obj/item/clothing/head/exceslior/excelsior_officer,
 /turf/simulated/floor/wood/wild1,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xhY" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -24169,7 +25433,10 @@
 "xiC" = (
 /obj/random/lowkeyrandom,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xiH" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/contraband,
@@ -24290,7 +25557,10 @@
 /obj/structure/curtain/medical,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xnX" = (
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/grass,
@@ -24359,7 +25629,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xrG" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
 /turf/simulated/floor/tiled/dark/danger,
@@ -24387,11 +25660,23 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xtL" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
+"xtV" = (
+/turf/simulated/wall/r_wall,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xtX" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -24419,7 +25704,10 @@
 "xvh" = (
 /obj/random/oddity_guns,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xvi" = (
 /obj/item/pizzabox/vegetable,
 /obj/random/boxes,
@@ -24538,7 +25826,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xBx" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 2
@@ -24560,11 +25851,17 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xCX" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xDd" = (
 /obj/effect/step_trigger/vault_bunker_2B,
 /turf/simulated/floor/tiled/dark/danger,
@@ -24593,7 +25890,10 @@
 /obj/machinery/door/airlock,
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xEO" = (
 /obj/structure/table/bench/wooden,
 /obj/item/trash/broken_robot_part,
@@ -24780,7 +26080,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xOk" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/busha1,
@@ -24840,7 +26143,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/item/trash/broken_robot_part,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xQu" = (
 /obj/structure/flora/small/busha2,
 /obj/effect/overlay/water,
@@ -24857,7 +26163,10 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xRr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/dark,
@@ -24882,7 +26191,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/sosjerky,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xSP" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -24898,7 +26210,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xTu" = (
 /obj/structure/sign/departmentold/medical1,
 /obj/structure/window/reinforced{
@@ -24923,7 +26238,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/complant_teleporter,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xUd" = (
 /obj/structure/sign/warning/armory{
 	pixel_x = 30
@@ -24991,7 +26309,10 @@
 /obj/structure/curtain/medical,
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "xZx" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/condiment/peppermill,
@@ -25057,7 +26378,10 @@
 /obj/effect/decal/cleanable/filth,
 /obj/structure/table/bench/standard,
 /turf/simulated/floor/tiled/dark/brown_platform,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ybU" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/scrap/poor,
@@ -25159,7 +26483,10 @@
 "yhY" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_perforated,
-/area/asteroid/rogue)
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "yiT" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/tool/advanced,
@@ -49491,8 +50818,8 @@ coU
 coU
 hwy
 oSA
-wRP
-iFU
+gBK
+tun
 gkh
 hwy
 coU
@@ -49693,30 +51020,30 @@ nxY
 nxY
 coU
 coU
-rKz
-rKz
-rKz
-rKz
-rKz
-mNA
+xtV
+xtV
+xtV
+xtV
+xtV
+aHN
 pdh
 fsd
 kfA
 pdh
-mNA
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
+aHN
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 coU
 coU
 coU
@@ -49902,7 +51229,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 amr
 hgL
 aXQ
@@ -49917,7 +51244,7 @@ wvJ
 cYh
 wtC
 fcB
-rKz
+xtV
 aLI
 wtz
 eas
@@ -49925,7 +51252,7 @@ wSZ
 wSZ
 aLI
 wSZ
-rKz
+xtV
 coU
 coU
 coU
@@ -50111,7 +51438,7 @@ nxY
 nxY
 coU
 coU
-qbU
+uHr
 jjD
 tlD
 nuE
@@ -50126,7 +51453,7 @@ hgL
 hgL
 pHI
 hgL
-rKz
+xtV
 hNR
 wSZ
 aLI
@@ -50134,7 +51461,7 @@ wSZ
 eas
 coO
 wSZ
-rKz
+xtV
 coU
 coU
 coU
@@ -50320,8 +51647,8 @@ nxY
 nxY
 coU
 coU
-qbU
-qbU
+uHr
+uHr
 lTl
 pHI
 hgL
@@ -50335,7 +51662,7 @@ hgL
 dnC
 hgL
 wvJ
-rKz
+xtV
 eBe
 aLI
 wSZ
@@ -50343,7 +51670,7 @@ gfM
 aLI
 wSZ
 wSZ
-rKz
+xtV
 coU
 coU
 coU
@@ -50529,7 +51856,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 jjD
 vJM
 ggb
@@ -50544,7 +51871,7 @@ hgL
 pHI
 hgL
 wvJ
-rKz
+xtV
 wSZ
 wSZ
 hNR
@@ -50552,7 +51879,7 @@ wSZ
 wSZ
 wSZ
 aLI
-rKz
+xtV
 coU
 coU
 coU
@@ -50738,7 +52065,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 wvJ
 hgL
 hgL
@@ -50753,7 +52080,7 @@ pHI
 hgL
 hgL
 wvJ
-rKz
+xtV
 hmx
 wSZ
 wSZ
@@ -50761,7 +52088,7 @@ aLI
 aLI
 hNR
 wSZ
-rKz
+xtV
 coU
 coU
 coU
@@ -50947,7 +52274,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 aHK
 fTh
 hox
@@ -50962,7 +52289,7 @@ hgL
 hox
 hgL
 gAk
-rKz
+xtV
 uCV
 glZ
 cOt
@@ -50970,7 +52297,7 @@ glZ
 glZ
 glZ
 cOt
-rKz
+xtV
 coU
 coU
 coU
@@ -51179,7 +52506,7 @@ jgj
 pHI
 hgL
 yhY
-rKz
+xtV
 coU
 coU
 coU
@@ -51365,7 +52692,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 hgL
 utC
 pHI
@@ -51380,7 +52707,7 @@ dpI
 hgL
 oxg
 hgL
-rKz
+xtV
 jgj
 qjc
 hgL
@@ -51388,7 +52715,7 @@ hgL
 owt
 hgL
 vJM
-rKz
+xtV
 coU
 coU
 coU
@@ -51574,7 +52901,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 vsV
 pHI
 pHI
@@ -51589,7 +52916,7 @@ utC
 hgL
 pHI
 rLO
-rKz
+xtV
 eGQ
 hgL
 wtC
@@ -51597,7 +52924,7 @@ pHI
 dpI
 vHs
 axV
-qbU
+uHr
 coU
 coU
 coU
@@ -51783,30 +53110,30 @@ nxY
 nxY
 coU
 coU
-rKz
-mNA
+xtV
+aHN
 szl
 szl
-mNA
-mNA
-mNA
-mNA
-mNA
-mNA
-mNA
-mNA
+aHN
+aHN
+aHN
+aHN
+aHN
+aHN
+aHN
+aHN
 szl
 szl
-mNA
-rKz
+aHN
+xtV
 lOU
 hgL
 hgL
 hgL
 jgj
 vJM
-qbU
-qbU
+uHr
+uHr
 coU
 coU
 coU
@@ -51992,7 +53319,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 oNj
 snd
 oNj
@@ -52007,7 +53334,7 @@ nQY
 oNj
 oNj
 oNj
-rKz
+xtV
 cEx
 dpI
 hgL
@@ -52015,7 +53342,7 @@ hgL
 vJM
 vJM
 axV
-qbU
+uHr
 coU
 coU
 coU
@@ -52201,7 +53528,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 hOw
 aDy
 thh
@@ -52216,7 +53543,7 @@ oNj
 cFk
 snd
 jio
-rKz
+xtV
 gjj
 fLB
 hgL
@@ -52224,7 +53551,7 @@ jgj
 hgL
 hgL
 axV
-qbU
+uHr
 coU
 coU
 coU
@@ -52410,7 +53737,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 aFi
 oNj
 aDy
@@ -52425,7 +53752,7 @@ cvA
 oNj
 aFi
 snd
-rKz
+xtV
 ufe
 pHI
 pHI
@@ -52433,7 +53760,7 @@ hgL
 sZH
 pHI
 chw
-rKz
+xtV
 coU
 coU
 coU
@@ -52619,7 +53946,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 snd
 snd
 snd
@@ -52634,7 +53961,7 @@ uhF
 bRP
 aFi
 nJu
-rKz
+xtV
 ubp
 ima
 ubp
@@ -52642,7 +53969,7 @@ ubp
 utC
 hgL
 pHI
-rKz
+xtV
 coU
 coU
 coU
@@ -52828,30 +54155,30 @@ nxY
 nxY
 coU
 coU
-rKz
-mNA
-mNA
-mNA
-mNA
-mNA
-mNA
+xtV
+aHN
+aHN
+aHN
+aHN
+aHN
+aHN
 oTT
 snd
-mNA
-mNA
-mNA
-mNA
-mNA
-mNA
-mNA
-rKz
-rKz
-rKz
-rKz
-rKz
+aHN
+aHN
+aHN
+aHN
+aHN
+aHN
+aHN
+xtV
+xtV
+xtV
+xtV
+xtV
 fLF
 fRD
-rKz
+xtV
 coU
 coU
 coU
@@ -53037,30 +54364,30 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 xrC
 nld
 nPJ
 azg
 oNj
-mNA
+aHN
 snd
 opq
-mNA
+aHN
 azg
 fyX
 rgT
 jmx
 rgT
 cGo
-mNA
+aHN
 cUA
 rRO
 qPt
 qPt
 kdd
 utC
-rKz
+xtV
 coU
 coU
 coU
@@ -53247,12 +54574,12 @@ nxY
 coU
 coU
 tCZ
-qbU
+uHr
 pMT
 oNj
 xTs
 oNj
-mNA
+aHN
 kZp
 oNj
 hwy
@@ -53262,14 +54589,14 @@ azg
 oNj
 rgT
 snd
-mNA
+aHN
 hgL
 dpI
 pHI
 utC
 hgL
 utC
-rKz
+xtV
 coU
 coU
 coU
@@ -53455,30 +54782,30 @@ nxY
 nxY
 coU
 coU
-qbU
-qbU
-qbU
+uHr
+uHr
+uHr
 pzz
 oNj
 oNj
-mNA
+aHN
 hOw
 thh
-mNA
+aHN
 myt
 fHd
 oNj
 bRP
 oNj
 snd
-mNA
+aHN
 iAz
 hgL
 hgL
 hgL
 pHI
 hyA
-rKz
+xtV
 coU
 coU
 coU
@@ -53664,30 +54991,30 @@ nxY
 nxY
 coU
 coU
-qbU
-qbU
-qbU
+uHr
+uHr
+uHr
 tIm
 rgT
 oNj
-mNA
+aHN
 wsa
 bRP
-mNA
+aHN
 uOI
 oNj
 rgT
 bRP
 azg
 kSE
-mNA
+aHN
 iAz
 hgL
 dnC
 qjc
 rWf
 jgj
-rKz
+xtV
 coU
 coU
 coU
@@ -53873,30 +55200,30 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 tIm
-qbU
+uHr
 tIm
 iHb
 qvg
-mNA
+aHN
 oNj
 bRP
-mNA
+aHN
 rgT
 oNj
 rgT
 oNj
 rgT
 qio
-mNA
+aHN
 vsV
 jgj
 dpI
 hgL
 kzu
 yhY
-rKz
+xtV
 coU
 coU
 coU
@@ -54082,7 +55409,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 uep
 tIm
 mjb
@@ -54091,21 +55418,21 @@ bRP
 tQp
 bCY
 sNe
-mNA
+aHN
 ftz
 oNj
 oNj
 xCX
 oNj
 dWp
-mNA
+aHN
 pHI
 pHI
 eCv
 wvi
 ssO
 wmo
-rKz
+xtV
 coU
 coU
 coU
@@ -54291,30 +55618,30 @@ nxY
 nxY
 coU
 coU
-rKz
-mNA
-mNA
-mNA
-mNA
-mNA
-mNA
+xtV
+aHN
+aHN
+aHN
+aHN
+aHN
+aHN
 oNj
 ucC
-mNA
-mNA
+aHN
+aHN
 szl
-mNA
-mNA
-mNA
-mNA
-mNA
+aHN
+aHN
+aHN
+aHN
+aHN
 pAW
 ofK
-mNA
-mNA
-mNA
+aHN
+aHN
+aHN
 kAK
-rKz
+xtV
 qbU
 qbU
 qbU
@@ -54500,7 +55827,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 dKT
 oNj
 nJu
@@ -54519,11 +55846,11 @@ oNj
 szl
 oNj
 oNj
-mNA
+aHN
 nMq
 iDM
 ubp
-rKz
+xtV
 ugY
 stv
 jkn
@@ -54709,13 +56036,13 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 dyP
 oNj
 fHd
 bRP
 opq
-mNA
+aHN
 mng
 oNj
 oNj
@@ -54728,7 +56055,7 @@ hBa
 szl
 snd
 aFi
-mNA
+aHN
 qts
 hgL
 ubp
@@ -54918,30 +56245,30 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 gia
 bRP
 oDU
 ybJ
 bRP
-mNA
+aHN
 obJ
-mNA
+aHN
 pve
-mNA
-mNA
+aHN
+aHN
 obJ
-mNA
-mNA
-mNA
-mNA
+aHN
+aHN
+aHN
+aHN
 snd
 qvg
-mNA
+aHN
 nZp
 iDM
 ima
-rKz
+xtV
 coU
 coU
 coU
@@ -55127,30 +56454,30 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 fVt
 oNj
 ksu
 nuW
 bRP
-mNA
+aHN
 oNj
 pmY
 oNj
 ice
-mNA
+aHN
 oNj
 ppl
 epY
 ice
-mNA
+aHN
 sNe
 bRP
-mNA
+aHN
 bCs
 hgL
 ubp
-rKz
+xtV
 coU
 coU
 coU
@@ -55336,7 +56663,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 kVt
 oNj
 aQr
@@ -55347,7 +56674,7 @@ hOw
 osM
 oNj
 kfH
-mNA
+aHN
 laf
 beH
 oNj
@@ -55355,11 +56682,11 @@ opq
 hwy
 oNj
 oNj
-mNA
+aHN
 kAK
 vjc
 obJ
-rKz
+xtV
 qbU
 coU
 coU
@@ -55545,30 +56872,30 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 ebi
 oNj
 oNj
 bRP
 dnv
-mNA
+aHN
 miU
 dTV
 osM
 cEA
-mNA
+aHN
 oXO
 qvM
 bRP
 cEA
-mNA
+aHN
 iey
 qGH
 oNj
 xCX
 oNj
 oNj
-rKz
+xtV
 qbU
 coU
 coU
@@ -55754,30 +57081,30 @@ nxY
 nxY
 coU
 coU
-rKz
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
+xtV
 mED
 mED
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 mED
-rKz
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
+xtV
 oel
 bRP
 snd
 bRP
 vBH
 afk
-rKz
+xtV
 qbU
 coU
 coU
@@ -55963,7 +57290,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 hnP
 oNj
 cMR
@@ -55986,7 +57313,7 @@ oNj
 bRP
 snd
 oNj
-rKz
+xtV
 qbU
 coU
 coU
@@ -56195,7 +57522,7 @@ thh
 snd
 bRP
 amQ
-rKz
+xtV
 qbU
 coU
 coU
@@ -56381,7 +57708,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 hOg
 kfS
 ceR
@@ -56397,14 +57724,14 @@ bRP
 kNe
 oNj
 qvg
-rKz
+xtV
 uhF
 snd
 oNj
 dbE
 bRP
 nBK
-rKz
+xtV
 qbU
 coU
 coU
@@ -56590,7 +57917,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 qHe
 kfS
 bRP
@@ -56601,19 +57928,19 @@ rCV
 jJO
 jJO
 pGP
-rKz
+xtV
 jlf
 oNj
 bRP
 bRP
-rKz
+xtV
 xRl
 snd
 axL
 igW
 lPa
 fWQ
-rKz
+xtV
 qbU
 coU
 coU
@@ -56815,14 +58142,14 @@ snd
 kaq
 bRP
 hBa
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 qbU
 coU
 coU
@@ -57019,19 +58346,19 @@ pXi
 pNG
 pXi
 xZn
-rKz
+xtV
 amQ
 pfV
 uWM
 bRR
-rKz
+xtV
 kBi
 pZG
 jgj
 jgj
 ckM
 oWB
-rKz
+xtV
 qbU
 coU
 coU
@@ -57217,7 +58544,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 vFk
 bRP
 pXi
@@ -57228,7 +58555,7 @@ pXi
 oNj
 izA
 izA
-rKz
+xtV
 ufW
 bRP
 oNj
@@ -57240,7 +58567,7 @@ jnq
 hgL
 hgL
 qhe
-rKz
+xtV
 qbU
 coU
 coU
@@ -57426,7 +58753,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 ttU
 bRP
 pXi
@@ -57437,7 +58764,7 @@ pXi
 oNj
 oNj
 oNj
-rKz
+xtV
 oNj
 oNj
 pMm
@@ -57449,7 +58776,7 @@ hgL
 ces
 hgL
 aME
-rKz
+xtV
 qbU
 coU
 coU
@@ -57635,7 +58962,7 @@ nxY
 nxY
 coU
 coU
-rKz
+xtV
 oNj
 lpc
 xmM
@@ -57646,19 +58973,19 @@ pXi
 jrF
 woR
 vnE
-rKz
+xtV
 aOF
 oNj
 oNj
 kts
-rKz
+xtV
 lNk
 pHI
 lQj
 pAv
 hgL
 tTP
-rKz
+xtV
 qbU
 coU
 coU
@@ -57844,30 +59171,30 @@ nxY
 nxY
 coU
 coU
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 oNj
 nxU
-rKz
-rKz
+xtV
+xtV
 mED
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 coU
 coU
 coU
@@ -58054,21 +59381,21 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 ddc
 ckM
 hgL
 hgL
-rKz
+xtV
 jgj
 lJy
 xTT
 uyY
 uea
-rKz
+xtV
 oNj
 bRP
-rKz
+xtV
 eHy
 vbn
 vHY
@@ -58076,7 +59403,7 @@ wJm
 wJm
 wqX
 xhW
-rKz
+xtV
 coU
 coU
 coU
@@ -58268,13 +59595,13 @@ dhV
 hgL
 pHI
 hYL
-rKz
+xtV
 aXQ
 dHR
 fyp
 pHI
 vQG
-rKz
+xtV
 bRP
 oNj
 wZW
@@ -58285,7 +59612,7 @@ wqX
 vbn
 wqX
 gQn
-rKz
+xtV
 coU
 coU
 coU
@@ -58472,7 +59799,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 kjp
 hox
 hgL
@@ -58483,10 +59810,10 @@ nAW
 hgL
 hgL
 ubp
-rKz
+xtV
 snd
 oNj
-rKz
+xtV
 eut
 wqX
 tqb
@@ -58494,7 +59821,7 @@ vbn
 vbn
 vbn
 jnl
-rKz
+xtV
 coU
 coU
 coU
@@ -58681,18 +60008,18 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 kjp
 hgL
 hgL
 kdd
-rKz
+xtV
 ugC
 pHI
 cDT
 hgL
 ubp
-rKz
+xtV
 laf
 hDc
 tCZ
@@ -58703,7 +60030,7 @@ phk
 wqX
 fGF
 fkD
-rKz
+xtV
 coU
 coU
 coU
@@ -58890,29 +60217,29 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 tWQ
 hgL
 pHI
 yhY
-rKz
+xtV
 fQG
 jnq
 pHI
 hgL
 ima
-rKz
+xtV
 lrx
 xEH
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
 mED
-rKz
+xtV
 nGW
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
 coU
 coU
 coU
@@ -59099,7 +60426,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 lgv
 hgL
 hgL
@@ -59121,7 +60448,7 @@ oNj
 oNj
 oNj
 sNe
-rKz
+xtV
 coU
 coU
 coU
@@ -59308,12 +60635,12 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 jkv
 gid
 kdd
 pZG
-rKz
+xtV
 laf
 sNe
 oNj
@@ -59330,7 +60657,7 @@ thh
 oNj
 xSJ
 lIh
-rKz
+xtV
 coU
 coU
 coU
@@ -59517,29 +60844,29 @@ nxY
 coU
 coU
 coU
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 mED
 oNj
 oNj
 bRR
-rKz
+xtV
 coU
 coU
 coU
@@ -59726,14 +61053,14 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 bMw
 xCH
 fDD
 shr
 uao
 gyS
-rKz
+xtV
 bRR
 srx
 bRP
@@ -59748,7 +61075,7 @@ jlL
 oNj
 oNj
 dez
-rKz
+xtV
 coU
 coU
 coU
@@ -59935,14 +61262,14 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 nle
 pHI
 pHI
 pHI
 cLU
 hgL
-rKz
+xtV
 oNj
 kaq
 oNj
@@ -59957,7 +61284,7 @@ jlL
 oNj
 dbE
 rhr
-rKz
+xtV
 bZw
 bZw
 bZw
@@ -60166,7 +61493,7 @@ jlL
 laf
 fsF
 nob
-rKz
+xtV
 bZw
 wqu
 sjS
@@ -60353,17 +61680,17 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 nrW
 hgL
 hgL
 dnC
 hgL
 hgL
-rKz
+xtV
 gIS
 qTm
-rKz
+xtV
 oNj
 nPm
 mED
@@ -60375,7 +61702,7 @@ bRP
 xav
 bRP
 fqQ
-rKz
+xtV
 bZw
 sBI
 sBI
@@ -60575,7 +61902,7 @@ hgL
 uJW
 cam
 snd
-rKz
+xtV
 oRj
 bRP
 oNj
@@ -60584,7 +61911,7 @@ bRP
 oNj
 xCX
 oRQ
-rKz
+xtV
 bZw
 sBI
 kVE
@@ -60771,7 +62098,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 wEw
 pHI
 pHI
@@ -60781,10 +62108,10 @@ pHI
 iDM
 hgL
 hgL
-rKz
+xtV
 hOw
 qvg
-rKz
+xtV
 ngB
 bRP
 pky
@@ -60793,7 +62120,7 @@ bRP
 bRP
 rAJ
 lMF
-rKz
+xtV
 bZw
 ayt
 sBI
@@ -60980,7 +62307,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 czs
 hgL
 bam
@@ -60990,7 +62317,7 @@ pHI
 vkM
 vkM
 vkM
-rKz
+xtV
 oNj
 oNj
 tCZ
@@ -61002,7 +62329,7 @@ oNj
 cEk
 lMF
 lMF
-rKz
+xtV
 bZw
 bZw
 bZw
@@ -61189,29 +62516,29 @@ nxY
 coU
 coU
 coU
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 vqZ
 xtL
-rKz
+xtV
 uIZ
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 coU
 coU
 coU
@@ -61398,7 +62725,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 iYP
 kSt
 mNF
@@ -61420,7 +62747,7 @@ hgL
 wvJ
 vHs
 jjD
-rKz
+xtV
 coU
 coU
 coU
@@ -61607,7 +62934,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 umz
 pHI
 hgL
@@ -61629,7 +62956,7 @@ hgL
 wvJ
 jjD
 axV
-rKz
+xtV
 coU
 coU
 coU
@@ -61816,7 +63143,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 vsV
 hgL
 hgL
@@ -61838,7 +63165,7 @@ hgL
 phC
 vJM
 yhY
-rKz
+xtV
 coU
 coU
 coU
@@ -62025,7 +63352,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 wvJ
 jnq
 dpI
@@ -62047,7 +63374,7 @@ hgL
 xvh
 jjD
 hgL
-qbU
+uHr
 coU
 coU
 coU
@@ -62256,7 +63583,7 @@ ssP
 umz
 vJM
 jjD
-qbU
+uHr
 coU
 coU
 coU
@@ -62443,7 +63770,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 gHH
 wvJ
 gHH
@@ -62465,7 +63792,7 @@ gHH
 wvJ
 gHH
 xiC
-rKz
+xtV
 coU
 coU
 coU
@@ -62652,7 +63979,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 vss
 gHH
 vEb
@@ -62674,7 +64001,7 @@ wvJ
 srt
 kQA
 gHH
-rKz
+xtV
 coU
 coU
 coU
@@ -62861,7 +64188,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 nCC
 hgL
 pHI
@@ -62883,7 +64210,7 @@ pHI
 scg
 ckM
 rww
-rKz
+xtV
 coU
 coU
 coU
@@ -63070,7 +64397,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 kQA
 kQA
 wvJ
@@ -63092,7 +64419,7 @@ gGm
 gHH
 gHH
 wvJ
-rKz
+xtV
 coU
 coU
 coU
@@ -63279,7 +64606,7 @@ nxY
 coU
 coU
 coU
-rKz
+xtV
 kQA
 uDS
 bqC
@@ -63301,7 +64628,7 @@ wvJ
 wvJ
 wvJ
 wvJ
-rKz
+xtV
 coU
 coU
 coU
@@ -63488,29 +64815,29 @@ nxY
 coU
 coU
 coU
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 tCZ
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
-rKz
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
+xtV
 coU
 coU
 coU

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -1789,8 +1789,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/port_gen/pacman/diesel/anchored,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
@@ -2188,6 +2187,7 @@
 "chw" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -4474,6 +4474,16 @@
 /obj/random/medical,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"ehe" = (
+/obj/random/junk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ehh" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -6976,12 +6986,6 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "gyS" = (
 /obj/structure/cable,
-/obj/item/circuitboard/apc,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28
-	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/dungeon/outside/prepper/vault{
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
@@ -14150,6 +14154,14 @@
 /obj/structure/flora/rock,
 /turf/simulated/floor/beach/sand/desert,
 /area/nadezhda/dungeon/outside/zoo)
+"ngA" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/brown_perforated,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "ngB" = (
 /obj/machinery/light{
 	dir = 1
@@ -14279,6 +14291,13 @@
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/meadow)
+"nlD" = (
+/obj/machinery/power/apc/inactive,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "nlG" = (
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -17452,6 +17471,13 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/smuggler_zone)
+"pTI" = (
+/obj/machinery/light,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/prepper/vault{
+	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
+	name = "Abandoned Bunker"
+	})
 "pTP" = (
 /obj/item/trash/material/circuit,
 /obj/effect/decal/cleanable/dirt,
@@ -51669,7 +51695,7 @@ wSZ
 gfM
 aLI
 wSZ
-wSZ
+pTI
 xtV
 coU
 coU
@@ -52505,7 +52531,7 @@ avp
 jgj
 pHI
 hgL
-yhY
+hgL
 xtV
 coU
 coU
@@ -52708,13 +52734,13 @@ hgL
 oxg
 hgL
 xtV
-jgj
+ehe
 qjc
 hgL
 hgL
 owt
 hgL
-vJM
+ngA
 xtV
 coU
 coU
@@ -61053,7 +61079,7 @@ nxY
 coU
 coU
 coU
-xtV
+nlD
 bMw
 xCH
 fDD

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -80,6 +80,10 @@
 /obj/item/remains/ribcage,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"afk" = (
+/obj/structure/flora/pottedplant/rotwood,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "afB" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
@@ -577,8 +581,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/dungeon/outside/safehouse)
 "aFi" = (
-/obj/random/lowkeyrandom,
-/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "aFP" = (
@@ -1332,6 +1336,14 @@
 	icon_state = "3,7"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"bvs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/flora/pottedplant/rotwood_green,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "bvC" = (
 /obj/structure/table/standard,
 /obj/random/powercell/medium_safe,
@@ -2631,6 +2643,7 @@
 /obj/effect/decal/cleanable/cobweb{
 	dir = 4
 	},
+/obj/machinery/porta_turret/excelsior/preloaded,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "cGz" = (
@@ -3126,6 +3139,13 @@
 	icon_state = "5,20"
 	},
 /area/colony/exposedsun/crashed_shop/outsider)
+"ddc" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/flora/pottedplant/drooping,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "ddO" = (
 /obj/structure/reagent_dispensers/watertank/huge,
 /obj/machinery/light/small{
@@ -5383,6 +5403,10 @@
 /obj/random/mob/undergroundmob,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"fyX" = (
+/obj/machinery/complant_teleporter,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fze" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt,
@@ -5746,6 +5770,11 @@
 /obj/structure/closet/random_hostilemobs,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"fTh" = (
+/obj/effect/decal/cleanable/filth,
+/obj/structure/flora/pottedplant/minitree,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "fTI" = (
 /obj/structure/target_stake,
 /obj/item/target/syndicate,
@@ -5866,6 +5895,7 @@
 /obj/effect/decal/cleanable/cobweb2{
 	icon_state = "cobweb1"
 	},
+/obj/structure/flora/pottedplant/rotwood_blue,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "fXI" = (
@@ -6435,6 +6465,10 @@
 /obj/random/lowkeyrandom,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
+"gAk" = (
+/obj/structure/flora/pottedplant/mysterious,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "gAr" = (
 /obj/machinery/seed_storage/random,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -10842,8 +10876,8 @@
 /turf/simulated/floor/asteroid/grass/dry,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "kXX" = (
-/obj/random/lowkeyrandom/low_chance,
 /obj/effect/decal/cleanable/filth,
+/obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "kYd" = (
@@ -11194,6 +11228,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/dungeon/outside/prepper)
+"lrL" = (
+/obj/random/scrap/dense_even,
+/obj/random/scrap/dense_even,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lrY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -11609,6 +11648,10 @@
 /obj/random/mob/undergroundmob/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/colony/exposedsun/crashed_shop/outsider)
+"lOU" = (
+/obj/structure/flora/pottedplant/star_root,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "lPa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/bench/wooden,
@@ -11973,6 +12016,7 @@
 "miU" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/dirt,
+/obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "mjb" = (
@@ -13625,6 +13669,11 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/outside/one_star)
+"nJu" = (
+/obj/effect/decal/cleanable/filth,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nJw" = (
 /obj/effect/decal/cleanable/rubble,
 /mob/living/simple_animal/hostile/bear/excelsior,
@@ -13685,6 +13734,12 @@
 /obj/structure/salvageable/console_broken_os,
 /turf/simulated/floor/tiled/derelict,
 /area/nadezhda/outside/one_star)
+"nPm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "nPq" = (
 /obj/structure/flora/small/busha2,
 /obj/random/flora/jungle_tree,
@@ -14750,6 +14805,13 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/mineral/random/rogue,
 /area/colony/exposedsun/crashed_shop/outsider)
+"oNj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/porta_turret/excelsior/preloaded,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oNq" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -14889,6 +14951,10 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"oTT" = (
+/obj/structure/flora/pottedplant/redshoot,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "oUc" = (
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -15550,8 +15616,7 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/nadezhda/outside/one_star)
 "pBg" = (
-/obj/structure/scrap_cube,
-/obj/random/lowkeyrandom/low_chance,
+/obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "pBC" = (
@@ -18465,6 +18530,10 @@
 /obj/item/trash/peachcan,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
+"snd" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "sns" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
@@ -18543,9 +18612,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "srt" = (
-/obj/random/lowkeyrandom/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/dense_even,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
+"srx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/pottedplant/green_rock,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "srB" = (
@@ -18691,6 +18765,10 @@
 /obj/random/mob/prepper_ranged,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
+"syp" = (
+/obj/structure/flora/pottedplant/stoutbush,
+/turf/simulated/floor/tiled/dark,
+/area/asteroid/rogue)
 "syE" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood/wild5,
@@ -20212,7 +20290,7 @@
 /area/nadezhda/dungeon/outside/prepper/vault/floor3)
 "uea" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank/huge/derelict,
+/obj/machinery/lapvend,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "uec" = (
@@ -20598,7 +20676,7 @@
 "uyY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank/huge/derelict,
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "uzt" = (
@@ -21786,8 +21864,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor2)
 "vEb" = (
-/obj/random/lowkeyrandom/low_chance,
 /obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "vEk" = (
@@ -21838,8 +21916,10 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/prepper)
 "vHY" = (
-/obj/machinery/door/airlock,
-/turf/space,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "vIA" = (
 /obj/structure/flora/small/bushc2,
@@ -24089,6 +24169,11 @@
 "xTR" = (
 /obj/random/traps/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
+/area/asteroid/rogue)
+"xTT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/complant_teleporter,
+/turf/simulated/floor/tiled/dark,
 /area/asteroid/rogue)
 "xUd" = (
 /obj/structure/sign/warning/armory{
@@ -49081,7 +49166,7 @@ hgL
 qmN
 hgL
 cYh
-bRP
+aFi
 fcB
 rKz
 aLI
@@ -50115,7 +50200,7 @@ coU
 coU
 rKz
 aHK
-dpI
+fTh
 hox
 sNe
 nZN
@@ -50127,7 +50212,7 @@ tBs
 hgL
 hox
 hgL
-hgL
+gAk
 rKz
 wSZ
 glZ
@@ -50341,7 +50426,7 @@ tCZ
 hgL
 hgL
 avp
-hgL
+snd
 bRP
 hgL
 yhY
@@ -50547,7 +50632,7 @@ hgL
 utC
 hgL
 rKz
-hgL
+snd
 jfz
 hgL
 hgL
@@ -50965,7 +51050,7 @@ tQp
 tQp
 mNA
 rKz
-hgL
+lOU
 hgL
 hgL
 hgL
@@ -51798,8 +51883,8 @@ kBY
 dpI
 dnC
 bRP
-bRP
-dpI
+aFi
+nJu
 rKz
 sEk
 xNJ
@@ -52001,7 +52086,7 @@ mNA
 mNA
 mNA
 mNA
-hgL
+oTT
 hgL
 mNA
 mNA
@@ -52214,7 +52299,7 @@ hgL
 yhY
 mNA
 azg
-hgL
+fyX
 rgT
 jmx
 rgT
@@ -53669,8 +53754,8 @@ coU
 rKz
 dKT
 hgL
-dpI
-bRP
+nJu
+aFi
 hgL
 tQp
 hgL
@@ -53679,7 +53764,7 @@ hgL
 jfz
 hgL
 qcp
-bRP
+bvs
 hgL
 hgL
 tQp
@@ -53890,7 +53975,7 @@ sEk
 hgL
 dpI
 mUI
-ojC
+hBa
 tQp
 hgL
 bRP
@@ -54942,7 +55027,7 @@ bRP
 sEk
 hgL
 vBH
-hgL
+afk
 rKz
 qbU
 coU
@@ -55354,7 +55439,7 @@ hgL
 crF
 hgL
 hBa
-vHY
+tQp
 hgL
 hgL
 jnq
@@ -55773,8 +55858,8 @@ hgL
 bRP
 ubp
 rKz
-hgL
-hgL
+snd
+snd
 axL
 igW
 lPa
@@ -56384,7 +56469,7 @@ nxY
 coU
 coU
 rKz
-laf
+oNj
 bRP
 pXi
 izA
@@ -57221,14 +57306,14 @@ coU
 coU
 coU
 rKz
-laf
+ddc
 xav
 hgL
 hgL
 rKz
+snd
 hgL
-hgL
-bRP
+xTT
 uyY
 uea
 rKz
@@ -57237,7 +57322,7 @@ hgL
 rKz
 eHy
 bRP
-hgL
+vHY
 hgL
 hgL
 hgL
@@ -57435,7 +57520,7 @@ hgL
 bRP
 hYL
 rKz
-hgL
+snd
 dHR
 fyp
 bRP
@@ -57650,7 +57735,7 @@ hgL
 hgL
 hgL
 rKz
-hgL
+snd
 hgL
 rKz
 eut
@@ -58901,15 +58986,15 @@ xCH
 gyS
 rKz
 hgL
-bRP
+srx
 hgL
 sEk
+sNe
 hgL
 hgL
 hgL
 hgL
-hgL
-hgL
+syp
 tCZ
 hgL
 hgL
@@ -59531,7 +59616,7 @@ gIS
 qTm
 rKz
 hgL
-xav
+nPm
 rKz
 hgL
 pHI
@@ -59740,7 +59825,7 @@ hgL
 hgL
 uJW
 cam
-hgL
+snd
 rKz
 sEk
 hgL
@@ -60568,8 +60653,8 @@ rKz
 bRP
 kSt
 mNF
-bRP
-bRP
+aFi
+aFi
 suV
 vZw
 fZu
@@ -60579,7 +60664,7 @@ xty
 bRP
 jfz
 ssP
-hgL
+sNe
 kaq
 dpI
 hgL
@@ -61611,24 +61696,24 @@ coU
 coU
 rKz
 gHH
-bqC
 pBg
-aFi
-wnh
+gHH
+kXX
+pBg
 gHH
 wnh
 kQA
 wnh
-hgL
+pBg
 xty
 llF
-hgL
+pBg
 xBs
-eLL
-bqC
+vEb
+pBg
 bqC
 gHH
-wnh
+pBg
 gHH
 wnh
 rKz
@@ -61821,22 +61906,22 @@ coU
 rKz
 gHH
 gHH
-eLL
-eLL
+vEb
+vEb
 kQA
-wnh
-bqC
+lrL
+pBg
 kXX
 vEb
-bRP
+vEb
 dgV
 hQJ
-hgL
-eLL
+pBg
+vEb
 kQA
 gHH
-wnh
-wnh
+pBg
+pBg
 srt
 kQA
 gHH
@@ -62239,10 +62324,10 @@ coU
 rKz
 kQA
 kQA
-wnh
+pBg
 bqC
-bqC
-wnh
+pBg
+pBg
 hJW
 hgL
 kXX
@@ -62250,14 +62335,14 @@ kXX
 eLL
 kQA
 wnh
-bqC
-bqC
-wnh
+pBg
+pBg
+pBg
 gHH
 gGm
 gHH
 gHH
-bqC
+pBg
 rKz
 coU
 coU
@@ -62449,24 +62534,24 @@ rKz
 kQA
 uDS
 bqC
-bqC
+pBg
 wnh
-wnh
-wnh
+pBg
+pBg
 xvh
 gyo
 wnh
 gHH
 tIm
 kQA
-eLL
-bqC
-wnh
-eLL
-bqC
-wnh
-bqC
-wnh
+vEb
+pBg
+pBg
+vEb
+pBg
+pBg
+pBg
+pBg
 rKz
 coU
 coU


### PR DESCRIPTION
Erases a sad attempt at a dungeon and replaces it with this Excelsior Fortress.

UPDATE: Found the issue, that's on me. #4791 
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So earlier today I found this... thing in the Deep Forest underground.
![image](https://github.com/sojourn-13/sojourn-station/assets/112383634/21bb1053-dfc5-4690-a65d-91bdbe7681ef)
This was going to be removed in a few hours because it was a disgusting carcass. Which is why I attempted to revamp it into a fully fledged dungeon for you all to enjoy.

	About The Pull Request
The dungeon is consisting of Excelsior troops, one big OKB-01 boss and a load of goodies for players to enjoy. This is mainly for mid/late game prospies and outsiders to have a pry at due to it's inhabitant's ability to sweep ass.

There are some slight additions to some items/mobs which are basically the same one with different flavour text and health. For instance, the 'Communist Manifesto' can be found at the end of the dungeon. There's also Greg attached onto the build.
![image](https://github.com/sojourn-13/sojourn-station/assets/112383634/308daf40-f189-429e-b4a9-06732ff98d93)
Other than that, just the dungeon.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--
Added: Cool ass dungeon.
Deleted: Whatever the fuck that was supposed to be.-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
