### PR TITLE
Title Tweak: Huntmaster not Hunt Master

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -316,7 +316,7 @@ var/list/rank_prefix = list(\
 	"Chief Executive Officer" = "Executive",\
 	"Prime" = "Prime",\
 	"Foreman" = "Foreman",\
-	"Lodge Hunt Master" = "Hunt Master",\
+	"Lodge Hunt Master" = "Huntmaster",\
 	)
 
 /mob/living/carbon/human/proc/rank_prefix_name(name)


### PR DESCRIPTION


## About The Pull Request
Basically changes Hunt Master to Huntmaster to fit in with more of the wiki and fits in more in temrs with the rest of the titles.

## Changelog
:cl:
Tweak: Huntmaster title
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
