### PR TITLE
Map Addition: Hunt Master has Gate access

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -316,6 +316,7 @@ var/list/rank_prefix = list(\
 	"Chief Executive Officer" = "Executive",\
 	"Prime" = "Prime",\
 	"Foreman" = "Foreman",\
+	"Lodge Hunt Master" = "Hunt Master",\
 	)
 
 /mob/living/carbon/human/proc/rank_prefix_name(name)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR gives the hunt master gate access to freely come into the colony as they are allied with the colony only the hunt master has access.
![image](https://github.com/sojourn-13/sojourn-station/assets/29418371/f2583262-d9fe-4cf6-86a0-3da607f65dee)
Only these two doors in the gate. Rest is all a IC issue. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
tweak: gate access with hunt master.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
