### PR TITLE
Guild burn engine and extra mapping

### DIFF
--- a/code/ATMOSPHERICS/components/unary/map_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/map_sink.dm
@@ -1,0 +1,53 @@
+/obj/machinery/atmospherics/pipe/simple/sink_heat
+	icon = 'icons/obj/structures.dmi'
+	icon_state = "down"
+	name = "heatsink network pipe"
+	desc = "A sturdy pipe that connects to a vast network of heat exchangers underground."
+	volume = 2000
+	var/temperature = T0C + 7 //We can be used for both heating and cooling. +7C being the underground water temperature
+	var/effective = 1 //Number from 0 to 1. Allows us to regulate how much gas an engineer needs to put in to cool/heat what ever system
+
+/obj/machinery/atmospherics/pipe/simple/sink_heat/Process()
+	if(!parent)
+		..()
+	else
+		var/datum/gas_mixture/pipe_air = return_air()
+		var/delta_temp = temperature - pipe_air.temperature
+		pipe_air.temperature += delta_temp * clamp(effective,0,1)
+
+/obj/machinery/atmospherics/pipe/simple/sink_heat/ex_act(severity)
+	return //We are unique!
+
+/obj/machinery/atmospherics/pipe/simple/sink_heat/attackby(obj/item/I, mob/user)
+	return //Maybe for later
+
+/obj/machinery/atmospherics/unary/sink_gas
+	icon = 'icons/obj/structures.dmi'
+	icon_state = "down"
+	name = "air duct network pipe"
+	desc = "A sturdy pipe that connects to a vast network of siphons and pumps to cycle outside air in and out."
+	var/internal_volume = 200 //Depending on how big our volume is, the faster/slower we vent/siphon
+	use_power = NO_POWER_USE
+	var/target_pressure = ONE_ATMOSPHERE
+	var/datum/gas_mixture/target_gas
+
+/obj/machinery/atmospherics/unary/sink_gas/New()
+	..()
+	target_gas = new
+	target_gas.volume = internal_volume
+	target_gas.temperature = T20C
+	air_contents.volume = internal_volume
+	target_gas.adjust_multi("oxygen",  (target_pressure*O2STANDARD)*(target_gas.volume)/(R_IDEAL_GAS_EQUATION*target_gas.temperature), \
+	                        "nitrogen",(target_pressure*N2STANDARD)*(target_gas.volume)/(R_IDEAL_GAS_EQUATION*target_gas.temperature))
+
+/obj/machinery/atmospherics/unary/sink_gas/Process()
+	if(network)
+		air_contents.gas = target_gas.gas
+		air_contents.temperature = target_gas.temperature
+		network.update = 1
+
+/obj/machinery/atmospherics/unary/sink_gas/ex_act(severity)
+	return //We are unique!
+
+/obj/machinery/atmospherics/unary/sink_gas/attackby(obj/item/I, mob/user)
+	return //Maybe for later

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -42236,12 +42236,6 @@
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/reception)
-"iKY" = (
-/obj/machinery/portable_atmospherics/powered/pump{
-	start_pressure = 15000
-	},
-/turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/workshop)
 "iLc" = (
 /obj/structure/boulder,
 /obj/structure/barricade,
@@ -188242,7 +188236,7 @@ cGH
 gfO
 bDF
 bpF
-iKY
+bpF
 hxQ
 tNm
 hBc

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -47749,6 +47749,7 @@
 	},
 /obj/item/circuitboard/telecomms/hub,
 /obj/item/circuitboard/telecomms/relay,
