### PR TITLE
Lowers cost of armament summoning litanies, ensures litanies consume power, couple other minor Church fixes

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -144,7 +144,7 @@
 /datum/ritual/cruciform/base/message/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C,list/targets)
 	var/mob/living/carbon/human/H = pick_disciple_global(user, TRUE)
 	if (!H)
-		return
+		return TRUE //You pay even if you don't actually talk to anyone. Sending shouldn't be a free version of Baptismal Record.
 
 	if(user == H)
 		fail("You feel stupid.",user,C,targets)
@@ -152,7 +152,7 @@
 
 	var/text = input(user, "What message will you send to the target? The message will be recieved telepathically.", "Sending a message") as text|null
 	if (!text)
-		return
+		return TRUE //You pay even if you don't actually talk to anyone. Sending shouldn't be a free version of Baptismal Record.
 	to_chat(H, "<span class='notice'><b><font size='3px'><font color='#ffaa00'>[user.real_name]'s voice speaks in your mind: \"[text]\"</font><b></span>")
 	to_chat(user, "<span class='info'><font color='#ffaa00'>You say to [H]: \"[text]\"</font></span>")
 	log_and_message_admins("[user.real_name] sent a message to [H] with text \"[text]\"")

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -44,7 +44,6 @@
 	cooldown_category = "bglow"
 
 /datum/ritual/cruciform/base/glow_book/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/cruciform/C)
-	var/successful = FALSE
 	if (istype(H.get_active_hand(), /obj/item/book/ritual/cruciform))
 		var/obj/item/book/ritual/cruciform/M = H.get_active_hand()
 		M.set_light(5) //Slightly better than as a lantern since you can only hold it in hand or within the belt slot.
@@ -54,11 +53,11 @@
 			SPAN_NOTICE("The ritual book you're holding begins to glow brightly.")
 		)
 		addtimer(CALLBACK(M, /obj/item/book/ritual/cruciform/proc/glowient), 6000)
-		successful = TRUE
 		set_personal_cooldown(H)
+		return TRUE
 	else
 		to_chat(H, SPAN_DANGER("You need to be holding a ritual book to perfom this rite."))
-	return successful
+		return FALSE
 
 /obj/item/book/ritual/cruciform/proc/glowient()
 	set_light(0)
@@ -149,7 +148,7 @@
 
 	if(user == H)
 		fail("You feel stupid.",user,C,targets)
-		return FALSE
+		return TRUE //You pay even if you don't actually talk to anyone. Sending shouldn't be a free version of Baptismal Record.
 
 	var/text = input(user, "What message will you send to the target? The message will be recieved telepathically.", "Sending a message") as text|null
 	if (!text)
@@ -159,6 +158,7 @@
 	log_and_message_admins("[user.real_name] sent a message to [H] with text \"[text]\"")
 	playsound(user.loc, 'sound/machines/signal.ogg', 50, 1)
 	playsound(H, 'sound/machines/signal.ogg', 50, 1)
+	return TRUE
 
 
 /datum/ritual/cruciform/base/revelation
@@ -287,7 +287,7 @@
 	var/turf/T = get_turf(user)
 	if (!(T.Adjacent(get_turf(H))))
 		to_chat(user, SPAN_DANGER("[H] is beyond your reach.."))
-		return
+		return FALSE
 
 	user.visible_message("[user] places their hands upon [H] and utters a prayer", "You lay your hands upon [H] and begin speaking the words of succor")
 	if (do_after(user, 40, H, TRUE))

--- a/code/modules/core_implant/cruciform/rituals/construction.dm
+++ b/code/modules/core_implant/cruciform/rituals/construction.dm
@@ -49,6 +49,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 			continue
 		listed_components += list("[blueprint.materials[placeholder]] [initial(placeholder.name)]")
 	to_chat(user, SPAN_NOTICE("[blueprint.name] requires: [english_list(listed_components)]."))
+	return TRUE
 
 /datum/ritual/cruciform/priest/construction
 	name = "Manifestation"
@@ -117,6 +118,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 	user.visible_message(SPAN_NOTICE("You hear a soft humming sound as [user] finishes his ritual."),SPAN_NOTICE("You take a deep breath as the divine manifestation finishes."))
 	var/build_path = blueprint.build_path
 	new build_path(target_turf)
