### PR TITLE
balances self surgery + fixes farmbots

### DIFF
--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -102,7 +102,7 @@
 	else if(href_list["collect"])
 		collects_produce = !collects_produce
 	else if(href_list["removedead"])
-		removes_dead = !removes_dead	
+		removes_dead = !removes_dead
 	else if(href_list["speakeron"])
 		speaker_on = !speaker_on
 
@@ -228,7 +228,7 @@
 				if(do_after(src, 30, A))
 					visible_message(SPAN_NOTICE("[src] waters \the [A]."))
 					playsound(loc, "robot_talk_heavy", 10, 0, 0)
-					T.reagents.add_reagent("ammonia", 10)
+					T.reagents.add_reagent("eznutrient", 10)
 		attacking = 0
 		action = ""
 		update_icons()

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -149,13 +149,18 @@
 
 	// Self-surgery increases failure chance
 	if(owner && user == owner)
-		difficulty_adjust = 80 // Godlike status required for surgery, in preparation for hardcap of stats at 120
+		difficulty_adjust = 90 // Godlike status required for surgery. Good luck keeping hands steady.
 		time_adjust = 40
 
 		//For if a user is doing 'surgery' on their own prosthetic bodypart
 		if(nature == MODIFICATION_SILICON)
-			difficulty_adjust = 60
-			time_adjust = 20
+			difficulty_adjust = 90 //this is VERY complicated work to do with perfect sightlines and ergonomics - let alone without these.
+			time_adjust = 40
+
+
+	if(user.stats.getPerk(PERK_SCUTTLEBUG || PERK_ICHOR || PERK_CHITINARMOR))
+		difficulty_adjust = -80 //We feel no pain, and are pretty used to working on ourselves due to metal paranoia. Still slightly worse than letting someone else do, due to limited ability to see inside
+		time_adjust = -30
 
 		// ...unless you are a carrion
 		// It makes sense that carrions have a way of making their flesh cooperate

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -160,7 +160,7 @@
 
 	if(user.stats.getPerk(PERK_SCUTTLEBUG || PERK_ICHOR || PERK_CHITINARMOR))
 		difficulty_adjust += -80 //We feel no pain, and are pretty used to working on ourselves due to metal paranoia. Still slightly worse than letting someone else do, due to limited ability to see inside
-		time_adjust = -30
+		time_adjust += -30
 
 		// ...unless you are a carrion
 		// It makes sense that carrions have a way of making their flesh cooperate

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -149,17 +149,17 @@
 
 	// Self-surgery increases failure chance
 	if(owner && user == owner)
-		difficulty_adjust = 90 // Godlike status required for surgery. Good luck keeping hands steady.
+		difficulty_adjust = 70 // Godlike status required for surgery. Good luck keeping hands steady.
 		time_adjust = 40
 
 		//For if a user is doing 'surgery' on their own prosthetic bodypart
 		if(nature == MODIFICATION_SILICON)
-			difficulty_adjust = 90 //this is VERY complicated work to do with perfect sightlines and ergonomics - let alone without these.
+			difficulty_adjust = 70 //this is VERY complicated work to do with perfect sightlines and ergonomics - let alone without these.
 			time_adjust = 40
 
 
 	if(user.stats.getPerk(PERK_SCUTTLEBUG || PERK_ICHOR || PERK_CHITINARMOR))
-		difficulty_adjust += -80 //We feel no pain, and are pretty used to working on ourselves due to metal paranoia. Still slightly worse than letting someone else do, due to limited ability to see inside
+		difficulty_adjust += -60 //We feel no pain, and are pretty used to working on ourselves due to metal paranoia. Still slightly worse than letting someone else do, due to limited ability to see inside
 		time_adjust += -30
 
 		// ...unless you are a carrion

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -159,7 +159,7 @@
 
 
 	if(user.stats.getPerk(PERK_SCUTTLEBUG || PERK_ICHOR || PERK_CHITINARMOR))
-		difficulty_adjust = -80 //We feel no pain, and are pretty used to working on ourselves due to metal paranoia. Still slightly worse than letting someone else do, due to limited ability to see inside
+		difficulty_adjust += -80 //We feel no pain, and are pretty used to working on ourselves due to metal paranoia. Still slightly worse than letting someone else do, due to limited ability to see inside
 		time_adjust = -30
 
 		// ...unless you are a carrion


### PR DESCRIPTION
Self surgery is now 12.5% harder for organics and 50% harder for robots.

Self surgery is now 50% easier for Cht'Mants

Fixes; Farmbots putting ammonia into hydroponics trays along with water, thus creating space cleaner. Fertilizing now uses ez nutrient.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
