### PR TITLE
Maxhp via leveling cap

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1374,6 +1374,6 @@ mob/proc/yank_out_object()
 	if(maxHealth && stats)
 		health += src.stats.getStat(STAT_ANA)
 		maxHealth += src.stats.getStat(STAT_ANA)
-		if(maxHealth > 200) //soft cap to keep players from becoming killable only by organ damage or pain.
-			health = 200
-			maxHealth = 200
+		if(maxHealth > 300) //soft cap to keep players from becoming killable only by organ damage or pain.
+			health = 300
+			maxHealth = 300

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1371,6 +1371,9 @@ mob/proc/yank_out_object()
 //SoJ
 
 /mob/proc/give_health_via_stats()
-	if(stats)
+	if(maxHealth && stats)
 		health += src.stats.getStat(STAT_ANA)
 		maxHealth += src.stats.getStat(STAT_ANA)
+		if(maxHealth > 200) //soft cap to keep players from becoming killable only by organ damage or pain.
+			health = 200
+			maxHealth = 200


### PR DESCRIPTION
Adds in a cap for gaining max health thru leveling. Cap is currently set to 300 and can be easily adjusted if needed in the future.