+	return TRUE
 
 /datum/ritual/cruciform/priest/construction/proc/items_check(mob/user,turf/target, datum/nt_blueprint/blueprint)
 	var/list/turf_contents = target.contents
@@ -188,6 +190,7 @@ GLOBAL_LIST_INIT(nt_constructs, init_nt_constructs())
 	user.visible_message(SPAN_NOTICE("Clanking of parts hit the floor as [user] finishes their prayer and the machine falls apart."),SPAN_NOTICE("Collect the evidence, and begin to atone."))
 
 	qdel(reclaimed)
+	return TRUE
 
 /datum/nt_blueprint/
 	var/name = "Report me"

--- a/code/modules/core_implant/cruciform/rituals/crusader.dm
+++ b/code/modules/core_implant/cruciform/rituals/crusader.dm
@@ -126,7 +126,7 @@
 	name = "Litany of Armaments"
 	phrase = "Supra Domini, bona de te peto. Audi me, et libera vocationem ad me munera tua."
 	desc = "Request a greatsword, tower shield, and suit of power armor from the church armory to become a real crusader. Establishing the connection takes a lot of power and this litany may only be used once every twelve hours."
-	power = 100
+	power = 75 //Only usable once per shift anyway, we don't need to use every drop of power the player has
 	cooldown = TRUE
 	cooldown_time = 12 HOURS
 	cooldown_category = "armaments"
@@ -139,3 +139,4 @@
 	new /obj/item/storage/belt/security/neotheology(usr.loc)
 	new /obj/item/clothing/suit/space/void/crusader(usr.loc)
 	set_personal_cooldown(user)
+	return TRUE

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -116,54 +116,6 @@
 
 	return TRUE
 
-
-
-/* Two AoE heals and they're not that helpful anyway in ErisMed
-/datum/ritual/cruciform/tessellate/desperate_calculation
-	name = "Desperate Calculation"
-	phrase = "Vere languores nostros ipse tulit, et dolores nostros ipse portavit." //"Surely he took up our pain and bore our suffering,"
-	desc = "An immensely powerful healing litany that restores any who hear it around the speaker, however the strength of the litany requires so much that the body of the speaker is temporarily ravaged by hunger. \
-	Due to the strength of this hymn, it can only be used once every half hour."
-	cooldown = TRUE
-	power = 60
-	cooldown_time = 30 MINUTES
-	cooldown_category = "dcalculation" //Seperate cooldown since it stuns the user.
-	nutri_cost = 150 //Leaving it in for this particular one: it's supposed to consume your nutrition to work. Sadly can't think of a good equivalent debuff for synths, but I rarely see synth Tesselates anyway
-
-/datum/ritual/cruciform/tessellate/desperate_calculation/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C)
-	var/list/people_around = list()
-	if(user.species?.reagent_tag != IS_SYNTHETIC)
-		if(user.nutrition >= nutri_cost)
-			user.nutrition -= nutri_cost
-		else
-			user.nutrition = 0 //No more blood cost, but it can and will drop your nutrition to zero
-	for(var/mob/living/carbon/human/H in view(user))
-		if(H != user && !isdeaf(H))
-			people_around.Add(H)
-
-	if(people_around.len > 0)
-		user.visible_message("<b><font color='red'>[user]'s cruciform glows brightly!</font><b>", "<b><font color='red'>Your feel the air thrum with an inaudible vibration, your cruciform withdrawing a lot of power to empower your litany!</font><b>", "<b><font color='red'>You hear a small crackle!</font><b>")
-		playsound(user.loc, 'sound/machines/signal.ogg', 50, 1)
-		for(var/mob/living/carbon/human/participant in people_around)
-			to_chat(participant, SPAN_NOTICE("You hear a silent signal..."))
-			heal_other(participant)
-			add_effect(participant, FILTER_HOLY_GLOW, 25)
-		set_personal_cooldown(user)
-		return TRUE
-	else
-		fail("Your cruciform sings, alone, unto the void.", user, C)
-		return FALSE
-
-/datum/ritual/cruciform/tessellate/desperate_calculation/proc/heal_other(mob/living/carbon/human/participant)
-		to_chat(participant, "<span class='info'>A sensation of relief bathes you, washing away most of your pain!</span>")
-		participant.reagents.add_reagent("laudanum", 10)
-		participant.adjustBruteLoss(-40)
-		participant.adjustFireLoss(-40)
-		participant.adjustOxyLoss(-80)
-		participant.adjustBrainLoss(-10)
-		participant.updatehealth()
-*/
-
 /datum/ritual/cruciform/tessellate/superstable //More powerful version of Absolution of Wounds, lacks inaprov but does some basic healing over time. No cooldown, but chems will OD if spammed on a patient.
 	name = "Spare the Dying"
 	phrase = "Et tenens manum puellae, ait illi: Talitha cumi, quod est interpretatum: Puella (tibi dico), surge." //" He took her by the hand and said to her, “Talitha koum!” (which means “Little girl, I say to you, get up!”)."
