### PR TITLE
Revert Soul Hunger damage back to toxins to stop burning cultist faces

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -40,7 +40,7 @@
 
 /datum/ritual/cruciform/base/soul_hunger/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/C)
 	H.nutrition += 50
-	H.adjustFireLoss(5)
+	H.adjustToxLoss(10)
 	return TRUE
 
 /datum/ritual/cruciform/base/glow_book


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
Reverts the 5 burn damage changed unannounced in the Erismed pr back to the 10 toxin damage it was originally.
<summary>
	Changes the fire damage from the Soul Hunger litany back to the toxin damage used previously
This makes it so soul hunger can be healed by Cahors again (run out of food on a pilgrimage? drink in wine and trust in faith) as well and prevents church followers from having a litany that can render their face unrecognizable.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: Changes the fire damage from the Soul Hunger litany back to the toxin damage used previously
This makes it so soul hunger can be healed by Cahors again as well and prevents church followers from having a litany render their face unrecognizable.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
