### PR TITLE
Map Bugfix: Prospector Blast Doors

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -20578,6 +20578,14 @@
 	icon_state = "12,2"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"epG" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	id = "ProspShop";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/nadezhda/pros/prep)
 "epH" = (
 /obj/machinery/light{
 	dir = 1
@@ -112028,15 +112036,16 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
 "xdH" = (
-/obj/machinery/door/blast/regular{
-	id = "ProspShop"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/northright{
 	req_access = list(78)
 	},
 /obj/machinery/door/window/southright,
+/obj/machinery/door/blast/regular{
+	id = "ProspShop";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/pros/prep)
 "xdV" = (
@@ -219526,7 +219535,7 @@ vIU
 vIU
 lkL
 vIU
-aLk
+epG
 wrj
 iMB
 pTs
@@ -219728,7 +219737,7 @@ hjV
 xgn
 kUX
 kUX
-aLk
+epG
 kau
 vfw
 nQd
@@ -220132,7 +220141,7 @@ kUX
 kUX
 kUX
 jxx
-aLk
+epG
 rvW
 hpt
 bBn


### PR DESCRIPTION
## About The Pull Request

Prospectors blast door. This bug was requested from K5 in the discord. Thank you for reporting it.
![image](https://github.com/sojourn-13/sojourn-station/assets/29418371/57f8c0a0-50e0-4447-a5e3-ff404806d563)
This discord links you to the bug report that was reported.
https://discord.com/channels/859887473940889640/1211030604523642992/1211030604523642992

<hr>
</details>

## Changelog
:cl:
bug: squash prospector blast door
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
