### PR TITLE
Adds the disk storage fridge

### DIFF
--- a/code/datums/autolathe/circuits.dm
+++ b/code/datums/autolathe/circuits.dm
@@ -108,6 +108,14 @@
 	name = "trade sending beacon"
 	build_path = /obj/item/circuitboard/trade_beacon/sending
 
+/datum/design/autolathe/circuit/smartfridge
+	name = "smartfridge"
+	build_path = /obj/item/circuitboard/smartfridge
+
+/datum/design/autolathe/circuit/smartfridge/disk
+	name = "disk storage"
+	build_path = /obj/item/circuitboard/smartfridge/disk
+
 //Soj thing
 /datum/design/autolathe/circuit/nanite_reconstitution_apparatus
 	name = "nanite reconstitution apparatus"

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -232,12 +232,18 @@
 	return
 
 
+/*******************
+*   Disk Storage
+********************/
+/obj/machinery/smartfridge/disk
+	name = "\improper Disk Storage"
+	desc = "For catalouging the tech you have acquired."
 
 
-
-
-
-
+/obj/machinery/smartfridge/disk/accept_check(var/obj/item/O as obj)
+	if(istype(O,/obj/item/computer_hardware/hard_drive/portable))
+		return 1
+	return 0
 
 
 

--- a/code/game/objects/items/weapons/autolathe_disk/guild_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guild_disks.dm
@@ -121,6 +121,8 @@
 		/datum/design/autolathe/part/cable_coil,
 		/datum/design/autolathe/container/hcase_parts,
 		/datum/design/autolathe/container/hcase_engi,
+		/datum/design/autolathe/circuit/smartfridge,
+		/datum/design/autolathe/circuit/smartfridge/disk,
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/logistics

