### PR TITLE
Bioreactor eris update.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -423,5 +423,14 @@
 		registered_z = new_z
 // if this returns true, interaction to turf will be redirected to src instead
 
+///Sets the anchored var and returns if it was sucessfully changed or not. Port from eris currently only used for the bioreactor
+/atom/movable/proc/bio_anchored(anchorvalue)
+	SHOULD_CALL_PARENT(TRUE)
+	if(anchored == anchorvalue || !can_anchor)
+		return FALSE
+	anchored = anchorvalue
+	LEGACY_SEND_SIGNAL(src, COMSIG_ATOM_UNFASTEN, anchored)
+	. = TRUE
+
 /atom/movable/proc/preventsTurfInteractions()
 	return FALSE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -423,7 +423,7 @@
 		registered_z = new_z
 // if this returns true, interaction to turf will be redirected to src instead
 
-///Sets the anchored var and returns if it was sucessfully changed or not. Port from eris currently only used for the bioreactor
+///Sets the anchored var and returns if it was sucessfully changed or not. Port from eris since I was getting problems currently only used for the bioreactor
 /atom/movable/proc/bio_anchored(anchorvalue)
 	SHOULD_CALL_PARENT(TRUE)
 	if(anchored == anchorvalue || !can_anchor)

--- a/code/modules/biomatter_manipulation/biogenerator.dm
+++ b/code/modules/biomatter_manipulation/biogenerator.dm
@@ -237,7 +237,7 @@
 				var/set_canister = FALSE
 				if(tank)
 					tank.can_anchor = TRUE
-					set_canister = tank.set_anchored(FALSE)
+					set_canister = tank.bio_anchored(FALSE)
 					if(set_canister)
 						tank.pixel_x = initial(tank.pixel_x)
 						tank = null
@@ -246,7 +246,7 @@
 				else
 					tank = locate(/obj/structure/reagent_dispensers) in get_turf(src)
 					if(tank)
-						set_canister = tank.set_anchored(TRUE)
+						set_canister = tank.bio_anchored(TRUE)
 						if(set_canister)
 							tank.can_anchor = FALSE
 							tank.pixel_x = 8
@@ -317,7 +317,7 @@
 	layer = LOW_OBJ_LAYER
 	var/obj/machinery/multistructure/biogenerator_part/generator/generator
 	var/working_cycles = 0
-	var/wearout_cycle = 500
+	var/wearout_cycle = 800
 	var/wires_integrity = 100
 	var/wires = TRUE
 
@@ -420,7 +420,7 @@
 	var/obj/machinery/multistructure/biogenerator_part/generator/generator
 	var/coil_condition = 100
 	var/working_cycles = 0
-	var/wearout_cycle = 600
+	var/wearout_cycle = 900
 	var/coil_frame = TRUE
 
 

--- a/code/modules/biomatter_manipulation/biogenerator.dm
+++ b/code/modules/biomatter_manipulation/biogenerator.dm
@@ -1,5 +1,3 @@
-
-
 //Power biomatter generator
 //This machine use biomatter reagent and some of O2 to produce power (it also produce CO2)
 //It has a few components that can be weared out, so operator should check this machine from time o time and tinker it
@@ -207,16 +205,16 @@
 
 
 /obj/machinery/multistructure/biogenerator_part/port/update_icon()
-	cut_overlays()
+	overlays.Cut()
 	if(panel_open)
-		add_overlay("port-opened")
+		overlays += "port-opened"
 		if(pipes_dirtiness)
 			if(pipes_dirtiness == 1)
-				add_overlay("port_dirty_low")
+				overlays += "port_dirty_low"
 			else if(pipes_dirtiness <= 3)
-				add_overlay("port_dirty_medium")
+				overlays += "port_dirty_medium"
 			else
-				add_overlay("port_dirty_full")
+				overlays += "port_dirty_full"
 
 
 /obj/machinery/multistructure/biogenerator_part/port/examine(mob/user)