@@ -312,6 +264,7 @@
 	new /obj/item/storage/lunchbox/lemniscate/full(usr.loc)
 	to_chat(user, SPAN_NOTICE("A lemniscate branded lunchbox that smells delicious appears at your feet, still warm and fresh from the kitchens!"))
 	set_personal_cooldown(user)
+	return TRUE
 
 /datum/ritual/cruciform/lemniscate/zoom_litany
 	name = "Infinite Hymn"
@@ -325,7 +278,7 @@
 
 /datum/ritual/cruciform/lemniscate/zoom_litany/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/cruciform/C,list/targets)
 	to_chat(H, "<span class='info'>You feel yourself speeding up, your senses and reaction times quickening!</span>")
-	H.add_chemical_effect(CE_SPEEDBOOST, 0.2, 5 MINUTES, "hyperzine")
+	H.reagents.add_reagent("hyperzine", 10)
 	H.updatehealth()
 	set_personal_cooldown(H)
 	return TRUE
@@ -480,7 +433,7 @@
 	name = "Canticle of Defense"
 	phrase = "At illi dixerunt: Nihil. Dixit ergo eis: Sed nunc qui habet sacculum, tollat; similiter et peram: et qui non habet, vendat tunicam suam et emat gladium." //"He said to them, “But now if you have a purse, take it, and also a bag; and if you don’t have a sword, sell your cloak and buy one."
 	desc = "Request a Counselor taser, absolutism tactical belt, and divisor garb from the church armory for defending yourself and your fellow disciples. Establishing the connection takes a lot of power and this litany may only be used once every four hours."
-	power = 50
+	power = 20 //Balanced mainly by 4 hour cooldown
 	cooldown = TRUE
 	cooldown_time = 4 HOURS
 	cooldown_category = "cdefn"
@@ -492,30 +445,8 @@
 	new /obj/item/clothing/head/rank/divisor(usr.loc)
 	new /obj/item/clothing/suit/greatcoat/divisor(usr.loc)
 	set_personal_cooldown(user)
-/*
-/datum/ritual/cruciform/divisor/div_flash
-	name = "Ire"
-	phrase = "Fortitudo mea et laus mea Dominus, et sicut in omnibus divitiis."
-	desc = "Knocks over everybody without cruciform in your view range. Though the energy emitted is quite powerful, a vigilant person may resist it. This litany can only be used once every 30 minutes."
-	cooldown = TRUE
-	cooldown_time = 30 MINUTES
-	cooldown_category = "dflas"
-	power = 50
-
-/datum/ritual/cruciform/divisor/div_flash/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C)
-	playsound(user.loc, 'sound/effects/cascade.ogg', 65, 1)
-	log_and_message_admins("performed an ire litany")
-	for(var/mob/living/victim in view(user))
-		if(!victim.get_core_implant(/obj/item/implant/core_implant/cruciform))
-			if(prob(100 - (victim.stats.getStat(STAT_VIG))))
-				to_chat(victim, SPAN_WARNING("You feel a blast of energy that knocks you down!"))
-				victim.Stun(3)
-				victim.Weaken(3)
-			else
-				to_chat(victim, SPAN_NOTICE("Your legs feel numb, but you managed to stay on your feet!"))
-	set_personal_cooldown(user)
 	return TRUE
-*/
+
 /datum/ritual/cruciform/divisor/echo_of_blasphemy
 	name = "Echo of Blasphemy"
 	phrase = "Ignem veni mittere in terram, et quid volo nisi ut accendatur?" //"I have come to bring fire on the earth, and how I wish it were already kindled!"
