### PR TITLE
Adds generic implant and known_cybernetics to adv medscanner

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -153,6 +153,13 @@
 		/obj/item/implant/core_implant/cruciform,
 		/obj/item/implant/excelsior
 	)
+	var/known_cybernetics = list(
+		/obj/item/organ_module/active/simple/wolverine,
+		/obj/item/organ_module/active/simple/armblade/energy_blade,
+		/obj/item/organ_module/active/simple/armblade/bs_tomahawk,
+		/obj/item/organ_module/active/simple/armblade/longsword,
+		/obj/item/organ_module/active/simple/armblade/ritual
+	)
 	var/delete
 	var/temphtml
 	name = "body scanner console"
@@ -367,6 +374,12 @@
 				if(is_type_in_list(I,known_implants))
 					var/obj/item/implant/device = I
 					other_wounds += "[device.get_scanner_name()] implanted"
+				else if(is_type_in_list(I,known_cybernetics))
+					var/obj/item/organ_module/active/simple/device = I
+					other_wounds += "[device.get_scanner_name()] detected"
+				else if(istype(I, /obj/item/implant/generic))
+					var/obj/item/implant/device = I
+					other_wounds += "[device.get_scanner_name()] detected"
 				else if(istype(I, /obj/item/material/shard/shrapnel))
 					other_wounds += "Embedded shrapnel"
 				else if(istype(I, /obj/item/implant))

--- a/code/game/objects/items/devices/organ_module/active/armblades.dm
+++ b/code/game/objects/items/devices/organ_module/active/armblades.dm
@@ -13,6 +13,9 @@
 	armor_penetration = ARMOR_PEN_MODERATE
 	tool_qualities = list(QUALITY_CUTTING = 20)
 
+/obj/item/organ_module/active/simple/proc/get_scanner_name()
+	return name
+
 /obj/item/organ_module/active/simple/armblade
 	name = "embedded armblade"
 	desc = "A mechanical blade designed to be inserted into an arm. Gives you a nice advantage in a brawl."

--- a/code/game/objects/items/weapons/implant/implanter.dm
+++ b/code/game/objects/items/weapons/implant/implanter.dm
@@ -1,5 +1,6 @@
 /obj/item/implanter
 	name = "implanter"
+	desc = "An implanter that allows safe and hygienic implant implantation even to untrained personel"
 	icon = 'icons/obj/items.dmi'
 	icon_state = "implanter"
 	item_state = "syringe_0"

--- a/code/game/objects/items/weapons/implant/implants/generic.dm
+++ b/code/game/objects/items/weapons/implant/implants/generic.dm
@@ -1,0 +1,4 @@
+/obj/item/implant/generic
+	name = "implant"
+	desc = "An generic implant that serves no function, no use."
+	icon_state = "implant_tracking"

--- a/code/game/objects/items/weapons/implant/implants/tracking.dm
+++ b/code/game/objects/items/weapons/implant/implants/tracking.dm
@@ -1,6 +1,6 @@
 /obj/item/implant/tracking
 	name = "tracking implant"
-	desc = "Track with this."
+	desc = "A small device used for tracking individuals."
 	icon_state = "implant_tracking"
 	var/id = 1.0
 	origin_tech = list(TECH_MATERIAL=2, TECH_MAGNET=2, TECH_DATA=2, TECH_BIO=2)

--- a/code/modules/client/preference_setup/loadout/lists/general.dm
+++ b/code/modules/client/preference_setup/loadout/lists/general.dm
@@ -73,14 +73,24 @@
 /datum/gear/implanter
 	display_name = "implanter (empty)"
 	path = /obj/item/implanter
+	cost = 0
 
 /datum/gear/implant_tracking
 	display_name = "implant (tracking)"
 	path = /obj/item/implant/tracking
+
+/datum/gear/implant_generic_1
+	display_name = "implant (generic) 1"
+	path = /obj/item/implant/generic
 	cost = 0
 
-/datum/gear/implant_generic
-	display_name = "implant (generic)"
+/datum/gear/implant_generic_2
+	display_name = "implant (generic) 2"
+	path = /obj/item/implant/generic
+	cost = 0
+
+/datum/gear/implant_generic_3
+	display_name = "implant (generic) 3"
 	path = /obj/item/implant/generic
 	cost = 0
 

--- a/code/modules/client/preference_setup/loadout/lists/general.dm
+++ b/code/modules/client/preference_setup/loadout/lists/general.dm
@@ -70,9 +70,19 @@
 	display_name = "spaceball booster pack"
 	path = /obj/item/pack/spaceball
 
-/datum/gear/trackingimplanter
-	display_name = "implanter (tracking)"
-	path = /obj/item/implanter/tracking
+/datum/gear/implanter
+	display_name = "implanter (empty)"
+	path = /obj/item/implanter
+
+/datum/gear/implant_tracking
+	display_name = "implant (tracking)"
+	path = /obj/item/implant/tracking
+	cost = 0
+
+/datum/gear/implant_generic
+	display_name = "implant (generic)"
+	path = /obj/item/implant/generic
+	cost = 0
 
 /datum/gear/photo_frame
     display_name = "photograph frame"

--- a/code/modules/psionics/psion.dm
+++ b/code/modules/psionics/psion.dm
@@ -151,7 +151,7 @@
 
 // This proc removes all implanters other then non-metal ones.
 /obj/item/organ/internal/psionic_tumor/proc/remove_implanted(metal_implant)
-	if(istype(metal_implant, /obj/item/implant))
+	if(istype(metal_implant, /obj/item/implant) && !istype(metal_implant, /obj/item/implant/generic))
 		var/obj/item/implant/R = metal_implant
 		if(R.implanted)
 			owner.visible_message(SPAN_DANGER("[R.name] rips through [owner]'s body."),\

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -1222,6 +1222,7 @@
 #include "code\game\objects\items\weapons\implant\implants\excelsior.dm"
 #include "code\game\objects\items\weapons\implant\implants\explosive.dm"
 #include "code\game\objects\items\weapons\implant\implants\freedom.dm"
+#include "code\game\objects\items\weapons\implant\implants\generic.dm"
 #include "code\game\objects\items\weapons\implant\implants\health.dm"
 #include "code\game\objects\items\weapons\implant\implants\spying.dm"
 #include "code\game\objects\items\weapons\implant\implants\tracking.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>

<summary>
	Adds generic implant to loadout you can give custom name to, it will show up on adv medical scanner for that extra RP, makes any implants one might have in their medical records A REALITY !!!
<br><br>
	For easier implanting of those generic (and in the future others ???) implants the currently avabile tracking implanter in loadout has been split into a empty implanter and a loose tracking implant for the same combined price as before.
<br><br>
	Additionally gives adv medical scanners ability to detect common cybernetics like razor boy/girl upbringing claws.
<br><br>
And yes /obj/item/implant/excelsior still properly shows up as death implant on adv medical scanners.
</summary>

</details>

![obraz](https://github.com/sojourn-13/sojourn-station/assets/66973657/3f3c14eb-fd47-4f02-8770-7cff295e35e7)


## Changelog
:cl:
add: Added generic implant to loadout, you can rename it so that whatever you name it shows up on medical scanner
tweak: Splits current loadout tracking implant into a empty implanter and the tracking implant, both still costing the same as before
tweak: known_cybernetics list added to adv medical scanner, it contains cybernetics like razor boy/girl upbringing claws that it should properly recognise
tweak: change/add implant/implanter descriptions
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
