### PR TITLE
No more connecting bioreactor to solidifier, but buffs transfer rate to canisters

### DIFF
--- a/code/modules/biomatter_manipulation/bioreactor/biotank.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/biotank.dm
@@ -26,6 +26,7 @@
 	var/obj/canister
 	var/pipes_opened = FALSE
 	var/pipes_cleanness = 200
+	var/transfer_rate = 50 //The units per processing tick that are moved into the attached canister
 
 
 /obj/machinery/multistructure/bioreactor_part/biotank_platform/Initialize()
@@ -66,7 +67,7 @@
 	if(!MS)
 		return
 	if(biotank.canister)
-		biotank.reagents.trans_to_holder(biotank.canister.reagents, 10)
+		biotank.reagents.trans_to_holder(biotank.canister.reagents, transfer_rate)
 
 
 /obj/machinery/multistructure/bioreactor_part/biotank_platform/attackby(var/obj/item/I, var/mob/user)

--- a/code/modules/biomatter_manipulation/solidifier.dm
+++ b/code/modules/biomatter_manipulation/solidifier.dm
@@ -16,7 +16,7 @@
 	idle_power_usage = 5
 	active_power_usage = 300
 	var/active = FALSE
-	var/port_dir = NORTH
+	var/port_dir = SOUTH
 	var/obj/structure/reagent_dispensers/biomatter/container
 	var/last_time_used = 0
 

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -100391,7 +100391,9 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
 "vcQ" = (
-/obj/effect/floor_decal/industrial/loading/white,
+/obj/effect/floor_decal/industrial/loading/white{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
 "vcV" = (
@@ -189350,8 +189352,8 @@ jZv
 jZv
 jZv
 xKc
-vcQ
 hrB
+vcQ
 nRi
 gvL
 qjW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Fixes the old bug of connecting bioreactors to solidifiers, buffs the transfer rate to canisters
</summary>
<hr>

Folks couldn't stop abusing it, so this puts a stop to it through a simple means: the port on the biomatter solidifier is now on the south side like on Eris, so you can't directly connect it to a bioreactor. This forces Church to once more use the intended method of filling canisters and solidifying them. I buffed the transfer rate of the bioreactor to canisters by 5x, though, to avoid it being **too** much of a constant chore. This should have the additional benefit of not runtiming and having the bioreactor no longer break consistently, since you're now forced to do things the right way which seems to avoid most of the errors.

Map change is just adjusting the positioning of the solidifier and pointing the arrow at the correct side.
![image](https://github.com/sojourn-13/sojourn-station/assets/29682682/6adf22ee-4394-42b1-b27e-4d1c5b6b29c3)

<hr>
</details>

## Changelog
:cl:
tweak: Biomatter solidifier port is now on the south side, preventing direct connection to the bioreactor
tweak: Bioreactor now transfers to canisters five times faster than it did before
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
