### PR TITLE
Passcard adding and tiny AI fix

### DIFF
--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -1555,6 +1555,7 @@ Anyone wearing it can open public church doors. You should do your best to keep 
 	desc = "A passcard issued to citizens of Aqua Fria. Tucked away in a heavily populated system, this large aquatic world has made a reputation for being a substantial food source and home to a number of research institutes."
 	icon_state = "passcard_aqua_fria"
 	item_state = "badge"
+
 /obj/item/clothing/accessory/passcard/wanderers_armada
 	name = "Wanderers Armada passcard"
 	desc = "A passcard issued to citizens of the Wanderers Armada, A wandering fleet of spacers massive enough to have it's own Citizenship status. Well known for it's black market trade and elicit activity."

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -1550,17 +1550,39 @@ Anyone wearing it can open public church doors. You should do your best to keep 
 	icon_state = "passcard_neopolis"
 	item_state = "passport"
 
-
 /obj/item/clothing/accessory/passcard/aqua_fria
 	name = "Aqua Fria passcard"
 	desc = "A passcard issued to citizens of Aqua Fria. Tucked away in a heavily populated system, this large aquatic world has made a reputation for being a substantial food source and home to a number of research institutes."
 	icon_state = "passcard_aqua_fria"
 	item_state = "badge"
+/obj/item/clothing/accessory/passcard/wanderers_armada
+	name = "Wanderers Armada passcard"
+	desc = "A passcard issued to citizens of the Wanderers Armada, A wandering fleet of spacers massive enough to have it's own Citizenship status. Well known for it's black market trade and elicit activity."
+	icon_state = "passcard_wanderers_armada"
+	item_state = "badge"
+
+/obj/item/clothing/accessory/passcard/kurilskaya
+	name = "Kurilskaya passcard"
+	desc = "A passcard issued to citizens of Kurilskaya, An old mining facility that grew into a lawless land. An unkind and very secretive facility on a gas giant. Not much is known about the place itself to the general public aside from that it's infested with cutthroats."
+	icon_state = "passcard_kurilskaya"
+	item_state = "kuri"
 
 /obj/item/clothing/accessory/passcard/donbettyr
 	name = "Donbettyr passcard"
 	desc = "A passcard issued to citizens of Donbettyr, the homeworld of the Akula. An old, primarily ocean world with two moons and few thousand separated areas of land making up a series of islands and archipelagos."
 	icon_state = "passcard_donbettyr"
+	item_state = "badge"
+
+/obj/item/clothing/accessory/passcard/norian
+	name = "Norian passcard"
+	desc = "A passcard issued to citizens of Norian, the homeworld of the Naramadi. A dangerous but pretty planet and home to many of the other Federation races."
+	icon_state = "passcard_norian"
+	item_state = "general_passport"
+
+/obj/item/clothing/accessory/passcard/marqua
+	name = "Marqua Homeworlds passcard"
+	desc = "A passcard issued to those who live on the many Marqua Homeworlds, standard on the mass of planets they control. Regardless of citizenship status."
+	icon_state = "passcard_marqua_homeworld"
 	item_state = "badge"
 
 /obj/item/clothing/accessory/passcard/passport_sol
@@ -1572,7 +1594,7 @@ Anyone wearing it can open public church doors. You should do your best to keep 
 /obj/item/clothing/accessory/passcard/passport_general
 	name = "passport"
 	desc = "A passport issued to Nadezhda Colonists that live on Amethyn, in the Chromin 8 system."
-	icon_state = "general_passport"
+	icon_state = "passport_general"
 	item_state = "general_passport"
 
 /obj/item/clothing/accessory/passcard/passport_kriosan

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -18,10 +18,10 @@ var/list/department_radio_keys = list(
 	"p" = "AI Private",
 	"t" = "Church",
 	"k" = "Prospector",
-	"1" = "Plasmatag B",
-	"2" = "Plasmatag R",
-	"3" = "Plasmatag Y",
-	"4" = "Plasmatag G"
+	"a" = "Plasmatag B",
+	"o" = "Plasmatag R",
+	"q" = "Plasmatag Y",
+	"z" = "Plasmatag G"
 )
 
 


### PR DESCRIPTION
Adds the Wanderers Armada, Kurilskaya, Marqua Homeworlds and Norian passcards in. They where lazing around in are code not being utilized and I don't believe it was intended. The sprites themselfs belong to Guidesa I believe. Attempted to give them fitting descs. I encourage anyone to give me better descs.

Fixes the general passport having no icon.

Changes the channel keys of the plasma tag channels. The old ones being 1-4 was making problems for the AI stating laws in some cases.

