### PR TITLE
RIG weirdness, star trader and objective bug fixs

### DIFF
--- a/code/game/machinery/vendor/one_star_vending.dm
+++ b/code/game/machinery/vendor/one_star_vending.dm
@@ -89,7 +89,7 @@
 	products = list(
 		/obj/item/clothing/mask/smokable/cigarette/os/nova = 25,
 		/obj/item/clothing/suit/space/void/os/nova = 15,
-		/obj/item/clothing/suit/greatcoat/os = 10,
+		/obj/item/clothing/suit/greatcoat/os/nova = 10,
 		/obj/item/clothing/under/os_jumpsuit/nova = 10,
 		/obj/item/clothing/under/os_jumpsuit/bdu/nova = 10,
 		/obj/item/clothing/under/iron_lock_security = 10,

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -43,7 +43,7 @@
 	desc = "Standard operative suit issued to blackshield and marshal operatives alike. Provides balanced overall protection against various threats and widely used on planets surface, space stations or in open space."
 	icon_state = "ihs_rig"
 	helm_type = /obj/item/clothing/head/helmet/space/rig/combat/ironhammer
-	suit_type = "ironhammer hardsuit"
+	suit_type = "security hardsuit"
 
 /obj/item/rig/combat/ironhammer/equipped
 	initial_modules = list(
@@ -60,7 +60,7 @@
 	name = "Blackshield Ops control module"
 	desc = "A Blackshield RIG module that has been tailored for CQC. Due to its plating, it's slightly bulkier than normal standard security hardsuits."
 	icon_state = "blackshield_rig"
-	suit_type = "light suit"
+	suit_type = "blackshield hardsuit"
 	armor_list = list(
 		melee = 60,
 		bullet = 55,
@@ -91,16 +91,11 @@
 		)
 
 /obj/item/clothing/suit/space/rig/combat/blackshield
-	name = "blackshield hazard suit"
 
 /obj/item/clothing/gloves/rig/combat/blackshield
-	name = "blackshield hazard gloves"
 
 /obj/item/clothing/shoes/magboots/rig/combat/blackshield
-	name = "blackshield hazard shoes"
-
 /obj/item/clothing/head/helmet/space/rig/combat/blackshield
-	name = "blackshield hazard hood"
 	desc = "A hazard hood modded to help against CQC combat."
 	camera_networks = list(NETWORK_SECURITY)
 
@@ -109,7 +104,7 @@
 	desc = "A RIG module for a \"Hussar\" model hardsuit, jointly manufactured by Divisors and Numericals of the New Testament. \
 	The Tau Cross shining brightly upon its shoulder, it offers moderate combat protection against many a type of threat to the Absolute."
 	icon_state = "hussar_rig" //Rig modula by Gundam Tanaka#9565
-	suit_type = "hussar rig"
+	suit_type = "hussar hardsuit"
 	armor_list = list(
 		melee = 50,
 		bullet = 45,
@@ -136,16 +131,13 @@
 		)
 
 /obj/item/clothing/suit/space/rig/combat/knight //Suit by Polyushko#0323
-	name = "hussar hardsuit breastplate"
 
 /obj/item/clothing/gloves/rig/combat/knight //Gloves by Gundam Tanaka#9565
-	name = "hussar hardsuit gauntlets"
 
 /obj/item/clothing/shoes/magboots/rig/combat/knight //Boots by Gundam Tanaka#9565
-	name = "hussar hardsuit greaves"
 
 /obj/item/clothing/head/helmet/space/rig/combat/knight //Helm by Polyushko#0323
-	name = "hussar hardsuit full helm"
+	name = "full helm"
 	desc = "One's spirit is generally the greatest shield."
 	light_overlay = "helmet_light_dual"
 	armor_list = list(
@@ -162,7 +154,7 @@
 	name = "tactical hardsuit control module"
 	desc = "A heavy duty RIG that any true sons and daughters of Sol(or terrorist, for that matter.) would instantly recognize as a slightly older style of tactical armor, often issued by system defense fleets for anti-piracy operations. Despite its age, it still smells brand new."
 	icon_state = "ert_rig"
-	suit_type = "combat hardsuit"
+	suit_type = "tactical armored hardsuit"
 	req_access = list(access_hos)
 	armor_list = list(
 		melee = 50,
@@ -195,16 +187,12 @@
 		)
 
 /obj/item/clothing/suit/space/rig/combat/ert
-	name = "tactical armored hardsuit"
 
 /obj/item/clothing/gloves/rig/combat/ert
-	name = "tactical armored gloves"
 
 /obj/item/clothing/shoes/magboots/rig/combat/ert
-	name = "tactical armored shoes"
 
 /obj/item/clothing/head/helmet/space/rig/combat/ert
-	name = "tactical armored helmet"
 	camera_networks = list(NETWORK_SECURITY)
 
 /obj/item/rig/combat/ert/co
@@ -212,7 +200,7 @@
 	desc = "A heavy duty RIG that any true sons and daughters of Sol(or terrorist, for that matter.) would instantly recognize as a slightly older style of tactical armor, often issued by system defense fleets for anti-piracy operations. This one appears to have been modified for CQB."
 	req_access = list(access_hos)
 	icon_state = "ert_rig"
-	suit_type = "combat hardsuit"
+	suit_type = "blackshield tactical hardsuit"
 	armor_list = list(
 		melee = 60,
 		bullet = 55,
@@ -230,7 +218,6 @@
 	initial_modules = list(/obj/item/rig_module/maneuvering_jets)
 
 /obj/item/clothing/head/helmet/space/rig/combat/ert/co
-	name = "tactical armored helmet"
 	camera_networks = list(NETWORK_SECURITY)
 
 /obj/item/rig/combat/ert/co/equipped
@@ -247,6 +234,7 @@
 	name = "marshals tactical hardsuit control module"
 	desc = "A heavy duty RIG that any true sons and daughters of Sol(or terrorist, for that matter.) would instantly recognize as a slightly older style of tactical armor, often issued by system defense fleets for anti-piracy operations. This one appears to have had some of its armor stripped and its servos upgraded.."
 	icon_state = "ert_rig_wo"
+	suit_type = "marshal tactical"
 	req_access = list(access_hos)
 	armor_list = list(
 		melee = 50,
@@ -276,7 +264,6 @@
 		)
 
 /obj/item/clothing/head/helmet/space/rig/combat/ert/co/wo
-	name = "tactical armored helmet"
 	camera_networks = list(NETWORK_SECURITY)
 
 /obj/item/rig/combat/solfed //Suffice it to say this should NOT see extensive use and should be reserved for specific events, the nature of this equipment is that it should NOT fall into player hands.
@@ -284,7 +271,7 @@
 	desc = "An incredibly rare and advanced RIG. Typically found in the hands of Solarian vanguard and special recon units, these suits strike fear into the hearts of colonial traitors the galaxy over for they signal\
 	the coming wrath of Sol."
 	icon_state = "military_rig"
-	suit_type = "combat hardsuit"
+	suit_type = "Pathfinder hardsuit advanced armored"
 	armor_list = list(
 		melee = 60,
 		bullet = 70,
@@ -320,14 +307,10 @@
 		)
 
 /obj/item/clothing/suit/space/rig/combat/solfed
-	name = "advanced armored hardsuit"
 
 /obj/item/clothing/gloves/rig/combat/solfed
-	name = "advanced armored gloves"
 
 /obj/item/clothing/shoes/magboots/rig/combat/solfed
-	name = "advanced armored boots"
 
 /obj/item/clothing/head/helmet/space/rig/combat/solfed
-	name = "advanced armored helmet"
 	camera_networks = null//list(NETWORK_SOYFED) //It is over general, I have depicted your murderous federation as the soyjack and my glorious homeland as the chad. To do, maybe actually set this up.

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -42,7 +42,7 @@
 	name = "SI 'Proto-Spacer' control module"
 	desc = "An ultra light, unarmoured rig suit. The precursor to the Soteria retainer model, quite lacking in armor and EMP protection but capable of fitting hardsuit modules."
 	icon_state = "hacker_rig"
-	suit_type = "light suit"
+	suit_type = "SI 'Spacer"
 	armor_list = list(
 		melee = 10,
 		bullet = 5,
@@ -63,22 +63,19 @@
 	glove_type = /obj/item/clothing/gloves/rig/light/ultra_light
 
 /obj/item/clothing/suit/space/rig/light/ultra_light
-	name = "SI 'Spacer' suit"
 
 /obj/item/clothing/gloves/rig/light/ultra_light
-	name = "SI 'Spacer' gloves"
 
 /obj/item/clothing/shoes/magboots/rig/light/ultra_light
-	name = "SI 'Spacer' shoes"
-
 /obj/item/clothing/head/helmet/space/rig/light/ultra_light
-	name = "SI 'Spacer' hood"
+	name = "HUD"
 	flags_inv = 0
 	camera_networks = list(NETWORK_RESEARCH)
 
 /obj/item/rig/light/hacker/steward
 	name = "SI 'Retainer' control module"
 	desc = "A Soteria Institute modification of the traditional light rig built for equal parts utility and defense."
+	suit_type = "SI 'retainer"
 	armor_list = list(
 		melee = 30,
 		bullet = 25,

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -170,7 +170,7 @@ Advanced Voidsuit: Guild Master
 	siemens_coefficient = 0
 
 /obj/item/clothing/shoes/magboots/rig/ce
-	name = "advanced magboots"
+	name = "magboots"
 	desc = "Advanced magnetic boots that have a lighter magnetic pull, placing less burden on the wearer."
 	mag_slow = 0
 
@@ -321,17 +321,13 @@ Technomancer RIG
 	req_access = list()
 
 /obj/item/clothing/suit/space/rig/advhazmat
-	name = "Advanced AMI suit"
 
 /obj/item/clothing/gloves/rig/advhazmat
-	name = "Advanced AMI gloves"
 	siemens_coefficient = 0
 
 /obj/item/clothing/shoes/magboots/rig/advhazmat
-	name = "Advanced AMI shoes"
 
 /obj/item/clothing/head/helmet/space/rig/advhazmat
-	name = "Advanced AMI void helm"
 	camera_networks = list(NETWORK_RESEARCH)
 
 /***************************************
@@ -418,6 +414,7 @@ Technomancer RIG
 	name = "SI 'Medtek' control module"
 	desc = "An upgraded and somewhat customized soteria 'retainer' RIGsuit. Though superficially and aesthetically similar this suit has undergone a series of upgrades so as to improve its utility \
 	for Soterias resident overworked Chief of Medicine. Improved servos are paired with neural-mnemonic sensors allowing the user unmatched speed and dexterity- one can easily forget that they are even wearing the suit."
+	suit_type = "SI 'Medtek"
 	armor_list = list(
 		melee = 0,
 		bullet = 0,
@@ -478,7 +475,7 @@ Technomancer RIG
 	name = "stewards hardsuit control module"
 	desc = "A modification of the traditional combat rig built for equal parts utility and defense. Marked with a seal of two Armstrong rifles crossing each other in a X at the base of the neck."
 	icon_state = "security_rig"
-	suit_type = "combat hardsuit"
+	suit_type = "stewards hardsuit"
 	armor_list = list(
 		melee = 40,
 		bullet = 40,

--- a/code/modules/nanogate/nanogate_items.dm
+++ b/code/modules/nanogate/nanogate_items.dm
@@ -10,7 +10,7 @@
 		energy = 30,
 		bomb = 25,
 		bio = 100,
-		rad = 50
+		rad = 100
 	)
 	slowdown = 0.3
 	item_flags = STOPPRESSUREDAMAGE | THICKMATERIAL | DRAG_AND_DROP_UNEQUIP | EQUIP_SOUNDS

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1208,7 +1208,7 @@
 		return FALSE
 
 /obj/machinery/power/apc/Process()
-	SEND_SIGNAL(area, COMSIG_AREA_APC_OPERATING, operating)
+	LEGACY_SEND_SIGNAL(area, COMSIG_AREA_APC_OPERATING, operating)
 	if(stat & (BROKEN|MAINT))
 		return
 	if(!area.requires_power)


### PR DESCRIPTION
starting with the small stuff: 
the greysons Star traders vender no longer gives out free **genuine** greyson coats. Now giving the star traders version at cost.

The guild APC disturbance objective now works. Trilby helped me with this one thanks. The one where you need to go power down a APC in a area (mostly). There is still a issue related to this objective selecting areas that don't exist on map. I will try and fix this later but the files I think are the problem are locked up currently. 

RIG stuff:

Goes through I believe every single RIG and standardizes their naming there should be no more weirdness of a ''hussar RIG hussar hardsuit boots'' across all RIGs. I did not test every single suit but it _should_ be fine I checked a fair few. 

The nanite RIG has been giving 100 rad protection this was meant to be done awhile back. I missed it since its hiding in its own file away from other RIGs.


Not changelog related note to coders: PLEASE if you make a RIGsuit. Follow the proper standard for this. Just lookie at the code its very simple! The Proto-Spacer is a good example if you wanna give the helmet/whatever a fancy name. Same standard all the older RIGs use. Dunno when this weird trend started on soj.