### PR TITLE
Removing Possum's Shit Code

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -346,12 +346,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	preloaded_reagents = list("nicotine" = 5,  "mint" = 5)
 
 /obj/item/clothing/mask/smokable/cigarette/khi
-	name = "\improper Kitsuhana Singularity cigarette"
+	name = "\improper Hippie's Delight cigarette"
 	icon_state = "khioff"
 	icon_on = "khion"
 	icon_off = "khioff"
 	type_butt = /obj/item/trash/cigbutt/khi
-	preloaded_reagents = list("mindbreaker" = 5, "serotrotium" = 5, "impedrezene" = 5, "space_drugs" = 5)
+	preloaded_reagents = list("mindbreaker" = 3, "serotrotium" = 2, "space_drugs" = 5)
 
 /obj/item/clothing/mask/smokable/cigarette/comred
 	name = "\improper ComRed light cigarette"

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -336,7 +336,7 @@ obj/item/storage/fancy/dogtreats/populate_contents()
 
 /obj/item/storage/fancy/cigarettes/khi
 	name = "\improper Hippie's Delight packet"
-	desc = "A packet of six Hippie's Delight cigarettes. A brand of cigaretts favorited by those whom live in Astrovans on public and private beaches everywhere. CAUTION: Contents may contain chemicals unsuitable for some people. Ride the wave, surf's up bro!"
+	desc = "A packet of six Hippie's Delight cigarettes. A brand of cigarettes favorited by those whom live in Astrovans on public and private beaches everywhere. CAUTION: Contents may contain chemicals unsuitable for some people. Ride the wave, surf's up bro!"
 	icon_state = "KhiCigPacket"
 	item_state = "KhiCigPacket"
 

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -335,8 +335,8 @@ obj/item/storage/fancy/dogtreats/populate_contents()
 	create_reagents(10 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
 
 /obj/item/storage/fancy/cigarettes/khi
-	name = "\improper Kitsuhana Singularity packet"
-	desc = "A packet of six Kitsuhana Singularity cigarettes. A brand made by LSD abusers who overdosed one night and invented these smokes, still finds popularity among retards with no sense of quality. WARNING: Contains the kind of chemicals needed to enjoy this type of brand."
+	name = "\improper Hippie's Delight packet"
+	desc = "A packet of six Hippie's Delight cigarettes. A brand of cigaretts favorited by those whom live in Astrovans on public and private beaches everywhere. CAUTION: Contents may contain chemicals unsuitable for some people. Ride the wave, surf's up bro!"
 	icon_state = "KhiCigPacket"
 	item_state = "KhiCigPacket"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	This will be changing the Kitsuhana Singularity cigarette's to no longer be a direct attack towards Virgo's code and lore while giving it a more aesthetically pleasing look.
</summary>
<hr>

It had come to my attention that the Kitsuhana Singularity cigarettes were created **intentionally and exclusively** to attack Virgo's lore as Kitsuhana is a big name in the Virgo codebase and server. Given the context, I believe that this is not only a low blow, but outright childish of a coder to be doing with Sojourn's codebase. While I cannot change the sprite as I do not know how to sprite, I am requesting that we consider changing these to something else, my idea is that it should be something relating more in line with a hippie van that lives on the beaches. Like beach bums that would otherwise enjoy being stoned while they smoke cigarettes. 

With that in mind, I have rebranded these to 'Hippie's Delight' a runner up brand was 'Stoner's Delight'. The brain damage chemical that was originally in the Kitsuhana Singularity cigs are removed in this update and leaving behind just the various chemicals left. To further try to steer the brand towards a more 'stoner' vibe, I reduced the serotinium and mindbreaker so that characters can smoke these without completely losing control of their character but also maintaining the 'funny cigarette' vibe. 
	
<hr>
</details>

## Changelog
:cl:
add: New Brand of Cigarettes
del: Removed Possum's childish behavior.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
