### PR TITLE
Makes carbons no longer spill their organs during bioreactor procesing and give too much biomatter

### DIFF
--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -96,7 +96,7 @@
 
 //This proc called on object/mob consumption
 /obj/machinery/multistructure/bioreactor_part/platform/proc/consume(atom/movable/object)
-	if(ishuman(object))
+	/*if(ishuman(object))
 		var/mob/living/carbon/human/H = object
 		for(var/obj/item/item in H.contents)
 			//non robotic limbs will be consumed
@@ -107,7 +107,7 @@
 				var/obj/machinery/multistructure/bioreactor_part/platform/neighbor_platform = pick(MS_bioreactor.platforms)
 				organ.forceMove(get_turf(neighbor_platform))
 				organ.removed()
-				continue
+				continue*/
 	qdel(object)
 	//now let's add some dirt to the glass
 	for(var/obj/structure/window/reinforced/bioreactor/glass in loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Comments out the code that ejects the organs from carbons and dissolves them separately so they don't get absurd amounts of biomass for their size
</summary>
<hr>

Exactly what it says on the tin. Humans no longer have more biomass than Empress spiders, they've got 100
	
<hr>
</details>

## Changelog
:cl:
tweak: Humans give a reasonable amount of biomass now rather than an absurd amount
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
