### PR TITLE
More church gun balance and small fixes.

### DIFF
--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -445,7 +445,7 @@
 	build_path = /obj/item/gun/energy/gun/martin
 
 /datum/design/autolathe/gun/ntpistol
-	name = "OT LP \"Serenity\""
+	name = "NT LP \"Serenity\""
 	build_path = /obj/item/gun/energy/ntpistol
 
 /datum/design/autolathe/gun/lasercore
@@ -457,27 +457,27 @@
 	build_path = /obj/item/gun/energy/firestorm
 
 /datum/design/autolathe/gun/energy_crossbow
-	name = "OT EC \"Nemesis\""
+	name = "NT EC \"Nemesis\""
 	build_path = /obj/item/gun/energy/crossbow
 
 /datum/design/autolathe/gun/large_energy_crossbow
-	name = "OT EC \"Themis\""
+	name = "NT EC \"Themis\""
 	build_path = /obj/item/gun/energy/crossbow/largecrossbow
 
 /datum/design/autolathe/gun/laser
-	name = "OT LG \"Lightfall\""
+	name = "NT LG \"Lightfall\""
 	build_path = /obj/item/gun/energy/laser
 
 /datum/design/autolathe/gun/ionrifle
-	name = "OT IR \"Halicon\""
+	name = "NT IR \"Halicon\""
 	build_path = /obj/item/gun/energy/ionrifle
 
 /datum/design/autolathe/gun/pulse
-	name = "OT PR \"Dominion\""
+	name = "NT PR \"Dominion\""
 	build_path = /obj/item/gun/energy/plasma
 
 /datum/design/autolathe/gun/pulse_destroyer
-	name = "OT PR \"Purger\""
+	name = "NT PR \"Purger\""
 	build_path = /obj/item/gun/energy/plasma/destroyer
 
 /datum/design/autolathe/gun/pulse_cassad

--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -497,7 +497,7 @@
 	build_path = /obj/item/gun/energy/cog
 
 /datum/design/autolathe/gun/plasma/martyr
-	name = "OT PR \"Martyr\""
+	name = "NT PR \"Martyr\""
 	build_path = /obj/item/gun/energy/plasma/martyr
 
 /datum/design/autolathe/gun/sunrise
@@ -505,15 +505,15 @@
 	build_path = /obj/item/gun/energy/sunrise
 
 /datum/design/autolathe/gun/concillium
-	name = "OT Las-MG \"Concillium\""
+	name = "NT Las-MG \"Concillium\""
 	build_path = /obj/item/gun/energy/concillium
 
 /datum/design/autolathe/gun/plasma/antebellum
-	name = "OT PR \"Antebellum\""
+	name = "NT PR \"Antebellum\""
 	build_path = /obj/item/gun/energy/plasma/antebellum
 
 /datum/design/autolathe/gun/carpediem
-	name = "OT LM \"Carpediem\""
+	name = "NT LM \"Carpediem\""
 	build_path = /obj/item/gun/energy/carpediem
 
 /datum/design/autolathe/gun/peacekeeper
@@ -525,7 +525,7 @@
 	build_path = /obj/item/gun/energy/zwang
 
 /datum/design/autolathe/gun/plasma/excubitor
-	name = "OT \"Excubitor\""
+	name = "NT \"Excubitor\""
 	build_path = /obj/item/gun/energy/plasma/excubitor
 
 // Gun mods

--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -69,7 +69,7 @@
 	build_path = /obj/item/gun/projectile/mk58/wood
 
 /datum/design/autolathe/gun/lemant
-	name = "NT 10/20mm \"Pilgrim\""
+	name = "OT 10/20mm \"Pilgrim\""
 	build_path = /obj/item/gun/projectile/revolver/lemant
 
 /datum/design/autolathe/gun/ten
@@ -445,7 +445,7 @@
 	build_path = /obj/item/gun/energy/gun/martin
 
 /datum/design/autolathe/gun/ntpistol
-	name = "NT LP \"Serenity\""
+	name = "OT LP \"Serenity\""
 	build_path = /obj/item/gun/energy/ntpistol
 
 /datum/design/autolathe/gun/lasercore
@@ -497,7 +497,7 @@
 	build_path = /obj/item/gun/energy/cog
 
 /datum/design/autolathe/gun/plasma/martyr
-	name = "NT PR \"Martyr\""
+	name = "OT PR \"Martyr\""
 	build_path = /obj/item/gun/energy/plasma/martyr
 
 /datum/design/autolathe/gun/sunrise
@@ -505,15 +505,15 @@
 	build_path = /obj/item/gun/energy/sunrise
 
 /datum/design/autolathe/gun/concillium
-	name = "NT Las-MG \"Concillium\""
+	name = "OT Las-MG \"Concillium\""
 	build_path = /obj/item/gun/energy/concillium
 
 /datum/design/autolathe/gun/plasma/antebellum
