### PR TITLE
more borg QOL tweaks and airlocks to the people

### DIFF
--- a/code/datums/craft/recipes/airlocks.dm
+++ b/code/datums/craft/recipes/airlocks.dm
@@ -6,7 +6,6 @@
 		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL),
 	)
 	related_stats = list(STAT_MEC)
-	requiredPerk = PERK_HANDYMAN
 
 /datum/craft_recipe/airlock/standard
 	name = "airlock assembly"

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -231,7 +231,7 @@
 		/obj/item/spacecash,
 		/obj/item/coin,
 		/obj/item/device/toner,
-		/obj/item/computer_hardware/hard_drive/portable/design
+		/obj/item/computer_hardware/hard_drive/portable
 		)
 
 /obj/item/gripper/research //A general usage gripper, used for toxins/robotics/xenobio/etc
@@ -290,7 +290,7 @@
 		/obj/item/tank,
 		/obj/item/reagent_containers/food/snacks/meat, //For grinding up roaches
 		/obj/item/reagent_containers/food/snacks/grown, //For grinding up herbs
-
+		/obj/item/genetics, //for doing genetics. Research borgs get this as well
 		/obj/item/stack/material/plasma
 		)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1305,8 +1305,7 @@ var/global/list/robot_modules = list(
 	P.synths = list(plastic)
 	src.modules += P
 
-	//We know guild work and robotics.
-	R.stats.addPerk(PERK_HANDYMAN)
+	//We know repair work and robotics.
 	R.stats.addPerk(PERK_ROBOTICS_EXPERT)
 	R.stats.addPerk(PERK_SI_SCI)
 


### PR DESCRIPTION
Finally allows both research and medical borgs to partake in genetics via the medical gripper. Can hold plates, injecters and purgers.
Fixes a small pathing issue I made with the paperwork gripper. Can now grip ALL types of data disks. 

Good news anyone can now craft airlocks and it is no longer (Weirdly) bound to the guild handyman perk. Bad news! Drones have lost the handyman perk and by extent AIs can no longer produce guild hand made products. This was not something I was intending to allow when buffing the engineering borgs omnitool.

I tested this pretty well. Nothing _should_ go weird and maint drones should still be able to pass every skillcheck they need 

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
