### PR TITLE
buffs Entreaty

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -92,9 +92,10 @@
 
 		var/obj/item/implant/core_implant/cruciform/CI = target.get_core_implant()
 		var/area/t = get_area(H)
+		var/turf/T = get_turf(H)
 
 		if((istype(CI)))
-			to_chat(target, SPAN_DANGER("[H], faithful cruciform follower, cries for salvation at [t.name]!"))
+			to_chat(target, SPAN_DANGER("[H], faithful cruciform follower, cries for salvation at [t.name] [T.x], [T.y], [T.z]!"))
 	return TRUE
 
 /datum/ritual/cruciform/base/reveal


### PR DESCRIPTION
Makes the common cruciform litany Entreaty give exact coordinates as well as area.  I simply believe the most common places this is useful have far to big a area to not provide coordinates. Junk fields, maint, dungeons etc.  ~~This is pretty difficult to test on a private server but it mimics the way death alarms handle it so SHOULD work.~~ Tested. Works.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
