### PR TITLE
Recycling vendor: consider stacks of materials in payout and storage

### DIFF
--- a/code/game/machinery/vendor/recycle_vendor.dm
+++ b/code/game/machinery/vendor/recycle_vendor.dm
@@ -162,9 +162,18 @@
 		if(i in materials_supported)
 			if(i in materials_allowed)
 				var/material/M = get_material_by_name(i)
-				var/obj/item/stack/material/S = new M.stack_type(null, stored_item_materials[i])
-				stored_item_value += S.get_item_cost()
-				stored_item_fluff += "<br>[i] - [stored_item_materials[i]] units, worth [S.get_item_cost()] credits."
+				var/obj/item/stack/material/temp_stack = stored_item_object
+
+				if (temp_stack)
+					var/obj/item/stack/material/S = new M.stack_type(null, stored_item_materials[i] * temp_stack.amount)
+					stored_item_value += S.get_item_cost()
+					stored_item_fluff += "<br>[i] - [stored_item_materials[i] * temp_stack.amount] units, worth [S.get_item_cost()] credits."
+				else
+					var/obj/item/stack/material/S = new M.stack_type(null, stored_item_materials[i])
+					stored_item_value += S.get_item_cost()
+					stored_item_fluff += "<br>[i] - [stored_item_materials[i]] units, worth [S.get_item_cost()] credits."
+
+
 			else
 				stored_item_fluff += "<br>Payouts for [i] suspended by LSS representative."
 		else // Bay leftover materials
@@ -187,15 +196,23 @@
 	var/datum/transaction/T = new(-stored_item_value, "", "Recycling payout for [stored_item_object.name]", src)
 	T.apply_to(merchants_pocket)
 
+	for(var/i in stored_item_materials)
+		var/obj/item/stack/material/temp_stack = stored_item_object
+		if (temp_stack)
+			if(i in materials_stored)
+				materials_stored[i] += stored_item_materials[i] * temp_stack.amount
+			else
+				materials_stored.Add(i)
+				materials_stored[i] = stored_item_materials[i] * temp_stack.amount
+		else
+			if(i in materials_stored)
+				materials_stored[i] += stored_item_materials[i]
+			else
+				materials_stored.Add(i)
+				materials_stored[i] = stored_item_materials[i]
+
 	qdel(stored_item_object)
 	stored_item_object = null
-
-	for(var/i in stored_item_materials)
-		if(i in materials_stored)
-			materials_stored[i] += stored_item_materials[i]
-		else
-			materials_stored.Add(i)
-			materials_stored[i] = stored_item_materials[i]
 
 	playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 50, 1)
 	spawn_money(stored_item_value, loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	When using the recycling vendor, consider stacks of materials.
</summary>
<hr>
 When you are using the recycling vendor and add a stack of materials, for example a stack of five plasma cubes, you will get the price of _one_ cube and _one_ cube will be stored into the vendor's storage. To circumvent that, you have to pop one item from the stack, put it in the vendor, click recycle, pop the next one, ... That sucks.

Now the code checks for material stacks. If the object hat has been shoved into the vendor is a stack, the amount is considered. The value is multiplied, the amount added to the internal storage as well.

Here, have a before/after of adding a stack of five plasma crystals. Everyone loves before/afters.

![image](https://github.com/sojourn-13/sojourn-station/assets/73559117/1c9a7331-27c1-47da-81b6-06f10cae6bb0)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl: dutop
fix: Consider stacks in recycling vendors
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
