### PR TITLE
Removes Dylovenes table salt byproduct

### DIFF
--- a/code/modules/reagents/recipes/recipes.dm
+++ b/code/modules/reagents/recipes/recipes.dm
@@ -9,7 +9,6 @@
 /datum/chemical_reaction/dylovene
 	result = "anti_toxin"
 	required_reagents = list("silicon" = 1, "potassium" = 1, "ammonia" = 1)
-	byproducts = list("sodiumchloride" = 0.1)
 	result_amount = 3
 
 /datum/chemical_reaction/carthatoline


### PR DESCRIPTION
Dylovene reaction no longer produces table salt as per the title.

I am not sure why this is a thing, I am not sure how this is a thing. Its kinda weird and insignificant but triggers OCD.

Like really. If there was a meaningful byproduct sure. But this is exclusive to dylovene. Not sure why. Its weird.

<hr>
</details>

## Changelog
:cl:
del: Dylovene no longer produces Tablesalt as byproduct in insignificant irrelevant amounts.
/:cl:


