### PR TITLE
IFF for allied mobs and unique turrets

### DIFF
--- a/code/game/machinery/excelsior/ex_turret.dm
+++ b/code/game/machinery/excelsior/ex_turret.dm
@@ -155,7 +155,7 @@
 	icon = 'icons/obj/machines/excelsior/turret.dmi'
 	name = "artificer turret"
 	desc = "A fully automated battery powered self-repairing anti-wildlife turret platform built by the Artificer's Guild. It features a three round burst fire automatic and an integrated \
-	non-sapient automated artificial-intelligence diagnostic repair system. In other words, the fanciest bit of forging the guild can make. Fires 7.62mm rounds and holds up to 180."
+	non-sapient automated artificial-intelligence diagnostic repair system. In other words, the fanciest bit of forging the guild can make. Fires 7.62mm rounds and holds up to 180. Capable of IFF."
 	icon_state = "turret_legs"
 	density = TRUE
 	lethal = TRUE
@@ -271,7 +271,7 @@
 					"<span class='notice'>You begin [anchored ? "un" : ""]securing the turret.</span>" \
 				)
 
-			if(do_after(user, 50, src))
+			if(I.use_tool(user, src, WORKTIME_NORMAL, QUALITY_BOLT_TURNING, FAILCHANCE_NORMAL, required_stat = STAT_MEC))
 				//This code handles moving the turret around. After all, it's a portable turret!
 				if(!anchored)
 					playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)

--- a/code/game/machinery/excelsior/ex_turret.dm
+++ b/code/game/machinery/excelsior/ex_turret.dm
@@ -15,6 +15,7 @@
 	var/ammo = 0 // number of bullets left.
 	var/ammo_max = 160
 	var/working_range = 30 // how far this turret operates from excelsior teleporter
+	faction_iff = "excelsior"
 	health = 300
 	maxHealth = 300
 	auto_repair = 1
@@ -359,6 +360,9 @@
 
 	if(L.faction == "neutral")
 		return TURRET_NOT_TARGET
+
+	if(is_excelsior(L))
+		return TURRET_PRIORITY_TARGET
 
 	if(L.lying)
 		return TURRET_SECONDARY_TARGET

--- a/code/game/machinery/excelsior/ex_turret.dm
+++ b/code/game/machinery/excelsior/ex_turret.dm
@@ -167,6 +167,7 @@
 	var/ammo = 0 // number of bullets left.
 	var/ammo_max = 180
 	var/obj/item/cell/large/cell = null
+	friendly_to_colony = 1 //Artificers perfection.
 	health = 150
 	auto_repair = 1
 	shot_delay = 3

--- a/code/game/machinery/os_portable_turret.dm
+++ b/code/game/machinery/os_portable_turret.dm
@@ -9,6 +9,7 @@
 	icon = 'icons/obj/machines/one_star/machines.dmi'
 	icon_state = "os_gauss" // sprite by Infrared Baron
 	circuit = /obj/item/circuitboard/os_turret
+	var/faction_iff = "greyson"
 	idle_power_usage = 30
 	active_power_usage = 2500
 	density = TRUE
@@ -310,6 +311,9 @@
 	set_dir(get_dir(src, target))
 	var/obj/item/projectile/P = new projectile(loc)
 	P.original_firer = src
+	P.faction_iff = faction_iff
+	if(!should_target_players)
+		P.friendly_to_colony = TRUE
 	P.launch(target, def_zone)
 	playsound(src, shot_sound, 60, 1)
 

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -35,6 +35,7 @@
 	var/projectile = null	//holder for bullettype
 	var/eprojectile = null	//holder for the shot when emagged
 	var/friendly_to_colony = FALSE //is our turret smart enough to bypass allies?
+	var/faction_iff = ""	//Are we the baddies?
 	var/reqpower = 500		//holder for power needed
 	var/iconholder = null	//holder for the icon_state. 1 for orange sprite, null for blue.
 	var/egun = null			//holder to handle certain guns switching bullettypes
@@ -75,6 +76,7 @@
 
 /obj/machinery/porta_turret/One_star
 	name = "greyson positronic turret"
+	faction_iff = "greyson"
 	installation = /obj/item/gun/energy/cog
 
 /obj/machinery/porta_turret/crescent
@@ -790,6 +792,7 @@ var/list/turret_icons
 	var/def_zone = get_exposed_defense_zone(target)
 	if(friendly_to_colony) //Reserved for more premium turrets
 		A.friendly_to_colony = TRUE
+	A.faction_iff = faction_iff
 	//Shooting Code:
 	A.launch(target, def_zone)
 

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -34,6 +34,7 @@
 	var/obj/item/gun/energy/installation = /obj/item/gun/energy/gun	//the weapon that's installed. Store as path to initialize a new gun on creation.
 	var/projectile = null	//holder for bullettype
 	var/eprojectile = null	//holder for the shot when emagged
+	var/friendly_to_colony = FALSE //is our turret smart enough to bypass allies?
 	var/reqpower = 500		//holder for power needed
 	var/iconholder = null	//holder for the icon_state. 1 for orange sprite, null for blue.
 	var/egun = null			//holder to handle certain guns switching bullettypes
@@ -787,6 +788,8 @@ var/list/turret_icons
 	//Turrets aim for the center of mass by default.
 	//If the target is grabbing someone then the turret smartly aims for extremities
 	var/def_zone = get_exposed_defense_zone(target)
