### PR TITLE
Liberty drill port.

### DIFF
--- a/code/modules/mining/drilling/termite_burrow.dm
+++ b/code/modules/mining/drilling/termite_burrow.dm
@@ -2,12 +2,9 @@
 	name = "termite burrow"
 	icon = 'icons/obj/burrows.dmi'
 	icon_state = "maint_hole"
-	desc = "A pile of rocks that regularly pulses as if it was alive."
-	density = TRUE
+	desc = "A pile of rocks that regularly pulses as if it was alive. It's constantly reinforced and opened as long as the termites are agitated."
 	anchored = TRUE
 
-	var/max_health = 50
-	health = 50
 	var/datum/termite_controller/controller
 
 /obj/structure/termite_burrow/New(loc, parent)
@@ -20,36 +17,6 @@
 		controller.burrows -= src
 		controller = null
 	..()
-
-/obj/structure/termite_burrow/attack_generic(mob/user, damage)
-	user.do_attack_animation(src)
-	visible_message(SPAN_DANGER("\The [user] smashes \the [src]!"))
-	take_damage(damage)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 1.5)
-
-/obj/structure/termite_burrow/attackby(obj/item/I, mob/user)
-	if (user.a_intent == I_HURT && user.Adjacent(src))
-		if(!(I.flags & NOBLUDGEON))
-			user.do_attack_animation(src)
-			var/damage = I.force * I.structure_damage_factor
-			var/volume =  min(damage * 3.5, 15)
-			if (I.hitsound)
-				playsound(src, I.hitsound, volume, 1, -1)
-			visible_message(SPAN_DANGER("[src] has been hit by [user] with [I]."))
-			take_damage(damage)
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN * 1.5)
-	return TRUE
-
-/obj/structure/termite_burrow/bullet_act(obj/item/projectile/Proj)
-	..()
-        // Bullet not really efficient against a pile of rock
-	if (!(Proj.testing))
-		take_damage(Proj.get_structure_damage() * 0.25)
-
-/obj/structure/termite_burrow/proc/take_damage(value)
-	health = min(max(health - value, 0), max_health)
-	if(health == 0)
-		qdel(src)
 
 /obj/structure/termite_burrow/proc/stop()
 	qdel(src)  // Delete burrow

--- a/code/modules/mining/drilling/termite_wave.dm
+++ b/code/modules/mining/drilling/termite_wave.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_INIT(termite_waves, list(/datum/termite_wave/dormant,
 
 /datum/termite_wave/dormant
 	burrow_count = 2
-	burrow_interval = 240 SECONDS
+	burrow_interval = 120 SECONDS
 	termite_spawn = 2
 	spawn_interval = 120 SECONDS
 	special_probability = 5
@@ -25,7 +25,7 @@ GLOBAL_LIST_INIT(termite_waves, list(/datum/termite_wave/dormant,
 
 /datum/termite_wave/negligible
 	burrow_count = 3
-	burrow_interval = 200 SECONDS
+	burrow_interval = 100 SECONDS
 	termite_spawn = 2
 	spawn_interval = 100 SECONDS
 	special_probability = 10
@@ -33,32 +33,32 @@ GLOBAL_LIST_INIT(termite_waves, list(/datum/termite_wave/dormant,
 
 /datum/termite_wave/typical
 	burrow_count = 3
-	burrow_interval = 180 SECONDS
+	burrow_interval = 80 SECONDS
 	termite_spawn = 3
-	spawn_interval = 90 SECONDS
+	spawn_interval = 80 SECONDS
 	special_probability = 15
 	mineral_multiplier = 1.7
 
 /datum/termite_wave/substantial
 	burrow_count = 4
-	burrow_interval = 160 SECONDS
+	burrow_interval = 70 SECONDS
 	termite_spawn = 3
-	spawn_interval = 80 SECONDS
+	spawn_interval = 70 SECONDS
 	special_probability = 4
 	mineral_multiplier = 20
 
 /datum/termite_wave/major
 	burrow_count = 5
-	burrow_interval = 140 SECONDS
+	burrow_interval = 60 SECONDS
 	termite_spawn = 4
-	spawn_interval = 70 SECONDS
+	spawn_interval = 60 SECONDS
 	special_probability = 35
 	mineral_multiplier = 2.3
 
 /datum/termite_wave/abnormal
 	burrow_count = 7
-	burrow_interval = 120 SECONDS
+	burrow_interval = 45 SECONDS
 	termite_spawn = 4
-	spawn_interval = 60 SECONDS
+	spawn_interval = 45 SECONDS
 	special_probability = 30
 	mineral_multiplier = 3.0


### PR DESCRIPTION
Ports : https://github.com/Liberty-Landing/Liberty-Station-13/pull/363

does not port the map changes because duh.

Drill heads now have a verb to configure their internal "Seismic Stimulator" in order to intentionally provoke or bait larger termite swarms, this does not let you lower their aggression, only increase it if desired.

Drill heads now fully excavate an entire tile before selecting another random tile in their range.

Drill head's base mining speed has doubled.

Termite burrows are not dense anymore, but have lost the ability to be destroyed by force, they only dissapear when the drill is stopped and the termite waves cease.

Termite waves' downtime between waves and new burrows spawned has been decreased.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
