### PR TITLE
Las mg fix

### DIFF
--- a/code/game/objects/items/weapons/autolathe_disk/absolute_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/absolute_disks.dm
@@ -474,7 +474,7 @@ obj/item/computer_hardware/hard_drive/portable/design/nt/valkirye/plus
 	license = 8
 	designs = list(
 		/datum/design/autolathe/gun/concillium = 3,
-		/datum/design/autolathe/cell/medium/high,
+		/datum/design/autolathe/cell/large/high,
 	)
 
 

--- a/code/modules/projectiles/guns/energy/laser/concilium.dm
+++ b/code/modules/projectiles/guns/energy/laser/concilium.dm
@@ -25,9 +25,9 @@
 	gun_tags = list(GUN_LASER, GUN_ENERGY)
 	init_firemodes = list(
 		FULL_AUTO_600,
-		list(mode_name="short bursts", mode_desc="dakka 5 shots in quick succession", burst=5,    burst_delay=2, move_delay=6,  icon="burst"),
-		list(mode_name="long bursts", mode_desc="Dakka 8 shots in succession",  burst=8, burst_delay=4, move_delay=8,  icon="burst"),
-		list(mode_name="suppressing fire", mode_desc="DAKKA 16 shots back to back to keep targets inside cover",  burst=16, burst_delay=4, move_delay=11,  icon="burst")
+		list(mode_name="short bursts", mode_desc="Fire 5 shots in quick succession", burst=5,    burst_delay=2, move_delay=6,  icon="burst"),
+		list(mode_name="long bursts", mode_desc="Fire 8 shots in succession",  burst=8, burst_delay=4, move_delay=8,  icon="burst"),
+		list(mode_name="suppressing fire", mode_desc="Fire 16 shots back to back to keep targets inside cover",  burst=16, burst_delay=4, move_delay=11,  icon="burst")
 		)
 	blacklist_upgrades = list(/obj/item/gun_upgrade/mechanism/greyson_master_catalyst = TRUE)
 	twohanded = TRUE


### PR DESCRIPTION
Updated the concilium lasMG disk to have large cells instead of medium cells since they were reworked to use large.
Removed a warhammer 40k reference on the concilium lasMG fire modes.