--- a/code/game/objects/items/weapons/circuitboards/machinery/smartfridge.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/smartfridge.dm
@@ -1,0 +1,14 @@
+/obj/item/circuitboard/smartfridge
+    build_name = "Smartfridge"
+    build_path = /obj/machinery/smartfridge
+    board_type = "machine"
+    origin_tech = list(TECH_DATA = 2)
+    req_components = list(
+    	/obj/item/stock_parts/matter_bin = 1,
+    	/obj/item/stock_parts/manipulator = 1,
+    	/obj/item/stock_parts/console_screen = 1
+    )
+
+/obj/item/circuitboard/smartfridge/disk
+    build_name = "Disk Storage"
+    build_path = /obj/machinery/smartfridge/disk

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -5595,7 +5595,7 @@
 	name = "Mixed Air Supply Control";
 	output_tag = "air_out";
 	pressure_setting = 2000;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -12951,7 +12951,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -19381,6 +19381,10 @@
 /obj/structure/closet/secure_closet/rare_loot,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"ejB" = (
+/obj/machinery/smartfridge/disk,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/rnd/research)
 "ejE" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -30652,7 +30656,7 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -35746,7 +35750,6 @@
 	},
 /area/shuttle/vasiliy_shuttle_area)
 "hIp" = (
-/obj/structure/table/steel_reinforced,
 /obj/item/computer_hardware/hard_drive/portable/design/security{
 	pixel_x = 7
 	},
@@ -35755,6 +35758,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/smartfridge/disk,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
 "hIw" = (
@@ -51358,7 +51362,7 @@
 	dir = 1;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon        Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous        Oxide", "waste_sensor" = "Gas        Mix        Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon        Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous        Oxide","waste_sensor"="Gas        Mix        Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
@@ -51798,7 +51802,7 @@
 	dir = 8;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon        Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous        Oxide", "waste_sensor" = "Gas        Mix        Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon        Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous        Oxide","waste_sensor"="Gas        Mix        Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
@@ -52238,9 +52242,9 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
 "llw" = (
-/obj/structure/table/marble,
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/machinery/smartfridge/disk,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
 "llz" = (
@@ -57566,9 +57570,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "msC" = (
-/obj/structure/table/rack/shelf,
 /obj/item/computer_hardware/hard_drive/portable/design/logistics,
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
+/obj/machinery/smartfridge/disk,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
 "msD" = (
@@ -61312,9 +61316,9 @@
 /area/nadezhda/command/courtroom)
 "ngA" = (
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
-/obj/structure/table/steel,
 /obj/random/lathe_disk,
 /obj/random/lathe_disk,
+/obj/machinery/smartfridge/disk,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
 "ngJ" = (
@@ -69531,7 +69535,7 @@
 	input_tag = "tox_in";
 	name = "Plasma Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -70586,12 +70590,12 @@
 /obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_smallarms,
 /obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_rifle,
 /obj/item/computer_hardware/hard_drive/portable/design/security,
-/obj/structure/table/reinforced,
 /obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo,
 /obj/item/computer_hardware/hard_drive/portable/design/nonlethal_ammo,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
+/obj/machinery/smartfridge/disk,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/tactical)
 "paa" = (
@@ -74823,7 +74827,7 @@
 /obj/item/computer_hardware/hard_drive/portable/design/nt_basic_arms{
 	pixel_x = -6
 	},
-/obj/structure/table/woodentable,
+/obj/machinery/smartfridge/disk,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "pUc" = (
@@ -75118,7 +75122,7 @@
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 1;
 	pixel_y = 3;
-	preloaded_reagents = list("plasma" = 30)
+	preloaded_reagents = list("plasma"=30)
 	},
 /obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -91529,7 +91533,7 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -92710,7 +92714,7 @@
 	input_tag = "waste_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "waste_out";
-	sensors = list("waste_sensor" = "Tank")
+	sensors = list("waste_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -101349,7 +101353,7 @@
 /obj/machinery/reagentgrinder/portable,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/glass/beaker{
-	preloaded_reagents = list("plasma" = 30)
+	preloaded_reagents = list("plasma"=30)
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
@@ -111208,7 +111212,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -114120,10 +114124,10 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "yej" = (
-/obj/structure/table/standard,
 /obj/machinery/recharger,
 /obj/structure/disposalpipe/segment,
 /obj/item/computer_hardware/hard_drive/portable/design/engineering,
+/obj/machinery/smartfridge/disk,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
 "yew" = (
@@ -172158,7 +172162,7 @@ brG
 hDX
 umk
 umk
-glv
+ejB
 brG
 brG
 glv

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -90671,10 +90671,10 @@
 	name = "Residential District Maintenance"
 	})
 "tnD" = (
-/obj/structure/table/reinforced,
 /obj/item/computer_hardware/hard_drive/portable/design/nonlethal_ammo,
 /obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo,
 /obj/random/lathe_disk/advanced/low_chance,
+/obj/machinery/smartfridge/disk,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "tnG" = (
@@ -114124,7 +114124,6 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "yej" = (
-/obj/machinery/recharger,
 /obj/structure/disposalpipe/segment,
 /obj/item/computer_hardware/hard_drive/portable/design/engineering,
 /obj/machinery/smartfridge/disk,
@@ -217807,8 +217806,8 @@ qXu
 rYM
 nfq
 vlP
-wSv
 ngA
+wSv
 dBM
 oAK
 ayn
@@ -218011,7 +218010,7 @@ kfI
 vlP
 dzs
 sTa
-kUX
+rUW
 rug
 kgr
 kUX

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -1193,6 +1193,7 @@
 #include "code\game\objects\items\weapons\circuitboards\machinery\recharger.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\research.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\shieldgen.dm"
+#include "code\game\objects\items\weapons\circuitboards\machinery\smartfridge.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\smelter.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\sorter.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\telecomms.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	 Adds a disk storage machine
</summary>
<hr>

Adds a subtype of smartfridge that holds disks, and maps them in at the places where a table/rack that held a faction's disks used to be, as well as the public lathe. More can be made with a board found on the Guild Circuits disk. Also adds the ability to make regular smartfridges for good measure, since those couldn't be made previously.
	
![image](https://github.com/sojourn-13/sojourn-station/assets/29682682/2920cf7b-cfda-4109-b99a-a50253902023)

<hr>
</details>

## Changelog
:cl:
add: New disk storage fridges
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
