### PR TITLE
Fixes janitor borg icons

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1336,4 +1336,4 @@
 				icon = 'icons/mob/robot_tall/science.dmi'
 
 			if("Custodial")
-				icon = 'icons/mob/robot_tall/science.dmi'
+				icon = 'icons/mob/robot_tall/janitor.dmi'


### PR DESCRIPTION
Suffer not the non-AA carbon rattling keys at a door. The AA tallborg will handle it all.