@@ -694,6 +625,7 @@
 		user.stats.addTempStat(STAT_VIG, debuff_amount, debuff_length, src.name)
 		addtimer(CALLBACK(src, .proc/debuff_over, user), debuff_length)
 		set_personal_cooldown(user)
+		return TRUE
 
 /datum/ritual/cruciform/factorial/self_repair/proc/debuff_over(user)
 	to_chat(user, "Your energy returns to you from your self-repairs, leaving you in full fighting shape once more.")
@@ -753,6 +685,7 @@
 		set_personal_cooldown(user)
 		to_chat(user, "You feel your energy flowing into those you have blessed. The drain will significantly interfere with your combat abilities for a few minutes.")
 		addtimer(CALLBACK(src, .proc/healer_debuff_over, user), debuff_length_healer)
+		return TRUE
 
 /datum/ritual/cruciform/factorial/mass_repair/proc/healed_debuff_over(mob/living/carbon/human/H)
 	to_chat(H,"You feel the interference dissipate, leaving you once more at combat readiness.") //Not entirely true if you got this stacked by multiple healers, but if you did that's your problem.

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -178,7 +178,7 @@
 	power = 100
 	category = "Episcopal"
 
-/datum/ritual/cruciform/priest/scrying/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C,list/targets)
+/datum/ritual/cruciform/priest/scrying/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C, list/targets)
 
 	if(!user.client)
 		return FALSE
@@ -307,9 +307,6 @@
 
 	return TRUE
 
-
-
-
 /datum/ritual/cruciform/priest/ejection
 	name = "Deprivation"
 	phrase = "Et revertatur pulvis in terram suam unde erat et spiritus redeat ad Deum qui dedit illum." //"and the dust returns to the ground it came from, and the spirit returns to God who gave it."
@@ -346,41 +343,6 @@
 	else
 		fail("Deprivation does not work upon the living.", user, C)
 		return FALSE
-
-/* We have the Remove Upgrade litany, we don't need this one
-/datum/ritual/cruciform/priest/unupgrade
-	name = "Asacris"
-	phrase = "Redi ad initium." //"Return to the beginning."*
-	desc = "This litany will remove any upgrade from the target's cruciform implant. Usuable only by primes."
-	power = 75
-	category = "Episcopal"
-
-/datum/ritual/cruciform/priest/unupgrade/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C)
-	var/obj/item/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/implant/core_implant/cruciform)
-
-	if(!CI)
-		fail("There is no cruciform on this one.", user, C)
-		return FALSE
-
-	if(!CI.wearer)
-		fail("Cruciform is not installed.", user, C)
-		return FALSE
-
-	if(!C.get_module(CRUCIFORM_PRIME))
-		fail("Only Primes can perform this litany.")
-		return FALSE
-
-	if(!istype(CI.upgrades) || length(CI.upgrades) <= 0)
-		fail("There is no upgrades on this one.", user, C)
-		return FALSE
-
-	for(var/obj/item/coreimplant_upgrade/CU in CI.upgrades)
-		CU.remove()
-		log_and_message_admins("removed upgrade from [C] cruciform with asacris litany")
-
-	return TRUE
-	*/
-
 
 ///////////////////////////////////////
 ///////////SHORT BOOST LITANIES////////
@@ -757,6 +719,7 @@
 	new /obj/item/coreimplant_upgrade/cruciform/priest(altar.loc)
 	altar.cooldown(altar_cooldown)
 	set_personal_cooldown(user)
+	return TRUE
 
 /datum/ritual/cruciform/priest/initiation
 	name = "Consecration"
@@ -782,7 +745,7 @@
 		fail("Target must have devout upgrade inside his cruciform.",user,C)
 		return FALSE
 	PC.activate()
-	log_and_message_admins("promoted disciple [C] to devout with the Consecration litany")
+	log_and_message_admins("promoted disciple [CI.wearer] to devout with the Consecration litany")
 
 	return TRUE
 
@@ -799,11 +762,16 @@
 		fail("Cruciform not found.", user, C)
 		return FALSE
 
+	var/mob/living/carbon/human/H = CI.wearer
+
 	if(CI.get_module(CRUCIFORM_CLERGY))
 		fail("Disciple is already a Vector.", user, C)
 		return FALSE
 	else
 		CI.make_vector()
