### PR TITLE
updates non-records warning

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -118,7 +118,8 @@
 						return
 				var/datum/preferences/records_check = client.prefs.get_records()
 				if(!records_check)
-					if(alert(src,"Are you sure you wish to spawn without records? Our rules require them!. \
+					if(alert(src,"Are you sure you wish to spawn without records? Our rules require them colonist roles. \
+								Visitors, Hunters and Outsiders are excluded and may ignore this warning. \
 								If not, go to the Backround section of Setup Character and set Records. \
 								Our records templates and requirement specifics can be found at: https://sojourn13.space/wiki/Example_Paperwork#Character_Records", \
 								"Player Setup", "Yes", "No") == "No")


### PR DESCRIPTION
Slightly adjusts the warning message when attempting to join the round with no records to clarify that records are required for COLONIST roles, not hunters outsiders or visitors

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
