### PR TITLE
Removes background restrictions for synthetic outsiders

### DIFF
--- a/code/datums/setup_option/backgrounds/origin_synthetic.dm
+++ b/code/datums/setup_option/backgrounds/origin_synthetic.dm
@@ -6,7 +6,7 @@
 
 	restricted_to_species = list(FORM_SOTSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/surgical)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
 		STAT_ROB = 0,
@@ -26,7 +26,7 @@
 
 	restricted_to_species = list(FORM_SOTSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/engineer)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
 		STAT_ROB = 0,
@@ -46,7 +46,7 @@
 
 	restricted_to_species = list(FORM_SOTSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/armblade/energy_blade)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
 		STAT_ROB = 20,
@@ -66,7 +66,7 @@
 
 	restricted_to_species = list(FORM_AGSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/engineer)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
 		STAT_ROB = 0,
@@ -86,7 +86,7 @@
 
 	restricted_to_species = list(FORM_AGSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/engineer)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
 		STAT_ROB = 10,
@@ -106,7 +106,7 @@
 
 	restricted_to_species = list(FORM_AGSYNTH)
 	racial_implants = (/obj/item/organ_module/active/multitool/miner)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 //Idea for this is that you were made with being a miner, thus giving you everything you need as one
 //The main boon being you get a bit of evey skill you /need/ to mine out faster and maintain tools / set up the big drills.
@@ -129,7 +129,7 @@
 
 	restricted_to_species = list(FORM_BSSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/taser/blackshield)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
 		STAT_ROB = 20,
@@ -149,7 +149,7 @@
 	restricted_to_species = list(FORM_BSSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/armblade/bs_tomahawk)
 	racial_implants_l = (/obj/item/organ_module/active/simple/armshield)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
 		STAT_ROB = 30,
@@ -163,12 +163,12 @@
 /datum/category_item/setup_option/background/ethnicity/blackshield_ranged
 	name = "Ballistic Model"
 	desc = "Synthetics are often times built with a specific purpose in mind to augment the qualities most appropriate to the purpose they're intended for. This model is designed for ranged engagements. \
-	Ballistic positronics are slightly less sturdy than their CQC and non-lethal counterparts, but still have a sturdy chassis and AI-guided targeting systems to aid in shooting. \
-	In-built armor plating and AI-fed combat techniques given on a subconscious level allow for robust and sturdy combatants. This model comes with an implanted .35 smg in the right arm."
+	Ranged positronics are slightly less sturdy than their CQC and non-lethal counterparts, but still have a sturdy chassis and AI-guided targeting systems to aid in shooting. \
+	In-built armor plating and AI-fed combat techniques given on a subconscious level allow for robust and sturdy combatants. This model comes with an implanted smg in the right arm."
 
 	restricted_to_species = list(FORM_BSSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/armsmg/blackshield)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
 		STAT_ROB = 10,
@@ -187,7 +187,7 @@
 
 	restricted_to_species = list(FORM_CHURCHSYNTH)
 	racial_implants = (/obj/item/organ_module/active/multitool/farmer)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
 		STAT_ROB = 0,
@@ -206,7 +206,7 @@
 
 	restricted_to_species = list(FORM_CHURCHSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/armblade/longsword)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 	//Compared to the soteria combat model and blackshield synths you get 20 armor across the body vs. 30/35 respectively, so what you lack in natural defense is made up in offense. -Kaz
 	stat_modifiers = list(
@@ -227,7 +227,7 @@
 	restricted_to_species = list(FORM_CHURCHSYNTH)
 	racial_implants = (/obj/item/organ_module/active/simple/bible)
 	racial_implants_l = (/obj/item/organ_module/active/simple/armblade/ritual)
-	restricted_jobs = list(/datum/job/outsider)
+	//restricted_jobs = list(/datum/job/outsider)
 
 	stat_modifiers = list(
 		STAT_ROB = 10,


### PR DESCRIPTION
Removes restrictions on synthetic backgrounds for outsiders. We allow synths to be outsiders....but don't bother to let them actually have their background options? Weird.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
