### PR TITLE
Generate Discord Link

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -313,7 +313,7 @@ var/world_topic_spam_protect_time = world.timeofday
 
 	s += "<b>[station_name()]</b>";
 	s += " ("
-	s += "<a href=\"https://discord.com/invite/aXrM3SDyEw">" //Change this to wherever you want the hub to link to.
+	s += "<a href=\"https://discord.com/invite/aXrM3SDyEw\">" //Change this to wherever you want the hub to link to.
 //	s += "[game_version]"
 	s += "Discord"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
 	s += "</a>"

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -313,9 +313,9 @@ var/world_topic_spam_protect_time = world.timeofday
 
 	s += "<b>[station_name()]</b>";
 	s += " ("
-	s += "<a href=\"http://\">" //Change this to wherever you want the hub to link to.
+	s += "<a href=\"https://discord.com/invite/aXrM3SDyEw">" //Change this to wherever you want the hub to link to.
 //	s += "[game_version]"
-	s += "Default"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
+	s += "Discord"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
 	s += "</a>"
 	s += ")"
 


### PR DESCRIPTION
This is to modify the HUB link from "https//\" to the link that we use to get to our discord from the wiki link. This is to hopefully avoid any confusion and allow players to easily locate our Discord. 

Kudos to plant from Discord finding this and bringing it to our attention! Thank you!