### PR TITLE
hydrogen plasma fixes and stuff

### DIFF
--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -410,7 +410,7 @@
 	name = "claymore"
 	result = /obj/item/tool/sword
 	steps = list(
-		list(CRAFT_MATERIAL, 15, MATERIAL_STEEL, "time" = 30),
+		list(CRAFT_MATERIAL, 15, MATERIAL_PLASTEEL, "time" = 30),
 		list(QUALITY_SAWING, 30, "time" = 60),
 		list(QUALITY_HAMMERING, 30, "time" = 40),
 		list(QUALITY_WELDING, 40, "time" = 60)

--- a/code/modules/projectiles/guns/energy/plasma/hydrogen.dm
+++ b/code/modules/projectiles/guns/energy/plasma/hydrogen.dm
@@ -22,7 +22,8 @@ Securing and unsecuring the flask is a long and hard task, and a failure when un
 	w_class = ITEM_SIZE_BULKY
 	init_recoil = CARBINE_RECOIL(0.1)
 	twohanded = FALSE
-	can_dual = TRUE
+	can_dual = FALSE
+	slot_flags = SLOT_BELT|SLOT_BACK
 	max_upgrades = 3
 	fire_delay = 10
 	fire_sound = 'sound/weapons/energy/hydrogen.ogg'

--- a/code/modules/projectiles/guns/energy/plasma/variant.dm
+++ b/code/modules/projectiles/guns/energy/plasma/variant.dm
@@ -43,7 +43,6 @@
 		list(mode_name = "overclock", mode_desc="A large ball of volatile hydrogen to blow up cover or targets", projectile_type = /obj/item/projectile/hydrogen/cannon/max, fire_sound = 'sound/weapons/energy/hydrogen_heavy.ogg', fire_delay = 50, icon = "vaporize", use_plasma_cost = 30)
 	)
 	twohanded = TRUE
-	can_dual = FALSE
 
 // Blue cross weapon, no overheat.
 /obj/item/gun/hydrogen/incinerator

--- a/code/modules/projectiles/guns/energy/plasma/variant.dm
+++ b/code/modules/projectiles/guns/energy/plasma/variant.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/guns/plasma/hydrogen.dmi'
 	icon_state = "pistol"
 	twohanded = FALSE
+	slot_flags = SLOT_BELT|SLOT_HOLSTER|SLOT_BACK
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 6, TECH_PLASMA = 5)
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_MHYDROGEN = 1, MATERIAL_TRITIUM = 1)
@@ -18,6 +19,7 @@
 		list(mode_name = "overclock", mode_desc="A large ball of volatile hydrogen to blow up cover or targets", projectile_type = /obj/item/projectile/hydrogen/pistol/max, fire_sound = 'sound/weapons/energy/hydrogen_heavy.ogg', icon = "vaporize", heat_per_shot = 40, use_plasma_cost = 20)
 	)
 
+	can_dual = TRUE
 	wield_delay = 0.3 SECOND
 	wield_delay_factor = 0.2 // 20 vig
 
@@ -30,6 +32,8 @@
 	icon_state = "cannon"
 	matter = list(MATERIAL_PLASTEEL = 25, MATERIAL_MHYDROGEN = 2, MATERIAL_TRITIUM = 1)
 	origin_tech = list(TECH_COMBAT = 9, TECH_MATERIAL = 7, TECH_PLASMA = 10)
+	w_class = ITEM_SIZE_HUGE
+	slot_flags = SLOT_BACK
 	projectile_type = /obj/item/projectile/hydrogen/cannon
 	use_plasma_cost = 15 // 10 shots
 	heat_per_shot = 50
@@ -76,6 +80,7 @@
 	var/obj/item/tool/plasma_torch/welder = null // Hold the welder the gun turns into.
 	serial_type = "INDEX"
 	serial_shown = FALSE
+	slot_flags = SLOT_BELT|SLOT_HOLSTER|SLOT_BACK
 
 
 // This is where the gun turn into a welder


### PR DESCRIPTION
Fixes the hydrogen plasma weapons missing slot_flag vars. Is that a hydrogen plasma cannon in your pocket or are you just happy to see me?

Pretty much funny thing fix. Could holster all hydrogen plasma weapons. The cannon! Included! So silly. I figure this was a oversight and unintended. Now ONLY the welder gun and hydrogen pistol can be holstered. Hydrogen cannon no longer fits in a bag as well. Only the pistol/welder can be duel wielded.

Tiny exploit fix to the guild claymore crafting recipe as well. You can no longer use it to convert steel into plasteel.