### PR TITLE
Makes the IC start time the server time, rounded to the nearest hour

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -14,7 +14,8 @@
 
 	return wtime + (time_offset + wusage) * world.tick_lag
 
-var/roundstart_hour = 0
+var/roundstart_hour = servertime2nums(1) //The hour in GMT that the server started. This will be adjusted for timezone by all time2text procs
+var/true_roundstart_hour = roundstart_hour + world.timezone //For use in any day/night calculations, this is the roundstart hour as it will actually appear
 var/station_date = ""
 var/next_station_date_change = 1 DAYS
 
@@ -24,7 +25,6 @@ var/next_station_date_change = 1 DAYS
 #define station_time_in_ticks (roundstart_hour HOURS + roundduration2text_in_ticks)
 
 /proc/stationtime2text()
-	if(!roundstart_hour) roundstart_hour = pick(2, 7, 12, 17)
 	return time2text(station_time_in_ticks, "hh:mm")
 
 /proc/stationdate2text()
@@ -44,8 +44,45 @@ var/next_station_date_change = 1 DAYS
 
 //Returns the world time in english
 /proc/worldtime2text(time = world.time, timeshift = 1)
-	if(!roundstart_hour) roundstart_hour = rand(0, 23)
 	return timeshift ? time2text(time+(roundstart_hour HOURS), "hh:mm") : time2text(time, "hh:mm")
+
+/proc/time2nums(T, precision = 2, floorit = FALSE) //T = time in deciseconds. Proc returns T in time form without a colon
+	if(T > 864000) //Times greater than 1 day get reduced to a time less than 24 hours
+		T %= 864000
+	var/sec = round(T/10) //Gives us the time in seconds rather than deciseconds.
+	var/midhours
+	var/midminutes
+	var/midseconds
+	var/output
+	switch(precision) //Precision is how many places we calculate. 1 returns hh, 2 returns hhmm, 3 returns hhmmss. Default is 2
+		if(1)
+			midhours = sec/3600 //Number of seconds in an hour
+			if(floorit) //Do we always round down?
+				output = round(midhours)
+			else //Or do we round to nearest?
+				output = round(midhours, 1)
+		if(2)
+			midhours = round(sec/3600) //Number of whole hours within our seconds
+			midminutes = (sec%3600)/60 //Number of minutes in the remainder
+			if(floorit)
+				output = midhours*100+round(midminutes)
+			else
+				output = midhours*100+round(midminutes, 1)
+		if(3)
+			midhours = round(sec/3600) //Number of whole hours within our seconds
+			midminutes = round((sec%3600)/60) //Number of whole minutes within our remaining seconds
+			midseconds = (sec%60)
+			output = midhours*1000+midminutes*100+midseconds //No need to option the rounding here, seconds are floored in line 1
+		else //Someone specified a precision outside the bounds? That's a paddlin
+			log_and_message_admins("time2nums was called by an idiot who gave it invalid precision. Yell at them in #code-dev.")
+			output = 0
+	return output
+
+/proc/servertime2nums(precision = 2) //Should return the UTC time, precision as above
+	return time2nums(world.timeofday, precision)
+
+/proc/getroundstarthour()
+	return true_roundstart_hour
 
 /proc/worldtime2hours()
 	if (!roundstart_hour)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Makes the start time of each round be the server's time, rounded to the nearest hour. A couple other procs are added for testing or getting the time.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
Rounds now start at the time on the server box, rounded to the nearest hour, so time actually progresses between shifts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
