### PR TITLE
Tisane description fix

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1920,7 +1920,7 @@
 
 /obj/item/reagent_containers/food/snacks/mercy_tisane
 	name = "mercys hand tisane"
-	desc = "A somewhat concentrated decoction of poppy flower. Not entirely pleasant tasting, but it does a better job of purging toxins than eating sun tears raw."
+	desc = "A somewhat concentrated decoction of mercy hand. Not entirely pleasant tasting, but it does a better job of purging toxins than eating mercy hand raw."
 	icon_state = "mercy_tisane"
 	nutriment_desc = list("tart tea" = 1)
 	nutriment_amt = 1


### PR DESCRIPTION
Fixes the description of mercys hand tisane to accurately reference itself instead of two separate wrong fruit.


Image to show the before and after results, and that it compiles/launches.

![image](https://github.com/sojourn-13/sojourn-station/assets/47806118/99c12bdb-cf05-40fc-a59b-aec24ce34312)
