### PR TITLE
Removes the restricted tag from several languages.

### DIFF
--- a/code/datums/perks/backgrounds.dm
+++ b/code/datums/perks/backgrounds.dm
@@ -58,7 +58,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	options["Yassari"] = LANGUAGE_YASSARI
 	options["Latin"] = LANGUAGE_LATIN
 	options["Kriosan"] = LANGUAGE_KRIOSAN
-	options["Akulan"] = LANGUAGE_AKULA
+	//options["Akulan"] = LANGUAGE_AKULA
 	options["Narad"] = LANGUAGE_MERP
 	var/choice = input(M,"Which language do you know?","Linguist Choice") as null|anything in options
 	if(src && choice)

--- a/code/datums/perks/backgrounds.dm
+++ b/code/datums/perks/backgrounds.dm
@@ -58,8 +58,8 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	options["Yassari"] = LANGUAGE_YASSARI
 	options["Latin"] = LANGUAGE_LATIN
 	options["Kriosan"] = LANGUAGE_KRIOSAN
-	//options["Akulan"] = LANGUAGE_AKULA
-	options["Narad"] = LANGUAGE_MERP
+	options["Akula"] = LANGUAGE_AKULA
+	options["Narad Pidgin"] = LANGUAGE_MERP
 	var/choice = input(M,"Which language do you know?","Linguist Choice") as null|anything in options
 	if(src && choice)
 		M.add_language(choice)

--- a/code/datums/perks/backgrounds.dm
+++ b/code/datums/perks/backgrounds.dm
@@ -57,6 +57,9 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	options["Lingua Romana"] = LANGUAGE_ROMANA
 	options["Yassari"] = LANGUAGE_YASSARI
 	options["Latin"] = LANGUAGE_LATIN
+	options["Kriosan"] = LANGUAGE_KRIOSAN
+	options["Akulan"] = LANGUAGE_AKULA
+	options["Narad"] = LANGUAGE_MERP
 	var/choice = input(M,"Which language do you know?","Linguist Choice") as null|anything in options
 	if(src && choice)
 		M.add_language(choice)

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -165,6 +165,9 @@
 	options["Lingua Romana"] = LANGUAGE_ROMANA
 	options["Yassari"] = LANGUAGE_YASSARI
 	options["Latin"] = LANGUAGE_LATIN
+	options["Kriosan"] = LANGUAGE_KRIOSAN
+	options["Akulan"] = LANGUAGE_AKULA
+	options["Narad"] = LANGUAGE_MERP
 	var/choice = input(M,"Which language do you know?","Linguist Choice") as null|anything in options
 	if(src && choice)
 		M.add_language(choice)

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -166,8 +166,8 @@
 	options["Yassari"] = LANGUAGE_YASSARI
 	options["Latin"] = LANGUAGE_LATIN
 	options["Kriosan"] = LANGUAGE_KRIOSAN
-	//options["Akulan"] = LANGUAGE_AKULA
-	options["Narad"] = LANGUAGE_MERP
+	options["Akula"] = LANGUAGE_AKULA
+	options["Narad Pidgin"] = LANGUAGE_MERP
 	var/choice = input(M,"Which language do you know?","Linguist Choice") as null|anything in options
 	if(src && choice)
 		M.add_language(choice)

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -166,7 +166,7 @@
 	options["Yassari"] = LANGUAGE_YASSARI
 	options["Latin"] = LANGUAGE_LATIN
 	options["Kriosan"] = LANGUAGE_KRIOSAN
-	options["Akulan"] = LANGUAGE_AKULA
+	//options["Akulan"] = LANGUAGE_AKULA
 	options["Narad"] = LANGUAGE_MERP
 	var/choice = input(M,"Which language do you know?","Linguist Choice") as null|anything in options
 	if(src && choice)

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -117,7 +117,6 @@
 	exclaim_verb = list("barks", "yips")
 	colour = "kriosan"
 	key = "k"
-	flags = RESTRICTED
 	has_written_form = FALSE	//Lore reason - Creolized German and their ancient native language. Therefor their written language is 'dead' effectively.
 	partial_understanding = list(
 		LANGUAGE_EURO = 75,
@@ -148,7 +147,6 @@
 	exclaim_verb = list("roars")
 	colour = "akula"
 	key = "a"
-	flags = RESTRICTED
 	has_written_form = FALSE //Lore reason - Warrior culture, likely did not adapt much of a writing system since it was unneeded. Literacy / Acedmia done in foreign tongues.
 	partial_understanding = list(
 		LANGUAGE_JANA = 10,
@@ -166,9 +164,9 @@
 	speech_verb = list("warbles")
 	ask_verb = list("trills")
 	exclaim_verb = list("rythmically trills")
+	flags = RESTRICTED
 	colour = "marqua"
 	key = "q"
-	flags = RESTRICTED
 	has_written_form = TRUE
 	partial_understanding = list(
 		LANGUAGE_JANA = 20,
@@ -198,7 +196,6 @@
 	speech_verb = list("says", "clicks")
 	ask_verb = list("chirps")
 	exclaim_verb = list("croaks")
-	flags = RESTRICTED
 	colour = "rough"
 	key = "n"
 	has_written_form = TRUE


### PR DESCRIPTION
Title. Makes several racial languages available for selection in theory. Namely, Kriosan, Akula, and Naramad. Mar'Qua, Cht'Mant and Opifexee were left out due to a variety of factors - being generally unspeakable by non-members, being integrated, or just being generally unspeakable.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
