### PR TITLE
Title Addition: Lodge Hunt Master

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -316,6 +316,7 @@ var/list/rank_prefix = list(\
 	"Chief Executive Officer" = "Executive",\
 	"Prime" = "Prime",\
 	"Foreman" = "Foreman",\
+	"Lodge Hunt Master" = "Hunt Master",\
 	)
 
 /mob/living/carbon/human/proc/rank_prefix_name(name)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So now you can see who is at the gate instead of waiting for like a two hours playing league of legends plus its the lodge "leadership" and you know whos in charge for the shift. 
Yes Trilby you can call this a cope PR if you are doing tags.
![image](https://github.com/sojourn-13/sojourn-station/assets/29418371/d4cfa538-4e82-4d7d-a2df-1fd0f6e6e861)


## Changelog
:cl:
add: Title broadcast for lodge hunt master
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
