### PR TITLE
radiation mod fix

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -71,6 +71,9 @@
 		if(IRRADIATE)
 			var/rad_protection = check_protection ? getarmor(null, ARMOR_RAD) / 100 : 0
 			radiation += max((1 - rad_protection) * effect, 0)//Rads auto check armor
+			if(ishuman(src))
+				var/mob/living/carbon/human/H = src
+				radiation *= H.species.radiation_mod
 		if(STUTTER)
 			if(status_flags & CANSTUN) // stun is usually associated with stutter
 				stuttering = max(stuttering,(effect))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Radiation mod now applies to the recieved value as well as the damage recieved.

Both the gene and cindarites were no longer immune to radiation because the majority of bad effects and damage procs were moved before the actual damage reduction, likewise not counting in the other nasty effects.

Fixes issue: #4866