### PR TITLE
Gives the Command panic bunker an exit to Security

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -1791,14 +1791,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"avb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/glass_security{
-	name = "Security Garden";
-	req_access = list(63)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/security/tactical_blackshield)
 "avd" = (
 /obj/structure/table/steel,
 /obj/random/material_resources,
@@ -10032,10 +10024,6 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
 "cks" = (
-/obj/machinery/door/airlock/glass_security{
-	name = "Security Garden";
-	req_access = list(63)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -10049,6 +10037,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/catwalk,
+/obj/machinery/door/airlock/glass_security{
+	name = "Corpsmen Triage";
+	req_access = list(63)
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/triage_blackshield)
 "ckE" = (
@@ -33946,6 +33938,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"hoT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/multiz/ladder/up,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/command/panic_room)
 "hoY" = (
 /obj/item/stool/custom,
 /obj/effect/floor_decal/spline/wood{
@@ -85969,12 +85968,13 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
 "smv" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Garden";
+	req_access = list(63)
 	},
-/obj/structure/multiz/ladder/up,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/command/panic_room)
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/security/tactical_blackshield)
 "smB" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
@@ -173724,7 +173724,7 @@ uAJ
 wCx
 fXW
 fXW
-smv
+hoT
 mMN
 mMN
 ghG
@@ -214118,7 +214118,7 @@ lpi
 bqJ
 mET
 nqF
-avb
+smv
 emZ
 veB
 bXG

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -34,7 +34,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/pros/foreman)
 "aak" = (
-/obj/machinery/door/airlock/maintenance_command,
+/obj/machinery/door/airlock/maintenance_command{
+	req_one_access = list(19, 1)
+	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/panic_room)
@@ -10023,7 +10025,7 @@
 /area/nadezhda/hallway/surface/section1)
 "cks" = (
 /obj/machinery/door/airlock/glass_security{
-	name = "Corpsmen Triage";
+	name = "Security Garden";
 	req_access = list(63)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13383,7 +13385,10 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
 "cVA" = (
-/obj/random/flora/small_jungle_tree,
+/obj/structure/multiz/ladder,
+/obj/structure/flora/big/bush3{
+	pixel_y = 5
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/tactical_blackshield)
 "cVC" = (
@@ -44766,8 +44771,8 @@
 /turf/simulated/floor/reinforced/oxygen,
 /area/nadezhda/engineering/atmos)
 "jDk" = (
-/obj/structure/flora/big/bush3,
 /obj/structure/flora/ausbushes/stalkybush,
+/obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/security/tactical_blackshield)
 "jDp" = (
@@ -73854,7 +73859,7 @@
 	})
 "pKg" = (
 /obj/machinery/door/airlock/glass_security{
-	name = "Corpsmen Triage";
+	name = "Security Garden";
 	req_access = list(63)
 	},
 /obj/structure/disposalpipe/segment,
@@ -81322,7 +81327,8 @@
 "rmU" = (
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "panicRoom";
-	name = "Panic Bunker"
+	name = "Panic Bunker";
+	req_access = list(19)
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -85955,15 +85961,13 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
 "smv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/closet/wall_mounted/emcloset{
-	pixel_y = -32
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/bluecorner,
-/area/nadezhda/security/sechall)
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Garden";
+	req_access = list(63)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/security/tactical_blackshield)
 "smB" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
@@ -100801,6 +100805,13 @@
 	icon_state = "13,15"
 	},
 /area/nadezhda/quartermaster/miningdock)
+"vnt" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/multiz/ladder/up,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/command/panic_room)
 "vnC" = (
 /obj/structure/scrap/poor,
 /obj/effect/decal/cleanable/rubble,
@@ -112368,6 +112379,9 @@
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted/emcloset{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "xJr" = (
@@ -173710,7 +173724,7 @@ uAJ
 wCx
 fXW
 fXW
-xjt
+vnt
 mMN
 mMN
 ghG
@@ -214103,8 +214117,8 @@ lpi
 lpi
 bqJ
 mET
+nqF
 smv
-oVA
 emZ
 veB
 bXG

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -1791,6 +1791,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"avb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Garden";
+	req_access = list(63)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/security/tactical_blackshield)
 "avd" = (
 /obj/structure/table/steel,
 /obj/random/material_resources,
@@ -73858,10 +73866,6 @@
 	name = "Residential District Maintenance"
 	})
 "pKg" = (
-/obj/machinery/door/airlock/glass_security{
-	name = "Security Garden";
-	req_access = list(63)
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73872,6 +73876,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass_security{
+	name = "Corpsmen Triage";
+	req_access = list(63)
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/triage_blackshield)
 "pKk" = (
@@ -85961,13 +85969,12 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
 "smv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/glass_security{
-	name = "Security Garden";
-	req_access = list(63)
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/security/tactical_blackshield)
+/obj/structure/multiz/ladder/up,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/command/panic_room)
 "smB" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
@@ -100805,13 +100812,6 @@
 	icon_state = "13,15"
 	},
 /area/nadezhda/quartermaster/miningdock)
-"vnt" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/multiz/ladder/up,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/command/panic_room)
 "vnC" = (
 /obj/structure/scrap/poor,
 /obj/effect/decal/cleanable/rubble,
@@ -173724,7 +173724,7 @@ uAJ
 wCx
 fXW
 fXW
-vnt
+smv
 mMN
 mMN
 ghG
@@ -214118,7 +214118,7 @@ lpi
 bqJ
 mET
 nqF
-smv
+avb
 emZ
 veB
 bXG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Adds an escape pathway for Command in the bunker, so it's not a deathtrap when attacked
</summary>
<hr>

Adds a simple ladder from the north part of the panic bunker to security's garden area. 
![Screenshot 2024-01-03 134610](https://github.com/sojourn-13/sojourn-station/assets/29682682/07f4e1d9-cbd3-476a-b293-26118b028c4a)
![Screenshot 2024-01-03 134622](https://github.com/sojourn-13/sojourn-station/assets/29682682/902f99ce-feac-4e24-833f-4c91c4260038)
The red circled airlock has access for command or security, the green circled airlock only has access for command. This allows security to pour in to defend the bunker if necessary but doesn't give them access to the bridge.
	
<hr>


</details>

## Changelog
:cl:
map: added an emergency exit to Command's panic bunker so they don't get trapped in it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