@@ -236,20 +234,27 @@
 				to_chat(user, SPAN_WARNING("You should close cover first."))
 				return
 			if(I.use_tool(user, src, WORKTIME_FAST, tool_type, FAILCHANCE_VERY_EASY,  required_stat = STAT_MEC))
+				var/set_canister = FALSE
 				if(tank)
-					tank.anchored = FALSE
-					tank.pixel_x = initial(tank.pixel_x)
-					tank = null
-					playsound(src, 'sound/machines/airlock_ext_open.ogg', 60, 1)
-					to_chat(user, SPAN_NOTICE("You detached [tank] from [src]."))
+					tank.can_anchor = TRUE
+					set_canister = tank.set_anchored(FALSE)
+					if(set_canister)
+						tank.pixel_x = initial(tank.pixel_x)
+						tank = null
+						playsound(src, 'sound/machines/airlock_ext_open.ogg', 60, 1)
+						to_chat(user, SPAN_NOTICE("You detached [tank] from [src]."))
 				else
 					tank = locate(/obj/structure/reagent_dispensers) in get_turf(src)
 					if(tank)
-						tank.anchored = TRUE
-						tank.pixel_x = 8
-						playsound(src, 'sound/machines/airlock_ext_close.ogg', 60, 1)
-						to_chat(user, SPAN_NOTICE("You attached [tank] to [src]."))
-
+						set_canister = tank.set_anchored(TRUE)
+						if(set_canister)
+							tank.can_anchor = FALSE
+							tank.pixel_x = 8
+							playsound(src, 'sound/machines/airlock_ext_close.ogg', 60, 1)
+							to_chat(user, SPAN_NOTICE("You attached [tank] to [src]."))
+				if(!set_canister)
+					to_chat(user, SPAN_WARNING("Ugh. You done something wrong!"))
+					tank = null
 		if(QUALITY_SCREW_DRIVING)
 			if(tank)
 				to_chat(user, SPAN_WARNING("You need to detach [tank] first."))
@@ -284,7 +289,6 @@
 	var/obj/machinery/atmospherics/binary/biogen_chamber/chamber
 	var/obj/machinery/power/biogenerator_core/core
 
-
 /obj/machinery/multistructure/biogenerator_part/generator/New()
 	. = ..()
 	chamber 	= new(loc)
@@ -313,7 +317,7 @@
 	layer = LOW_OBJ_LAYER
 	var/obj/machinery/multistructure/biogenerator_part/generator/generator
 	var/working_cycles = 0
-	var/wearout_cycle = 800
+	var/wearout_cycle = 500
 	var/wires_integrity = 100
 	var/wires = TRUE
 
@@ -391,7 +395,7 @@
 			working_cycles = 0
 			wires = TRUE
 		else
-			to_chat(user, SPAN_WARNING("You need atleast 10 cables to replace wiring."))
+			to_chat(user, SPAN_WARNING("You need at least 10 cables to replace wiring."))
 	update_icon()
 
 
@@ -416,7 +420,7 @@
 	var/obj/machinery/multistructure/biogenerator_part/generator/generator
 	var/coil_condition = 100
 	var/working_cycles = 0
-	var/wearout_cycle = 900
+	var/wearout_cycle = 600
 	var/coil_frame = TRUE
 
 
@@ -437,10 +441,10 @@
 
 
 /obj/machinery/power/biogenerator_core/update_icon()
-	cut_overlays()
-	add_overlay("core-pipe")
+	overlays.Cut()
+	overlays += "core-pipe"
 	if(!coil_frame)
-		add_overlay("core-coil")
+		overlays += "core-coil"
 
 
 /obj/machinery/power/biogenerator_core/examine(mob/user)

--- a/code/modules/biomatter_manipulation/bioreactor/biotank.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/biotank.dm
@@ -25,7 +25,7 @@
 	var/obj/structure/biomatter_tank/biotank
 	var/obj/canister
 	var/pipes_opened = FALSE
-	var/pipes_cleanness = 100
+	var/pipes_cleanness = 200
 
 
 /obj/machinery/multistructure/bioreactor_part/biotank_platform/Initialize()
