### PR TITLE
prevents harmless guns from harming you. + lodge fix

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -739,6 +739,28 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 			mouthshoot = FALSE
 			return
 
+	if (istype(in_chamber))
+		user.visible_message(SPAN_WARNING("[user] pulls the trigger."))
+		if(silenced)
+			playsound(user, fire_sound, 10, 1)
+		else
+			playsound(user, fire_sound, 60, 1)
+		if(istype(in_chamber, /obj/item/projectile/bullet/cap))
+			user.show_message(SPAN_WARNING("You feel rather silly, trying to commit suicide with a toy."))
+			mouthshoot = FALSE
+			return
+
+	if (istype(in_chamber))
+		user.visible_message(SPAN_WARNING("[user] pulls the trigger."))
+		if(silenced)
+			playsound(user, fire_sound, 10, 1)
+		else
+			playsound(user, fire_sound, 60, 1)
+		if(istype(in_chamber, /obj/item/projectile/chameleon))
+			user.show_message(SPAN_WARNING("The gun fired but...you feel fine?"))
+			mouthshoot = FALSE
+			return
+
 		in_chamber.on_hit(M)
 		if (!in_chamber.is_halloss())
 			log_and_message_admins("[key_name(user)] commited suicide using \a [src]")

--- a/maps/__Nadezhda/area/_Nadezhda_areas.dm
+++ b/maps/__Nadezhda/area/_Nadezhda_areas.dm
@@ -358,11 +358,13 @@
 /area/nadezhda/outside/forest/hunting_lodge
 	name = "Hunting Lodge"
 	icon_state = "forest"
+	is_maintenance = FALSE
 	is_dungeon_lootable = FALSE
 
 /area/nadezhda/outside/forest/hunting_lodge_dark
 	name = "Hunting Lodge"
 	icon_state = "erisblue"
+	is_maintenance = FALSE
 	dynamic_lighting = TRUE
 	is_dungeon_lootable = FALSE
 


### PR DESCRIPTION
Finally figured this one out. Prevents cap guns and cham guns from letting you commit suicide. 

Minor map area bug fix: fixes #4901 lodge was getting incorrectly defined as a maint area via it's parent 

tested and works.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
