### PR TITLE
Elite Mercenary moved from Simple Mob

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/solelite/solelite
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/solelite/solelite
@@ -1,6 +1,6 @@
 /mob/living/carbon/superior_animal/human/solelite
-	name = "Solfed Elite"
-	desc = "Black and charred hardsuit, sub-machine gun in-hand, a being of absolute terror to traitors of the Federation."
+	name = "Elite Operative"
+	desc = "Black and charred hardsuit, sub-machine gun in-hand, a being of absolute terror to those who dare approach."
 	icon = 'icons/mob/mobs-humanoid.dmi'
 	icon_state = "syndicate_stormtrooper_smg"
 	stop_automated_movement_when_pulled = 1
@@ -49,7 +49,6 @@
 
 	inherent_mutations = list(MUTATION_HEART, MUTATION_LUNG, MUTATION_LIVER, MUTATION_BLOOD_VESSEL, MUTATION_MUSCLES, MUTATION_NERVES)
 
-	drop_items = list(/obj/item/gun/projectile/)
 	faction = "elitemerc"
 
 /mob/living/carbon/superior_animal/human/solelite/handle_breath(datum/gas_mixture/breath) //we have are own air supplies
@@ -64,7 +63,7 @@
 
 /mob/living/carbon/superior_animal/human/solelite/melee
 	icon_state = "syndicate_stormtrooper_melee"
-	desc = "Black and charred hardsuit, sword and shield to match, a being of absolute terror to traitors of the Federation."
+	desc = "Black and charred hardsuit, sword and shield to match, a being of absolute terror to those who dare approach."
 	armor = list(melee = 65, bullet = 65, energy = 80, bomb = 80, bio = 90, rad = 25) //Melee shield
 	ranged = 0
 	melee_damage_lower = 40
@@ -72,7 +71,7 @@
 
 
 /mob/living/carbon/superior_animal/human/solelite/pistol
-	desc = "Black and charred hardsuit, revolver in-hand, a being of absolute terror to traitors of the Federation."
+	desc = "Black and charred hardsuit, revolver in-hand, a being of absolute terror to those who dare approach"
 	icon_state = "syndicate_stormtrooper_pistol"
 	projectiletype = /obj/item/projectile/bullet/rifle_75/hv
 	drop_items = list(/obj/item/gun/projectile/revolver/hornet)
@@ -82,7 +81,7 @@
 	mags_left = 5 //5+1
 
 /mob/living/carbon/superior_animal/human/solelite/shotgunner
-	desc = "Black and charred hardsuit, omnirifle shotgun in-hand, a being of absolute terror to traitors of the Federation."
+	desc = "Black and charred hardsuit, omnirifle shotgun in-hand, a being of absolute terror to those who dare approach."
 	icon_state = "syndicate_stormtrooper_shotgun"
 	projectiletype = /obj/item/projectile/bullet/shotgun
 	drop_items = list(/obj/item/gun/projectile/automatic/omnirifle/hustler)

