### PR TITLE
Foreshadowing the end of an era: removes the Guild bullet fab and adds a board to GM locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -27,6 +27,7 @@
 	new /obj/item/device/t_scanner/advanced(src)
 	new /obj/item/storage/hcases/parts(src)
 	new /obj/item/storage/hcases/engi(src)
+	new /obj/item/circuitboard/bullet_fab(src)
 	new /obj/item/rpd(src)
 	new /obj/item/gun/energy/laser/railgun/pistol/slab(src)
 	if(prob(50))

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -111351,7 +111351,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/bulletfabricator,
+/obj/structure/table/rack,
+/obj/item/paper/monitorkey,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/gmaster)
 "xny" = (
@@ -111697,7 +111698,6 @@
 /obj/item/stack/material/plastic{
 	amount = 120
 	},
-/obj/item/paper/monitorkey,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/steel/gray_perforated,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Removes the bullet fab from the GM's vault and adds a board to their locker instead
</summary>
<hr>

This should lessen the problem of regular adepts casually breaking in to grab the fab. Eventually I do hope that it's removed, but until then we can at least limit it to when there's actually a GM to set it up.

![image](https://github.com/sojourn-13/sojourn-station/assets/29682682/e836ffa2-23c5-46e4-bff8-58f702601202)

	
<hr>
</details>

## Changelog
:cl:
tweak: Removes the Guild's prebuilt bullet fab but adds a board to the GM's locker to discourage Adepts stealing it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
