### PR TITLE
Taser changes.

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -210,6 +210,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 /obj/item/projectile/beam/stun
 	name = "stun beam"
 	icon_state = "stun"
+	armor_penetration = 0
 	nodamage = 1
 	taser_effect = 1
 	agony = 30

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -50,6 +50,7 @@
 	name = "electrode"
 	icon_state = "spark"
 	mob_hit_sound = list('sound/weapons/tase.ogg')
+	armor_penetration = 20
 	nodamage = 1
 	taser_effect = 1
 	agony = 40
@@ -60,6 +61,7 @@
 /obj/item/projectile/energy/electrode/stunshot
 	name = "stunshot"
 	damage_types = list(BURN = 5)
+	armor_penetration = 40
 	taser_effect = 1
 	agony = 80
 	affective_damage_range = 2

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -61,7 +61,6 @@
 /obj/item/projectile/energy/electrode/stunshot
 	name = "stunshot"
 	damage_types = list(BURN = 5)
-	armor_penetration = 40
 	taser_effect = 1
 	agony = 80
 	affective_damage_range = 2


### PR DESCRIPTION
Taser beam has lost its AP, the combination of hitscan, commonality and pain damage makes me think it really...doesnt deserve AP.

Electrode bolt(such as those used by the counselor and zeus.) which DIDN't have AP have been given the AP that taser beams had, they are slower and a bit harder to use - and giiven that they fit the 'heavy big boy stuns, this seems fiine'.

Stunbolts(as used by the counselors big boy fire mode and shotgun stunslugs) have the above +20 ap, though I mused on giving them extra in light of how limited these shots tend to be, but for now just 20AP.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