@@ -47,9 +47,9 @@
 		return
 	switch(get_dirtiness_level())
 		if(DIRT_LVL_LOW)
-			to_chat(user, SPAN_NOTICE("Pipes are weared a bit, it's slightly dirty. You see a signs of biomass inside these pipes."))
+			to_chat(user, SPAN_NOTICE("Pipes are a bit worn, it's also slightly dirty. You see a signs of biomass inside these pipes."))
 		if(DIRT_LVL_MEDIUM)
-			to_chat(user, SPAN_WARNING("It's very dirty. Solid biomass block atleast half of space inside the pipes. Better to clean it up."))
+			to_chat(user, SPAN_WARNING("It's very dirty. Solid biomass block at least half of space inside the pipes. Better to clean it up."))
 		if(DIRT_LVL_HIGH)
 			to_chat(user, SPAN_WARNING("You see a high amount of biomass. Pipes are fully blocked. You need to clean this first if you want bioreactor to work."))
 		else
@@ -72,7 +72,7 @@
 /obj/machinery/multistructure/bioreactor_part/biotank_platform/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/mop))
 		var/dirtiness_lvl = get_dirtiness_level()
-		to_chat(user, SPAN_NOTICE("You begin cleaning pipes with [I]... O-of, what a smell!"))
+		to_chat(user, SPAN_NOTICE("You begin cleaning pipes with your [I]... O-of, what a smell!"))
 		if(do_after(user, CLEANING_TIME * dirtiness_lvl, src))
 			to_chat(user, SPAN_NOTICE("You cleaned up the pipes."))
 			pipes_cleanness = initial(pipes_cleanness)

--- a/code/modules/biomatter_manipulation/bioreactor/loader.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/loader.dm
@@ -13,7 +13,6 @@
 	var/dir_input = WEST
 	var/dir_output = NORTH
 
-
 /obj/machinery/multistructure/bioreactor_part/loader/Initialize()
 	. = ..()
 	set_light(1, 1, COLOR_LIGHTING_BLUE_MACHINERY)
@@ -32,18 +31,24 @@
 		return
 	use_power(2)
 	if(contents.len)
-		for(var/obj/object in contents)
+		for(var/atom/movable/A in contents)
 			var/obj/machinery/multistructure/bioreactor_part/platform/empty_platform = MS_bioreactor.get_unoccupied_platform()
 			if(empty_platform)
-				object.forceMove(get_step(src, dir_output))
+				A.forceMove(get_step(src, dir_output))
 	else
 		grab()
 
 
 /obj/machinery/multistructure/bioreactor_part/loader/proc/grab()
-	var/obj/item/target = locate() in get_step(src, dir_input)
-	if(target && !target.anchored && contents.len <= 10)
-		target.forceMove(loc)
-		spawn(1)
-			target.forceMove(src)
-			flick("loader_take", src)
+	var/turf/T = get_step(src, dir_input)
+	for(var/atom/movable/A in T)
+		if(!A.anchored && contents.len <= 10)
+			if(isliving(A))
+				var/mob/living/L = A
+				if(L.stat != DEAD || ishuman(L))
+					continue
+			A.forceMove(loc)
+			spawn(1)
+				A.forceMove(src)
+				flick("loader_take", src)
+			break

--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -87,11 +87,11 @@
 		var/obj/item/stack/material/glass = I
 		var/list/glassless_dirs = get_opened_dirs()
 		if(glass.use(glassless_dirs.len))
-			to_chat(user, SPAN_NOTICE("[user] you careful placing [I] into [src]'s holders, making glass wall."))
+			to_chat(user, SPAN_NOTICE("[user] you carefully place [I] into [src]'s holders, making a glass wall."))
 			if(do_after(user, 3*glassless_dirs.len SECONDS, src))
 				make_windows()
 		else
-			to_chat(user, SPAN_WARNING("Not enough amount of [I]."))
+			to_chat(user, SPAN_WARNING("Not enough [I]."))
 	..()
 
 
@@ -191,7 +191,7 @@
 		if(1)
 			to_chat(user, SPAN_NOTICE("There are a few stains on it. Except this, [src] looks pretty clean."))
 		if(2)