-	name = "NT PR \"Antebellum\""
+	name = "OT PR \"Antebellum\""
 	build_path = /obj/item/gun/energy/plasma/antebellum
 
 /datum/design/autolathe/gun/carpediem
-	name = "NT LM \"Carpediem\""
+	name = "OT LM \"Carpediem\""
 	build_path = /obj/item/gun/energy/carpediem
 
 /datum/design/autolathe/gun/peacekeeper
@@ -525,7 +525,7 @@
 	build_path = /obj/item/gun/energy/zwang
 
 /datum/design/autolathe/gun/plasma/excubitor
-	name = "NT \"Excubitor\""
+	name = "OT \"Excubitor\""
 	build_path = /obj/item/gun/energy/plasma/excubitor
 
 // Gun mods

--- a/code/game/objects/items/weapons/autolathe_disk/absolute_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/absolute_disks.dm
@@ -207,7 +207,6 @@
 		/datum/design/autolathe/gun/regulator = 3,
 		/datum/design/autolathe/gun/lemant = 3,
 		/datum/design/autolathe/gun/taser,
-		/datum/design/autolathe/gun/laser = 2,
 		/datum/design/autolathe/gun/sniperrifle = 6,
 		/datum/design/autolathe/ammo/pistol_ammobox_biomatter,
 		/datum/design/autolathe/ammo/magnum_ammobox_biomatter = 2

--- a/code/modules/core_implant/cruciform/rituals/construction.dm
+++ b/code/modules/core_implant/cruciform/rituals/construction.dm
@@ -590,7 +590,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 		/obj/item/stack/material/plasteel = 40,
 		/obj/item/stack/material/wood = 25,
 		/obj/item/stack/material/glass = 15,
-		/obj/item/stack/material/gold = 3,
+		/obj/item/stack/material/gold = 10,
 		/obj/item/stack/material/silver = 5
 	)
 	build_time = 8 SECONDS

--- a/code/modules/core_implant/cruciform/rituals/construction.dm
+++ b/code/modules/core_implant/cruciform/rituals/construction.dm
@@ -590,7 +590,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 		/obj/item/stack/material/plasteel = 40,
 		/obj/item/stack/material/wood = 25,
 		/obj/item/stack/material/glass = 15,
-		/obj/item/stack/material/gold = 10,
+		/obj/item/stack/material/gold = 5,
 		/obj/item/stack/material/silver = 5
 	)
 	build_time = 8 SECONDS

--- a/code/modules/projectiles/guns/energy/laser/concilium.dm
+++ b/code/modules/projectiles/guns/energy/laser/concilium.dm
@@ -10,7 +10,7 @@
 	fire_sound = 'sound/weapons/energy/laser_rifle.ogg' // Big unwieldy gun, despite the shit lasers
 	slot_flags = null
 	w_class = ITEM_SIZE_HUGE
-	matter = list(MATERIAL_PLASTEEL = 40, MATERIAL_WOOD = 25, MATERIAL_GLASS = 15, MATERIAL_SILVER = 5, MATERIAL_GOLD = 10)
+	matter = list(MATERIAL_PLASTEEL = 40, MATERIAL_WOOD = 25, MATERIAL_GLASS = 15, MATERIAL_SILVER = 5, MATERIAL_GOLD = 5)
 	projectile_type = /obj/item/projectile/beam/drone
 	init_recoil = CARBINE_RECOIL(2)
 	fire_delay = 2

--- a/code/modules/projectiles/guns/energy/laser/concilium.dm
+++ b/code/modules/projectiles/guns/energy/laser/concilium.dm
@@ -10,9 +10,10 @@
 	fire_sound = 'sound/weapons/energy/laser_rifle.ogg' // Big unwieldy gun, despite the shit lasers
 	slot_flags = null
 	w_class = ITEM_SIZE_HUGE
-	matter = list(MATERIAL_PLASTEEL = 40, MATERIAL_WOOD = 25, MATERIAL_GLASS = 15, MATERIAL_SILVER = 5, MATERIAL_GOLD = 3)
+	matter = list(MATERIAL_PLASTEEL = 40, MATERIAL_WOOD = 25, MATERIAL_GLASS = 15, MATERIAL_SILVER = 5, MATERIAL_GOLD = 10)
 	projectile_type = /obj/item/projectile/beam/drone
-	init_recoil = CARBINE_RECOIL(1)
+	init_recoil = CARBINE_RECOIL(2)
+	fire_delay = 2
 	charge_cost = 100 //130 shots on a large spark
 	wield_delay = 1.5 SECOND
 	wield_delay_factor = 0.5 // 50 vig to instant wield heavy chonker gun
