### PR TITLE
Update eyes.dm

### DIFF
--- a/code/modules/organs/internal/internal_wounds/eyes.dm
+++ b/code/modules/organs/internal/internal_wounds/eyes.dm
@@ -78,11 +78,11 @@
 	name = "charred sclera"
 
 /datum/component/internal_wound/organic/eyes_burn/scorch
-	name = "scorched deep tissue"
+	name = "scorched tissue"
 	treatments_tool = list(QUALITY_RETRACTING = FAILCHANCE_HARD)
-	scar = /datum/component/internal_wound/organic/eyes_deep_burn
+	//scar = /datum/component/internal_wound/organic/eyes_deep_burn
 
-/datum/component/internal_wound/organic/eyes_deep_burn //stage 2
+/datum/component/internal_wound/organic/eyes_burn/eyes_deep_burn //stage 2
 	name = "scorched deep tissue"
 	severity = 3 // starts with max damage as it is a second stage
 	severity_max = 3


### PR DESCRIPTION
Fixes an issue where one particular burn wound on the eye could be generated and be unable to be removed. The creator of the original PR is apparently working on a fix to the issue but for now we'll just comment it out.