### PR TITLE
senseable guest passes

### DIFF
--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -67,12 +67,13 @@
 		if(!giver && user.unEquip(O))
 			O.loc = src
 			giver = O
-
+//Soj edit commenting this out. Less confusion this way.
+/*
 			//By default we'll set it to all accesses on the inserted ID, rather than none
 			accesses = list()
 			for (var/A in giver.access)
 				accesses.Add(A)
-
+*/
 			updateUsrDialog()
 		else if(giver)
 			to_chat(user, SPAN_WARNING("There is already ID card inside."))


### PR DESCRIPTION
comments out a few lines of code making guest pass computers default to deselected rather then all selected. 90% of the time this is used for letting outsiders in meaning no access! On the off time its not better to opt in to access then forget somewhere important opting out of access . Gone are the days of commanders giving a outsider access to the armory! (as funny as it was)

Tested and works

Super short changelog without long winded explanation and reasoning to appease CDB: 

comments out a few lines of code making guest pass computers default to all deselected rather then all selected. No real balance implications just QOL many have asked for/complained about.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
