### PR TITLE
Psionic food power now burns rather than takes blood, also reflavored

### DIFF
--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -23,18 +23,18 @@
 //Heals hunger
 /obj/item/organ/internal/psionic_tumor/proc/psychosomatictransfer()
 	set category = "Psionic powers"
-	set name = "Psychosomatic Transference (1)"
-	set desc = "Expend a single point of your psi essence to fill your stomach with cannibalized proteins from your own body. Beware, this will generate toxins and expend some of your blood."
+	set name = "Psychosomatic Fullness (1)"
+	set desc = "Expend a single point of your psi essence to convince your stomach it's not actually that hungry, burning fat reserves to keep going strong. Taxing on the mind and causes minor burns."
 	psi_point_cost = 1
 
 	if(pay_power_cost(psi_point_cost))
 		if(!owner.stats.getPerk(PERK_PSI_ATTUNEMENT))
-			owner.nutrition = 400
-			owner.drip_blood(54)
+			owner.nutrition += 100 //Twice as strong as Soul Hunger
+			owner.adjustFireLoss(10) //You're not using your nutrition to fuel things like Church used to, this should be fine
 		else
-			owner.nutrition = 400
-			owner.drip_blood(26)
-		to_chat(owner, "You feel sick and woozy, a sudden full sensation in your gut almost making you want to vomit.")
+			owner.nutrition += 100
+			owner.adjustFireLoss(5)
+		to_chat(owner, "You feel energized, though there is minor pain from burning so much fat so quickly.")
 
 // Heals stuns/other misc things
 /obj/item/organ/internal/psionic_tumor/proc/chosen_control()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Makes the psionic food power now give some burns rather than take your blood, changes the amount, and reflavors it
</summary>
<hr>

Psychosomatic Transference is renamed Psychosomatic Fullness, and is flavored as convincing your stomach it's not actually that hungry (which fits the actual meaning of the word psychosomatic). Changed it to give +100 nutrition rather than just setting your nutrition to 400. This is twice as strong as Soul Hunger, but given that 1 psi point is a bigger expenditure than 20 faith and this has a stronger downside I think it's fine. Gave it 10 burn damage (5 with Psi Attunement) rather than costing blood, because the blood cost would almost instantly negate the nutrition gain if you didn't have Attunement. Shouldn't run into the problem Church did with burn damage before, as you shouldn't need to spam this power to do other things with the nutrition.
	
<hr>
</details>

## Changelog
:cl:
tweak: Psionic food power is now called Psychosomatic Fullness and burns you rather than costing so much blood it's useless.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
