### PR TITLE
Buffs the heavy pulse rifle

### DIFF
--- a/code/modules/projectiles/guns/energy/pulse/heavypulserifle.dm
+++ b/code/modules/projectiles/guns/energy/pulse/heavypulserifle.dm
@@ -12,7 +12,7 @@
 	w_class = ITEM_SIZE_HUGE
 	force = WEAPON_FORCE_PAINFUL
 	projectile_type = /obj/item/projectile/beam/pulse/heavy
-	charge_cost = 6000 //1 heavy shot of this with most basic cells. Titanic but with bigger stats basiclly
+	charge_cost = 2000 //8 heavy shot of this with with a large posi. Titanic but trading number of shots for per shot damage  basiclly
 	fire_delay = 36 //Upgrades will make this fire way faster making it something you have to modife more then once to get a real bang out of it
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_SILVER = 10)
 	twohanded = TRUE

--- a/code/modules/projectiles/guns/energy/pulse/heavypulserifle.dm
+++ b/code/modules/projectiles/guns/energy/pulse/heavypulserifle.dm
@@ -12,7 +12,7 @@
 	w_class = ITEM_SIZE_HUGE
 	force = WEAPON_FORCE_PAINFUL
 	projectile_type = /obj/item/projectile/beam/pulse/heavy
-	charge_cost = 2000 //8 heavy shot of this with with a large posi. Titanic but trading number of shots for per shot damage  basiclly
+	charge_cost = 2000 //8 heavy shots of this with with a large posi. Damage per cell of a Titanic but trading number of shots for per shot damage basiclly
 	fire_delay = 36 //Upgrades will make this fire way faster making it something you have to modife more then once to get a real bang out of it
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_SILVER = 10)
 	twohanded = TRUE


### PR DESCRIPTION
tweak making the heavy pulse rifle (the energy one guild makes via converting a rare exosuit pulse cannon) have the same damage output per cell as a Titanic. Essentially trades fire rate and shot capacity for per shot damage compared to the las-cannon finally making it a useful (if still not very practical) gun.
