### PR TITLE
Adds Ostwind to WO primary selection and gives them an ammo pouch

### DIFF
--- a/code/game/objects/items/weapons/storage/hardcases.dm
+++ b/code/game/objects/items/weapons/storage/hardcases.dm
@@ -500,6 +500,7 @@ obj/item/storage/hcases/attackby(obj/item/W, mob/user)
 		var/list/options = list() // Moved the Galaxy to secondary selection
 		options["Osprey - precision rifle"] = list(/obj/item/gun/projectile/automatic/omnirifle/scoped/fancy,/obj/item/ammo_magazine/heavy_rifle_408,/obj/item/ammo_magazine/heavy_rifle_408, /obj/item/ammo_magazine/heavy_rifle_408/rubber)
 		options["SWAT - combat shotgun"] = list(/obj/item/gun/projectile/shotgun/pump/swat, /obj/item/ammo_magazine/ammobox/shotgun/beanbags/pepperball, /obj/item/ammo_magazine/ammobox/c10x24_small)
+		options["Ostwind - police carbine"] = list(/obj/item/gun/projectile/automatic/ostwind, /obj/item/ammo_magazine/light_rifle_257, /obj/item/ammo_magazine/light_rifle_257, /obj/item/ammo_magazine/light_rifle_257/rubber/pepperball)
 		var/choice = input(user,"What type of equipment?") as null|anything in options
 		if(src && choice)
 			var/list/things_to_spawn = options[choice]

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -66,6 +66,7 @@
 	new /obj/item/device/holowarrant(src)
 	new /obj/item/taperoll/police(src)
 	new /obj/item/gunbox/warrantofficer(src) // Primary on their locker, secondary on their hardcase.
+	new /obj/item/storage/pouch/ammo(src)
 	new /obj/item/clothing/gloves/stungloves(src)
 	new /obj/item/device/taperecorder(src)
 	new /obj/item/clipboard(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Adds the Ostwind to the Warrant Officer's primary weapon choices, and adds an ammo pouch to their locker
</summary>
<hr>

Currently WOs have two options, whereas the lower ranks get three. Those two options are a DMR and a pump-action shotgun, which fill two different niches, but they don't have a burst-fire option. The Ostwind's a pretty solid gun and its description denotes it as a high-end police carbine. 6.5mm isn't the strongest caliber, but with that comes a low propensity for overpenetration, which is useful for if you might need to fire into an area with others. They get 2 standard carbine mags and one pepperball mag with it. Also adds an ammo pouch to their locker, since unlike other roles they don't get a box that holds it when they spawn their weapon.

<hr>
</details>

## Changelog
:cl:
add: Adds the Ostwind to the Warrant Officer's selection of primary weapons, and an ammo pouch to their locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
