### PR TITLE
Tweaks to job restrictions (mostly for synths)

### DIFF
--- a/code/datums/setup_option/backgrounds/origin_chtmant.dm
+++ b/code/datums/setup_option/backgrounds/origin_chtmant.dm
@@ -27,12 +27,11 @@
 			Due to the physical weakness of the Ru caste they are barred from taking roles as security, as their importance to their relative hive structure makes them far more suited in other roles.."
 
 	restricted_to_species = list(FORM_CHTMANT)
-	restricted_depts = SECURITY
 
 	allow_modifications = FALSE
 	perks = list(PERK_ICHOR)
 	racial_implants = (/obj/item/organ_module/active/simple/surgical/cht_mant)
-	restricted_jobs = list(/datum/job/pro)
+	restricted_jobs = list(/datum/job/pro,/datum/job/smc,/datum/job/swo, /datum/job/supsec, /datum/job/serg, /datum/job/inspector, /datum/job/trooper, /datum/job/officer)
 
 	stat_modifiers = list(
 		STAT_ROB = -8,
@@ -45,7 +44,7 @@
 
 /datum/category_item/setup_option/background/ethnicity/chtmantra
 	name = "Ra Caste"
-	desc = "Ra are the warriors and sentries of the hives. Numbering in the hundreds they would tower over Ru’s and even \
+	desc = "Ra are the warriors and sentries of the hives. Numbering in the hundreds they would tower over Ruï¿½s and even \
 			most workers, the Ro. Their bodies were highly adapted for combat and they know only loyalty unto death for the good of \
 			the hive. Due to this, and the existence of the Ru, they often heavily lack any cognitive thinking skills and would \
 			rely on winning battles by sheer weight of numbers or pure attrition. The severe lack of intelligence they exhibit also bars them from most medical roles and all of science, engineering, and command roles."

--- a/code/datums/setup_option/backgrounds/origin_synthetic.dm
+++ b/code/datums/setup_option/backgrounds/origin_synthetic.dm
@@ -113,7 +113,7 @@
 //-0Loss Stats +15Gained Stat
 
 	stat_modifiers = list(
-		STAT_ROB = 20,
+		STAT_ROB = 25,
 		STAT_TGH = 0,
 		STAT_VIG = 0,
 		STAT_BIO = 0,

--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -16,7 +16,7 @@
 		)
 	allowed_depts = CHURCH
 	allow_modifications = TRUE
-	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_OPIFEX, FORM_CINDAR, FORM_CHURCHSYNTH)
+	restricted_to_species = list(FORM_HUMAN, FORM_EXALT_HUMAN, FORM_SABLEKYNE, FORM_KRIOSAN, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_OPIFEX, FORM_CINDAR, FORM_CHURCHSYNTH, FORM_UNBRANDED, FORM_FBP)
 
 /datum/category_item/setup_option/core_implant/psionic_tumor
 	name = "Psionic Organ"

--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -19,7 +19,7 @@
 	access = list(
 		access_nt_preacher, access_nt_disciple, access_morgue, access_chapel_office, access_crematorium, access_maint_tunnels, access_RC_announce, access_keycard_auth, access_heads, access_sec_doors
 	)
-	disallow_species = list(FORM_FBP, FORM_UNBRANDED, FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_NASHEF)
 
 
 	wage = WAGE_COMMAND //The church has deep pockets
@@ -88,7 +88,7 @@
 	STAT_VIG = 10,
 	STAT_TGH = 5,
 	)
-	disallow_species = list(FORM_FBP, FORM_UNBRANDED, FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_BSSYNTH, FORM_NASHEF)
 
 	core_upgrades = list(
 		CRUCIFORM_PRIEST

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -17,7 +17,7 @@
 	minimum_character_age = 25
 	health_modifier = 5
 
-	disallow_species = list(FORM_UNBRANDED, FORM_SOTSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 	outfit_type = /decl/hierarchy/outfit/job/engineering/exultant
 
 	access = list(
@@ -83,7 +83,7 @@
 		access_external_airlocks, access_construction, access_atmospherics
 	)
 
-	disallow_species = list(FORM_SOTSYNTH, FORM_BSSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_BSSYNTH, FORM_NASHEF)
 
 
 	stat_modifiers = list(

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -83,7 +83,7 @@
 		access_external_airlocks, access_construction, access_atmospherics
 	)
 
-	disallow_species = list(FORM_BSSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_SOTSYNTH, FORM_BSSYNTH, FORM_NASHEF)
 
 
 	stat_modifiers = list(

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -128,7 +128,7 @@ Avoid the deeper tunnels unless otherwise instructed, however - this domain is h
 	wage = WAGE_LABOUR_HAZARD //The miners union is stubborn
 	health_modifier = 5
 
-	disallow_species = list(FORM_BSSYNTH,)
+	disallow_species = list(FORM_BSSYNTH, FORM_CHURCHSYNTH)
 	outfit_type = /decl/hierarchy/outfit/job/cargo/mining
 
 	description = "The Miner is a professional resource procurer, acquiring valuable minerals for Lonestar Shipping Solutions.<br>\

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -128,7 +128,7 @@ Avoid the deeper tunnels unless otherwise instructed, however - this domain is h
 	wage = WAGE_LABOUR_HAZARD //The miners union is stubborn
 	health_modifier = 5
 
-	disallow_species = list(FORM_BSSYNTH, FORM_CHURCHSYNTH)
+	disallow_species = list(FORM_BSSYNTH,)
 	outfit_type = /decl/hierarchy/outfit/job/cargo/mining
 
 	description = "The Miner is a professional resource procurer, acquiring valuable minerals for Lonestar Shipping Solutions.<br>\

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -123,7 +123,7 @@
 	selection_color = "#bdb1bb"
 	wage = WAGE_PROFESSIONAL
 	department_account_access = TRUE
-	disallow_species = list(FORM_AGSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 
 
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -314,7 +314,7 @@
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
 	health_modifier = 5
-	disallow_species = list(FORM_SOTSYNTH, FORM_AGSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_AGSYNTH, FORM_NASHEF)
 
 	outfit_type = /decl/hierarchy/outfit/job/security/medspec
 


### PR DESCRIPTION
Lotta little changes so might miss something here but.

The Church has now FINALLY permitted unbranded and standard FBPs to join the fold and work directly for the Church. Department synthetics are still as they where due to security concerns.

SI is now willing to outsource robotics work to guild synthetics. Guild in return has also permitted SI engineering synths to work with them.

Lonestar is now willing to allow church synthetics to work in mining. Buffs the ''Depts-Class'' Guild synth background robustness by 5 points to not make them redundant in mining (same as the highest robustness church synth background their implant sucks anyways tbh). Fixes what I assume to be a spelling mistake. ''Depts-Class'' is now Depths-Class

Blackshield has now permitted SI synthetics to work as corpsman after the awkward realization their synths can barely use a splint. 

Ru Caste Cht'mant have also been allowed to work as Corpsman.



If anyone has any more examples of very weird and strange job restrictions do let me know to add/remove them


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
