### PR TITLE
more consistent overwear

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -230,21 +230,6 @@ obj/item/clothing/suit/fluff/miko
 	name = "universal sling"
 	desc = "A generic universal equipment sling for whatever you could need on your back."
 	icon_state = "universal_sling"
-	allowed = list (/obj/item/gun,
-	/obj/item/device,
-	/obj/item/material,
-	/obj/item/storage/pouch,
-	/obj/item/storage/box,
-	/obj/item/storage/firstaid,
-	/obj/item/storage/lockbox,
-	/obj/item/storage/part_replacer,
-	/obj/item/storage/secure,
-	/obj/item/storage/toolbox,
-	/obj/item/storage/briefcase,
-	/obj/item/tank,
-	/obj/item/ammo_magazine,
-	/obj/item/ammo_magazine/ammobox/
-	)
 
 /obj/item/clothing/suit/storage/punkvest
 	name = "punk vest"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -228,7 +228,7 @@ obj/item/clothing/suit/fluff/miko
 
 /obj/item/clothing/suit/sling
 	name = "universal sling"
-	desc = "A generic universal equipment sling for whatever you could need on your back."
+	desc = "A generic universal equipment sling for whatever you could need on your back. More versatile then other choices just don't expect it to protect you from anything."
 	icon_state = "universal_sling"
 	extra_allowed = list(
 	/obj/item/storage/firstaid,

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -230,6 +230,15 @@ obj/item/clothing/suit/fluff/miko
 	name = "universal sling"
 	desc = "A generic universal equipment sling for whatever you could need on your back."
 	icon_state = "universal_sling"
+	extra_allowed = list(
+	/obj/item/storage/firstaid,
+	/obj/item/storage/lockbox,
+	/obj/item/storage/part_replacer,
+	/obj/item/storage/secure,
+	/obj/item/storage/toolbox,
+	/obj/item/storage/briefcase,
+	/obj/item/material,
+	/obj/item/device)
 
 /obj/item/clothing/suit/storage/punkvest
 	name = "punk vest"

--- a/code/modules/research/xenoarchaeology/tools/anomaly_suit.dm
+++ b/code/modules/research/xenoarchaeology/tools/anomaly_suit.dm
@@ -5,7 +5,6 @@
 	item_state = "anomaly_suit"
 	slowdown = 0
 	armor_list = list(melee = 5, bullet = 5, energy = 25, bomb = 0, bio = 100, rad = 100)
-	allowed = list(/obj/item/device/lighting/toggleable/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit)
 
 /obj/item/clothing/head/helmet/space/anomaly
 	name = "Expedition hood"


### PR DESCRIPTION
Removes unique allowed items list for slings and Expedition suits. This making it default to what all overwear use (vests, jackets, etc). This was just....odd and unnecessary.

Also technically fixes a small bug allowing it to hold /obj/item/storage/box it being able to do so made some very odd sprite related things involving becoming a massive cardboard box. Switches the sling to use a extra_allowed list to retain it's niche use cases on the bases that it has no armor values.

Flat out buff to the Expedition suit but needs it....it's easily one of the worst bits of ''armor'' in the game.

Fixes #4728

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
