### PR TITLE
Fixing the croon's firerate (using burst delay instead of fire_delay).dm

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/mac.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/mac.dm
@@ -70,8 +70,8 @@
 	fire_sound = 'sound/weapons/guns/fire/m41_shoot.ogg'
 
 	init_firemodes = list(
-		FULL_AUTO_600_NOLOSS,
-		list(mode_name="fuller auto", mode_desc = "Hold down trigger to make anything you point it at have 32 more holes around it", mode_type = /datum/firemode/automatic, fire_delay=0, icon="fuller"),
+		FULL_AUTO_300,
+		list(mode_name="fuller auto", mode_desc = "Hold down trigger to make anything you point it at have 32 more holes around it", mode_type = /datum/firemode/automatic, burst_delay=1.25, fire_delay=1, icon="fuller"),
 		)
 
 /obj/item/gun/projectile/automatic/mac/croon/update_icon()


### PR DESCRIPTION
This is an actual fix of the croon. To put it simply, this weapon from eye cybermancy meant to have a firerate similar to a minigun in a small package had been badly coded, the person who tried to make it fire fast actually only modified fire_delay, but that has little effect on the actual tested firerate of the gun, instead, now, I make it use burst_delay, which ironically full auto weapons use to regulate their firerate more precisely.  It used to have the firerate of any regular SMG, now, it's actually the gun it was meant to be. The little damage value of the gun means it's still a rare and not really viable SMG, but now the weapon is actually cool to use.

Not only this, but before, the firemodes of the weapon were also scuffed, you only had fuller auto and.. fuller auto. Now there's a proper difference, there's a full auto with a lower firerate, and a fuller auto. 
Keep in mind, this is not a buff, this is fixing what a previous modification of its code had scuffed.