+		to_chat(H, SPAN_NOTICE("You feel divine power growing within your cruciform as you are ordained."))
+		to_chat(user, SPAN_NOTICE("The cruciform of [H] thrums with a power only you can feel as they are ordained."))
+		log_and_message_admins("[user] has given [H] access to Vector litanies with Ordination.")
 	return TRUE
 
 /datum/ritual/cruciform/priest/reduction
@@ -862,6 +830,7 @@
 		to_chat(H, SPAN_DANGER("You feel a cold emptiness as you are cut off from the Absolute and the faithful. Your cruciform falls from your chest and down to the floor, lifeless."))
 		to_world("The cruciform of [H] falls to the ground, inactive.")
 		log_and_message_admins("removed [H]'s cruciform with the Separation litany.")
+		return TRUE
 
 /datum/ritual/cruciform/priest/adoption
 	name = "Adoption"
@@ -876,34 +845,23 @@
 		fail("Cruciform not found.", user, C)
 		return FALSE
 
+	var/mob/living/carbon/human/H = CI.wearer
+
 	var/designation = alert("Do you wish to give access to common or clergy (Prime) doors?", "Litany of Adoption", "Common","Clergy")
 	if(designation == "Common")
 		CI.security_clearance = CLEARANCE_COMMON
+		to_chat(H, SPAN_NOTICE("You feel paths open before you as you are granted access to the common doors of the Church."))
+		log_and_message_admins("[user] has given [H] access to common Church doors with Adoption.")
 	else if(designation == "Clergy")
 		if(C.security_clearance < CLEARANCE_CLERGY) //No more Vectors letting each other into the Prime's office
-			fail("You cannot give access to doors you yourself lack access to.")
+			fail("You cannot give access to doors you yourself lack access to.", user, C)
 			return FALSE
 		else
 			CI.security_clearance = CLEARANCE_CLERGY
+			to_chat(H, SPAN_NOTICE("You feel paths open before you as you are granted access to the clergy doors of the Church."))
+			log_and_message_admins("[user] has given [H] access to clergy Church doors with Adoption.")
 	return TRUE
 
-/*
-/datum/ritual/cruciform/priest/passage
-	name = "Passage"
-	phrase = "Gloriam sapientes possidebunt stultorum exaltatio ignominia."
-	desc = "Opens clergy doors for target disciple."
-	power = 15
-
-/datum/ritual/cruciform/priest/passage/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C,list/targets)
-	var/obj/item/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/implant/core_implant/cruciform)
-
-	if(!CI || !CI.wearer || !ishuman(CI.wearer) || !CI.active)
-		fail("Cruciform not found.", user, C)
-		return FALSE
-
-	CI.security_clearance = CLEARANCE_CLERGY
-	return TRUE
-	*/
 
 /datum/ritual/cruciform/priest/omission
 	name = "Omission"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Lowers the price of a couple litanies, ensures all litanies return TRUE when they succeed and thus actually spend their power, and fixes a couple other minor issues
</summary>
<hr>

Lowers the price of the Canticle of Defense (divisor weapon summon litany) and Litany of Armaments (crusader weapon summon litany) from 50 to 20 and from 100 to 75 respectively. Canticle of Defense has a four hour cooldown which means it can be used at most twice in a shift anyways, and Litany of Armaments has a 12 hour cooldown, it can never be used more than once in a shift. Canticle of Defense in particular is often used (at least by me) to get some Church looking clothes and a nonlethal weapon while not on duty as a Vector, and having a 50 cost just delays getting it for several more minutes.

While testing this, I also noticed that a lot of litanies didn't actually use the power, just failed if you didn't have it, and realized that "return TRUE" is necessary for power to be spent. Went through and ensured all litanies will return TRUE on a success. Sending will return TRUE even if no message is sent to make it not useable as a free version of Baptismal Record. Made a few of the litanies I added with my big PR more verbose, including logging and messaging admins when additional power/access is given to another believer.
	
<hr>
</details>

## Changelog
:cl:
tweak: Divisor and Crusader weapon summoning litanies are a bit cheaper energy-wise since they have massive cooldowns
fix: All litanies should now actually spend power upon success. Sending will spend power even if no message is sent so it can't be used as a free version of Baptismal Record
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
