### PR TITLE
Makes maintenance areas make sense

### DIFF
--- a/maps/__Nadezhda/area/_Nadezhda_areas.dm
+++ b/maps/__Nadezhda/area/_Nadezhda_areas.dm
@@ -126,9 +126,17 @@
 	name = "Underground Floor 2 South Maintenance"
 	icon_state = "erisgreen"
 
-/area/nadezhda/maintenance/surface_maints_1
+/area/nadezhda/maintenance/surfacenorth
 	name = "Surface North Maintenance"
 	icon_state = "erisyellow"
+
+/area/nadezhda/maintenance/surfaceeast
+	name = "Surface East Maintenance"
+	icon_state = "erisgreen"
+
+/area/nadezhda/maintenance/surfacesec
+	name = "Surface Security Maintenance"
+	icon_state = "erisblue"
 
 /area/nadezhda/maintenance/cavehideout
 	name = "Abandoned Cave Shed"

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -46,15 +46,10 @@
 /obj/item/device/lighting/toggleable/lamp,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aaB" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/mineral,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "aaH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -121,7 +116,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "abn" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -473,7 +468,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "agd" = (
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
@@ -508,6 +503,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
+"agq" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "agu" = (
 /obj/machinery/light{
 	dir = 8
@@ -777,14 +778,14 @@
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "aiZ" = (
 /obj/structure/multiz/stairs/active{
 	dir = 8
 	},
 /obj/structure/railing,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ajg" = (
 /obj/structure/bed/chair/sofa/black/corner{
 	dir = 8;
@@ -969,7 +970,7 @@
 /obj/random/ammo_lowcost,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "alm" = (
 /obj/random/lowkeyrandom,
 /turf/simulated/floor/plating/under,
@@ -1214,7 +1215,7 @@
 /obj/structure/table/glass,
 /obj/item/oddity/common/redbrick,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/hallway/surface/section1)
+/area/nadezhda/maintenance/surfacenorth)
 "anK" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -1236,7 +1237,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/moderate_weighted/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "aoh" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
@@ -1270,13 +1271,13 @@
 	},
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "aoQ" = (
 /obj/structure/table/standard,
 /obj/random/medical,
 /obj/random/medical,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "aoT" = (
 /obj/machinery/camera/network/engineering{
 	dir = 8
@@ -1289,7 +1290,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "apk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1395,7 +1396,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "aqu" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -1411,6 +1412,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"aqF" = (
+/obj/machinery/door/airlock/maintenance_common,
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aqM" = (
 /obj/machinery/conveyor/east{
 	dir = 1;
@@ -1418,7 +1426,7 @@
 	},
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "aqN" = (
 /obj/machinery/optable,
 /obj/machinery/alarm{
@@ -1881,7 +1889,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "avD" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "0,5"
@@ -1924,7 +1932,7 @@
 /obj/random/rations/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "avU" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -2075,7 +2083,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "axF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2255,7 +2263,7 @@
 	req_access = list(50)
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "azp" = (
 /obj/structure/sign/warning/nosmoking/small{
 	pixel_x = -32;
@@ -2287,7 +2295,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "azO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/structure/table/reinforced,
@@ -2342,7 +2350,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "aAv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2388,7 +2396,7 @@
 /obj/random/powercell/low_chance,
 /obj/random/tool/advanced/low_chance,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aAS" = (
 /obj/random/structures,
 /obj/effect/decal/cleanable/rubble,
@@ -2675,7 +2683,7 @@
 /obj/random/medical_lowcost,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aDp" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -2719,6 +2727,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"aDK" = (
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "aDP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -2831,7 +2842,7 @@
 /obj/structure/table/steel,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aEJ" = (
 /obj/machinery/camera/network/security{
 	dir = 4
@@ -2936,7 +2947,7 @@
 /obj/machinery/computer/arcade,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aGu" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Engine - Main - 1";
@@ -3120,7 +3131,12 @@
 /obj/structure/barricade,
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
+"aIA" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aIE" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -3136,6 +3152,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"aIL" = (
+/turf/simulated/open,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aIM" = (
 /obj/item/stool/padded,
 /obj/landmark/join/start/foreigner,
@@ -3303,7 +3322,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "aLr" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3513,7 +3532,7 @@
 /obj/random/powercell/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aNa" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/light{
@@ -3606,7 +3625,7 @@
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aOH" = (
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/rock,
@@ -3646,7 +3665,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aPf" = (
 /obj/structure/sign/security/showers,
 /turf/simulated/wall,
@@ -3933,7 +3952,7 @@
 "aTu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aTw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -4008,7 +4027,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aUO" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -4052,7 +4071,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "aVs" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/random/furniture/pottedplant,
@@ -4143,7 +4162,7 @@
 /obj/item/pen/multi,
 /obj/item/device/lighting/toggleable/lamp/green,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "aWu" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -4157,7 +4176,7 @@
 /obj/random/contraband,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "aWG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4375,7 +4394,7 @@
 /obj/random/material_resources/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "aYT" = (
 /obj/structure/table/reinforced,
 /obj/random/powercell,
@@ -4570,7 +4589,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "baX" = (
 /obj/effect/floor_decal/border/carpet/lightblue,
 /obj/effect/decal/cleanable/dirt,
@@ -4635,7 +4654,7 @@
 /obj/random/material_rare,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bbJ" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light{
@@ -4709,7 +4728,7 @@
 "bcp" = (
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bct" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/random/traps/low_chance{
@@ -4858,7 +4877,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bdL" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/pointybush,
@@ -4871,7 +4890,7 @@
 /obj/random/lowkeyrandom/low_chance,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "bdS" = (
 /obj/machinery/atmospherics/valve/digital{
 	dir = 4;
@@ -4900,7 +4919,7 @@
 /obj/random/cloth/under/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bed" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -5204,7 +5223,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bhp" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 9
@@ -5287,7 +5306,7 @@
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bih" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -5381,7 +5400,7 @@
 /obj/item/book/manual/nonfiction/manthereformer,
 /obj/item/book/manual/nonfiction/metaphysics,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bja" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "7,19";
@@ -5459,7 +5478,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bjx" = (
 /obj/effect/floor_decal/industrial/road{
 	dir = 1;
@@ -5601,7 +5620,7 @@
 "bli" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bls" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -5727,7 +5746,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bnh" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -5791,7 +5810,7 @@
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bok" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5877,7 +5896,7 @@
 	},
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/reinforced,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "boW" = (
 /obj/structure/flora/small/bushc1,
 /turf/simulated/floor/beach/water/shallow,
@@ -5929,7 +5948,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bpe" = (
 /obj/structure/boulder,
 /obj/structure/boulder,
@@ -5984,7 +6003,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bpF" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/workshop)
@@ -6057,7 +6076,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "bqU" = (
 /obj/structure/flora/small/grassb4,
 /obj/effect/decal/cleanable/dirt,
@@ -6200,7 +6219,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "bsl" = (
 /turf/simulated/wall,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
@@ -6484,6 +6503,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/smc/quarters)
+"bvb" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfaceeast)
 "bve" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/pouch/engineering_tools,
@@ -6580,6 +6604,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"bvT" = (
+/obj/random/mob/roaches,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bvW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -6752,7 +6781,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bxU" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/structure/cable/cyan{
@@ -6818,7 +6847,7 @@
 "byD" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "byG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -6870,7 +6899,7 @@
 	id = "QMLoad"
 	},
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "bzo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
@@ -6914,7 +6943,7 @@
 /obj/item/device/lighting/toggleable/lamp/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bzQ" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -6997,7 +7026,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bBf" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -7069,7 +7098,7 @@
 /obj/effect/spider/stickyweb,
 /obj/structure/grille/broken,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bBZ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -7114,7 +7143,7 @@
 	dir = 1
 	},
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bCy" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -7361,7 +7390,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "bFt" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8;
@@ -7413,7 +7442,7 @@
 /obj/random/pack/rare,
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bFU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -7471,7 +7500,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/wall,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bGq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -7570,7 +7599,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/closet/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bHQ" = (
 /obj/machinery/door/unpowered/simple/wood/saloon{
 	name = "Church Foyer"
@@ -7601,7 +7630,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bIc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/damagedfloor/fire,
@@ -7615,7 +7644,7 @@
 "bIg" = (
 /obj/machinery/vending/dinnerware/cost,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bIh" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -7792,6 +7821,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
+"bJv" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bJF" = (
 /obj/random/mob/spiders,
 /turf/simulated/floor/plating/under,
@@ -7823,7 +7867,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "bJY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -7955,7 +7999,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/random/junk,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bLh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -7985,7 +8029,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
+"bLs" = (
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/surfacesec)
 "bLD" = (
 /obj/machinery/camera/network/medbay{
 	dir = 1
@@ -8094,6 +8141,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/medical/morgue)
+"bMF" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfaceeast)
 "bMM" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
@@ -8201,7 +8251,7 @@
 /obj/random/medical_lowcost/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bOp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -8216,7 +8266,7 @@
 /obj/random/rations,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bOr" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/machinery/meter,
@@ -8361,21 +8411,13 @@
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/bridge)
 "bRx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/simulated/floor/beach/water/jungledeep{
+	desc = "Filthy, stinking bilge water.";
+	name = "murky water"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bRC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
@@ -8387,7 +8429,7 @@
 /obj/structure/barricade,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "bRH" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -8512,7 +8554,7 @@
 /obj/item/book/manual/nonfiction/politics,
 /obj/item/book/manual/nonfiction/suntzu,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bTj" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -8537,7 +8579,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bTE" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -8602,7 +8644,7 @@
 "bUu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/mineral,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "bUx" = (
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
@@ -8616,7 +8658,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "bUI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -8739,7 +8781,7 @@
 /obj/machinery/washing_machine,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "bVu" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -8827,7 +8869,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "bVV" = (
 /obj/structure/bed/chair/sofa/black/corner{
 	dir = 8;
@@ -9023,7 +9065,7 @@
 /obj/random/medical_lowcost/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "bXS" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
@@ -9087,7 +9129,7 @@
 "bZg" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bZi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
@@ -9390,7 +9432,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "cce" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -9482,7 +9524,7 @@
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cdL" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -9570,7 +9612,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ceW" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -9587,7 +9629,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "cfc" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -9678,7 +9720,7 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cgf" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -9689,7 +9731,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cgj" = (
 /obj/structure/bed/chair/wood{
 	dir = 4;
@@ -9703,7 +9745,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cgl" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -9711,7 +9753,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cgp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -9806,7 +9848,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/roach/roachling,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "chI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9828,7 +9870,7 @@
 /obj/random/ammo_lowcost/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "chQ" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -9862,7 +9904,7 @@
 "cig" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cih" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
@@ -10188,7 +10230,7 @@
 /obj/machinery/door/airlock/maintenance_common,
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "clM" = (
 /obj/machinery/light_switch{
 	pixel_y = 32
@@ -10211,7 +10253,7 @@
 "clU" = (
 /obj/effect/window_lwall_spawn,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "clW" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable/cyan{
@@ -10341,7 +10383,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "cno" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -10369,7 +10411,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/cloth,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "cnB" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1
@@ -10433,7 +10475,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "coz" = (
 /obj/structure/toilet{
 	dir = 8
@@ -10496,6 +10538,15 @@
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/command/captain/quarters)
+"cpj" = (
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cpl" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -10506,7 +10557,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cpp" = (
 /obj/structure/flora/small/rock5,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -10585,7 +10636,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "cqn" = (
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance{
@@ -10646,7 +10697,7 @@
 /obj/structure/table/rack/shelf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cri" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/grass,
@@ -10665,7 +10716,7 @@
 	},
 /obj/structure/multiz/stairs/active/bottom,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "crq" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -10877,7 +10928,7 @@
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cuv" = (
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -10979,7 +11030,7 @@
 /obj/structure/scrap_cube,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "cvi" = (
 /obj/random/mecha/damaged/low_chance,
 /turf/simulated/floor/rock,
@@ -11006,7 +11057,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cvx" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/decal/cleanable/dirt,
@@ -11097,7 +11148,7 @@
 /obj/structure/scrap/food,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cwC" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/outside/inside_colony)
@@ -11163,7 +11214,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cxs" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -11247,7 +11298,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cyw" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "4,9"
@@ -11382,7 +11433,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cAa" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -11390,7 +11441,7 @@
 "cAb" = (
 /obj/random/junk/nondense,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cAq" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -11439,7 +11490,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cAQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11517,14 +11568,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "cBF" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/random/traps/low_chance{
 	spawn_nothing_percentage = 90
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cBL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -11552,7 +11603,7 @@
 /obj/structure/table/reinforced,
 /obj/random/circuitboard/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "cCc" = (
 /obj/machinery/genetics/cloner,
 /obj/structure/disposalpipe/trunk{
@@ -11688,7 +11739,7 @@
 "cDg" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cDh" = (
 /obj/structure/railing{
 	dir = 8
@@ -11965,7 +12016,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cGc" = (
 /obj/structure/low_wall,
 /turf/simulated/floor/plating,
@@ -11995,7 +12046,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cGq" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -12161,7 +12212,7 @@
 /obj/item/stack/material/wood/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cId" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -12176,7 +12227,7 @@
 /obj/random/ammo,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cIo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12359,7 +12410,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cKK" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/structure/sign/warning/nosmoking/small{
@@ -12720,7 +12771,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "cOx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12781,7 +12832,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cOM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12847,7 +12898,7 @@
 /obj/random/closet_tech/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cPm" = (
 /obj/machinery/door/airlock/maintenance_engineering{
 	name = "Engineering Maintenance";
@@ -12886,7 +12937,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cPz" = (
 /obj/random/furniture/painting,
 /turf/simulated/wall,
@@ -12966,7 +13017,7 @@
 /obj/structure/reagent_dispensers/watertank/huge/derelict,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cQm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13000,7 +13051,7 @@
 /obj/item/stool/padded,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cQJ" = (
 /obj/structure/cyberplant,
 /obj/effect/spider/stickyweb,
@@ -13012,7 +13063,7 @@
 	desc = "Filthy, stinking bilge water.";
 	name = "murky water"
 	},
-/area/asteroid/cave)
+/area/nadezhda/maintenance/surfaceeast)
 "cQT" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 1;
@@ -13192,7 +13243,7 @@
 /obj/random/spider_trap/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "cSM" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/structure/closet/wall_mounted/emcloset{
@@ -13276,7 +13327,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cTJ" = (
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/dark,
@@ -13336,7 +13387,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "cUt" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -13403,6 +13454,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/medical/morgue)
+"cVs" = (
+/obj/structure/boulder,
+/turf/simulated/floor/rock,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cVy" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -13546,7 +13601,7 @@
 /obj/random/cloth/helmet/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cWm" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -13589,7 +13644,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "cWS" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/structure/disposalpipe/segment,
@@ -13854,7 +13909,7 @@
 	},
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "cZo" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 4
@@ -13932,6 +13987,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/docking)
+"dac" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	operating = 0
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfaceeast)
 "dak" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/light/small{
@@ -13962,7 +14031,11 @@
 /obj/random/closet_maintloot/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
+"daV" = (
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/surfacesec)
 "dba" = (
 /obj/effect/floor_decal/industrial/box/white/corners{
 	dir = 1
@@ -14072,7 +14145,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dcY" = (
 /obj/structure/sign/directions/room3,
 /turf/simulated/wall,
@@ -14372,7 +14445,7 @@
 	},
 /obj/structure/railing,
 /turf/simulated/floor/reinforced,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dfF" = (
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -14491,7 +14564,7 @@
 /obj/item/reagent_containers/food/snacks/cube/roach,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dhs" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/table/standard,
@@ -14564,7 +14637,7 @@
 /obj/item/cell/small,
 /obj/item/cell/small,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dib" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -14604,7 +14677,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "dio" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/quartermaster/miningdock)
@@ -14800,7 +14873,7 @@
 	name = "AI core maintenance hatch"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dkQ" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/simulated/floor/bluegrid{
@@ -14823,7 +14896,7 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dll" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -14915,12 +14988,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dmw" = (
 /obj/structure/salvageable/machine,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dmy" = (
 /obj/machinery/light{
 	dir = 4
@@ -14944,7 +15017,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/roach/roachling,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dmC" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
@@ -14990,7 +15063,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dmM" = (
 /obj/structure/table/woodentable,
 /obj/item/folder/blue,
@@ -15005,7 +15078,7 @@
 /obj/structure/railing/grey,
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dmT" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -15109,7 +15182,7 @@
 	id = "QMLoad2"
 	},
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "doj" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/structure/disposalpipe/broken,
@@ -15126,7 +15199,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "doA" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/random/flora/jungle_tree,
@@ -15199,7 +15272,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dpc" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -15373,7 +15446,7 @@
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "drw" = (
 /obj/effect/meteor/dust,
 /turf/simulated/floor/holofloor/space{
@@ -15523,7 +15596,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dtp" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -15550,7 +15623,7 @@
 /obj/structure/boulder,
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dtu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15601,11 +15674,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "duc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "due" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15791,7 +15864,7 @@
 "dvZ" = (
 /obj/random/contraband/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dwc" = (
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/farm)
@@ -16259,7 +16332,7 @@
 "dAn" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dAu" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -16361,7 +16434,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/item/device/lighting/toggleable/lantern,
 /turf/simulated/floor/rock,
-/area/asteroid/cave)
+/area/nadezhda/maintenance/surfaceeast)
 "dBz" = (
 /obj/item/toy/desk/dippingbird,
 /obj/structure/table/woodentable,
@@ -16531,7 +16604,7 @@
 "dDr" = (
 /mob/living/carbon/superior_animal/roach,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dDt" = (
 /obj/structure/sign/plaque/goldplaque/grant{
 	pixel_x = -32
@@ -16575,7 +16648,7 @@
 	desc = "Filthy, stinking bilge water.";
 	name = "murky water"
 	},
-/area/asteroid/cave)
+/area/nadezhda/maintenance/surfaceeast)
 "dEn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -16615,6 +16688,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/tactical)
 "dEu" = (
@@ -16861,7 +16939,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dGC" = (
 /obj/machinery/computer/diseasesplicer,
 /turf/simulated/floor/tiled/white,
@@ -17051,7 +17129,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "dIO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17090,7 +17168,7 @@
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dJl" = (
 /obj/item/storage/box/lights/mixed,
 /obj/effect/spider/stickyweb,
@@ -17119,18 +17197,13 @@
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dJz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "dJF" = (
 /obj/structure/flora/small/grassb5,
 /obj/random/flora/jungle_tree,
@@ -17301,7 +17374,7 @@
 /obj/random/gun_parts/low,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "dLv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -17400,7 +17473,7 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dMv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -17457,7 +17530,7 @@
 "dMP" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dMR" = (
 /obj/structure/table/standard,
 /obj/random/lathe_disk/low_chance,
@@ -17705,7 +17778,7 @@
 "dPH" = (
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "dPI" = (
 /obj/item/device/radio/beacon,
 /obj/structure/disposalpipe/sortjunction/wildcard/flipped{
@@ -17804,7 +17877,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "dQI" = (
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -17873,7 +17946,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dRO" = (
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
@@ -18168,7 +18241,7 @@
 /obj/structure/table/steel,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dVz" = (
 /obj/structure/closet/radiation,
 /obj/effect/decal/cleanable/dirt,
@@ -18192,7 +18265,7 @@
 "dWa" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "dWb" = (
 /obj/random/cluster/spiders,
 /obj/effect/spider/stickyweb,
@@ -18308,6 +18381,11 @@
 "dWU" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/workshop)
+"dWW" = (
+/obj/structure/filingcabinet/filingcabinet,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/maintenance/surfaceeast)
 "dWZ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -18459,7 +18537,7 @@
 /obj/random/pack/cloth/low_chance,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dYo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -18482,7 +18560,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "dYs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/wall/r_wall,
@@ -18648,6 +18726,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"dZS" = (
+/obj/machinery/door/airlock/maintenance_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "dZX" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -18715,7 +18798,7 @@
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "eaU" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/small/bushb2,
@@ -18817,7 +18900,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ebQ" = (
 /obj/machinery/recharger,
 /obj/random/tool_upgrade/low_chance,
@@ -18990,6 +19073,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/crew_quarters/fitness)
+"edR" = (
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "edT" = (
 /obj/structure/flora/small/rock4,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -19041,7 +19128,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "eeG" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "1,0"
@@ -19125,7 +19212,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/loading,
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "efv" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -19327,12 +19414,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eha" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/spiders/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"ehj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ehp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/chapel,
@@ -19437,7 +19528,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/roach/roachling,
 /turf/simulated/floor/carpet/blucarpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eiN" = (
 /obj/structure/catwalk,
 /mob/living/carbon/superior_animal/giant_spider/nurse,
@@ -19565,7 +19656,7 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ekl" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -19578,7 +19669,7 @@
 /obj/random/tool_upgrade/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ekq" = (
 /obj/effect/floor_decal/industrial/box/red,
 /obj/machinery/disposal,
@@ -19599,7 +19690,7 @@
 "ekw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "ekH" = (
 /obj/machinery/light{
 	dir = 4
@@ -19650,7 +19741,7 @@
 /obj/random/tool/advanced/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "elN" = (
 /obj/structure/spider_nest,
 /turf/simulated/floor/plating/under,
@@ -19797,7 +19888,7 @@
 	},
 /obj/item/oddity/common/book_unholy/closed,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "emX" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/closet_tech/low_chance,
@@ -19964,6 +20055,10 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/foyer)
+"eon" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/surfacesec)
 "eoo" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -20066,7 +20161,7 @@
 /obj/random/lowkeyrandom,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "epa" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/rock,
@@ -20259,7 +20354,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "eqU" = (
 /obj/machinery/light{
 	dir = 1
@@ -20352,6 +20447,10 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"erK" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "erO" = (
 /obj/structure/bed/chair/office/light,
 /obj/structure/disposalpipe/segment{
@@ -20365,7 +20464,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "erT" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -20374,7 +20473,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "erX" = (
 /obj/machinery/holoposter{
 	pixel_x = 32
@@ -20506,7 +20605,7 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "esI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk/low_chance,
@@ -20914,7 +21013,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "exk" = (
 /obj/structure/noticeboard/medical,
 /turf/simulated/wall/r_wall,
@@ -20986,7 +21085,7 @@
 /obj/machinery/microwave,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "eyj" = (
 /obj/random/mob/nightmare/low_chance,
 /turf/simulated/floor/rock,
@@ -21195,7 +21294,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eAy" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -21208,7 +21307,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eAK" = (
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
@@ -21489,7 +21588,11 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
+"eEk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/maintenance/surfacesec)
 "eEm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21581,7 +21684,7 @@
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "eFz" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "15,6";
@@ -21622,7 +21725,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "eGt" = (
 /obj/machinery/light{
 	dir = 8
@@ -21738,7 +21841,7 @@
 "eHP" = (
 /mob/living/carbon/superior_animal/roach/elektromagnetisch,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eIb" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -21914,7 +22017,7 @@
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eJZ" = (
 /obj/effect/spider/stickyweb,
 /obj/random/pack/junk_machine,
@@ -22191,7 +22294,7 @@
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -22665,17 +22768,26 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
+"eQp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eQq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "eQt" = (
 /obj/random/closet_maintloot/low_chance,
 /obj/random/gun_parts/low,
 /obj/random/ammo,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eQu" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/small/busha2,
@@ -22741,7 +22853,7 @@
 "eRg" = (
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eRh" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -22807,7 +22919,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "eRP" = (
 /obj/structure/flora/small/grassa3,
 /turf/simulated/floor/asteroid/grass,
@@ -23028,6 +23140,15 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"eVo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "eVr" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -23122,7 +23243,7 @@
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eWh" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -23449,7 +23570,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eYS" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush2,
@@ -23488,6 +23609,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
+"eZh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfaceeast)
 "eZk" = (
 /obj/structure/railing{
 	dir = 8
@@ -23526,7 +23658,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/multiz/ladder,
 /turf/simulated/floor/tiled/dark/panels,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "eZv" = (
 /obj/effect/window_lwall_spawn/smartspawnplasma,
 /obj/machinery/door/firedoor,
@@ -23592,7 +23724,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "fam" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23745,7 +23877,7 @@
 /obj/item/book/manual/nonfiction/thescienceofright,
 /obj/item/book/manual/nonfiction/thetranscendentalist,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fdk" = (
 /turf/simulated/shuttle/floor/science{
 	icon_state = "11,4"
@@ -23867,7 +23999,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "feS" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -24127,7 +24259,7 @@
 /obj/machinery/vending/snack,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fhl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -24392,7 +24524,7 @@
 /obj/structure/scrap/food/large,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "fjC" = (
 /obj/structure/flora/small/busha3,
 /turf/simulated/mineral,
@@ -24690,7 +24822,7 @@
 /obj/structure/table/steel,
 /obj/item/oddity/common/old_id,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fmp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -24698,7 +24830,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fmz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24819,7 +24951,7 @@
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fnF" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall12";
@@ -24987,6 +25119,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/reception)
+"foB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "West APC";
+	pixel_x = -28;
+	operating = 0
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfacenorth)
 "foC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25153,7 +25299,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "fqs" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/structure/cable/yellow{
@@ -25221,7 +25367,7 @@
 "fre" = (
 /obj/structure/curtain/black,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "frn" = (
 /obj/structure/closet/random_milsupply,
 /obj/structure/catwalk,
@@ -25231,7 +25377,7 @@
 "frv" = (
 /obj/structure/sign/department/cargo_dock,
 /turf/simulated/wall,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "frw" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/scrap/dense_weighted,
@@ -25327,7 +25473,7 @@
 /obj/structure/catwalk,
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fsS" = (
 /obj/landmark/join/start/scientist,
 /obj/effect/decal/cleanable/dirt,
@@ -25340,7 +25486,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fte" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "15,5"
@@ -25411,7 +25557,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "ftS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -25490,7 +25636,7 @@
 /obj/structure/filingcabinet/medical,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fvd" = (
 /obj/structure/sink{
 	dir = 4;
@@ -25510,7 +25656,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "fvs" = (
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -25527,7 +25673,17 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
+"fvA" = (
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fvD" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "5,13"
@@ -25540,7 +25696,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fvG" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -25593,7 +25749,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "fwv" = (
 /obj/random/scrap/sparse_weighted/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -25808,7 +25964,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fyU" = (
 /obj/structure/curtain/medical,
 /obj/effect/window_lwall_spawn,
@@ -25898,7 +26054,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fzI" = (
 /turf/simulated/wall/church_reinforced,
 /area/nadezhda/absolutism/skyyard)
@@ -25936,7 +26092,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fAq" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/breath,
@@ -26137,7 +26293,7 @@
 "fCA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fCE" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -26242,7 +26398,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "fDM" = (
 /obj/landmark/machinery/output,
 /obj/machinery/conveyor/south{
@@ -26303,7 +26459,7 @@
 	},
 /obj/item/oddity/common/book_omega/closed,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fEt" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -26351,7 +26507,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fEV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26428,7 +26584,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "fFF" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
@@ -26472,11 +26628,11 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fGi" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "fGj" = (
 /obj/structure/ore_box,
 /obj/machinery/camera/network/cargo{
@@ -26584,7 +26740,7 @@
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fHD" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/medical,
@@ -26679,7 +26835,7 @@
 /obj/item/book/manual/fiction/rimeoftheancientmariner,
 /obj/item/book/manual/fiction/littlewomen,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fII" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,10"
@@ -26844,7 +27000,7 @@
 /obj/item/hand_labeler,
 /obj/random/powercell/low_chance,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "fKO" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Marshals Brig";
@@ -26881,6 +27037,10 @@
 /obj/item/folder/cyan,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
+"fLq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fLr" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/white/cyancorner,
@@ -26946,7 +27106,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "fMf" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/effect/decal/cleanable/rubble,
@@ -26999,7 +27159,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fMA" = (
 /obj/machinery/telecomms/server/presets/medical,
 /turf/simulated/floor/bluegrid{
@@ -27146,7 +27306,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fOr" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
@@ -27168,7 +27328,7 @@
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fOP" = (
 /obj/structure/closet/secure_closet/personal/prospector,
 /turf/simulated/floor/tiled/white/techfloor_grid,
@@ -27201,11 +27361,11 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fPf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fPm" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -27227,7 +27387,7 @@
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fPK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -27283,6 +27443,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"fQx" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fQD" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -27376,14 +27540,14 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fRx" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /obj/structure/scrap/medical/large,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fRy" = (
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -27456,7 +27620,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "fSA" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/console/preset/command{
@@ -27550,7 +27714,7 @@
 	pixel_x = -27
 	},
 /turf/simulated/floor/carpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fTK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -27575,6 +27739,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"fTV" = (
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "fTX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27613,13 +27780,13 @@
 /obj/structure/bed/padded,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fUO" = (
 /obj/machinery/door/airlock/maintenance_common{
 	req_access = list(12)
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fUP" = (
 /obj/machinery/door/blast/regular/open{
 	id = "xenobio8";
@@ -27638,7 +27805,7 @@
 "fUS" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "fUT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -28048,7 +28215,7 @@
 	},
 /obj/structure/multiz/stairs/enter,
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "fZC" = (
 /obj/machinery/camera/network/engineering{
 	dir = 1
@@ -28089,6 +28256,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
 "gag" = (
@@ -28124,7 +28296,7 @@
 /obj/random/closet_maintloot/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "gaG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -28139,7 +28311,7 @@
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "gaL" = (
 /obj/structure/catwalk,
 /obj/machinery/floodlight,
@@ -28286,7 +28458,7 @@
 /obj/landmark/storyevent/hidden_vent_antag,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gcw" = (
 /obj/machinery/computer/genetics/clone_console,
 /obj/structure/disposalpipe/segment{
@@ -28321,13 +28493,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"gcJ" = (
+/obj/random/junk/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gcP" = (
 /obj/random/scrap/sparse_even/low_chance,
 /obj/random/structures/low_chance,
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "gcQ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -28452,7 +28629,7 @@
 	req_access = list(1e+012)
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "gdM" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Breakroom";
@@ -28503,13 +28680,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"gef" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "geg" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gej" = (
 /obj/structure/low_wall,
 /obj/structure/railing{
@@ -28629,6 +28810,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/tcommsat/computer)
+"gfo" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gfw" = (
 /obj/structure/multiz/stairs/active/bottom,
 /obj/structure/railing{
@@ -28924,7 +29110,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ghD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -28943,7 +29129,7 @@
 /obj/random/melee/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ghM" = (
 /obj/structure/flora/small/trailrocka3,
 /turf/simulated/floor/rock,
@@ -29059,7 +29245,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gjE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -29169,7 +29355,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gkx" = (
 /obj/structure/railing{
 	dir = 4
@@ -29248,7 +29434,7 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "glF" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/knife,
@@ -29306,7 +29492,7 @@
 /obj/random/cluster/termite_no_despawn/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gmd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29370,7 +29556,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gmQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29417,7 +29603,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gnT" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
@@ -29474,7 +29660,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "goy" = (
 /obj/machinery/camera/network/cargo{
 	dir = 8
@@ -29509,7 +29695,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "goC" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -29526,7 +29712,7 @@
 /obj/structure/table/marble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "goI" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -29641,7 +29827,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "gpp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -29781,7 +29967,7 @@
 /obj/random/prothesis,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gqz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -30004,7 +30190,7 @@
 	req_access = list(50)
 	},
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "gsU" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint,
@@ -30013,7 +30199,7 @@
 	})
 "gsX" = (
 /turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "gsY" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section5";
@@ -30200,7 +30386,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "guQ" = (
 /obj/machinery/conveyor/north{
 	id = "disposals upper";
@@ -30415,6 +30601,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
 "gxm" = (
@@ -30491,7 +30682,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "gyC" = (
 /obj/random/scrap/sparse_weighted,
 /obj/effect/decal/cleanable/dirt,
@@ -30617,7 +30808,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "gzR" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/random/flora/small_jungle_tree,
@@ -30650,7 +30841,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "gAa" = (
 /obj/machinery/camera/network/gate{
 	dir = 10;
@@ -31096,7 +31287,7 @@
 "gGO" = (
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "gGT" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -31143,7 +31334,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "gHp" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -31229,7 +31420,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "gIx" = (
 /obj/machinery/light,
 /obj/machinery/recharge_station/upgraded_t_three,
@@ -31295,7 +31486,7 @@
 /obj/random/pouch/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gJz" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -31303,7 +31494,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "gJB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood,
@@ -31314,13 +31505,18 @@
 /obj/structure/closet/crate/secure,
 /obj/item/stack/os_cash/random,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "gJP" = (
 /obj/structure/table/bar_special,
 /obj/item/toy/plushie/spider,
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"gJS" = (
+/obj/random/mob/roaches/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gJU" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
@@ -31402,7 +31598,7 @@
 /obj/structure/table/rack/shelf,
 /obj/item/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "gKV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
@@ -31476,7 +31672,7 @@
 /obj/item/storage/deferred/crate/alcohol,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gMn" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -31550,7 +31746,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "gNp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -31666,7 +31862,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gOb" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -31769,7 +31965,7 @@
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gPn" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -31806,18 +32002,18 @@
 /obj/random/booze,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gPO" = (
 /obj/random/closet_maintloot/low_chance,
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gPP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gPQ" = (
 /obj/structure/noticeboard/blackshield{
 	pixel_y = 32
@@ -31835,7 +32031,7 @@
 	tag = "icon-cryopod_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "gQh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31863,7 +32059,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/rock,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gQk" = (
 /obj/structure/boulder,
 /turf/unsimulated/mineral,
@@ -31969,7 +32165,7 @@
 "gRx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gRC" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/prisoncells{
@@ -32222,7 +32418,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "gTH" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/grass/green,
@@ -32251,14 +32447,9 @@
 /area/shuttle/rocinante_shuttle_area)
 "gUb" = (
 /obj/structure/boulder,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "gUf" = (
 /obj/structure/flora/small/bushb2,
 /turf/simulated/floor/asteroid/grass,
@@ -32275,6 +32466,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/absolutism/skyyard)
+"gUk" = (
+/obj/random/junk/low_chance,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gUm" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -32358,7 +32553,7 @@
 /obj/item/caution/cone,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "gVf" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -32389,7 +32584,7 @@
 /obj/item/coin/silver,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gVA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -32403,7 +32598,7 @@
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gVG" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters/glass{
@@ -32442,7 +32637,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gWd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32606,7 +32801,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "gXu" = (
 /obj/structure/noticeboard/research{
 	pixel_x = 32
@@ -32883,7 +33078,7 @@
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hbs" = (
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/crew_quarters/hydroponics)
@@ -33337,7 +33532,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hgy" = (
 /obj/structure/flora/rock/variant2,
 /turf/simulated/floor/asteroid/grass,
@@ -33411,7 +33606,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "hgV" = (
 /obj/random/junkfood/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -33583,6 +33778,10 @@
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"hjD" = (
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hjL" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -33716,7 +33915,7 @@
 "hkL" = (
 /obj/structure/sign/directions/room4,
 /turf/simulated/wall,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hkT" = (
 /obj/structure/sign/faction/neotheology_cross/gold{
 	pixel_y = -32
@@ -33781,7 +33980,7 @@
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hli" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -33791,7 +33990,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "hlu" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -33914,7 +34113,7 @@
 /obj/random/junkfood/rotten/low_chance,
 /obj/random/junkfood/rotten/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hmA" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -34210,7 +34409,7 @@
 /obj/structure/railing,
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hpS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
@@ -34304,7 +34503,7 @@
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hru" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/manipulator,
@@ -34329,6 +34528,13 @@
 /obj/machinery/biomatter_solidifier,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
+"hrD" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hrL" = (
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
@@ -34381,7 +34587,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hso" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -34425,7 +34631,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hsW" = (
 /obj/structure/flora/small/rock3,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -34707,7 +34913,7 @@
 	},
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hvY" = (
 /obj/structure/bookcase/guncase,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -34804,11 +35010,11 @@
 /obj/item/ammo_kit,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hxi" = (
 /obj/random/cluster/termite_no_despawn/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "hxl" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -34965,7 +35171,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "hyA" = (
 /mob/living/simple_animal/hostile/nightmare/dream_daemon,
 /turf/simulated/floor/rock,
@@ -35131,7 +35337,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hAt" = (
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/soda,
@@ -35267,7 +35473,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "hBo" = (
 /obj/machinery/computer/telecomms/monitor{
 	dir = 4
@@ -35447,7 +35653,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hDn" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -35474,7 +35680,7 @@
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hDs" = (
 /obj/structure/bed/chair/sofa/black/right{
 	dir = 4
@@ -35525,7 +35731,7 @@
 /obj/structure/scrap/guns,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hDH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
@@ -35698,6 +35904,13 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"hFL" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hFN" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -35740,7 +35953,7 @@
 /obj/item/storage/deferred/crate,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hGB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -36011,7 +36224,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hIE" = (
 /obj/machinery/power/apc{
 	name = "South APC";
@@ -36070,7 +36283,7 @@
 /obj/item/device/lighting/toggleable/lamp/green,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hIW" = (
 /obj/structure/curtain/black,
 /obj/effect/decal/cleanable/dirt,
@@ -36078,7 +36291,7 @@
 	spawn_nothing_percentage = 90
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hJc" = (
 /obj/structure/flora/small/trailrockb4,
 /obj/structure/boulder,
@@ -36355,6 +36568,11 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
+"hLg" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hLj" = (
 /obj/structure/closet/secure_closet/freezer,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
@@ -36396,6 +36614,16 @@
 /obj/structure/boulder,
 /turf/simulated/mineral,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"hLD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hLE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36531,7 +36759,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hMF" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -36580,7 +36808,17 @@
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
+"hNs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hNv" = (
 /obj/machinery/light{
 	dir = 4
@@ -36707,6 +36945,9 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
+"hPE" = (
+/turf/simulated/wall/r_wall,
+/area/nadezhda/maintenance/surfacesec)
 "hPL" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 4
@@ -36754,7 +36995,7 @@
 /obj/random/ammo/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hRg" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -36809,7 +37050,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/food/large,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "hRX" = (
 /obj/machinery/door/airlock/maintenance_interior,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -36855,7 +37096,7 @@
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "hTh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -36888,7 +37129,7 @@
 /obj/random/material_resources,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "hTt" = (
 /obj/machinery/camera/network/church{
 	dir = 1
@@ -37123,7 +37364,7 @@
 "hVm" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hVt" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -37175,7 +37416,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hVH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/bush,
@@ -37262,7 +37503,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hWx" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/power/shield_generator,
@@ -37273,7 +37514,7 @@
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "hWN" = (
 /obj/structure/table/woodentable,
 /obj/structure/sign/faction/neotheology_cross/gold{
@@ -37479,6 +37720,11 @@
 "hYi" = (
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/command/cro)
+"hYl" = (
+/obj/random/scrap/sparse_even/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "hYm" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Lobby Access";
@@ -37783,7 +38029,7 @@
 /obj/structure/barricade,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "iaH" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
@@ -37884,7 +38130,7 @@
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ibw" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -37923,7 +38169,7 @@
 "ibP" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "icd" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -37936,7 +38182,7 @@
 /obj/structure/flora/pottedplant/dead,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "icr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -37999,7 +38245,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "icQ" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/industrial/warningwhite{
@@ -38064,7 +38310,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/mineral,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "idi" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -38154,7 +38400,7 @@
 /obj/random/material_resources/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "iey" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -38251,7 +38497,7 @@
 /obj/random/powercell/large_safe,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ifl" = (
 /obj/machinery/button/remote/blast_door{
 	id = "AI_maint_hatch";
@@ -38271,7 +38517,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ifw" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -38287,13 +38533,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "ifA" = (
 /obj/item/storage/deferred/crate/uniform_brown,
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ifN" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -38337,7 +38583,7 @@
 /obj/structure/closet/cabinet,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "igp" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/asteroid/dirt,
@@ -38348,7 +38594,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "igv" = (
 /obj/structure/flora/small/trailrocka4,
 /obj/structure/flora/small/trailrocka3,
@@ -38499,7 +38745,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ihV" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -38542,7 +38788,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iiN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -38852,6 +39098,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
+"ilZ" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ima" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -38882,7 +39135,7 @@
 /obj/item/oddity/common/book_bible,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "imk" = (
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
@@ -38973,7 +39226,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "imX" = (
 /obj/structure/table/bench/steel,
 /obj/random/mob/spiders,
@@ -39021,7 +39274,7 @@
 /obj/structure/catwalk,
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/hallway/surface/section1)
+/area/nadezhda/maintenance/surfacenorth)
 "inm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -39079,6 +39332,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/maingate)
+"inL" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "inU" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -39099,7 +39357,7 @@
 /obj/random/closet_tech,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ioj" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
@@ -39195,7 +39453,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ipm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -39243,7 +39501,7 @@
 /obj/random/lowkeyrandom/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ipN" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/railing{
@@ -39327,7 +39585,7 @@
 /obj/item/stack/rods/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "irj" = (
 /obj/structure/reagent_dispensers/fueltank/huge,
 /turf/simulated/shuttle/floor/mining{
@@ -39363,7 +39621,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "irO" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -39406,6 +39664,10 @@
 "ise" = (
 /turf/simulated/floor/carpet/turcarpet,
 /area/nadezhda/command/captain)
+"iss" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "isw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -39536,7 +39798,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ito" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -39565,7 +39827,7 @@
 	},
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "itD" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/camera/network/gate{
@@ -39713,7 +39975,7 @@
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iuW" = (
 /obj/structure/table/woodentable,
 /obj/item/stamp/fr,
@@ -39791,7 +40053,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ivI" = (
 /obj/structure/flora/small/trailrockb1,
 /obj/machinery/light/small{
@@ -39905,7 +40167,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ixL" = (
 /obj/machinery/portable_atmospherics/hydroponics{
 	pixel_y = 4
@@ -39925,7 +40187,7 @@
 /obj/random/closet_maintloot/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ixT" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
@@ -40013,6 +40275,10 @@
 	icon_state = "7,8"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"iyx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/nadezhda/maintenance/surfaceeast)
 "iyz" = (
 /mob/living/simple_animal/penguin{
 	desc = "The Blackshield's finest corporal, the only Blackshield personnel to not have a friendly fired incident.";
@@ -40063,13 +40329,13 @@
 "iyV" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ize" = (
 /obj/structure/table/bench/steel,
 /obj/item/clothing/head/ushanka,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "izj" = (
 /obj/structure/bed{
 	dir = 4
@@ -40147,7 +40413,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "iAp" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "5,1"
@@ -40429,7 +40695,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iDm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40507,19 +40773,19 @@
 /obj/structure/closet/secure_closet/personal/cargotech,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "iEz" = (
 /obj/structure/barricade,
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "iEB" = (
 /obj/machinery/conveyor_switch{
 	id = "QMLoad2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "iEI" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -40654,7 +40920,7 @@
 /obj/machinery/door/airlock/glass,
 /obj/random/traps/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iGH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -40676,7 +40942,7 @@
 /obj/random/junkfood/low_chance,
 /obj/random/junkfood/rotten/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iHh" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -40748,7 +41014,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iHD" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/nuke_storage)
@@ -40818,7 +41084,7 @@
 "iHZ" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iIb" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -40839,6 +41105,17 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
+"iIh" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock,
+/area/nadezhda/maintenance/surfaceeast)
+"iIm" = (
+/obj/machinery/door/unpowered/simple/wood,
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "iIp" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
@@ -40954,7 +41231,7 @@
 /obj/structure/table/bench/steel,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iJk" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/multiz/ladder,
@@ -41007,7 +41284,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iKq" = (
 /obj/structure/sign/department/atmos,
 /turf/simulated/wall/r_wall,
@@ -41027,7 +41304,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iKK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -41284,7 +41561,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "iNS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/colony_underground{
@@ -41472,7 +41749,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iPx" = (
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
@@ -41565,7 +41842,7 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/barricade,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iQv" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -41598,7 +41875,7 @@
 /obj/random/cloth/under/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "iQS" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/effect/decal/cleanable/dirt,
@@ -41628,7 +41905,7 @@
 /obj/machinery/vending/snack,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "iRu" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/random/flora/small_jungle_tree,
@@ -41643,7 +41920,7 @@
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iRA" = (
 /obj/structure/cyberplant{
 	emagged = 1;
@@ -41651,7 +41928,7 @@
 	pixel_y = 12
 	},
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "iRC" = (
 /obj/structure/table/woodentable,
 /obj/item/gavelblock,
@@ -41924,7 +42201,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iVo" = (
 /obj/structure/multiz/stairs/enter,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -41937,7 +42214,7 @@
 /obj/structure/reagent_dispensers/fueltank/derelict,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "iVu" = (
 /obj/structure/closet/secure_closet/personal/doctor,
 /obj/machinery/light{
@@ -41962,7 +42239,7 @@
 "iVA" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "iVD" = (
 /obj/landmark/join/start/hydro,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -42039,7 +42316,7 @@
 /obj/random/scrap/dense_even,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iWF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -42064,12 +42341,12 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "iWX" = (
 /obj/structure/salvageable/computer,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iXd" = (
 /mob/living/simple_animal/yithian,
 /turf/simulated/floor/wood/wild4,
@@ -42087,7 +42364,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iXl" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/big/bush2,
@@ -42126,7 +42403,7 @@
 /obj/machinery/papershredder,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "iXO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard,
@@ -42308,6 +42585,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"jae" = (
+/obj/structure/scrap/medical/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jah" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -42573,7 +42855,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jcy" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -42610,7 +42892,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "jde" = (
 /obj/machinery/light{
 	dir = 4
@@ -42667,6 +42949,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical_blackshield)
+"jdE" = (
+/turf/simulated/wall,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jdF" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Robotics Lab";
@@ -42734,7 +43019,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint_panels,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "jev" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/tool/shovel/spade,
@@ -42922,7 +43207,7 @@
 /obj/random/mob/roaches,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jgG" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/reedbush,
@@ -42949,7 +43234,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "jgP" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -43082,7 +43367,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "jie" = (
 /obj/structure/multiz/stairs/enter{
 	dir = 4
@@ -43165,7 +43450,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jiR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43225,7 +43510,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jjy" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -43236,7 +43521,7 @@
 	req_access = list(12)
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jjU" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "3,23"
@@ -43339,13 +43624,13 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jkO" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/roach/roachling,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jkS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -43400,11 +43685,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jlG" = (
 /obj/machinery/cryopod,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jlL" = (
 /obj/machinery/porta_turret{
 	dir = 1
@@ -43684,7 +43969,7 @@
 /obj/item/book/manual/fiction/robinsoncrusoe,
 /obj/item/book/manual/fiction/littlewomen,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jof" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/yellowdouble,
@@ -44076,7 +44361,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap_cube,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jrW" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white/monofloor,
@@ -44094,7 +44379,7 @@
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jsj" = (
 /obj/structure/closet/secure_closet/reinforced/engineering_chief,
 /obj/machinery/button/windowtint{
@@ -44165,7 +44450,7 @@
 /obj/random/pouch/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jti" = (
 /obj/structure/cryofeed{
 	dir = 4;
@@ -44217,7 +44502,7 @@
 /obj/random/tool_upgrade,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jtP" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/cobweb2{
@@ -44265,7 +44550,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "juj" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -44338,7 +44623,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "juA" = (
 /obj/structure/table/reinforced,
 /obj/random/material/low_chance,
@@ -44346,7 +44631,7 @@
 /obj/random/ammo,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "juC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -44434,7 +44719,7 @@
 "jvp" = (
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jvw" = (
 /obj/machinery/light{
 	dir = 1
@@ -44495,7 +44780,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jwp" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -44619,7 +44904,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jxh" = (
 /obj/random/structures,
 /obj/effect/decal/cleanable/dirt,
@@ -44701,7 +44986,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jyH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -44713,7 +44998,7 @@
 /obj/random/cluster/spiders/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "jzs" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -44923,7 +45208,7 @@
 /obj/item/stack/material/wood/random,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jBQ" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -45104,7 +45389,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jEf" = (
 /obj/machinery/door/blast/shutters/glass{
 	id = "AISHIELD";
@@ -45232,7 +45517,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jFs" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -45552,7 +45837,7 @@
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "jIj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -45690,7 +45975,7 @@
 /obj/random/scrap/dense_even,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jKi" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/bushc1,
@@ -45884,7 +46169,7 @@
 /obj/structure/table/woodentable,
 /obj/item/hand_labeler,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jMC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -45976,7 +46261,7 @@
 "jNp" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "jNq" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -46019,7 +46304,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "jNH" = (
 /obj/structure/curtain/open,
 /obj/machinery/shower{
@@ -46154,7 +46439,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "jPj" = (
 /obj/structure/table/bench/steel,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -46242,6 +46527,11 @@
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
+"jQe" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/surfaceeast)
 "jQk" = (
 /obj/structure/table/steel,
 /obj/random/lowkeyrandom/low_chance,
@@ -46481,7 +46771,7 @@
 /obj/random/lathe_disk/advanced,
 /obj/random/lathe_disk/advanced,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jSJ" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light{
@@ -46814,7 +47104,7 @@
 "jWx" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "jWy" = (
 /obj/structure/multiz/stairs/enter,
 /turf/simulated/floor/tiled/steel/danger,
@@ -46830,7 +47120,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jWK" = (
 /turf/simulated/floor/rock/alt{
 	dir = 4
@@ -46839,13 +47129,13 @@
 "jWM" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/wall,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "jXq" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jXt" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall2";
@@ -46885,7 +47175,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jXP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -46946,7 +47236,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "jYE" = (
 /obj/effect/floor_decal/industrial/box/red,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -47023,7 +47313,7 @@
 /obj/random/mob/roaches,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "jZt" = (
 /obj/structure/sink/kitchen{
 	name = "utility sink";
@@ -47169,7 +47459,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "kaL" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -47187,7 +47477,7 @@
 /obj/structure/closet/crate/internals,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kaY" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/decal/cleanable/dirt,
@@ -47306,7 +47596,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "kcB" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -47525,7 +47815,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "keJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/meter,
@@ -47573,7 +47863,7 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "kfg" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/port_gen/pacman/mrs/anchored,
@@ -47715,7 +48005,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kgB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -47916,6 +48206,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"kid" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kii" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -47942,6 +48241,15 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
+"kiU" = (
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kiX" = (
 /obj/machinery/door/blast/regular/open{
 	id = "xenobio7";
@@ -47956,7 +48264,7 @@
 /obj/random/lowkeyrandom/low_chance,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kjf" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -48056,7 +48364,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "kke" = (
 /obj/structure/table/rack,
 /obj/item/rcd/industrial,
@@ -48103,7 +48411,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kkw" = (
 /obj/machinery/light_switch{
 	pixel_y = 30
@@ -48136,11 +48444,14 @@
 /obj/random/flora/small_jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"kkH" = (
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/surfaceeast)
 "kkU" = (
 /obj/structure/table/bench/standard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kla" = (
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
@@ -48158,7 +48469,7 @@
 /obj/structure/catwalk,
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "klq" = (
 /obj/machinery/vending/dinnerware/cost,
 /turf/simulated/floor/tiled/steel/cyancorner,
@@ -48218,6 +48529,11 @@
 	},
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"klR" = (
+/obj/random/structures/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "klT" = (
 /obj/machinery/conveyor/east{
 	dir = 2;
@@ -48225,7 +48541,7 @@
 	},
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "kme" = (
 /obj/machinery/light{
 	dir = 4
@@ -48255,6 +48571,11 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
+"kmq" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/surfacesec)
 "kmr" = (
 /obj/structure/table/steel,
 /obj/random/boxes,
@@ -48581,7 +48902,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kpN" = (
 /obj/structure/table/woodentable,
 /obj/machinery/chemical_dispenser/soda,
@@ -48813,7 +49134,7 @@
 "ksk" = (
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ksF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -48852,7 +49173,7 @@
 /obj/structure/closet/crate/medical,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ksX" = (
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/outside/inside_colony)
@@ -48904,7 +49225,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ktF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -48958,7 +49279,7 @@
 	})
 "kuc" = (
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kuj" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -49102,7 +49423,7 @@
 /obj/machinery/light/small,
 /obj/random/scrap/sparse_even/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kvv" = (
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/fnest)
@@ -49135,7 +49456,7 @@
 /obj/random/tool/advanced,
 /obj/random/tool/advanced,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kwc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -49292,7 +49613,7 @@
 /area/nadezhda/crew_quarters/toilet/public)
 "kxs" = (
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kxt" = (
 /obj/landmark/corpse/excelsior,
 /obj/effect/decal/cleanable/rubble,
@@ -49358,7 +49679,7 @@
 /obj/random/lowkeyrandom/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kxW" = (
 /obj/structure/table/marble,
 /obj/structure/barricade,
@@ -49381,7 +49702,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "kyi" = (
 /obj/structure/closet/cabinet,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
@@ -49414,7 +49735,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kyK" = (
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -49482,6 +49803,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/tactical)
 "kzj" = (
@@ -49542,7 +49868,7 @@
 /obj/structure/table/bench/steel,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "kzQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -49617,6 +49943,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/armory)
+"kAk" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfacesec)
 "kAl" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -49671,7 +50001,7 @@
 /obj/structure/table/rack/shelf,
 /obj/random/scrap/beacon,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "kBm" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lamp/green,
@@ -49706,15 +50036,20 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"kBB" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kBO" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kBP" = (
 /obj/structure/scrap/cloth,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kBV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
@@ -49730,7 +50065,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "kCo" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/asteroid/grass,
@@ -49854,7 +50189,7 @@
 /obj/random/rations,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kDO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49975,7 +50310,7 @@
 /obj/random/material_rare,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kEL" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -50166,7 +50501,7 @@
 	},
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "kGO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -50235,7 +50570,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/roach/roachling,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kIN" = (
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
@@ -50278,7 +50613,7 @@
 /area/nadezhda/command/swo/quarters)
 "kJn" = (
 /turf/simulated/wall/r_wall,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "kJu" = (
 /obj/machinery/power/smes/buildable,
 /turf/simulated/shuttle/plating,
@@ -50440,7 +50775,7 @@
 "kLb" = (
 /obj/structure/railing,
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kLe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
@@ -50558,7 +50893,7 @@
 /obj/item/stamp,
 /obj/random/credits/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kMX" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -50693,7 +51028,10 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
+"kOR" = (
+/turf/simulated/wall,
+/area/nadezhda/maintenance/surfacesec)
 "kOY" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -50812,7 +51150,7 @@
 	},
 /mob/living/carbon/superior_animal/roach/golden,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kPx" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -50871,7 +51209,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kQh" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -50901,7 +51239,7 @@
 /obj/structure/table/steel,
 /obj/random/rig_module/rare/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kQv" = (
 /obj/structure/table/bench/steel,
 /obj/machinery/light,
@@ -50910,7 +51248,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kQE" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/techmaint,
@@ -50919,14 +51257,14 @@
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kQM" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kQN" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
@@ -50942,7 +51280,7 @@
 /obj/random/gun_energy_cheap/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kRc" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -50958,13 +51296,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "kRg" = (
 /obj/structure/multiz/stairs/enter{
 	dir = 1
 	},
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kRj" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/nitrogen/prechilled,
@@ -51022,6 +51360,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"kRY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfacesec)
 "kSd" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -51076,7 +51418,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kSC" = (
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
@@ -51099,7 +51441,7 @@
 /obj/item/caution/cone,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kTf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -51133,7 +51475,7 @@
 	name = "Toilet"
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "kTH" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -51324,7 +51666,7 @@
 "kVN" = (
 /obj/machinery/door/airlock/external,
 /turf/simulated/floor/reinforced,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "kVQ" = (
 /obj/random/furniture/pottedplant,
 /obj/structure/window/reinforced,
@@ -51469,7 +51811,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "kXG" = (
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
@@ -51497,7 +51839,7 @@
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/accessory/work_visa_sol,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "kXU" = (
 /obj/machinery/camera/network/church{
 	dir = 8
@@ -51678,7 +52020,7 @@
 	},
 /mob/living/carbon/superior_animal/roach/roachling_gold,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "laV" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4;
@@ -51925,7 +52267,7 @@
 	dir = 1
 	},
 /turf/simulated/wall,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "lea" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -52159,6 +52501,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"lga" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lgg" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -52249,6 +52595,9 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/crew_quarters/kitchen)
+"lhN" = (
+/turf/simulated/floor/rock,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lhU" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -52348,6 +52697,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/medical)
+"liT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfaceeast)
 "liU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/closet_maintloot,
@@ -52490,7 +52843,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "llh" = (
 /obj/structure/railing{
 	dir = 1;
@@ -52623,7 +52976,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "lno" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -52947,7 +53300,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lqM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -53013,7 +53366,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "lrA" = (
 /obj/structure/catwalk,
 /obj/random/scrap/sparse_weighted,
@@ -53027,7 +53380,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lrJ" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -53052,7 +53405,7 @@
 /obj/structure/salvageable/computer,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "lrX" = (
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/side/f2section1)
@@ -53164,7 +53517,7 @@
 /obj/random/scrap,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ltw" = (
 /obj/structure/flora/small/rock5,
 /obj/structure/flora/small/busha3,
@@ -53185,7 +53538,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "ltE" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -53239,7 +53592,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "luh" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/forest)
@@ -53251,12 +53604,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "lum" = (
 /obj/random/closet_tech/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "luq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -53272,7 +53625,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "luv" = (
 /obj/structure/bed/chair/wood{
 	dir = 4;
@@ -53449,7 +53802,7 @@
 	},
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "lwq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -53471,7 +53824,7 @@
 "lww" = (
 /obj/structure/closet,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "lwy" = (
 /obj/structure/table/bar_special,
 /obj/machinery/chemical_dispenser/soda,
@@ -53496,7 +53849,7 @@
 	icon_state = "32-2"
 	},
 /turf/simulated/open,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "lwP" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
@@ -53543,14 +53896,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lxC" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "lxE" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -53569,6 +53922,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"lxT" = (
+/obj/structure/bed/chair,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lyg" = (
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -53592,7 +53950,7 @@
 /obj/random/ammo_fancy/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lyx" = (
 /obj/random/spider_trap_burrowing/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -53903,7 +54261,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "lCp" = (
 /obj/machinery/vending/dinnerware,
 /obj/structure/sign/warning/smoking/small{
@@ -54040,7 +54398,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "lDw" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -54175,7 +54533,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "lFr" = (
 /obj/effect/floor_decal/industrial/stand_clear/red,
 /obj/machinery/door/window/brigdoor/southleft{
@@ -54205,7 +54563,7 @@
 "lFF" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "lFG" = (
 /obj/random/mob/hakhma/low_chance,
 /turf/simulated/floor/asteroid/dirt,
@@ -54628,7 +54986,7 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "lJD" = (
 /obj/structure/table/rack/shelf,
 /obj/item/gun/energy/taser,
@@ -54840,7 +55198,7 @@
 "lMx" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lMy" = (
 /obj/structure/multiz/stairs/enter,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -55026,12 +55384,12 @@
 	},
 /obj/structure/railing,
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lOY" = (
 /obj/structure/flora/pottedplant/dead,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lOZ" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
@@ -55117,7 +55475,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lPB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -55434,11 +55792,11 @@
 	dir = 1
 	},
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "lST" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "lTg" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -55468,6 +55826,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
+"lTo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lTv" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -55503,7 +55866,7 @@
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "lTF" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/generic,
@@ -55576,7 +55939,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "lUc" = (
 /obj/item/trash/chips,
 /obj/effect/decal/cleanable/dirt,
@@ -55685,7 +56048,7 @@
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "lVg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -55747,6 +56110,10 @@
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/tactical_blackshield)
+"lVS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lVU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/damagedfloor/fire,
@@ -55823,7 +56190,7 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/superior_animal/giant_spider/plasma,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "lXf" = (
 /obj/structure/catwalk,
 /obj/random/scrap/dense_weighted,
@@ -55845,7 +56212,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "lXq" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -55988,7 +56355,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "lYv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -56026,7 +56393,7 @@
 "lZm" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "lZn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -56259,7 +56626,7 @@
 /obj/random/powercell/small_safe_lonestar,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mbZ" = (
 /obj/structure/flora/small/bushc3,
 /obj/structure/flora/big/bush2,
@@ -56274,7 +56641,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "mch" = (
 /obj/structure/sign/department/drones,
 /turf/simulated/wall/r_wall,
@@ -56308,7 +56675,7 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mcF" = (
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/detectives_office)
@@ -56632,7 +56999,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "mfs" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -56655,7 +57022,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mfz" = (
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "medbay exit";
@@ -56684,7 +57051,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mfF" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -56694,7 +57061,7 @@
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mfN" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -57367,7 +57734,11 @@
 	desc = "Filthy, stinking bilge water.";
 	name = "murky water"
 	},
-/area/asteroid/cave)
+/area/nadezhda/maintenance/surfaceeast)
+"mmu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mmz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -57449,7 +57820,7 @@
 	desc = "Filthy, stinking bilge water.";
 	name = "murky water"
 	},
-/area/asteroid/cave)
+/area/nadezhda/maintenance/surfaceeast)
 "mna" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/railing{
@@ -57539,6 +57910,10 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"moz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "moD" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -57651,6 +58026,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/outside/forest)
+"mpR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/nadezhda/maintenance/surfaceeast)
 "mpT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -57746,7 +58125,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mqO" = (
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/grass,
@@ -57837,7 +58216,7 @@
 "mrL" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "mrQ" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -57886,7 +58265,7 @@
 "msn" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "msx" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -57921,6 +58300,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"msL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_panels,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "msP" = (
 /obj/effect/floor_decal/industrial/botright/yellow,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -58005,7 +58388,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "mtS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -58087,7 +58470,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "muO" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
@@ -58136,7 +58519,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "mvs" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable/cyan{
@@ -58153,6 +58536,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/outside/inside_colony)
+"mvx" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/surfaceeast)
 "mvB" = (
 /obj/structure/lattice,
 /turf/simulated/floor/fixed/hydrotile,
@@ -58187,7 +58574,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "mwe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -58227,7 +58614,7 @@
 "mwB" = (
 /obj/structure/scrap_cube,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "mwC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -58535,6 +58922,17 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"mAD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	operating = 0
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfacesec)
 "mAG" = (
 /obj/machinery/door/airlock/maintenance_engineering{
 	name = "Engineering Maintenance";
@@ -58679,7 +59077,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "mBL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/damagedfloor/fire,
@@ -58783,7 +59181,7 @@
 /obj/structure/flora/pottedplant/drooping,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "mCS" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 8
@@ -58841,7 +59239,7 @@
 	},
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mDn" = (
 /obj/structure/flora/small/busha2,
 /obj/random/flora/jungle_tree,
@@ -59017,7 +59415,7 @@
 "mFb" = (
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mFh" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -59237,7 +59635,7 @@
 /obj/item/stool/padded,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mHc" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -59245,7 +59643,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "mHe" = (
 /obj/item/tool/knife/neotritual,
 /obj/item/clothing/gloves/psionic_ring,
@@ -59271,7 +59669,7 @@
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mHq" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -59292,7 +59690,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "mHv" = (
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
@@ -59484,7 +59882,7 @@
 	req_access = list(1e+012)
 	},
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "mJD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -59956,7 +60354,7 @@
 /obj/item/stash_spawner,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mOU" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "14,21"
@@ -60026,7 +60424,7 @@
 /obj/structure/closet/wardrobe/color/blue,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "mPs" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light{
@@ -60034,7 +60432,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mPu" = (
 /obj/item/modular_computer/console/preset/command{
 	dir = 1
@@ -60166,7 +60564,7 @@
 /obj/item/tool/knife,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "mRt" = (
 /obj/machinery/vending/fitness,
 /obj/machinery/camera/network/colony_surface{
@@ -60266,7 +60664,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "mSD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -60427,7 +60825,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "mUH" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -60526,7 +60924,7 @@
 /obj/random/scrap/sparse_even,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "mVT" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 8;
@@ -60693,7 +61091,7 @@
 /obj/structure/closet/wardrobe/color/mixed,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "mXR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -61159,7 +61557,7 @@
 /obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "naZ" = (
 /obj/random/closet_tech/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -61331,7 +61729,7 @@
 /obj/random/tool/advanced,
 /obj/random/surgery_tool,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "ncn" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 8
@@ -61401,18 +61799,17 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ndm" = (
 /obj/structure/multiz/stairs/active{
 	dir = 1
 	},
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ndn" = (
 /obj/structure/boulder,
-/obj/random/traps/wire_splicing/low_chance,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/turf/simulated/floor/rock,
+/area/nadezhda/maintenance/surfaceeast)
 "ndz" = (
 /obj/structure/flora/big/bush1,
 /turf/simulated/floor/asteroid/dirt,
@@ -61454,7 +61851,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "nel" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -61665,7 +62062,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ngg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61742,7 +62139,7 @@
 	desc = "Filthy, stinking bilge water.";
 	name = "murky water"
 	},
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "nhn" = (
 /obj/structure/table/rack/shelf,
 /obj/item/ammo_magazine/ammobox/light_rifle_257/rubber,
@@ -61773,7 +62170,7 @@
 	spawn_nothing_percentage = 90
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nhI" = (
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
@@ -61803,7 +62200,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "nio" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/machinery/light{
@@ -61822,7 +62219,7 @@
 /obj/random/rations/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "niD" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Research and Development";
@@ -61901,7 +62298,7 @@
 /obj/item/storage/box/cups,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "njo" = (
 /obj/random/furniture/pottedplant,
 /obj/effect/decal/cleanable/dirt,
@@ -62165,7 +62562,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nly" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -62293,13 +62690,13 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "nng" = (
 /obj/random/mob/spiders,
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "nnn" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stack/material/plasteel/random,
@@ -62383,6 +62780,16 @@
 "noA" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos/surface)
+"noE" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "noH" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/spider/stickyweb,
@@ -62657,14 +63064,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "nrv" = (
 /obj/machinery/disposal,
 /obj/item/contraband/poster/placed/generic/wizard{
 	pixel_y = -32
 	},
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "nrA" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/floor_decal/industrial/loading{
@@ -62731,7 +63138,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
+"nsq" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nsw" = (
 /obj/structure/scrap_cube,
 /obj/structure/catwalk,
@@ -62867,7 +63281,7 @@
 /obj/item/clothing/head/helmet/steelpot,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ntw" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -62933,7 +63347,7 @@
 /obj/structure/table/reinforced,
 /obj/random/toolbox,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "ntZ" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/wood,
@@ -63191,7 +63605,7 @@
 /obj/random/lowkeyrandom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nxk" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -63260,7 +63674,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "nxZ" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/under,
@@ -63268,7 +63682,7 @@
 /obj/random/cloth/under,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nye" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 8
@@ -63307,7 +63721,7 @@
 /obj/machinery/computer/arcade,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_flat,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nyv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
@@ -63392,7 +63806,7 @@
 /obj/item/clothing/accessory/hawaiian/jade,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "nyZ" = (
 /obj/structure/flora/small/grassb1,
 /obj/structure/flora/small/busha1,
@@ -63402,7 +63816,7 @@
 /obj/machinery/vending/dinnerware/cost,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nzl" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -63419,7 +63833,7 @@
 /obj/random/cloth/under/low_chance,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nzs" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -63792,7 +64206,7 @@
 /obj/item/coin/silver,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nCU" = (
 /obj/structure/sign/faction/astersguild{
 	pixel_y = 32
@@ -63890,7 +64304,7 @@
 /obj/machinery/camera/network/security,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nDF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -64000,7 +64414,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "nEC" = (
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
@@ -64014,7 +64428,7 @@
 /obj/machinery/microwave,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nET" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -64353,7 +64767,7 @@
 /obj/random/closet_tech/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "nIG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/light/small{
@@ -64505,7 +64919,7 @@
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nJO" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
@@ -64524,13 +64938,13 @@
 /obj/structure/spider_nest,
 /obj/item/stack/rods/random,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "nKf" = (
 /obj/structure/table/rack/shelf,
 /obj/random/cloth/under/low_chance,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nKg" = (
 /obj/machinery/newscaster{
 	dir = 4;
@@ -64569,7 +64983,7 @@
 /obj/random/powercell/low_chance,
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "nKz" = (
 /obj/effect/decal/cleanable/cobweb2{
 	icon_state = "cobweb1";
@@ -64579,7 +64993,7 @@
 /obj/structure/flora/pottedplant/xmas,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "nKB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -64603,7 +65017,7 @@
 /obj/machinery/floodlight,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "nKS" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/belt/webbing,
@@ -64618,7 +65032,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "nKX" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -64680,7 +65094,7 @@
 /obj/structure/closet/wardrobe/color/black,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "nLx" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "2,3"
@@ -64807,7 +65221,7 @@
 "nMI" = (
 /obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "nMO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -64879,7 +65293,7 @@
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nNz" = (
 /obj/machinery/light,
 /obj/machinery/holoposter{
@@ -65010,6 +65424,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"nPd" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/surfacesec)
 "nPg" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
@@ -65020,7 +65439,7 @@
 /obj/random/scrap/sparse_even/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "nPB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -65237,6 +65656,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"nSk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nSr" = (
 /turf/simulated/shuttle/floor/mining,
 /area/turbolift/ElevatorOne/underground)
@@ -65527,6 +65955,9 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"nVR" = (
+/turf/simulated/wall/r_wall,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "nVS" = (
 /obj/effect/floor_decal/industrial/box/white,
 /obj/landmark/join/late/cryo/elevator,
@@ -65711,7 +66142,7 @@
 "nWX" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "nXf" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "4,13"
@@ -65778,7 +66209,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nXz" = (
 /obj/structure/table/steel,
 /obj/random/knife,
@@ -65835,7 +66266,7 @@
 /obj/random/melee/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nYg" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
@@ -65872,7 +66303,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "nYy" = (
 /obj/machinery/light{
 	dir = 1
@@ -65890,7 +66321,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "nYA" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -65898,7 +66329,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nYI" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -65927,7 +66358,7 @@
 "nYV" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "nYY" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/burned,
@@ -66031,7 +66462,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "oal" = (
 /obj/machinery/disposal/deliveryChute{
 	name = "plant chute"
@@ -66052,7 +66483,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/random/cluster/termite_no_despawn/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "oaq" = (
 /obj/structure/bed/chair/sofa/teal/right{
 	dir = 1
@@ -66153,6 +66584,11 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
+"oaQ" = (
+/obj/random/closet/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oaT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66429,7 +66865,7 @@
 /obj/structure/scrap/cloth/large,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "oeb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -66525,7 +66961,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ofn" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/ammo_magazine/ammobox/light_rifle_257/practice,
@@ -66552,7 +66988,7 @@
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "ofB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled/techmaint,
@@ -66779,7 +67215,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "oij" = (
 /turf/simulated/wall/wood_barrel,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -66911,6 +67347,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/engine_room)
+"ojh" = (
+/obj/structure/scrap/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ojn" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "11,11"
@@ -67024,7 +67465,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ojR" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/medical,
@@ -67089,7 +67530,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "okV" = (
 /obj/machinery/door/blast/regular/open{
 	id = "genetics2";
@@ -67107,7 +67548,7 @@
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "olc" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = -32
@@ -67148,7 +67589,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "oll" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/effect/decal/cleanable/dirt,
@@ -67438,14 +67879,14 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "opb" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/railing/grey{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "opd" = (
 /obj/machinery/door/unpowered/simple/wood/saloon{
 	name = "Church Foyer"
@@ -67661,7 +68102,7 @@
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "orA" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -67813,7 +68254,7 @@
 "osU" = (
 /obj/random/scrap/moderate_weighted/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "osV" = (
 /obj/machinery/reagentgrinder/advanced,
 /turf/simulated/floor/tiled/white/danger,
@@ -67929,7 +68370,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "otG" = (
 /obj/item/farmbot_arm_assembly,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -68106,7 +68547,7 @@
 	},
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "ovO" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/asteroid/grass,
@@ -68141,7 +68582,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "owd" = (
 /obj/structure/filingcabinet/employment,
 /obj/machinery/alarm{
@@ -68207,6 +68648,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"owQ" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "owT" = (
 /obj/machinery/telecomms/relay/preset/station,
 /turf/simulated/floor/bluegrid{
@@ -68411,6 +68856,11 @@
 	temperature = 80
 	},
 /area/nadezhda/command/tcommsat/computer)
+"ozq" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfacesec)
 "ozA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -68759,7 +69209,7 @@
 /obj/random/scrap/dense_even,
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "oCZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -68791,6 +69241,10 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
+"oDt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/maintenance/surfaceeast)
 "oDv" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/regular,
@@ -68835,7 +69289,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "oDR" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Robotics Surgery Lab";
@@ -68861,7 +69315,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "oDX" = (
 /obj/structure/flora/small/rock2,
 /turf/simulated/floor/asteroid/grass,
@@ -68996,6 +69450,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"oFM" = (
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/surfaceeast)
 "oFP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -69037,14 +69495,14 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "oGo" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/vacantoffice2)
 "oGv" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "oGz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -69103,7 +69561,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/random/cluster/termite_no_despawn/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "oGY" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/closet_maintloot,
@@ -69237,7 +69695,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/cloth/armor,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "oIF" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -69264,7 +69722,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "oIR" = (
 /obj/machinery/atmospherics/tvalve/mirrored/digital/bypass,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -69418,7 +69876,7 @@
 "oJS" = (
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "oJV" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,18"
@@ -69624,11 +70082,11 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "oMa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "oMe" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -69643,7 +70101,7 @@
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "oMi" = (
 /obj/structure/flora/small/bushc1,
 /turf/simulated/floor/asteroid/grass,
@@ -69707,7 +70165,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "oNl" = (
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/dorm4)
@@ -69877,7 +70335,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "oPm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/xenomorphs,
@@ -70230,6 +70688,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/genetics)
+"oSz" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/surfaceeast)
 "oSE" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/rock3,
@@ -70312,7 +70775,7 @@
 	desc = "Filthy, stinking bilge water.";
 	name = "murky water"
 	},
-/area/asteroid/cave)
+/area/nadezhda/maintenance/surfaceeast)
 "oTN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70357,7 +70820,7 @@
 "oUr" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oUz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/junction{
@@ -70639,7 +71102,7 @@
 /obj/item/coin/silver,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "oXb" = (
 /obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/asteroid/grass,
@@ -70732,7 +71195,7 @@
 /obj/random/scrap/dense_weighted,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "oYd" = (
 /obj/machinery/light{
 	dir = 8
@@ -70889,12 +71352,12 @@
 /obj/item/storage/deferred/crate/uniform_light,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "oZF" = (
 /obj/structure/barricade,
 /obj/item/device/radio/beacon/bacon,
 /turf/simulated/floor/rock,
-/area/asteroid/cave)
+/area/nadezhda/maintenance/surfaceeast)
 "oZK" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -70953,7 +71416,7 @@
 /obj/random/cluster/roaches,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "paj" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/light/small{
@@ -71061,7 +71524,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "pbz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -71221,23 +71684,18 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pdx" = (
 /obj/structure/table/rack/shelf,
 /obj/random/material_resources,
 /obj/random/material_resources/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pdE" = (
 /obj/effect/decal/cleanable/rubble,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "pdI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -71342,7 +71800,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cargo,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "peR" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/grass,
@@ -71389,7 +71847,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "pfv" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -71642,12 +72100,12 @@
 "pij" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pio" = (
 /obj/random/toy/arcadejunk,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pip" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/structure/noticeboard/lonestar_supply{
@@ -71655,7 +72113,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "pix" = (
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/generic,
@@ -71884,7 +72342,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "pkA" = (
 /obj/effect/floor_decal/industrial/outline,
 /obj/effect/decal/cleanable/dirt,
@@ -72008,7 +72466,7 @@
 /obj/effect/decal/weldable/cracks,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pmT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
@@ -72052,7 +72510,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "pni" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -72065,6 +72523,10 @@
 /obj/structure/medical_stand,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/medical/sleeper)
+"pnm" = (
+/obj/random/structures/low_chance,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pnn" = (
 /obj/item/stamp/clown,
 /obj/item/device/pda/clown,
@@ -72090,7 +72552,7 @@
 "pnK" = (
 /obj/item/caution/cone,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pnL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72100,7 +72562,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "pnP" = (
 /obj/random/junk/low_chance,
 /obj/item/contraband/poster/placed/generic/walk{
@@ -72176,7 +72638,7 @@
 /obj/random/lowkeyrandom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "poN" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -72311,7 +72773,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ppE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -72348,7 +72810,7 @@
 /obj/item/storage/deferred/crate/tools,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pqm" = (
 /obj/structure/railing{
 	dir = 8
@@ -72498,7 +72960,7 @@
 /obj/random/toolbox,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "psn" = (
 /obj/machinery/door/window/eastleft,
 /obj/machinery/door/window/brigdoor/westright{
@@ -73070,6 +73532,22 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
+"pxX" = (
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28;
+	operating = 0
+	},
+/obj/structure/cable/cyan,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "pyb" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -73236,7 +73714,7 @@
 "pzz" = (
 /obj/item/material/shard,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pzI" = (
 /obj/structure/scrap/food/large,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -73298,12 +73776,12 @@
 /obj/random/cluster/roaches,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "pAo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "pAq" = (
 /obj/machinery/door/airlock/centcom,
 /obj/structure/catwalk,
@@ -73335,7 +73813,7 @@
 	desc = "Filthy, stinking bilge water.";
 	name = "murky water"
 	},
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "pAO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -73536,7 +74014,7 @@
 /obj/random/powercell/large_safe_lonestar,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pCW" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "7,10"
@@ -73576,7 +74054,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pDl" = (
 /obj/structure/table/woodentable,
 /obj/structure/reagent_dispensers/cahorsbarrel,
@@ -73658,7 +74136,7 @@
 /obj/random/melee/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pDL" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/engineering/engine_room)
@@ -73713,7 +74191,7 @@
 "pES" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "pFb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/modular_computer/console/preset/command{
@@ -73759,7 +74237,7 @@
 /obj/item/book/manual/fiction/frankenstein,
 /obj/item/book/manual/fiction/dracula,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "pFw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73821,7 +74299,7 @@
 /obj/random/lowkeyrandom,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pGp" = (
 /obj/structure/closet/secure_closet/reinforced/CMO,
 /obj/item/computer_hardware/hard_drive/portable/design/medical/cmo,
@@ -73868,7 +74346,7 @@
 /obj/machinery/seed_extractor,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pGy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
@@ -74385,7 +74863,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "pMh" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
@@ -74439,7 +74917,7 @@
 /obj/item/stamp/denied,
 /obj/item/stamp,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "pMX" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -74488,6 +74966,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"pNf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/nadezhda/maintenance/surfacesec)
 "pNi" = (
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
@@ -74648,7 +75130,7 @@
 "pOx" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pOz" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/asteroid/dirt/dark/plough,
@@ -74666,12 +75148,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "pOR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pOT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -74770,7 +75252,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "pPA" = (
 /obj/structure/closet/random_milsupply,
 /obj/structure/catwalk,
@@ -74880,6 +75362,11 @@
 /obj/landmark/join/start/scientist,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
+"pQH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pQK" = (
 /obj/structure/flora/small/grassa4,
 /turf/simulated/floor/asteroid/grass,
@@ -74922,7 +75409,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pRf" = (
 /obj/machinery/door/blast/shutters/glass{
 	name = "Fireplace  Cover"
@@ -74981,6 +75468,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
+"pRE" = (
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfacesec)
 "pRH" = (
 /obj/structure/table/rack/shelf,
 /obj/item/ammo_magazine/ammobox/heavy_rifle_408/hv,
@@ -75260,7 +75751,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "pUT" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -75378,6 +75869,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"pVq" = (
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pVs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -75409,7 +75903,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "pVy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -75457,12 +75951,12 @@
 /obj/random/medical,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pVX" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "pVY" = (
 /obj/structure/table/woodentable,
 /obj/machinery/button/windowtint{
@@ -75599,7 +76093,7 @@
 	},
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pXH" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -75700,7 +76194,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pYE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
@@ -75717,12 +76211,12 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /obj/item/material/shard,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "pYG" = (
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "pYK" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -75730,7 +76224,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "pYU" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -75869,7 +76363,7 @@
 /obj/structure/closet/random_hostilemobs,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qaT" = (
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
@@ -75981,7 +76475,7 @@
 /obj/random/material_rare/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qbK" = (
 /obj/structure/table/standard,
 /obj/item/folder/blue,
@@ -76321,7 +76815,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "qfp" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -76481,7 +76975,7 @@
 "qhC" = (
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qhN" = (
 /obj/random/scrap/sparse_weighted,
 /obj/effect/decal/cleanable/dirt,
@@ -76555,7 +77049,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qiI" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -76684,7 +77178,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qjW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -76711,7 +77205,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qkl" = (
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /obj/structure/cable/cyan{
@@ -76753,7 +77247,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qkB" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
@@ -76782,8 +77276,9 @@
 "qkG" = (
 /obj/machinery/light/small,
 /obj/random/closet/low_chance,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qkJ" = (
 /obj/structure/bed/chair/sofa/teal{
 	dir = 8
@@ -76874,7 +77369,7 @@
 /obj/random/cloth/head/low_chance,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qlG" = (
 /obj/machinery/door/airlock/glass{
 	name = "Break Room"
@@ -77024,7 +77519,7 @@
 /obj/random/cloth/under,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qnn" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -77090,7 +77585,7 @@
 /obj/structure/salvageable/autolathe,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qon" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77161,7 +77656,7 @@
 /obj/random/medical,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qoY" = (
 /obj/structure/table/standard,
 /obj/item/stack/medical/splint,
@@ -77222,7 +77717,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qps" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/genericbush,
@@ -77263,7 +77758,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "qpV" = (
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /obj/structure/cable/yellow{
@@ -77299,6 +77794,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/medical)
+"qqy" = (
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qqF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77309,7 +77808,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/cloth,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "qqM" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/fiction/warandpeace,
@@ -77336,7 +77835,7 @@
 /obj/random/cloth/armor/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qrd" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -77358,7 +77857,7 @@
 "qro" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qrq" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4
@@ -77437,7 +77936,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qrM" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/command/hallway)
@@ -77558,7 +78057,7 @@
 /obj/random/medical,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qsS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -77636,7 +78135,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qtE" = (
 /obj/structure/closet/malf/suits,
 /turf/simulated/floor/tiled/steel/danger,
@@ -77665,7 +78164,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qtX" = (
 /obj/effect/floor_decal/industrial/loading/red{
 	pixel_y = -4
@@ -77745,7 +78244,7 @@
 /obj/random/traps/wire_splicing/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qvh" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -77967,7 +78466,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/moderate_weighted/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "qxn" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -78135,6 +78634,12 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/gmaster)
+"qzi" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfacesec)
 "qzj" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall6";
@@ -78168,7 +78673,7 @@
 /obj/item/storage/secure/briefcase,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qzy" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/atmospherics/portables_connector{
@@ -78289,6 +78794,13 @@
 "qBg" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"qBj" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qBk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -78360,7 +78872,7 @@
 /obj/structure/barricade,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "qCg" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -78461,7 +78973,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "qDd" = (
 /obj/item/storage/pouch/tubular,
 /obj/structure/closet/crate/serbcrate{
@@ -78480,7 +78992,7 @@
 	oldified = 1
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qDo" = (
 /obj/structure/sign/warning/internals_required/small2,
 /turf/simulated/wall/r_wall,
@@ -78595,7 +79107,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qEr" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha1,
@@ -78636,12 +79148,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qEK" = (
+/obj/structure/table/standard,
+/obj/random/lowkeyrandom,
+/obj/machinery/recharger,
+/obj/random/powercell,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qET" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "qEU" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/hallway)
@@ -78654,7 +79174,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qFb" = (
 /obj/structure/flora/small/lavarock3,
 /obj/structure/flora/ausbushes/brflowers,
@@ -78801,13 +79321,13 @@
 /obj/structure/salvageable/computer,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qGo" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qGr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -78825,7 +79345,7 @@
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qGA" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/simulated/floor/bluegrid{
@@ -79052,7 +79572,7 @@
 	},
 /obj/item/book/manual/fiction/thetimemachine,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qIm" = (
 /obj/machinery/atm{
 	pixel_y = 32
@@ -79081,7 +79601,7 @@
 /obj/machinery/microwave,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qIN" = (
 /obj/random/material/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -79139,7 +79659,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "qJR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -79203,7 +79723,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "qKA" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -79231,6 +79751,10 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"qKX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qLa" = (
 /obj/machinery/door/blast/regular/open{
 	id = "xenobio1";
@@ -79279,7 +79803,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qLp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79319,7 +79843,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qLW" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "13,1"
@@ -79367,7 +79891,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qMG" = (
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
@@ -79432,7 +79956,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase/guncase,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qNS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
@@ -79618,7 +80142,7 @@
 /obj/random/melee/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qQa" = (
 /obj/structure/scrap/poor,
 /obj/effect/decal/cleanable/dirt,
@@ -79810,7 +80334,7 @@
 /obj/random/toolbox/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qSe" = (
 /obj/structure/sign/security/court{
 	pixel_x = -16;
@@ -79919,7 +80443,7 @@
 "qTn" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qTv" = (
 /obj/machinery/camera/motion/security,
 /turf/simulated/floor/bluegrid,
@@ -79983,7 +80507,7 @@
 "qTZ" = (
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qUe" = (
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -79999,7 +80523,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qUD" = (
 /obj/structure/closet/crate/secure,
 /obj/item/flame/lighter/zippo/gold,
@@ -80007,12 +80531,12 @@
 /obj/item/roach_egg/gold,
 /obj/item/coin/gold,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qUH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qUI" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/sleeper)
@@ -80079,6 +80603,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/tcommsat/computer)
+"qVC" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "qVD" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/golden,
@@ -80141,7 +80669,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "qWq" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -80198,7 +80726,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "qXc" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -80243,7 +80771,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "qXL" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/dirt,
@@ -80366,7 +80894,7 @@
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "qZj" = (
 /obj/structure/table/woodentable,
 /obj/machinery/button/remote/airlock{
@@ -80564,7 +81092,7 @@
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rbu" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -80608,13 +81136,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rbV" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rca" = (
 /obj/structure/table/woodentable,
 /obj/structure/mirror{
@@ -80708,7 +81236,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "rdk" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/dungeon/outside/trashcave)
@@ -80720,6 +81248,10 @@
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"rdu" = (
+/obj/structure/grille,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rdM" = (
 /obj/structure/closet/crate/solar,
 /obj/effect/decal/cleanable/dirt,
@@ -80849,7 +81381,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "reJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -80865,7 +81397,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "reP" = (
 /obj/structure/table/woodentable,
 /obj/item/clipboard,
@@ -80967,7 +81499,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/moderate_weighted/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "rfo" = (
 /obj/effect/damagedfloor/fire,
 /turf/simulated/floor/asteroid/grass,
@@ -81011,7 +81543,7 @@
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rfN" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -81131,7 +81663,7 @@
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rgZ" = (
 /obj/structure/table/standard,
 /obj/random/boxes,
@@ -81140,7 +81672,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rhe" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "9,21"
@@ -81405,7 +81937,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rjU" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/drinks/bottle/small/beer,
@@ -81542,7 +82074,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rlH" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 9
@@ -81728,7 +82260,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rnH" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "15,18"
@@ -81819,7 +82351,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "roq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -81957,7 +82489,7 @@
 	},
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rpW" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -82159,6 +82691,9 @@
 /obj/machinery/light/floor,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/genetics)
+"rsN" = (
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rsQ" = (
 /obj/structure/flora/small/bushc1,
 /obj/structure/flora/big/bush3,
@@ -82172,7 +82707,7 @@
 "rtf" = (
 /obj/random/structures,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rtm" = (
 /obj/machinery/door/airlock/command{
 	name = "Steward's Quarters";
@@ -82309,7 +82844,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rut" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -82343,6 +82878,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/server)
+"ruz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
+"ruK" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ruL" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/junk/low_chance,
@@ -82779,7 +83323,7 @@
 	name = "Stolen Valor Vault"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "rze" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -82888,7 +83432,7 @@
 /obj/random/pack/gun_loot/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rAj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -82904,7 +83448,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rAA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -83013,12 +83557,12 @@
 /obj/structure/catwalk,
 /obj/structure/railing,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "rBY" = (
 /obj/random/toy,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rBZ" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stack/material/steel/random,
@@ -83239,6 +83783,11 @@
 "rEh" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/absolutism/hallways)
+"rEq" = (
+/obj/random/cluster/termite_no_despawn/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rEB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -83729,11 +84278,16 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"rKI" = (
+/obj/random/spider_trap/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfaceeast)
 "rKK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/caution/cone,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rKU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -83895,7 +84449,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rMu" = (
 /obj/structure/table/rack/shelf,
 /obj/item/tank/emergency_oxygen/double,
@@ -83930,7 +84484,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rME" = (
 /obj/structure/low_wall,
 /mob/living/simple_animal/jungle_bird,
@@ -84027,7 +84581,7 @@
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rNj" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -84081,7 +84635,7 @@
 /obj/random/cloth/head/low_chance,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rNE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -84101,7 +84655,7 @@
 "rNV" = (
 /obj/machinery/bookbinder,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rOa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -84346,7 +84900,7 @@
 /obj/structure/table/steel,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rRe" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Core";
@@ -84396,7 +84950,7 @@
 "rRp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "rRq" = (
 /obj/item/book/ritual/cruciform,
 /obj/item/book/ritual/cruciform,
@@ -84413,7 +84967,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/oddity/common/book_eyes,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rRv" = (
 /turf/simulated/floor/reinforced,
 /area/nadezhda/security/sechall)
@@ -84563,7 +85117,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "rTK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade,
@@ -84648,7 +85202,7 @@
 "rUO" = (
 /mob/living/carbon/superior_animal/roach/benzin,
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rUW" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
@@ -84679,7 +85233,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rVx" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "13,12"
@@ -84735,6 +85289,11 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"rVY" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rVZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -84820,7 +85379,7 @@
 /obj/random/closet/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "rWV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -84838,7 +85397,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "rXh" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -84886,12 +85445,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rXv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "rXw" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -85004,7 +85563,7 @@
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "rYr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/recharger,
@@ -85017,7 +85576,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "rYx" = (
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/steel,
@@ -85033,7 +85592,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap_cube,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "rYK" = (
 /obj/item/stool,
 /obj/machinery/light/small{
@@ -85304,7 +85863,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "saK" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -85383,7 +85942,7 @@
 /obj/item/reagent_containers/glass/fertilizer/rh,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sbK" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light/small{
@@ -85670,7 +86229,7 @@
 "sek" = (
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sem" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/small/bushb1,
@@ -85679,7 +86238,7 @@
 /area/nadezhda/outside/forest)
 "sep" = (
 /turf/simulated/floor/carpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ses" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -85701,7 +86260,7 @@
 /obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "seL" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -85933,7 +86492,7 @@
 /obj/random/powercell/low_chance,
 /obj/random/tool/advanced/low_chance,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "shy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -86085,6 +86644,9 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
+"sju" = (
+/turf/simulated/wall/r_wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sjv" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -86268,7 +86830,7 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "slM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -86435,6 +86997,10 @@
 /obj/item/device/radio/beacon/bacon,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/shuttle/surface_transport_lz)
+"snr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sns" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -86564,7 +87130,7 @@
 /obj/random/medical/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "soA" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section8";
@@ -86635,7 +87201,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sps" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -86675,7 +87241,7 @@
 "spU" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/mineral,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "spV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -87222,7 +87788,7 @@
 /obj/random/cloth/under/low_chance,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "suI" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet,
@@ -87375,6 +87941,14 @@
 /mob/living/simple_animal/frog,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/forest)
+"svT" = (
+/obj/structure/bed/chair,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "svV" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -87388,7 +87962,7 @@
 	},
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "swf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -87468,7 +88042,7 @@
 /obj/random/material_resources/low_chance,
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "swV" = (
 /obj/structure/table/onestar,
 /obj/item/pen,
@@ -87530,7 +88104,7 @@
 "sxC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "sxF" = (
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/burned_outpost)
@@ -87704,7 +88278,7 @@
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "szf" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -87729,7 +88303,7 @@
 /obj/random/ammo_lowcost,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "szw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -87765,7 +88339,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "szQ" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical)
@@ -87903,7 +88477,7 @@
 /obj/machinery/vending/cola,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sBc" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/structure/sign/warning/docking_area/small2,
@@ -87933,7 +88507,7 @@
 "sBo" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sBy" = (
 /obj/structure/table/woodentable,
 /obj/item/folder/cyan,
@@ -87961,7 +88535,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "sBJ" = (
 /obj/item/contraband/poster/placed/generic/work_for_a_future{
 	pixel_y = 32
@@ -88016,6 +88590,10 @@
 "sCn" = (
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"sCI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sCN" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -88048,7 +88626,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "sCZ" = (
 /obj/structure/railing{
 	dir = 8
@@ -88099,7 +88677,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "sDz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -88181,6 +88759,9 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/bar)
+"sEL" = (
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sEN" = (
 /obj/machinery/vending/gamers,
 /turf/simulated/floor/wood/wild1,
@@ -88305,7 +88886,7 @@
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sFR" = (
 /obj/structure/closet/secure_closet/freezer,
 /obj/random/junkfood,
@@ -88474,7 +89055,11 @@
 "sIp" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
+"sIs" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "sIx" = (
 /obj/structure/catwalk,
 /obj/structure/extinguisher_cabinet{
@@ -88491,7 +89076,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "sIC" = (
 /obj/structure/closet/l3closet,
 /obj/structure/cable/green,
@@ -88523,7 +89108,7 @@
 /obj/item/remains,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sIQ" = (
 /obj/structure/table/reinforced,
 /obj/random/rig_module/low_chance,
@@ -88687,7 +89272,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sLf" = (
 /obj/machinery/media/jukebox,
 /obj/effect/spider/stickyweb,
@@ -88713,7 +89298,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sLz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -88927,12 +89512,12 @@
 /obj/item/clothing/suit/rank/chef/classic,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sNp" = (
 /obj/structure/flora/pottedplant/dead,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "sNJ" = (
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/dirt,
@@ -89099,7 +89684,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "sPy" = (
 /obj/machinery/light{
 	dir = 8
@@ -89157,7 +89742,7 @@
 /obj/random/rations/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sPM" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/reinforced,
@@ -89486,6 +90071,15 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/tactical_blackshield)
+"sTL" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/beach/water/jungledeep{
+	desc = "Filthy, stinking bilge water.";
+	name = "murky water"
+	},
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sTM" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -89648,7 +90242,7 @@
 "sVu" = (
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sVE" = (
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
@@ -89704,7 +90298,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "sWx" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/structure/cable/cyan{
@@ -89856,7 +90450,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sXT" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -89948,7 +90542,7 @@
 /obj/structure/grille,
 /obj/effect/damagedfloor/rust,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "sZe" = (
 /obj/machinery/light{
 	dir = 8
@@ -90126,7 +90720,7 @@
 /obj/structure/table/bench/steel,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "taP" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -90149,12 +90743,12 @@
 /obj/structure/table/steel,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "taZ" = (
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tba" = (
 /obj/item/device/radio/intercom/department/security{
 	pixel_y = 25
@@ -90509,7 +91103,7 @@
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tfr" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/cable/green{
@@ -90587,7 +91181,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tgx" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall3";
@@ -90607,7 +91201,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "thd" = (
 /obj/machinery/papershredder,
 /obj/machinery/light/small,
@@ -90698,7 +91292,7 @@
 /obj/random/pack/cloth/low_chance,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "thV" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6;
@@ -90742,6 +91336,9 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"tin" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfacesec)
 "tio" = (
 /obj/structure/window/reinforced,
 /obj/structure/multiz/stairs/enter{
@@ -90783,7 +91380,7 @@
 /obj/structure/barricade,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "tiz" = (
 /obj/machinery/door/holy{
 	name = "Church"
@@ -90846,7 +91443,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "tjz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -91031,7 +91628,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tlw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -91057,7 +91654,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "tlB" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/dirt,
@@ -91141,7 +91738,7 @@
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tnt" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -91331,7 +91928,7 @@
 /obj/machinery/power/port_gen/pacman/diesel,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tqb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -91388,7 +91985,7 @@
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tqv" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -91780,6 +92377,9 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"tvc" = (
+/turf/simulated/wall,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tvk" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/structure/grille,
@@ -91800,7 +92400,7 @@
 "tvr" = (
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "tvy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -91916,7 +92516,7 @@
 /obj/item/reagent_containers/food/snacks/cube/roach/jager,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "twj" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -91955,7 +92555,7 @@
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "twK" = (
 /obj/effect/floor_decal/border/carpet/black{
 	dir = 9
@@ -92058,7 +92658,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "txk" = (
 /obj/structure/railing{
 	dir = 4
@@ -92131,7 +92731,7 @@
 /obj/item/book/manual/nonfiction/ethics,
 /obj/item/book/manual/nonfiction/leviathan,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "txW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -92140,7 +92740,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "txY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/bushc1,
@@ -92161,6 +92761,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"tyl" = (
+/obj/structure/salvageable/computer{
+	pixel_y = 10
+	},
+/obj/structure/table/standard,
+/obj/random/cloth/armor/low_chance,
+/obj/random/cloth/shoes/low_chance,
+/obj/random/cloth/suit/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tym" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
@@ -92309,7 +92920,7 @@
 	pixel_y = 20
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "tzr" = (
 /obj/structure/scrap/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -92531,7 +93142,7 @@
 /obj/structure/table/woodentable,
 /obj/item/device/camera_film,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tCl" = (
 /obj/effect/floor_decal/industrial/box/red,
 /obj/machinery/disposal,
@@ -92550,7 +93161,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
+"tCv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tCy" = (
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating/under,
@@ -92700,11 +93315,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/teleporter)
 "tDR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/turf/simulated/wall,
+/area/nadezhda/maintenance/surfaceeast)
 "tDY" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/cobweb,
@@ -92843,7 +93455,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "tFu" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -92853,7 +93465,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "tFv" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 1
@@ -93021,7 +93633,7 @@
 /obj/random/cloth/under/low_chance,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tGQ" = (
 /obj/structure/table/standard,
 /obj/item/clothing/accessory/stethoscope,
@@ -93058,7 +93670,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tHt" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
@@ -93082,7 +93694,7 @@
 /obj/random/scrap/sparse_even/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tHP" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -93258,7 +93870,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tJk" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -93384,7 +93996,7 @@
 /obj/random/gun_parts/low,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tKz" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/dirt/burned,
@@ -93519,7 +94131,7 @@
 /obj/structure/salvageable/server,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tMh" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -93539,7 +94151,7 @@
 	},
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tMr" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -93613,7 +94225,7 @@
 /obj/random/toolbox,
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "tNd" = (
 /obj/machinery/optable/altar,
 /obj/item/rig/combat/knight/equipped,
@@ -93991,7 +94603,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tQe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -94046,7 +94658,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tQF" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -94059,7 +94671,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "tQK" = (
 /obj/structure/flora/small/trailrocka3,
 /obj/structure/boulder,
@@ -94199,6 +94811,11 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate)
+"tSD" = (
+/obj/random/structures/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tSH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor_switch{
@@ -94315,7 +94932,7 @@
 /obj/random/cloth/under/low_chance,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tTA" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1;
@@ -94329,7 +94946,7 @@
 /obj/structure/barricade,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tTH" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 9
@@ -94442,7 +95059,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "tUS" = (
 /obj/structure/closet/secure_closet/personal/salvager,
 /obj/machinery/light{
@@ -94572,7 +95189,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tWL" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -94593,7 +95210,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tWU" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -94637,7 +95254,7 @@
 "tXy" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "tXB" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -94654,7 +95271,7 @@
 "tXG" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "tXH" = (
 /obj/landmark/join/start/chemist,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -94749,14 +95366,14 @@
 /obj/effect/floor_decal/industrial/stand_clear/red,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "tYH" = (
 /obj/structure/table/rack/shelf,
 /obj/random/rations/roachcube,
 /obj/random/rations/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "tYK" = (
 /obj/structure/table/rack,
 /obj/item/tool/hammer/dumbbell,
@@ -94949,7 +95566,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "uaw" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/steel/monofloor{
@@ -95011,7 +95628,7 @@
 /obj/item/clothing/accessory/hawaiian/motu,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "ubg" = (
 /obj/effect/floor_decal/rust,
 /obj/random/closet_maintloot,
@@ -95056,7 +95673,7 @@
 /obj/random/closet_tech/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ubB" = (
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/asteroid/grass,
@@ -95116,7 +95733,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "uck" = (
 /obj/structure/multiz/stairs/enter{
 	dir = 4
@@ -95188,7 +95805,7 @@
 /obj/random/lowkeyrandom/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ucW" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -95245,7 +95862,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "udk" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "12,3"
@@ -95336,7 +95953,7 @@
 	desc = "Filthy, stinking bilge water.";
 	name = "murky water"
 	},
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ueB" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/effect/decal/cleanable/dirt,
@@ -95350,7 +95967,7 @@
 /obj/random/ammo/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ueH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -95480,7 +96097,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ufC" = (
 /obj/item/remains/ribcage,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -95544,7 +96161,7 @@
 "ufR" = (
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ufY" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -95583,7 +96200,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "uge" = (
 /obj/structure/flora/pottedplant/dead{
 	oldified = 1;
@@ -95594,6 +96211,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"ugg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/maintenance/surfaceeast)
 "ugh" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "11,0"
@@ -95682,7 +96304,7 @@
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "ugO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -95781,7 +96403,7 @@
 /obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uhW" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/industrial/hatch,
@@ -95917,7 +96539,7 @@
 "ujx" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /turf/simulated/open,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "ujJ" = (
 /obj/machinery/door/airlock/security{
 	name = "Sergeant Office";
@@ -95935,7 +96557,7 @@
 /obj/random/gun_parts/frames/better_spawns,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ujX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -95975,13 +96597,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "uko" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ukp" = (
 /obj/structure/disposalpipe/tagger{
 	dir = 4;
@@ -96088,6 +96710,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/captain/quarters)
+"ulm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "West APC";
+	pixel_x = -28;
+	operating = 0
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ulp" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -96332,7 +96975,7 @@
 "unB" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "unD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -96479,6 +97122,11 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"upT" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "upX" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
@@ -96764,7 +97412,7 @@
 /area/nadezhda/crew_quarters/dorm4)
 "utf" = (
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "utn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 5
@@ -96780,7 +97428,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "utC" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/bag/produce,
@@ -96894,7 +97542,7 @@
 /obj/random/scrap/dense_weighted,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uvh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -96943,7 +97591,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uvq" = (
 /obj/structure/invislight,
 /turf/simulated/mineral,
@@ -97043,7 +97691,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "uxt" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -97143,7 +97791,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uyv" = (
 /obj/machinery/light{
 	dir = 1
@@ -97188,6 +97836,9 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
+"uyN" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uyQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -97323,7 +97974,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uAl" = (
 /obj/structure/table/rack,
 /obj/item/gun/projectile/automatic/texan{
@@ -97386,7 +98037,7 @@
 	tag = "icon-railing0 (NORTH)"
 	},
 /turf/simulated/floor/rock,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uAI" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/effect/floor_decal/spline/wood{
@@ -97451,12 +98102,12 @@
 "uBN" = (
 /obj/random/scrap/sparse_even/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uBQ" = (
 /obj/structure/table/steel,
 /obj/random/tool,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uBR" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -97671,7 +98322,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "uEG" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/machinery/light/floor,
@@ -97682,7 +98333,7 @@
 /obj/machinery/cash_register,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uEL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -97838,7 +98489,7 @@
 /obj/random/ammo,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "uGz" = (
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/asteroid/dirt,
@@ -97846,7 +98497,7 @@
 "uGJ" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uGM" = (
 /obj/structure/flora/small/grassa5,
 /obj/structure/railing{
@@ -97954,7 +98605,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "uHQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -98042,7 +98693,7 @@
 /obj/random/scrap/sparse_even/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "uIt" = (
 /obj/item/circuitboard/apc,
 /turf/simulated/floor/wood/wild4,
@@ -98230,7 +98881,7 @@
 /obj/random/traps/wire_splicing/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uKq" = (
 /obj/structure/bed/chair/custom/bar_special{
 	dir = 8
@@ -99130,7 +99781,7 @@
 "uRL" = (
 /obj/structure/sign/misc/rent,
 /turf/simulated/wall,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "uRM" = (
 /obj/random/scrap/sparse_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -99231,7 +99882,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uSM" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/white/orangecorner,
@@ -99283,6 +99934,10 @@
 /obj/structure/flora/small/bushc3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"uTo" = (
+/obj/random/junk/low_chance,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uTp" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/storage/lunchbox,
@@ -99321,7 +99976,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "uTM" = (
 /obj/structure/sign/warning/server_room,
 /turf/simulated/wall/r_wall,
@@ -99376,7 +100031,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "uUq" = (
 /obj/machinery/autolathe,
 /obj/machinery/light_switch{
@@ -99529,7 +100184,7 @@
 /area/nadezhda/medical/cryo)
 "uVB" = (
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "uVH" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
@@ -99886,7 +100541,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "uZB" = (
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
@@ -99903,7 +100558,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "uZN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -99990,6 +100645,11 @@
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/command/bridge)
+"vaM" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vaO" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -100262,7 +100922,7 @@
 /obj/random/lowkeyrandom/low_chance,
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "veL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -100681,7 +101341,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/moderate_weighted/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "viV" = (
 /turf/simulated/mineral,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -100762,7 +101422,7 @@
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/item/tool/hammer,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "vjs" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -100953,7 +101613,7 @@
 /obj/random/lowkeyrandom/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vlv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -101208,7 +101868,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "vnR" = (
 /obj/structure/salvageable/autolathe,
 /obj/effect/decal/cleanable/dirt,
@@ -101251,7 +101911,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vol" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/catwalk,
@@ -101347,6 +102007,11 @@
 /obj/item/storage/fancy/candle_box,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"vpC" = (
+/obj/machinery/door/airlock/maintenance_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "vpD" = (
 /obj/structure/toilet,
 /obj/effect/decal/cleanable/cobweb,
@@ -101386,7 +102051,7 @@
 "vqb" = (
 /obj/random/pack/machine,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "vqc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -101431,7 +102096,7 @@
 /obj/structure/largecrate,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vqv" = (
 /obj/machinery/door/window/southright{
 	icon_state = "left";
@@ -101467,6 +102132,21 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"vqJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfacesec)
 "vqK" = (
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
@@ -101604,7 +102284,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "vsF" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8;
@@ -101684,7 +102364,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "vtB" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -101929,7 +102609,7 @@
 /obj/structure/spider_nest,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "vvQ" = (
 /obj/random/medical/low_chance,
 /obj/random/medical/low_chance,
@@ -102154,7 +102834,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "vyx" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
@@ -102345,7 +103025,7 @@
 /obj/random/junk/nondense,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vBn" = (
 /obj/item/mop,
 /obj/effect/spider/stickyweb,
@@ -102371,7 +103051,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "vBR" = (
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/dirt/burned,
@@ -102790,7 +103470,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "vGd" = (
 /obj/machinery/repair_station,
 /obj/machinery/camera/network/research{
@@ -102989,7 +103669,7 @@
 /obj/random/common_oddities,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vIl" = (
 /obj/structure/table/standard,
 /obj/random/toolbox/low_chance,
@@ -103060,7 +103740,7 @@
 "vJx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vJA" = (
 /obj/random/scrap/sparse_even/low_chance,
 /turf/simulated/floor/carpet/bcarpet,
@@ -103079,12 +103759,12 @@
 /obj/random/closet_maintloot/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "vJI" = (
 /obj/structure/barricade,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "vJM" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -103114,7 +103794,7 @@
 /obj/random/booze/low_chance,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vKb" = (
 /obj/structure/bed/chair/sofa/black/right{
 	dir = 4
@@ -103279,7 +103959,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "vLq" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Core";
@@ -103521,7 +104201,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "vNA" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "13,15"
@@ -103538,7 +104218,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "vNE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -103571,6 +104251,10 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
+"vOq" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vOw" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
@@ -103588,7 +104272,7 @@
 "vOz" = (
 /obj/structure/table/bench/standard,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "vOG" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stack/material/glass/random,
@@ -103835,7 +104519,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vRo" = (
 /obj/structure/table/rack/shelf,
 /obj/random/ammo_lowcost/low_chance,
@@ -103847,7 +104531,7 @@
 /obj/random/toolbox/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vRp" = (
 /obj/machinery/chemical_dispenser,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -103969,7 +104653,7 @@
 /obj/random/cluster/spiders/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "vSu" = (
 /obj/structure/catwalk,
 /obj/structure/invislight,
@@ -103981,7 +104665,7 @@
 /obj/machinery/door/blast/shutters/glass,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vSx" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 5
@@ -104006,7 +104690,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "vSH" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/steel,
@@ -104168,6 +104852,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/command/panic_room)
+"vUf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "vUm" = (
 /obj/structure/table/marble,
 /obj/item/pen,
@@ -104462,7 +105150,12 @@
 /obj/item/storage/box/donkpockets,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
+"vWG" = (
+/obj/random/closet_maintloot,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vWN" = (
 /obj/machinery/light{
 	dir = 8
@@ -104513,7 +105206,7 @@
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vXi" = (
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -104737,7 +105430,7 @@
 /obj/random/cluster/termite_no_despawn/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "vZO" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "11,13"
@@ -104864,7 +105557,7 @@
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "wbe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -104979,7 +105672,7 @@
 /obj/random/gun_cheap/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wcl" = (
 /obj/structure/sign/faction/neotheology_cross/gold{
 	pixel_y = -32
@@ -105107,7 +105800,7 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "wdA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/marble,
@@ -105188,7 +105881,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/rock,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "weo" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -105233,7 +105926,7 @@
 /obj/structure/largecrate/animal/welder_roach,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "weN" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "7,9"
@@ -105251,7 +105944,7 @@
 /obj/structure/table/reinforced,
 /obj/random/material_resources/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "wfg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -105368,7 +106061,7 @@
 "wgw" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wgK" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -105403,7 +106096,7 @@
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "who" = (
 /obj/structure/sink{
 	dir = 1;
@@ -105430,7 +106123,7 @@
 /obj/structure/closet/crate/secure/large,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "whC" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security)
@@ -105505,7 +106198,7 @@
 /obj/structure/closet/crate/freezer/rations,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "whQ" = (
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/wood,
@@ -105528,7 +106221,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "wik" = (
 /obj/effect/spider/stickyweb,
 /mob/living/carbon/superior_animal/giant_spider/nurse,
@@ -105590,6 +106283,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/sec)
+"wiO" = (
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wiQ" = (
 /obj/structure/flora/small/busha2,
 /turf/unsimulated/wall/jungle,
@@ -105632,7 +106329,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wjx" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -105731,7 +106428,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "wkE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -105805,7 +106502,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wls" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/table/marble,
@@ -105829,7 +106526,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wlu" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /obj/effect/floor_decal/industrial/warningred{
@@ -106013,6 +106710,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"wnw" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wnI" = (
 /obj/machinery/firealarm{
 	pixel_y = 32
@@ -106035,6 +106737,10 @@
 /obj/random/gun_handmade/low_chance,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/outside/forest)
+"wob" = (
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/surfacesec)
 "wod" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/shuttle/floor/mining{
@@ -106048,13 +106754,13 @@
 /obj/structure/table/bench/steel,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "woj" = (
 /obj/structure/table/woodentable,
 /obj/machinery/librarypubliccomp,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wok" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -106075,7 +106781,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
+"woq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wot" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/asteroid/dirt/dark/plough,
@@ -106104,7 +106814,7 @@
 /obj/structure/disposalconstruct,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "woY" = (
 /obj/structure/closet/random_medsupply,
 /obj/effect/spider/stickyweb,
@@ -106223,7 +106933,7 @@
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wpw" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -106233,7 +106943,7 @@
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wpx" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /turf/simulated/open,
@@ -106453,7 +107163,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "wqZ" = (
 /obj/structure/table/standard,
 /obj/random/pack/tech_loot,
@@ -106555,7 +107265,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wrE" = (
 /obj/structure/bed/chair/sofa/black/right,
 /obj/effect/decal/cleanable/dirt,
@@ -106569,6 +107279,9 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
+"wrK" = (
+/turf/simulated/wall/r_wall,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wrL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -107021,7 +107734,7 @@
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wxx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood,
@@ -107084,7 +107797,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wyg" = (
 /obj/machinery/constructable_frame/machine_frame{
 	state = 2
@@ -107146,7 +107859,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wzj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -107200,6 +107913,10 @@
 /obj/item/towel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/medical/sleeper)
+"wzF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/surfaceeast)
 "wzG" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/atmospherics/unary/vent_pump,
@@ -107303,7 +108020,7 @@
 "wAs" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wAv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -107351,7 +108068,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "wBF" = (
 /obj/structure/railing{
 	dir = 4
@@ -107382,7 +108099,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wBQ" = (
 /obj/machinery/light,
 /obj/structure/cable/green,
@@ -107428,7 +108145,7 @@
 	tag = "icon-railing0 (WEST)"
 	},
 /turf/simulated/open,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wCg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -107522,7 +108239,7 @@
 /obj/random/cluster/termite_no_despawn/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wDe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/green{
@@ -107564,7 +108281,7 @@
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wDx" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
@@ -107656,6 +108373,9 @@
 /obj/item/storage/box/cdeathalarm_kit,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory_blackshield)
+"wEB" = (
+/turf/simulated/wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wED" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -107852,7 +108572,7 @@
 "wHj" = (
 /obj/random/scrap/sparse_weighted/low_chance,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wHn" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -107931,6 +108651,10 @@
 	icon_state = "8,0"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"wId" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wIh" = (
 /obj/structure/railing{
 	dir = 8
@@ -107944,7 +108668,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "wIu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -107964,8 +108688,13 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "wIx" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /turf/simulated/floor/wood/wild4,
@@ -108142,7 +108871,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "wKq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/shuttle/floor/mining{
@@ -108260,7 +108989,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "wLP" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/rocks3,
@@ -108278,7 +109007,7 @@
 	desc = "Filthy, stinking bilge water.";
 	name = "murky water"
 	},
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wLY" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/wood/wild3,
@@ -108291,7 +109020,7 @@
 "wMd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wMi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/damagedfloor/fire,
@@ -108355,7 +109084,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "wMO" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/box/masks,
@@ -108501,6 +109230,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"wOL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wOM" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/machinery/light/small,
@@ -108563,7 +109296,7 @@
 	},
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -108780,7 +109513,7 @@
 	},
 /obj/item/oddity/common/book_unholy/closed,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "wRO" = (
 /obj/structure/flora/big/rocks2,
 /obj/random/flora/jungle_tree,
@@ -108838,7 +109571,7 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "wSi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -108991,7 +109724,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "wUv" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet,
@@ -109014,7 +109747,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wUG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -109103,7 +109836,7 @@
 /obj/random/lowkeyrandom/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wVB" = (
 /turf/unsimulated/mineral/transition,
 /area/nadezhda/outside/forest)
@@ -109123,7 +109856,7 @@
 /obj/random/tool_upgrade/rare/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "wVH" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -109360,7 +110093,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/pouch/hardcase_scrap,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "wYd" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = -32
@@ -109563,7 +110296,7 @@
 /obj/random/rations/crayon,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xaF" = (
 /obj/random/oddity_guns,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -109669,7 +110402,7 @@
 /obj/random/tool_upgrade/rare,
 /obj/random/tool_upgrade/low_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "xbK" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/wild3,
@@ -109686,7 +110419,7 @@
 "xbU" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "xbV" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/industrial/hatch,
@@ -109712,7 +110445,7 @@
 "xci" = (
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xcG" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -109736,7 +110469,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xcR" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/small/busha1,
@@ -109787,7 +110520,7 @@
 /obj/random/techpart/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xdX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -109829,7 +110562,7 @@
 /obj/structure/catwalk,
 /obj/machinery/microwave/burnbarrel,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xeM" = (
 /obj/machinery/light{
 	dir = 4;
@@ -109871,7 +110604,7 @@
 "xff" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xfo" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/ausbushes/reedbush,
@@ -109901,7 +110634,7 @@
 /obj/item/clothing/accessory/medal/gold/heroism,
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/steel/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "xfH" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -109934,7 +110667,7 @@
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xfQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
@@ -110000,7 +110733,7 @@
 "xgq" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/white/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xgv" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/item/contraband/poster/placed/generic/no_erp{
@@ -110171,14 +110904,14 @@
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xib" = (
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "xii" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -110346,7 +111079,7 @@
 /area/nadezhda/outside/forest)
 "xjU" = (
 /turf/simulated/floor/tiled/dark/golden,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xkc" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
@@ -110535,7 +111268,7 @@
 /obj/item/stash_spawner,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xlt" = (
 /obj/effect/decal/cleanable/ash,
 /obj/random/mob/roaches/low_chance,
@@ -110584,6 +111317,15 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/teleporter)
+"xlX" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xlZ" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -110652,6 +111394,9 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security)
+"xmQ" = (
+/turf/simulated/wall/r_wall,
+/area/nadezhda/maintenance/surfaceeast)
 "xmY" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -110802,7 +111547,7 @@
 	name = "Valor Shop"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "xoR" = (
 /obj/structure/toilet,
 /turf/simulated/floor/tiled/steel/panels,
@@ -111303,6 +112048,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"xuh" = (
+/obj/random/junk/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xur" = (
 /obj/structure/table/glass,
 /obj/effect/spider/stickyweb,
@@ -111323,7 +112073,7 @@
 /turf/simulated/floor/tiled/steel/monofloor{
 	dir = 4
 	},
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "xuB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/arcade,
@@ -111430,7 +112180,7 @@
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xvO" = (
 /obj/structure/medical_stand,
 /obj/effect/decal/cleanable/dirt,
@@ -111694,7 +112444,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "xyt" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -112101,7 +112851,7 @@
 /obj/random/lowkeyrandom/low_chance,
 /obj/machinery/door/blast/shutters/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xBZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -112146,7 +112896,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xCl" = (
 /obj/structure/flora/big/bush2,
 /obj/effect/decal/cleanable/dirt,
@@ -112557,7 +113307,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xGz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
@@ -112755,7 +113505,7 @@
 /obj/structure/salvageable/computer,
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xIT" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -112821,7 +113571,7 @@
 /obj/structure/scrap/food/large,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xJA" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -112832,7 +113582,7 @@
 /obj/item/reagent_containers/food/snacks/bigroachburger,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xJC" = (
 /obj/random/furniture/pottedplant,
 /obj/effect/decal/cleanable/cobweb2,
@@ -113024,7 +113774,7 @@
 /obj/item/paper/crumpled,
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xLj" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -113033,7 +113783,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "xLm" = (
 /obj/structure/flora/big/bush1,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -113148,7 +113898,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/cluster/roaches/lower_chance,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/surface_maints_1)
+/area/nadezhda/maintenance/surfacenorth)
 "xMT" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
@@ -113304,7 +114054,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/random/junk,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xPt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -113346,7 +114096,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "xPO" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
@@ -113514,6 +114264,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/lab)
+"xRk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/surfaceeast)
 "xRp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -113653,12 +114408,12 @@
 	},
 /obj/structure/railing,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xSl" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xSm" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -113746,13 +114501,21 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xTm" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
+"xTs" = (
+/obj/machinery/door/airlock/maintenance_common,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xTx" = (
 /obj/machinery/camera/network/research{
 	dir = 8
@@ -113820,7 +114583,7 @@
 "xUC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xUJ" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Chemistry Lab";
@@ -113862,7 +114625,7 @@
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xVd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/airlock{
@@ -113922,7 +114685,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xVB" = (
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/beach/sand,
@@ -113974,7 +114737,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "xVT" = (
 /obj/structure/table/steel,
 /obj/item/oddity/common/paper_bundle{
@@ -114272,7 +115035,7 @@
 	name = "Tropical Shop"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1north)
+/area/nadezhda/maintenance/surfacesec)
 "xYY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -114325,7 +115088,7 @@
 /obj/random/gun_parts/low,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "xZK" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "11,0"
@@ -114355,6 +115118,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"xZU" = (
+/obj/structure/low_wall,
+/obj/item/material/shard,
+/turf/simulated/floor/plating,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "xZX" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -114422,6 +115190,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"yaJ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "yaQ" = (
 /obj/machinery/door/airlock/maintenance_engineering{
 	name = "Engineering Maintenance";
@@ -114504,7 +115279,7 @@
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ybE" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = 32
@@ -114617,7 +115392,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "ydj" = (
 /obj/machinery/multistructure/bioreactor_part/bioport,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -114715,6 +115490,11 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"yet" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2west)
 "yew" = (
 /obj/structure/sign/departmentold/viro1,
 /turf/simulated/wall/r_wall,
@@ -114751,7 +115531,7 @@
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "yeQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -114903,7 +115683,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
-/area/nadezhda/maintenance/undergroundfloor1east)
+/area/nadezhda/maintenance/surfaceeast)
 "yhg" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin,
@@ -115004,7 +115784,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor1west)
+/area/nadezhda/maintenance/undergroundfloor2west)
 "yhO" = (
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall,
@@ -115047,6 +115827,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/toilet/public)
+"yib" = (
+/obj/structure/table/standard,
+/obj/random/lowkeyrandom,
+/obj/item/clothing/head/ushanka,
+/obj/random/rations,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2north)
 "yii" = (
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
@@ -159455,9 +160243,9 @@ cZb
 cZb
 cZb
 cZb
-toi
-toi
-toi
+tvc
+tvc
+tvc
 cZb
 cZb
 cZb
@@ -159657,13 +160445,13 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 aiZ
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
 cZb
 cZb
 cZb
@@ -159859,13 +160647,13 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 xSk
-wUG
+yet
 rMp
-qPD
-mfF
-toi
+moz
+wnw
+tvc
 cZb
 cZb
 cZb
@@ -160061,13 +160849,13 @@ cZb
 cZb
 cZb
 cZb
-toi
-wUG
-wUG
-wUG
-qPD
-qPD
-toi
+tvc
+yet
+yet
+yet
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -160258,18 +161046,18 @@ cZb
 cZb
 cZb
 cZb
-toi
-toi
-toi
-toi
-toi
-toi
-ltj
-xEX
-xEX
-qPD
-qPD
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+gef
+owQ
+owQ
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -160460,7 +161248,7 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 hIV
 dGz
 txV
@@ -160468,10 +161256,10 @@ fTG
 wRL
 xUC
 fIz
-xEX
-qPD
-qPD
-toi
+owQ
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -160662,7 +161450,7 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 imd
 cKJ
 biW
@@ -160671,9 +161459,9 @@ fcF
 wDj
 qIk
 cge
-qPD
-qPD
-toi
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -160805,13 +161593,13 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
 cZb
 cZb
 cZb
@@ -160856,26 +161644,26 @@ tad
 tad
 cZb
 cZb
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 rjS
 emV
 sep
 fEp
 xUC
 joe
-xEX
-qPD
-mfF
-toi
+owQ
+moz
+wnw
+tvc
 cZb
 cZb
 cZb
@@ -161007,13 +161795,13 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 ign
-giu
-swg
-giu
+ehj
+yaJ
+ehj
 uyr
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -161058,15 +161846,15 @@ tad
 tad
 cZb
 cZb
-toi
+tvc
 lYu
 lYu
 eMN
-qPD
+moz
 mUG
-qPD
+moz
 lww
-toi
+tvc
 rRq
 xUC
 bTe
@@ -161075,9 +161863,9 @@ pFv
 xUC
 xUC
 qtP
-wUG
-wUG
-toi
+yet
+yet
+tvc
 cZb
 cZb
 cZb
@@ -161209,13 +161997,13 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 xIL
 ppD
 ucV
-gWi
+fLq
 dvZ
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -161260,15 +162048,15 @@ tad
 cZb
 cZb
 cZb
-toi
+tvc
 rbt
 rXr
 eMN
-qPD
+moz
 kkU
-qPD
+moz
 lZm
-toi
+tvc
 uci
 fPf
 xUC
@@ -161276,10 +162064,10 @@ xUC
 xUC
 ipl
 xUC
-upE
-wUG
-wUG
-toi
+sIs
+yet
+yet
+tvc
 cZb
 cZb
 cZb
@@ -161401,23 +162189,23 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
 cZb
 cZb
-uyF
+jdE
 kMW
 qDf
 xLg
-gWi
+fLq
 uvp
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -161462,15 +162250,15 @@ tad
 cZb
 cZb
 cZb
-toi
-toi
-toi
-toi
-qPD
+tvc
+tvc
+tvc
+tvc
+moz
 kkU
-qPD
+moz
 lZm
-toi
+tvc
 bpx
 qro
 xUC
@@ -161479,9 +162267,9 @@ xUC
 ipl
 aWq
 cge
-qPD
-qPD
-toi
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -161603,23 +162391,23 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 ift
-aYX
+svT
 qPW
 kEJ
 bBe
 wVF
-uyF
+jdE
 cZb
 cZb
-uyF
+jdE
 lMx
 voj
-gWi
-gWi
+fLq
+fLq
 svZ
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -161664,15 +162452,15 @@ tad
 cZb
 cZb
 cZb
-toi
+tvc
 lYu
 lYu
 eMN
-qPD
+moz
 kkU
-qPD
+moz
 lww
-toi
+tvc
 vGc
 fPf
 xUC
@@ -161680,10 +162468,10 @@ xUC
 ipl
 xUC
 tCk
-xEX
-qPD
-qPD
-toi
+owQ
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -161805,30 +162593,30 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 oXZ
-djf
+lxT
 hTo
 nYf
 wjw
 rNi
-uyF
+jdE
 cZb
 cZb
-uyF
+jdE
 lMx
-gWi
+fLq
 wCS
-giu
+ehj
 uvp
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
 cZb
 cZb
 cZb
@@ -161866,15 +162654,15 @@ tad
 cZb
 cZb
 cZb
-toi
+tvc
 rbt
 rXr
 eMN
-qPD
+moz
 kkU
-mfF
-toi
-toi
+wnw
+tvc
+tvc
 ipl
 mwd
 eAH
@@ -161883,9 +162671,9 @@ xUC
 xUC
 wgw
 cge
-qPD
-qPD
-toi
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -162007,30 +162795,30 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 sLt
-giu
-mHH
-giu
-giu
+ehj
+rEq
+ehj
+ehj
 nlv
-uyF
+jdE
 cZb
 cZb
-uyF
-uyF
-giu
-giu
-uyF
-uyF
-uyF
+jdE
+jdE
+ehj
+ehj
+jdE
+jdE
+jdE
 kiY
 qlF
 qlF
 nxZ
 nxZ
 aEB
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -162068,15 +162856,15 @@ tad
 cZb
 cZb
 cZb
-toi
-toi
-toi
-toi
-qPD
+tvc
+tvc
+tvc
+tvc
+moz
 kkU
-qPD
+moz
 lww
-toi
+tvc
 pYK
 tJh
 goG
@@ -162084,10 +162872,10 @@ iHZ
 xUC
 xUC
 rNV
-xEX
-qPD
-mfF
-toi
+owQ
+moz
+wnw
+tvc
 cZb
 cZb
 cZb
@@ -162102,15 +162890,15 @@ cZb
 cZb
 cZb
 cZb
-bbA
-bbA
-bbA
-bbA
-bbA
-bbA
-bbA
-bbA
-bbA
+nVR
+nVR
+nVR
+nVR
+nVR
+nVR
+nVR
+nVR
+nVR
 cZb
 cZb
 cZb
@@ -162209,30 +162997,30 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 rNi
-giu
-giu
+ehj
+ehj
 gcp
-giu
+ehj
 ekn
-uyF
+jdE
 cZb
 cZb
 cZb
-uyF
+jdE
 jud
-giu
-uyF
+ehj
+jdE
 cZb
-uyF
+jdE
 nzm
 gRx
 gRx
 aga
 gRx
 thO
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -162270,26 +163058,26 @@ tad
 cZb
 cZb
 cZb
-toi
+tvc
 lYu
 lYu
 eMN
-qPD
+moz
 kkU
-qPD
+moz
 lZm
-toi
+tvc
 qMx
-wCl
+tCv
 eWg
-toi
+tvc
 bzM
 xUC
 nrv
-toi
-qPD
-qPD
-toi
+tvc
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -162304,15 +163092,15 @@ cZb
 cZb
 cZb
 cZb
-bbA
-bbA
-bbA
-bbA
-bbA
-bbA
-bbA
-bbA
-bbA
+nVR
+nVR
+nVR
+nVR
+nVR
+nVR
+nVR
+nVR
+nVR
 cZb
 cZb
 cZb
@@ -162411,30 +163199,30 @@ cZb
 kUx
 kUx
 cZb
-uyF
+jdE
 rNi
-giu
-giu
-giu
-giu
+ehj
+ehj
+ehj
+ehj
 xdW
-uyF
+jdE
 cZb
 cZb
 cZb
-uyF
+jdE
 dfE
-giu
-uyF
+ehj
+jdE
 cZb
-uyF
+jdE
 tTv
 gRx
 odW
 mOS
 kBP
 dYl
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -162472,26 +163260,26 @@ tad
 cZb
 cZb
 cZb
-toi
+tvc
 rbt
 rXr
 eMN
-qPD
+moz
 kkU
-qPD
+moz
 lZm
-toi
+tvc
 hWt
-wCl
-wCl
-toi
+tCv
+tCv
+tvc
 woj
 bUG
 fUS
-toi
-qPD
-qPD
-toi
+tvc
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -162506,15 +163294,15 @@ cZb
 cZb
 cZb
 cZb
-bbA
-bbA
+nVR
+nVR
 kvZ
 laQ
 kPw
 jXO
 qUD
-bbA
-bbA
+nVR
+nVR
 cZb
 cZb
 cZb
@@ -162606,37 +163394,37 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
 jWM
-spU
-uyF
-uyF
-uyF
+lga
+jdE
+jdE
+jdE
 sIp
-npt
+aqF
 sIp
 sIp
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-giu
-giu
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+ehj
+ehj
+jdE
+jdE
+jdE
 iRA
 gRx
 gRx
 mfD
 aga
 suG
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -162674,26 +163462,26 @@ tad
 cZb
 cZb
 cZb
-toi
-toi
-toi
-toi
-qPD
-qPD
-qPD
+tvc
+tvc
+tvc
+tvc
+moz
+moz
+moz
 lww
-toi
+tvc
 eJW
 tXG
 bIg
-toi
+tvc
 jMB
 tWS
 oJS
 hkL
-qPD
-qPD
-toi
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -162708,15 +163496,15 @@ cZb
 cZb
 cZb
 cZb
-bbA
-bbA
+nVR
+nVR
 jSD
 dDr
 xjU
 dDr
 gJN
-bbA
-bbA
+nVR
+nVR
 cZb
 cZb
 cZb
@@ -162808,29 +163596,29 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 crl
 pYF
 gXs
-vtI
-oLR
-gHn
+ruK
+vaM
+aIA
 wpu
-hZc
-fLN
-hZc
+erK
+uyN
+erK
 oGO
-fLN
-fLN
+uyN
+uyN
 fAn
-giu
+ehj
 uZx
-giu
-giu
-giu
-giu
-vkB
-hMJ
+ehj
+ehj
+ehj
+ehj
+msL
+xTs
 mfy
 gRx
 bhd
@@ -162838,7 +163626,7 @@ dmq
 bhd
 uSK
 suG
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -162878,24 +163666,24 @@ cZb
 cZb
 cZb
 cZb
-toi
-toi
+tvc
+tvc
 pbq
 pbq
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-qPD
-qPD
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -162910,21 +163698,21 @@ cZb
 cZb
 cZb
 cZb
-bbA
-bbA
+nVR
+nVR
 ndk
 dDr
 rUO
 dDr
 qzr
-bbA
-bbA
-toi
-toi
-toi
-toi
-toi
-toi
+nVR
+nVR
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 cZb
 cZb
 cZb
@@ -163010,29 +163798,29 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 ruq
 jiD
 iEz
-hZc
-rDo
+erK
+qqy
 dtq
-vtI
-vtI
-hZc
-fLN
-hZc
-fLN
-fLN
-fLN
-mHH
-whp
-giu
-giu
-giu
-giu
-vkB
-nJt
+ruK
+ruK
+erK
+uyN
+erK
+uyN
+uyN
+uyN
+rEq
+eVo
+ehj
+ehj
+ehj
+ehj
+msL
+dZS
 kSv
 gRx
 bhd
@@ -163040,7 +163828,7 @@ bhd
 bhd
 bhd
 nKf
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -163080,24 +163868,24 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 eRg
-qPD
-qPD
+moz
+moz
 oMa
 oMa
 oMa
 oMa
 oMa
-toi
+tvc
 cgk
 xSl
 ize
-toi
-toi
-qPD
-qPD
-toi
+tvc
+tvc
+moz
+moz
+tvc
 cZb
 cZb
 cZb
@@ -163112,21 +163900,21 @@ cZb
 cZb
 cZb
 cZb
-bbA
-bbA
+nVR
+nVR
 gKU
 dDr
 eHP
 dDr
 gKU
-bbA
-bbA
-toi
+nVR
+nVR
+tvc
 whi
 twD
 twD
 iRz
-toi
+tvc
 cZb
 cZb
 cZb
@@ -163212,37 +164000,37 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
-uyF
-uyF
-uyF
-arU
-uyF
-uyF
-mVM
-mVM
-kla
-mVM
-mVM
-kla
-uyF
-giu
-whp
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
+fTV
+jdE
+jdE
+hjD
+hjD
+edR
+hjD
+hjD
+edR
+jdE
+ehj
+eVo
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
 iRA
 gRx
 beb
 rQX
 gRx
 thO
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -163282,53 +164070,53 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 vOz
-qPD
-qPD
+moz
+moz
 oMa
 ueA
 nhi
 nhi
 oMa
-toi
+tvc
 cgk
-nho
+vUf
 taE
-toi
-toi
-qPD
-qPD
-toi
+tvc
+tvc
+moz
+moz
+tvc
 cZb
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-cZb
-cZb
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 cZb
 cZb
 cZb
-bbA
-bbA
+cZb
+cZb
+nVR
+nVR
 gKU
 dDr
 xjU
 dDr
 gKU
-bbA
-bbA
-toi
+nVR
+nVR
+tvc
 ltu
 fHz
 fHz
 fHz
-toi
+tvc
 cZb
 cZb
 cZb
@@ -163420,31 +164208,31 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
+jdE
+jdE
 dAn
 pzz
-sJn
-sJn
-fLN
-fLN
-uyF
-giu
-whp
-uyF
-uyF
+sEL
+sEL
+uyN
+uyN
+jdE
+ehj
+eVo
+jdE
+jdE
 sPL
 avT
 nir
 tYH
-uyF
+jdE
 tGI
 kBP
 ipK
 gRx
 gRx
 xBX
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -163484,53 +164272,53 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 sIz
-qPD
-qPD
+moz
+moz
 oMa
 pAK
 pAK
 pAK
 pky
-toi
-nho
-nho
-nho
-toi
-toi
-qPD
-mfF
-toi
+tvc
+vUf
+vUf
+vUf
+tvc
+tvc
+moz
+wnw
+tvc
 cZb
-toi
+tvc
 mVR
 mVR
 uTs
 ybB
 drr
 mVR
-toi
+tvc
 cZb
 cZb
 cZb
 cZb
 cZb
-bbA
-bbA
-bbA
+nVR
+nVR
+nVR
 bFQ
 kxs
 vqb
-bbA
-bbA
-bbA
-toi
+nVR
+nVR
+nVR
+tvc
 sDt
 tHK
 pAk
 gcP
-toi
+tvc
 cZb
 cZb
 cZb
@@ -163622,31 +164410,31 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
-uyF
-qDG
+jdE
+jdE
+jdE
+xZU
 nYV
-wwP
-sXV
-uyF
-uyF
-giu
-whp
-lIt
+vOq
+iss
+jdE
+jdE
+ehj
+eVo
+pnm
 sBo
-gWi
-gWi
-gWi
-gWi
-uyF
+fLq
+fLq
+fLq
+fLq
+jdE
 tGI
 gRx
 ipK
 kBP
 gRx
 qnl
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -163686,53 +164474,53 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 vOz
-qPD
-qPD
+moz
+moz
 oMa
 wLS
 wLS
 wLS
 oMa
-toi
+tvc
 cgk
 oMh
 cxr
-toi
-toi
-qPD
-qPD
-toi
+tvc
+tvc
+moz
+moz
+tvc
 cZb
-toi
+tvc
 mVR
-nho
-nho
-nho
-nho
+vUf
+vUf
+vUf
+vUf
 qaN
-toi
+tvc
 cZb
 cZb
 cZb
 cZb
 cZb
-bbA
-bbA
-bbA
-bbA
+nVR
+nVR
+nVR
+nVR
 mJq
-bbA
-bbA
-bbA
-bbA
-toi
+nVR
+nVR
+nVR
+nVR
+tvc
 tHK
 ltu
 tHK
 tHK
-toi
+tvc
 cZb
 cZb
 cZb
@@ -163824,7 +164612,7 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 nCS
 gPj
 aTu
@@ -163832,23 +164620,23 @@ hsD
 aUF
 sKZ
 pDi
-uyF
-giu
-whp
+jdE
+ehj
+eVo
 cAb
 sBo
-gWi
+fLq
 xaC
 pGe
-gWi
-uyF
+fLq
+jdE
 rNB
 vSw
 rQX
 gRx
 gkw
 rNB
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -163863,18 +164651,18 @@ cZb
 cZb
 cZb
 cZb
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 cZb
 cZb
 cZb
@@ -163888,53 +164676,53 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 eRg
-qPD
-qPD
+moz
+moz
 oMa
 oMa
 oMa
 oMa
 oMa
-toi
+tvc
 cgk
-nho
+vUf
 taE
-toi
-toi
-qPD
-qPD
-toi
+tvc
+tvc
+moz
+moz
+tvc
 cZb
-toi
-nho
+tvc
+vUf
 oMh
 oMh
 pVX
 tns
-nho
-toi
+vUf
+tvc
 cZb
 cZb
 cZb
 cZb
 cZb
-bbA
-bbA
-bbA
-bbA
+nVR
+nVR
+nVR
+nVR
 qTn
-bbA
-bbA
-bbA
-bbA
-toi
+nVR
+nVR
+nVR
+nVR
+tvc
 hNp
 hNp
 hNp
 hNp
-toi
+tvc
 cZb
 cZb
 cZb
@@ -164026,31 +164814,31 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 aGj
 cQF
-hoa
+hLg
 gVE
 guN
 aOE
 pio
-uyF
-giu
-whp
-cCQ
+jdE
+ehj
+eVo
+gUk
 sBo
-gWi
+fLq
 pGe
 wVy
-gWi
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
+fLq
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
 cZb
 cZb
 cZb
@@ -164065,7 +164853,7 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 iWX
 lTZ
 reI
@@ -164076,80 +164864,80 @@ oIC
 iXN
 fuU
 daI
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
 cZb
 cZb
 cZb
 cZb
-toi
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 pbq
 pbq
-toi
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 iGB
-toi
-toi
-toi
+tvc
+tvc
+tvc
 clH
 clH
-toi
-toi
-toi
-xEX
-xEX
+tvc
+tvc
+tvc
+owQ
+owQ
 cig
 cig
-xEX
-xEX
-toi
-toi
-toi
-toi
-toi
-toi
-bbA
-bbA
-bbA
-bbA
+owQ
+owQ
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+nVR
+nVR
+nVR
+nVR
 mJq
-bbA
-bbA
-bbA
-bbA
-toi
+nVR
+nVR
+nVR
+nVR
+tvc
 byD
 byD
 byD
 byD
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 cZb
-toi
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 cZb
 cZb
 cZb
@@ -164228,7 +165016,7 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 aGj
 oIL
 dcW
@@ -164236,23 +165024,23 @@ nyu
 oXa
 gRx
 cTG
-uyF
-giu
-whp
+jdE
+ehj
+eVo
 xci
 sBo
-gWi
+fLq
 vlr
 kxR
-gWi
+fLq
 uEK
-giu
-uyF
+ehj
+jdE
 kaV
 ksW
 whM
 sFL
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -164267,7 +165055,7 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 iWX
 rAz
 vSC
@@ -164278,80 +165066,80 @@ rAz
 rAz
 rAz
 vSC
-toi
+tvc
 ksk
 ksk
 ksk
-toi
+tvc
 cZb
 cZb
 cZb
-toi
-toi
-tVT
-tVT
-tVT
-tVT
+tvc
+tvc
+fQx
+fQx
+fQx
+fQx
 jFr
-tVT
-tVT
-tVT
-tVT
+fQx
+fQx
+fQx
+fQx
 iPu
 iPu
 ydc
 iPu
-tVT
-tVT
-tVT
-tVT
-tVT
+fQx
+fQx
+fQx
+fQx
+fQx
 jFr
-tVT
-tVT
+fQx
+fQx
 jFr
-tVT
-tVT
-tVT
-tVT
-tVT
-tVT
-tVT
-tVT
-tVT
+fQx
+fQx
+fQx
+fQx
+fQx
+fQx
+fQx
+fQx
+fQx
 jFr
-tVT
-tVT
-tVT
-tVT
+fQx
+fQx
+fQx
+fQx
 jFr
-tVT
-tVT
-tVT
-tVT
-tVT
-tVT
+fQx
+fQx
+fQx
+fQx
+fQx
+fQx
 jFr
-tVT
-tVT
-tVT
-tVT
-tVT
-tVT
-tVT
-tVT
-tVT
-tVT
+fQx
+fQx
+fQx
+fQx
+fQx
+fQx
+fQx
+fQx
+fQx
+fQx
 jFr
-toi
-toi
-toi
+tvc
+tvc
+tvc
 feQ
 feQ
 rMA
 feQ
 feQ
-toi
+tvc
 cZb
 cZb
 cZb
@@ -164430,7 +165218,7 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 aGj
 mGZ
 cvw
@@ -164438,23 +165226,23 @@ qvc
 jJX
 aga
 aoZ
-uyF
-giu
-whp
-uyF
-uyF
-gWi
+jdE
+ehj
+eVo
+jdE
+jdE
+fLq
 pGe
 vlr
-gWi
+fLq
 dVy
 wjw
-uyF
+jdE
 vJx
 vZK
 bli
 dRK
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -164469,7 +165257,7 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 qGe
 lTZ
 vSC
@@ -164484,33 +165272,20 @@ cIc
 vnO
 tQD
 xTl
-toi
+tvc
 cZb
 cZb
-toi
-toi
+tvc
+tvc
 jFr
-tVT
+fQx
 feQ
 feQ
 feQ
 feQ
 feQ
-tVT
-tVT
-feQ
-feQ
-feQ
-feQ
-feQ
-feQ
-feQ
-feQ
-feQ
-feQ
-feQ
-tVT
-tVT
+fQx
+fQx
 feQ
 feQ
 feQ
@@ -164522,9 +165297,8 @@ feQ
 feQ
 feQ
 feQ
-feQ
-tVT
-tVT
+fQx
+fQx
 feQ
 feQ
 feQ
@@ -164537,24 +165311,38 @@ feQ
 feQ
 feQ
 feQ
-tVT
-tVT
+fQx
+fQx
 feQ
 feQ
 feQ
 feQ
 feQ
-tVT
-tVT
-toi
-toi
+feQ
+feQ
+feQ
+feQ
+feQ
+feQ
+feQ
+fQx
+fQx
+feQ
+feQ
+feQ
+feQ
+feQ
+fQx
+fQx
+tvc
+tvc
 jlG
 jlG
 jlG
 jlG
 jlG
-toi
-toi
+tvc
+tvc
 cZb
 cZb
 cZb
@@ -164632,7 +165420,7 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 fMv
 gRx
 woX
@@ -164640,23 +165428,23 @@ uKl
 pmL
 tqt
 qiH
-uyF
-giu
+jdE
+ehj
 fPb
-uyF
-uyF
-gWi
+jdE
+jdE
+fLq
 dVy
 sex
-gWi
-hkB
-giu
-uyF
+fLq
+kBB
+ehj
+jdE
 vJx
 bli
 rlx
 qjV
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -164671,7 +165459,7 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 gaK
 vSC
 xGy
@@ -164686,12 +165474,12 @@ jBN
 dmz
 nim
 cpl
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
 xeC
-tVT
+fQx
 hvQ
 kuc
 kuc
@@ -164747,8 +165535,8 @@ kuc
 kuc
 kuc
 cgf
-tVT
-tVT
+fQx
+fQx
 mrL
 duc
 duc
@@ -164756,7 +165544,7 @@ duc
 duc
 duc
 qEf
-toi
+tvc
 cZb
 cZb
 cZb
@@ -164834,7 +165622,7 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 dkX
 big
 aTu
@@ -164842,23 +165630,23 @@ aTu
 irE
 rBY
 gVr
-uyF
-giu
-whp
-fLN
+jdE
+ehj
+eVo
+uyN
 pOx
-gWi
-gWi
-gWi
-gWi
-gWi
-gWi
+fLq
+fLq
+fLq
+fLq
+fLq
+fLq
 dMP
 bli
 rlx
 bli
-hoa
-uyF
+hLg
+jdE
 cZb
 cZb
 cZb
@@ -164873,7 +165661,7 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 qpp
 vSC
 vSC
@@ -164950,15 +165738,15 @@ kuc
 kuc
 kuc
 lVf
-tVT
-toi
+fQx
+tvc
 tlu
 fCA
 fCA
 fCA
 fCA
 dhY
-toi
+tvc
 cZb
 cZb
 cZb
@@ -165034,32 +165822,32 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-giu
-whp
-fLN
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+ehj
+eVo
+uyN
 pOx
-gWi
-gWi
+fLq
+fLq
 wCS
-gWi
-gWi
-gWi
+fLq
+fLq
+fLq
 dMP
 bli
 bli
-hoa
-rDs
+hLg
+gfo
 cZb
 cZb
 cZb
@@ -165075,7 +165863,7 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 lrR
 vSC
 vvL
@@ -165094,7 +165882,7 @@ ibt
 wxS
 nng
 rpR
-tVT
+fQx
 klf
 kuc
 kuc
@@ -165152,7 +165940,7 @@ kuc
 kuc
 kuc
 lVf
-tVT
+fQx
 wAs
 fCA
 fCA
@@ -165160,7 +165948,7 @@ fCA
 fCA
 fCA
 nEz
-toi
+tvc
 cZb
 cZb
 cZb
@@ -165236,33 +166024,33 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uFL
-giu
-giu
-swg
-giu
-giu
-esy
-uyF
+jdE
+vWG
+ehj
+ehj
+yaJ
+ehj
+ehj
+klR
+jdE
 eRD
 bcp
-giu
+ehj
 fPb
-uyF
-uyF
-gWi
+jdE
+jdE
+fLq
 lOY
-czH
-gWi
-czH
-gWi
-uyF
+ilZ
+fLq
+ilZ
+fLq
+jdE
 whB
 glY
 bli
-hoa
-rDo
+hLg
+qqy
 cZb
 cZb
 cZb
@@ -165277,7 +166065,7 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 lrR
 vSC
 vSC
@@ -165296,7 +166084,7 @@ hDr
 kpI
 fOO
 rpR
-tVT
+fQx
 klf
 kuc
 kuc
@@ -165354,7 +166142,7 @@ kuc
 kuc
 kuc
 lVf
-tVT
+fQx
 wAs
 fCA
 fCA
@@ -165362,7 +166150,7 @@ fCA
 fCA
 fCA
 xVq
-toi
+tvc
 cZb
 cZb
 cZb
@@ -165433,38 +166221,38 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uFL
-giu
-giu
-giu
-giu
-giu
-esy
-uyF
-xEb
-uyF
-giu
-whp
-uyF
-uyF
-gWi
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+vWG
+ehj
+ehj
+ehj
+ehj
+ehj
+klR
+jdE
+inL
+jdE
+ehj
+eVo
+jdE
+jdE
+fLq
 jsX
 pdx
-gWi
+fLq
 pDD
-gWi
-uyF
+fLq
+jdE
 whB
 bli
 rlx
 oZD
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -165479,7 +166267,7 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 iWC
 vSC
 iCU
@@ -165498,7 +166286,7 @@ wPq
 bBQ
 cZl
 iQp
-tVT
+fQx
 klf
 kuc
 kuc
@@ -165556,15 +166344,15 @@ kuc
 kuc
 kuc
 lVf
-tVT
-toi
+fQx
+tvc
 tlu
 fCA
 fCA
 fCA
 fCA
 aoQ
-toi
+tvc
 cZb
 cZb
 cZb
@@ -165624,49 +166412,49 @@ tad
 tad
 tad
 cZb
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
 tMc
-gWi
+fLq
 bTy
 chM
-uyF
-uyF
-mVM
-uyF
-lIt
-esy
-giu
-giu
+jdE
+jdE
+hjD
+jdE
+pnm
+klR
+ehj
+ehj
 owb
-giu
-uyF
-giu
-whp
+ehj
+jdE
+ehj
+eVo
 rtf
 sBo
-gWi
+fLq
 gJy
 ies
-gWi
+fLq
 ghL
-gWi
+fLq
 xff
 vJx
 bli
 bli
 ifA
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -165681,7 +166469,7 @@ cZb
 cZb
 cZb
 cZb
-toi
+tvc
 daI
 vSC
 reI
@@ -165696,12 +166484,12 @@ cIc
 iri
 nim
 fvy
-toi
-toi
-toi
-toi
-tVT
-tVT
+tvc
+tvc
+tvc
+tvc
+fQx
+fQx
 ork
 kuc
 kuc
@@ -165757,8 +166545,8 @@ kuc
 kuc
 kuc
 rYq
-tVT
-tVT
+fQx
+fQx
 mrL
 duc
 duc
@@ -165766,7 +166554,7 @@ duc
 duc
 duc
 qEX
-toi
+tvc
 cZb
 cZb
 cZb
@@ -165826,49 +166614,49 @@ tad
 tad
 tad
 cZb
-uyF
+jdE
 wck
 qkw
 ueC
-uyF
+jdE
 ntp
-giu
-crk
-hXc
+ehj
+qEK
+yib
 ixJ
 fzz
-uyF
+jdE
 qoj
-gWi
-tJo
+fLq
+gJS
 psc
-uyF
-uyF
-wYR
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-giu
-whp
+jdE
+jdE
+iIm
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+ehj
+eVo
 xci
 sBo
-gWi
+fLq
 ifj
 mbU
-gWi
+fLq
 bbI
-gWi
+fLq
 xff
 vJx
 bli
 bli
 gjz
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -165883,12 +166671,12 @@ cZb
 cZb
 cZb
 cZb
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 oCR
 nne
 nne
@@ -165898,47 +166686,20 @@ jjs
 coy
 ebP
 nim
-toi
+tvc
 cZb
 cZb
-toi
-toi
+tvc
+tvc
 wlq
-tVT
+fQx
 fPH
 fPH
 fPH
 fPH
 fPH
-tVT
-tVT
-fPH
-fPH
-fPH
-fPH
-fPH
-fPH
-fPH
-fPH
-fPH
-fPH
-fPH
-tVT
-tVT
-fPH
-fPH
-fPH
-fPH
-fPH
-fPH
-tVT
-tVT
-tVT
-tVT
-fPH
-fPH
-tVT
-tVT
+fQx
+fQx
 fPH
 fPH
 fPH
@@ -165950,25 +166711,52 @@ fPH
 fPH
 fPH
 fPH
-fPH
-tVT
-tVT
-fPH
+fQx
+fQx
 fPH
 fPH
 fPH
 fPH
-tVT
-tVT
-toi
-toi
+fPH
+fPH
+fQx
+fQx
+fQx
+fQx
+fPH
+fPH
+fQx
+fQx
+fPH
+fPH
+fPH
+fPH
+fPH
+fPH
+fPH
+fPH
+fPH
+fPH
+fPH
+fPH
+fQx
+fQx
+fPH
+fPH
+fPH
+fPH
+fPH
+fQx
+fQx
+tvc
+tvc
 gPR
 gPR
 gPR
 gPR
 gPR
-toi
-toi
+tvc
+tvc
 cZb
 cZb
 cZb
@@ -166028,49 +166816,49 @@ tad
 tad
 tad
 cZb
-uyF
+jdE
 szr
-giu
-giu
+ehj
+ehj
 fre
-giu
-gWi
+ehj
+fLq
 dMr
-gWi
+fLq
 syU
 mfK
-uyF
+jdE
 hDF
-gWi
-gWi
+fLq
+fLq
 jtL
-uyF
-uyF
-giu
+jdE
+jdE
+ehj
 vBk
-rPb
-uyF
+gcJ
+jdE
 cAO
-ooF
-gWi
-uyF
+rVY
+fLq
+jdE
 sYW
-giu
+ehj
 xCk
-cCQ
+gUk
 sBo
-gWi
+fLq
 aMZ
 pCS
-gWi
+fLq
 qbJ
-gWi
+fLq
 xff
 vJx
 bli
 bli
 pqe
-uyF
+jdE
 cZb
 qBg
 qBg
@@ -166090,86 +166878,86 @@ qBg
 rLm
 rLm
 rLm
-toi
-toi
+tvc
+tvc
 keE
 uUm
 iWX
 daI
-toi
+tvc
 ksk
 daI
 daI
-toi
+tvc
 cZb
 cZb
 cZb
-toi
-toi
-tVT
-tVT
-tVT
-tVT
+tvc
+tvc
+fQx
+fQx
+fQx
+fQx
 wlq
-tVT
+fQx
 cGn
-fgA
-fgA
-fgA
-fgA
+cpj
+cpj
+cpj
+cpj
 qtC
-fgA
-fgA
-fgA
-fgA
-fgA
-fgA
+cpj
+cpj
+cpj
+cpj
+cpj
+cpj
 qtC
-fgA
-fgA
+cpj
+cpj
 qtC
-fgA
-fgA
+xlX
+pxX
 bpd
-fgA
-fgA
-fgA
-fgA
-fgA
-fgA
-fgA
-fgA
-fgA
-fgA
-fgA
+cpj
+cpj
+cpj
+cpj
+cpj
+cpj
+cpj
+cpj
+cpj
+cpj
+cpj
 qtC
-fgA
-fgA
-fgA
-fgA
+cpj
+cpj
+cpj
+cpj
 bpd
-fgA
+cpj
 qtC
-fgA
-fgA
-fgA
-fgA
+cpj
+cpj
+cpj
+cpj
 uEF
-tVT
-tVT
-tVT
-tVT
-tVT
+fQx
+fQx
+fQx
+fQx
+fQx
 wlq
-toi
-toi
-toi
+tvc
+tvc
+tvc
 wBL
 wBL
 wBL
 wBL
 wBL
-toi
+tvc
 cZb
 cZb
 cZb
@@ -166230,49 +167018,49 @@ tad
 tad
 tad
 cZb
-uyF
+jdE
 alk
-giu
+ehj
 ixJ
 fre
-giu
-gWi
+ehj
+fLq
 igt
 hAn
 qUH
-cUq
+ruz
 hIW
-giu
-gWi
+ehj
+fLq
 rgZ
 pdp
-uyF
-uyF
+jdE
+jdE
 gVQ
-giu
+ehj
 vBk
-uyF
+jdE
 elH
-gWi
-gWi
+fLq
+fLq
 aAR
-aWM
-giu
-whp
-lIt
+rdu
+ehj
+eVo
+pnm
 sBo
-gWi
-gWi
-gWi
-gWi
-gWi
-gWi
+fLq
+fLq
+fLq
+fLq
+fLq
+fLq
 xff
 vJx
 bli
 bli
 vJx
-uyF
+jdE
 cZb
 qBg
 hEq
@@ -166293,51 +167081,51 @@ prf
 lHL
 rLm
 rLm
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 cZb
 cZb
 cZb
 cZb
-toi
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 eEi
 jvp
-toi
-toi
+tvc
+tvc
 jvp
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
 wAs
 wAs
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 bGn
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
 oOA
 wRG
 htd
@@ -166348,30 +167136,30 @@ htd
 htd
 htd
 htd
-toi
-toi
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 ojP
-toi
+tvc
 mrL
 kVN
 boU
 mrL
-toi
-toi
+tvc
+tvc
 cZb
-toi
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 cZb
 cZb
 cZb
@@ -166432,49 +167220,49 @@ tad
 tad
 tad
 cZb
-uyF
+jdE
 aPb
 gPI
 kQX
-fgl
+wrK
 hDe
 hlf
 hRc
 aWy
-gWi
+fLq
 iVs
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uFL
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+vWG
 cdE
-giu
-uyF
+ehj
+jdE
 qSb
 hlf
-gWi
+fLq
 shu
-aWM
-giu
+rdu
+ehj
 xCk
-uyF
-uyF
+jdE
+jdE
 bXN
 bNV
 aDo
 soz
 qsO
 gqx
-uyF
+jdE
 vqs
 weI
 gLT
 hGu
-uyF
+jdE
 cZb
 qBg
 aKu
@@ -166516,21 +167304,21 @@ gco
 gco
 gco
 gqf
-iRW
-qPD
-toi
-rgF
-qPD
-qPD
-bvv
-toi
+eQp
+moz
+tvc
+tSD
+moz
+moz
+hYl
+tvc
 kOQ
 cgl
 fCA
 fCA
 fCA
 nLn
-toi
+tvc
 cZb
 cZb
 gQD
@@ -166550,21 +167338,21 @@ uIy
 eie
 wHW
 htd
-toi
-toi
+tvc
+tvc
 ght
 ght
 ght
 gJz
 wMd
-toi
-iRW
-toi
+tvc
+eQp
+tvc
 woh
 kQM
 kQM
 woh
-toi
+tvc
 cZb
 cZb
 cZb
@@ -166634,49 +167422,49 @@ tad
 tad
 tad
 cZb
-uyF
-uyF
-uyF
-uyF
-uyF
-pUr
-gWi
-gWi
-gWi
-tJo
+jdE
+jdE
+jdE
+jdE
+jdE
+tyl
+fLq
+fLq
+fLq
+gJS
 qIL
-uyF
-uFL
+jdE
+vWG
 sbJ
 pGw
 cQj
-uyF
-uyF
+jdE
+jdE
 hsg
-giu
-giu
-uyF
+ehj
+ehj
+jdE
 qrF
-gWi
-gWi
+fLq
+fLq
 tgW
-aWM
-giu
-whp
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
+rdu
+ehj
+eVo
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
 cZb
 qBg
 mwY
@@ -166718,21 +167506,21 @@ gco
 xwY
 oVn
 gqf
-iRW
-qPD
-toi
-rgF
-qPD
-qPD
+eQp
+moz
+tvc
+tSD
+moz
+moz
 nPw
-toi
+tvc
 kOQ
 fCA
 gsX
 fCA
 fCA
 nLn
-toi
+tvc
 vFB
 vFB
 fUl
@@ -166752,21 +167540,21 @@ fam
 uaD
 uaD
 jkA
-toi
-toi
+tvc
+tvc
 aVr
 wMd
 wMd
 wMd
 wMd
 qUp
-fjM
-toi
+noE
+tvc
 cyq
 sxC
 sxC
 kQv
-toi
+tvc
 cZb
 cZb
 cZb
@@ -166836,35 +167624,35 @@ tad
 tad
 tad
 cZb
-uyF
+jdE
 lym
-giu
+ehj
 iod
-uyF
+jdE
 iQK
-giu
-giu
+ehj
+ehj
 tPV
-giu
-giu
+ehj
+ehj
 nhG
-giu
-gWi
-tJo
-gWi
-uyF
-uyF
+ehj
+fLq
+gJS
+fLq
+jdE
+jdE
 vRo
-giu
-giu
-wYR
-gWi
-gWi
-gWi
+ehj
+ehj
+iIm
+fLq
+fLq
+fLq
 uGJ
-aWM
-giu
-whp
+rdu
+ehj
+eVo
 xff
 fhg
 tfp
@@ -166872,12 +167660,12 @@ dhp
 jEe
 dox
 icg
-sXV
+iss
 bxS
 xJA
 pRb
 jyz
-uyF
+jdE
 cZb
 cZb
 qBg
@@ -166921,20 +167709,20 @@ hAc
 nDm
 sOE
 oak
-qPD
-toi
-ryb
-qPD
-qPD
+moz
+tvc
+xuh
+moz
+moz
 gaF
-toi
+tvc
 kOQ
 fCA
 iJe
 iJe
 fCA
 mPq
-toi
+tvc
 cZb
 cZb
 fUl
@@ -166954,21 +167742,21 @@ fam
 hxa
 hxa
 jkA
-toi
-toi
+tvc
+tvc
 wMd
 tWD
 wMd
 wMd
 wMd
-toi
+tvc
 ufz
-toi
+tvc
 eZt
 rnD
 rnD
 rnD
-toi
+tvc
 cZb
 cZb
 cZb
@@ -167038,35 +167826,35 @@ tad
 tad
 tad
 cZb
-uyF
+jdE
 cWl
 taZ
 lum
-uyF
-uyF
+jdE
+jdE
 xcM
-uyF
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
 lqI
-tJo
-gWi
+gJS
+fLq
 muN
-uyF
-uyF
+jdE
+jdE
 vRo
-giu
+ehj
 vBk
-uyF
+jdE
 ekd
 eFu
 dmw
-uyF
+jdE
 tMn
-giu
-whp
+ehj
+eVo
 xff
 bli
 tfp
@@ -167074,12 +167862,12 @@ taS
 naR
 dox
 bli
-sXV
+iss
 okY
 bdK
 twi
 kXw
-uyF
+jdE
 cZb
 cZb
 qBg
@@ -167124,19 +167912,19 @@ gco
 gqf
 hME
 nPw
-toi
-bvv
-qPD
-qPD
+tvc
+hYl
+moz
+moz
 ubv
-toi
+tvc
 kyH
 fCA
 fCA
 fCA
 fCA
 mXL
-toi
+tvc
 iGz
 iGz
 iGz
@@ -167156,21 +167944,21 @@ cYw
 hxa
 eWC
 vXQ
-toi
-toi
+tvc
+tvc
 peQ
-toi
+tvc
 peQ
-toi
+tvc
 peQ
-toi
+tvc
 ojP
-toi
+tvc
 wrD
 wrD
 esG
 esG
-toi
+tvc
 cZb
 cZb
 cZb
@@ -167240,35 +168028,35 @@ tad
 tad
 tad
 cZb
-uyF
+jdE
 qra
-giu
+ehj
 lum
-uyF
-uyF
-she
+jdE
+jdE
+qVC
 qoV
 qLH
 aPb
 aPb
-uyF
+jdE
 mcC
 mPs
 mcC
 mcC
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-giu
-whp
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+ehj
+eVo
 xff
 vJx
 vJx
@@ -167276,12 +168064,12 @@ vJx
 vJx
 pab
 vJx
-uyF
-qCS
-qCS
-qCS
-qCS
-uyF
+jdE
+qKX
+qKX
+qKX
+qKX
+jdE
 cZb
 cZb
 qBg
@@ -167319,26 +168107,26 @@ hIO
 hIO
 iJO
 gco
-wne
-wne
-toi
-wne
-toi
+aDK
+aDK
+tvc
+aDK
+tvc
 hME
-rgF
-toi
-toi
-toi
-toi
-toi
-toi
-toi
+tSD
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 kOQ
 kOQ
 kOQ
 kOQ
-toi
-toi
+tvc
+tvc
 mul
 hVz
 lia
@@ -167358,21 +168146,21 @@ htd
 tbO
 htd
 htd
-toi
-toi
+tvc
+tvc
 lnk
-toi
+tvc
 xln
-toi
+tvc
 lui
-toi
+tvc
 szO
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 cZb
 cZb
 cZb
@@ -167442,48 +168230,48 @@ tad
 tad
 tad
 cZb
-uyF
-uyF
-kuz
-uyF
-uyF
-uyF
+jdE
+jdE
+pVq
+jdE
+jdE
+jdE
 geg
 pVT
-giu
+ehj
 xvL
 tpV
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-giu
-jzN
-giu
-cUq
-cUq
-giu
-giu
-giu
-giu
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+ehj
+hNs
+ehj
+ruz
+ruz
+ehj
+ehj
+ehj
+ehj
 xgq
 bli
 bli
 bli
 rWZ
-uyF
+jdE
 cZb
 cZb
 qBg
@@ -167527,7 +168315,7 @@ dkM
 fvE
 dkM
 gzW
-qPD
+moz
 hVm
 ubv
 jZr
@@ -167560,12 +168348,12 @@ inE
 qeA
 qeA
 htd
-toi
-toi
-toi
-toi
-toi
-toi
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 rWi
 rWi
 hoc
@@ -167644,48 +168432,48 @@ tad
 tad
 tad
 cZb
-rDo
+qqy
 uAe
-wXd
-wXd
-wXd
-wXd
-cPt
-gWi
+wOL
+wOL
+wOL
+wOL
+upT
+fLq
 cdE
-giu
-giu
-giu
-giu
+ehj
+ehj
+ehj
+ehj
 cdE
-giu
-giu
-giu
+ehj
+ehj
+ehj
 uvb
-giu
-giu
+ehj
+ehj
 ixQ
 gPO
 uvb
-giu
-giu
-giu
-giu
-cUq
+ehj
+ehj
+ehj
+ehj
+ruz
 fEU
-cUq
-giu
-cUq
-rPb
-rPb
-giu
-giu
+ruz
+ehj
+ruz
+gcJ
+gcJ
+ehj
+ehj
 xgq
 bli
 bli
 mHk
-qCS
-uyF
+qKX
+jdE
 cZb
 cZb
 qBg
@@ -167723,16 +168511,16 @@ xlu
 xlu
 vNA
 gco
-wne
-wne
-toi
-wne
-toi
+aDK
+aDK
+tvc
+aDK
+tvc
 dJy
-qPD
+moz
 hVm
-rgF
-qPD
+tSD
+moz
 cIj
 kal
 xhw
@@ -167847,47 +168635,47 @@ tad
 tad
 cZb
 cZb
-rDo
+qqy
 xPq
 qhC
-sJn
-sJn
-sJn
-sJn
-phG
+sEL
+sEL
+sEL
+sEL
+agq
 wxt
 fRx
 cdE
 uvb
 tPV
-giu
-giu
+ehj
+ehj
 cdE
-giu
-giu
-giu
-giu
-giu
-giu
-giu
-giu
+ehj
+ehj
+ehj
+ehj
+ehj
+ehj
+ehj
+ehj
 uvb
-giu
-cUq
+ehj
+ruz
 pYz
-uyF
-uyF
-uyF
-uyF
-uyF
-giu
-giu
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
+ehj
+ehj
+jdE
 ftd
-qCS
-qCS
+qKX
+qKX
 cWO
-uyF
+jdE
 cZb
 cZb
 qBg
@@ -167929,11 +168717,11 @@ kUx
 kUx
 kUx
 kUx
-toi
+tvc
 uIn
-qPD
+moz
 hVm
-rgF
+tSD
 jsf
 hxe
 kal
@@ -168049,47 +168837,47 @@ tad
 tad
 cZb
 cZb
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
 bLg
 ufR
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-giu
-whp
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+ehj
+eVo
+jdE
 cZb
 cZb
 cZb
-uyF
-giu
-giu
-sXV
+jdE
+ehj
+ehj
+iss
 vWE
-qCS
-qCS
+qKX
+qKX
 oGv
-uyF
+jdE
 cZb
 cZb
 qBg
@@ -168131,12 +168919,12 @@ cZb
 cZb
 cZb
 cZb
-toi
-rIX
-qPD
+tvc
+bJv
+moz
 hVm
 ubv
-qPD
+moz
 xZw
 kal
 xhw
@@ -168264,10 +169052,10 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
 cZb
 cZb
 cZb
@@ -168276,22 +169064,22 @@ cZb
 cZb
 cZb
 cZb
-uyF
-giu
-whp
-uyF
+jdE
+ehj
+eVo
+jdE
 cZb
 cZb
 cZb
-uyF
-giu
-giu
-sXV
+jdE
+ehj
+ehj
+iss
 exY
 iNP
 sBa
-uyF
-uyF
+jdE
+jdE
 cZb
 cZb
 qBg
@@ -168333,13 +169121,13 @@ cZb
 cZb
 cZb
 kUx
-toi
+tvc
 iKt
-qww
-toi
-toi
+vpC
+tvc
+tvc
 jvp
-toi
+tvc
 kal
 xhw
 owy
@@ -168478,21 +169266,21 @@ cZb
 cZb
 cZb
 cZb
-uyF
-giu
-whp
-uyF
+jdE
+ehj
+eVo
+jdE
 cZb
 cZb
 cZb
-uyF
-giu
-xEb
-uyF
-uyF
-uyF
-uyF
-uyF
+jdE
+ehj
+inL
+jdE
+jdE
+jdE
+jdE
+jdE
 cZb
 cZb
 cZb
@@ -168535,11 +169323,11 @@ cZb
 cZb
 cZb
 kUx
-bvv
+hYl
 qXD
-qPD
+moz
 jvp
-qPD
+moz
 saI
 aYR
 kal
@@ -168680,17 +169468,17 @@ cZb
 cZb
 cZb
 cZb
-uyF
-giu
-whp
-uyF
+jdE
+ehj
+eVo
+jdE
 cZb
 cZb
 cZb
-uyF
-giu
-rPb
-uyF
+jdE
+ehj
+gcJ
+jdE
 cZb
 cZb
 cZb
@@ -168737,12 +169525,12 @@ cZb
 cZb
 cZb
 kUx
-bvv
+hYl
 qXD
 jZr
-toi
+tvc
 gaF
-wUG
+yet
 eQt
 kal
 xhw
@@ -168882,17 +169670,17 @@ cZb
 cZb
 cZb
 cZb
-uyF
-giu
-whp
-uyF
+jdE
+ehj
+eVo
+jdE
 cZb
 cZb
 cZb
-uyF
-giu
-giu
-uyF
+jdE
+ehj
+ehj
+jdE
 cZb
 cZb
 cZb
@@ -168939,12 +169727,12 @@ cZb
 cZb
 cZb
 kUx
-bvv
+hYl
 qXD
-bvv
+hYl
 hVm
-rgF
-wUG
+tSD
+yet
 dLt
 kal
 oFU
@@ -169084,17 +169872,17 @@ cZb
 cZb
 cZb
 cZb
-uyF
-giu
-whp
-uyF
+jdE
+ehj
+eVo
+jdE
 cZb
 cZb
 cZb
-uyF
-giu
-giu
-uyF
+jdE
+ehj
+ehj
+jdE
 cZb
 cZb
 cZb
@@ -169141,11 +169929,11 @@ cZb
 cZb
 cZb
 kUx
-kEu
+ojh
 qXD
-bvv
+hYl
 hVm
-rgF
+tSD
 ktA
 uGt
 kal
@@ -169282,21 +170070,21 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
-uyF
-uyF
-uyF
-giu
+jdE
+jdE
+jdE
+jdE
+jdE
+ehj
 fPb
-uyF
+jdE
 cZb
 cZb
 cZb
-uyF
-giu
-vtI
-rDo
+jdE
+ehj
+ruK
+qqy
 cZb
 cZb
 cZb
@@ -169343,12 +170131,12 @@ bbV
 bbV
 bbV
 bbV
-jyb
+jae
 qXD
-bvv
+hYl
 hVm
-rgF
-wUG
+tSD
+yet
 tKy
 kal
 drw
@@ -169484,21 +170272,21 @@ cZb
 cZb
 cZb
 cZb
-uyF
+jdE
 nNw
 pXD
 mDf
-uyF
-giu
-whp
-uyF
+jdE
+ehj
+eVo
+jdE
 cZb
 cZb
 cZb
-uyF
-hoa
-rDo
-arU
+jdE
+hLg
+qqy
+fTV
 cZb
 cZb
 cZb
@@ -169545,12 +170333,12 @@ aUP
 gZm
 juq
 bbV
-kEu
+ojh
 qXD
-bvv
+hYl
 hVm
-rgF
-wUG
+tSD
+yet
 juA
 kal
 jAb
@@ -169675,32 +170463,32 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
 cZb
-uyF
+jdE
 rtf
-fLN
-fLN
+uyN
+uyN
 bcp
-giu
-whp
-uyF
+ehj
+eVo
+jdE
 cZb
 cZb
 cZb
-uyF
-giu
-vtI
-uyF
+jdE
+ehj
+ruK
+jdE
 cZb
 cZb
 cZb
@@ -169749,8 +170537,8 @@ ulO
 dQk
 mfq
 rVr
-toi
-toi
+tvc
+tvc
 aYR
 jgv
 qTZ
@@ -169877,32 +170665,32 @@ cZb
 cZb
 cZb
 cZb
-uyF
-giu
-giu
-giu
-giu
+jdE
+ehj
+ehj
+ehj
+ehj
 taZ
-giu
-giu
-giu
-uyF
+ehj
+ehj
+ehj
+jdE
 cZb
-uyF
+jdE
 fmo
 uBQ
 kQt
-sXV
+iss
 bne
 txW
-uyF
+jdE
 cZb
 cZb
 cZb
-uyF
-rPb
-giu
-uyF
+jdE
+gcJ
+ehj
+jdE
 cZb
 cZb
 cZb
@@ -169949,12 +170737,12 @@ bJk
 gVA
 rwW
 crq
-rIX
-qPD
+bJv
+moz
 jvp
-qPD
-qPD
-qPD
+moz
+moz
+moz
 qNO
 kal
 goC
@@ -170079,32 +170867,32 @@ cZb
 cZb
 cZb
 cZb
-uyF
-cUq
-cUq
-giu
+jdE
+ruz
+ruz
+ehj
 dub
 gPP
 gPP
 gPP
 fmp
-uyF
-uyF
-uyF
-sXV
-sXV
-sXV
-sXV
+jdE
+jdE
+jdE
+iss
+iss
+iss
+iss
 jxb
-uyF
-uyF
+jdE
+jdE
 cZb
 cZb
 cZb
-uyF
-giu
-giu
-uyF
+jdE
+ehj
+ehj
+jdE
 cZb
 cZb
 dPU
@@ -170153,11 +170941,11 @@ qqw
 crq
 eAu
 baW
-toi
-toi
+tvc
+tvc
 hVm
 hVm
-toi
+tvc
 sqp
 bhp
 ajH
@@ -170278,35 +171066,35 @@ cZb
 cZb
 cZb
 cZb
-uyF
-uyF
-uyF
-uyF
-giu
-giu
-uyF
+jdE
+jdE
+jdE
+jdE
+ehj
+ehj
+jdE
 nge
 kQJ
-uyF
-giu
+jdE
+ehj
 wUF
-uyF
-utf
+jdE
+aIL
 ndm
 kRg
-she
-she
-she
-dky
-uyF
+qVC
+qVC
+qVC
+fvA
+jdE
 cZb
 cZb
 cZb
 cZb
-uyF
-giu
-xEb
-uyF
+jdE
+ehj
+inL
+jdE
 cZb
 cZb
 dPU
@@ -170355,11 +171143,11 @@ ftA
 rMT
 iXj
 qLn
-qPD
-qPD
-qPD
-eYg
-qPD
+moz
+moz
+moz
+bvT
+moz
 dxx
 cnB
 tQe
@@ -170480,35 +171268,35 @@ cZb
 cZb
 cZb
 cZb
-uyF
-giu
-giu
-giu
-giu
-giu
-uyF
+jdE
+ehj
+ehj
+ehj
+ehj
+ehj
+jdE
 wUF
-giu
-uyF
-giu
+ehj
+jdE
+ehj
 wUF
-uyF
-utf
-utf
+jdE
+aIL
+aIL
 wCd
 wCd
 wCd
 fnE
-nFR
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-giu
-giu
-uyF
+kiU
+jdE
+jdE
+jdE
+jdE
+jdE
+jdE
+ehj
+ehj
+jdE
 cZb
 cZb
 dPU
@@ -170557,11 +171345,11 @@ dmW
 bbV
 doY
 sCW
-qPD
-qPD
-bvv
-rgF
-kEu
+moz
+moz
+hYl
+tSD
+ojh
 sqp
 hBY
 plB
@@ -170683,34 +171471,34 @@ tJI
 tJI
 tJI
 tJI
-giu
-giu
-giu
-giu
-xEb
-uyF
+ehj
+ehj
+ehj
+ehj
+inL
+jdE
 wUF
-xEb
-uyF
-giu
+inL
+jdE
+ehj
 wUF
-uyF
-uyF
-utf
-utf
-utf
-utf
+jdE
+jdE
+aIL
+aIL
+aIL
+aIL
 kLb
 cus
 ihJ
 jcx
 ihJ
 lrH
-uyF
-fLN
-giu
-giu
-uyF
+jdE
+uyN
+ehj
+ehj
+jdE
 cZb
 cZb
 dPU
@@ -170885,34 +171673,34 @@ bBf
 bbJ
 wgu
 tJI
-uyF
-uyF
+jdE
+jdE
 kBO
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
 wUF
-giu
-uyF
-giu
+ehj
+jdE
+ehj
 ofj
-giu
-uyF
-uyF
-utf
-utf
-utf
+ehj
+jdE
+jdE
+aIL
+aIL
+aIL
 kLb
 pnK
 bCo
 wCd
 lOO
-nFR
+kiU
 cBF
-fLN
-giu
-cCQ
-uyF
+uyN
+ehj
+gUk
+jdE
 cZb
 cZb
 dPU
@@ -171090,31 +171878,31 @@ tJI
 xJy
 xJy
 cww
-qCS
+qKX
 nzg
-uyF
+jdE
 nDA
-giu
-uyF
-giu
+ehj
+jdE
+ehj
 ofj
-cUq
-giu
-uyF
-utf
-utf
-utf
-utf
-utf
+ruz
+ehj
+jdE
+aIL
+aIL
+aIL
+aIL
+aIL
 lSS
-utf
+aIL
 kLb
-dky
-uyF
-uyF
-uyF
-uyF
-uyF
+fvA
+jdE
+jdE
+jdE
+jdE
+jdE
 cZb
 cZb
 cZb
@@ -171302,17 +172090,17 @@ oVA
 luf
 qGo
 ugN
-uyF
-utf
-utf
-utf
+jdE
+aIL
+aIL
+aIL
 kLb
-utf
-utf
-utf
+aIL
+aIL
+aIL
 kLb
 mqL
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -171492,7 +172280,7 @@ yaf
 dwu
 tJI
 vWE
-qCS
+qKX
 mRr
 sIK
 cWO
@@ -171501,20 +172289,20 @@ sGN
 sMk
 wlx
 oVA
-fgl
-giu
+wrK
+ehj
 wUF
-uyF
-utf
-utf
-utf
+jdE
+aIL
+aIL
+aIL
 kLb
 pnK
 lSS
-utf
+aIL
 kLb
 itA
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -171703,20 +172491,20 @@ mHN
 gqo
 ukU
 oVA
-fgl
-giu
+wrK
+ehj
 wUF
-uyF
+jdE
 hpQ
-utf
-utf
+aIL
+aIL
 kLb
 cDg
 lSS
-utf
+aIL
 kLb
 tHq
-uyF
+jdE
 cZb
 cZb
 cZb
@@ -171905,27 +172693,27 @@ wEG
 aBb
 oVA
 oVA
-fgl
-giu
+wrK
+ehj
 wUF
-uyF
+jdE
 fsO
-utf
-utf
+aIL
+aIL
 kLb
 cDg
 lSS
-utf
+aIL
 kLb
-nFR
-uyF
+kiU
+jdE
 cZb
 cZb
 cZb
 cZb
-lTx
-vtB
-nFD
+cVs
+bRx
+sTL
 cZb
 cZb
 cZb
@@ -172107,29 +172895,29 @@ dEo
 jrH
 oua
 oVA
-fgl
-giu
+wrK
+ehj
 wUF
-uyF
-sJn
-utf
-utf
+jdE
+sEL
+aIL
+aIL
 kLb
 cDg
 lSS
-utf
+aIL
 kLb
-nFR
-uyF
+kiU
+jdE
 cZb
 cZb
 cZb
 cZb
-nFD
-vtB
-vtB
-vtB
-nFD
+sTL
+bRx
+bRx
+bRx
+sTL
 cZb
 cZb
 dPU
@@ -172309,30 +173097,30 @@ klG
 cEb
 mrJ
 oVA
-fgl
-giu
+wrK
+ehj
 wUF
-uyF
-utf
-utf
+jdE
+aIL
+aIL
 itl
 nYA
 cDg
 lPz
 itl
 nYA
-nFR
-uyF
+kiU
+jdE
 cZb
 cZb
 cZb
 cZb
-vtB
-vtB
-vtB
-vtB
-vtB
-nFD
+bRx
+bRx
+bRx
+bRx
+bRx
+sTL
 cZb
 dPU
 dPU
@@ -172511,30 +173299,30 @@ cQm
 aeQ
 sTK
 oVA
-fgl
-giu
+wrK
+ehj
 wUF
-uyF
-utf
-she
-she
-she
-she
-she
-she
-she
-nFR
-uyF
+jdE
+aIL
+qVC
+qVC
+qVC
+qVC
+qVC
+qVC
+qVC
+kiU
+jdE
 cZb
 cZb
 cZb
-lTx
-vtB
-xuK
-vtB
-vtB
-vtB
-vtB
+cVs
+bRx
+lhN
+bRx
+bRx
+bRx
+bRx
 cZb
 cZb
 mpm
@@ -172713,29 +173501,29 @@ cQm
 tCF
 oVA
 oVA
-fgl
-giu
+wrK
+ehj
 wUF
-uyF
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
 cBF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
 jxb
-uyF
-uyF
-uyF
-uyF
-uyF
+jdE
+jdE
+jdE
+jdE
+jdE
 weg
-xuK
-xuK
-vtB
-kXs
+lhN
+lhN
+bRx
+wId
 cZb
 cZb
 cZb
@@ -172915,32 +173703,32 @@ fHy
 cmr
 oVA
 oVA
-fgl
-cUq
+wrK
+ruz
 ofj
-giu
-giu
-giu
-giu
-giu
-giu
-giu
-giu
-giu
-tQg
-huF
-huF
-huF
-huF
-huF
+ehj
+ehj
+ehj
+ehj
+ehj
+ehj
+ehj
+ehj
+ehj
+nSk
+kid
+kid
+kid
+kid
+kid
 kku
 uAD
 gQj
 weg
-lTx
-kUx
-kUx
-kUx
+cVs
+jdE
+jdE
+jdE
 mpm
 yky
 wpL
@@ -173117,8 +173905,8 @@ fHy
 aeQ
 sTK
 oVA
-fgl
-giu
+wrK
+ehj
 lxA
 gPP
 gPP
@@ -173136,13 +173924,13 @@ gPP
 gNV
 gPP
 cOL
-huF
-huF
-huF
-huF
-huF
-huF
-huF
+kid
+kid
+kid
+kid
+kid
+kid
+kid
 bwm
 jRm
 wpL
@@ -173319,27 +174107,27 @@ aEz
 npm
 mrJ
 oVA
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
-fgl
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
+wrK
 wUF
 vXg
-lTx
+cVs
 erG
 erG
 erG
@@ -173538,9 +174326,9 @@ fXW
 fXW
 fXW
 fXW
-fgl
+wrK
 wUF
-giu
+ehj
 hgw
 erG
 tYL
@@ -173740,10 +174528,10 @@ ojR
 emz
 eXt
 fXW
-fgl
+wrK
 wUF
-giu
-giu
+ehj
+ehj
 mAG
 muH
 vLM
@@ -173942,10 +174730,10 @@ olE
 olE
 hIk
 fXW
-fgl
+wrK
 wUF
-giu
-xEb
+ehj
+inL
 erG
 ahp
 iCG
@@ -174144,9 +174932,9 @@ qgc
 fce
 fvK
 fXW
-fgl
+wrK
 wUF
-giu
+ehj
 rbV
 erG
 kAI
@@ -174346,10 +175134,10 @@ qgc
 oON
 deH
 fXW
-fgl
+wrK
 wUF
 vXg
-vtB
+bRx
 erG
 erG
 erG
@@ -174548,11 +175336,11 @@ qgc
 oON
 iWn
 fXW
-fgl
+wrK
 wUF
 vXg
-vtB
-lTx
+bRx
+cVs
 cZb
 hSX
 hSX
@@ -174750,12 +175538,12 @@ bXM
 bXM
 deH
 fXW
-fgl
+wrK
 wUF
 vXg
-vtB
-vtB
-xuK
+bRx
+bRx
+lhN
 hSX
 oBH
 qoF
@@ -174952,12 +175740,12 @@ hMc
 wlR
 pOV
 fXW
-fgl
+wrK
 wUF
 vXg
-vtB
-vtB
-xuK
+bRx
+bRx
+lhN
 hSX
 mAq
 ghp
@@ -175154,12 +175942,12 @@ fXW
 juZ
 urz
 fXW
-fgl
+wrK
 wUF
 vXg
-vtB
-vtB
-lTx
+bRx
+bRx
+cVs
 hSX
 fZb
 ghp
@@ -175356,11 +176144,11 @@ tPi
 rmU
 tPi
 tPi
-fgl
+wrK
 wUF
 vXg
-vtB
-lTx
+bRx
+cVs
 cZb
 hSX
 jAk
@@ -175558,11 +176346,11 @@ fTX
 skX
 mKQ
 tPi
-fgl
+wrK
 ceJ
 vXg
-vtB
-vtB
+bRx
+bRx
 cZb
 hSX
 aJw
@@ -175760,12 +176548,12 @@ pNJ
 skX
 pqS
 tPi
-fgl
+wrK
 wUF
 vXg
-vtB
-vtB
-lTx
+bRx
+bRx
+cVs
 hSX
 xyV
 xsM
@@ -175962,11 +176750,11 @@ gdo
 sXk
 fCw
 tPi
-fgl
+wrK
 wUF
 vXg
-vtB
-vtB
+bRx
+bRx
 cZb
 hSX
 hev
@@ -176164,12 +176952,12 @@ qxe
 skX
 lfW
 tPi
-fgl
+wrK
 wUF
 vXg
-vtB
-vtB
-vtB
+bRx
+bRx
+bRx
 hSX
 rtx
 cvn
@@ -176366,12 +177154,12 @@ vwc
 skX
 qyF
 tPi
-fgl
+wrK
 wUF
 vXg
-vtB
-vtB
-lTx
+bRx
+bRx
+cVs
 hSX
 lHG
 ghp
@@ -176568,11 +177356,11 @@ uFm
 xSd
 luN
 tPi
-fgl
+wrK
 wUF
 vXg
-vtB
-vtB
+bRx
+bRx
 cZb
 hSX
 nyO
@@ -176770,12 +177558,12 @@ vtG
 tPi
 tPi
 tPi
-fgl
+wrK
 wUF
 vXg
-vtB
-vtB
-xuK
+bRx
+bRx
+lhN
 hSX
 ebQ
 ncE
@@ -176971,13 +177759,13 @@ tit
 ile
 vHW
 tPi
-fgl
-giu
+wrK
+ehj
 ofj
-cUq
+ruz
 rgS
-vtB
-lTx
+bRx
+cVs
 jnW
 hSX
 hSX
@@ -177173,11 +177961,11 @@ fTX
 qAY
 qAY
 tPi
-fgl
-bXH
+wrK
+hrD
 ofj
-cUq
-giu
+ruz
+ehj
 oNS
 oNS
 oNS
@@ -177375,11 +178163,11 @@ tit
 rVN
 aBe
 tPi
-fgl
-giu
+wrK
+ehj
 ofj
-cUq
-giu
+ruz
+ehj
 oNS
 bfj
 hIw
@@ -182013,15 +182801,15 @@ nHw
 tEv
 bUJ
 bUJ
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
 cZb
 cZb
 mpm
@@ -182214,7 +183002,7 @@ kyy
 wuC
 xjL
 bUJ
-saK
+sju
 bZg
 iyV
 osU
@@ -182416,7 +183204,7 @@ syK
 qGA
 ocF
 bUJ
-saK
+sju
 wzg
 fyR
 czY
@@ -182618,15 +183406,15 @@ kyy
 mYN
 tbh
 bUJ
-saK
+sju
 jlC
 gmJ
-iBY
-iBY
-iBY
-iBY
-iBY
-iBY
+snr
+snr
+snr
+snr
+snr
+snr
 dTV
 bbM
 bbM
@@ -182820,14 +183608,14 @@ lfO
 wuC
 kGI
 bUJ
-saK
+sju
 bHP
-tFo
+hLD
 xfM
 kvp
-mcl
-mcl
-mcl
+wEB
+wEB
+wEB
 vpF
 vpF
 tJd
@@ -183022,12 +183810,12 @@ bUJ
 bUJ
 bUJ
 bUJ
-saK
+sju
 erT
-tFo
+hLD
 wHj
 mFb
-mcl
+wEB
 cZb
 cZb
 vpF
@@ -183226,10 +184014,10 @@ bUJ
 bUJ
 bUJ
 erT
-tFo
-fWY
-mcl
-mcl
+hLD
+uTo
+wEB
+wEB
 cZb
 cZb
 vpF
@@ -183430,7 +184218,7 @@ tMv
 jwo
 uko
 uBN
-kUx
+wEB
 cZb
 cZb
 cZb
@@ -183630,9 +184418,9 @@ ubE
 ubE
 jtG
 erT
-tFo
-fWY
-kUx
+hLD
+uTo
+wEB
 cZb
 cZb
 cZb
@@ -183830,11 +184618,11 @@ noA
 noA
 cZb
 cZb
-mcl
+wEB
 erT
-tFo
+hLD
 uBN
-kUx
+wEB
 cZb
 cZb
 cZb
@@ -184034,12 +184822,12 @@ noA
 noA
 vyU
 erT
-tFo
-fWY
-mcl
-mcl
-mcl
-mcl
+hLD
+uTo
+wEB
+wEB
+wEB
+wEB
 vpF
 vpF
 vpF
@@ -184237,7 +185025,7 @@ lqm
 tvD
 axr
 wlt
-bRx
+czY
 czY
 czY
 czY
@@ -184437,17 +185225,17 @@ lZp
 tTJ
 cOu
 qxL
-iBY
-iBY
-ifQ
+snr
+snr
+snr
 qkG
-mcl
-mcl
-mcl
-mcl
-mcl
-iBY
-iBY
+wEB
+wEB
+wEB
+wEB
+wEB
+snr
+snr
 bHX
 jrR
 kSX
@@ -184639,17 +185427,17 @@ noA
 noA
 noA
 vyU
-mcl
-mcl
+wEB
+wEB
 fUO
-mcl
-mcl
-mcl
+wEB
+wEB
+wEB
 iuN
 iuN
-mcl
+wEB
 cqW
-iBY
+snr
 bHX
 rfK
 kSX
@@ -184839,19 +185627,19 @@ kAc
 lMj
 noA
 hrq
-rRp
-lST
-lST
-lST
-lST
-lST
-lST
+mmu
+sCI
+sCI
+sCI
+sCI
+sCI
+sCI
 jjN
 iiK
 pij
-mcl
+wEB
 cPl
-iBY
+snr
 bHX
 hmx
 kSX
@@ -185041,19 +185829,19 @@ wUx
 eoM
 noA
 nJN
-rRp
-lST
+mmu
+sCI
 bLr
 bLr
-lST
-lST
+sCI
+sCI
 nJN
-mcl
+wEB
 sXR
 hbo
-mcl
+wEB
 kgw
-iBY
+snr
 bHX
 iGS
 kSX
@@ -185244,24 +186032,24 @@ noA
 noA
 eYQ
 bog
-lST
+sCI
 poA
 rAc
-dIM
-lST
+nsq
+sCI
 spn
-mcl
+wEB
 tgt
-kBV
-mcl
+woq
+wEB
 xia
-iBY
+snr
 vRn
 czY
 czY
 czY
 czY
-czY
+ulm
 czY
 czY
 czY
@@ -185443,34 +186231,34 @@ cZb
 cZb
 cZb
 cZb
-mcl
+wEB
 nxf
-rRp
-lST
+mmu
+sCI
 aaA
 bOq
-dIM
-lST
+nsq
+sCI
 fUL
-mcl
+wEB
 nEP
-kBV
-mcl
-sqb
-iBY
-iBY
-iBY
-tUH
-iBY
-tUH
-oOw
-iBY
-iBY
-tUH
-iBY
-iBY
-oOw
-iBY
+woq
+wEB
+oaQ
+snr
+snr
+snr
+lTo
+snr
+lTo
+qBj
+snr
+snr
+lTo
+snr
+snr
+qBj
+snr
 vpF
 whU
 dWf
@@ -185645,34 +186433,34 @@ cZb
 cZb
 cZb
 cZb
-mcl
+wEB
 fUL
 bog
-lST
-uZI
-uZI
+sCI
+hFL
+hFL
 qki
-lST
+sCI
 fUL
-mcl
+wEB
 uhP
 vIi
-mcl
-mcl
-iBY
-iBY
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
+wEB
+wEB
+snr
+snr
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
 vpF
 vpF
 vpF
@@ -185847,23 +186635,23 @@ cZb
 cZb
 cZb
 cZb
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
 rKK
 pOR
-mcl
+wEB
 cZb
 cZb
 cZb
@@ -186058,14 +186846,14 @@ cZb
 cZb
 cZb
 cZb
-mcl
-mcl
-mcl
-mcl
-mcl
+wEB
+wEB
+wEB
+wEB
+wEB
 tTB
 vJX
-kGl
+wiO
 cZb
 cZb
 cZb
@@ -186260,14 +187048,14 @@ cZb
 cZb
 cZb
 cZb
-mcl
+wEB
 iKp
 jWI
-mcl
-mcl
+wEB
+wEB
 pOR
 avz
-qIn
+rsN
 cZb
 cZb
 cZb
@@ -186462,14 +187250,14 @@ cZb
 cZb
 cZb
 cZb
-mcl
+wEB
 iVg
 nXu
-mcl
-mcl
-iBY
+wEB
+wEB
+snr
 kSY
-mcl
+wEB
 cZb
 cZb
 cZb
@@ -186664,14 +187452,14 @@ cZb
 cZb
 cZb
 cZb
-mcl
-kEf
-kEf
-iBY
-iBY
-utY
-utY
-mcl
+wEB
+lVS
+lVS
+snr
+snr
+pQH
+pQH
+wEB
 cZb
 cZb
 cZb
@@ -186866,14 +187654,14 @@ cZb
 cZb
 cZb
 cZb
-mcl
-kEf
-kEf
-tUH
-tUH
-oOw
-iBY
-mcl
+wEB
+lVS
+lVS
+lTo
+lTo
+qBj
+snr
+wEB
 cZb
 cZb
 cZb
@@ -187068,14 +187856,14 @@ cZb
 cZb
 cZb
 cZb
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
 cZb
 cZb
 cZb
@@ -200981,10 +201769,10 @@ gBD
 gBD
 gBD
 gBD
-uyF
-uyF
-uyF
-uyF
+kOR
+kOR
+kOR
+kOR
 gBD
 gBD
 gBD
@@ -201182,13 +201970,13 @@ gBD
 gBD
 gBD
 gBD
-uyF
-uyF
+kOR
+kOR
 nWX
 pES
-uyF
-uyF
-rDo
+kOR
+kOR
+daV
 gBD
 gBD
 gBD
@@ -201384,14 +202172,14 @@ gBD
 gBD
 gBD
 gBD
-uyF
+kOR
 tzq
 eez
 lXn
 sOZ
-uyF
+kOR
 oLR
-rDo
+daV
 gBD
 gBD
 gBD
@@ -201586,14 +202374,14 @@ gBD
 gBD
 gBD
 gBD
-uyF
+kOR
 gzQ
 lXn
 pUR
 lle
-uyF
-fLN
-vtI
+kOR
+tin
+eon
 vhT
 gBD
 gBD
@@ -201788,13 +202576,13 @@ gBD
 gBD
 gBD
 gBD
-uyF
+kOR
 xuw
 lXn
 lXn
 lXn
 aIy
-hZc
+kAk
 hxi
 vhT
 pcg
@@ -201986,33 +202774,33 @@ iYY
 gBD
 gBD
 gBD
-fgl
-fgl
-fgl
-fgl
-fgl
+hPE
+hPE
+hPE
+hPE
+hPE
 otE
 lXn
 lXn
 lXn
 xoO
-giu
-hZc
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
+kRY
+kAk
+kOR
+kOR
+kOR
+kOR
+kOR
+kOR
+kOR
+kOR
+kOR
+kOR
 gBD
 gBD
-uyF
-uyF
-uyF
+kOR
+kOR
+kOR
 gBD
 gBD
 gBD
@@ -202188,32 +202976,32 @@ iYY
 gBD
 gBD
 gBD
-fgl
+hPE
 qKt
 oDN
 kXQ
-fgl
+hPE
 dYr
 lXn
 lXn
 lXn
 clU
-giu
-giu
-giu
-krV
+kRY
+kRY
+kRY
+ozq
 xib
-vtI
-giu
-krV
-giu
-krV
+eon
+kRY
+ozq
+kRY
+ozq
 nKG
 iaG
-rDo
+daV
 gBD
-rDo
-rDo
+daV
+daV
 gBD
 gBD
 gBD
@@ -202390,7 +203178,7 @@ iYY
 gBD
 gBD
 gBD
-fgl
+hPE
 pVu
 fSx
 png
@@ -202401,22 +203189,22 @@ lXn
 lXn
 aIy
 cUq
-giu
-krV
-giu
-vtI
-rDo
+kRY
+ozq
+kRY
+eon
+daV
 oLR
-giu
-giu
-giu
-giu
-giu
-vtI
-rDo
-vtI
+kRY
+kRY
+kRY
+kRY
+kRY
+eon
+daV
+eon
 oLR
-uyF
+kOR
 uSy
 uSy
 uSy
@@ -202592,11 +203380,11 @@ iYY
 gBD
 gBD
 gBD
-arU
-rDo
+bLs
+daV
 okP
 xfG
-fgl
+hPE
 wqX
 vNB
 olk
@@ -202604,21 +203392,21 @@ tlA
 uRL
 cUq
 gVe
-giu
-vtI
-rDo
-arU
-rDo
-vtI
+kRY
+eon
+daV
+bLs
+daV
+eon
 gVe
-krV
-giu
-krV
-mVM
-vtI
-giu
-giu
-uyF
+ozq
+kRY
+ozq
+pRE
+eon
+kRY
+kRY
+kOR
 uSy
 cKc
 cdB
@@ -202794,33 +203582,33 @@ iYY
 gBD
 gBD
 gBD
-arU
-arU
-fgl
-fgl
-fgl
-uyF
-uyF
-uyF
-uyF
-uyF
+bLs
+bLs
+hPE
+hPE
+hPE
+kOR
+kOR
+kOR
+kOR
+kOR
 uty
-giu
-giu
-mVM
-vtI
-rDo
-arU
-rDo
-kla
-giu
-giu
-giu
-giu
-giu
-giu
-krV
-uyF
+kRY
+kRY
+pRE
+eon
+daV
+bLs
+daV
+wob
+kRY
+kRY
+kRY
+kRY
+kRY
+kRY
+ozq
+kOR
 uSy
 cKc
 rRv
@@ -203000,21 +203788,21 @@ gBD
 gBD
 gBD
 gBD
-arU
-uyF
-uyF
-uyF
-uyF
-uyF
+bLs
+kOR
+kOR
+kOR
+kOR
+kOR
 uty
 mBE
-uyF
-uyF
-uyF
-rDo
-arU
+kOR
+kOR
+kOR
+daV
+bLs
 spU
-vtI
+eon
 wUn
 vsC
 vsC
@@ -203022,7 +203810,7 @@ vsC
 vsC
 vsC
 vsC
-uyF
+kOR
 uSy
 cKc
 rRv
@@ -203204,18 +203992,18 @@ gBD
 gBD
 gBD
 wSg
-vtI
-mVM
+eon
+pRE
 xye
-giu
+kRY
 din
 cUq
 fZy
 rdj
-uyF
-arU
+kOR
+bLs
 idd
-rDo
+daV
 utf
 utf
 utf
@@ -203224,7 +204012,7 @@ utf
 utf
 utf
 utf
-uyF
+kOR
 uSy
 cKc
 rRv
@@ -203407,17 +204195,17 @@ gBD
 gBD
 gBD
 gHn
-vtI
+eon
 bRF
-giu
+kRY
 din
 cUq
 reL
 cqj
-uyF
-arU
-arU
-rDo
+kOR
+bLs
+bLs
+daV
 utf
 utf
 utf
@@ -203426,7 +204214,7 @@ utf
 utf
 utf
 utf
-uyF
+kOR
 uSy
 cKc
 rRv
@@ -203608,18 +204396,18 @@ gBD
 gBD
 gBD
 vhT
-uyF
-uyF
-uyF
-uyF
+kOR
+kOR
+kOR
+kOR
 cUq
 fDI
-uyF
-uyF
-uyF
-arU
-rDo
-cFd
+kOR
+kOR
+kOR
+bLs
+daV
+nPd
 gyi
 gyi
 gyi
@@ -203628,7 +204416,7 @@ gyi
 gyi
 gyi
 gyi
-uyF
+kOR
 uSy
 cKc
 rRv
@@ -203810,27 +204598,27 @@ gBD
 gBD
 gBD
 gBD
-uyF
-uyF
-uyF
-uyF
-giu
-fLN
+kOR
+kOR
+kOR
+kOR
+kRY
+tin
 msn
-vtI
-rDo
-rDo
+eon
+daV
+daV
 iaG
-giu
-krV
-giu
-giu
-krV
-giu
-giu
-giu
-krV
-uyF
+kRY
+ozq
+kRY
+kRY
+ozq
+kRY
+kRY
+kRY
+ozq
+kOR
 uSy
 cKc
 rRv
@@ -204011,28 +204799,28 @@ gBD
 gBD
 gBD
 gBD
-rDo
+daV
 nyW
 udj
 mSu
 uRL
-giu
-fLN
-hZc
-fLN
-vtI
-vtI
-giu
-krV
+kRY
+tin
+kAk
+tin
+eon
+eon
+kRY
+ozq
 gVe
-krV
-krV
-giu
-giu
-giu
-giu
-giu
-uyF
+ozq
+ozq
+kRY
+kRY
+kRY
+kRY
+kRY
+kOR
 uSy
 vZg
 rRv
@@ -204212,29 +205000,29 @@ gBD
 gBD
 gBD
 gBD
-uyF
+kOR
 oao
-hoa
+kmq
 lXn
 lXn
 aIy
-giu
-giu
-giu
-giu
+kRY
+kRY
+kRY
+kRY
 gVe
-giu
-ghj
+kRY
+qzi
 cUq
 cUq
-ghj
+qzi
 cUq
 cUq
 cUq
-giu
-krV
-giu
-uyF
+kRY
+ozq
+kRY
+kOR
 uSy
 cKc
 lKS
@@ -204414,18 +205202,18 @@ gBD
 gBD
 gBD
 gBD
-uyF
+kOR
 ube
 lXn
 lXn
 hgU
 clU
-giu
-giu
-giu
-krV
-giu
-giu
+kRY
+kRY
+kRY
+ozq
+kRY
+kRY
 cUq
 cUq
 cUq
@@ -204433,10 +205221,10 @@ cUq
 cUq
 cUq
 cBE
-giu
-giu
+kRY
+kRY
 vJI
-uyF
+kOR
 uSy
 cKc
 rIb
@@ -204616,14 +205404,14 @@ gBD
 gBD
 gBD
 gBD
-uyF
+kOR
 qJO
 lXn
 lXn
 lXn
 xYV
-giu
-giu
+kRY
+kRY
 lDu
 mcd
 mcd
@@ -204633,12 +205421,12 @@ mcd
 mcd
 mcd
 hyy
-giu
-ghj
-giu
-vtI
-vtI
-uyF
+kRY
+qzi
+kRY
+eon
+eon
+kOR
 uSy
 cKc
 rhe
@@ -204818,28 +205606,28 @@ gBD
 gBD
 gBD
 gBD
-uyF
+kOR
 lCj
 lXn
 lXn
 lXn
 clU
-giu
-giu
+kRY
+kRY
 eqL
-giu
-giu
-giu
-giu
-giu
+kRY
+kRY
+kRY
+kRY
+kRY
 abm
 azL
-eqL
-giu
+vqJ
+mAD
 abm
-vtI
-rDo
-rDo
+eon
+daV
+daV
 gBD
 uSy
 cKc
@@ -205020,20 +205808,20 @@ gBD
 gBD
 gBD
 gBD
-uyF
+kOR
 slI
 lXn
 pUR
 cfa
 clU
-giu
-giu
+kRY
+kRY
 eqL
-giu
-uyF
-uyF
-uyF
-uyF
+kRY
+kOR
+kOR
+kOR
+kOR
 ajp
 ajp
 kzd
@@ -205222,17 +206010,17 @@ gBD
 gBD
 gBD
 gBD
-uyF
+kOR
 fwt
 lXn
 lXn
 aLo
 clU
-giu
+kRY
 hBn
 eqL
-giu
-uyF
+kRY
+kOR
 gBD
 gBD
 gBD
@@ -205424,17 +206212,17 @@ gBD
 gBD
 gBD
 gBD
-uyF
-uyF
+kOR
+kOR
 nWX
 kRe
-uyF
-uyF
-uyF
-uyF
+kOR
+kOR
+kOR
+kOR
 tjs
-uyF
-uyF
+kOR
+kOR
 gBD
 gBD
 gBD
@@ -205627,16 +206415,16 @@ gBD
 gBD
 gBD
 gBD
-uyF
-uyF
-uyF
-uyF
+kOR
+kOR
+kOR
+kOR
 bVq
 bVq
 pfr
 pnL
-qCS
-uyF
+eEk
+kOR
 ajp
 ajp
 ajp
@@ -205832,13 +206620,13 @@ gBD
 gBD
 gBD
 gBD
-uyF
+kOR
 jNw
 aiT
 cOv
 wkv
 kaI
-uyF
+kOR
 ajp
 rpL
 qCv
@@ -206034,13 +206822,13 @@ gBD
 gBD
 gBD
 gBD
-uyF
+kOR
 tCt
 brY
 wLL
 jPg
 kaI
-uyF
+kOR
 ajp
 opK
 rUb
@@ -206236,13 +207024,13 @@ gBD
 gBD
 gBD
 gBD
-uyF
-uyF
+kOR
+kOR
 kTC
-uyF
+kOR
 kTC
-uyF
-uyF
+kOR
+kOR
 ajp
 gkW
 cII
@@ -206438,13 +207226,13 @@ gBD
 gBD
 gBD
 gBD
-uyF
-uyF
+kOR
+kOR
 tQF
-pBR
+pNf
 tQF
-uyF
-arU
+kOR
+bLs
 ajp
 jNe
 rUb
@@ -206640,13 +207428,13 @@ gBD
 gBD
 gBD
 gBD
-uyF
-uyF
-uyF
-uyF
-uyF
-uyF
-arU
+kOR
+kOR
+kOR
+kOR
+kOR
+kOR
+bLs
 ajp
 uhJ
 jDr
@@ -216547,7 +217335,7 @@ dYi
 dYi
 dYi
 tfv
-ekw
+foB
 wIv
 ekw
 ekw
@@ -216561,9 +217349,9 @@ kJn
 fGi
 fGi
 kJn
-bGh
-bGh
-bGh
+fGi
+fGi
+fGi
 dIt
 vqc
 dyN
@@ -216765,7 +217553,7 @@ ekw
 gdH
 inh
 anw
-bGh
+fGi
 cMF
 fhx
 uaP
@@ -216965,9 +217753,9 @@ ekw
 ekw
 pAo
 kJn
-bGh
-bGh
-bGh
+fGi
+fGi
+fGi
 cMF
 fhx
 cMF
@@ -223411,8 +224199,8 @@ gBD
 gBD
 gBD
 gBD
-mcl
-iBY
+tDR
+liT
 tUH
 dPH
 qKe
@@ -223613,7 +224401,7 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 tUH
 pPy
 goB
@@ -223815,10 +224603,10 @@ gBD
 gBD
 gBD
 gBD
-mcl
-iBY
+tDR
+liT
 juu
-iBY
+liT
 qKe
 lCV
 pFC
@@ -224017,10 +224805,10 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 ovH
 juu
-iBY
+liT
 noA
 noA
 keZ
@@ -224219,10 +225007,10 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 tUH
 juu
-iBY
+liT
 noA
 mqw
 pwQ
@@ -224419,12 +225207,12 @@ gBD
 gBD
 gBD
 gBD
-qIy
+ndn
 oZF
-mLO
-iBY
+pdE
+liT
 juu
-iBY
+liT
 noA
 brt
 qko
@@ -224619,14 +225407,14 @@ gBD
 gBD
 gBD
 gBD
-qIy
-ukH
-ukH
-ukH
+ndn
+iIh
+iIh
+iIh
 gGO
-iBY
+liT
 juu
-iBY
+liT
 noA
 kzv
 iJk
@@ -224643,8 +225431,8 @@ oYL
 noA
 vjr
 roo
-tDR
-tDR
+dJz
+dJz
 xoW
 axb
 fss
@@ -224822,13 +225610,13 @@ gBD
 gBD
 mmq
 dBq
-ukH
-ukH
-qIy
+iIh
+iIh
+ndn
 gGO
 jcW
 juu
-iBY
+liT
 noA
 brt
 oay
@@ -225024,13 +225812,13 @@ gBD
 gBD
 mmq
 mmq
-ukH
-ukH
-gBD
+iIh
+iIh
+aaB
 waX
 jcW
 juu
-iBY
+liT
 noA
 mqw
 nPE
@@ -225229,8 +226017,8 @@ cQK
 gBD
 gBD
 gBD
-mcl
-iBY
+tDR
+liT
 juu
 tUH
 noA
@@ -225243,14 +226031,14 @@ lfl
 tJq
 noA
 noA
-mcl
-mcl
-mcl
-mcl
+tDR
+tDR
+tDR
+tDR
 mwB
 tFo
-ifQ
-mcl
+bMF
+tDR
 aBx
 jVR
 aQR
@@ -225431,10 +226219,10 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 sWp
 juu
-iBY
+liT
 noA
 noA
 noA
@@ -225444,15 +226232,15 @@ noA
 noA
 noA
 noA
-mcl
-mcl
+tDR
+tDR
 jNp
 qYT
 fMa
-iBY
+liT
 tFo
-utY
-mcl
+xRk
+tDR
 aBx
 aBx
 aBx
@@ -225633,28 +226421,28 @@ gBD
 gBD
 gBD
 gBD
-mcl
-iBY
+tDR
+liT
 juu
-iBY
-iBY
-iBY
-iBY
+liT
+liT
+liT
+liT
 kGN
-iBY
-iBY
-iBY
-iBY
+liT
+liT
+liT
+liT
 gNo
-iBY
-iBY
+liT
+liT
 ofA
 qYT
 kyg
-iBY
+liT
 tFo
-iBY
-mcl
+liT
+tDR
 aBx
 jVR
 aQR
@@ -225835,8 +226623,8 @@ gBD
 gBD
 gBD
 gBD
-mcl
-iBY
+tDR
+liT
 bVU
 goB
 goB
@@ -225844,19 +226632,19 @@ goB
 goB
 wKe
 goB
-goB
-goB
+eZh
 dJz
-tDR
-tDR
-tDR
+dJz
+dJz
+dJz
+dJz
 ukl
 nKV
 nKV
 pOI
 lFf
-iBY
-mcl
+liT
+tDR
 aBx
 aBx
 aBx
@@ -226037,28 +226825,28 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 tUH
-iBY
-iBY
-iBY
-iBY
-iBY
-hJh
-iBY
-iBY
-iBY
-wcL
-iBY
-iBY
-oSn
-xbR
-aGP
-aGP
-iBY
-oSn
+liT
+liT
+liT
+liT
+liT
+iyx
+liT
+dac
+liT
+liT
+liT
+liT
+bvb
+mpR
+jQe
+jQe
+liT
+bvb
 ltA
-mcl
+tDR
 gBD
 gBD
 gBD
@@ -226237,30 +227025,30 @@ gBD
 gBD
 gBD
 gBD
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
 pdE
 tvr
-mcl
-mcl
+tDR
+tDR
 qCb
-kGl
-kGl
-mcl
-iBY
-iBY
-mcl
+oFM
+oFM
+tDR
+liT
+liT
+tDR
 gBD
 gBD
 gBD
@@ -226437,9 +227225,9 @@ gBD
 gBD
 gBD
 tol
-llz
-llz
-aGP
+oSz
+oSz
+jQe
 jYz
 cbN
 cbN
@@ -226448,21 +227236,21 @@ cbN
 cbN
 jYz
 cbN
-mcl
+tDR
 gBD
 gBD
-mcl
+tDR
 gUb
-mLO
-mcl
+pdE
+tDR
 gBD
-kGl
+oFM
 gBD
 gBD
-mcl
-iBY
-iBY
-mcl
+tDR
+liT
+liT
+tDR
 gBD
 gBD
 gBD
@@ -226637,34 +227425,34 @@ gBD
 gBD
 gBD
 gBD
-mcl
-llz
-aGP
-aGP
-szN
+tDR
+oSz
+jQe
+jQe
+wzF
 kcA
-szN
+wzF
 kcA
-szN
-szN
-szN
-szN
-szN
-mcl
+wzF
+wzF
+wzF
+wzF
+wzF
+tDR
 gBD
 gBD
-qIn
 aaB
-kGl
-qIn
+aaB
+oFM
+aaB
 gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 nxY
 xVR
-mcl
+tDR
 gBD
 gBD
 gBD
@@ -226839,34 +227627,34 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 lus
-szN
+wzF
 wMM
-szN
+wzF
 iAj
-szN
-szN
-szN
+wzF
+wzF
+wzF
 bqM
 tYB
-szN
-szN
-mcl
+wzF
+wzF
+tDR
 gBD
 gBD
-qIn
-ndn
-qIn
-qIn
+aaB
+gUb
+aaB
+aaB
 gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 xLj
 mtO
-mcl
+tDR
 xBe
 gBD
 eFf
@@ -227041,34 +227829,34 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 hTc
-szN
-szN
-szN
+wzF
+wzF
+wzF
 iAj
-szN
-szN
-szN
+wzF
+wzF
+wzF
 bqM
-szN
-szN
-szN
-mcl
+wzF
+wzF
+wzF
+tDR
 gBD
 gBD
-qIn
+aaB
 tix
-llz
-mcl
+oSz
+tDR
 gBD
 gBD
 gBD
 gBD
-mcl
-mcl
-mcl
-mcl
+tDR
+tDR
+tDR
+tDR
 gBD
 gBD
 eFf
@@ -227243,26 +228031,26 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 hTc
-szN
-szN
-szN
+wzF
+wzF
+wzF
 iAj
-szN
-szN
-szN
+wzF
+wzF
+wzF
 bqM
-szN
-szN
-szN
-mcl
+wzF
+wzF
+wzF
+tDR
 gBD
 gBD
-mcl
-iBY
-aGP
-mcl
+tDR
+liT
+jQe
+tDR
 gBD
 gBD
 gBD
@@ -227445,26 +228233,26 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 hTc
-szN
-szN
-szN
+wzF
+wzF
+wzF
 iAj
-szN
+wzF
 vSj
-szN
+wzF
 bqM
-szN
+wzF
 cSI
-szN
-mcl
+wzF
+tDR
 gBD
 gBD
-mcl
+tDR
 nYs
-iBY
-mcl
+liT
+tDR
 gBD
 gBD
 gBD
@@ -227647,28 +228435,28 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 qfo
-szN
-szN
-szN
+wzF
+wzF
+wzF
 iAj
-szN
-szN
-szN
+wzF
+wzF
+wzF
 bqM
-szN
-szN
-szN
-mcl
-mcl
-mcl
-mcl
-iBY
-iBY
-mcl
-mcl
-mcl
+wzF
+wzF
+wzF
+tDR
+tDR
+tDR
+tDR
+liT
+liT
+tDR
+tDR
+tDR
 gBD
 gBD
 gBD
@@ -227849,32 +228637,32 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 hTc
-szN
+wzF
 wMM
-szN
+wzF
 iAj
-szN
-szN
-szN
+wzF
+wzF
+wzF
 bqM
 tYB
-szN
-szN
-mcl
-mcl
+wzF
+wzF
+tDR
+tDR
 wIs
 wIs
-iBY
-iBY
+liT
+liT
 wIs
 wIs
-mcl
-mcl
-mcl
-mcl
-mcl
+tDR
+tDR
+tDR
+tDR
+tDR
 gBD
 gBD
 gBD
@@ -228051,32 +228839,32 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 hTc
-szN
-szN
-szN
+wzF
+wzF
+wzF
 iAj
 cnf
-szN
+wzF
 cnf
 bqM
-szN
-szN
-szN
-mcl
-mcl
+wzF
+wzF
+wzF
+tDR
+tDR
 sWp
-iBY
-iBY
-oQt
-iBY
-iBY
-iBY
+liT
+liT
+rKI
+liT
+liT
+liT
 gNo
-iBY
+liT
 mCR
-mcl
+tDR
 gBD
 gBD
 gBD
@@ -228253,9 +229041,9 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 tXy
-saK
+xmQ
 xbU
 xbU
 lvV
@@ -228265,20 +229053,20 @@ gsT
 aoL
 xbU
 xbU
-mcl
-mcl
-mcl
+tDR
+tDR
+tDR
 sNp
-iBY
-iBY
-iBY
-iBY
-iBY
-iBY
-iBY
-iBY
-iBY
-mcl
+liT
+liT
+liT
+liT
+liT
+liT
+liT
+liT
+liT
+tDR
 gBD
 gBD
 gBD
@@ -228455,11 +229243,11 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 tXy
 rBV
 nKz
-szN
+wzF
 dQD
 oNb
 neg
@@ -228467,20 +229255,20 @@ qCX
 vLn
 jgL
 xPC
-mcl
-mcl
-mcl
-mcl
+tDR
+tDR
+tDR
+tDR
 dWa
 dWa
 yeM
 dWa
-mcl
-mcl
-mcl
+tDR
+tDR
+tDR
 ibP
-mcl
-mcl
+tDR
+tDR
 gBD
 gBD
 gBD
@@ -228657,32 +229445,32 @@ gBD
 gBD
 gBD
 gBD
-mcl
-mcl
+tDR
+tDR
 jid
 nIx
-szN
+wzF
 dQD
-aGP
-llz
-aGP
+jQe
+oSz
+jQe
 eQq
 nsp
 jIi
-mcl
+tDR
 frv
 iEB
-mcl
+tDR
 fKM
 pMS
 kkb
 kff
-mcl
+tDR
 iWO
 dIM
 rRp
 rWT
-mcl
+tDR
 gBD
 gBD
 gBD
@@ -228860,31 +229648,31 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 uxo
 nIx
-szN
-aGP
-llz
+wzF
+jQe
+oSz
 bUu
-llz
-aGP
+oSz
+jQe
 eQq
 vLn
 aqM
 doe
-cbE
+kkH
 glA
-fGf
-mMM
-mMM
+ugg
+oDt
+oDt
 erQ
-mcl
+tDR
 uZI
 lST
 lJB
 lST
-mcl
+tDR
 gBD
 gBD
 gBD
@@ -229062,31 +229850,31 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 eGl
 vJG
-szN
-aGP
-llz
+wzF
+jQe
+oSz
 bUu
 bUu
-llz
+oSz
 oGm
 eQq
 azl
 mHc
 wdz
 glA
-fGf
-mMM
-mMM
-mMM
+ugg
+oDt
+oDt
+oDt
 nMI
 rRp
 wol
 rRp
 rWT
-mcl
+tDR
 gBD
 gBD
 gBD
@@ -229264,31 +230052,31 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 rBV
 vJG
-szN
+wzF
 dQD
-aGP
-llz
-llz
-aGP
+jQe
+oSz
+oSz
+jQe
 eQq
 eaN
 xbU
-eyR
+mvx
 ldO
-mcl
-vbY
-mMM
-mMM
-mMM
-mcl
-mcl
-mcl
+tDR
+dWW
+oDt
+oDt
+oDt
+tDR
+tDR
+tDR
 ibP
-mcl
-mcl
+tDR
+tDR
 gBD
 gBD
 gBD
@@ -229466,14 +230254,14 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 sBF
 vJG
-szN
+wzF
 dQD
 fal
-aGP
-aGP
+jQe
+jQe
 eQq
 eQq
 eQq
@@ -229481,16 +230269,16 @@ azl
 efr
 tFu
 glA
-fGf
-mMM
-mMM
-mMM
-mcl
+ugg
+oDt
+oDt
+oDt
+tDR
 kzP
 kzP
 rRp
 rWT
-mcl
+tDR
 gBD
 gBD
 gBD
@@ -229668,9 +230456,9 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 qET
-szN
+wzF
 cSI
 pMe
 kCn
@@ -229681,18 +230469,18 @@ kCn
 kCn
 klT
 bzi
-szN
+wzF
 glA
 ygR
-mMM
+oDt
 lxC
 uHI
-mcl
+tDR
 rRp
 rRp
 jyN
 lST
-mcl
+tDR
 gBD
 gBD
 gBD
@@ -229870,31 +230658,31 @@ gBD
 gBD
 gBD
 gBD
-mcl
+tDR
 uVB
-szN
+wzF
 ftQ
-szN
+wzF
 vSj
-szN
+wzF
 pip
 ftQ
-szN
+wzF
 lTC
-mcl
+tDR
 frv
 exj
-mcl
+tDR
 jWx
 rYt
 hWL
 unB
-mcl
+tDR
 rWT
 fFD
 pYG
 iEq
-mcl
+tDR
 gBD
 gBD
 gBD
@@ -230072,31 +230860,31 @@ gBD
 gBD
 gBD
 gBD
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
-mcl
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
+tDR
 gBD
 gBD
 gBD

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -63356,6 +63356,22 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/rbreakroom)
+"nuh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "West APC";
+	pixel_x = -28;
+	operating = 0
+	},
+/obj/structure/cable/cyan,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor1north)
 "nuk" = (
 /obj/structure/flora/small/grassb4,
 /obj/effect/decal/cleanable/dirt,
@@ -98909,7 +98925,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan,
 /obj/machinery/power/apc{
-	locked = 0;
 	name = "South APC";
 	pixel_y = -28;
 	operating = 0
@@ -142046,7 +142061,7 @@ huF
 nDe
 huF
 huF
-huF
+nuh
 huF
 huF
 huF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Adjusts the areas for most maintenance sections so that they correctly name the floor.
</summary>
<hr>

For some reason, most of our maintenance areas on level 2 are labeled as being level 1. This fixes that, and adds new APCs to areas that need them. Additionally adds an APC to the maints area east of security since it had none at all before.	
<hr>
</details>

## Changelog
:cl:
tweak: Changes the areas of much of maintenance, especially Floor 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