+	if(friendly_to_colony) //Reserved for more premium turrets
+		A.friendly_to_colony = TRUE
 	//Shooting Code:
 	A.launch(target, def_zone)
 

--- a/code/game/objects/items/weapons/implant/implants/excelsior.dm
+++ b/code/game/objects/items/weapons/implant/implants/excelsior.dm
@@ -90,6 +90,7 @@
 			return
 
 	make_antagonist_faction(wearer.mind, antag_id, F, check = FALSE)
+	target.friendly_to_colony = FALSE
 
 
 /obj/item/implant/excelsior/on_uninstall()
@@ -99,6 +100,7 @@
 	for(var/datum/antagonist/A in wearer.mind.antagonist)
 		if(A.id == antag_id)
 			A.remove_antagonist()
+	wearer.friendly_to_colony = TRUE
 
 	//if(prob(66))
 	//	wearer.adjustBrainLoss(200)

--- a/code/modules/mob/living/carbon/superior_animal/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/attack.dm
@@ -156,7 +156,7 @@
 					if (possible_target)
 						if (possible_target == target)
 							continue //we made the concious choice to attack them
-						else if (!(prob(do_friendly_fire_chance)) && (((!attack_same && (possible_target.faction == faction)) || (possible_target in friends)) || (possible_target.friendly_to_colony && friendly_to_colony)))
+						else if (!(prob(do_friendly_fire_chance)) && !friendly_to_colony && (((!attack_same && (possible_target.faction == faction)) || (possible_target in friends))))
 							do_we_shoot = FALSE
 							break
 
@@ -170,6 +170,8 @@
 		if (do_we_shoot)
 			var/offset_temp = right_before_firing()
 			A.original_firer = src
+			if(friendly_to_colony)
+				A.friendly_to_colony = TRUE
 			A.launch(target, def_zone, firer_arg = src, angle_offset = offset_temp) //this is where we actually shoot the projectile
 			right_after_firing()
 			SEND_SIGNAL(src, COMSIG_SUPERIOR_FIRED_PROJECTILE, A)

--- a/code/modules/mob/living/carbon/superior_animal/drone/types/roomba.dm
+++ b/code/modules/mob/living/carbon/superior_animal/drone/types/roomba.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/superior_animal/handmade/roomba
 	name = "Custom-Made Roomba Drone"
-	desc = "Built from the Soteria robotics division's craftsmanship, and gathered designs of Greyson positronics, each of these fully robotic automatons is a unique, handmade, heavily armored assembly."
+	desc = "Built from the Soteria robotics division's craftsmanship, and gathered designs of Greyson positronics, each of these fully robotic automatons is a unique, handmade, heavily armored assembly. Capable of IFF."
 	faction = "neutral"
 	icon_state = "roomba"
 	melee_damage_lower = 10

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -45,6 +45,7 @@
 	var/def_zone = ""	//Aiming at
 	var/mob/firer = null//Who shot it
 	var/mob/original_firer //Who shot it. Never changes, even after ricochet.
+	var/friendly_to_colony = FALSE //If we bypass allies or not.
 	var/silenced = FALSE	//Attack message
 	var/yo = null
 	var/xo = null
@@ -365,6 +366,9 @@
 		return
 
 	if(target_mob == firer) // Do not hit the shooter if the bullet hasn't ricocheted yet. The firer changes upon ricochet, so this should not prevent ricocheting shots from hitting their shooter.
+		return FALSE
+
+	if(friendly_to_colony && target_mob.friendly_to_colony) // Used for automated defenses
 		return FALSE
 
 	//roll to-hit

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -46,6 +46,7 @@
 	var/mob/firer = null//Who shot it
 	var/mob/original_firer //Who shot it. Never changes, even after ricochet.
 	var/friendly_to_colony = FALSE //If we bypass allies or not.
+	var/faction_iff = "" //Used for Excel and Greyson turrets
 	var/silenced = FALSE	//Attack message
 	var/yo = null
 	var/xo = null
@@ -369,6 +370,9 @@
 		return FALSE
 
 	if(friendly_to_colony && target_mob.friendly_to_colony) // Used for automated defenses
+		return FALSE
+
+	if(faction_iff == target_mob.faction)
 		return FALSE
 
 	//roll to-hit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
IFF (Identification Friend or Foe)
This PR allows projectiles to be given the abillity to bypass friendly_to_colony people.
This abillity was then given to the artificer turret and ranged friendly mobs.

Reasoning:
After playing with both the guild turret and the handmade roomba from soteria I noticed lack of practicallity quite quickly.
The guild turrets often or not will friendly fire people by either you standing infront, or behind the enemy and since the turrets shoots in bursts, it will always overkill and shoot you again. Both the roomba suffers from this to a lesser extend but due to its nature, it is always behind you following. Sure, you can move around and manouver it infront of you but it can happen that it will shoot you still even with that 10% chance.
In both cases, if either the guild turret friendly fires or the roomba, you end up with an injury that requires medical to fix. Be it the shrapnel or the organ damage from the roomba.
I think it is also a good point why both features were being so rarely used and those times they were being used, only to be tried out. I believe it would really help robotics feel more useful at making roombas again and guild to help and contribute with making turrets that wont shoot half of blackshield from behind. Do note, this doesn't apply to all turrets. The basic turrets still friendly fire.

Little mention:
Yes the code is quite simple but it works and it can expanded and improved on in the future to contain a proper list of all "friendlies" and not just use friendly_to_colony