+/obj/item/circuitboard/ntnet_relay,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
 "jSg" = (
@@ -89328,7 +89329,20 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "srU" = (
-/obj/structure/table/rack/shelf,
+/obj/random/rig_module/low_chance,
+/obj/random/techpart/low_chance,
+/obj/random/techpart/low_chance,
+/obj/random/science/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/rig_module/low_chance,
+/obj/random/powercell/low_chance,
+/obj/random/science/low_chance,
+/obj/random/rig/damaged/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/structure/table/rack,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
 "ssb" = (
@@ -102547,14 +102561,20 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "uZd" = (
+/obj/random/rig_module/low_chance,
+/obj/random/techpart/low_chance,
+/obj/random/techpart/low_chance,
+/obj/random/science/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/tool/low_chance,
+/obj/random/rig_module/low_chance,
+/obj/random/powercell/low_chance,
+/obj/random/science/low_chance,
+/obj/random/rig/damaged/low_chance,
+/obj/random/tool_upgrade/low_chance,
+/obj/random/tool_upgrade/low_chance,
 /obj/structure/table/rack,
-/obj/item/circuitboard/autolathe{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/computer_hardware/hard_drive/portable/design/circuits,
-/obj/item/computer_hardware/hard_drive/portable/design/components,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
@@ -103924,13 +103944,17 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "vnU" = (
 /obj/structure/table/rack,
-/obj/item/circuitboard/rdserver{
-	pixel_x = 3;
+/obj/item/circuitboard/tele_inhibitor,
+/obj/item/circuitboard/tele_inhibitor{
+	pixel_x = -2;
 	pixel_y = -3
 	},
-/obj/item/circuitboard/destructive_analyzer,
-/obj/item/circuitboard/protolathe,
-/obj/item/circuitboard/aifixer,
+/obj/item/circuitboard/pile_ripper{
+	pixel_x = 2
+	},
+/obj/item/circuitboard/smelter{
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
 "vnV" = (
@@ -107100,16 +107124,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
 "vUs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	dir = 2;
-	locked = 0;
-	name = "South APC";
-	operating = 1;
-	pixel_y = -28
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -154906,7 +154925,7 @@ rib
 dWw
 mGB
 tud
-vUs
+drX
 wDx
 xvk
 bLh
@@ -155917,7 +155936,7 @@ tpl
 ddS
 ego
 nXo
-tXB
+vUs
 kFC
 htK
 htK

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -18810,7 +18810,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
 "dWw" = (
-/obj/machinery/constructable_frame/machine_frame,
+/obj/machinery/constructable_frame/machine_frame{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "dWE" = (

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -170,6 +170,12 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/outside/forest)
+"acc" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "acf" = (
 /obj/structure/flora/pottedplant/small,
 /obj/structure/cable/green{
@@ -284,6 +290,23 @@
 /obj/structure/closet/custodial,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/hallways)
+"adv" = (
+/obj/structure/table/rack,
+/obj/item/circuitboard/powermonitor{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/circuitboard/stationalert{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/circuitboard/atmos_alert{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/circuitboard/telecomms/relay,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "adN" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/wood/wild2,
@@ -434,6 +457,20 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
+"afr" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/engineering/atmos)
 "afw" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/dirt,
@@ -528,22 +565,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "agu" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/item/device/scanner/gas{
-	pixel_y = 10
-	},
-/obj/item/inflatable/wall,
-/obj/item/inflatable/wall,
-/obj/item/inflatable/door,
-/obj/item/inflatable/door,
-/obj/structure/sign/warning/nosmoking/small{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
+/obj/machinery/camera/network/engineering,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "agv" = (
 /obj/machinery/portable_atmospherics/hydroponics{
@@ -1297,7 +1323,7 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
 	frequency = 1441;
-	id = "teg_outlit";
+	id = "waste_in";
 	pixel_y = 1;
 	use_power = 1
 	},
@@ -1394,6 +1420,13 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
+"apI" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 8;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "apT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -1925,6 +1958,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"avf" = (
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/box/red/corners{
+	dir = 1;
+	icon_state = "box_corners_red"
+	},
+/obj/effect/floor_decal/industrial/box/red/corners{
+	dir = 4;
+	icon_state = "box_corners_red"
+	},
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/atmos)
 "avm" = (
 /obj/item/stool/padded,
 /obj/effect/decal/cleanable/dirt,
@@ -2965,13 +3015,8 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
 "aEP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plating/under,
+/obj/structure/sign/warning/hazard_coldloop,
+/turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
 "aFa" = (
 /turf/simulated/wall/r_wall,
@@ -3826,9 +3871,18 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
 "aPT" = (
-/obj/structure/sign/warning/fire,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/atmos)
+/obj/structure/closet/crate,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/obj/item/am_shielding_container,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "aPU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3992,6 +4046,19 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/bridge)
+"aSO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/engineering/atmos)
 "aSP" = (
 /obj/machinery/space_heater,
 /obj/machinery/firealarm{
@@ -4146,6 +4213,18 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"aVm" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/panels,
+/area/nadezhda/engineering/atmos)
 "aVo" = (
 /obj/machinery/light{
 	dir = 8
@@ -4196,7 +4275,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
 "aVE" = (
-/obj/machinery/portable_atmospherics/powered/pump,
+/obj/machinery/portable_atmospherics/powered/pump{
+	start_pressure = 15000
+	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
@@ -4368,12 +4449,12 @@
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/medical/reception)
 "aYf" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 6
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "aYj" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -5466,14 +5547,9 @@
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/colony)
 "biK" = (
-/obj/machinery/door/blast/regular{
-	id = "turbineexit"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/nadezhda/engineering/atmos)
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "biP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5959,12 +6035,8 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armoryshop)
 "boB" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "boF" = (
 /obj/structure/table/rack/shelf,
@@ -9109,6 +9181,10 @@
 /obj/random/junkfood/rotten,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/workshop)
+"bWE" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "bWI" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 1
@@ -11076,16 +11152,12 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
 "cul" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/cryopod/robot,
+/obj/machinery/camera/network/engineering{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "cum" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -11374,6 +11446,20 @@
 /obj/item/ammo_magazine/magnum_40,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
+"cwN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "cwO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11627,6 +11713,17 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"czW" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "czY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11970,6 +12067,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/substation/medical)
+"cDy" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "cDz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11990,6 +12098,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"cDT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "cDV" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -12560,11 +12675,22 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/courtroom)
 "cJC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/machinery/door/window/northright{
+	dir = 2;
+	name = "Atmospherics Hardsuits";
+	req_access = list(24)
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/engineering,
+/obj/item/clothing/head/helmet/space/void/engineering,
+/obj/item/tank/jetpack/oxygen,
+/obj/structure/fireaxecabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "cJH" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -12745,6 +12871,16 @@
 /obj/structure/flora/bush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"cLT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/obj/structure/noticeboard/guild{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/atmos)
 "cLZ" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/orange,
@@ -13309,13 +13445,22 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
 "cRc" = (
-/obj/machinery/light,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "cRf" = (
 /obj/structure/kitchenspike,
@@ -13474,6 +13619,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
+"cSK" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/workshop)
 "cSM" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/structure/closet/wall_mounted/emcloset{
@@ -14486,10 +14647,8 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/sleeper)
 "ddS" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/valve,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "ddT" = (
@@ -14955,16 +15114,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/quartermaster/miningdock)
 "diq" = (
-/obj/machinery/atmospherics/unary/freezer{
-	icon_state = "freezer_1";
-	power_setting = 20;
-	set_temperature = 73;
-	use_power = 1
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "dir" = (
 /obj/structure/table/standard,
@@ -15806,6 +15961,18 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/turret_protected/ai_upload)
+"drX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "dsd" = (
 /obj/structure/catwalk,
 /obj/random/structures,
@@ -16771,17 +16938,25 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/medical/psych)
 "dBA" = (
-/obj/machinery/button/remote/blast_door{
-	id = "turbineexit";
-	name = "remote VENT blast door-control";
-	pixel_y = -32
-	},
 /obj/structure/cable/yellow{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "dBG" = (
 /turf/simulated/shuttle/wall/mining,
@@ -18464,6 +18639,10 @@
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"dTL" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/engineering/atmos)
 "dTT" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush2,
@@ -18640,6 +18819,10 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"dWw" = (
+/obj/machinery/constructable_frame/machine_frame,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "dWE" = (
 /obj/machinery/light{
 	dir = 4
@@ -18777,14 +18960,8 @@
 	name = "Residential District Maintenance"
 	})
 "dXw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plating/under,
+/obj/machinery/atmospherics/pipe/simple/visible/blue,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "dXy" = (
 /obj/structure/table/rack/shelf,
@@ -18897,8 +19074,12 @@
 	},
 /area/nadezhda/maintenance/surfacesec)
 "dYs" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "dYC" = (
 /obj/structure/table/woodentable,
@@ -19043,17 +19224,8 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "dZP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
+/obj/item/modular_computer/console/preset/engineering/power,
+/turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
 "dZS" = (
 /obj/machinery/door/airlock/maintenance_common,
@@ -19648,6 +19820,17 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "egr" = (
@@ -19656,11 +19839,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "egv" = (
-/obj/machinery/atmospherics/unary/heat_exchanger,
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
-/area/nadezhda/engineering/atmos)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "egy" = (
 /obj/structure/table/steel,
 /obj/structure/flora/pottedplant/dead{
@@ -19909,17 +20090,13 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
 "ejf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "ejh" = (
 /obj/structure/cable/cyan{
@@ -21194,11 +21371,12 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/crew_quarters/dorm1)
 "evd" = (
-/obj/machinery/sparker{
-	id = "tubine_sparker";
-	pixel_x = -32
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
 "evl" = (
 /obj/random/furniture/pottedplant,
@@ -21418,12 +21596,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "exo" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 6
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/meter,
-/obj/structure/lattice,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "exp" = (
 /obj/structure/flora/small/lavarock1,
@@ -21898,11 +22076,9 @@
 	name = "\improper Clinic"
 	})
 "eDr" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "eDs" = (
 /obj/machinery/light_switch{
 	pixel_y = 32
@@ -22689,6 +22865,19 @@
 	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/pros/foreman)
+"eMJ" = (
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engineering Hallway";
+	req_one_access = list(10)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/workshop)
 "eMM" = (
 /obj/structure/closet/crate/trashcart,
 /obj/machinery/alarm{
@@ -22920,17 +23109,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/bridge)
 "eOs" = (
-/obj/structure/sign/warning/fire/small,
-/turf/simulated/wall/r_wall,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "eOx" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 4
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
-/area/nadezhda/engineering/atmos)
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "eOI" = (
 /obj/structure/closet/secure_closet/personal/hydroponics,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -23359,6 +23547,12 @@
 /obj/random/firstaid,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"eSc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/engineering/atmos)
 "eSp" = (
 /obj/item/modular_computer/console/preset/trade{
 	dir = 4
@@ -24537,17 +24731,11 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "ffR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_x = -28
 	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
 "ffT" = (
 /obj/effect/decal/cleanable/rubble,
@@ -26026,19 +26214,18 @@
 /area/nadezhda/hallway/side/f2section1)
 "fuP" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "fuT" = (
 /obj/effect/damagedfloor/rust,
@@ -26426,10 +26613,16 @@
 	name = "Residential District Maintenance"
 	})
 "fzi" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
 "fzo" = (
 /obj/machinery/door/airlock/maintenance_engineering{
@@ -27181,13 +27374,14 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/medical/sleeper)
 "fHI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/meter,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "fHV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27315,12 +27509,14 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
 "fJk" = (
-/obj/machinery/button/remote/blast_door{
-	id = "turbineexit";
-	name = "remote VENT blast door-control";
-	pixel_y = 32
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "fJt" = (
 /obj/machinery/door/blast/shutters{
@@ -28007,17 +28203,11 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
 "fSa" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "fSc" = (
 /obj/machinery/power/apc{
@@ -28525,6 +28715,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"fYk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/atmos)
 "fYw" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -30034,6 +30228,13 @@
 /obj/random/medical_lowcost/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"gnn" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/mineral,
+/area/colony)
 "gnC" = (
 /obj/machinery/light{
 	dir = 1
@@ -30199,6 +30400,21 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/command/cbo)
+"goP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "goQ" = (
 /obj/structure/table/rack/shelf,
 /obj/item/tool/pickaxe/drill,
@@ -31047,11 +31263,14 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "gwZ" = (
-/obj/machinery/power/terminal{
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/sink_heat{
 	dir = 4
 	},
-/obj/structure/cable/cyan,
-/turf/simulated/floor/plating,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "gxa" = (
 /obj/random/scrap/dense_weighted/low_chance,
@@ -31940,12 +32159,9 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "gJa" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "gJe" = (
 /obj/random/cluster/roaches/low_chance,
@@ -32313,15 +32529,12 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
 "gNH" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 8;
+	icon_state = "map"
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "gNJ" = (
 /obj/structure/disposalpipe/segment{
@@ -32409,6 +32622,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"gOm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/atmos)
 "gOx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -33737,12 +33960,11 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/crematorium)
 "hcz" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 28
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "hcA" = (
 /obj/structure/showcase/sign2{
@@ -34294,6 +34516,19 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/absolutism/bioreactor)
+"hiM" = (
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/warningred,
+/obj/effect/floor_decal/industrial/box/red/corners{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/box/red/corners{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "hji" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -35637,17 +35872,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
 "hya" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/power/breakerbox{
-	RCon_tag = "Trubine Substation Bypass"
-	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/valve,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "hyh" = (
 /obj/machinery/door/airlock/command{
@@ -35739,6 +35967,13 @@
 /mob/living/simple_animal/hostile/nightmare/dream_daemon,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"hyC" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "hyM" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -36402,6 +36637,16 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
+"hEQ" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access = newlist();
+	req_one_access = list(24,10)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/engineering/atmos)
 "hES" = (
 /obj/machinery/light{
 	dir = 8
@@ -37468,6 +37713,24 @@
 "hOi" = (
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"hOt" = (
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/machinery/door/window/northright{
+	dir = 2;
+	name = "Atmospherics Hardsuits";
+	req_access = list(24)
+	},
+/obj/machinery/camera/network/engineering,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/engineering,
+/obj/item/clothing/head/helmet/space/void/engineering,
+/obj/item/tank/jetpack/oxygen,
+/obj/structure/sign/faction/technomancers{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "hOw" = (
 /obj/structure/computerframe{
 	anchored = 1;
@@ -38453,16 +38716,19 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "hZe" = (
-/obj/machinery/button/ignition{
-	id = "tubine_sparker";
-	pixel_y = -24
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/tool/tape_roll/fiber,
-/obj/item/reagent_containers/spray/krag_b_gone,
-/obj/item/reagent_containers/spray/krag_b_gone,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "hZj" = (
 /obj/machinery/button/remote/blast_door{
@@ -41022,6 +41288,10 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "waste_sensor"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/nadezhda/engineering/atmos)
 "izK" = (
@@ -41983,6 +42253,12 @@
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/reception)
+"iKY" = (
+/obj/machinery/portable_atmospherics/powered/pump{
+	start_pressure = 15000
+	},
+/turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/workshop)
 "iLc" = (
 /obj/structure/boulder,
 /obj/structure/barricade,
@@ -42540,6 +42816,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"iQY" = (
+/obj/machinery/power/rad_collector,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "iRc" = (
 /obj/item/tool/wrench/improvised,
 /obj/effect/decal/cleanable/dirt,
@@ -42935,7 +43215,6 @@
 	name = "\improper SIPHON PUMP";
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/binary/pump/high_power,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "iWc" = (
@@ -43887,6 +44166,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"jgD" = (
+/obj/structure/low_wall,
+/turf/simulated/floor/plating,
+/area/nadezhda/engineering/atmos)
 "jgG" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/reedbush,
@@ -44159,13 +44442,10 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "jiZ" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "jjc" = (
@@ -44201,6 +44481,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"jjx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "jjy" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -44320,6 +44615,12 @@
 /mob/living/carbon/superior_animal/roach/roachling,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"jkR" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "jkS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -44901,10 +45202,11 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
 "jqU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4;
+	icon_state = "intact"
 	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "jqZ" = (
 /obj/random/junk/low_chance,
@@ -46953,6 +47255,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"jNc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
+"jNd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "jNe" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/suit/space/void/security,
@@ -47349,17 +47664,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/bridge)
 "jRm" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -47439,6 +47754,20 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"jSf" = (
+/obj/structure/table/rack,
+/obj/item/circuitboard/telecomms/processor,
+/obj/item/circuitboard/telecomms/receiver,
+/obj/item/circuitboard/telecomms/server,
+/obj/item/circuitboard/telecomms/bus,
+/obj/item/circuitboard/telecomms/broadcaster,
+/obj/item/circuitboard/message_monitor{
+	pixel_y = -5
+	},
+/obj/item/circuitboard/telecomms/hub,
+/obj/item/circuitboard/telecomms/relay,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "jSg" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -47534,13 +47863,8 @@
 	name = "Residential District Maintenance"
 	})
 "jSQ" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
-/area/nadezhda/engineering/atmos)
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "jSY" = (
 /obj/machinery/porta_turret/gate,
 /turf/simulated/floor/asteroid/dirt,
@@ -48179,10 +48503,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
 "kaz" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 9
-	},
-/obj/machinery/meter,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "kaF" = (
@@ -48560,7 +48880,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "keT" = (
 /obj/random/mob/roaches/low_chance,
@@ -48610,11 +48936,6 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
 "kfi" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5;
-	tag = "icon-intact (NORTHEAST)"
-	},
-/obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/engineering/atmos)
 "kfj" = (
@@ -49148,10 +49469,16 @@
 /obj/machinery/light_switch{
 	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "kky" = (
 /obj/structure/closet/wall_mounted/firecloset{
@@ -49430,12 +49757,11 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
 "knF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/red{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "knJ" = (
 /obj/structure/cable/green{
@@ -49565,14 +49891,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kpn" = (
 /obj/structure/cable/yellow{
@@ -49592,11 +49911,18 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
 "kpo" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice,
-/turf/simulated/floor/plating/under,
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kpw" = (
 /obj/effect/decal/mecha_wreckage/ripley,
@@ -50324,6 +50650,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"kwX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/contraband/poster/placed/generic/firesafety{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6;
+	tag = "icon-intact (SOUTHEAST)"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "kxb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -51176,20 +51513,13 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
 "kFC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/catwalk,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kFF" = (
 /obj/structure/cable/green{
@@ -51607,6 +51937,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
+"kLv" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "kLC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
@@ -51644,15 +51992,8 @@
 	},
 /area/nadezhda/command/tcommsat/computer)
 "kMe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/light/floor,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kMg" = (
 /turf/simulated/wall/r_wall,
@@ -51986,12 +52327,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "kPP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
 /obj/machinery/camera/network/engineering{
 	dir = 4
 	},
-/turf/simulated/floor/plating/under,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "kPR" = (
 /obj/machinery/hologram/holopad,
@@ -52113,9 +52453,9 @@
 /turf/simulated/open,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "kRj" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/nitrogen/prechilled,
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kRl" = (
 /obj/effect/decal/cleanable/rubble,
@@ -52598,14 +52938,10 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "kXg" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "kXi" = (
 /obj/structure/disposalpipe/segment{
@@ -53411,12 +53747,12 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/dorm2)
 "lhd" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4
 	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
+/obj/effect/floor_decal/industrial/box,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "lhi" = (
 /obj/random/mob/roaches/low_chance,
@@ -53518,10 +53854,8 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/detectives_office)
 "liC" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 8
-	},
-/turf/simulated/wall/r_wall,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "liE" = (
 /obj/structure/scrap/poor,
@@ -53798,8 +54132,8 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "lmG" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "lmN" = (
@@ -54084,14 +54418,12 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/quartermaster/miningdock)
 "lpR" = (
-/obj/machinery/atmospherics/pipeturbine{
-	dir = 8
-	},
-/obj/structure/cable/cyan{
+/obj/structure/cable/yellow{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "lpT" = (
 /obj/structure/flora/small/busha2,
@@ -55032,6 +55364,10 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
+"lBn" = (
+/obj/machinery/power/emitter,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "lBt" = (
 /obj/structure/bookcase{
 	name = "bookcase (Religious)"
@@ -55351,13 +55687,17 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
+"lEh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "lEk" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
-	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "lEl" = (
 /obj/structure/closet/wall_mounted/emcloset{
@@ -55944,15 +56284,13 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "lKx" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "lKy" = (
 /obj/structure/shuttle_part/mining{
@@ -58500,21 +58838,13 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "mkU" = (
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
 "mkW" = (
 /turf/simulated/shuttle/wall/mining{
@@ -58756,6 +59086,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"mnd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "mns" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/bush3,
@@ -59082,7 +59421,9 @@
 	name = "Residential District Maintenance"
 	})
 "mra" = (
-/turf/simulated/mineral,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/blue,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "mrk" = (
 /obj/structure/catwalk,
@@ -60210,11 +60551,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "mDd" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Engineering";
-	req_access = list(10)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5;
+	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -60570,9 +60911,13 @@
 	name = "Residential District Maintenance"
 	})
 "mGB" = (
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/freezer{
+	cooling = 1;
+	dir = 8;
+	set_temperature = 0
 	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "mGF" = (
 /obj/structure/shuttle_part/mining{
@@ -61544,7 +61889,13 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/techfloor_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "mQK" = (
 /obj/effect/floor_decal/spline/wood,
@@ -62116,19 +62467,8 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
 "mXT" = (
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Engi Turbine";
-	charge = 5e+006;
-	output_attempt = 1;
-	output_level = 200000;
-	output_level_max = 250000;
-	outputting = 2
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "mXV" = (
 /obj/effect/floor_decal/border/carpet/lightblue{
@@ -63635,6 +63975,10 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
+"nlZ" = (
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/engineering/atmos)
 "nma" = (
 /obj/structure/catwalk,
 /obj/random/scrap,
@@ -64092,6 +64436,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"nrl" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/power/generator,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/engineering/atmos)
 "nrr" = (
 /obj/machinery/light{
 	dir = 8
@@ -66630,6 +66979,13 @@
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/outside/inside_colony)
+"nQg" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/engineering/atmos)
 "nQh" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -67318,7 +67674,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access = newlist();
+	req_one_access = list(24,10)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "nXr" = (
@@ -68060,6 +68422,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"oeT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "oeY" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -68788,7 +69159,13 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "olX" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -69376,15 +69753,20 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
 "osG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/table/rack,
+/obj/item/circuitboard/med_data{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/item/circuitboard/scan_consolenew,
+/obj/machinery/light/floor,
+/obj/item/circuitboard/secure_data{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "osJ" = (
 /obj/structure/table/woodentable,
 /obj/item/flame/candle,
@@ -69409,7 +69791,11 @@
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
 "osY" = (
-/turf/unsimulated/mineral,
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "otc" = (
 /obj/structure/table/reinforced,
@@ -69886,7 +70272,13 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "oyk" = (
 /obj/machinery/door/airlock/maintenance_common{
@@ -69918,6 +70310,21 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/detectives_office)
+"oyz" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "oyA" = (
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -70688,19 +71095,25 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters)
 "oGI" = (
-/obj/structure/sign/warning/fire/small,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
 "oGO" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/cluster/termite_no_despawn/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"oGP" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -27;
+	req_one_access = newlist();
+	target_temperature = 313.15
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "oGY" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/closet_maintloot,
@@ -70776,6 +71189,15 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"oHK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/box,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "oHM" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -70862,7 +71284,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "oIR" = (
-/obj/machinery/atmospherics/tvalve/mirrored/digital/bypass,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "oIV" = (
@@ -71024,6 +71447,27 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"oJT" = (
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "oJV" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,18"
@@ -73174,16 +73618,16 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
 "pgK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
@@ -73233,8 +73677,9 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "phC" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/dark/cargo,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "phD" = (
 /obj/structure/bed/chair{
@@ -73608,6 +74053,13 @@
 "plK" = (
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"plP" = (
+/obj/structure/closet/crate/radiation,
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "plW" = (
 /obj/effect/floor_decal/rust,
 /obj/item/reagent_containers/glass/bucket,
@@ -74534,8 +74986,9 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/barracks)
 "pvq" = (
-/obj/item/contraband/poster/placed/generic/firesafety,
-/turf/simulated/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
 "pvw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -75097,10 +75550,11 @@
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/chemistry)
 "pBw" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4
 	},
+/obj/effect/floor_decal/industrial/box,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "pBy" = (
 /obj/effect/decal/cleanable/rubble,
@@ -77526,6 +77980,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"pZE" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/effect/floor_decal/industrial/box,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "pZL" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/small/trailrocka4,
@@ -77843,9 +78302,10 @@
 /turf/simulated/floor/wood/wild1,
 /area/colony)
 "qdj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
@@ -78176,6 +78636,10 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/sleeper)
+"qgX" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "qhb" = (
 /obj/machinery/light_switch{
 	pixel_y = 32
@@ -78685,6 +79149,16 @@
 /obj/structure/flora/pottedplant/grave_poppers,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/bar)
+"qmh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "qmi" = (
 /obj/structure/table/rack,
 /obj/item/storage/backpack/industrial{
@@ -80294,6 +80768,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"qDm" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warningdust/fulltile,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos)
 "qDo" = (
 /obj/structure/sign/warning/internals_required/small2,
 /turf/simulated/wall/r_wall,
@@ -80361,6 +80842,17 @@
 /obj/item/material/shard,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"qDM" = (
+/obj/structure/table/rack,
+/obj/item/circuitboard/autolathe{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/computer_hardware/hard_drive/portable/design/circuits,
+/obj/item/computer_hardware/hard_drive/portable/design/components,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "qDN" = (
 /obj/landmark/join/start/chief_engineer,
 /obj/structure/bed/chair/office/dark{
@@ -81216,14 +81708,19 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters)
 "qMM" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 6
+/obj/effect/floor_decal/industrial/warningdust/fulltile,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "qNn" = (
 /obj/machinery/power/hydroelectric_control,
 /obj/structure/cable/yellow,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/engine_room)
 "qNv" = (
@@ -81270,14 +81767,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "qNW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "qNY" = (
 /obj/structure/disposalpipe/segment{
@@ -81976,11 +82475,11 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate/west)
 "qWh" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on{
-	dir = 8;
-	target_pressure = 5000
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "qWl" = (
 /obj/structure/cable/cyan{
@@ -82264,6 +82763,13 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"qZA" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "qZC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -82483,6 +82989,14 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/nadezhda/crew_quarters/clownoffice)
+"rcb" = (
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/engineering/atmos)
 "rcg" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -83022,6 +83536,21 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
+"rhv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "rhw" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 6
@@ -83104,12 +83633,8 @@
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
 "rib" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
-	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
+/obj/random/structures,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "rid" = (
 /obj/item/grenade/chem_grenade/metalfoam,
@@ -83468,16 +83993,10 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
 "rmu" = (
-/obj/machinery/power/turbinemotor{
-	dir = 4
-	},
-/obj/structure/cable/cyan,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/under,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/circulator,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "rmD" = (
 /obj/machinery/light/small,
@@ -83724,12 +84243,11 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/reception)
 "roU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/noticeboard/guild{
 	pixel_x = 32
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "roX" = (
 /obj/effect/floor_decal/spline/plain{
@@ -84763,11 +85281,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical)
 "rzS" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 1
 	},
-/obj/structure/sign/warning/nosmoking/small,
-/turf/simulated/wall/r_wall,
+/obj/effect/floor_decal/industrial/box,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "rAc" = (
 /obj/structure/table/standard,
@@ -84935,14 +85453,13 @@
 	},
 /area/shuttle/vasiliy_shuttle_area)
 "rCl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "rCm" = (
 /obj/structure/shuttle_part/mining{
@@ -85391,6 +85908,18 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"rIi" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/panels,
+/area/nadezhda/engineering/atmos)
 "rIq" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/door/blast/regular/open{
@@ -85791,10 +86320,17 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory_blackshield)
 "rMw" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
 "rMA" = (
 /obj/structure/catwalk,
@@ -86534,6 +87070,13 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
+"rVp" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/engineering/atmos)
 "rVq" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/floor_decal/spline/wood{
@@ -87328,6 +87871,15 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/disposaldrop)
+"scb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos)
 "scd" = (
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
@@ -88214,6 +88766,23 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/command/teleporter)
+"smC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/sensor{
+	long_range = 1;
+	name = "Powernet Sensor - Thermoelectric";
+	name_tag = "Thermoelectric Subgrid"
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "smJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -88782,25 +89351,8 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "srU" = (
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
 /obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/dark/techfloor,
+/turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
 "ssb" = (
 /turf/simulated/shuttle/wall/mining{
@@ -88942,16 +89494,18 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
 "stc" = (
-/obj/machinery/light,
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/warningred,
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/box/red/corners{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -90012,6 +90566,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"sDh" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/atmos)
 "sDr" = (
 /turf/simulated/floor/plating/under,
 /area/asteroid/cave)
@@ -90324,12 +90885,14 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
 "sHc" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "sHt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -90951,13 +91514,9 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/pros/shuttle)
 "sOC" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 1;
-	tag = "icon-intact (NORTH)"
-	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "sOE" = (
 /obj/machinery/door/airlock/maintenance_rnd{
@@ -91192,18 +91751,11 @@
 	name = "Residential District Maintenance"
 	})
 "sQG" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "sQP" = (
 /obj/structure/disposalpipe/segment,
@@ -92188,6 +92740,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/rnd/xenobiology)
+"tcg" = (
+/obj/machinery/porta_turret{
+	dir = 1
+	},
+/obj/machinery/camera/motion/security{
+	dir = 1
+	},
+/turf/simulated/floor/plating/under,
+/area/turret_protected/ai)
 "tck" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -93239,6 +93800,13 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"tpl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "tpo" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
@@ -93557,6 +94125,10 @@
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
+"tta" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/atmos)
 "ttd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -93632,6 +94204,10 @@
 /obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/fitness)
+"tud" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "tue" = (
 /obj/structure/closet/syndicate,
 /turf/simulated/shuttle/floor/mining{
@@ -93931,15 +94507,11 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "twX" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/portable_atmospherics/powered/pump{
+	start_pressure = 15000
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawnplasma,
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/atmos)
+/area/nadezhda/engineering/workshop)
 "twY" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -94161,11 +94733,22 @@
 	},
 /area/nadezhda/hallway/main/stairwell)
 "tyF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/machinery/door/window/northright{
+	dir = 2;
+	name = "Atmospherics Hardsuits";
+	req_access = list(24)
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/engineering,
+/obj/item/clothing/head/helmet/space/void/engineering,
+/obj/item/tank/jetpack/oxygen,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "tyH" = (
 /obj/machinery/vending/theomat,
 /obj/structure/sign/faction/neotheology_cross/gold{
@@ -94759,6 +95342,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"tEY" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "tEZ" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -94954,8 +95551,11 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "tGA" = (
-/obj/item/contraband/poster/placed/generic/firefighter,
-/turf/simulated/wall/r_wall,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "tGI" = (
 /obj/structure/table/rack/shelf,
@@ -95408,6 +96008,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"tLv" = (
+/obj/structure/table/standard,
+/obj/item/storage/briefcase/inflatable,
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/atmos)
 "tLF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -96431,6 +97040,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
+"tUY" = (
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "tVg" = (
 /mob/living/simple_animal/frog,
 /turf/simulated/floor/beach/water/jungle,
@@ -98368,6 +98984,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"unI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "unO" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/effect/decal/cleanable/dirt,
@@ -101242,9 +101864,15 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "uSp" = (
-/obj/machinery/atmospherics/binary/circulator,
-/turf/simulated/floor/reinforced,
-/area/nadezhda/engineering/atmos)
+/obj/structure/table/rack,
+/obj/item/circuitboard/autolathe_industrial,
+/obj/item/circuitboard/biogenerator,
+/obj/item/circuitboard/unary_atmos/cooler,
+/obj/item/circuitboard/unary_atmos/cooler,
+/obj/item/circuitboard/unary_atmos/heater,
+/obj/item/circuitboard/unary_atmos/heater,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "uSq" = (
 /obj/random/oddity_guns,
 /obj/random/scrap/dense_weighted,
@@ -101400,24 +102028,20 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/server)
 "uTP" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/industrial/warningdust/fulltile,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "uTT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "uUa" = (
 /obj/landmark/storyevent/midgame_stash_spawn,
@@ -101515,6 +102139,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/workshop)
+"uUJ" = (
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
 "uUN" = (
 /obj/structure/table,
@@ -101928,6 +102556,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"uYQ" = (
+/obj/structure/table/standard,
+/obj/item/device/scanner/gas,
+/obj/item/device/scanner/gas,
+/obj/machinery/camera/network/engineering,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/atmos)
 "uZa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -102109,6 +102744,16 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
+"vbp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "vbq" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -103123,7 +103768,13 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/shuttle/surface_transport_lz)
 "vmd" = (
-/turf/simulated/floor/reinforced,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "vme" = (
 /obj/effect/overlay/water,
@@ -103299,6 +103950,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"vnU" = (
+/obj/structure/table/rack,
+/obj/item/circuitboard/rdserver{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/circuitboard/destructive_analyzer,
+/obj/item/circuitboard/protolathe,
+/obj/item/circuitboard/aifixer,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "vnV" = (
 /obj/structure/table/rack,
 /obj/effect/decal/cleanable/cobweb,
@@ -104262,9 +104924,9 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
 "vyj" = (
-/obj/effect/window_lwall_spawn/smartspawnplasma,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/engineering/atmos,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
 "vyv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -104626,6 +105288,10 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"vDh" = (
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "vDi" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/item/mine/armed,
@@ -105086,6 +105752,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"vHT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "vHU" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 4
@@ -106358,6 +107029,19 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
+"vTC" = (
+/obj/machinery/atmospherics/unary/sink_gas{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/obj/structure/sign/warning/vent_port/small{
+	pixel_y = 29
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos)
 "vTN" = (
 /obj/machinery/light{
 	dir = 4
@@ -106443,6 +107127,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"vUs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 2;
+	locked = 0;
+	name = "South APC";
+	operating = 1;
+	pixel_y = -28
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/atmos)
 "vUu" = (
 /obj/machinery/door/airlock/command{
 	name = "CBO Quarters";
@@ -106512,11 +107214,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "vVf" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/effect/floor_decal/industrial/box,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "vVh" = (
 /obj/structure/flora/small/trailrockb2,
@@ -107224,9 +107926,11 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/tactical)
 "wco" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/workshop)
 "wcs" = (
 /obj/effect/floor_decal/border/carpet/orange,
 /obj/effect/decal/cleanable/dirt,
@@ -107850,7 +108554,13 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/white/corners,
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "wjj" = (
 /obj/machinery/light{
@@ -108000,12 +108710,23 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "wkH" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted/emcloset{
+	pixel_x = 32
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/box/white/corners{
+	dir = 4;
+	icon_state = "box_corners_white"
+	},
+/obj/effect/floor_decal/industrial/box/white/corners{
+	dir = 1;
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "wlg" = (
 /obj/structure/bed/chair{
@@ -108579,6 +109300,15 @@
 /obj/structure/multiz/stairs/active/bottom,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
+"wqk" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos)
 "wqv" = (
 /obj/structure/table/standard,
 /obj/item/clothing/mask/breath{
@@ -109970,6 +110700,14 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
+"wFp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warningdust/fulltile,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/atmos)
 "wFz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -110909,13 +111647,22 @@
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/command/swo/quarters)
 "wPL" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 9;
+	pixel_y = -22
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "turbineexit";
-	name = "remote VENT blast door-control";
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -111156,11 +111903,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
 "wSy" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
-/turf/simulated/floor/reinforced,
-/area/nadezhda/engineering/atmos)
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/colony)
 "wSC" = (
 /obj/structure/sign/warning/smoking/small{
 	pixel_x = 32;
@@ -111173,11 +111917,11 @@
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
 "wSR" = (
-/obj/machinery/power/generator,
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "wSS" = (
 /obj/structure/coatrack,
@@ -111338,15 +112082,10 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security)
 "wUU" = (
-/obj/machinery/atmospherics/unary/heat_exchanger{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/nitrogen{
-	temperature = 273.15
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "wVb" = (
 /obj/structure/shuttle_part/escpod{
@@ -113102,7 +113841,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "xoJ" = (
 /obj/structure/cable/green{
@@ -113358,6 +114099,15 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"xrG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/engineering/atmos)
 "xrI" = (
 /obj/random/structures,
 /obj/effect/decal/cleanable/dirt,
@@ -113401,6 +114151,18 @@
 /obj/effect/floor_decal/corner_techfloor_grid,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/command/gmaster)
+"xsd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/panels,
+/area/nadezhda/engineering/atmos)
 "xsg" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/suit/armor/flakvest/militia,
@@ -113679,6 +114441,15 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
+"xvb" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/atmos)
 "xvd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -114553,14 +115324,11 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
 "xDn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 6;
+	icon_state = "intact"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "xDo" = (
 /obj/machinery/button/remote/blast_door{
@@ -114866,6 +115634,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"xGw" = (
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "xGy" = (
 /obj/random/cluster/spiders,
 /obj/effect/spider/stickyweb,
@@ -115220,18 +116005,21 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "xKi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/closet/crate,
+/obj/item/circuitboard/smes,
+/obj/item/circuitboard/smes,
+/obj/item/stock_parts/smes_coil,
+/obj/item/stock_parts/smes_coil,
+/obj/item/stock_parts/smes_coil/super_capacity,
+/obj/item/stock_parts/smes_coil/super_capacity,
+/obj/item/stock_parts/smes_coil/super_io,
+/obj/item/stock_parts/smes_coil/super_io,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#0892d0"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/atmos)
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/workshop)
 "xKn" = (
 /obj/structure/catwalk,
 /obj/random/structures,
@@ -115739,11 +116527,13 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "xQh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 9
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/meter,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "xQl" = (
 /obj/machinery/door/unpowered/simple/wood/saloon,
@@ -117151,6 +117941,10 @@
 "yeY" = (
 /turf/simulated/floor/reinforced/airless,
 /area/nadezhda/engineering/atmos)
+"yfc" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/nadezhda/engineering/atmos)
 "yfe" = (
 /obj/random/lathe_disk/advanced,
 /turf/simulated/floor/rock,
@@ -117339,7 +118133,13 @@
 	dir = 4;
 	name = "gas pump to turbine"
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
 "yhH" = (
 /obj/structure/cable/yellow{
@@ -130536,7 +131336,7 @@ ygG
 jME
 xBr
 vqe
-gkv
+tcg
 yfl
 tad
 tad
@@ -151319,7 +152119,7 @@ cZb
 cZb
 cZb
 tad
-wDx
+tad
 wDx
 iiS
 wDx
@@ -151341,13 +152141,13 @@ cHX
 kWh
 tTN
 wDx
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wDx
+wDx
+wDx
+wDx
+wDx
+wDx
+wDx
 cZb
 cZb
 cZb
@@ -151521,9 +152321,9 @@ cZb
 cZb
 tad
 tad
+tad
 wDx
-jkS
-nQJ
+lIU
 wDx
 miO
 xrd
@@ -151541,15 +152341,15 @@ ezp
 kbs
 kbs
 wEv
-uHu
+afr
+hEQ
+xrG
+pvq
+aSO
+ffR
+eSc
+ksJ
 wDx
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
 cZb
 cZb
 cZb
@@ -151722,10 +152522,10 @@ cZb
 tad
 tad
 tad
+tad
+tad
 wDx
-wDx
-iiS
-wDx
+lIU
 wDx
 wwK
 goI
@@ -151745,13 +152545,13 @@ kbs
 wEv
 uHu
 wDx
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+liC
+dTL
+osY
+yfc
+nQg
+mXT
+wDx
 cZb
 cZb
 cZb
@@ -151924,13 +152724,13 @@ tad
 tad
 tad
 tad
+tad
+tad
 wDx
-jkS
-aEP
-wDx
-wDx
+scb
+wUU
 phC
-eYn
+rIi
 vhQ
 ksJ
 qkY
@@ -151947,13 +152747,13 @@ ksJ
 viL
 buB
 wDx
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+liC
+dTL
+nlZ
+yfc
+eOs
+mXT
+wDx
 cZb
 cZb
 cZb
@@ -152125,9 +152925,9 @@ tad
 tad
 tad
 tad
-wDx
-wDx
-iiS
+tad
+tad
+tad
 wDx
 wDx
 wDx
@@ -152149,13 +152949,13 @@ ksJ
 acC
 eMy
 wDx
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+liC
+dTL
+rcb
+rVp
+eOs
+mXT
+wDx
 cZb
 cZb
 cZb
@@ -152322,16 +153122,16 @@ vch
 vch
 tad
 tad
-osY
 tad
 tad
 tad
 tad
-wDx
-jkS
-aEP
-wDx
-mra
+tad
+tad
+tad
+tad
+tad
+tad
 wDx
 wDx
 wjf
@@ -152351,13 +153151,13 @@ hoR
 hoR
 fQv
 wDx
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wDx
+wDx
+wDx
+wDx
+wDx
+wDx
+wDx
 cZb
 cZb
 cZb
@@ -152521,19 +153321,19 @@ vch
 vch
 vch
 vch
-vch
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+tad
 tad
 wDx
 wDx
 wDx
-wDx
-wDx
-wDx
-wDx
-iiS
-wDx
-wDx
-wDx
+tad
 wDx
 wDx
 olM
@@ -152722,23 +153522,23 @@ vch
 vch
 vch
 vch
-vch
-cZb
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+aEP
+gwZ
+wDx
 tad
 wDx
-jkS
-qdj
-qdj
-qdj
-qdj
-qdj
-aEP
-wDx
-mra
-wDx
-diq
 kfi
-mhl
+xsd
 qZx
 tXB
 xaG
@@ -152924,11 +153724,8 @@ vch
 vch
 vch
 vch
-cZb
-cZb
 tad
 wDx
-lIU
 wDx
 wDx
 wDx
@@ -152938,8 +153735,11 @@ wDx
 wDx
 wDx
 wDx
-kRj
-wco
+wqk
+wDx
+wDx
+wDx
+kfi
 oyd
 eKF
 tXB
@@ -153126,25 +153926,25 @@ vch
 vch
 vch
 vch
-cZb
-cZb
 tad
 wDx
-lIU
-wDx
-mra
-wDx
-aYf
-wUU
-egv
+vyj
+bLh
+aZC
+aZC
+jkR
+aZC
+aZC
+aZC
+aZC
 jqU
-liC
+bLh
 dYs
-dYs
-rMw
+wDx
+wDx
 kkw
 xoI
-tuQ
+aVm
 tuQ
 lKL
 pcC
@@ -153328,24 +154128,24 @@ vch
 vch
 vch
 vch
-cZb
-cZb
 tad
 wDx
-lIU
 wDx
+xpD
+xDn
+dXw
 mra
-wDx
-eOx
-boB
-pBw
-sOC
-rzS
+mra
+mra
+mra
+dXw
+mWK
+bLh
 exo
-cJC
+wDx
 iVR
 kaz
-wDx
+fYk
 yhG
 qzy
 xEn
@@ -153530,19 +154330,19 @@ vch
 cZb
 vch
 vch
-cZb
-cZb
 tad
 wDx
-lIU
-wDx
-mra
-wDx
-hcz
+rmu
+bLh
+cDT
+pZE
+wFp
+bLh
+bLh
 gNH
-pBw
-lEk
-eOs
+apI
+mWK
+aZC
 knF
 wDx
 wDx
@@ -153732,19 +154532,19 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
 tad
 wDx
-lIU
-wDx
-mra
-wDx
-hcz
-rib
+rmu
+aZC
+cDT
+rzS
+qDm
+bLh
+bLh
+bLh
 pBw
 lhd
-wDx
+aZC
 kpo
 wDx
 fDZ
@@ -153935,25 +154735,25 @@ tad
 tad
 tad
 tad
-tad
-tad
 wDx
-lIU
-wDx
-mra
-wDx
+nrl
+bLh
+wSR
+aZC
+aZC
+kRj
 sQG
 lEk
 boB
 sOC
-eDr
+bLh
 kXg
 wDx
 jWF
 aZC
 bLh
 rCl
-kbs
+aZC
 rSC
 uFx
 pzq
@@ -154137,19 +154937,19 @@ tad
 tad
 tad
 tad
-tad
-tad
-wDx
-lIU
 wDx
 wDx
-wDx
-jSQ
+hcz
+wSR
 rib
-lhd
+rib
+rib
+rDV
+rib
+dWw
 mGB
-wDx
-wDx
+tud
+vUs
 wDx
 xvk
 bLh
@@ -154340,23 +155140,23 @@ tad
 tad
 tad
 tad
-tad
 wDx
-lIU
-wDx
+bLh
 wSR
-wDx
-biK
-wDx
-wDx
-vyj
-eOs
-wDx
+aZC
+aZC
+oIR
+rDV
+aZC
+aZC
+bLh
+aZC
+drX
 wDx
 fDZ
 bLh
 wDx
-dZP
+hso
 wDx
 bMd
 oXM
@@ -154542,23 +155342,23 @@ tad
 tad
 tad
 tad
-tad
 wDx
-lIU
-wDx
-vmd
-evd
+bLh
+jNd
+uTP
+dXw
+uTP
 qWh
-vmd
-lmG
-agu
+aZC
+aZC
+bLh
 hZe
+cwN
 wDx
 wDx
 wDx
 wDx
-wDx
-dZP
+hso
 bUb
 dGc
 cvC
@@ -154744,23 +155544,23 @@ tad
 tad
 tad
 tad
-tad
 wDx
-lIU
 tGA
+bLh
+qMM
 vmd
 qMM
 xQh
-vmd
-lmG
-fzi
+aZC
+bLh
+oIR
 stc
 wDx
 wDx
 npV
 jgP
 kpi
-xKi
+hso
 aZC
 jZX
 bei
@@ -154946,22 +155746,22 @@ tad
 tad
 tad
 tad
-tad
 wDx
-lIU
-wDx
+kwX
+jNc
+uTP
 fJk
 uTP
-rmu
+fJk
 vVf
 mDd
 oIR
 wPL
 wDx
-dXw
-xDn
-tyF
-osG
+wDx
+acc
+aZC
+aZC
 hso
 aZC
 ogG
@@ -155148,19 +155948,19 @@ tad
 tad
 tad
 tad
-tad
 wDx
-lIU
-wDx
-uSp
+oHK
+oIR
+aZC
+lKx
 kMe
 lpR
-wSy
-lmG
+bLh
+tpl
 ddS
 ego
 nXo
-ffR
+tXB
 kFC
 htK
 htK
@@ -155350,20 +156150,20 @@ tad
 tad
 tad
 tad
-tad
 wDx
-lIU
-aPT
-uSp
-wkH
-lKx
-vmd
 jiZ
-gwZ
+oIR
+aZC
+lKx
+aZC
+lKx
+aZC
+jiZ
+bLh
 cRc
-pvq
 wDx
-cul
+wDx
+wDx
 wDx
 xpD
 jJz
@@ -155552,20 +156352,20 @@ tad
 tad
 tad
 tad
-tad
 wDx
-lIU
-wDx
-wDx
-wDx
-oGI
+agu
+bLh
+bLh
+lKx
+aZC
+lKx
 lmG
-twX
-mXT
+hso
+bLh
 fuP
 wDx
-wDx
-iiS
+tad
+tad
 wDx
 kvn
 yiw
@@ -155754,20 +156554,20 @@ tad
 tad
 tad
 tad
-tad
 wDx
-uTT
-qdj
+czW
+gJa
+gJa
 fHI
-wDx
+tXB
 sHc
 gJa
 fSa
 hya
 dBA
 wDx
-wDx
-iiS
+tad
+tad
 wDx
 wDx
 gfZ
@@ -155956,20 +156756,20 @@ tad
 tad
 tad
 tad
-tad
 wDx
-wDx
-wDx
+unI
+wkH
+vbp
 uTT
-fHI
+mnd
+oyz
+tEY
+smC
+cDy
+kLv
 wDx
-wDx
-wDx
-wDx
-wDx
-wDx
-wDx
-iiS
+tad
+tad
 wDx
 wDx
 wDx
@@ -156158,21 +156958,21 @@ tad
 tad
 tad
 tad
+wDx
+wDx
+wDx
+wDx
+wDx
+uYQ
+tta
+gOm
+jgD
+qdj
+fzi
+wDx
 tad
 tad
 tad
-wDx
-wDx
-uTT
-qdj
-qdj
-qdj
-qdj
-qdj
-qdj
-qdj
-nQJ
-wDx
 tad
 wDx
 hiD
@@ -156365,16 +157165,16 @@ tad
 tad
 tad
 wDx
+dZP
+sDh
+evd
+jgD
+aYf
+rMw
 wDx
-wDx
-wDx
-wDx
-wDx
-wDx
-wDx
-wDx
-wDx
-wDx
+tad
+tad
+tad
 tad
 wrT
 wDx
@@ -156566,14 +157366,14 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+wDx
+tLv
+avf
+cLT
+jgD
+oGI
+xvb
+wDx
 tad
 tad
 tad
@@ -156613,7 +157413,7 @@ cZb
 cZb
 cZb
 cZb
-cZb
+gnn
 cZb
 cZb
 cZb
@@ -156768,14 +157568,14 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+wDx
+wDx
+wDx
+wDx
+wDx
+wDx
+diq
+wDx
 tad
 tad
 tad
@@ -156975,9 +157775,9 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
+wDx
+vTC
+wDx
 tad
 tad
 tad
@@ -157177,9 +157977,9 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
+wDx
+wDx
+wDx
 tad
 tad
 tad
@@ -175521,7 +176321,7 @@ kid
 kid
 bwm
 jRm
-wpL
+jjx
 htN
 xkR
 brG
@@ -175723,7 +176523,7 @@ erG
 erG
 erG
 dfH
-wpL
+goP
 htN
 epJ
 brG
@@ -175925,7 +176725,7 @@ xJr
 dSm
 jik
 pgK
-wpL
+rhv
 gLz
 pWh
 rZs
@@ -187271,7 +188071,7 @@ ilR
 oAI
 rlu
 jHi
-jHi
+cSK
 eIO
 vJg
 nkQ
@@ -187466,7 +188266,7 @@ cGH
 gfO
 bDF
 bpF
-bpF
+iKY
 hxQ
 tNm
 hBc
@@ -187675,7 +188475,7 @@ bpF
 bpF
 bpF
 bpF
-bpF
+eMJ
 bpF
 bpF
 bpF
@@ -187874,14 +188674,14 @@ vPE
 iIE
 dMh
 bpF
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
-cZb
+tyF
+oGP
+hyC
+qmh
+cul
+oJT
+xGw
+bpF
 cZb
 bpF
 xXy
@@ -188075,15 +188875,15 @@ swN
 swN
 gkD
 lmN
-jwK
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
-cZb
+bpF
+hOt
+jSQ
+egv
+qmh
+jSQ
+egv
+hiM
+bpF
 cZb
 hrP
 hrP
@@ -188277,15 +189077,15 @@ ePG
 swN
 tBh
 bWD
-jwK
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
-cZb
+bpF
+cJC
+jSQ
+jSQ
+qmh
+egv
+egv
+jSf
+bpF
 vVN
 vVN
 jLN
@@ -188479,15 +189279,15 @@ jqc
 swN
 sGw
 jvi
-jwK
-jwK
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
-cZb
+bpF
+bpF
+uUJ
+eDr
+oeT
+eOx
+egv
+vnU
+bpF
 vVN
 lNB
 tra
@@ -188682,14 +189482,14 @@ swN
 cUt
 iIE
 pei
-jwK
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
-cZb
+bpF
+tUY
+vDh
+wco
+bWE
+egv
+osG
+bpF
 vVN
 lNB
 bBk
@@ -188884,14 +189684,14 @@ swN
 swN
 sGw
 wfx
-jwK
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
-hrP
+bpF
+jSQ
+egv
+lEh
+qZA
+egv
+adv
+bpF
 lRi
 lNB
 bBk
@@ -189086,14 +189886,14 @@ qDp
 qyf
 dll
 mRl
-jwK
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
-cZb
+bpF
+biK
+biK
+egv
+twX
+egv
+qDM
+bpF
 vVN
 lNB
 bBk
@@ -189288,14 +190088,14 @@ fov
 gDw
 dWU
 pTq
-jwK
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
-cZb
+bpF
+lBn
+lBn
+egv
+jSQ
+egv
+uSp
+bpF
 jLN
 lNB
 bBk
@@ -189490,14 +190290,14 @@ sEV
 gDw
 dWU
 mRl
-jwK
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
-cZb
+bpF
+jSQ
+egv
+vHT
+egv
+jSQ
+jSQ
+bpF
 rga
 vVN
 gIz
@@ -189692,14 +190492,14 @@ jZv
 jZv
 jZv
 jwK
-jwK
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
-tad
+bpF
+qgX
+qgX
+xKi
+plP
+iQY
+aPT
+bpF
 cZb
 cZb
 cZb
@@ -189894,14 +190694,14 @@ dhu
 dhu
 jZv
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-tad
+bpF
+bpF
+bpF
+bpF
+bpF
+bpF
+bpF
+bpF
 cZb
 cZb
 cZb
@@ -191916,7 +192716,7 @@ cZb
 cZb
 cZb
 cZb
-cZb
+wSy
 cZb
 cZb
 cZb

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -101101,7 +101101,7 @@
 /area/nadezhda/security/tactical_blackshield)
 "uLW" = (
 /obj/machinery/power/breakerbox{
-	RCon_tag = "Crg Substation Bypass"
+	RCon_tag = "Sci Substation Bypass"
 	},
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/floor_decal/industrial/danger{

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -1698,7 +1698,7 @@
 /area/nadezhda/crew_quarters/hydroponics)
 "asM" = (
 /obj/machinery/camera/network/gate{
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/west)
@@ -2345,7 +2345,7 @@
 /obj/structure/catwalk,
 /obj/machinery/camera/network/gate{
 	dir = 10;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2941,7 +2941,7 @@
 "aEv" = (
 /obj/machinery/camera/network/gate{
 	dir = 8;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -4543,7 +4543,7 @@
 "aYN" = (
 /obj/machinery/camera/network/gate{
 	dir = 10;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/west)
@@ -5305,7 +5305,7 @@
 	dir = 10
 	},
 /obj/machinery/camera/network/gate{
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7612,7 +7612,7 @@
 /obj/structure/flora/small/rock2,
 /obj/machinery/camera/network/gate{
 	dir = 10;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/east)
@@ -11093,7 +11093,7 @@
 	},
 /obj/machinery/camera/network/gate{
 	dir = 10;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
@@ -11452,11 +11452,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -15966,11 +15961,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "dsd" = (
@@ -19345,6 +19335,9 @@
 /obj/item/ammo_magazine/ammobox/shotgun/beanbags,
 /obj/item/ammo_magazine/ammobox/shotgun/stunshells,
 /obj/machinery/camera/network/command,
+/obj/item/device/radio/intercom{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/armory)
 "ebE" = (
@@ -19510,7 +19503,7 @@
 "ecW" = (
 /obj/machinery/camera/network/gate{
 	dir = 10;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/security/maingate/west)
@@ -19825,11 +19818,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -22546,7 +22534,7 @@
 	},
 /obj/machinery/camera/network/colony_surface{
 	dir = 4;
-	network = list("Nadzedha                                                                Wall                                                                Colony")
+	network = list("Nadzedha                                                                                                                                Wall                                                                                                                                Colony")
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
@@ -30034,7 +30022,7 @@
 "gkJ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/camera/network/gate{
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate)
@@ -31542,7 +31530,7 @@
 "gAa" = (
 /obj/machinery/camera/network/gate{
 	dir = 10;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/security/maingate/east)
@@ -38723,11 +38711,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "hZj" = (
@@ -39838,7 +39821,7 @@
 "iko" = (
 /obj/machinery/camera/network/gate{
 	dir = 4;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/security/maingate/west)
@@ -40745,7 +40728,7 @@
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/camera/network/gate{
 	dir = 8;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -53136,7 +53119,7 @@
 	dir = 1;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon                                                                                                                                Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous                                                                                                                                Oxide","waste_sensor"="Gas                                                                                                                                Mix                                                                                                                                Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon                                                                                                                                                                                                                                                                Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous                                                                                                                                                                                                                                                                Oxide","waste_sensor"="Gas                                                                                                                                                                                                                                                                Mix                                                                                                                                                                                                                                                                Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
@@ -53589,7 +53572,7 @@
 	dir = 8;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon                                                                                                                                Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous                                                                                                                                Oxide","waste_sensor"="Gas                                                                                                                                Mix                                                                                                                                Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon                                                                                                                                                                                                                                                                Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous                                                                                                                                                                                                                                                                Oxide","waste_sensor"="Gas                                                                                                                                                                                                                                                                Mix                                                                                                                                                                                                                                                                Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
@@ -57199,7 +57182,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/gate{
 	dir = 8;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -61295,7 +61278,7 @@
 "mKM" = (
 /obj/machinery/camera/network/gate{
 	dir = 10;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/security/maingate/east)
@@ -64865,7 +64848,7 @@
 "nvf" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/camera/network/gate{
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/east)
@@ -67262,7 +67245,7 @@
 "nTu" = (
 /obj/machinery/camera/network/gate{
 	dir = 8;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/asteroid/dirt,
@@ -71648,7 +71631,7 @@
 	},
 /obj/machinery/camera/network/gate{
 	dir = 4;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
@@ -71952,9 +71935,6 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/armory)
 "oPv" = (
@@ -71993,7 +71973,7 @@
 	},
 /obj/machinery/camera/network/colony_surface{
 	dir = 8;
-	network = list("Nadzedha                                                                Wall                                                                Colony")
+	network = list("Nadzedha                                                                                                                                Wall                                                                                                                                Colony")
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
@@ -80265,9 +80245,6 @@
 "qxC" = (
 /obj/landmark/storyevent/hidden_vent_antag,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/armory)
 "qxG" = (
@@ -87607,7 +87584,7 @@
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "rZN" = (
 /obj/machinery/camera/network/gate{
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/east)
@@ -89502,11 +89479,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "stj" = (
@@ -91036,7 +91008,7 @@
 /obj/effect/floor_decal/industrial/road/straight2,
 /obj/machinery/camera/network/colony_surface{
 	dir = 8;
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/manmade/road,
@@ -97145,7 +97117,7 @@
 	},
 /obj/machinery/camera/network/colony_surface{
 	dir = 8;
-	network = list("Nadzedha                                                                Wall                                                                Colony")
+	network = list("Nadzedha                                                                                                                                Wall                                                                                                                                Colony")
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
@@ -107139,10 +107111,6 @@
 	operating = 1;
 	pixel_y = -28
 	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "vUu" = (
@@ -111477,9 +111445,6 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/device/radio/intercom{
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/armory)
 "wNF" = (
@@ -111659,11 +111624,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
 "wPS" = (
@@ -111902,9 +111862,6 @@
 /obj/item/device/radio/off,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
-"wSy" = (
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/colony)
 "wSC" = (
 /obj/structure/sign/warning/smoking/small{
 	pixel_x = 32;
@@ -115292,7 +115249,7 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/machinery/camera/network/gate{
-	network = list("Nadzedha                Wall                Colony")
+	network = list("Nadzedha                                Wall                                Colony")
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
@@ -171444,7 +171401,7 @@ cZb
 jdE
 jdE
 jdE
-cZb
+jdE
 cZb
 cZb
 cZb
@@ -192716,7 +192673,7 @@ cZb
 cZb
 cZb
 cZb
-wSy
+cZb
 cZb
 cZb
 cZb

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -71087,8 +71087,7 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -27;
-	req_one_access = newlist();
-	target_temperature = 313.15
+	req_one_access = newlist()
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/workshop)

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -31253,7 +31253,8 @@
 "gwZ" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/sink_heat{
-	dir = 4
+	dir = 4;
+	effective = 0.05
 	},
 /obj/machinery/camera/network/engineering{
 	dir = 4

--- a/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Solar_Area.dmm
@@ -2113,6 +2113,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/outside/mountainsolars)
 "DI" = (
@@ -2895,9 +2900,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/outside/mountainsolars)
 "Td" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
 	},

--- a/sojourn-station.dme
+++ b/sojourn-station.dme
@@ -200,6 +200,7 @@
 #include "code\ATMOSPHERICS\components\unary\generator_input.dm"
 #include "code\ATMOSPHERICS\components\unary\heat_exchanger.dm"
 #include "code\ATMOSPHERICS\components\unary\heat_source.dm"
+#include "code\ATMOSPHERICS\components\unary\map_sink.dm"
 #include "code\ATMOSPHERICS\components\unary\outlet_injector.dm"
 #include "code\ATMOSPHERICS\components\unary\oxygen_generator.dm"
 #include "code\ATMOSPHERICS\components\unary\unary_base.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds two new mapper pipes to cooldown/heat up gasses and another that replaces its contents with air, allowing it to be siphoned or waste gas to be pumped inside.

Additionally 3 major map changes and few minor map fixes.

Minor fixes: breaker box name fix for science substation, added a camera for the hydroelectric turbine, removed a duplicate pipe at mountain top, added a missing wire at mountain top, fixed a connection where the main grid connected to the science grid.

Major changes: Replace the old turbine with the classic TEG. Offering more options, varierty and atmosian shenagigans to be done. Utilized the two new mapper pipes as well so we are no longer pumping into an area and a tree. And no longer using giant nitrogen tank as a heatsink which made little to no IC sense. In both cases it should hopefully help with performance as well.
![grafik](https://github.com/sojourn-13/sojourn-station/assets/21098781/e827b840-89bc-4757-a202-edf4b2d928dd)

Added a simple canister storage to atmos that was removed from last map:
![grafik](https://github.com/sojourn-13/sojourn-station/assets/21098781/b381ac11-aea3-40f0-8b9c-6ca685010cf6)

Added a tech/hard storage that were also removed during the map swap:
![grafik](https://github.com/sojourn-13/sojourn-station/assets/21098781/43e1e918-2475-4a18-a559-255c129f7273)