-			to_chat(user, SPAN_NOTICE("You see a sign of biomatter on this [src]. Better to clean it up."))
+			to_chat(user, SPAN_NOTICE("You see signs of biomatter on this [src]. Better to clean it up."))
 		if(3)
 			to_chat(user, SPAN_WARNING("This [src] has clear signs and stains of biomatter."))
 		if(4)
@@ -199,7 +199,7 @@
 		if(5)
 			to_chat(user, SPAN_WARNING("Now it's hard to see what's inside. Better to clean this [src]."))
 		else
-			to_chat(user, SPAN_NOTICE("This [src] is so clean, that you can see your reflection. Is that something green at your teeth?"))
+			to_chat(user, SPAN_NOTICE("This [src] is so clean, that you can see your reflection. Is that something green in your teeth?"))
 
 
 /obj/structure/window/reinforced/bioreactor/update_icon()

--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -13,9 +13,10 @@
 	active_power_usage = 400
 	var/make_glasswalls_after_creation = FALSE
 
-/obj/machinery/multistructure/bioreactor_part/platform/Initialize(mapload)
+/obj/machinery/multistructure/bioreactor_part/platform/Initialize()
 	. = ..()
 	update_icon()
+
 
 /obj/machinery/multistructure/bioreactor_part/platform/Process()
 	if(!MS)
@@ -33,7 +34,7 @@
 					victim.forceMove(MS_bioreactor.misc_output)
 					continue
 				//if our target has hazard protection, apply damage based on the protection percentage.
-				var/hazard_protection = victim.getarmor(null, "bio")
+				var/hazard_protection = victim.getarmor(null, ARMOR_BIO)
 				var/damage = BIOREACTOR_DAMAGE_PER_TICK - (BIOREACTOR_DAMAGE_PER_TICK * (hazard_protection/100))
 				victim.apply_damage(damage, BRUTE, used_weapon = "Biological")
 				victim.adjustOxyLoss(BIOREACTOR_DAMAGE_PER_TICK / 2)	// Snowflake shit, but we need the mob to die within a reasonable time frame
@@ -53,7 +54,7 @@
 				var/obj/item/target = M
 				//if we found biomatter, let's start processing
 				//it will slowly disappear. Time based at size of object and we manipulate with its alpha (we also check for it)
-				if(MATERIAL_BIOMATTER in target.matter)
+				if((MATERIAL_BIOMATTER in target.matter) && !target.unacidable)
 					target.alpha -= round(100 / target.w_class)
 					var/icon/I = new(target.icon, icon_state = target.icon_state)
 					//we turn this things to degenerate sprite a bit
@@ -86,28 +87,29 @@
 		var/obj/item/stack/material/glass = I
 		var/list/glassless_dirs = get_opened_dirs()
 		if(glass.use(glassless_dirs.len))
-			to_chat(user, SPAN_NOTICE("[user] you carefully place [I] into [src]'s holders, making a glass wall."))
+			to_chat(user, SPAN_NOTICE("[user] you careful placing [I] into [src]'s holders, making glass wall."))
 			if(do_after(user, 3*glassless_dirs.len SECONDS, src))
 				make_windows()
 		else
-			to_chat(user, SPAN_WARNING("Not enough [I]."))
+			to_chat(user, SPAN_WARNING("Not enough amount of [I]."))
 	..()
 
 
 //This proc called on object/mob consumption
 /obj/machinery/multistructure/bioreactor_part/platform/proc/consume(atom/movable/object)
