### PR TITLE
bugfix for leaking bluespace

### DIFF
--- a/modular_sojourn/spaceleak.dm
+++ b/modular_sojourn/spaceleak.dm
@@ -45,4 +45,4 @@
 		victim.apply_damage(max(0, damage * hazard_protection / 100 * victim.reagent_permeability()), CLONE)
 		if(ishuman(victim))
 			var/mob/living/carbon/human/H = victim
-			H.sanity.breakdown(TRUE)
+			H.sanity.breakdown()


### PR DESCRIPTION
Makes leaking bluespace no longer guarantee positive breakdowns. Still abuseable tbh but you'll be bruteforcing negative breakdowns to get positive ones.

Port of: https://github.com/Liberty-Landing/Liberty-Station-13/pull/375

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
