### PR TITLE
Take 2 at making nanopaste not cringe.

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -102,6 +102,8 @@
 #define PERK_REZ_SICKNESS_SEVERE /datum/perk/rezsickness/severe
 #define PERK_REZ_SICKNESS_FATAL /datum/perk/rezsickness/severe/fatal
 
+#define PERK_FSYNDROME /datum/perk/fsyndrome
+
 //////////////
 //Race Perks//
 //////////////

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -361,10 +361,24 @@
 	if(holder.buckled)
 		cooldown_time -= 2 SECONDS
 
+/datum/perk/fsyndrome
+	name = "Flatline Syndrome"
+	desc = "Whether on purpose or on accident your grey-matter was nearly destroyed. The miracles of modern medicine have brought you back, but only barely. Your constition fails you and unlike the more common forms of revival-sickness it's going to take more than a powernap to walk this one off."
+
+/datum/perk/fsyndrome/assign(mob/living/carbon/human/H)
+	..()
+	holder.brute_mod_perk += 0.5
+	holder.burn_mod_perk += 0.5
+	holder.oxy_mod_perk += 0.5
+	holder.toxin_mod_perk += 0.5
+	holder.stats.changeStat(STAT_ROB, -40)
+	holder.stats.changeStat(STAT_TGH, -40)
+	holder.stats.changeStat(STAT_VIG, -40)
+
 /datum/perk/racial/slime_rez_sickness
 	name = "Aulvae Decohesion Syndrome"
 	desc = "You've recently been returned to cohesion via the use of high-energy toxins which have left your form in a semi-stable state."
-	gain_text = "Your core vibrates and crackles with barely contained energy as you're revived. You feel stronger than ever, but your form is unstable and fragile. Perhaps it'd be best to lie down and allow time for this to pass, lest you loose cohesion once again."
+	gain_text = "Your core vibrates and crackles with barely contained energy as you're revived. You feel stronger than ever, but your form is unstable and fragile. Perhaps it'd be best to lie down and allow time for this to pass, lest you lose cohesion once again."
 	lose_text = "The thunder bouncing around just beneath your dermis has passed and you feel stable once again."
 	var/initial_time
 

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -4,7 +4,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_admin_say, R_ADMIN|R_MOD, TRUE)
 	set category = "Special Verbs"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	set hidden = 1
-	if(!check_rights(R_ADMIN|R_MOD)) return
+	if(!check_rights(R_ADMIN|R_MOD))	return
 
 	msg = sanitize(msg)
 	if(!msg)	return

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -4,7 +4,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_admin_say, R_ADMIN|R_MOD, TRUE)
 	set category = "Special Verbs"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	set hidden = 1
-	if(!check_rights(R_ADMIN|R_MOD))	return
+	if(!check_rights(R_ADMIN))	return
 
 	msg = sanitize(msg)
 	if(!msg)	return

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -4,7 +4,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_admin_say, R_ADMIN|R_MOD, TRUE)
 	set category = "Special Verbs"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	set hidden = 1
-	if(!check_rights(R_ADMIN))	return
+	if(!check_rights(R_ADMIN|R_MOD)) return
 
 	msg = sanitize(msg)
 	if(!msg)	return

--- a/code/modules/surgery/wound_repair.dm
+++ b/code/modules/surgery/wound_repair.dm
@@ -191,7 +191,7 @@
 	else if(!advanced_medical)
 		to_chat(user, SPAN_WARNING("You don't have the first idea how you'd repair the damaged tissue."))
 	else if(target.stats.getPerk(PERK_FSYNDROME))