--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/solelite/solelite
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/solelite/solelite
@@ -1,0 +1,101 @@
+/mob/living/carbon/superior_animal/human/solelite
+	name = "Solfed Elite"
+	desc = "Black and charred hardsuit, sub-machine gun in-hand, a being of absolute terror to traitors of the Federation."
+	icon = 'icons/mob/mobs-humanoid.dmi'
+	icon_state = "syndicate_stormtrooper_smg"
+	stop_automated_movement_when_pulled = 1
+	wander = 0
+	maxHealth = 300
+	health = 300
+
+	armor = list(melee = 55, bullet = 55, energy = 70, bomb = 80, bio = 90, rad = 25) //Legitmently their armor (melee is higher {45} to account for AI stupidness)
+
+	//range/ammo stuff
+	ranged = 1
+	rapid = 1
+	rapid_fire_shooting_amount = 5
+	ranged_cooldown = 2
+	projectiletype = /obj/item/projectile/bullet/magnum_40/hv
+	projectilesound = 'sound/weapons/guns/fire/smg_fire.ogg'
+	limited_ammo = TRUE
+	mag_drop = TRUE
+	rounds_left = 20
+	mag_type = /obj/item/ammo_magazine/smg_magnum_40/empty
+	mags_left = 4 //4+1
+
+	melee_damage_lower = 20
+	melee_damage_upper = 30
+	breath_required_type = 0 // Doesn't need to breath, in a hardsuit
+	breath_poison_type = 0 // Can't be poisoned
+	min_air_pressure = 0 // Doesn't need pressure
+	attacktext = "slashed"
+	attack_sound = 'sound/weapons/bladeslice.ogg'
+	meat_amount = 0
+	meat_type = null
+	leather_amount = 0
+	bones_amount = 0
+//They are all wearing suits
+	breath_required_type = NONE
+	breath_poison_type = NONE
+	min_breath_required_type = 0
+	min_breath_poison_type = 0
+
+	min_air_pressure = 0
+	min_bodytemperature = 0
+
+//Drops
+	meat_amount = 1
+	meat_type = /obj/item/reagent_containers/food/snacks/meat/human
+
+	inherent_mutations = list(MUTATION_HEART, MUTATION_LUNG, MUTATION_LIVER, MUTATION_BLOOD_VESSEL, MUTATION_MUSCLES, MUTATION_NERVES)
+
+	drop_items = list(/obj/item/gun/projectile/)
+	faction = "elitemerc"
+
+/mob/living/carbon/superior_animal/human/solelite/handle_breath(datum/gas_mixture/breath) //we have are own air supplies
+	return
+
+/mob/living/carbon/superior_animal/human/solelite/handle_environment(var/datum/gas_mixture/environment) //are armor legit is a hardsuit
+	return
+
+/mob/living/carbon/superior_animal/human/solelite/start_pulling(var/atom/movable/AM)
+	to_chat(src, SPAN_WARNING("Your hand gets pushed away from \the [src]. !"))
+	return
+
+/mob/living/carbon/superior_animal/human/solelite/melee
+	icon_state = "syndicate_stormtrooper_melee"
+	desc = "Black and charred hardsuit, sword and shield to match, a being of absolute terror to traitors of the Federation."
+	armor = list(melee = 65, bullet = 65, energy = 80, bomb = 80, bio = 90, rad = 25) //Melee shield
+	ranged = 0
+	melee_damage_lower = 40
+	melee_damage_upper = 55
+
+
+/mob/living/carbon/superior_animal/human/solelite/pistol
+	desc = "Black and charred hardsuit, revolver in-hand, a being of absolute terror to traitors of the Federation."
+	icon_state = "syndicate_stormtrooper_pistol"
+	projectiletype = /obj/item/projectile/bullet/rifle_75/hv
+	drop_items = list(/obj/item/gun/projectile/revolver/hornet)
+	projectilesound = 'sound/weapons/guns/fire/12mm_revolver.ogg'
+	rounds_left = 6
+	mag_type = /obj/item/ammo_magazine/speed_loader_kurtz_50/empty
+	mags_left = 5 //5+1
+
+/mob/living/carbon/superior_animal/human/solelite/shotgunner
+	desc = "Black and charred hardsuit, omnirifle shotgun in-hand, a being of absolute terror to traitors of the Federation."
+	icon_state = "syndicate_stormtrooper_shotgun"
+	projectiletype = /obj/item/projectile/bullet/shotgun
+	drop_items = list(/obj/item/gun/projectile/automatic/omnirifle/hustler)
+	projectilesound = 'sound/weapons/guns/fire/shotgunp_fire.ogg'
+	rounds_left = 10
+	mag_type = /obj/item/ammo_magazine/speed_loader_shotgun/empty
+	mags_left = 3 //3+1
+
+
+/mob/living/carbon/superior_animal/human/solelite/death(gibbed, deathmessage = "drops its weapon as it explodes in a shower of gore when their deadman's switch detonates!")
+	..()
+	new /obj/effect/gibspawner/human(src.loc)
+	playsound(src, 'sound/effects/Explosion2.ogg', 75, 1, -3)
+	drop_death_loot()
+	qdel(src)
+	return

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -244,6 +244,7 @@
 	stop_automated_movement_when_pulled = 0
 	maxHealth = 350
 	health = 350
+	armor = list(melee = 45, bullet = 50, energy = 30, bomb = 0, bio = 100, rad = 50)
 	vision_range = 16
 	harm_intent_damage = 5
 	melee_damage_lower = 10
@@ -285,6 +286,7 @@
 	melee_damage_upper = 35
 	maxHealth = 450 //Boosted because melee given armor/shield
 	health = 450
+	armor = list(melee = 65, bullet = 40, energy = 30, bomb = 0, bio = 100, rad = 50)
 	icon_state = "syndicate_stormtrooper_sword"
 	drop_items = list(/obj/item/melee/energy/sword/red, /obj/item/shield/buckler/energy)
 	attacktext = "slashed"
@@ -310,6 +312,9 @@
 /mob/living/simple_animal/hostile/elitemercenary/range/space/heavy/shotgun
 	ranged_cooldown = 4
 	rapid = 0
+	armor = list(melee = 65, bullet = 50, energy = 20, bomb = 0, bio = 100, rad = 50)
+	health = 450
+	maxHealth = 450
 	icon_state = "syndicate_stormtrooper_shotgun"
 	projectilesound = 'sound/weapons/guns/fire/shotgunp_fire.ogg'
 	projectiletype = /obj/item/projectile/bullet/shotgun

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -304,6 +304,7 @@
 /mob/living/simple_animal/hostile/elitemercenary/range/gunslinger
 	ranged_cooldown = 2
 	rapid = 0
+	ranged = 1
 	icon_state = "syndicate_stormtrooper_pistol"
 	projectilesound = 'sound/weapons/guns/fire/revolver_fire.ogg'
 	projectiletype = /obj/item/projectile/bullet/kurtz_50
@@ -311,11 +312,12 @@
 
 /mob/living/simple_animal/hostile/elitemercenary/range/space/heavy/shotgun
 	ranged_cooldown = 4
-	rapid = 0
+	rapid = 1
+	ranged = 1
 	armor = list(melee = 65, bullet = 50, energy = 20, bomb = 0, bio = 100, rad = 50)
 	health = 450
 	maxHealth = 450
 	icon_state = "syndicate_stormtrooper_shotgun"
 	projectilesound = 'sound/weapons/guns/fire/shotgunp_fire.ogg'
 	projectiletype = /obj/item/projectile/bullet/shotgun
-	drop_items = list(/obj/item/gun/projectile/shotgun/pump/combat)
+	drop_items = list(/obj/item/gun/projectile/automatic/omnirifle/hustler)


### PR DESCRIPTION
So for my events, I've been using the Elite Mercenary group of mobs, which are simple mobs. As such, I am moving them to Superior Mobs with some added benefits.

> Mobs are generally strong, so aren't really spam-able for events
> Mobs are also dangerous, with automatic shotguns, revolvers, SMGs and melee. 
> Should hopefully be much more useful in events.