### PR TITLE
New-New Bar

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -135,6 +135,7 @@
 #define COLOR_LIGHTING_CREW_SOFT						"#fef9e7"
 #define COLOR_LIGHTING_SCI_BRIGHT						"#6a6c71"
 #define COLOR_LIGHTING_SCI_DARK							"#4f535f"
+#define COLOR_LIGHTING_BAR_BLUE							"#87a2f5"
 
 
 

--- a/maps/__Nadezhda/area/_Nadezhda_areas.dm
+++ b/maps/__Nadezhda/area/_Nadezhda_areas.dm
@@ -811,6 +811,7 @@
 	name = "\improper Bar"
 	icon_state = "bar"
 	sound_env = LARGE_SOFTFLOOR
+	area_light_color = COLOR_LIGHTING_BAR_BLUE
 
 /area/nadezhda/crew_quarters/bar/vip
 	name = "\improper VIP Room"

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -6301,9 +6301,7 @@
 	},
 /obj/effect/floor_decal/spline/wood,
 /turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "btQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7966,9 +7964,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "bKW" = (
 /obj/structure/bed/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
@@ -8581,9 +8577,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "bTR" = (
 /obj/item/modular_computer/console/preset/command/access{
 	dir = 4
@@ -9495,9 +9489,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "cdB" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/security{
@@ -19417,9 +19409,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "egV" = (
 /obj/structure/table/glass,
 /obj/random/rations,
@@ -23244,10 +23234,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
 "eWd" = (
-/obj/effect/window_lwall_spawn,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
 	})
 "eWe" = (
 /obj/structure/cable/yellow{
@@ -24121,6 +24117,17 @@
 /obj/structure/reagent_dispensers/fueltank/huge,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"ffE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "ffH" = (
 /obj/random/booze,
 /obj/random/booze,
@@ -24728,9 +24735,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "flq" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -27125,9 +27130,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "fLZ" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/grass/dry,
@@ -29019,9 +29022,7 @@
 /obj/structure/table/woodentable,
 /obj/item/flame/candle,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "ggD" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -30156,11 +30157,6 @@
 "gsq" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
@@ -30173,9 +30169,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "gsr" = (
 /obj/structure/bed/chair/sofa/brown/left,
 /turf/simulated/floor/wood,
@@ -32701,9 +32695,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "gVH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33744,9 +33736,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/asteroid/grass/jungle,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "hhx" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -35856,9 +35846,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "hDS" = (
 /obj/item/stack/ore,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -36964,9 +36952,7 @@
 	id = "Bar"
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "hNV" = (
 /obj/machinery/chemical_dispenser/industrial{
 	fancy_hack = 1
@@ -43346,9 +43332,7 @@
 /obj/item/flame/candle,
 /obj/machinery/camera/network/colony_underground,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "jgG" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/reedbush,
@@ -48372,17 +48356,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"kiV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
 "kiX" = (
 /obj/machinery/door/blast/regular/open{
 	id = "xenobio7";
@@ -48428,9 +48401,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "kjx" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -55214,10 +55185,17 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/farm)
 "lKe" = (
-/turf/simulated/wall/r_wall,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/obj/effect/floor_decal/spline/wood,
+/obj/effect/floor_decal/spline/wood{
+	dir = 8;
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/floor_decal/spline/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/crew_quarters/kitchen)
 "lKh" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -56124,9 +56102,7 @@
 	},
 /obj/machinery/door/unpowered/simple/wood/saloon,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "lTW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -59326,9 +59302,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "mBw" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -61127,9 +61101,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "mUL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -65930,9 +65902,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "nSe" = (
 /obj/structure/table/steel,
 /obj/random/common_oddities/low_chance,
@@ -66931,9 +66901,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "obE" = (
 /obj/landmark/join/start/supsec,
 /obj/effect/decal/cleanable/dirt,
@@ -79214,9 +79182,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "qCv" = (
 /obj/machinery/light{
 	dir = 8
@@ -80702,9 +80668,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/grass/jungle,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "qSC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -90787,9 +90751,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "sZy" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/igniter,
@@ -93402,18 +93364,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"tCZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
 "tDe" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/turcarpet,
@@ -95719,9 +95669,7 @@
 /obj/structure/railing/grey,
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "uar" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -98178,9 +98126,7 @@
 /obj/item/flame/candle,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "uAy" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "2,8"
@@ -101972,23 +101918,6 @@
 	icon_state = "13,15"
 	},
 /area/nadezhda/quartermaster/miningdock)
-"vnn" = (
-/obj/effect/floor_decal/spline/wood,
-/obj/effect/floor_decal/spline/wood{
-	dir = 8;
-	icon_state = "road_edge_decal4"
-	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
 "vnC" = (
 /obj/structure/scrap/poor,
 /obj/effect/decal/cleanable/rubble,
@@ -102092,9 +102021,7 @@
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "voK" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/door/airlock/maintenance_common,
@@ -102851,9 +102778,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "vww" = (
 /obj/machinery/door/blast/regular{
 	id = "Mil Armory";
@@ -102917,21 +102842,9 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "vxh" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28;
-	operating = 0
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "vxm" = (
 /obj/structure/sign/warning/armory/small,
 /turf/simulated/wall/church_reinforced,
@@ -103129,9 +103042,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "vAy" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/sleeper{
@@ -108415,9 +108326,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "wCP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -108760,9 +108669,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "wHh" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = 32
@@ -110605,9 +110512,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "xbR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -111679,9 +111584,7 @@
 /obj/landmark/join/start/clubworker,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "xob" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
@@ -112309,10 +112212,11 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "xvd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -112629,9 +112533,7 @@
 /obj/structure/railing/grey,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "xyb" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1
@@ -112885,9 +112787,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "xAL" = (
 /obj/machinery/power/nt_obelisk,
 /obj/machinery/camera/network/church{
@@ -115491,9 +115391,7 @@
 /area/nadezhda/maintenance/undergroundfloor2west)
 "ybE" = (
 /turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
+/area/nadezhda/crew_quarters/kitchen)
 "ybH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
@@ -178401,12 +178299,12 @@ bCN
 bCN
 bCN
 bCN
-lKe
-lKe
-lKe
-lKe
-lKe
-lKe
+bCN
+bCN
+bCN
+bCN
+bCN
+bCN
 wFV
 tnO
 fUB
@@ -179009,7 +178907,7 @@ eHE
 wls
 xAD
 ybE
-xva
+lKe
 xnW
 nRZ
 hNT
@@ -179206,15 +179104,15 @@ ijo
 xNt
 orF
 bCN
-eWd
+ilr
 ilr
 bCN
 bTI
 flb
-vnn
+xva
 gVG
 mUH
-lKe
+bCN
 whU
 tnO
 whU
@@ -179413,7 +179311,7 @@ cdh
 btG
 xAD
 kju
-xva
+lKe
 hDH
 cdh
 hNT
@@ -179817,7 +179715,7 @@ nRZ
 btG
 xAD
 qCt
-xva
+lKe
 obw
 bKS
 hNT
@@ -180016,13 +179914,13 @@ ilr
 bCN
 hNT
 hNT
-lKe
+bCN
 lTV
 vAx
-lKe
+bCN
 hNT
 hNT
-lKe
+bCN
 rtI
 due
 fpd
@@ -180220,9 +180118,9 @@ sEF
 pQg
 bfB
 tXI
-tCZ
+eWd
 exf
-kiV
+ffE
 uLq
 lVY
 xrC

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -5034,9 +5034,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "bfC" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7800,9 +7798,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "bJv" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -14962,14 +14958,6 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"dmf" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
 "dmj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -17224,12 +17212,12 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "dJS" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "dJT" = (
 /obj/item/modular_computer/console/preset/command{
 	dir = 4;
@@ -18348,9 +18336,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "dWI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -21006,9 +20992,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "exg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22957,9 +22941,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "eRV" = (
 /obj/structure/catwalk,
 /obj/structure/table/rack/shelf,
@@ -23242,9 +23224,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "eWe" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -23837,9 +23817,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "fby" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -24125,9 +24103,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "ffH" = (
 /obj/random/booze,
 /obj/random/booze,
@@ -26068,9 +26044,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "fzw" = (
 /obj/machinery/conveyor/south{
 	id = "mining_internal"
@@ -26558,9 +26532,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "fFh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -29447,9 +29419,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "glv" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -40627,9 +40597,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "iBD" = (
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/techmaint,
@@ -42082,18 +42050,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"iSE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
 "iSI" = (
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
@@ -48585,9 +48541,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "klv" = (
 /obj/structure/table/woodentable,
 /obj/machinery/recharger,
@@ -51088,9 +51042,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "kNN" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
@@ -56308,9 +56260,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "lWd" = (
 /obj/effect/floor_decal/industrial/box/red,
 /obj/machinery/disposal,
@@ -63640,9 +63590,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "nuv" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -67101,9 +67049,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "odx" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 9
@@ -71063,9 +71009,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "oTO" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = -32
@@ -88966,9 +88910,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "sEL" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
@@ -95411,9 +95353,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "tXL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -99115,9 +99055,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "uLs" = (
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -106932,9 +106870,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "woX" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/generic,
@@ -108419,9 +108355,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "wDM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
@@ -113591,9 +113525,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1{
-	name = "Bar Hallway"
-	})
+/area/nadezhda/hallway/side/f2section1)
 "xIm" = (
 /obj/structure/grille,
 /obj/structure/railing,
@@ -180110,12 +180042,12 @@ pVp
 pQg
 fFg
 sEF
-iSE
+tVy
 eRT
 fbj
 fzr
 sEF
-pQg
+dJS
 bfB
 tXI
 eWd
@@ -180311,11 +180243,11 @@ jre
 guA
 hRx
 gll
-dmf
-dmf
+qwh
+qwh
 oTN
 nut
-dJS
+kgK
 bJu
 klq
 odw

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -118,8 +118,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacesec)
 "abn" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/bed/chair/sofa/blue/right{
+	dir = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/crew_quarters/bar)
 "abq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1748,6 +1751,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/chem_master/condimaster,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "auz" = (
@@ -2672,6 +2676,7 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/modular_computer/console/preset/trade,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics)
 "aDo" = (
@@ -3838,20 +3843,12 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/pros/shuttle)
 "aRL" = (
-/obj/structure/railing/grey{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Kitchen Access";
+	req_access = list(25)
 	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/wood,
-/obj/structure/bed/chair/custom/wood/wings{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "aRW" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -4909,7 +4906,10 @@
 /area/nadezhda/hallway/side/f2section1)
 "beg" = (
 /obj/effect/floor_decal/rust,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
@@ -5023,18 +5023,20 @@
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/podrooms)
 "bfB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/multiz/stairs/enter{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "bfC" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5426,14 +5428,14 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/smc/quarters)
 "bjl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/marble,
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar1";
+	name = "glass shutter"
 	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 1
-	},
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/item/toy/desk/newtoncradle,
+/obj/effect/floor_decal/spline/wood,
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "bjm" = (
 /obj/structure/ore_box,
@@ -5493,13 +5495,14 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
 "bjP" = (
-/obj/effect/floor_decal/spline/wood,
 /obj/structure/railing/grey,
-/obj/machinery/atmospherics/unary/vent_pump,
-/obj/structure/bed/chair/sofa/beige{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "bjR" = (
 /obj/machinery/door/holy{
@@ -5663,12 +5666,16 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
 "blY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/chapel{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted/emcloset{
+	pixel_x = -32
+	},
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/crew_quarters/bar)
 "bmp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -6239,15 +6246,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
 "btk" = (
-/obj/structure/bed/chair/sofa/teal{
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/button/windowtint{
-	id = "BARA";
-	pixel_y = -29
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/bar)
 "btp" = (
 /obj/structure/disposalpipe/segment{
@@ -6286,12 +6292,18 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "btG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/custom/bar_special{
-	dir = 8
+/obj/effect/floor_decal/spline/wood{
+	dir = 8;
+	icon_state = "road_edge_decal4"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/floor_decal/spline/wood{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/wood,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "btQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7784,12 +7796,15 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/maingate/west)
 "bJu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "bJv" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -7946,18 +7961,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "bKS" = (
-/obj/structure/window/reinforced{
-	pixel_x = -3;
+/obj/structure/bed/chair/sofa/blue/left{
 	dir = 8
 	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "bKW" = (
 /obj/structure/bed/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
@@ -7985,13 +7996,19 @@
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "bLm" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/industrial/box/red,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/structure/table/marble,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
+"bLo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/slotmachine{
+	dir = 8
+	},
+/obj/machinery/camera/network/colony_underground{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/crew_quarters/bar)
 "bLr" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -8554,16 +8571,25 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "bTI" = (
-/obj/machinery/door/blast/shutters/glass{
-	id = "buffet2";
-	name = "buffet"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/table/marble,
-/obj/machinery/cash_register{
-	dir = 8
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#0892d0"
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "bTR" = (
 /obj/item/modular_computer/console/preset/command/access{
 	dir = 4
@@ -8726,9 +8752,18 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "bVo" = (
@@ -9462,16 +9497,13 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
 "cdh" = (
-/obj/machinery/atm{
-	dir = 8;
-	pixel_x = -30
+/obj/structure/bed/chair/sofa/blue/right{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	pixel_x = -3;
-	dir = 1
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "cdB" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/security{
@@ -10807,18 +10839,23 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
 "csM" = (
+/obj/structure/table/marble,
+/obj/machinery/cash_register{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters/glass{
+	id = "buffet2";
+	name = "buffet"
+	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "csU" = (
 /obj/machinery/conveyor/north{
 	id = "disposals upper";
@@ -12826,9 +12863,8 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "cOU" = (
-/obj/machinery/door/unpowered/simple/wood/saloon,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "cPb" = (
 /obj/structure/railing{
@@ -13584,12 +13620,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "cWm" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "cWv" = (
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/engineering/engine_room)
@@ -13760,7 +13799,9 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/item/reagent_containers/food/snacks/sliceable/bread,
-/obj/item/tool/knife,
+/obj/item/tool/knife{
+	name = "potato knife"
+	},
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/box/matches,
@@ -13806,6 +13847,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"cYu" = (
+/obj/effect/floor_decal/spline/wood{
+	dir = 8
+	},
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/crew_quarters/bar)
 "cYv" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,17"
@@ -14252,7 +14299,10 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "des" = (
 /obj/structure/table/rack/shelf,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/item/grenade/chem_grenade/antiweed,
 /obj/item/grenade/chem_grenade/antiweed,
 /obj/item/grenade/chem_grenade/antiweed,
@@ -14810,9 +14860,9 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "dkt" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/bar_flat,
+/obj/landmark/join/start/clubmanager,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/crew_quarters/bar)
 "dky" = (
 /obj/structure/catwalk,
@@ -14927,17 +14977,13 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "dmf" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 4
-	},
-/obj/structure/bed/chair/sofa/beige/right{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "dmj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -17192,14 +17238,12 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "dJS" = (
-/obj/structure/bed/chair/custom/wood{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "dJT" = (
 /obj/item/modular_computer/console/preset/command{
 	dir = 4;
@@ -18307,13 +18351,15 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical_blackshield)
 "dWG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/small/busha1,
-/obj/structure/flora/big/bush1{
-	pixel_x = -15
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "dWI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -18469,23 +18515,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "dYe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/table/gamblingtable,
+/obj/item/paper/card/heart,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/sofa/beige/left{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 9
-	},
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/crew_quarters/bar)
 "dYi" = (
 /turf/simulated/wall/r_wall,
@@ -18955,7 +18988,10 @@
 /area/nadezhda/security/range)
 "ecO" = (
 /obj/structure/mopbucket,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/item/mop,
 /obj/item/soap/church,
 /obj/machinery/light/small,
@@ -19378,10 +19414,13 @@
 /turf/simulated/mineral,
 /area/nadezhda/command/tcommsat/computer)
 "egR" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/coffee_master,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "egV" = (
 /obj/structure/table/glass,
 /obj/random/rations,
@@ -19400,10 +19439,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "ehp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/chapel,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/obj/structure/railing/grey,
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/bar)
 "eht" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
@@ -19432,13 +19474,8 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ehN" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/bed/chair/sofa/beige/right{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/bed/chair/sofa/blue/corner,
+/turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/crew_quarters/bar)
 "ehT" = (
 /obj/structure/catwalk,
@@ -19754,19 +19791,15 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/xenobiology)
 "elY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_x = -32
+/obj/structure/flora/big/bush1,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
 	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/box/red/corners,
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/bar)
 "ema" = (
 /obj/structure/sink{
 	density = 1;
@@ -20972,24 +21005,18 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "exf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/sofa/brown/left{
+/obj/machinery/holoposter{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = -3
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "exg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21560,7 +21587,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/genetics)
 "eDT" = (
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/item/mop,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -21654,23 +21684,12 @@
 /turf/simulated/floor/plating/under,
 /area/colony)
 "eFn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/sofa/brown{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/structure/multiz/stairs/enter,
+/obj/machinery/light{
 	dir = 4;
-	pixel_x = -3
+	light_color = "#0892d0"
 	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "eFu" = (
 /obj/effect/decal/cleanable/generic,
@@ -21822,9 +21841,9 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "eHE" = (
-/obj/machinery/door/unpowered/simple/wood/saloon,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/wood/wild1,
+/obj/effect/window_lwall_spawn,
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/bar)
 "eHG" = (
 /turf/simulated/floor/wood,
@@ -22184,7 +22203,10 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /obj/machinery/atmospherics/unary/vent_scrubber,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/structure/sink{
 	dir = 1;
 	pixel_y = 32
@@ -22824,8 +22846,14 @@
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "eQP" = (
 /obj/structure/table/rack,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
@@ -22925,14 +22953,16 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
 "eRT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "eRV" = (
 /obj/structure/catwalk,
 /obj/structure/table/rack/shelf,
@@ -23123,9 +23153,21 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/medical/sleeper)
 "eVm" = (
-/obj/effect/floor_decal/spline/wood,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/machinery/button/remote/blast_door{
+	id = "bar1";
+	name = "north bar access";
+	pixel_x = -6;
+	pixel_y = 27;
+	req_access = list(25)
+	},
+/obj/effect/floor_decal/spline/wood{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	pixel_y = 28;
+	pixel_x = -17
+	},
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "eVo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23195,13 +23237,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
 "eWd" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_x = -3
-	},
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/window_lwall_spawn,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "eWe" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -23585,19 +23625,12 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "eZe" = (
-/obj/machinery/door/airlock{
-	name = "Bartender's room";
-	req_access = list(25)
+/obj/structure/railing/grey,
+/obj/structure/flora/small/lavarock3,
+/obj/machinery/camera/network/colony_underground{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
+/turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/crew_quarters/bar)
 "eZh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23794,11 +23827,16 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/bcave)
 "fbj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "fby" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -24573,6 +24611,13 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
+"fke" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/crew_quarters/bar)
 "fkl" = (
 /obj/structure/table/woodentable,
 /obj/item/gun_upgrade/mechanism/bikehorn,
@@ -24666,13 +24711,15 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "flb" = (
-/obj/structure/table/marble,
-/obj/machinery/door/blast/shutters/glass{
-	id = "bar1";
-	name = "glass shutter"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "flq" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -25165,9 +25212,6 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "fpe" = (
-/obj/item/modular_computer/console/preset/trade{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics)
 "fpj" = (
@@ -25242,7 +25286,10 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm2)
 "fqf" = (
-/obj/machinery/chemical_dispenser/coffee_master,
+/obj/machinery/chemical_dispenser/coffee_master{
+	pixel_y = 25;
+	pixel_x = 16
+	},
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/bridge)
@@ -25337,6 +25384,14 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"frs" = (
+/obj/item/stool/custom/bar_special,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/crew_quarters/bar)
 "frv" = (
 /obj/structure/sign/department/cargo_dock,
 /turf/simulated/wall,
@@ -25942,19 +25997,14 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "fzc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/directions/medical{
-	dir = 8;
-	pixel_y = 36
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/obj/structure/sign/directions/science{
-	dir = 8;
-	pixel_y = 31
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/nadezhda/crew_quarters/bar)
 "fzd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -25994,10 +26044,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/sec)
 "fzr" = (
+/obj/machinery/camera/network/colony_underground{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "fzw" = (
 /obj/machinery/conveyor/south{
 	id = "mining_internal"
@@ -26480,13 +26537,14 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "fFg" = (
-/obj/machinery/door/unpowered/simple/wood/saloon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "fFh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27043,11 +27101,22 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "fLT" = (
-/obj/structure/table/marble,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/flame/lighter/zippo,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/wood,
+/obj/effect/floor_decal/spline/wood{
+	dir = 8;
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/floor_decal/spline/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "fLZ" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/grass/dry,
@@ -28936,11 +29005,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
 "ggB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/table/woodentable,
+/obj/item/flame/candle,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "ggD" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -29361,11 +29431,13 @@
 	},
 /area/nadezhda/hallway/main/stairwell)
 "gll" = (
-/obj/machinery/door/unpowered/simple/wood/saloon,
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "glv" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -29822,13 +29894,21 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "gpP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood/wild1,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/crew_quarters/bar)
 "gpS" = (
 /obj/machinery/door/window/brigdoor/westright{
@@ -30063,12 +30143,28 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/detectives_office)
 "gsq" = (
-/obj/machinery/light/floor,
-/obj/landmark/join/start/clubmanager,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "gsr" = (
 /obj/structure/bed/chair/sofa/brown/left,
 /turf/simulated/floor/wood,
@@ -30279,6 +30375,7 @@
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/bowl,
+/obj/item/book/manual/wiki/chef_recipes,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "gul" = (
@@ -30310,17 +30407,24 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/captain)
 "guA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/multiz/stairs/enter{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "guL" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -31576,7 +31680,9 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
 "gLs" = (
-/obj/machinery/slotmachine,
+/obj/machinery/slotmachine{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
@@ -31887,12 +31993,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
 "gOS" = (
-/obj/effect/floor_decal/spline/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/sofa/beige/left{
+/obj/structure/bed/chair/sofa/blue{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/crew_quarters/bar)
 "gOT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -32575,16 +32680,16 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "gVG" = (
-/obj/structure/table/marble,
-/obj/machinery/door/blast/shutters/glass{
-	id = "bar1";
-	name = "glass shutter"
-	},
-/obj/machinery/cash_register{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "gVH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33535,15 +33640,20 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "hgB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	pixel_x = -3;
-	dir = 8
+/obj/structure/table/marble,
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar1";
+	name = "glass shutter"
 	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#0892d0"
+	},
+/obj/machinery/reagentgrinder,
+/obj/effect/floor_decal/spline/wood{
 	dir = 4
 	},
-/turf/simulated/floor/wood/wild3,
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "hgC" = (
 /obj/machinery/shower{
@@ -33609,9 +33719,20 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/command/prime)
 "hht" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass/jungle,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "hhx" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -33977,13 +34098,15 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
 "hlv" = (
-/obj/effect/floor_decal/spline/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/obj/structure/bed/chair/sofa/beige/left{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "hlw" = (
 /obj/structure/table/rack,
@@ -34963,9 +35086,11 @@
 	name = "\improper Clinic"
 	})
 "hwZ" = (
-/obj/item/stool/custom/bar_special,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild1,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/flora/small/lavarock2,
+/turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/crew_quarters/bar)
 "hxa" = (
 /turf/simulated/floor/carpet,
@@ -35112,10 +35237,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "hyr" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/turf/simulated/floor/wood/wild1,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/crew_quarters/bar)
 "hys" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -35711,15 +35838,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "hDH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	pixel_x = -3
+/obj/structure/bed/chair/sofa/blue/left{
+	dir = 4
 	},
-/obj/structure/bed/chair/custom/bar_special{
-	dir = 8
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "hDS" = (
 /obj/item/stack/ore,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -36820,10 +36945,12 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/tactical_blackshield)
 "hNT" = (
-/obj/machinery/light,
-/obj/structure/table/bar_special,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "hNV" = (
 /obj/machinery/chemical_dispenser/industrial{
 	fancy_hack = 1
@@ -37002,10 +37129,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/servist)
 "hRx" = (
-/obj/machinery/smartfridge,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark/brown_perforated,
-/area/nadezhda/crew_quarters/kitchen)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "hRA" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -38099,18 +38227,15 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "ibb" = (
-/obj/effect/floor_decal/spline/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/wood{
-	dir = 10
-	},
-/obj/structure/bed/chair/sofa/beige/right{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "ibo" = (
 /obj/structure/flora/big/bush3,
@@ -38421,21 +38546,10 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "ieD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/gamblingtable,
+/obj/item/card_carp/stunted_wolf,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = -3
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/crew_quarters/bar)
 "ieK" = (
 /obj/machinery/conveyor/north{
@@ -39018,12 +39132,8 @@
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ilr" = (
-/obj/machinery/door/blast/shutters/glass{
-	id = "buffet2";
-	name = "buffet"
-	},
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/cafe,
+/obj/effect/window_lwall_spawn,
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/kitchen)
 "ilu" = (
 /obj/structure/table/rack,
@@ -39342,10 +39452,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "ioj" = (
-/obj/structure/bed/chair/comfy/brown{
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/simulated/floor/wood/wild3,
+/obj/machinery/door/unpowered/simple/wood/saloon,
+/turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/bar)
 "ioo" = (
 /obj/structure/cable/yellow{
@@ -40216,7 +40328,10 @@
 /obj/structure/railing,
 /obj/structure/table/reinforced,
 /obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/structure/sign/warning/nosmoking/small{
 	pixel_y = 32
 	},
@@ -40505,13 +40620,14 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/bcave)
 "iBw" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_x = -3
+/obj/machinery/holoposter{
+	pixel_x = 32
 	},
-/obj/structure/flora/small/busha1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "iBD" = (
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/techmaint,
@@ -40619,7 +40735,10 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "iCA" = (
 /obj/structure/table/woodentable,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "iCB" = (
@@ -40674,12 +40793,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "iDm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/multiz/stairs/enter{
+	dir = 1
 	},
-/obj/structure/railing/grey,
-/obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/beach/water/shallow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "iDp" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -41029,16 +41148,12 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
 "iHQ" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_x = -3
+/obj/structure/railing/grey,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/smoking/small{
-	pixel_x = 32;
-	pixel_y = -30
-	},
-/turf/simulated/floor/wood/wild1,
+/obj/machinery/media/jukebox,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "iHT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -41973,14 +42088,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/pottedplant/star_root{
-	pixel_x = -7
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "iSI" = (
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
@@ -42412,6 +42523,24 @@
 /obj/effect/decal/cleanable/flour,
 /obj/structure/table/marble,
 /obj/item/reagent_containers/cooking_with_jane/cooking_container/pan,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "iYP" = (
@@ -43011,7 +43140,10 @@
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/tool/wirecutters,
 /obj/item/plantspray/pests,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/item/device/scanner/plant,
 /obj/item/storage/bag/produce,
 /obj/item/tool/minihoe,
@@ -44675,11 +44807,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/workshop)
 "jvn" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_x = -3
+/obj/structure/table/marble,
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar1";
+	name = "glass shutter"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/spline/wood{
+	dir = 4
+	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "jvo" = (
@@ -44701,8 +44836,7 @@
 /area/nadezhda/quartermaster/hangarsupply)
 "jvz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/bar_flat,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "jvR" = (
 /obj/structure/flora/small/busha3,
@@ -44903,7 +45037,10 @@
 "jxK" = (
 /obj/structure/table/standard,
 /obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jxY" = (
@@ -45537,10 +45674,14 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/range)
 "jFJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/simple/wood/saloon,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/crew_quarters/bar)
 "jFP" = (
 /turf/simulated/shuttle/wall/science{
@@ -48001,24 +48142,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "kgS" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/door/airlock/glass{
+	name = "Kitchen Access";
+	req_access = list(25)
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/obj/structure/sink{
-	pixel_y = 25
-	},
-/obj/structure/table/marble,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "kha" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -48254,12 +48383,12 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "kju" = (
-/obj/structure/table/marble,
-/obj/item/contraband/poster/placed/generic/fancierborg{
-	pixel_x = -32
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "kjx" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -48379,7 +48508,8 @@
 /area/nadezhda/maintenance/undergroundfloor2north)
 "kkw" = (
 /obj/machinery/light_switch{
-	pixel_y = 30
+	pixel_y = 28;
+	pixel_x = -17
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -48436,9 +48566,15 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "klq" = (
-/obj/machinery/vending/dinnerware/cost,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/crew_quarters/bar)
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "klv" = (
 /obj/structure/table/woodentable,
 /obj/machinery/recharger,
@@ -50929,13 +51065,19 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/command/prime)
 "kNM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/media/jukebox,
-/obj/structure/disposalpipe/segment{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "kNN" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
@@ -50983,14 +51125,10 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/dcave)
 "kOH" = (
-/obj/machinery/door/airlock/multi_tile/metal{
-	name = "Bar - Room A"
-	},
-/obj/machinery/holosign/service{
-	id = "room_a"
-	},
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/carpet/blucarpet,
+/area/nadezhda/maintenance{
+	name = "Residential District Maintenance"
+	})
 "kOP" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/small/busha2,
@@ -53027,6 +53165,9 @@
 	},
 /obj/machinery/camera/network/colony_underground,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "loe" = (
@@ -53283,7 +53424,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
 "lqI" = (
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
@@ -54254,10 +54398,11 @@
 	},
 /area/nadezhda/maintenance/surfacesec)
 "lCp" = (
-/obj/machinery/vending/dinnerware,
 /obj/structure/sign/warning/smoking/small{
 	pixel_x = -32
 	},
+/obj/structure/table/marble,
+/obj/machinery/microwave,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "lCA" = (
@@ -54938,18 +55083,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/bridge)
 "lJl" = (
-/obj/structure/cyberplant,
-/obj/machinery/holoposter{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	pixel_y = -7
-	},
+/obj/machinery/vending/cigarette,
+/obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/smoking/small{
-	pixel_x = -32;
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/crew_quarters/bar)
 "lJo" = (
@@ -55026,9 +55162,10 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/farm)
 "lKe" = (
-/obj/structure/table/bar_special,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/wall/r_wall,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "lKh" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -55325,14 +55462,24 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "lOj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	name = "South APC";
+	pixel_y = -28;
+	operating = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild1,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/crew_quarters/bar)
 "lOk" = (
 /obj/structure/low_wall,
@@ -55876,7 +56023,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "lTH" = (
 /obj/machinery/door/airlock/glass{
-	name = "Kitchen Access";
+	name = "Bar Access";
 	req_access = list(25)
 	},
 /obj/machinery/door/firedoor,
@@ -55911,12 +56058,23 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "lTV" = (
-/obj/structure/bed/chair/sofa/brown/right,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/unpowered/simple/wood/saloon,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "lTW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -56115,13 +56273,13 @@
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/outside/forest)
 "lVY" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "lWd" = (
 /obj/effect/floor_decal/industrial/box/red,
 /obj/machinery/disposal,
@@ -56655,8 +56813,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "mcu" = (
-/obj/structure/table/bar_special,
-/turf/simulated/floor/tiled/steel/bar_flat,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "mcv" = (
 /obj/structure/table/standard,
@@ -56798,9 +56959,7 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/courtroom)
 "mei" = (
-/obj/structure/table/bar_special,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/steel/bar_flat,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "meq" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -57155,6 +57314,16 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
+"mgI" = (
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
+/obj/item/tool/knife{
+	name = "potato knife"
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "mgM" = (
 /obj/item/reagent_containers/blood/AMinus{
 	pixel_x = -7;
@@ -57720,7 +57889,10 @@
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/tool/wirecutters,
 /obj/item/plantspray/pests,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/item/device/scanner/plant,
 /obj/item/storage/makeshift_grinder,
 /obj/machinery/light{
@@ -58845,8 +59017,17 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/obj/structure/flora/pottedplant/star_root,
-/turf/simulated/floor/tiled/steel/cyancorner,
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/bar)
 "mzr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -59087,13 +59268,22 @@
 /turf/simulated/floor/tiled/steel/panels,
 /area/nadezhda/command/tcommsat/computer)
 "mBu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/structure/bed/chair/custom/bar_special{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "mBw" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -59819,14 +60009,19 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "mIf" = (
-/obj/machinery/light/small{
+/obj/machinery/vending/boozeomat{
+	density = 0;
+	pixel_y = 20;
+	pixel_x = -16
+	},
+/obj/machinery/chemical_dispenser/coffee_master{
+	pixel_y = 25;
+	pixel_x = 10
+	},
+/obj/effect/floor_decal/spline/wood{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/wood,
-/obj/structure/bed/chair/custom/wood/wings{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "mIl" = (
 /turf/simulated/shuttle/wall/science{
@@ -59982,6 +60177,14 @@
 	icon_state = "11,3"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"mKv" = (
+/obj/structure/table/woodentable,
+/obj/item/flame/candle,
+/obj/machinery/camera/network/colony_underground,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "mKx" = (
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -60588,11 +60791,11 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "mQK" = (
-/obj/effect/floor_decal/spline/wood,
-/obj/structure/bed/chair/custom/wood/wings{
-	dir = 8
+/obj/item/stool/custom/bar_special,
+/obj/structure/sign/neon/barsign{
+	pixel_y = 32
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "mQZ" = (
 /turf/simulated/open,
@@ -60614,7 +60817,9 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "mRr" = (
-/obj/item/tool/knife,
+/obj/item/tool/knife{
+	name = "potato knife"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor2north)
@@ -60726,15 +60931,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/bridge)
 "mSH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/cigarette,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/contraband/poster/placed/generic/high_class_martini{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/crew_quarters/bar)
 "mSL" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -60880,17 +61078,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "mUH" = (
-/obj/structure/railing/grey{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 8
-	},
-/obj/structure/bed/chair/sofa/beige{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/disposal,
+/obj/machinery/light,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "mUL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -61217,14 +61416,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical)
 "mYi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/small/busha1,
-/obj/structure/flora/big/bush1{
-	pixel_x = -15;
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/vending/dinnerware,
+/turf/simulated/floor/tiled/white/brown_platform,
+/area/nadezhda/crew_quarters/kitchen)
 "mYn" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -62811,10 +63005,8 @@
 /turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/outside/forest)
 "nol" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/wood/wild1,
+/obj/structure/multiz/stairs/enter,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "nos" = (
 /obj/effect/decal/cleanable/dirt,
@@ -63427,13 +63619,18 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "nut" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/smoking/small{
-	pixel_y = -30;
-	pixel_x = -32
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted/emcloset{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "nuv" = (
 /obj/random/closet_maintloot,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -63591,7 +63788,10 @@
 "nwj" = (
 /obj/structure/table/woodentable,
 /obj/item/tool/shovel/spade,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/farm)
 "nwk" = (
@@ -64169,8 +64369,9 @@
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "nCe" = (
-/obj/effect/window_lwall_spawn,
-/turf/simulated/floor/tiled/cafe,
+/obj/machinery/vending/snack,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/crew_quarters/bar)
 "nCj" = (
 /obj/effect/floor_decal/industrial/danger/corner{
@@ -64255,13 +64456,13 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "nCS" = (
@@ -64739,20 +64940,8 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
 "nHn" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_x = -3
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/bed/chair/sofa/beige/left{
-	dir = 4
-	},
-/obj/structure/sign/painting/paintingvalley{
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/machinery/atmospherics/unary/vent_scrubber,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "nHw" = (
 /obj/structure/salvageable/data,
@@ -65697,10 +65886,13 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
 "nRZ" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/soda,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/bed/chair/sofa/blue/left{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "nSe" = (
 /obj/structure/table/steel,
 /obj/random/common_oddities/low_chance,
@@ -66544,15 +66736,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfacesec)
 "oaq" = (
-/obj/structure/bed/chair/sofa/teal/right{
+/obj/structure/flora/big/bush1,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/button/switch/holosign{
-	id = "room_a";
-	pixel_y = -29
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/bar)
 "oav" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -66695,12 +66886,14 @@
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
 "obw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/border/carpet/black{
+/obj/structure/bed/chair/sofa/blue/right{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "obE" = (
 /obj/landmark/join/start/supsec,
 /obj/effect/decal/cleanable/dirt,
@@ -66887,8 +67080,22 @@
 	name = "Residential District Maintenance"
 	})
 "odw" = (
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "odx" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 9
@@ -67964,8 +68171,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "opg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/obj/structure/table/glass,
+/obj/item/storage/fancy/cigarettes,
+/turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/crew_quarters/bar)
 "opp" = (
 /obj/machinery/atmospherics/unary/vent_pump,
@@ -68805,8 +69013,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/smc/quarters)
 "oyb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/bar_flat,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "oyd" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
@@ -68931,17 +69140,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacesec)
 "ozA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/marble,
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar1";
+	name = "glass shutter"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/sofa/beige/right{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/effect/floor_decal/spline/wood,
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "ozH" = (
 /obj/structure/closet/wall_mounted/emcloset{
@@ -69869,8 +70074,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/directions/generic{
 	name = "stairs sign";
 	pixel_y = 32
@@ -69883,6 +70086,7 @@
 	dir = 1;
 	pixel_y = 26
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "oJI" = (
@@ -70240,10 +70444,9 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/medical/virology)
 "oNs" = (
-/obj/structure/bed/chair/sofa/teal/right{
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/crew_quarters/bar)
 "oNv" = (
@@ -70840,12 +71043,21 @@
 	},
 /area/nadezhda/maintenance/surfaceeast)
 "oTN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/holoposter{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild1,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "oTO" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = -32
@@ -71316,18 +71528,14 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/security/barracks)
 "oYB" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_x = -3
+/obj/machinery/chemical_dispenser/beer{
+	pixel_y = 20;
+	pixel_x = 4
 	},
-/obj/effect/floor_decal/spline/wood,
-/obj/structure/bed/chair/custom/wood/wings{
-	dir = 4
+/obj/effect/floor_decal/spline/wood{
+	dir = 1
 	},
-/obj/structure/sign/painting/paintingtemple{
-	pixel_y = 32
-	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "oYH" = (
 /obj/machinery/door/window/southright{
@@ -72422,15 +72630,15 @@
 	name = "Residential District Maintenance"
 	})
 "pla" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild1,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/crew_quarters/bar)
 "plh" = (
 /obj/machinery/light{
@@ -72480,7 +72688,10 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "plW" = (
 /obj/effect/floor_decal/rust,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/random/structures/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -75371,7 +75582,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "pQo" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /turf/simulated/floor/wood/wild3,
@@ -75499,7 +75712,10 @@
 "pRC" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 8
@@ -76488,20 +76704,9 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
 "qbs" = (
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/wood,
-/obj/effect/floor_decal/spline/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/grey,
-/obj/structure/bed/chair/sofa/beige/right{
-	dir = 4
-	},
-/mob/living/carbon/human/monkey/punpun,
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/flora/rock,
+/turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/crew_quarters/bar)
 "qbx" = (
 /obj/structure/lattice,
@@ -77121,14 +77326,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "qiI" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cyberplant{
-	emagged = 1;
-	name = "holodancer";
-	pixel_y = 12
-	},
-/turf/simulated/floor/tiled/steel/bar_flat,
+/obj/structure/table/glass,
+/turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/crew_quarters/bar)
 "qiJ" = (
 /obj/machinery/light{
@@ -77350,11 +77549,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "qkJ" = (
-/obj/structure/bed/chair/sofa/teal{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/slotmachine{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "qkN" = (
 /turf/simulated/floor/tiled/white/monofloor,
@@ -77471,10 +77670,8 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/detectives_office)
 "qlZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/flora/pottedplant/grave_poppers,
+/obj/effect/decal/cleanable/dirt,
+/obj/landmark/join/start/clubmanager,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "qmi" = (
@@ -78070,10 +78267,8 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "qsr" = (
-/obj/effect/window_lwall_spawn/reinforced/polarized{
-	id = "BARA"
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/effect/window_lwall_spawn,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "qst" = (
 /obj/random/junk/low_chance,
@@ -78975,14 +79170,10 @@
 	})
 "qCt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/custom/wood{
-	dir = 4
-	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "qCv" = (
 /obj/machinery/light{
 	dir = 8
@@ -80456,10 +80647,21 @@
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
 "qSv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/asteroid/grass/jungle,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "qSC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -80469,18 +80671,8 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
 "qSM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/custom/wood/wings,
-/obj/effect/floor_decal/spline/wood{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 5
-	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/structure/cyberplant,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "qSQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -82606,12 +82798,15 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
 "rqU" = (
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/flora/small/lavarock2,
-/turf/simulated/floor/beach/water/shallow,
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/structure/railing/grey,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/bar)
 "rqY" = (
 /obj/random/structures,
@@ -82852,6 +83047,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = 36
+	},
+/obj/structure/sign/directions/science{
+	dir = 8;
+	pixel_y = 31
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "rtL" = (
@@ -82864,10 +83067,9 @@
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "rtV" = (
-/obj/structure/bed/chair/sofa/beige{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/item/stool/custom/bar_special,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "rug" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -84073,12 +84275,6 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
 "rHX" = (
-/obj/structure/table/marble,
-/obj/item/material/kitchen/rollingpin,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/cookingoil,
-/obj/machinery/reagentgrinder/portable,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "rIb" = (
@@ -85837,20 +86033,13 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory)
 "sax" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/smoking/small{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/obj/structure/flora/big/bush1{
-	pixel_y = -10
-	},
-/obj/structure/flora/big/bush1{
-	pixel_x = -15;
-	pixel_y = -10
-	},
-/obj/structure/flora/small/busha1,
-/turf/simulated/floor/asteroid/grass,
+/turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/crew_quarters/bar)
 "saz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -86743,10 +86932,17 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "skW" = (
-/obj/effect/floor_decal/spline/wood,
-/obj/structure/railing/grey,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/colony_underground{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "skX" = (
 /obj/structure/cable/green{
@@ -86934,6 +87130,21 @@
 	icon_state = "5,7"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"smL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = -11
+	},
+/obj/machinery/camera/network/colony_underground{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "smQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
@@ -88679,6 +88890,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"sDw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stool/padded,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "sDz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -88723,8 +88939,12 @@
 /turf/unsimulated/mineral,
 /area/asteroid/cave)
 "sDW" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/wood/wild1,
+/obj/item/stool/custom/bar_special,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "sEh" = (
 /obj/machinery/firealarm{
@@ -88748,18 +88968,18 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "sEB" = (
-/obj/machinery/holosign/service{
-	id = "room_a"
-	},
-/turf/simulated/floor/tiled/steel/bar_flat,
+/obj/structure/multiz/stairs/enter,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "sEF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/wall/r_wall,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "sEL" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
@@ -90537,26 +90757,14 @@
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
 "sZv" = (
-/obj/machinery/button/remote/blast_door{
-	id = "bar1";
-	name = "north bar access";
-	pixel_x = -6;
-	pixel_y = 27;
-	req_access = list(25)
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
+/obj/structure/bed/chair/sofa/blue/left{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -32
-	},
-/obj/machinery/camera/network/colony_underground{
-	dir = 4
-	},
-/obj/structure/table/marble,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "sZy" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/igniter,
@@ -92635,12 +92843,10 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/maingate)
 "txD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/structure/flora/big/bush1,
 /obj/structure/railing/grey,
-/obj/structure/flora/small/trailrocka4,
-/turf/simulated/floor/beach/water/shallow,
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/bar)
 "txJ" = (
 /turf/simulated/wall/r_wall,
@@ -92875,13 +93081,15 @@
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
 "tzB" = (
-/obj/structure/table/marble,
-/obj/machinery/door/blast/shutters/glass{
-	id = "bar1";
-	name = "glass shutter"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/vending/drink_showcase,
-/turf/simulated/floor/wood/wild3,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/crew_quarters/bar)
 "tzE" = (
 /obj/random/mob/termite_no_despawn,
@@ -93047,6 +93255,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "tBE" = (
@@ -93341,16 +93550,12 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
 "tEW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 8
+/obj/structure/bed/chair/sofa/blue/right{
+	dir = 1
 	},
-/obj/structure/flora/small/busha3,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/beach/water/shallow,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/crew_quarters/bar)
 "tEX" = (
 /obj/structure/disposalpipe/segment,
@@ -95206,27 +95411,22 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
 "tXI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/sofa/brown/corner,
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = -3
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_x = -3
-	},
-/obj/effect/floor_decal/spline/wood{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "tXL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -95479,12 +95679,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/cargo)
 "uag" = (
-/obj/effect/window_lwall_spawn/reinforced/polarized{
-	id = "BARA"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/railing/grey,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "uar" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -96342,7 +96542,10 @@
 "uhY" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/structure/reagent_dispensers/ammonia{
 	pixel_y = -32
 	},
@@ -97379,19 +97582,10 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "utI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/smoking/small{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/simulated/floor/wood/wild1,
+/turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/crew_quarters/bar)
 "utL" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
@@ -97936,12 +98130,13 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "uAx" = (
+/obj/structure/table/woodentable,
+/obj/item/flame/candle,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	pixel_x = -3
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "uAy" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "2,8"
@@ -98215,11 +98410,20 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "uEj" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/unpowered/simple/wood/saloon,
+/turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/bar)
 "uEq" = (
 /obj/structure/cable/cyan{
@@ -98555,10 +98759,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "uIb" = (
@@ -98917,28 +99117,14 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "uLq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	pixel_x = -3
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 4
-	},
-/obj/structure/bed/chair/comfy/brown{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "uLs" = (
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -99741,7 +99927,9 @@
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = 4
 	},
-/obj/item/tool/knife,
+/obj/item/tool/knife{
+	name = "potato knife"
+	},
 /obj/item/material/kitchen/utensil/spoon,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/captain/quarters)
@@ -100576,8 +100764,8 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "vaS" = (
-/obj/machinery/slotmachine,
-/turf/simulated/floor/wood/wild1,
+/obj/structure/flora/small/lavarock1,
+/turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/crew_quarters/bar)
 "vbn" = (
 /obj/structure/table/woodentable,
@@ -100880,13 +101068,16 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/courtroom)
 "veV" = (
-/obj/structure/table/marble,
-/obj/machinery/microwave,
-/obj/machinery/camera/network/colony_underground{
-	dir = 1
+/obj/structure/railing/grey,
+/obj/structure/bed/chair/sofa/blue/corner{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/crew_quarters/kitchen)
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#0892d0"
+	},
+/turf/simulated/floor/carpet/blucarpet,
+/area/nadezhda/crew_quarters/bar)
 "veX" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -101089,7 +101280,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 2;
+	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/cafe,
@@ -101834,14 +102025,12 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/maintenance/substation/medical)
 "vow" = (
+/obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/big/bush1{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/structure/flora/small/busha1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "voK" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/door/airlock/maintenance_common,
@@ -102591,14 +102780,16 @@
 /area/nadezhda/dungeon/outside/burned_outpost)
 "vwq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/flour,
-/obj/structure/table/bar_special,
 /obj/structure/sign/painting/paintingsea{
 	pixel_y = 32
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/bed/chair/sofa/blue/right{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "vww" = (
 /obj/machinery/door/blast/regular{
 	id = "Mil Armory";
@@ -102662,11 +102853,21 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "vxh" = (
-/obj/machinery/vending/boozeomat{
-	req_access = list(25)
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "West APC";
+	pixel_x = -28;
+	operating = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "vxm" = (
 /obj/structure/sign/warning/armory/small,
 /turf/simulated/wall/church_reinforced,
@@ -102858,10 +103059,12 @@
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
 "vAx" = (
-/obj/machinery/light/floor,
-/obj/structure/table/bar_special,
-/turf/simulated/floor/carpet/bcarpet,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/unpowered/simple/wood/saloon,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "vAy" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/sleeper{
@@ -103136,9 +103339,9 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "vDF" = (
-/obj/structure/table/bar_special,
-/obj/random/booze,
-/turf/simulated/floor/tiled/steel/bar_flat,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/standard,
+/turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/crew_quarters/bar)
 "vDJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -104485,19 +104688,14 @@
 	},
 /area/shuttle/vasiliy_shuttle_area)
 "vRs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/marble,
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar1";
+	name = "glass shutter"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/custom/wood/wings,
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_x = -3
-	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/item/storage/fancy/cigar,
+/obj/effect/floor_decal/spline/wood,
+/turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "vRy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -104816,37 +105014,14 @@
 /area/nadezhda/maintenance/undergroundfloor2west)
 "vUm" = (
 /obj/structure/table/marble,
-/obj/item/pen,
-/obj/item/paper_bin,
-/obj/item/book/manual/wiki/chef_recipes,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -32
 	},
+/obj/item/reagent_containers/food/condiment/cookingoil,
+/obj/item/material/kitchen/rollingpin,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/machinery/reagentgrinder/portable,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "vUn" = (
@@ -105155,8 +105330,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/hut_cell1)
 "vWY" = (
-/obj/effect/window_lwall_spawn,
 /obj/machinery/door/firedoor,
+/obj/machinery/smartfridge,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
 "vXc" = (
@@ -106469,13 +106644,15 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "wls" = (
-/obj/effect/decal/cleanable/generic,
 /obj/structure/table/marble,
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/door/blast/shutters/glass{
+	id = "buffet2";
+	name = "buffet"
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "wlt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -106600,7 +106777,10 @@
 /area/nadezhda/command/swo/quarters)
 "wmF" = (
 /obj/structure/table/standard,
-/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
 /obj/item/tool/minihoe,
 /obj/item/reagent_containers/glass/fertilizer/rh,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -106768,11 +106948,15 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "woU" = (
-/obj/effect/floor_decal/chapel{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_x = 32
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "woX" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/generic,
@@ -108159,14 +108343,14 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
 "wCM" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/beer,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -32
+/obj/structure/bed/chair/sofa/blue/right{
+	dir = 4
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "wCP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -108257,8 +108441,11 @@
 "wDH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/crew_quarters/bar)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "wDM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
@@ -108430,17 +108617,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "wGi" = (
-/obj/structure/bed/chair/sofa/teal/corner{
-	dir = 8
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
 	},
-/obj/machinery/holoposter{
-	pixel_y = -32
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central6{
-	pixel_y = -7
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/bar)
 "wGp" = (
 /turf/unsimulated/mineral,
@@ -109904,23 +110087,12 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/cbo)
 "wWx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 1
-	},
-/obj/effect/floor_decal/border/carpet/black{
+/obj/structure/multiz/stairs/enter,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/border/carpet/black{
-	dir = 9
-	},
-/obj/structure/cyberplant{
-	emagged = 1;
-	name = "holodancer";
-	pixel_y = 12
-	},
-/turf/simulated/floor/carpet/bcarpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "wWI" = (
 /obj/structure/bed/chair{
@@ -110342,9 +110514,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
 "xbK" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/railing/grey,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "xbR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -110555,12 +110733,15 @@
 	name = "Residential District Maintenance"
 	})
 "xfu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
 	},
 /obj/structure/railing/grey,
-/obj/structure/flora/small/lavarock2,
-/turf/simulated/floor/beach/water/shallow,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/bar)
 "xfF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -111407,11 +111588,15 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
 "xnW" = (
-/obj/effect/floor_decal/chapel{
-	dir = 1
+/obj/structure/bed/chair/sofa/blue/right{
+	dir = 8
 	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/landmark/join/start/clubworker,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "xob" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
@@ -111659,11 +111844,14 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "xrh" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/wood/wild1,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/crew_quarters/bar)
 "xrn" = (
 /obj/structure/sink/kitchen{
@@ -111705,7 +111893,6 @@
 "xrC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -112025,9 +112212,19 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
 "xva" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/floor_decal/spline/wood,
+/obj/effect/floor_decal/spline/wood{
+	dir = 8;
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/floor_decal/spline/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "xvd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -112341,11 +112538,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "xya" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/railing/grey,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "xyb" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1
@@ -112586,8 +112784,22 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
 "xAD" = (
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/crew_quarters/bar)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "xAL" = (
 /obj/machinery/power/nt_obelisk,
 /obj/machinery/camera/network/church{
@@ -112744,17 +112956,16 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
 "xBJ" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_x = -3
-	},
-/obj/effect/floor_decal/spline/wood,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/grey,
-/obj/structure/bed/chair/sofa/beige/right{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "xBX" = (
 /obj/structure/table/rack/shelf,
@@ -113148,6 +113359,12 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xFW" = (
+/obj/machinery/vending/drink_showcase,
+/obj/structure/table/marble,
+/obj/machinery/door/blast/shutters/glass{
+	id = "bar1";
+	name = "glass shutter"
+	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
 "xFY" = (
@@ -113377,14 +113594,18 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/dorm1)
 "xIh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/small/busha1,
-/obj/structure/flora/big/bush1{
-	pixel_x = -15
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
 	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/bar)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/colony_underground{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "xIm" = (
 /obj/structure/grille,
 /obj/structure/railing,
@@ -113798,12 +114019,10 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xMv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/multiz/stairs/enter{
+	dir = 1
 	},
-/obj/structure/railing/grey,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/beach/water/shallow,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "xMH" = (
 /obj/machinery/door/unpowered/simple/wood,
@@ -114085,17 +114304,11 @@
 /turf/simulated/floor/reinforced,
 /area/nadezhda/engineering/atmos)
 "xQl" = (
-/obj/machinery/door/unpowered/simple/wood/saloon,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/wood/wild1,
+/turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/crew_quarters/bar)
 "xQo" = (
 /obj/effect/floor_decal/industrial/arrows/white{
@@ -114379,17 +114592,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/cargo)
 "xSN" = (
-/obj/effect/floor_decal/spline/wood,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/spline/wood{
+/obj/structure/railing/grey,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/railing/grey,
-/obj/structure/bed/chair/sofa/beige/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "xSO" = (
 /obj/structure/burrow{
@@ -114832,10 +115042,9 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
 "xXV" = (
-/obj/effect/floor_decal/spline/wood{
-	dir = 8
-	},
-/turf/simulated/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/crew_quarters/bar)
 "xYd" = (
 /obj/machinery/camera/network/security,
@@ -115193,13 +115402,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "ybE" = (
-/obj/structure/closet/wall_mounted/emcloset{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "ybH" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5;
@@ -138302,7 +138508,7 @@ cZb
 cZb
 bgV
 jHH
-nvz
+mYi
 rNE
 oKd
 uyF
@@ -175962,7 +176168,7 @@ sSE
 ods
 ods
 wDM
-wDM
+kOH
 lDS
 rWi
 ghg
@@ -178103,16 +178309,16 @@ bCN
 bCN
 vWY
 kpx
-hRx
 bCN
-cPd
-cPd
-cPd
-cPd
-cPd
-cPd
-cPd
-cPd
+bCN
+bCN
+bCN
+lKe
+lKe
+lKe
+lKe
+lKe
+lKe
 wFV
 tnO
 fUB
@@ -178306,15 +178512,15 @@ vUm
 rHX
 bVe
 vrX
-veV
-cPd
+gmt
+gmt
 kgS
 vxh
-kju
+smL
 fLT
 sZv
 wCM
-cPd
+hNT
 whU
 rXw
 kgK
@@ -178501,7 +178707,7 @@ tSY
 wEu
 bCN
 iVK
-wAa
+cWm
 aut
 iaX
 iaX
@@ -178509,14 +178715,14 @@ tBx
 vhj
 uHZ
 hUI
-eZe
+uHZ
 csM
 gsq
 xya
 qSv
 ggB
 egR
-cPd
+hNT
 whU
 tnO
 iZA
@@ -178701,7 +178907,7 @@ evR
 sOJ
 tSY
 uAn
-bCN
+ilr
 tAk
 wAa
 xAl
@@ -178710,15 +178916,15 @@ sDC
 hiG
 guj
 bLm
-gmt
-nCe
+sDw
+mgI
 wls
 xAD
-xAD
+ybE
 xva
-xAD
+xnW
 nRZ
-cPd
+hNT
 sDb
 ojo
 whU
@@ -178903,7 +179109,7 @@ evR
 aKG
 tSY
 mAJ
-bCN
+ilr
 gPp
 poo
 nFv
@@ -178912,15 +179118,15 @@ ijo
 xNt
 orF
 bCN
+eWd
+ilr
 bCN
-cPd
-tzB
+bTI
 flb
-flb
-flb
+xva
 gVG
-cPd
-cPd
+mUH
+lKe
 whU
 tnO
 whU
@@ -179114,15 +179320,15 @@ gjS
 ldd
 iYO
 bCN
-mYi
+hDH
 cdh
 btG
-btG
-mBu
-btG
+xAD
+kju
+xva
 hDH
-sax
-cPd
+cdh
+hNT
 bbM
 tQp
 xsN
@@ -179316,15 +179522,15 @@ knK
 ayH
 acQ
 bCN
-hgB
-xAD
+mKv
+uag
 hht
-hht
+mBu
 xbK
 hht
 uAx
 vow
-stI
+hNT
 bbM
 tnO
 bbM
@@ -179519,14 +179725,14 @@ mPz
 fCW
 bCN
 vwq
+nRZ
+btG
 xAD
-xAD
-wWx
 qCt
-dJS
+xva
 obw
 bKS
-stI
+hNT
 bbM
 tQp
 ilF
@@ -179718,17 +179924,17 @@ bCN
 lTH
 mhx
 ilr
-bTI
+ilr
 bCN
-ioj
-xnW
-woU
+hNT
+hNT
+lKe
 lTV
 vAx
 lKe
-odw
 hNT
-cPd
+hNT
+lKe
 rtI
 due
 fpd
@@ -179917,18 +180123,18 @@ lAo
 pVp
 pQg
 fFg
-fbj
+sEF
 iSE
 eRT
 fbj
 fzr
 sEF
-guA
+pQg
 bfB
 tXI
-eFn
+sEF
 exf
-ieD
+sEF
 uLq
 lVY
 xrC
@@ -180116,24 +180322,24 @@ jzW
 drb
 gwo
 jre
-mln
-bbM
+guA
+hRx
 gll
-qhP
-qhP
+dmf
+dmf
 oTN
 nut
-qhP
+dJS
 bJu
-qhP
-lOj
+klq
+odw
 kNM
 iBw
 dWG
-dWG
+woU
 xIh
 wDH
-fzc
+tIQ
 vAG
 xsP
 tGr
@@ -180323,17 +180529,17 @@ nNz
 cPd
 aRL
 xFW
-dYe
-mUH
-qbs
-tEW
-hyr
-lOj
-qlZ
-xXV
-stI
-stI
-cWm
+cPd
+cPd
+cPd
+cPd
+ioj
+uEj
+cPd
+cPd
+cPd
+cPd
+cPd
 cPd
 oJC
 pSZ
@@ -180522,21 +180728,21 @@ ceX
 kgK
 xYx
 whU
-stI
+cPd
 eVm
-xFW
+cYu
 bjl
-abn
+frs
 skW
 iDm
-hyr
-gpP
-nol
+sax
+tzB
+wWx
 cOU
 blY
-whU
+xXV
 elY
-wHi
+eHE
 bbM
 hGK
 cVH
@@ -180726,19 +180932,19 @@ mRV
 whU
 cPd
 mIf
-xFW
+qhP
 ozA
 rtV
 hlv
 xMv
-hyr
+fzc
 gpP
 nol
-jFJ
-ehp
-whU
-whU
-wHi
+jvz
+jvz
+jvz
+wGi
+eHE
 bbM
 mln
 qvS
@@ -180928,20 +181134,20 @@ mRV
 whU
 cPd
 oYB
-xFW
+qlZ
 vRs
-eWd
+rtV
 xBJ
 xfu
 hyr
 lOj
-xrh
 cPd
 mSH
-klq
+mSH
+jvz
 myS
-cPd
-ybE
+eHE
+bbM
 mRV
 axX
 gFl
@@ -181128,20 +181334,20 @@ gwo
 uLk
 mRV
 whU
-stI
-eVm
-xFW
+cPd
+hgB
+jvn
 qSM
-uEj
+jvz
 bjP
 txD
 hyr
 pla
-cPd
-cPd
 qsr
-qsr
-qsr
+opg
+qiI
+mei
+nCe
 cPd
 hIx
 ydV
@@ -181333,16 +181539,16 @@ whU
 cPd
 mQK
 sDW
-qhP
-dmf
+cOU
+cOU
 xSN
 rqU
 hyr
-lOj
+pla
 qsr
 qiI
-oyb
-opg
+qiI
+jvz
 lJl
 cPd
 lnZ
@@ -181535,18 +181741,18 @@ whU
 cPd
 nHn
 ibb
-qhP
-jvn
+jvz
+jvz
 iHQ
-qhP
-qhP
-lOj
-kOH
+ehp
+oNs
+jFJ
+cPd
 dkt
 vDF
-mcu
+jvz
 oaq
-cPd
+eHE
 gNJ
 mRV
 whU
@@ -181734,21 +181940,21 @@ hDW
 amq
 rBi
 whU
-stI
+eHE
 abn
-eVm
-qhP
+ieD
+dYe
+tEW
 hwZ
-hwZ
-cPd
-hyr
-lOj
+qbs
+fke
+xrh
 sEB
 oyb
 mcu
 mei
 btk
-cPd
+eHE
 gNJ
 hGK
 axX
@@ -181936,21 +182142,21 @@ gEJ
 whU
 epe
 whU
-cPd
+eHE
 ehN
 gOS
-qhP
+gOS
+veV
 vaS
-vaS
-cPd
-hyr
+eZe
+xQl
 utI
-qsr
+eFn
 jvz
-oNs
 qkJ
+bLo
 wGi
-cPd
+eHE
 gdi
 hyp
 bwI
@@ -182139,19 +182345,19 @@ aYQ
 nMd
 rYf
 cPd
-cPd
-stI
+eHE
+eHE
 stI
 cPd
 cPd
 cPd
 eHE
-xQl
+eHE
 cPd
-uag
-uag
-uag
-uag
+cPd
+cPd
+cPd
+cPd
 cPd
 cWM
 mln

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -7997,18 +7997,12 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "bLm" = (
 /obj/structure/table/marble,
+/obj/machinery/button/windowtint{
+	id = "Bar";
+	range = 5
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
-"bLo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/slotmachine{
-	dir = 8
-	},
-/obj/machinery/camera/network/colony_underground{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/crew_quarters/bar)
 "bLr" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -17563,6 +17557,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"dMY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stool/padded,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "dMZ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/reinforced,
@@ -21841,10 +21840,15 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "eHE" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/bar)
+/obj/item/reagent_containers/glass/bucket{
+	name = "potato peel bucket";
+	desc = "A bucket used for storing potato peels after peeling them."
+	},
+/obj/item/tool/knife{
+	name = "potato knife"
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/crew_quarters/kitchen)
 "eHG" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance{
@@ -36946,7 +36950,9 @@
 /area/nadezhda/security/tactical_blackshield)
 "hNT" = (
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn,
+/obj/effect/window_lwall_spawn/reinforced/polarized{
+	id = "Bar"
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/kitchen{
 	name = "\improper Dining Area"
@@ -43325,6 +43331,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"jgD" = (
+/obj/structure/table/woodentable,
+/obj/item/flame/candle,
+/obj/machinery/camera/network/colony_underground,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "jgG" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/reedbush,
@@ -44808,12 +44822,16 @@
 /area/nadezhda/engineering/workshop)
 "jvn" = (
 /obj/structure/table/marble,
+/obj/effect/floor_decal/spline/wood{
+	dir = 4
+	},
+/obj/machinery/button/windowtint{
+	id = "Bar2";
+	range = 5
+	},
 /obj/machinery/door/blast/shutters/glass{
 	id = "bar1";
 	name = "glass shutter"
-	},
-/obj/effect/floor_decal/spline/wood{
-	dir = 4
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
@@ -53497,6 +53515,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"lrt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/slotmachine{
+	dir = 8
+	},
+/obj/machinery/camera/network/colony_underground{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/crew_quarters/bar)
 "lrA" = (
 /obj/structure/catwalk,
 /obj/random/scrap/sparse_weighted,
@@ -57314,16 +57342,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
-"mgI" = (
-/obj/item/reagent_containers/glass/bucket{
-	name = "potato peel bucket";
-	desc = "A bucket used for storing potato peels after peeling them."
-	},
-/obj/item/tool/knife{
-	name = "potato knife"
-	},
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/crew_quarters/kitchen)
 "mgM" = (
 /obj/item/reagent_containers/blood/AMinus{
 	pixel_x = -7;
@@ -60177,14 +60195,6 @@
 	icon_state = "11,3"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"mKv" = (
-/obj/structure/table/woodentable,
-/obj/item/flame/candle,
-/obj/machinery/camera/network/colony_underground,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
 "mKx" = (
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -87130,21 +87140,6 @@
 	icon_state = "5,7"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"smL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -32;
-	pixel_y = -11
-	},
-/obj/machinery/camera/network/colony_underground{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/nadezhda/crew_quarters/kitchen{
-	name = "\improper Dining Area"
-	})
 "smQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
@@ -87848,8 +87843,10 @@
 	},
 /area/shuttle/vasiliy_shuttle_area)
 "stI" = (
-/obj/effect/window_lwall_spawn,
 /obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/reinforced/polarized{
+	id = "Bar2"
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/bar)
 "stJ" = (
@@ -88890,11 +88887,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"sDw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stool/padded,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/crew_quarters/kitchen)
 "sDz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -97464,6 +97456,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"urG" = (
+/obj/effect/window_lwall_spawn/reinforced/polarized{
+	id = "Bar"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/nadezhda/command/captain/quarters)
 "urR" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
@@ -108681,6 +108680,21 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
+"wHf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -32;
+	pixel_y = -11
+	},
+/obj/machinery/camera/network/colony_underground{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "wHh" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = 32
@@ -178516,7 +178530,7 @@ gmt
 gmt
 kgS
 vxh
-smL
+wHf
 fLT
 sZv
 wCM
@@ -178916,8 +178930,8 @@ sDC
 hiG
 guj
 bLm
-sDw
-mgI
+dMY
+eHE
 wls
 xAD
 ybE
@@ -179522,7 +179536,7 @@ knK
 ayH
 acQ
 bCN
-mKv
+jgD
 uag
 hht
 mBu
@@ -180099,7 +180113,7 @@ vpT
 vpT
 pdT
 enj
-vpT
+urG
 pdT
 pdT
 pdT
@@ -180742,7 +180756,7 @@ cOU
 blY
 xXV
 elY
-eHE
+stI
 bbM
 hGK
 cVH
@@ -180944,7 +180958,7 @@ jvz
 jvz
 jvz
 wGi
-eHE
+stI
 bbM
 mln
 qvS
@@ -181146,7 +181160,7 @@ mSH
 mSH
 jvz
 myS
-eHE
+stI
 bbM
 mRV
 axX
@@ -181752,7 +181766,7 @@ dkt
 vDF
 jvz
 oaq
-eHE
+stI
 gNJ
 mRV
 whU
@@ -181940,7 +181954,7 @@ hDW
 amq
 rBi
 whU
-eHE
+stI
 abn
 ieD
 dYe
@@ -181954,7 +181968,7 @@ oyb
 mcu
 mei
 btk
-eHE
+stI
 gNJ
 hGK
 axX
@@ -182142,7 +182156,7 @@ gEJ
 whU
 epe
 whU
-eHE
+stI
 ehN
 gOS
 gOS
@@ -182154,9 +182168,9 @@ utI
 eFn
 jvz
 qkJ
-bLo
+lrt
 wGi
-eHE
+stI
 gdi
 hyp
 bwI
@@ -182345,14 +182359,14 @@ aYQ
 nMd
 rYf
 cPd
-eHE
-eHE
+stI
+stI
 stI
 cPd
 cPd
 cPd
-eHE
-eHE
+stI
+stI
 cPd
 cPd
 cPd

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -21012,6 +21012,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1{
 	name = "Bar Hallway"
@@ -24720,6 +24723,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/nadezhda/crew_quarters/kitchen{
 	name = "\improper Dining Area"
@@ -32689,6 +32696,9 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/kitchen{
@@ -48362,6 +48372,17 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"kiV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "kiX" = (
 /obj/machinery/door/blast/regular/open{
 	id = "xenobio7";
@@ -48403,6 +48424,9 @@
 "kju" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/nadezhda/crew_quarters/kitchen{
 	name = "\improper Dining Area"
@@ -48584,11 +48608,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "klq" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1{
 	name = "Bar Hallway"
@@ -56304,6 +56328,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1{
 	name = "Bar Hallway"
@@ -61096,6 +61123,9 @@
 	},
 /obj/machinery/disposal,
 /obj/machinery/light,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/kitchen{
 	name = "\improper Dining Area"
@@ -64470,8 +64500,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -79180,6 +79210,9 @@
 	})
 "qCt" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/nadezhda/crew_quarters/kitchen{
 	name = "\improper Dining Area"
@@ -93369,6 +93402,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"tCZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1{
+	name = "Bar Hallway"
+	})
 "tDe" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/turcarpet,
@@ -99120,6 +99165,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1{
 	name = "Bar Hallway"
@@ -101924,6 +101972,23 @@
 	icon_state = "13,15"
 	},
 /area/nadezhda/quartermaster/miningdock)
+"vnn" = (
+/obj/effect/floor_decal/spline/wood,
+/obj/effect/floor_decal/spline/wood{
+	dir = 8;
+	icon_state = "road_edge_decal4"
+	},
+/obj/effect/floor_decal/spline/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/simulated/floor/wood/wild1,
+/area/nadezhda/crew_quarters/kitchen{
+	name = "\improper Dining Area"
+	})
 "vnC" = (
 /obj/structure/scrap/poor,
 /obj/effect/decal/cleanable/rubble,
@@ -103060,6 +103125,9 @@
 "vAx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/unpowered/simple/wood/saloon,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/kitchen{
 	name = "\improper Dining Area"
@@ -110533,6 +110601,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/nadezhda/crew_quarters/kitchen{
 	name = "\improper Dining Area"
@@ -111910,6 +111981,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "xrE" = (
@@ -179137,7 +179211,7 @@ ilr
 bCN
 bTI
 flb
-xva
+vnn
 gVG
 mUH
 lKe
@@ -180146,9 +180220,9 @@ sEF
 pQg
 bfB
 tXI
-sEF
+tCZ
 exf
-sEF
+kiV
 uLq
 lVY
 xrC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new layout to the bar! The Customer (platonic, abstract, not a certain person) is right when it comes to matters of taste, after all!
Also changes the bar's area lighting color to a pleasant blue hue to match the aesthetic.
Also adds a sub-variety of area for easier tracking via sensor consoles (and to avoid having the dining area be lit in blue) _(see image 2)_
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>

IMAGE 1: BAR AREAS
![areas](https://github.com/sojourn-13/sojourn-station/assets/69877576/0c028b2a-af93-4fa8-9750-fff9464c5773)

IMAGE 2: BAR SUB-AREA (dining area :3)
![diningarea](https://github.com/sojourn-13/sojourn-station/assets/69877576/77743ed0-f284-48ef-96cc-d357725486fc)

IMAGE 3: CURRENT LAYOUT OF THE BAR (the current version that I wish to merge w/ all of the slot machines and jukebox)
![wholebarunlit](https://github.com/sojourn-13/sojourn-station/assets/69877576/2c6c7695-43ba-4d3d-95d6-83eff5e3b654)

IMAGE 4: SLIGHTLY OUTDATED LAYOUT OF THE BAR (It's taken on a test server I didn't bother to re-launch after seeing the lighting worked, lacks minor details such as benches being fixed and slotmachines being added)
![bar1](https://github.com/sojourn-13/sojourn-station/assets/69877576/18ce1f63-fb72-480d-b925-9924bdcb23ab)

IMAGE 5: CLOSER LOOK AT THE DINING AREA (also a tad bit outdated, I added a stool and bucket behind the chef's counter)
![bar2](https://github.com/sojourn-13/sojourn-station/assets/69877576/f258a44b-f90f-4db9-b4e4-c3e381d2d341)


## Changelog
:cl:
add: Added a new area variation
code: changed some area lighting code 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