-	/*if(ishuman(object))
+	if(ishuman(object))
 		var/mob/living/carbon/human/H = object
 		for(var/obj/item/item in H.contents)
 			//non robotic limbs will be consumed
 			if(istype(item, /obj/item/organ))
 				var/obj/item/organ/organ = item
-				if(istype(organ, /obj/item/organ/external) && (organ.nature == MODIFICATION_ORGANIC || organ.nature == MODIFICATION_SUPERIOR))
+				if(istype(organ, /obj/item/organ/external) && organ.nature == MODIFICATION_ORGANIC)
 					continue
 				var/obj/machinery/multistructure/bioreactor_part/platform/neighbor_platform = pick(MS_bioreactor.platforms)
 				organ.forceMove(get_turf(neighbor_platform))
 				organ.removed()
-				continue*/
+				continue
+
 	qdel(object)
 	//now let's add some dirt to the glass
 	for(var/obj/structure/window/reinforced/bioreactor/glass in loc)
@@ -189,7 +191,7 @@
 		if(1)
 			to_chat(user, SPAN_NOTICE("There are a few stains on it. Except this, [src] looks pretty clean."))
 		if(2)
-			to_chat(user, SPAN_NOTICE("You see signs of biomatter on this [src]. Better to clean it up."))
+			to_chat(user, SPAN_NOTICE("You see a sign of biomatter on this [src]. Better to clean it up."))
 		if(3)
 			to_chat(user, SPAN_WARNING("This [src] has clear signs and stains of biomatter."))
 		if(4)
@@ -197,11 +199,11 @@
 		if(5)
 			to_chat(user, SPAN_WARNING("Now it's hard to see what's inside. Better to clean this [src]."))
 		else
-			to_chat(user, SPAN_NOTICE("This [src] is so clean, that you can see your reflection. Is that something green in your teeth?"))
+			to_chat(user, SPAN_NOTICE("This [src] is so clean, that you can see your reflection. Is that something green at your teeth?"))
 
 
 /obj/structure/window/reinforced/bioreactor/update_icon()
-	cut_overlays()
+	overlays.Cut()
 	..()
 	if(contamination_level)
 		var/biomass_alpha = min((50*contamination_level), 255)
@@ -210,7 +212,7 @@
 		biomass.Turn(-40, 40)
 		biomass.Blend(rgb(0, 0, 0, biomass_alpha))
 		default.Blend(biomass, ICON_MULTIPLY)
-		add_overlay(default)
+		overlays += default
 
 
 /obj/structure/window/reinforced/bioreactor/proc/apply_dirt(var/amount)
@@ -220,7 +222,7 @@
 		opacity = FALSE
 	if(contamination_level <= 0)
 		contamination_level = 0
-		opacity = FALSE
+		opacity = TRUE
 	update_icon()
 
 
@@ -233,7 +235,7 @@
 		if(user.loc != loc)
 			to_chat(user, SPAN_WARNING("You need to be inside to clean it up."))
 			return
-		to_chat(user, SPAN_NOTICE("You begin cleaning [src] with your [I]..."))
+		to_chat(user, SPAN_NOTICE("You begin cleaning [src] with [I]..."))
 		if(do_after(user, CLEANING_TIME * contamination_level, src))
 			to_chat(user, SPAN_NOTICE("You clean \the [src]."))
 			toxin_attack(user, 5*contamination_level)

--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -36,7 +36,7 @@
 				//if our target has hazard protection, apply damage based on the protection percentage.
 				var/hazard_protection = victim.getarmor(null, ARMOR_BIO)
 				var/damage = BIOREACTOR_DAMAGE_PER_TICK - (BIOREACTOR_DAMAGE_PER_TICK * (hazard_protection/100))
-				victim.apply_damage(damage, BRUTE, used_weapon = "Biological")
+				victim.apply_damage(damage, BURN, used_weapon = "Biological")
 				victim.adjustOxyLoss(BIOREACTOR_DAMAGE_PER_TICK / 2)	// Snowflake shit, but we need the mob to die within a reasonable time frame
 
 				if(prob(10))
@@ -97,7 +97,7 @@
 
 //This proc called on object/mob consumption
 /obj/machinery/multistructure/bioreactor_part/platform/proc/consume(atom/movable/object)
