### PR TITLE
church melee balance

### DIFF
--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -140,7 +140,7 @@
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK | SLOT_BELT
 	throwforce = WEAPON_FORCE_LETHAL * 1.5
-	armor_penetration = ARMOR_PEN_HALF
+	armor_penetration = ARMOR_PEN_MASSIVE
 	throw_speed = 3
 	price_tag = 150
 	matter = list(MATERIAL_BIOMATTER = 20, MATERIAL_PLASTEEL = 10) // More expensive, high-end spear
@@ -230,6 +230,7 @@
 	item_state = "nt_warhammer"
 	wielded_icon = "nt_warhammer_wielded"
 	force = WEAPON_FORCE_DANGEROUS //Naturally weaker do to knockbacking are targets (can stun lock)
+	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
 	armor_penetration = ARMOR_PEN_EXTREME
 	w_class = ITEM_SIZE_BULKY
 	price_tag = 800
@@ -266,7 +267,7 @@
 	switched_on_qualities = list(QUALITY_CUTTING = 30, QUALITY_SAWING = 30)
 	switched_off_qualities = list(QUALITY_CUTTING = 10, QUALITY_SAWING = 10)
 	tool_qualities = list(QUALITY_CUTTING = 10, QUALITY_SAWING = 10)
-	active_time = 50
+	active_time = 100
 	var/faith_cost = 50 //How much faith does it take to use this?
 
 /obj/item/tool/sword/nt/power/attack_self(mob/living/user)

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -267,7 +267,7 @@
 	switched_on_qualities = list(QUALITY_CUTTING = 30, QUALITY_SAWING = 30)
 	switched_off_qualities = list(QUALITY_CUTTING = 10, QUALITY_SAWING = 10)
 	tool_qualities = list(QUALITY_CUTTING = 10, QUALITY_SAWING = 10)
-	active_time = 100
+	active_time = 10 SECONDS
 	var/faith_cost = 50 //How much faith does it take to use this?
 
 /obj/item/tool/sword/nt/power/attack_self(mob/living/user)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -183,6 +183,7 @@
 		/obj/item/soap,
 		/obj/item/reagent_containers/spray/cleaner,
 		/obj/item/tool/knife/dagger/nt,
+		/obj/item/tool/sword/nt/shortsword,
 		/obj/item/reagent_containers/food/drinks/bottle/ntcahors,
 		/obj/item/gun/projectile/boltgun/flare_gun,
 		/obj/item/ammo_casing/flare,
@@ -515,6 +516,7 @@
 		/obj/item/gun/energy/crossbow,
 		/obj/item/gun/energy/taser, //specially fitted to hold the counselor
 		/obj/item/tool/knife/dagger/nt,
+		/obj/item/tool/sword/nt/shortsword,
 		/obj/item/reagent_containers/food/drinks/bottle/ntcahors,
 		/obj/item/gun/projectile/boltgun/flare_gun,
 		/obj/item/ammo_casing/flare,


### PR DESCRIPTION
long needed look at of church melee weapons. I may do more I may call it good here. Input is welcome from anyone in terms of what needs changing.

So far changes are as follows:

Both church belts can now hold the church shortsword. Making it have a place as a effective backup melee.

The warhammer now has bonus structural damage idk why it never had such.

The NT spear has had its god damn 50! AP reduced to 30 making it no longer the best PVE church melee.

The Vexilar force blade has had its active time doubled. The most expensive church melee should likely not just be a gimmick. Around 12 seconds or so but mileage may vary with tickrate as usual.