### PR TITLE
cap pain multiplier from nerves

### DIFF
--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -51,7 +51,7 @@
 		. += organ.internal_wound_hal_dam
 		if(organ && (organ.is_broken() || (!BP_IS_ROBOTIC(organ) && organ.open)))
 			. += 25
-		. *= clamp((get_specific_organ_efficiency(OP_NERVE, organ.organ_tag)/100), 0.5, 1.5)
+		. *= clamp((get_specific_organ_efficiency(OP_NERVE, organ.organ_tag)/100), 0.5, 1)
 
 /mob/living/carbon/proc/get_dynamic_pain()
 	. = 1.33 * halloss

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -45,13 +45,13 @@
 	. = getFireLoss() + getBruteLoss()
 
 /mob/living/carbon/human/get_limb_damage()
-	for(var/obj/item/organ/external/organ in organs)
-		var/limb_damage = min(organ.burn_dam + organ.brute_dam, organ.max_damage)	// Limbs can be damaged beyond their max damage, but max pain is max damage
-		. += limb_damage
-		. += organ.internal_wound_hal_dam
-		if(organ && (organ.is_broken() || (!BP_IS_ROBOTIC(organ) && organ.open)))
-			. += 25
-		. *= clamp((get_specific_organ_efficiency(OP_NERVE, organ.organ_tag)/100), 0.5, 1)
+    for(var/obj/item/organ/external/organ in organs)
+        var/limb_damage = min(organ.burn_dam + organ.brute_dam, organ.max_damage)    // Limbs can be damaged beyond their max damage, but max pain is max damage
+        if(organ && (organ.is_broken() || (!BP_IS_ROBOTIC(organ) && organ.open)))
+            limb_damage += 25
+        limb_damage += organ.internal_wound_hal_dam
+        limb_damage *= clamp((get_specific_organ_efficiency(OP_NERVE, organ.organ_tag)/100), 0.5, 1.25)
+        . += limb_damage
 
 /mob/living/carbon/proc/get_dynamic_pain()
 	. = 1.33 * halloss

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -51,7 +51,7 @@
 		. += organ.internal_wound_hal_dam
 		if(organ && (organ.is_broken() || (!BP_IS_ROBOTIC(organ) && organ.open)))
 			. += 25
-		. *= max((get_specific_organ_efficiency(OP_NERVE, organ.organ_tag)/100), 0.5)
+		. *= clamp((get_specific_organ_efficiency(OP_NERVE, organ.organ_tag)/100), 0.5, 1)
 
 /mob/living/carbon/proc/get_dynamic_pain()
 	. = 1.33 * halloss

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -51,7 +51,7 @@
 		. += organ.internal_wound_hal_dam
 		if(organ && (organ.is_broken() || (!BP_IS_ROBOTIC(organ) && organ.open)))
 			. += 25
-		. *= clamp((get_specific_organ_efficiency(OP_NERVE, organ.organ_tag)/100), 0.5, 1)
+		. *= clamp((get_specific_organ_efficiency(OP_NERVE, organ.organ_tag)/100), 0.5, 1.5)
 
 /mob/living/carbon/proc/get_dynamic_pain()
 	. = 1.33 * halloss

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -69,7 +69,7 @@
 
 		if(damagetype == HALLOSS)
 			//First we get the nervs!
-			effective_damage = round(effective_damage * clamp((get_specific_organ_efficiency(OP_NERVE, def_zone) / 100), 0.5, 1))
+			effective_damage = round(effective_damage * clamp((get_specific_organ_efficiency(OP_NERVE, def_zone) / 100), 0.5, 1.5))
 			var/pain_armor = max(0, (src.getarmor(def_zone, "bullet") +  src.getarmor(def_zone, "melee") - armour_pen))//All brute over-pen checks bullet rather then melee for simple mobs to keep melee viable
 			var/pain_no_matter_what = (effective_damage * 0.15) //we deal 15% of are pain, this is to stop rubbers being *completely* uses with basic armor - Its not perfect in melee
 			effective_damage = max(pain_no_matter_what, (effective_damage - pain_armor))
@@ -131,7 +131,7 @@
 		//Pain part of the damage, that simulates impact from armor absorbtion
 		//For balance purposes, it's lowered by ARMOR_HALLOS_COEFFICIENT
 		if(!(damagetype == HALLOSS ))