-	if(ishuman(object))
+	/*if(ishuman(object))
 		var/mob/living/carbon/human/H = object
 		for(var/obj/item/item in H.contents)
 			//non robotic limbs will be consumed
@@ -108,7 +108,7 @@
 				var/obj/machinery/multistructure/bioreactor_part/platform/neighbor_platform = pick(MS_bioreactor.platforms)
 				organ.forceMove(get_turf(neighbor_platform))
 				organ.removed()
-				continue
+				continue*/
 
 	qdel(object)
 	//now let's add some dirt to the glass

--- a/code/modules/biomatter_manipulation/bioreactor/unloader.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/unloader.dm
@@ -8,7 +8,6 @@
 	active_power_usage = 180
 	var/dir_output = NORTH
 
-
 /obj/machinery/multistructure/bioreactor_part/unloader/Process()
 	if(!MS)
 		use_power(1)

--- a/code/modules/biomatter_manipulation/solidifier.dm
+++ b/code/modules/biomatter_manipulation/solidifier.dm
@@ -4,10 +4,11 @@
 
 #define BIOMATTER_PER_SHEET 		1
 #define CONTAINER_PIXEL_OFFSET 		6
+#define BIOMATTER_SHEETS_PER_TIME  5 // X sheets per 2 seconds
 
 /obj/machinery/biomatter_solidifier
 	name = "biomatter solidifier"
-	desc = "A church of absolute machine that converts liquid biomatter into the solid."
+	desc = "A Neotheology machine that converts liquid biomatter into the solid."
 	icon = 'icons/obj/machines/simple_nt_machines.dmi'
 	icon_state = "solidifier"
 	density = TRUE
@@ -15,82 +16,108 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
 	active_power_usage = 300
+	reagent_flags = TRANSPARENT
+
 	var/active = FALSE
 	var/port_dir = SOUTH
 	var/obj/structure/reagent_dispensers/biomatter/container
 	var/last_time_used = 0
 
-/obj/machinery/biomatter_solidifier/New()
+/obj/machinery/biomatter_solidifier/Initialize(mapload, d, bolt=TRUE)
 	. = ..()
-	add_overlay(image(icon = src.icon, icon_state = "tube", layer = LOW_OBJ_LAYER, dir = port_dir))
+	create_reagents(BIOMATTER_PER_SHEET*BIOMATTER_SHEETS_PER_TIME*3)
+	anchored = bolt
+	overlays += image(icon = src.icon, icon_state = "tube", layer = LOW_OBJ_LAYER, dir = port_dir)
 
 /obj/machinery/biomatter_solidifier/update_icon()
 	if(active)
 		icon_state = initial(icon_state) + "_on"
 	else
 		icon_state = initial(icon_state)
-	cut_overlays()
-	add_overlay(image(icon = src.icon, icon_state = "tube", layer = LOW_OBJ_LAYER, dir = port_dir))
-
+	overlays = list()
+	overlays += image(icon = src.icon, icon_state = "tube", layer = LOW_OBJ_LAYER, dir = port_dir)
 
 /obj/machinery/biomatter_solidifier/Process()
 	if(active)
-		if(!container)
-			abort("Container of liquid biomatter required.")
+		if(reagents.get_free_space() >= BIOMATTER_PER_SHEET)
+			if(reagents.total_volume < BIOMATTER_PER_SHEET)
+				if(!container)
+					abort("Container of liquid biomatter required.")
+					return
+				else if(!container.reagents.has_reagent(MATERIAL_BIOMATTER, BIOMATTER_PER_SHEET))
+					abort("Insufficient amount of biomatter.")
+					return
+			if(container && container.reagents.has_reagent(MATERIAL_BIOMATTER, BIOMATTER_PER_SHEET))
+				var/quantity = min(reagents.get_free_space(), BIOMATTER_PER_SHEET*BIOMATTER_SHEETS_PER_TIME)
+				container.reagents.trans_id_to(src, MATERIAL_BIOMATTER, quantity, TRUE)
+		if(reagents.get_reagent_amount(MATERIAL_BIOMATTER) >= BIOMATTER_PER_SHEET)
+			process_biomatter()
 		else
