### PR TITLE
Makes Excel Spawners actually give you the implant, buffs armored Excel

### DIFF
--- a/code/game/objects/effects/spawners/ghostroles.dm
+++ b/code/game/objects/effects/spawners/ghostroles.dm
@@ -65,8 +65,20 @@
 		STAT_COG = 10
 	)
 
-/obj/effect/mob_spawn/human/exl_armored
+/obj/effect/mob_spawn/human/exl_civ/special(mob/living/H)
+	var/obj/item/implant/excelsior/E = new /obj/item/implant/excelsior(H)
+	E.install(H, BP_HEAD, H)
+
+/obj/effect/mob_spawn/human/exl_civ/armored
 	outfit = /decl/hierarchy/outfit/antagonist/mercenary/excelsior/equipped
+	stat_modifiers = list( //Should be beefy, they're antags who are supposed to face fully awakened Blackshield
+		STAT_ROB = 50,
+		STAT_TGH = 50,
+		STAT_BIO = 25,
+		STAT_MEC = 25,
+		STAT_VIG = 50,
+		STAT_COG = 10
+	)
 
 /obj/effect/mob_spawn/human/void_wolf
 	name = "storage sleeper"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	The admin Excel spawners now actually has an implant. Also, the armored one has stats and perks now
</summary>
<hr>

Adds code to make the Excel spawners actually give the individual the Excel implant. Also makes the armored one a child of the original so it gets the perks, and gives them a decently beefy stat set fit for an antag.	
<hr>
</details>

## Changelog
:cl:
Fix: Makes admin-spawned Excel actually have an implant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