-			var/agony_gamage = round( ( effective_damage * armor_effectiveness * ARMOR_HALLOS_COEFFICIENT * clamp((get_specific_organ_efficiency(OP_NERVE, def_zone) / 100), 0.5, 1) / 100))
+			var/agony_gamage = round( ( effective_damage * armor_effectiveness * ARMOR_HALLOS_COEFFICIENT * clamp((get_specific_organ_efficiency(OP_NERVE, def_zone) / 100), 0.5, 1.5) / 100))
 			adjustHalLoss(agony_gamage)
 
 		//Actual part of the damage that passed through armor

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -69,7 +69,7 @@
 
 		if(damagetype == HALLOSS)
 			//First we get the nervs!
-			effective_damage = round(effective_damage * max(0.5, (get_specific_organ_efficiency(OP_NERVE, def_zone) / 100)))
+			effective_damage = round(effective_damage * clamp((get_specific_organ_efficiency(OP_NERVE, def_zone) / 100), 0.5, 1))
 			var/pain_armor = max(0, (src.getarmor(def_zone, "bullet") +  src.getarmor(def_zone, "melee") - armour_pen))//All brute over-pen checks bullet rather then melee for simple mobs to keep melee viable
 			var/pain_no_matter_what = (effective_damage * 0.15) //we deal 15% of are pain, this is to stop rubbers being *completely* uses with basic armor - Its not perfect in melee
 			effective_damage = max(pain_no_matter_what, (effective_damage - pain_armor))
@@ -131,7 +131,7 @@
 		//Pain part of the damage, that simulates impact from armor absorbtion
 		//For balance purposes, it's lowered by ARMOR_HALLOS_COEFFICIENT
 		if(!(damagetype == HALLOSS ))
-			var/agony_gamage = round( ( effective_damage * armor_effectiveness * ARMOR_HALLOS_COEFFICIENT * max(0.5, (get_specific_organ_efficiency(OP_NERVE, def_zone) / 100)) / 100))
+			var/agony_gamage = round( ( effective_damage * armor_effectiveness * ARMOR_HALLOS_COEFFICIENT * clamp((get_specific_organ_efficiency(OP_NERVE, def_zone) / 100), 0.5, 1) / 100))
 			adjustHalLoss(agony_gamage)
 
 		//Actual part of the damage that passed through armor

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -92,7 +92,7 @@ mob/living/carbon/human/proc/handle_pain()
 		if(E.status&ORGAN_DEAD || BP_IS_ROBOTIC(E))
 			continue
 		var/dam = E.get_damage()
-		dam *= (min(get_specific_organ_efficiency(OP_NERVE, E.organ_tag)/100, 1))
+		dam *= (min(get_specific_organ_efficiency(OP_NERVE, E.organ_tag)/100, 1.5))
 		// make the choice of the organ depend on damage,
 		// but also sometimes use one of the less damaged ones
 		if(dam > maxdam && (maxdam == 0 || prob(70)) )

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -92,7 +92,7 @@ mob/living/carbon/human/proc/handle_pain()
 		if(E.status&ORGAN_DEAD || BP_IS_ROBOTIC(E))
 			continue
 		var/dam = E.get_damage()
-		dam *= (get_specific_organ_efficiency(OP_NERVE, E.organ_tag)/100)
+		dam *= (min(get_specific_organ_efficiency(OP_NERVE, E.organ_tag)/100, 1))
 		// make the choice of the organ depend on damage,
 		// but also sometimes use one of the less damaged ones
 		if(dam > maxdam && (maxdam == 0 || prob(70)) )


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pain damage multilier now cannot exceed over 1.

This is a straight forward and simple fix to the current problem that exalts are basically unplayable when it comes to combat.
Do I think that more sensitive nerves should make you feel more pain? Maybe. The concept of nerve efficency is quite abstract and you could also argue that these nerves are "smarter" and know how to "filter" information. Being able to feel pain to an intelligent point next to still being able to feel the gentle touch of a feather.

Gameplay wise it also means that having an upgraded nerve organ will no longer be a downside which was quite counter intuitive. The extra NSA never really played that much of a benefit that would outweight the negatives.