-			if(!container.reagents.has_reagent("biomatter", BIOMATTER_PER_SHEET))
-				abort("Insufficient amount of biomatter.")
+			abort("Insufficient amount of biomatter.")
+
+/obj/machinery/biomatter_solidifier/proc/process_biomatter()
+	var/quantity = min(reagents.get_reagent_amount(MATERIAL_BIOMATTER), BIOMATTER_PER_SHEET*BIOMATTER_SHEETS_PER_TIME)
+	reagents.remove_reagent(MATERIAL_BIOMATTER, quantity)
+
+	while(quantity > 0)
+		var/obj/item/stack/material/biomatter/current_stack
+		//if there any stacks here, let's check them
+		if(locate(/obj/item/stack/material/biomatter) in loc)
+			for(var/obj/item/stack/material/biomatter/stack_on_my_loc in loc)
+				if(stack_on_my_loc.amount < stack_on_my_loc.max_amount)
+					current_stack = stack_on_my_loc
+					break
+		//if we found not full stack
+		if(current_stack)
+			if(current_stack.amount + round(quantity / BIOMATTER_PER_SHEET) >= current_stack.max_amount)
+				//if stack cannot hold all quantity we will just fill it and go to next
+				var/diff = current_stack.max_amount - current_stack.amount
+				current_stack.add(diff)
+				quantity -= diff * BIOMATTER_PER_SHEET
+				continue
 			else
-				container.reagents.remove_reagent("biomatter", BIOMATTER_PER_SHEET)
-				var/obj/item/stack/material/biomatter/current_stack
-				//if there any stacks here, let's check them
-				if(locate(/obj/item/stack/material/biomatter) in loc)
-					for(var/obj/item/stack/material/biomatter/stack_on_my_loc in loc)
-						//if this isn't full, we use that stack(current)
-						if(stack_on_my_loc.amount < stack_on_my_loc.max_amount)
-							current_stack = stack_on_my_loc
-							break
-
-				if(current_stack)
-					current_stack.add(1)
-					if(current_stack.amount == current_stack.max_amount)
-						state("Stack is ready.")
-						ping()
-				else
-					current_stack = new(loc)
-
+				current_stack.add(round(quantity / BIOMATTER_PER_SHEET))
+				quantity = 0
+				return
+		//if we not found not full stack
+		else
+			current_stack = new(loc)
+			quantity -= 1 * BIOMATTER_PER_SHEET
 
 /obj/machinery/biomatter_solidifier/MouseDrop_T(obj/structure/reagent_dispensers/biomatter/tank, mob/user)
 	if(get_dir(loc, tank.loc) != port_dir)
 		to_chat(user, SPAN_WARNING("Doesn't connect. Port direction located at [dir2text(port_dir)] side of [src]"))
 		return
-
 	if(!container)
-		container = tank
-		container.anchored = TRUE
-		switch(port_dir)
-			if(SOUTH)
-				container.pixel_y += CONTAINER_PIXEL_OFFSET
-			if(NORTH)
-				container.pixel_y -= CONTAINER_PIXEL_OFFSET
-			if(WEST)
-				container.pixel_x += CONTAINER_PIXEL_OFFSET
-			if(EAST)
-				container.pixel_x -= CONTAINER_PIXEL_OFFSET
-		playsound(src, 'sound/machines/airlock_ext_close.ogg', 60, 1)
-		to_chat(user, SPAN_NOTICE("You attached [tank] to [src]."))
+		if(tank.bio_anchored(TRUE))
+			container = tank
+			container.can_anchor = FALSE
+			switch(port_dir)
+				if(SOUTH)
+					container.pixel_y += CONTAINER_PIXEL_OFFSET
+				if(NORTH)
+					container.pixel_y -= CONTAINER_PIXEL_OFFSET
+				if(WEST)
+					container.pixel_x += CONTAINER_PIXEL_OFFSET
+				if(EAST)
+					container.pixel_x -= CONTAINER_PIXEL_OFFSET
+			playsound(src, 'sound/machines/airlock_ext_close.ogg', 60, 1)
+			to_chat(user, SPAN_NOTICE("You attached [tank] to [src]."))
+		else
+			to_chat(user, SPAN_WARNING("Ugh. You done something wrong!"))
+		toxin_attack(user)
+	else if(container == tank)
+		container.can_anchor = TRUE
+		tank.bio_anchored(FALSE)
+		container.pixel_y = initial(container.pixel_y)
+		container.pixel_x = initial(container.pixel_x)
+		playsound(src, 'sound/machines/airlock_ext_open.ogg', 60, 1)
+		to_chat(user, SPAN_NOTICE("You dettached [tank] from [src]."))
+		container = null
 		toxin_attack(user)
 	else
