### PR TITLE
machete exploit/handtele fix

### DIFF
--- a/code/__HELPERS/bluespace_entropy.dm
+++ b/code/__HELPERS/bluespace_entropy.dm
@@ -12,6 +12,8 @@ GLOBAL_VAR_INIT(bluespace_distotion_cooldown, 10 MINUTES)
 	do_teleport(ateleatom, adestination, aprecision, afteleport, aeffectin, aeffectout, asoundin, asoundout)
 
 /proc/bluespace_entropy(max_value=1, turf/T, minor_distortion=FALSE)
+	if(!T)
+		return
 	var/entropy_value = rand(0, max_value) * GLOB.chaos_level
 	var/area/A = get_area(T)
 	if(minor_distortion && A)

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -161,7 +161,7 @@ Frequency:
 		to_chat(user, SPAN_WARNING("[src] battery is dead or missing."))
 		return
 	var/turf/current_location = get_turf(user)//What turf is the user on?
-	if(!current_location||current_location.z>=7)//If turf was not found or they're on z >7 which does not currently exist.
+	if(!current_location||current_location.z>=25)//If turf was not found or they're on z >25 which does not currently exist.
 		to_chat(user, SPAN_NOTICE("\The [src] is malfunctioning!"))
 		return
 	var/list/L = list()

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -492,6 +492,7 @@
 	force = WEAPON_FORCE_ROBUST
 	w_class = ITEM_SIZE_NORMAL
 	price_tag = 120
+	matter = list(MATERIAL_STEEL = 15)
 
 /obj/item/tool/sword/cleaver
 	name = "sun cleaver"


### PR DESCRIPTION
Makes the machete contain 15 steel rather then 15 plasteel fixing a exploit involving guild crafting.

Fixes the NT BSD "Jumper" aka handtele not working in most off-colony zlevels. To my surprise this is actually unintended as far as I'm aware.

Fixes items existing in nullspace being able to create entropy. Only real example of this being the bluespace trade vender. Should be less ooooppps 300 entropy. (trilby did all the work I just found the issue and tested her fix)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