-		to_chat(user, SPAN_WARNING("This mind appears to have already been rejuvenated once using nanites, further attempts are futile."))
+		to_chat(user, SPAN_WARNING("This brain appears to have already been rejuvenated once using nanites, further attempts are futile."))
 
 	if (world.time - target.timeofdeath > DEFIB_TIME_LIMIT)
 		user.visible_message(SPAN_NOTICE("[user] begins repairing any neural degradation with the [tool_name]."), \

--- a/code/modules/surgery/wound_repair.dm
+++ b/code/modules/surgery/wound_repair.dm
@@ -178,12 +178,28 @@
 		to_chat(user, SPAN_WARNING("[tool_name] has no more uses left."))
 		return
 
-	if (target.getToxLoss() >= 0 || world.time - target.timeofdeath > DEFIB_TIME_LIMIT)
-		user.visible_message(SPAN_NOTICE("[user] begins filtering out any toxins in [target]'s body and repairing any neural degradation with the [tool_name]."), \
-		SPAN_NOTICE("You begin to filter out any toxins to [target]'s body and repair any neural degradation with the [tool_name].") )
+	var/advanced_medical = user.stats.getPerk(PERK_ADVANCED_MEDICAL)
+	var/obj/item/organ/internal/vital/brain/B
+	if(target.getBrainLoss()>= 200 && tool.amount == 5 && advanced_medical && !target.stats.getPerk(PERK_FSYNDROME))
+		user.visible_message(SPAN_NOTICE("[user] begins rejuvenating damaged tissue with the [tool_name]."))
+		target.stats.addPerk(PERK_FSYNDROME)
+		tool.amount -= 5
+		B.rejuvenate()
+		log_and_message_admins("Added devestating rez sickness to [target].")
+	else if(tool.amount <=5)
+		to_chat(user, SPAN_WARNING("There's not enough nanites left to rejuvenate the damaged tissue."))
+	else if(!advanced_medical)
+		to_chat(user, SPAN_WARNING("You don't have the first idea how you'd repair the damaged tissue."))
+	else if(target.stats.getPerk(PERK_FSYNDROME))
+		to_chat(user, SPAN_WARNING("This mind appears to have already been rejuvenated once using nanites, further attempts are futile."))
+
+	if (world.time - target.timeofdeath > DEFIB_TIME_LIMIT)
+		user.visible_message(SPAN_NOTICE("[user] begins repairing any neural degradation with the [tool_name]."), \
+		SPAN_NOTICE("You begin to repair any neural degradation with the [tool_name].") )
 
 	target.custom_pain("The pain in your [affected.name] is living hell!",1)
 	..()
+
 
 /datum/old_surgery_step/external/tox_heal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/stack/tool)
 	var/tool_name = "\the [tool]"

--- a/code/modules/surgery/wound_repair.dm
+++ b/code/modules/surgery/wound_repair.dm
@@ -180,7 +180,7 @@
 
 	var/advanced_medical = user.stats.getPerk(PERK_ADVANCED_MEDICAL)
 	var/obj/item/organ/internal/vital/brain/B
-	if(target.getBrainLoss()>= 200 && tool.amount == 5 && advanced_medical && !target.stats.getPerk(PERK_FSYNDROME))
+	if(target.getBrainLoss()>= 200 && tool.amount >= 5 && advanced_medical && !target.stats.getPerk(PERK_FSYNDROME))
 		user.visible_message(SPAN_NOTICE("[user] begins rejuvenating damaged tissue with the [tool_name]."))
 		target.stats.addPerk(PERK_FSYNDROME)
 		tool.amount -= 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
Attempts to resolve an issue where one couldn't be "properly" revived when their brain dies. Nanopaste is once again able to rejuvenate a brain that has fully died. When repaired in this way, the individual permanently gains "Flatline Syndrome" a wasting weakness that serves as a particularly severe form of resurrection sickness that utterly nuked physical stats and applies severe added damage. This is offered as an alternative to my prior attempt to resolve people getting revived with destroyed brains(By making it impossible to do so). This allows you to get revived, at a severe cost. Obviously, you should strive to avoid having this done to you.

Also removes reference to filtering toxins out using nanopaste since that isn't really relevant to current med. Toxin buildup is repaired in other ways
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
