### PR TITLE
When putting a bedsheet on a bed, remove pixel shift

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -28,6 +28,10 @@ LINEN BINS
 	if(!user || user.incapacitated() || !user.Adjacent(A))
 		return
 	if(toggle_fold(user))
+		pixel_x = 0
+		pixel_y = 0
+		pixel_z = 0
+		pixel_w = 0
 		user.drop_item()
 		forceMove(get_turf(A))
 		add_fingerprint(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	When putting a bedsheet on a bed, remove pixel shift
</summary>
<hr>
If you put a folded bedsheet on a table, the bedsheet will be put to the location on the table where the click was located (pixel shift). This shift will be stored in the bedsheet object. When that folded bedsheet is put on a bed, this shift is used again and the bedsheet lands at a ridiculous location. This is solved by re-setting the pixel_x, y, z and w variables to zero when unfolding the sheet.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl: dutop
fix: Remove pixel shift when putting bedsheets
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