-		if(container == tank)
-			container.pixel_y = initial(container.pixel_y)
-			container.pixel_x = initial(container.pixel_x)
-			container.anchored = FALSE
-			playsound(src, 'sound/machines/airlock_ext_open.ogg', 60, 1)
-			to_chat(user, SPAN_NOTICE("You dettached [tank] from [src]."))
-			container = null
-			toxin_attack(user)
-		else
-			to_chat(user, SPAN_WARNING("There are already connected container."))
+		to_chat(user, SPAN_WARNING("There are already connected container."))
+
 	update_icon()
 
 /obj/machinery/biomatter_solidifier/attack_hand(mob/user)
@@ -102,16 +129,14 @@
 		update_icon()
 
 
-/obj/machinery/biomatter_solidifier/proc/abort(var/msg)
+/obj/machinery/biomatter_solidifier/proc/abort(msg)
 	state(msg)
 	active = !active
 	ping()
 	update_icon()
 
-/////////////////////
-
 /obj/machinery/neotheology
 	icon = 'icons/obj/neotheology_machinery.dmi'
 
+#undef BIOMATTER_SHEETS_PER_TIME
 #undef CONTAINER_PIXEL_OFFSET
-#undef BIOMATTER_PER_SHEET

--- a/code/modules/biomatter_manipulation/solidifier.dm
+++ b/code/modules/biomatter_manipulation/solidifier.dm
@@ -16,7 +16,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
 	active_power_usage = 300
-	reagent_flags = TRANSPARENT
+	reagent_flags = OPENCONTAINER
 
 	var/active = FALSE
 	var/port_dir = SOUTH

--- a/code/modules/biomatter_manipulation/solidifier.dm
+++ b/code/modules/biomatter_manipulation/solidifier.dm
@@ -8,7 +8,7 @@
 
 /obj/machinery/biomatter_solidifier
 	name = "biomatter solidifier"
-	desc = "A Neotheology machine that converts liquid biomatter into the solid."
+	desc = "A Church of Absolute machine that converts liquid biomatter into the solid."
 	icon = 'icons/obj/machines/simple_nt_machines.dmi'
 	icon_state = "solidifier"
 	density = TRUE

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -417,7 +417,7 @@
 	default_type = MATERIAL_BIOMATTER
 	price_tag = 1 //to keep biomatter in the player economy as the church and science use it.
 	novariants = FALSE
-	var/biomatter_in_sheet = 1
+	var/biomatter_in_sheet = BIOMATTER_PER_SHEET // defined in solidifier.dm
 
 /obj/item/stack/material/biomatter/random
 	rand_min = 5


### PR DESCRIPTION
Ports over the near current state of the bioreactor from eris while keeping most of the tweaks/buffs we added to it over the years and some of my own minor fixes. Balance impact minimal. Tested everything pretty thoroughly

Change stuff:
Bioreactor should no longer have issues with its acid overlay not appearing (hopefully)
Bioreactor should no longer lock up and cease working (hopefully)
Bioreactor now does burn damage rather then brute preventing blood from being scattered under it. It's acid why was it like this? (my change)
Bioreactor port now allows non-human mobs to be automatically inserted via the disposals belt system
Biomatter solidifier now makes 5 sheets per cycle (5x faster) removing the tedious chore of spamming down several of them (trilby helped get this working thanks trilby)
Biomatter solidifier can no longer be hooked up in any way shape of form to the bioreactor. It's so over!
Biomatter solidifier no longer allows for multi connected canisters via stacking/lining them up. 


