### PR TITLE
Update economy.dm

### DIFF
--- a/code/controllers/subsystems/economy.dm
+++ b/code/controllers/subsystems/economy.dm
@@ -5,6 +5,7 @@
 SUBSYSTEM_DEF(economy)
 	name = "Economy"
 	init_order = INIT_ORDER_LATELOAD
+	runlevels =  RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	wait = 300 //Ticks once per 30 seconds
 	var/payday_interval = 1 HOURS


### PR DESCRIPTION
Switches the economy subsystem to start firing once the round starts. Rather then before. 


As for why?: If the round start is delayed from lack of LC/guild/players the payroll system will carry on counting causing payrolls to be highly inconsistent. This will make them happen nearly on the hour without fail.

Could have unforeseen consequences touching controllers so test merge proly but I tested things where working and I can't see any reason for it to not be like this.