### PR TITLE
revert auretian nerf

### DIFF
--- a/code/modules/projectiles/guns/energy/plasma/centurio_auretian.dm
+++ b/code/modules/projectiles/guns/energy/plasma/centurio_auretian.dm
@@ -12,6 +12,7 @@
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASMA = 5)
 	price_tag = 1250
 	damage_multiplier = 1
+	init_recoil = HANDGUN_RECOIL(0.2)
 	init_firemodes = list(
 		list(mode_name="melt", mode_desc="Hard hitting plasma bolt that melts flesh and armor alike", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/energy/incinerate.ogg', fire_delay = 9, icon="destroy", projectile_color = "#006633"),
 		list(mode_name="ion shot", mode_desc="An iodizing shot to disable cells, electronics and cybernetics ", projectile_type=/obj/item/projectile/ion, fire_sound='sound/effects/supermatter.ogg', fire_delay = 25, icon="stun", projectile_color = "#ff7f24"),
@@ -38,8 +39,10 @@
 	suitable_cell = /obj/item/cell/small
 	charge_cost = 20
 	damage_multiplier = 1
+	init_recoil = HANDGUN_RECOIL(0.2)
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 8, MATERIAL_PLASMA = 2, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 3)
 	gun_tags = list(GUN_LASER, GUN_ENERGY)
+	blacklist_upgrades = list()
 
 	init_firemodes = list(
 		list(mode_name="plasma", mode_desc="Hard hitting plasma bolt that melts flesh and armor alike", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/energy/melt.ogg', fire_delay=9, icon="destroy", projectile_color = "#00FFFF"),

--- a/code/modules/projectiles/guns/energy/plasma/centurio_auretian.dm
+++ b/code/modules/projectiles/guns/energy/plasma/centurio_auretian.dm
@@ -42,7 +42,6 @@
 	init_recoil = HANDGUN_RECOIL(0.2)
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 8, MATERIAL_PLASMA = 2, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 3)
 	gun_tags = list(GUN_LASER, GUN_ENERGY)
-	blacklist_upgrades = list()
 
 	init_firemodes = list(
 		list(mode_name="plasma", mode_desc="Hard hitting plasma bolt that melts flesh and armor alike", projectile_type=/obj/item/projectile/plasma/heavy, fire_sound='sound/weapons/energy/melt.ogg', fire_delay=9, icon="destroy", projectile_color = "#00FFFF"),

--- a/code/modules/projectiles/guns/energy/plasma/centurio_auretian.dm
+++ b/code/modules/projectiles/guns/energy/plasma/centurio_auretian.dm
@@ -36,7 +36,7 @@
 	can_dual = TRUE
 	sel_mode = 1
 	suitable_cell = /obj/item/cell/small
-	charge_cost = 50
+	charge_cost = 20
 	damage_multiplier = 1
 	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_PLASTIC = 8, MATERIAL_PLASMA = 2, MATERIAL_SILVER = 3, MATERIAL_URANIUM = 3)
 	gun_tags = list(GUN_LASER, GUN_ENERGY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The auretian was nerfed in PR #4552 by a factor of 2.5 which put it down from 20 shots down to 8.
I believe that this was an accidential nerf because the auretian is using a small cell and not a medium cell which most other guns in that PR were balanced around.

The auretian is a Soteria exclusive, high cost and research heavy weapon that is ment to act as a side arm. At the current state the sidearm is just more than useless now, it was fine before. It wasn't the greatest side arm but still a very good one to have and very much worth its investment. Not it is sadly just pure trash and a classica is more usuable than it

Edit: Fixed recoil: Auretian no longer has rifle recoil and instead handgun while the centurio recieved a recoil nerf.
The blacklist restriction that was inherented from the plasma rifle was lifted since the auretian is not full automatic, unlike the church plasma guns
