### PR TITLE
Creates the Eventwolf

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/eventwolf/eventwolf
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/eventwolf/eventwolf
@@ -1,0 +1,51 @@
+/mob/living/carbon/superior_animal/human/eventwolf
+	name = "Void Wolf Marauder"
+	desc = "A Void Wolf mercenary, heavily armoured with a large power-hammer."
+	melee_damage_lower = 60
+	melee_damage_upper = 70
+	icon_state = "voidwolfmarauder"
+	icon_dead = "voidwolfmarauder_dead"
+	health = 450
+	maxHealth = 450
+	ranged = FALSE
+
+
+	armor = list(melee = 50, bullet = 35, energy = 35, bomb = 0, bio = 100, rad = 50)
+	faction = "pirate"
+	icon = 'icons/mob/mobs-humanoid.dmi'
+
+/mob/living/carbon/superior_animal/human/eventwolf/handle_breath(datum/gas_mixture/breath) //we have are own air supplies
+	return
+
+/mob/living/carbon/superior_animal/human/eventwolf/handle_environment(var/datum/gas_mixture/environment) //are armor legit is a void suit
+	return
+
+/mob/living/carbon/superior_animal/human/eventwolf/start_pulling(var/atom/movable/AM)
+	to_chat(src, SPAN_WARNING("Your hand gets pushed away from \the [src]. !"))
+	return
+
+	get_stat_modifier = FALSE
+	breath_required_type = 0 // Doesn't need to breath, in a space suit
+	breath_poison_type = 0 // Can't be poisoned
+	min_air_pressure = 0 // Doesn't need pressure
+
+
+/mob/living/carbon/superior_animal/human/eventwolf/explosive
+	name = "Void Wolf Bomber"
+	desc = "A Void Wolf with an explosive rig around it's chest..."
+	icon_state = "voidwolfsuicider"
+	health = 100
+	maxHealth = 100
+	move_to_delay = 3
+	stop_automated_movement_when_pulled = 0
+	melee_damage_lower = 10
+	melee_damage_upper = 10
+	armor = list(melee = 10, bullet = 10, energy = 10, bomb = 0, bio = 100, rad = 50)
+
+
+/mob/living/carbon/superior_animal/human/voidwolf/eventwolf/explosive/UnarmedAttack()
+	. = ..()
+	if(.) // If we succeeded in hitting.
+		visible_message(SPAN_DANGER("\The [src] charges in and detonates!"))
+		explosion(get_turf(loc), 0, 0, 2, 3)
+		death()

--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/eventwolf/eventwolf.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/eventwolf/eventwolf.dm
@@ -10,7 +10,7 @@
 	ranged = FALSE
 
 
-	armor = list(melee = 50, bullet = 35, energy = 35, bomb = 0, bio = 100, rad = 50)
+	armor = list(melee = 35, bullet = 70, energy = 35, bomb = 35, bio = 100, rad = 50)
 	faction = "pirate"
 	icon = 'icons/mob/mobs-humanoid.dmi'
 

--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/eventwolf/eventwolf.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/eventwolf/eventwolf.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/superior_animal/human/eventwolf
-	name = "Void Wolf Marauder"
+	name = "Void Wolf Juggernaut"
 	desc = "A Void Wolf mercenary, heavily armoured with a large power-hammer."
 	melee_damage_lower = 60
 	melee_damage_upper = 70


### PR DESCRIPTION
The Eventwolves aren't meant to be in-game due to their general power and ability to fuck-shit-up. As such, these will be seen in events such as raids or similar.

> Marauders are high health high damage, used with other melee voidwolves to break into lines and do damage. 
> Suicide bombers are weak, but explode on impact. Great for breaching into places, _like colony defences_. (Basically the boomba with a different sprite.)