### PR TITLE
Language Adjustment: Opifexee

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput_override.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_override.css
@@ -62,6 +62,7 @@
 .marqua					{color: #00FFFF}
 .akula					{color: #f8412c}
 .plant					{color: #882d17}
+.opifex					{color: #aa00aa}
 
 .good                   {color: #4f8529; font-weight: bold;}
 .bad                    {color: #ee0000; font-weight: bold;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_override.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_override.css
@@ -59,10 +59,10 @@
 .romana					{color: #ed7961}
 .euro					{color: #6533da}
 .yassari				{color: #5fbf4e}
-.marqua					{color: #00FFFF}
+.marqua					{color: #5ec2e7}
 .akula					{color: #f8412c}
 .plant					{color: #882d17}
-.opifex					{color: #aa00aa}
+.opifex					{color: #e96443}
 
 .good                   {color: #4f8529; font-weight: bold;}
 .bad                    {color: #ee0000; font-weight: bold;}

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -91,21 +91,16 @@
 	speech_verb = list("squawks")
 	ask_verb = list("chirps")
 	exclaim_verb = list("screeches")
-	colour = "cult"
+	colour = "opifex"
 	key = "f"
 	flags = RESTRICTED
 	partial_understanding = list(
 		LANGUAGE_YASSARI = 20
 	)
-	space_chance = 100
+	space_chance = 60
 	has_written_form = TRUE
-	syllables = list("ire","ego","nahlizet","certum","veri","jatkaa","mgar","balaq", "karazet", "geeri", \
-		"orkan", "allaq", "sas'so", "c'arta", "forbici", "tarem", "n'ath", "reth", "sh'yro", "eth", "d'raggathnor", \
-		"mah'weyh", "pleggh", "at", "e'ntrath", "tok-lyr", "rqa'nap", "g'lt-ulotf", "ta'gh", "fara'qha", "fel", "d'amar det", \
-		"yu'gular", "faras", "desdae", "havas", "mithum", "javara", "umathar", "uf'kal", "thenar", "rash'tla", \
-		"sektath", "mal'zua", "zasan", "therium", "viortia", "kla'atu", "barada", "nikt'o", "fwe'sh", "mah", "erl", "nyag", "r'ya", \
-		"gal'h'rfikk", "harfrandid", "mud'gib", "fuu", "ma'jin", "dedo", "ol'btoh", "n'ath", "reth", "sh'yro", "eth", \
-		"d'rekkathnor", "khari'd", "gual'te", "nikka", "nikt'o", "barada", "kla'atu", "barhah", "hra" ,"zar'garis")
+	syllables = list("ti","ti","ti","hi","hi","ki","ki","ki","ki","ya","ta","ha","ka","ya","chi","cha","kah", \
+	"SKRE","AHK","EHK","RAWK","KRA","AAA","EEE","KI","II","KRI","KA")
 	shorthand = "N/A"
 
 //Kriosan racial language. Lore: German creolization due to Sol-Gov occupation; therefor intelligibility with German.

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -105,6 +105,7 @@ h1.alert, h2.alert		{color: #000000;}
 .marqua					{color: #00FFFF}
 .akula					{color: #f8412c}
 .plant					{color: #882d17}
+.opifex					{color: #aa00aa}
 
 .interface				{color: #330033;}
 

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -102,10 +102,10 @@ h1.alert, h2.alert		{color: #000000;}
 .romana					{color: #ed7961}
 .yassari				{color: #5fbf4e}
 .kriosan				{color: #ff8000}
-.marqua					{color: #00FFFF}
+.marqua					{color: #5ec2e7}
 .akula					{color: #f8412c}
 .plant					{color: #882d17}
-.opifex					{color: #aa00aa}
+.opifex					{color: #e96443}
 
 .interface				{color: #330033;}
 


### PR DESCRIPTION
## About The Pull Request
What this PR does is:
Brings the Opifex in line with old "Opifex" by bringing back there old syllables, which is vox, as the language states before it is basically vox, but changes the color to soft red. That way it isnt too similar to Cultist and people dont get confused between the two.;

Color has changed to red on suggested by Trilby
![image](https://github.com/sojourn-13/sojourn-station/assets/29418371/a0bfca80-091a-4056-a015-c667b1b3949f)
![image](https://github.com/sojourn-13/sojourn-station/assets/29418371/068d8ab7-d5f5-4fbe-bc0b-451a904aca14)

Rcolor has been changed from Marqua
![image](https://github.com/sojourn-13/sojourn-station/assets/29418371/c9bd6dc7-92b5-46a8-a62a-f8faa96cc3ae)
![image](https://github.com/sojourn-13/sojourn-station/assets/29418371/787eb129-f9d5-40ec-ac38-b4dea8c0c581)


Color: 
https://www.colorhexa.com/e96443
https://www.colorhexa.com/5ec2e7
## Changelog
:cl:
add: Red Opifex, Blue Marqua and "new" syllables for opifex
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
