### PR TITLE
Fixes two zero interaction infinite money exploits (ZI-IMEs)

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
@@ -16,8 +16,8 @@
 	automated. It's a wonder it hasn't been raided, but then again its protected by a massive army of still functioning combat drones. This one specializes in a wide variety of interesting goods.")
 	inventory = list(
 		"Sheji pan" = list(
-			/obj/item/computer_hardware/hard_drive/portable/design/onestar/stockparts = good_data("GP Stockpart Disk", list(30, 50), 900),
-			/obj/item/computer_hardware/hard_drive/portable/design/onestar = good_data("GP Tool Disk", list(30, 50), 1200)
+			/obj/item/computer_hardware/hard_drive/portable/design/onestar/stockparts = good_data("GP Stockpart Disk", list(30, 50), 10000),
+			/obj/item/computer_hardware/hard_drive/portable/design/onestar = good_data("GP Tool Disk", list(30, 50), 22000)
 		),
 		"Gongju" = list(
 			/obj/item/tool/crowbar/onestar = custom_good_nameprice("GP Crowbar", list(-100, -50)),


### PR DESCRIPTION
As described in the title

## About The Pull Request


Greyson tools and disks are either taken directly from source (Prospectors who raid Greyson base) or printed by SI. This supposedly creates two loops between two factions: 

Loop A): Prospectors loot greyson and sell the tool disk, spare tools they dont need and spare parts they dont need to Lonestar. You know, a company invests into thugs and the thugs do a little stealing and kneecapping.
Loop B): Lonestar delivers materials to Soteria and Soteria prints the tools so they can make money of them. You know a normal RnD cycle. A company invests into a lab and the lab begins to churn out new products.

Currently both supply cycle loops are broken by Lonestar being able to set up Gmod Money printers completely on their own with no outside input. This is **_very similar_** to money duping. Currently the disk for Greyson tools costs 1200 and yields 20 prints. Material costs are offset easily even at T1 parts; this creates an easy infinite money loop with zero player interaction, hence the name zero-interaction-infinite-money-exploit. The other disk for parts costs 900.

I am going to update the prices for the disks accordingly once I get in-game and open the Lonestar app and check how much bounties pay on average. 20k for the disk is a first estimate. Might get higher might get lower.



## Changelog
:cl:
fix: Fixes two Zero Interaction Infinite Money Exploits (ZI-IMEs). There are far more probably, this is just the tip of the iceberg.
/:cl:


