### PR TITLE
psi monsters pannel + blueprint exploit fixes

### DIFF
--- a/code/game/gamemodes/events/hivemind_controller.dm
+++ b/code/game/gamemodes/events/hivemind_controller.dm
@@ -113,10 +113,10 @@ GLOBAL_VAR_INIT(hivemind_panel, new /datum/hivemind_panel)
 	data += "<br>Prevent Hivemind Gibbing Dead Victims: [GLOB.hive_data_bool["gibbing_dead"] ? "Enabled" : "Disabled"] \
 	<a href='?src=\ref[src];toggle_gibbing_dead=1'>\[TOGGLE\]</a>"
 
-	data += "<br>Prevent Hivemind Events Below 15 Pop: [GLOB.hive_data_bool["pop_lock"] ? "Enabled" : "Disabled"] \
+	data += "<br>Prevent Hivemind Events Below 7 Pop: [GLOB.hive_data_bool["pop_lock"] ? "Enabled" : "Disabled"] \
 	<a href='?src=\ref[src];toggle_pop_lock=1'>\[TOGGLE\]</a>"
 
-	data += "<br>Prevent Blob Events Below 7 Pop: [GLOB.hive_data_bool["slime_pop_lock"] ? "Enabled" : "Disabled"] \
+	data += "<br>Prevent Blob Events Below 4 Pop: [GLOB.hive_data_bool["slime_pop_lock"] ? "Enabled" : "Disabled"] \
 	<a href='?src=\ref[src];toggle_slime_pop_lock=1'>\[TOGGLE\]</a>"
 
 	data += "</td></tr></table>"

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -76,6 +76,7 @@ move an amendment</a> to the drawing.</p>
 	if(istype(A, /area/space))
 		return AREA_SPACE
 	var/list/SPECIALS = list(
+		/area/deepmaint,
 		/area/shuttle,
 		/area/admin,
 		/area/arrival,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -207,6 +207,14 @@ ADMIN_VERB_ADD(/client/proc/hivemind_panel, R_FUN, TRUE)
 		var/datum/hivemind_panel/H = GLOB.hivemind_panel
 		H.main_interact()
 
+ADMIN_VERB_ADD(/client/proc/deepmaints_panel, R_FUN, TRUE)
+/client/proc/deepmaints_panel()
+	set category = "Fun"
+	set name = "Deepmaint Psionic Panel"
+	if(holder && GLOB.deepmaints_panel)
+		var/datum/deepmaints_panel/H = GLOB.deepmaints_panel
+		H.main_interact()
+
 #define MAX_WARNS 3
 #define AUTOBANTIME 10
 

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/ai.dm
@@ -30,7 +30,6 @@
 			src.visible_message(SPAN_DANGER(death_gasp))
 			new death_spawn_gift(src.loc)
 
-
 	if(psionic_respawn && GLOB.deepmaints_data_bool["allow_respawning"])
 		var/my_little_location = get_turf(src)
 		addtimer(CALLBACK(my_little_location, /turf/proc/psionic_respawn, my_little_location, respawn_mob_type), rand(fast_respawn,slow_respawn))

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/ai.dm
@@ -28,7 +28,7 @@
 		new death_spawn_gift(src.loc)
 
 
-	if(psionic_respawn)
+	if(psionic_respawn && GLOB.deepmaints_data_bool["allow_respawning"])
 		var/my_little_location = get_turf(src)
 		addtimer(CALLBACK(my_little_location, /turf/proc/psionic_respawn, my_little_location, respawn_mob_type), rand(fast_respawn,slow_respawn))
 
@@ -36,16 +36,16 @@
 
 	//You killed something not of this planet. Congrats...
 
-	if(affects_chaos)
+	if(affects_chaos && GLOB.deepmaints_data_bool["chaos_lowering"])
 		GLOB.chaos_level -= 1
 
 	. = ..()
 
 /turf/proc/psionic_respawn(my_little_location, respawn_mob_type)
-	if(holy)
+	if(holy && GLOB.deepmaints_data_bool["holy_water_delay"])
 		//5% for a different higher power to step in blocking the defailing of the playground. Killing it for the round.
 		//This comes at a cost of sending a playtime rune being sent somewere.
-		if(prob(5))
+		if(prob(5) && GLOB.deepmaints_data_bool["holy_water_despawning"])
 			var/obj/effect/decal/cleanable/crayon/trap/rebound_joy = new /obj/effect/decal/cleanable/crayon/trap(src.loc)
 			rebound_joy.caprice_spell()
 		else

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/ai.dm
@@ -20,12 +20,15 @@
 		drop_from_inventory(I)
 		I.throw_at(get_edge_target_turf(src,pick(alldirs)), rand(1,3), round(30/I.w_class))
 
-	new momento_mori(src.loc)
-	drop_death_loot(src.loc)
+	if(GLOB.deepmaints_data_bool["deepmaints_ash_drops"])
+		new momento_mori(src.loc)
 
-	if(death_present)
-		src.visible_message(SPAN_DANGER(death_gasp))
-		new death_spawn_gift(src.loc)
+	if(GLOB.deepmaints_data_bool["deepmaints_loot_drops"])
+		drop_death_loot(src.loc)
+
+		if(death_present)
+			src.visible_message(SPAN_DANGER(death_gasp))
+			new death_spawn_gift(src.loc)
 
 
 	if(psionic_respawn && GLOB.deepmaints_data_bool["allow_respawning"])

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/deepmaints_psionic_controler.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/deepmaints_psionic_controler.dm
@@ -1,0 +1,63 @@
+GLOBAL_LIST_INIT(deepmaints_data_bool, list(
+	"allow_leaving"					= FALSE,
+	"allow_respawning"				= TRUE,
+	"holy_water_delay"				= TRUE,
+	"holy_water_despawning"			= TRUE,
+	"chaos_lowering"				= TRUE,
+	"king_teleporting"				= TRUE))
+
+GLOBAL_VAR_INIT(deepmaints_panel, new /datum/deepmaints_panel)
+
+/datum/deepmaints_panel
+
+/datum/deepmaints_panel/New()
+
+/datum/deepmaints_panel/proc/main_interact()
+	var/data = "<center><font size='3'><b>DEEPMAINTS PANEL</b></font></center>"
+	data += "<table><tr><td><a href='?src=\ref[src];refresh=1'>\[REFRESH\]</a>"
+
+	data += "<br>Allow All Deepmaints Mobs To Leave To Colony: [GLOB.deepmaints_data_bool["allow_leaving"] ? "Enabled" : "Disabled"]] \
+	<a href='?src=\ref[src];allow_leaving=1'>\[SET\]</a>"
+
+	data += "<br>Allow Deepmaints Mob Respawning: [GLOB.deepmaints_data_bool["allow_respawning"] ? "Enabled" : "Disabled"] \
+	<a href='?src=\ref[src];allow_respawning=1'>\[TOGGLE\]</a>"
+
+	data += "<br>Allow Holy Tiles Delaying Respawning: [GLOB.deepmaints_data_bool["holy_water_delay"] ? "Enabled" : "Disabled"] \
+	<a href='?src=\ref[src];holy_water_delay=1'>\[TOGGLE\]</a>"
+
+	data += "<br>Allow Holy Tiles Prevent Deepmaints Mob Respawning: [GLOB.deepmaints_data_bool["holy_water_despawning"] ? "Enabled" : "Disabled"] \
+	<a href='?src=\ref[src];holy_water_despawning=1'>\[TOGGLE\]</a>"
+
+	data += "<br>Allow Deepmaints Lowering Chaos Level: [GLOB.deepmaints_data_bool["chaos_lowering"] ? "Enabled" : "Disabled"] \
+	<a href='?src=\ref[src];chaos_lowering=1'>\[TOGGLE\]</a>"
+
+	data += "<br>Allow Dreaming King Teleportation: [GLOB.deepmaints_data_bool["king_teleporting"] ? "Enabled" : "Disabled"] \
+	<a href='?src=\ref[src];king_teleporting=1'>\[TOGGLE\]</a>"
+
+	data += "</td></tr></table>"
+	usr << browse(data, "window=hive_main;size=600x600")
+
+
+/datum/deepmaints_panel/Topic(href,href_list)
+	if(!check_rights(R_FUN))
+		return
+
+	if(href_list["allow_leaving"])
+		GLOB.deepmaints_data_bool["allow_leaving"] = !GLOB.deepmaints_data_bool["allow_leaving"]
+
+	if(href_list["allow_respawning"])
+		GLOB.deepmaints_data_bool["allow_respawning"] = !GLOB.deepmaints_data_bool["allow_respawning"]
+
+	if(href_list["holy_water_delay"])
+		GLOB.deepmaints_data_bool["holy_water_delay"] = !GLOB.deepmaints_data_bool["holy_water_delay"]
+
+	if(href_list["holy_water_despawning"])
+		GLOB.deepmaints_data_bool["holy_water_despawning"] = !GLOB.deepmaints_data_bool["holy_water_despawning"]
+
+	if(href_list["chaos_lowering"])
+		GLOB.deepmaints_data_bool["chaos_lowering"] = !GLOB.deepmaints_data_bool["chaos_lowering"]
+
+	if(href_list["king_teleporting"])
+		GLOB.deepmaints_data_bool["king_teleporting"] = !GLOB.deepmaints_data_bool["king_teleporting"]
+
+	main_interact()

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/deepmaints_psionic_controler.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/deepmaints_psionic_controler.dm
@@ -1,4 +1,7 @@
 GLOBAL_LIST_INIT(deepmaints_data_bool, list(
+	"active_psionics"				= TRUE,
+	"deepmaints_ash_drops"			= TRUE,
+	"deepmaints_loot_drops"			= TRUE,
 	"allow_leaving"					= FALSE,
 	"allow_respawning"				= TRUE,
 	"holy_water_delay"				= TRUE,
@@ -16,7 +19,16 @@ GLOBAL_VAR_INIT(deepmaints_panel, new /datum/deepmaints_panel)
 	var/data = "<center><font size='3'><b>DEEPMAINTS PANEL</b></font></center>"
 	data += "<table><tr><td><a href='?src=\ref[src];refresh=1'>\[REFRESH\]</a>"
 
-	data += "<br>Allow All Deepmaints Mobs To Leave To Colony: [GLOB.deepmaints_data_bool["allow_leaving"] ? "Enabled" : "Disabled"]] \
+	data += "<br>Psionic Implant Powers Active: [GLOB.deepmaints_data_bool["active_psionics"] ? "Enabled" : "Disabled"] \
+	<a href='?src=\ref[src];active_psionics=1'>\[SET\]</a>"
+
+	data += "<br>Deepmaints Mobs Ash Drops: [GLOB.deepmaints_data_bool["deepmaints_ash_drops"] ? "Enabled" : "Disabled"] \
+	<a href='?src=\ref[src];deepmaints_ash_drops=1'>\[SET\]</a>"
+
+	data += "<br>Deepmaints Mobs Loot Drops: [GLOB.deepmaints_data_bool["deepmaints_loot_drops"] ? "Enabled" : "Disabled"] \
+	<a href='?src=\ref[src];deepmaints_loot_drops=1'>\[SET\]</a>"
+
+	data += "<br>Allow All Deepmaints Mobs To Leave To Colony: [GLOB.deepmaints_data_bool["allow_leaving"] ? "Enabled" : "Disabled"] \
 	<a href='?src=\ref[src];allow_leaving=1'>\[SET\]</a>"
 
 	data += "<br>Allow Deepmaints Mob Respawning: [GLOB.deepmaints_data_bool["allow_respawning"] ? "Enabled" : "Disabled"] \
@@ -41,6 +53,15 @@ GLOBAL_VAR_INIT(deepmaints_panel, new /datum/deepmaints_panel)
 /datum/deepmaints_panel/Topic(href,href_list)
 	if(!check_rights(R_FUN))
 		return
+
+	if(href_list["active_psionics"])
+		GLOB.deepmaints_data_bool["active_psionics"] = !GLOB.deepmaints_data_bool["active_psionics"]
+
+	if(href_list["deepmaints_ash_drops"])
+		GLOB.deepmaints_data_bool["deepmaints_ash_drops"] = !GLOB.deepmaints_data_bool["deepmaints_ash_drops"]
+
+	if(href_list["deepmaints_loot_drops"])
+		GLOB.deepmaints_data_bool["deepmaints_loot_drops"] = !GLOB.deepmaints_data_bool["deepmaints_loot_drops"]
 
 	if(href_list["allow_leaving"])
 		GLOB.deepmaints_data_bool["allow_leaving"] = !GLOB.deepmaints_data_bool["allow_leaving"]

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/life.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/life.dm
@@ -12,7 +12,7 @@
 		spawn(3) if(src) animate(src, alpha = chameleon_skill, time = 2)
 
 	//Deepmaints mobs **can not** survive outside deepmaints, this just codeifies it
-	if(!can_leave)
+	if(!can_leave && !GLOB.deepmaints_data_bool["allow_leaving"])
 		var/area/my_area = get_area(src.loc)
 		if(!my_area || my_area.name != "Deep Maintenance")
 			//We nest this to save on proccessing useless data
@@ -40,15 +40,17 @@
 
 /mob/living/carbon/superior_animal/psi_monster/dreaming_king/Life()
 	. = ..()
+	//Used for teleports, we grab it here to not repeat same code
+	var/turf/simulated/floor/target
+	var/list/validtargets = list()
 	if(health <= (maxHealth * 0.66) && first_teleport == FALSE)
-		var/turf/simulated/floor/target
-		var/list/validtargets = list()
+		if(GLOB.deepmaints_data_bool["king_teleporting"])
 
-		for(var/area/A in world)
-			if(istype(A, /area/deepmaint))
-				for(var/turf/simulated/floor/T in A)
-					validtargets += T
-		target = pick(validtargets)
+			for(var/area/A in world)
+				if(istype(A, /area/deepmaint))
+					for(var/turf/simulated/floor/T in A)
+						validtargets += T
+			target = pick(validtargets)
 
 		do_sparks(1, 0, src.loc)
 		new /obj/effect/gibspawner/human(src.loc)
@@ -84,14 +86,13 @@
 		first_teleport = TRUE
 
 	if(health <= (maxHealth * 0.33) && second_teleport == FALSE)
-		var/turf/simulated/floor/target
-		var/list/validtargets = list()
+		if(GLOB.deepmaints_data_bool["king_teleporting"])
 
-		for(var/area/A in world)
-			if(istype(A, /area/deepmaint))
-				for(var/turf/simulated/floor/T in A)
-					validtargets += T
-		target = pick(validtargets)
+			for(var/area/A in world)
+				if(istype(A, /area/deepmaint))
+					for(var/turf/simulated/floor/T in A)
+						validtargets += T
+			target = pick(validtargets)
 
 		do_sparks(1, 0, src.loc)
 		new /obj/effect/gibspawner/human(src.loc)

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/life.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/life.dm
@@ -11,6 +11,33 @@
 		spawn(3) if(src) animate(src, alpha = 55, time = 2)
 		spawn(3) if(src) animate(src, alpha = chameleon_skill, time = 2)
 
+	//Deepmaints mobs **can not** survive outside deepmaints, this just codeifies it
+	if(!can_leave)
+		var/area/my_area = get_area(src.loc)
+		if(!my_area || my_area.name != "Deep Maintenance")
+			//We nest this to save on proccessing useless data
+			var/turf/simulated/floor/target					//this is where we are teleporting
+			var/list/validtargets = list()					//list of valid tiles to teleport to
+
+			for(var/area/A in world)						//Clumbsy, but less intensive than iterating every tile
+				if(istype(A, /area/deepmaint))				//First find our deepmaint areas
+					for(var/turf/simulated/floor/T in A)	//Pull a list of valid floor tiles from deepmaint
+						validtargets += T					//Add them to the list
+
+			target = pick(validtargets)					//Now we pick a target
+
+
+			//If we cant get a target then were in a test server or something critical wrong has happen!
+			if(!target)
+				message_admins("[src.name] was unable to find a target and was forcefuly moved outside of deepmaints! Was in [my_area.name]")
+				log_game("[src.name] was unable to find a target and was forcefuly moved outside of deepmaints! Was in [my_area.name]")
+				psionic_respawn = FALSE
+				death() //Your honour, League of Legends
+				return
+			visible_message("<span class='alert'>[src.name] becomes unstable and droops down before suddenly sinks into the floor howling in pain.</span>")
+			forceMove(target)							//Moves the caster
+
+
 /mob/living/carbon/superior_animal/psi_monster/dreaming_king/Life()
 	. = ..()
 	if(health <= (maxHealth * 0.66) && first_teleport == FALSE)

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
@@ -101,6 +101,8 @@
 	var/steal_amount = 1
 	var/mob/living/Victim = null
 
+	var/can_leave = FALSE
+
 
 /mob/living/carbon/superior_animal/psi_monster/New()
 	..()

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/Ploge.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/Ploge.dm
@@ -39,6 +39,7 @@
 	size_pixel_offset_x = 0
 
 	var/transform_ed = FALSE
+	can_leave = TRUE
 
 // BUMP!
 /mob/living/carbon/superior_animal/psi_monster/ploge/UnarmedAttack(atom/A, proximity)

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
@@ -60,6 +60,7 @@
 
 	drop_items = list(/obj/item/tool/sword/cult/deepmaints)
 
+	can_leave = TRUE //freedom
 
 	//Same armor that they are warning
 	armor = list(melee = 35, bullet = 35, energy = 35, bomb = 30, bio = 100, rad = 50)

--- a/code/modules/psionics/psion.dm
+++ b/code/modules/psionics/psion.dm
@@ -183,6 +183,10 @@
 
 //This proc handles checking whether a power can be used for reasons other than cost. It is called after pay cost
 /obj/item/organ/internal/psionic_tumor/proc/check_possibility(targeted = FALSE, var/mob/living/carbon/human/target, require_target_active = FALSE)
+	if(!GLOB.deepmaints_data_bool["active_psionics"])
+		to_chat(usr,"Your mind struggles to tap into any psionic ablities!")
+		return
+
 	if(owner.psi_blocking >= 10)
 		owner.stun_effect_act(0, owner.psi_blocking * 5, BP_HEAD)
 		owner.weakened = owner.psi_blocking

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -2329,6 +2329,7 @@
 #include "code\modules\mob\living\carbon\superior_animal\nanobot\nanobot.dm"
 #include "code\modules\mob\living\carbon\superior_animal\psi_monsters\ai.dm"
 #include "code\modules\mob\living\carbon\superior_animal\psi_monsters\attack.dm"
+#include "code\modules\mob\living\carbon\superior_animal\psi_monsters\deepmaints_psionic_controler.dm"
 #include "code\modules\mob\living\carbon\superior_animal\psi_monsters\life.dm"
 #include "code\modules\mob\living\carbon\superior_animal\psi_monsters\psi_monster.dm"
 #include "code\modules\mob\living\carbon\superior_animal\psi_monsters\types\corrupted_beings.dm"


### PR DESCRIPTION
## About The Pull Request
Blueprints cant rename deepmaints
By default disables deepmaints mobs that are locked away in deepmaints from being free to wounder the upper levels
adds in deepmaints pannel - Like hivemind pannel but for deepmaints
It allows r_fun users to toggle:
Allowing all deepmaints mobs to be free on the surface wowie
Allows the toggleing off for *all deepmaints mobs* respawning
Disabling holy tiles delay
Disabling holy tiles preventing respawning
Disabling crown of the hound and dreaming king teleport
Disabling the dreaming king from even lowing global chaos