### PR TITLE
Add projectile tag to rpg

### DIFF
--- a/code/modules/projectiles/guns/projectile/other/RPG.dm
+++ b/code/modules/projectiles/guns/projectile/other/RPG.dm
@@ -21,7 +21,7 @@
 	init_recoil = HANDGUN_RECOIL(3)
 	bulletinsert_sound = 'sound/weapons/guns/interact/china_lake_reload.ogg'
 	twohanded = TRUE
-	gun_tags = list(GUN_SCOPE)
+	gun_tags = list(GUN_SCOPE, GUN_PROJECTILE)
 	allow_racking = FALSE
 	auto_rack = TRUE //so if we get loaded were good
 	serial_type = "SA"


### PR DESCRIPTION
Does what it says on the tin, this adds a projectile firing tag to the RPG allowing it to be modded like other projectile guns.