### PR TITLE
Refactors psionic powers, plus misc. improvements

### DIFF
--- a/code/modules/psionics/psion.dm
+++ b/code/modules/psionics/psion.dm
@@ -163,23 +163,49 @@
 				H.update_implants()
 
 
-// This proc handles paying for your powers and checks if you attempt to use your power while you are dead or unconcious. Placed here so it doesn't need to be in every power function.
+// This proc handles paying for your powers and checks if you attempt to use your power while you are dead or unconcious. Placed here so it doesn't need to be in every power function. Dead/unconscious checks are here so you can't somehow spend power points while unconscious
 /obj/item/organ/internal/psionic_tumor/proc/pay_power_cost(var/psi_cost)
 	if(disabled == 1)
 		to_chat(src, "Your connection is cut to your psionic essence, something is wrong!.")
 		return FALSE
 	if(owner.stat == DEAD)
 		to_chat(src, "You are dead.")
-		return
+		return FALSE
 	if(owner.stat == UNCONSCIOUS)
 		to_chat(src, "You cannot use your psionic powers while unconscious.")
-		return
+		return FALSE
 	if(psi_points < psi_cost)
 		to_chat(usr,"You lack the psionic essence to do this.")
 		return FALSE
 	else
 		psi_points -= psi_cost
-		if(owner.psi_blocking >= 10)
-			to_chat(usr,"Your mind struggles to break the confines of its prison, but cannot escape.")
-			return FALSE
 		return TRUE
+
+//This proc handles checking whether a power can be used for reasons other than cost. It is called after pay cost
+/obj/item/organ/internal/psionic_tumor/proc/check_possibility(targeted = FALSE, var/mob/living/carbon/human/target, require_target_active = FALSE)
+	if(owner.psi_blocking >= 10)
+		owner.stun_effect_act(0, owner.psi_blocking * 5, BP_HEAD)
+		owner.weakened = owner.psi_blocking
+		to_chat(usr,"Your mind struggles to break the confines of its prison, but cannot escape.")
+		return FALSE
+	if(targeted) //This should be used only for directly targeted effects, like telepathy, healing, or sleep, not on anything telekinetic.
+		if(!target)
+			usr.show_message(SPAN_NOTICE("You reach out with your mind, but there's nobody in front of you."))
+		if(target.psi_blocking >= 10) //If we try to affect someone with psi blocking, it hurts!
+			owner.stun_effect_act(0, target.psi_blocking * 5, BP_HEAD)
+			owner.weakened = target.psi_blocking
+			usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
+			return FALSE
+		if(target.species?.reagent_tag == IS_SYNTHETIC) //Can't affect synths
+			usr.show_message(SPAN_NOTICE("You feel no mind to touch within this person!"))
+			return FALSE
+		if(target.stat == DEAD) //Can't affect the dead
+			usr.show_message(SPAN_NOTICE("The mind within this person is dead and unable to be affected."))
+			return FALSE
+		if(target.get_core_implant(/obj/item/implant/core_implant/cruciform)) //Can't affect the baptized
+			usr.show_message(SPAN_NOTICE("You feel something greater than your own mind pressing back, resisting your power."))
+			return FALSE
+		if(require_target_active && target.stat == UNCONSCIOUS) //Some powers like telepathy can't affect the sleeping
+			usr.show_message(SPAN_NOTICE("You feel the mind you are attempting to reach is slumbering."))
+			return FALSE
+	return TRUE