@@ -24,8 +25,8 @@
 	price_tag = 2000
 	gun_tags = list(GUN_LASER, GUN_ENERGY)
 	init_firemodes = list(
-		FULL_AUTO_600,
-		list(mode_name="short bursts", mode_desc="Fire 5 shots in quick succession", burst=5,    burst_delay=2, move_delay=6,  icon="burst"),
+		FULL_AUTO_300,
+		list(mode_name="short bursts", mode_desc="Fire 5 shots in succession", burst=5,    burst_delay=4, move_delay=6,  icon="burst"),
 		list(mode_name="long bursts", mode_desc="Fire 8 shots in succession",  burst=8, burst_delay=4, move_delay=8,  icon="burst"),
 		list(mode_name="suppressing fire", mode_desc="Fire 16 shots back to back to keep targets inside cover",  burst=16, burst_delay=4, move_delay=11,  icon="burst")
 		)

--- a/code/modules/projectiles/guns/energy/laser/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser/laser.dm
@@ -7,13 +7,14 @@
 	item_charge_meter = TRUE
 	fire_sound = 'sound/weapons/energy/laser_rifle.ogg'
 	slot_flags = SLOT_BACK
-	w_class = ITEM_SIZE_NORMAL
+	w_class = ITEM_SIZE_BULKY
 	force = WEAPON_FORCE_NORMAL
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
-	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 5)
-	price_tag = 550
+	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 10)
+	price_tag = 900
 	projectile_type = /obj/item/projectile/beam/midlaser
 	fire_delay = 5
+	charge_cost = 50
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 	init_firemodes = list(
 		WEAPON_NORMAL,

--- a/code/modules/projectiles/guns/energy/plasma/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma/plasma.dm
@@ -8,7 +8,7 @@
 	w_class = ITEM_SIZE_HUGE
 	slot_flags = SLOT_BACK
 	force = WEAPON_FORCE_PAINFUL
-	matter = list(MATERIAL_PLASTEEL = 17, MATERIAL_WOOD = 8, MATERIAL_SILVER = 6, MATERIAL_URANIUM = 4)
+	matter = list(MATERIAL_PLASTEEL = 17, MATERIAL_WOOD = 8, MATERIAL_SILVER = 6, MATERIAL_URANIUM = 5)
 	price_tag = 2000
 	origin_tech = list(TECH_COMBAT = 3, TECH_PLASMA = 2)
 	fire_sound = 'sound/weapons/energy/pulse.ogg'

--- a/code/modules/projectiles/guns/energy/projectile/railgun.dm
+++ b/code/modules/projectiles/guns/energy/projectile/railgun.dm
@@ -245,6 +245,7 @@
 		list(mode_name="powered-rod", mode_desc="fires a metal rod at incredible speeds", projectile_type=/obj/item/projectile/bullet/gauss, icon="kill"),
 		list(mode_name="fragmented scrap", mode_desc="fires a brittle, sharp piece of scrap-metal", projectile_type=/obj/item/projectile/bullet/grenade/frag, charge_cost=30000, icon="grenade"),
 	)
+	serial_type = "AG"
 	consume_cell = FALSE
 	price_tag = 6000
 

--- a/code/modules/psionics/psionic_items/psi_weptools.dm
+++ b/code/modules/psionics/psionic_items/psi_weptools.dm
@@ -167,8 +167,8 @@
 	psigun = 1
 	origin_tech = list()
 	matter = list()
-	damage_multiplier = 0.9
-	penetration_multiplier = 0.9
+	damage_multiplier = 0.8
+	penetration_multiplier = 0.8
 	price_tag = 0
 	serial_shown = FALSE
 


### PR DESCRIPTION
Bug fixes first: Fixes the Bat'ko grabbing its serial number from the lightfall
Fixes many church weapons mislabeling themselves as NT (new testament) and vice versa for OT (old testament). inside autolathes. Removes the lightfall from the OT disk. It was on both idk why. Lives on NT disk only now.

Important balance stuff: Concillium has seen well needed nerfs/fixes from my last time touching it. Fixes it incorrectly having 1 fire delay if you never change the fire mode. 
Pretty substantially reduces it's fire rate. I never wanted this to be a DPS monster and somehow it ended up that way.
It's recoil is now a factor. By no means is it bad but if you want it to be recoilless you'll be modding it or bracing it. Should discourage running and gunning as well
Ups its gold cost even more. Really trying to avoid slapping a uranium cost onto this one.

slightly bumps the cost of the Dominion from 2 to 2.5 (in bioprinters). Apparently? It was just cheap enough if you took a loadout wrist PDA for a extra atom cell you could print one of these nearly round start.

After many requests Lightfall has been buffed a fair amount. Halfing its charge cost. It's now comparable to a better fire rate cog (aside from in mat costs) Silver cost up to 10 as well (5 in bioprinter) and it's size was changed to bulky. No funny pocket rifle!