### PR TITLE
more_layered_shielding

### DIFF
--- a/code/modules/psionics/psion_powers/gear_summoning_powers.dm
+++ b/code/modules/psionics/psion_powers/gear_summoning_powers.dm
@@ -65,7 +65,73 @@
 /obj/item/organ/internal/psionic_tumor/proc/psionic_shield()
 	set category = "Psionic powers"
 	set name = "Psychic Shield (1)"
-	set desc = "Expend a single point of your psi essence to create an energy shield capable of blocking bullets, energy beams, and melee attacks."
+	set desc = "Expend a single point of your psi essence to create an energy shield capable of blocking melee attacks. \
+	If you already have a shield inhand it will enhance it making it capable of blocking lasers and bullets at the cost of its durablity.\
+	If the shield inhand is already enhanced it will be be healed"
+	psi_point_cost = 1
+
+	if(pay_power_cost(psi_point_cost))
+		//Used to tell if we need to spawn new shield or not
+		var/successfully_enhanced = FALSE
+		//Grabs the item on the mobs *actively selected hand*
+		var/active = owner.get_active_hand()
+		//Grabs the item on the mobs *non-selected hand*
+		var/inactive = owner.get_inactive_hand()
+		//Small tracker of how many shields we have use for preventing a spawning of a 3rd shield
+		var/num_of_shields = 0
+
+		//This is a little messy as we are going to do the same thing basically twice, but if you have 2 shields\
+		Then you get to enhanced one for free!
+		if(active)
+			if(istype(active, /obj/item/shield/riot/crusader/psionic))
+				var/obj/item/shield/riot/crusader/psionic/PS = active
+				num_of_shields += 1
+				if(!PS.can_block_proj)
+					PS.can_block_proj = TRUE
+					PS.base_block_chance += 10
+					PS.adjustShieldDurability(-10, owner)
+					successfully_enhanced = TRUE
+				else
+					//We healed are shield at the cost of a point
+					PS.adjustShieldDurability(80, owner)
+					PS.base_block_chance += 5
+		if(inactive)
+			if(istype(inactive, /obj/item/shield/riot/crusader/psionic))
+				num_of_shields += 1
+				var/obj/item/shield/riot/crusader/psionic/PS = inactive
+				if(!PS.can_block_proj)
+					PS.can_block_proj = TRUE
+					PS.base_block_chance += 10
+					PS.adjustShieldDurability(-10, owner)
+					successfully_enhanced = TRUE
+				else
+					//We healed are shield at the cost of a poins
+					PS.adjustShieldDurability(80, owner)
+					PS.base_block_chance += 5
+
+		//Did we improve a shield that was in are hands?
+		//If so tell the player and stop this proc
+		if(successfully_enhanced || num_of_shields >= 2)
+			owner.visible_message(
+			"[owner] looks at the psy-shield and forcefully compresses it!",
+			"Its hard to tell but you can feel that the shield well more solidified. This should be able capable of blocking lasers and bullets."
+			)
+			return
+
+		//Spawn the item inside the owner (mob that has the psionic implant)
+		//We then tell the player a fancy message well playing a sound and forcemoving it to a in_active hand if possable
+		var/obj/item/shield/riot/crusader/psionic/shield = new /obj/item/shield/riot/crusader/psionic(src, owner)
+		owner.visible_message(
+			"[owner] clenches their fist, electricity crackling before a psy-shield forms in their hand!",
+			"You feel the rush of electric essence shocking your hand lightly before a psy-shield forms!"
+			)
+		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
+		usr.put_in_active_hand(shield)
+
+/obj/item/organ/internal/psionic_tumor/proc/psionic_shield_layered()
+	set category = "Psionic powers"
+	set name = "Layered Psychic Shield (1)"
+	set desc = "Expend a single point of your psi essence to create a layered shield capable of blocking bullets, energy beams, and melee attacks."
 	psi_point_cost = 1
 
 	if(pay_power_cost(psi_point_cost))
@@ -76,6 +142,7 @@
 			)
 		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
 		usr.put_in_active_hand(shield)
+
 
 /obj/item/organ/internal/psionic_tumor/proc/telekinetic_fist()
 	set category = "Psionic powers"

--- a/code/modules/psionics/psion_powers/gear_summoning_powers.dm
+++ b/code/modules/psionics/psion_powers/gear_summoning_powers.dm
@@ -80,8 +80,8 @@
 		//Small tracker of how many shields we have use for preventing a spawning of a 3rd shield
 		var/num_of_shields = 0
 