--- a/code/modules/psionics/psion_powers/armour_powers.dm
+++ b/code/modules/psionics/psion_powers/armour_powers.dm
@@ -7,7 +7,7 @@
 	set desc = "Creates a set of armor from somewhere that does not exist. Anything taken off disappears and whatever clothing you are wearing when this power is used is destroyed."
 	psi_point_cost = 4
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		playsound(usr.loc, pick('sound/mecha/lowpower.ogg','sound/effects/magic/Blind.ogg','sound/effects/phasein.ogg'), 50, 1, -3)
 		owner.visible_message(
 			SPAN_DANGER("[src.owner]'s flesh and clothing contort and shimmer, reforming into flowing, black and bronze robes!"),
@@ -24,7 +24,7 @@
 	set desc = "Creates a set of very strong armor, using your mind and the environment as the material. Each piece of armor replaces the clothes you are already wearing, and provides additional strength to your body, in exchange for your psionic abilities."
 	psi_point_cost = 8
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		playsound(usr.loc, pick('sound/mecha/lowpower.ogg','sound/effects/magic/Blind.ogg','sound/effects/phasein.ogg'), 50, 1, -3)
 		owner.visible_message(
 			SPAN_DANGER("[src.owner]'s Flesh and clothing merge together, tiny crumbs, small objects, streams of thoughts and ideas are pulled together to him, forming on his body a solid armor woven from matter itself, held together by only one will of the psion!"),
@@ -41,7 +41,7 @@
 	set desc = "When applied, it creates an ultra-light protected cloak, spurring the wearer to new adventures in the kingdom of the king of dreams! Each part of the kit enhances the psion's thinking abilities and accelerates his step."
 	psi_point_cost = 6
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		playsound(usr.loc, pick('sound/mecha/lowpower.ogg','sound/effects/magic/Blind.ogg','sound/hallucinations/i_see_you2.ogg','sound/effects/phasein.ogg'), 50, 1, 1, -3)
 		owner.visible_message(
 			SPAN_DANGER("[src.owner]'s Flesh and clothing merge together, tiny crumbs, small objects, streams of thoughts and ideas are pulled together to him, forming on his body a solid armor woven from matter itself, held together by only one will of the psion!"),

--- a/code/modules/psionics/psion_powers/deepmaints_themed_powers.dm
+++ b/code/modules/psionics/psion_powers/deepmaints_themed_powers.dm
@@ -6,7 +6,7 @@
 	set desc = "Expend three psi points to break all the lights connected to the power grid near you. Does not work on independent light sources, sunlight, or grant you sight in darkness."
 	psi_point_cost = 3
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		playsound(owner.loc, 'sound/hallucinations/growl1.ogg', 25,1,8,8)
 		var/area/A = get_area(owner)
 		for(var/obj/machinery/power/apc/apc in A)
@@ -25,7 +25,7 @@
 	set desc = "Expend two psi points to expel gore, blood, and smoke to decorate the world as the king desires."
 	psi_point_cost = 2
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/datum/effect/effect/system/smoke_spread/bad/smoke
 		smoke = new
 		playsound(loc, 'sound/effects/smoke.ogg', 50, 1, -3)
@@ -86,7 +86,7 @@
 	psi_point_cost = 10
 
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		if(alert(usr, "Are you sure you want to do this? It will absoutely kill you.", "Merge Flesh and Steel", "Yes", "No") == "Yes")
 			new /obj/machinery/hivemind_machine/node(owner.loc)
 			owner.gib()
@@ -101,28 +101,23 @@
 
 	if(get_front_mob(owner))
 		var/mob/living/carbon/human/L = get_front_mob(owner)
-		if(L.psi_blocking >= 10)
-			owner.stun_effect_act(0, L.psi_blocking * 5, BP_HEAD)
-			owner.weakened = L.psi_blocking
-			usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
-			return
-
-		if(istype(L, /mob/living/carbon/human) && L.stat == CONSCIOUS)
-			if(L.ckey)
-				if(alert(L, "An alien presence touches your mind, offering you power and insight into the very fabric of reality. Do you accept its offer and become a Psion?",
-					"Become Psion", "No", "Yes") != "Yes")
-					to_chat(owner, "They refused your gift!")
-					return
-				else
-					if(L && isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC)
-						visible_message(
-							SPAN_WARNING("[src] grabs [L]! Psionic energy alights [src]'s eyes as they focus intently on [L] !"),
-							SPAN_WARNING("You project your psionic essence, turning it towards [L].")
-						)
-						L.make_psion()
-						owner.adjustBrainLoss(10)
-						to_chat(owner, "You feel a horrible splitting migraine as the process ends.")
-						to_chat(L, "Your mind is aflame with possibilities! You can see, you can SEE, YOU CAN SEE IT ALL!")
+		if(pay_power_cost(psi_point_cost) && check_possibility(TRUE, L))
+			if(istype(L, /mob/living/carbon/human) && L.stat == CONSCIOUS)
+				if(L.ckey)
+					if(alert(L, "An alien presence touches your mind, offering you power and insight into the very fabric of reality. Do you accept its offer and become a Psion?",
+						"Become Psion", "No", "Yes") != "Yes")
+						to_chat(owner, "They refused your gift!")
+						return
+					else
+						if(L && isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC)
+							visible_message(
+								SPAN_WARNING("[src] grabs [L]! Psionic energy alights [src]'s eyes as they focus intently on [L] !"),
+								SPAN_WARNING("You project your psionic essence, turning it towards [L].")
+							)
+							L.make_psion()
+							owner.adjustBrainLoss(10)
+							to_chat(owner, "You feel a horrible splitting migraine as the process ends.")
+							to_chat(L, "Your mind is aflame with possibilities! You can see, you can SEE, YOU CAN SEE IT ALL!")
 	else
 		to_chat(src, "You must face your target!")
 

--- a/code/modules/psionics/psion_powers/faction_powers.dm
+++ b/code/modules/psionics/psion_powers/faction_powers.dm
@@ -7,6 +7,6 @@
 	set desc = "Expend a single psi point to realign your mind to that of nightmare stalkers, causing them to not react to your presence, even when you attack them. May have unforseen consequences."
 	psi_point_cost = 1
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		owner.faction = "stalker"
 		usr.show_message("\blue How easy it would be, to peel back the skin, to see the flesh writhe and bleed as tendons were cut and viscera sliced out with your claws.")

--- a/code/modules/psionics/psion_powers/gear_summoning_powers.dm
+++ b/code/modules/psionics/psion_powers/gear_summoning_powers.dm
@@ -10,7 +10,7 @@
 	var/stat_bio = 25
 	var/stat_rob = 25
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/obj/item/tool/psionic_omnitool/tool = new /obj/item/tool/psionic_omnitool(src, owner)
 		if (owner.stats.getStat(STAT_MEC) > 32)
 			stat_mec = owner.stats.getStat(STAT_MEC) * 0.8
@@ -38,7 +38,7 @@
 	set desc = "Expend a single point of your psi essence to create a tiny flickering fire in your hand that will shine light and ignite combustible materials, can be thrown but will extinguish quickly."
 	psi_point_cost = 1
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/obj/item/flame/pyrokinetic_spark/flame = new /obj/item/flame/pyrokinetic_spark(src, owner)
 		owner.visible_message(
 			"[owner] raises their arm, electricity crackling before a small flame juts from their hand!",
@@ -53,7 +53,7 @@
 	set desc = "Expend a single point of your psi essence to create a low quality but still deadly knife. It's power and damage scale with your robustness."
 	psi_point_cost = 1
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/obj/item/tool/knife/psionic_blade/knife = new /obj/item/tool/knife/psionic_blade(src, owner)
 		owner.visible_message(
 			"[owner] clenches their fist, electricity crackling before a psionic blade forms in their hand!",
@@ -70,7 +70,7 @@
 	If the shield inhand is already enhanced it will be be healed"
 	psi_point_cost = 1
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		//Used to tell if we need to spawn new shield or not
 		var/successfully_enhanced = FALSE
 		//Grabs the item on the mobs *actively selected hand*
@@ -145,7 +145,7 @@
 	set desc = "Expend a single point of your psi essence to create a layered shield capable of blocking bullets, energy beams, and melee attacks."
 	psi_point_cost = 1
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/obj/item/shield/riot/crusader/psionic/layered/shield = new /obj/item/shield/riot/crusader/psionic/layered(src, owner)
 		owner.visible_message(
 			"[owner] clenches their fist, electricity crackling before a psy-shield forms in their hand!",
@@ -162,7 +162,7 @@
 	scales with your physical robustness."
 	psi_point_cost = 1
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/obj/item/tool/hammer/telekinetic_fist/fist = new /obj/item/tool/hammer/telekinetic_fist(src, owner)
 		owner.visible_message(
 			"[owner] clenches their hand into a fist, electric energy crackling around it before a telekinetic fist forms over it!",
@@ -178,7 +178,7 @@
 	psi_point_cost = 2
 	var/timer = 10 SECONDS
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/obj/item/shield_projector/line/psionic/shield = new(src, owner.stats.getStat(STAT_COG), owner.dir)
 		owner.visible_message(
 			"[owner] stares ahead as a psychic barrier forms from thin air!",
@@ -197,7 +197,7 @@
 	set desc = "Expend none of your essence to create a kinetic orb in hand, a ranged weapon that grows in power with your cognition and expends a single psi point per shot."
 	psi_point_cost = 0
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/obj/item/gun/kinetic_blaster/KB = new(src, owner, src)
 		owner.visible_message(
 			"[owner] clenches their hand into a fist, electric energy crackling around it before a kinetic blaster forms over it!",
@@ -214,7 +214,7 @@
 	Deals no damage on its own, but the sudden blast of cold stuns whoever it hits for a short time."
 	psi_point_cost = 0
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/obj/item/gun/kinetic_blaster/cryo/KB = new(src, owner, src)
 		owner.visible_message(
 			"[owner] clenches their hand into a fist, electric energy crackling around it before a cryo-kinetic orb forms over it!",
@@ -230,7 +230,7 @@
 	The heat generated from pyro blasts fast enough to not cause fires, but the sudden expansion of hot air is highly explosive."
 	psi_point_cost = 0
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/obj/item/gun/kinetic_blaster/pyro/KB = new(src, owner, src)
 		owner.visible_message(
 			"[owner] clenches their hand into a fist, electric energy crackling around it before a pyro-kinetic orb forms over it!",
@@ -246,7 +246,7 @@
 	Much stronger than kinetic blasts and doesn't need to travel towards its target, being electric."
 	psi_point_cost = 0
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/obj/item/gun/kinetic_blaster/electro/KB = new(src, owner, src)
 		owner.visible_message(
 			"[owner] clenches their hand into a fist, electric energy crackling around it before an electro-kinetic orb forms over it!",

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -27,7 +27,7 @@
 	set desc = "Expend a single point of your psi essence to convince your stomach it's not actually that hungry, burning fat reserves to keep going strong. Taxing on the mind and causes minor burns."
 	psi_point_cost = 1
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		if(!owner.stats.getPerk(PERK_PSI_ATTUNEMENT))
 			owner.nutrition += 100 //Twice as strong as Soul Hunger
 			owner.adjustFireLoss(10) //You're not using your nutrition to fuel things like Church used to, this should be fine
@@ -43,7 +43,7 @@
 	set desc = "Expend four psi points to clear all effects that impede one's control. Remove stuns, paralysis, pain, agony, restrainments, and clears the users body of all chemicals and addictions."
 	psi_point_cost = 4
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		owner.visible_message(
 			"[owner] shimmers strangely!",
 			"You remind the universe that it bends to your will!"
@@ -77,7 +77,7 @@
 	set desc = "Expend two psi points of your psi essence to focus your mind and increase your sanity."
 	psi_point_cost = 2
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		if(owner.sanity.level >= (owner.sanity.max_level - 10))
 			psi_points += psi_point_cost
 			owner.visible_message(

--- a/code/modules/psionics/psion_powers/locator_powers.dm
+++ b/code/modules/psionics/psion_powers/locator_powers.dm
@@ -16,7 +16,7 @@
 	if (isnull(target))
 		return
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility()) //Doesn't use the normal check possibility flags since we want it to work on dead people
 		if(target.psi_blocking >= 10)
 			owner.stun_effect_act(0, target.psi_blocking * 5, BP_HEAD)
 			owner.weakened = target.psi_blocking

--- a/code/modules/psionics/psion_powers/mob_affecting_powers.dm
+++ b/code/modules/psionics/psion_powers/mob_affecting_powers.dm
@@ -7,7 +7,7 @@
 	set desc = "Expend two points of your psi essence to call creatures from nearby burrows. They are not inherently friendly to you. Use at your own risks."
 	psi_point_cost = 2
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		playsound(src.loc, 'sound/voice/shriek1.ogg', 75, 1, 8, 8)
 		spawn(2)
 		playsound(src.loc, 'sound/voice/shriek1.ogg', 75, 1, 8, 8)
@@ -25,7 +25,7 @@
 	resist your psychic influence."
 	psi_point_cost = 4
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		playsound(src.loc, 'sound/voice/hiss6.ogg', 75, 1, 8, 8)
 		spawn(2)
 		playsound(src.loc, 'sound/voice/hiss6.ogg', 75, 1, 8, 8)
@@ -43,7 +43,7 @@
 	incapable of proper violence, such as rats."
 	psi_point_cost = 3
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		var/mob/living/carbon/superior_animal/S = get_grabbed_mob(owner)
 		if(istype(S, /mob/living/carbon/superior_animal))
 			usr.visible_message(
@@ -73,7 +73,7 @@
 	set desc = "Expend five psi points and wither your body and mind to call three dreaming daemons from somewhere else. They are not inherently allied to you."
 	psi_point_cost = 5
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		owner.stats.changeStat(STAT_TGH, -20)
 		owner.stats.changeStat(STAT_VIG, -20)
 		owner.stats.changeStat(STAT_ROB, -20)

--- a/code/modules/psionics/psion_powers/oddity_powers.dm
+++ b/code/modules/psionics/psion_powers/oddity_powers.dm
@@ -12,7 +12,7 @@
 		if(!active.oddity_stats)
 			to_chat(usr, "This oddity has no aspects to build a weapon from!")
 			return
-		if(pay_power_cost(psi_point_cost))
+		if(pay_power_cost(psi_point_cost) && check_possibility())
 			var/list/LStats = active.oddity_stats
 			var/obj/item/cultweaponchoice = pickweight(list(
 				/obj/item/gun/energy/plasma/auretian/cult = (1 + LStats[STAT_ROB]),
@@ -47,7 +47,7 @@
 			to_chat(usr, "This oddity has no aspects to build a weapon from!")
 			return
 
-		if(pay_power_cost(psi_point_cost))
+		if(pay_power_cost(psi_point_cost) && check_possibility())
 			var/list/LStats = active.oddity_stats
 			var/obj/item/cultweaponchoice = pickweight(list(
 				/obj/item/tool/sword/cult = (1 + LStats[STAT_ROB]),
@@ -83,7 +83,7 @@
 		if(!active.oddity_stats)
 			to_chat(usr, "This oddity has no aspects to build a weapon from!")
 			return
-		if(pay_power_cost(psi_point_cost))
+		if(pay_power_cost(psi_point_cost) && check_possibility())
 			var/list/LStats = active.oddity_stats
 			var/obj/item/cultweaponchoice = pickweight(list(
 				/obj/item/tool/shovel/combat/cult = (1 + LStats[STAT_ROB]),
@@ -121,7 +121,7 @@
 		to_chat(owner, SPAN_NOTICE("You're not holding an oddity or proper anomaly!"))
 		return FALSE
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		owner.visible_message("<b><font color='purple'>[owner] concentrates on the anomaly in their hand, something about it changing in a subtle way.</font><b>", "<b><font color='purple'>You focus on the energies around the object, swaying them to your will and trying to change it!</font><b>")
 
 		if(O.oddity_stats)

--- a/code/modules/psionics/psion_powers/oldification_powers.dm
+++ b/code/modules/psionics/psion_powers/oldification_powers.dm
@@ -7,7 +7,7 @@
 	set desc = "Expend a single psi point to wither an object, making it rust away and weaken."
 	psi_point_cost = 1
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		if(owner.get_active_hand())
 			var/obj/A = owner.get_active_hand()
 			A.make_old()
@@ -26,24 +26,18 @@
 			L = get_grabbed_mob(owner)
 			if(istype(L, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = L
-
-				if(H.psi_blocking >= 10)
-					owner.stun_effect_act(0, H.psi_blocking * 5, BP_HEAD)
-					owner.weakened = H.psi_blocking
-					usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
-					return
-
-				for(var/obj/objects in H.contents)
-					if(istype(objects, /obj/item/organ))
-						continue
-					if(istype(objects, /obj/parallax))
-						continue
-					if(istype(objects, /obj/item/grab))
-						continue
-					else
-						objects.make_old()
-						visible_message(
-						SPAN_DANGER("[objects] rusts and decays!"),
-						)
+				if(check_possibility(TRUE, L))
+					for(var/obj/objects in H.contents)
+						if(istype(objects, /obj/item/organ))
+							continue
+						if(istype(objects, /obj/parallax))
+							continue
+						if(istype(objects, /obj/item/grab))
+							continue
+						else
+							objects.make_old()
+							visible_message(
+							SPAN_DANGER("[objects] rusts and decays!"),
+							)
 	else
 		to_chat(src, "You must grab your target!")

--- a/code/modules/psionics/psion_powers/psion_starter_powers.dm
+++ b/code/modules/psionics/psion_powers/psion_starter_powers.dm
@@ -21,16 +21,11 @@
 		to_chat(owner, "Your psionic attunement allows you to bypass fully using your essence.")
 		psi_point_cost = 0
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility(TRUE, target))
 		var/say = sanitize(input("What do you wish to say"))
-		if(target.psi_blocking >= 10)
-			owner.stun_effect_act(0, target.psi_blocking * 5, BP_HEAD)
-			owner.weakened = target.psi_blocking
-			usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
-		else
-			target.show_message("\blue <b><font size='3px'> You hear [usr.real_name]'s voice: [say] </font></b>")
-			usr.show_message("\blue You project your mind into [target.real_name]: [say]")
-			log_say("[key_name(usr)] sent a telepathic message to [key_name(target)]: [say]")
-			for(var/mob/observer/ghost/G in world)
-				G.show_message("<i>Telepathic message from <b>[owner]</b> to <b>[target]</b>: [say]</i>")
+		target.show_message("\blue <b><font size='3px'> You hear [usr.real_name]'s voice: [say] </font></b>")
+		usr.show_message("\blue You project your mind into [target.real_name]: [say]")
+		log_say("[key_name(usr)] sent a telepathic message to [key_name(target)]: [say]")
+		for(var/mob/observer/ghost/G in world)
+			G.show_message("<i>Telepathic message from <b>[owner]</b> to <b>[target]</b>: [say]</i>")
 

--- a/code/modules/psionics/psion_powers/pyschiatrist_powers.dm
+++ b/code/modules/psionics/psion_powers/pyschiatrist_powers.dm
@@ -11,29 +11,19 @@
 	var/obj/item/grab/G = locate() in owner
 	if(!G || !istype(G))
 		usr.show_message(SPAN_DANGER("You are not grabbing anyone."))
-		psi_points += psi_point_cost
 		return
 
 	if(G.state < GRAB_AGGRESSIVE)
 		usr.show_message(SPAN_DANGER("You must have an aggressive grab to put someone to sleep!"))
-		psi_points += psi_point_cost
 		return
 
 	if(pay_power_cost(psi_point_cost))
-		if(L && isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC)
+		if(check_possibility(TRUE, L, TRUE)) //The second "True" makes you unable to use this on someone already sleeping... no stacking it on itself
 			usr.visible_message(
 					SPAN_DANGER("[usr] places a hand upon [L] attempting to put them to sleep!"),
 					SPAN_DANGER("You place your hand on [L] expanding your mind and attempting to put them to sleep!")
 					)
 			L.AdjustSleeping(60)
-		else
-			usr.show_message("\blue You are not holding someone you can use this power on.")
-
-	if(L.psi_blocking >= 10)
-		owner.stun_effect_act(0, L.psi_blocking * 5, BP_HEAD)
-		owner.weakened = L.psi_blocking
-		usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
-		return
 
 /obj/item/organ/internal/psionic_tumor/proc/psionic_heal_other()
 	set category = "Psionic powers"
@@ -44,22 +34,13 @@
 
 	var/mob/living/carbon/human/L = get_grabbed_mob(owner)
 
-	if(L.psi_blocking >= 10)
-		owner.stun_effect_act(0, L.psi_blocking * 5, BP_HEAD)
-		owner.weakened = L.psi_blocking
-		usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
-		return
-
-
 	if(pay_power_cost(psi_point_cost))
-		if(L && isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC)
+		if(check_possibility(TRUE, L))
 			usr.visible_message(
 					SPAN_DANGER("[usr] places a hand on [L], their wounds cleanly sealing and healing!"),
 					SPAN_DANGER("You place your hand upon [L], focusing your thoughts and carefully reconstructing each injury with your talented mind!")
 					)
 			L.heal_overall_damage(30,30)
-		else
-			usr.show_message("\blue You are not holding someone you can use this power on.")
 
 
 /obj/item/organ/internal/psionic_tumor/proc/meditative_focus_other()
@@ -73,22 +54,15 @@
 	if(!L)
 		usr.show_message("\blue You are not holding someone you can use this power on.")
 		return
-
-	if(L.psi_blocking >= 10)
-		owner.stun_effect_act(0, L.psi_blocking * 5, BP_HEAD)
-		owner.weakened = L.psi_blocking
-		usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
-		return
-
-	if(pay_power_cost(psi_point_cost))
-		if(isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC && L.sanity.level >= (L.sanity.max_level - 10))
+	if(pay_power_cost(psi_point_cost) && check_possibility(TRUE, L))
+		if(L.sanity.level >= (L.sanity.max_level - 10))
 			psi_points += psi_point_cost //Refunds?
 			usr.visible_message(
 					"[usr] places a hand on [L], a soft hum raidates around them and quickly fades away",
 					"You place your hand upon [L], concentrating [L]'s thoughts... but their mind is already calm."
 					)
 			return
-		else if(isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC && L.sanity.level < (L.sanity.max_level - 10))
+		else if(L.sanity.level < (L.sanity.max_level - 10))
 			usr.visible_message(
 					"[usr] places a hand on [L], a soft hum raidates around them",
 					"You place your hand upon [L], calming [L]'s thoughts!"
@@ -99,8 +73,6 @@
 				L.sanity.changeLevel(20)
 			if(owner.stats.getPerk(PERK_PSI_MANIA))
 				L.sanity.changeLevel(10)
-		else
-			usr.show_message("\blue You are not holding someone you can use this power on.")
 
 /obj/item/organ/internal/psionic_tumor/proc/psionic_heal_brain()
 	set category = "Psionic powers"
@@ -110,41 +82,28 @@
 
 	var/mob/living/carbon/human/L = get_grabbed_mob(owner)
 
-	if(L.psi_blocking >= 10)
-		owner.stun_effect_act(0, L.psi_blocking * 5, BP_HEAD)
-		owner.weakened = L.psi_blocking
-		usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
-		return
 	if(pay_power_cost(psi_point_cost))
-		if(L && isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC)
+		if(!L && check_possibility()) //Need to check this first to avoid people getting false messages from the targeted elements of the check_possibility proc
+			usr.show_message("\blue You feel your power turning inward, healing any potential brain trauma you may have.")
+			owner.adjustBrainLoss(-60)
+		else if(check_possibility(TRUE, L))
 			usr.visible_message(
 					SPAN_DANGER("[usr] places a hand on [L], the air seeming to shimmer for a moment!"),
 					SPAN_DANGER("You place your hand upon [L], focusing your thoughts as you carefully reconstruct any brain damage!")
 					)
 			L.adjustBrainLoss(-60)
-		else if(!L)
-			usr.show_message("\blue You feel your power turning inward, healing any potential brain trauma you may have.")
-			owner.adjustBrainLoss(-60)
-		else
-			usr.show_message("\blue You are not holding someone you can use this power on.")
 
 /obj/item/organ/internal/psionic_tumor/proc/psionic_gift()
 	set category = "Psionic powers"
 	set name = "Gift of the Psion (4)"
 	set desc = "Expend four psi points of your psi essence to offer enhanced mental powers to whoever you are grappling. In psions, you allow them to recover their psi essence twice as often. \
-	In non-psions, you enhance the body and mind by an exceptional degree."
+	In non-psions, you enhance the body and mind by an exceptional degree. The target must be awake to benefit from your mental guidance."
 	psi_point_cost = 4
 
 	var/mob/living/carbon/human/L = get_grabbed_mob(owner)
 
-	if(L.psi_blocking >= 10)
-		owner.stun_effect_act(0, L.psi_blocking * 5, BP_HEAD)
-		owner.weakened = L.psi_blocking
-		usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
-		return
-
 	if(pay_power_cost(psi_point_cost))
-		if(L && isliving(L) && !L.get_core_implant(/obj/item/implant/core_implant/cruciform) && L.species?.reagent_tag != IS_SYNTHETIC)
+		if(check_possibility(TRUE, L, TRUE))
 			if(L && L.stats.getPerk(PERK_PSION))
 				usr.visible_message(
 						SPAN_DANGER("[usr] places a hand on [L], the air seeming to shimmer for a moment!"),
@@ -158,5 +117,3 @@
 						)
 				L.stats.addPerk(PERK_PSI_PEACE)
 			log_and_message_admins("[owner] has attempted to use gift of the psion on [L]!")
-		else
-			usr.show_message("\blue You are not holding someone you can use this power on.")

--- a/code/modules/psionics/psion_powers/telekinetsis_powers.dm
+++ b/code/modules/psionics/psion_powers/telekinetsis_powers.dm
@@ -9,7 +9,7 @@
 		to_chat(owner, "Your psionic attunement allows you to bypass fully using your essence.")
 		psi_point_cost = 0
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost) && check_possibility())
 		if (!(TK in owner.mutations)) // We can't get TK if we already have TK
 			owner.mutations.Add(TK)
 			to_chat(owner, "You feel your abilities expanding, your mind growing outward, allowing you to manipulate and move objects with your mind.")
@@ -22,7 +22,7 @@
 	set desc = "End your telekinesis at will, at no essence cost. Beware, you will need to expend more to get telekinesis back."
 	psi_point_cost = 0
 
-	if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost)) //No possibility check; this is just stopping a power that's in process
 		if((TK in owner.mutations)) // We can't remove TK if we don't already have TK
 			owner.mutations.Remove(TK)
 			to_chat(owner, "You feel your telekinetic powers becoming dormant as your mind withdraws into itself, for now.")

--- a/code/modules/psionics/psion_powers/teleporation_powers.dm
+++ b/code/modules/psionics/psion_powers/teleporation_powers.dm
@@ -13,14 +13,16 @@
 			var/mob/living/L = get_grabbed_mob(owner)		//Grab anyone we have grabbed
 			var/turf/simulated/floor/target					//this is where we are teleporting
 			var/list/validtargets = list()					//list of valid tiles to teleport to
+			var/mob/living/carbon/human/H
 
 			if(ishuman(L))
-				var/mob/living/carbon/human/H = L
+				H = L
 
-				if(H.psi_blocking >= 10)
-					owner.stun_effect_act(0, H.psi_blocking * 5, BP_HEAD)
-					owner.weakened = H.psi_blocking
-					usr.show_message(SPAN_DANGER("Your head pulsates with pain as your mind bashes against an unbreakable barrier!"))
+			if(H) //If H was assigned, we need to check if we can teleport them
+				if(!check_possibility(TRUE, H))
+					return
+			else //If H wasn't assigned, just need the normal check_possibility
+				if(!check_possibility())
 					return
 
 			for(var/area/A in world)						//Clumbsy, but less intensive than iterating every tile


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Creates a general proc to check if a psion can use their power and implements it instead of piecemeal copy/paste code. Also misc. improvements to psionics code.
</summary>
<hr>

Reworks the normal list of checks that was in so many psion powers and condenses it to a single proc that can be called on every one. Also tries to remove synthetics and dead people from the list of potential telepathy targets. **This PR needs to be testmerged on a lowpop round because it is impossible to test telepathy on a solo server. I do not know whether this works perfectly, has no change, or completely borks telepathy.**
	
<hr>
</details>

## Changelog
:cl:
tweak: Refactors psionics to have a generalize check_possibility proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
