### PR TITLE
Fix aberrant infinit reagent

### DIFF
--- a/code/modules/aberrants/organs/mods/component/output.dm
+++ b/code/modules/aberrants/organs/mods/component/output.dm
@@ -103,7 +103,7 @@
 				if(reagent_amount < initial(output.overdose) || !initial(output.overdose))
 					var/amount_to_add = possible_outputs[output] * organ_multiplier * input_multiplier
 					if(!initial(output.overdose) && reagent_amount < 50) //Some reagents have no overdose
-						RM.add_reagent(initial(output.id), clamp(30 / 10 * amount_to_add,0, 30 - reagent_amount))
+						RM.add_reagent(initial(output.id), clamp(50 / 10 * amount_to_add,0, 50 - reagent_amount))
 					else //add a tenth of our overdose up until 90%
 						RM.add_reagent(initial(output.id), clamp(initial(output.overdose) / 10 * amount_to_add,0, initial(output.overdose) * 0.9 - reagent_amount))
 					triggered = TRUE

--- a/code/modules/aberrants/organs/mods/component/output.dm
+++ b/code/modules/aberrants/organs/mods/component/output.dm
@@ -99,9 +99,10 @@
 			if(is_input_valid && index <= LAZYLEN(possible_outputs))
 				var/input_multiplier = input[i]
 				var/datum/reagent/output = possible_outputs[index]
-				var/amount_to_add = possible_outputs[output] * organ_multiplier * input_multiplier
-				RM.add_reagent(initial(output.id), amount_to_add)
-				triggered = TRUE
+				if(RM.get_reagent_amount(initial(output.id)) < 5)
+					var/amount_to_add = possible_outputs[output] * organ_multiplier * input_multiplier
+					RM.add_reagent(initial(output.id), amount_to_add)
+					triggered = TRUE
 
 	if(triggered)
 		LEGACY_SEND_SIGNAL(holder, COMSIG_ABERRANT_COOLDOWN, TRUE)

--- a/code/modules/aberrants/organs/mods/component/output.dm
+++ b/code/modules/aberrants/organs/mods/component/output.dm
@@ -99,9 +99,13 @@
 			if(is_input_valid && index <= LAZYLEN(possible_outputs))
 				var/input_multiplier = input[i]
 				var/datum/reagent/output = possible_outputs[index]
-				if(RM.get_reagent_amount(initial(output.id)) < 5)
+				var/reagent_amount = RM.get_reagent_amount(initial(output.id))
+				if(reagent_amount < initial(output.overdose) || !initial(output.overdose))
 					var/amount_to_add = possible_outputs[output] * organ_multiplier * input_multiplier
-					RM.add_reagent(initial(output.id), amount_to_add)
+					if(!initial(output.overdose) && reagent_amount < 50) //Some reagents have no overdose
+						RM.add_reagent(initial(output.id), clamp(30 / 10 * amount_to_add,0, 30 - reagent_amount))
+					else //add a tenth of our overdose up until 90%
+						RM.add_reagent(initial(output.id), clamp(initial(output.overdose) / 10 * amount_to_add,0, initial(output.overdose) * 0.9 - reagent_amount))
 					triggered = TRUE
 
 	if(triggered)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Aberrent organs now stop producing reagents at 7 units. Preventing organs to fill up someones body up to 1000 units.

Edit: Chem production now scales with OD. It will stop producing at 90% of OD at its current selected target, preventing OD. Note it is still possible to OD by having it to apply to both stomach and bloodstream for double benefits as well, a good trade off. Reagents with no OD cap at 50.