-		//This is a little messy as we are going to do the same thing basically twice, but if you have 2 shields\
-		Then you get to enhanced one for free!
+		// This is a little messy as we are going to do the same thing basically twice, but if you have 2 shields
+		// Then you get to enhanced one for free!
 		if(active)
 			if(istype(active, /obj/item/shield/riot/crusader/psionic))
 				var/obj/item/shield/riot/crusader/psionic/PS = active

--- a/code/modules/psionics/psion_powers/gear_summoning_powers.dm
+++ b/code/modules/psionics/psion_powers/gear_summoning_powers.dm
@@ -129,7 +129,7 @@
 		//If we have 60 TGH we automatically make the basic shield block proj skipping 1 psionic point cost
 		//This is so that if you have tanked cog or just power level TGH to be able to use the shield more affectively you can still be tanky!
 		//If you pick bedlam backround you also bypass the need of 2 points to block proj.
-		if (owner.stats.getStat(STAT_TGH) >= STAT_LEVEL_PROF || owner.stats.getPerk(PERK_PSI_MANIA)
+		if (owner.stats.getStat(STAT_TGH) >= STAT_LEVEL_PROF || owner.stats.getPerk(PERK_PSI_MANIA))
 			owner.visible_message(
 			"[owner] looks at the psy-shield and forcefully compresses it!",
 			"Its hard to tell but you can feel that the shield well more solidified. This should be able capable of blocking lasers and bullets."

--- a/code/modules/psionics/psion_powers/gear_summoning_powers.dm
+++ b/code/modules/psionics/psion_powers/gear_summoning_powers.dm
@@ -128,7 +128,8 @@
 		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
 		//If we have 60 TGH we automatically make the basic shield block proj skipping 1 psionic point cost
 		//This is so that if you have tanked cog or just power level TGH to be able to use the shield more affectively you can still be tanky!
-		if (owner.stats.getStat(STAT_TGH) >= STAT_LEVEL_PROF)
+		//If you pick bedlam backround you also bypass the need of 2 points to block proj.
+		if (owner.stats.getStat(STAT_TGH) >= STAT_LEVEL_PROF || owner.stats.getPerk(PERK_PSI_MANIA)
 			owner.visible_message(
 			"[owner] looks at the psy-shield and forcefully compresses it!",
 			"Its hard to tell but you can feel that the shield well more solidified. This should be able capable of blocking lasers and bullets."
@@ -145,7 +146,7 @@
 	psi_point_cost = 1
 
 	if(pay_power_cost(psi_point_cost))
-		var/obj/item/shield/riot/crusader/psionic/shield = new /obj/item/shield/riot/crusader/psionic(src, owner)
+		var/obj/item/shield/riot/crusader/psionic/layered/shield = new /obj/item/shield/riot/crusader/psionic/layered(src, owner)
 		owner.visible_message(
 			"[owner] clenches their fist, electricity crackling before a psy-shield forms in their hand!",
 			"You feel the rush of electric essence shocking your hand lightly before a psy-shield forms!"

--- a/code/modules/psionics/psion_powers/gear_summoning_powers.dm
+++ b/code/modules/psionics/psion_powers/gear_summoning_powers.dm
@@ -126,6 +126,16 @@
 			"You feel the rush of electric essence shocking your hand lightly before a psy-shield forms!"
 			)
 		playsound(usr.loc, pick('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg'), 50, 1, -3)
+		//If we have 60 TGH we automatically make the basic shield block proj skipping 1 psionic point cost
+		//This is so that if you have tanked cog or just power level TGH to be able to use the shield more affectively you can still be tanky!
+		if (owner.stats.getStat(STAT_TGH) >= STAT_LEVEL_PROF)
+			owner.visible_message(
+			"[owner] looks at the psy-shield and forcefully compresses it!",
+			"Its hard to tell but you can feel that the shield well more solidified. This should be able capable of blocking lasers and bullets."
+			)
+			shield.can_block_proj = TRUE
+			shield.base_block_chance += 10
+			shield.adjustShieldDurability(-10, owner)
 		usr.put_in_active_hand(shield)
 
 /obj/item/organ/internal/psionic_tumor/proc/psionic_shield_layered()

--- a/code/modules/psionics/psionic_items/psi_catalysts.dm
+++ b/code/modules/psionics/psionic_items/psi_catalysts.dm
@@ -150,7 +150,8 @@
 /obj/item/device/psionic_catalyst/Light_psi_armor
 	name = "psionic catalyst: Void robe"
 	desc = "Psionic catalysts, other worldly items not quite understood, but valuable for the powers they may grant a psion. To everyone else, they have research value in a deconstructor or may be \
-	recycled for the somewhat rare materials that make them. Holding it feels quite strange. Even to an unattuned mind, one can hear the faintly glowing object whispering, the eager voices say: TEST"
+	recycled for the somewhat rare materials that make them. Holding it feels quite strange. Even to an unattuned mind, one can hear the faintly glowing object whispering, the eager voices say: \
+	Can we really afford to not be in are shell?"
 	stored_power = /obj/item/organ/internal/psionic_tumor/proc/Light_psi_armor
 
 /obj/item/device/psionic_catalyst/Hpsi_armor
@@ -159,6 +160,13 @@
 	recycled for the somewhat rare materials that make them. Holding it feels quite strange. Even to an unattuned mind, one can hear the faintly glowing object whispering, the eager voices say: \
 	Pain accompanies you, broken bones, torn flesh have become your companions. This catalyst will help to minimize suffering by giving your mind and body a rest."
 	stored_power = /obj/item/organ/internal/psionic_tumor/proc/Hpsi_armor
+
+/obj/item/device/psionic_catalyst/layered_psi_shield
+	name = "psionic catalyst: Layered Shield"
+	desc = "Psionic catalysts, other worldly items not quite understood, but valuable for the powers they may grant a psion. To everyone else, they have research value in a deconstructor or may be \
+	recycled for the somewhat rare materials that make them. Holding it feels quite strange. Even to an unattuned mind, one can hear the faintly glowing object whispering, the eager voices say: \
+	If we put are mind to it, we can think of many shapes at the same time."
+	stored_power = /obj/item/organ/internal/psionic_tumor/proc/psionic_shield_layered
 
 /obj/item/device/psionic_catalyst/add_initial_transforms()
 	. = ..()
@@ -202,6 +210,7 @@
 				/obj/item/device/psionic_catalyst/psionic_ascension = 10,
 				/obj/item/device/psionic_catalyst/Hpsi_armor = 4,
 				/obj/item/device/psionic_catalyst/Light_psi_armor = 4,
+				/obj/item/device/psionic_catalyst/layered_psi_shield = 8,
 				/obj/item/device/psionic_catalyst/heretical_ascension = 1))
 
 // Psi-related lore paperwork. Not really a good place to put this so here it is. -Kaz

--- a/code/modules/psionics/psionic_items/psi_temp_items.dm
+++ b/code/modules/psionics/psionic_items/psi_temp_items.dm
@@ -204,7 +204,7 @@
 
 /obj/item/shield/riot/crusader/psionic
 	name = "psychic combat shield"
-	desc = "A shield projected by the mind of a psion, it's speed and skill depend on the toughness of the psionic that created it. Useful for blocking energy beams, bullets, and melee attacks. \
+	desc = "A shield projected by the mind of a psion, it's speed and skill depend on the toughness of the psionic that created it. Useful for blocking melee attacks. \
 	A simple thought can deploy or shrink the shield at will."
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "psishield1"
@@ -220,6 +220,8 @@
 	armor_list = list(melee = 15, bullet = 15, energy = 35, bomb = 15, bio = 0, rad = 0)
 	base_block_chance = 40
 	var/mob/living/carbon/holder // The one that prevent the blade from fading
+	//Got to do a little more effort to make this block proj (min cost of 2 points)
+	can_block_proj = FALSE
 
 /obj/item/shield/riot/crusader/psionic/New(var/loc, var/mob/living/carbon/Maker)
 	..()
@@ -233,6 +235,15 @@
 		STOP_PROCESSING(SSobj, src)
 		qdel(src)
 		return
+
+/obj/item/shield/riot/crusader/psionic/layered
+	name = "layered psychic combat shield"
+	desc = "Unlike the idea of a shield this one is made of many thin layers allowing it to block projectiles and attacks easier \
+	Due to this process of layering it can not be enhanced or modified without destroying itself."
+	max_durability = 120
+	durability = 120
+	base_block_chance = 50
+	armor_list = list(melee = 25, bullet = 20, energy = 40, bomb = 25, bio = 0, rad = 0)
 
 // Psionic gun.
 /obj/item/gun/kinetic_blaster


### PR DESCRIPTION
Psionic shields by default no longer block proj
Psionic shields now when activated again with one in hand will gain blocking for proj at the cost of 10 durably, but gain 10 more block odds
If you have more then 60 TGH (STAT_LEVEL_PROF aka Master) you will for free condense the shield as if you used an additional psionic point for free

Psionic shields if able to already block proj will gain 80 durability back + 5% more blocking odds 

New psionic shield type Layered Psionic shield, costs 1 point found in deepmaints catalysts. Blocks proj by default as well as has more max durability and armor values 