### PR TITLE
Adds Pain Infliction Psionic Power

### DIFF
--- a/code/modules/organs/internal/psionic.dm
+++ b/code/modules/organs/internal/psionic.dm
@@ -46,6 +46,7 @@
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_tool,
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_call,
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_banish,
+        /obj/item/organ/internal/psionic_tumor/proc/powerword_pain,
 		/obj/item/organ/internal/psionic_tumor/proc/journey_to_nowhere,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_armor,
 		/obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster

--- a/code/modules/organs/internal/psionic.dm
+++ b/code/modules/organs/internal/psionic.dm
@@ -46,7 +46,7 @@
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_tool,
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_call,
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_banish,
-        /obj/item/organ/internal/psionic_tumor/proc/powerword_pain,
+        /obj/item/organ/internal/psionic_tumor/proc/pain_infliction,
 		/obj/item/organ/internal/psionic_tumor/proc/journey_to_nowhere,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_armor,
 		/obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster
@@ -71,7 +71,7 @@
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_tool,
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_call,
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_banish,
-        /obj/item/organ/internal/psionic_tumor/proc/powerword_pain,
+        /obj/item/organ/internal/psionic_tumor/proc/pain_infliction,
 		/obj/item/organ/internal/psionic_tumor/proc/journey_to_nowhere,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_armor,
 		/obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster,

--- a/code/modules/organs/internal/psionic.dm
+++ b/code/modules/organs/internal/psionic.dm
@@ -71,6 +71,7 @@
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_tool,
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_call,
 		/obj/item/organ/internal/psionic_tumor/proc/psychic_banish,
+        /obj/item/organ/internal/psionic_tumor/proc/powerword_pain,
 		/obj/item/organ/internal/psionic_tumor/proc/journey_to_nowhere,
 		/obj/item/organ/internal/psionic_tumor/proc/psionic_armor,
 		/obj/item/organ/internal/psionic_tumor/proc/kinetic_blaster,

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -22,28 +22,28 @@
 
 //antiheals people with halloss
 /obj/item/organ/internal/psionic_tumor/proc/pain_infliction()
-    set category = "Psionic powers"
-    set name = "Pain Infliction (2)"
-    set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
-    psi_point_cost = 2 //Two Points. Yes slightly spamable but considering what people can do with grabs for free this is relatively tame.
+	set category = "Psionic powers"
+        set name = "Pain Infliction (2)"
+	set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
+	psi_point_cost = 2 //Two Points. Yes spamable to pain somebody but considering what people can do with grabs for free this is relatively tame. Needs aggressive grab, people with deep psi pools usually invested into that and lack robustness
 
-    var/mob/living/carbon/human/L = get_grabbed_mob(owner)
-    var/obj/item/grab/G = locate() in owner
-    if(!G || !istype(G))
+	var/mob/living/carbon/human/L = get_grabbed_mob(owner)
+	var/obj/item/grab/G = locate() in owner
+	if(!G || !istype(G))
 		usr.show_message(SPAN_DANGER("You can't inflict pain if you are not grabbing anyone."))
 		return
 
-    if(G.state < GRAB_AGGRESSIVE)
+	if(G.state < GRAB_AGGRESSIVE)
 		usr.show_message(SPAN_DANGER("You must have an aggressive grab to inflict pain upon somebody!"))
 		return
 
-    if(pay_power_cost(psi_point_cost))
+	if(pay_power_cost(psi_point_cost))
 		if(check_possibility(TRUE, L))
 			usr.visible_message(
 					SPAN_DANGER("[usr] forcefully presses a hand upon [L] in an attempt to inflict pain upon them!"),
 					SPAN_DANGER("You force your hand on [L] expanding your mind and inflicting pain upon them!")
 					)
-			L.adjustHalLoss(30)
+			L.AdjustHalLoss(30)
 
 //Heals hunger
 /obj/item/organ/internal/psionic_tumor/proc/psychosomatictransfer()

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -1,5 +1,5 @@
 
-//Powers that heal people or self
+//Powers that heal people or self, or antiheal people
 
 /obj/item/organ/internal/psionic_tumor/proc/psionic_healing()
 	set category = "Psionic powers"
@@ -19,6 +19,30 @@
 			SPAN_DANGER("[owner]'s flesh begins to hiss and bubble as their wounds mend!"),
 			SPAN_DANGER("A wave of agony envelops you as your wounds begin to close!")
 			)
+
+//antiheals people with halloss
+/obj/item/organ/internal/psionic_tumor/proc/powerword_pain()
+	set name = "Pain Infliction (2)"
+	set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
+	psi_point_cost = 2 //Two Points. Yes slightly spamable but considering what people can do with grabs for free this is relatively tame. Needs aggressive grab, people with deep psi pools usually invested into that and lack robustness
+
+	var/mob/living/carbon/human/L = get_grabbed_mob(owner)
+	var/obj/item/grab/G = locate() in owner
+	if(!G || !istype(G))
+		usr.show_message(SPAN_DANGER("You can't inflict pain if you are not grabbing anyone."))
+		return
+
+	if(G.state < GRAB_AGGRESSIVE)
+		usr.show_message(SPAN_DANGER("You must have an aggressive grab to inflict pain upon somebody!"))
+		return
+
+	if(pay_power_cost(psi_point_cost))
+		if(check_possibility(TRUE, L))
+			usr.visible_message(
+					SPAN_DANGER("[usr] forcefully presses a hand upon [L] in an attempt to inflict pain upon them!"),
+					SPAN_DANGER("You force your hand on [L] expanding your mind and inflicting pain upon them!")
+					)
+			L.AdjustHalLoss(50)
 
 //Heals hunger
 /obj/item/organ/internal/psionic_tumor/proc/psychosomatictransfer()

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -42,7 +42,7 @@
 					SPAN_DANGER("[usr] forcefully presses a hand upon [L] in an attempt to inflict pain upon them!"),
 					SPAN_DANGER("You force your hand on [L] expanding your mind and inflicting pain upon them!")
 					)
-			L.AdjustHalLoss(50)
+			L.adjustHalLoss(50)
 
 //Heals hunger
 /obj/item/organ/internal/psionic_tumor/proc/psychosomatictransfer()

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -23,7 +23,7 @@
 //antiheals people with halloss
 /obj/item/organ/internal/psionic_tumor/proc/pain_infliction()
 	set category = "Psionic powers"
-        set name = "Pain Infliction (2)"
+	set name = "Pain Infliction (2)"
 	set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
 	psi_point_cost = 2 //Two Points. Yes spamable to pain somebody but considering what people can do with grabs for free this is relatively tame. Needs aggressive grab, people with deep psi pools usually invested into that and lack robustness
 

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -25,19 +25,19 @@
     set category = "Psionic powers"
     set name = "Pain Infliction (2)"
     set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
-	psi_point_cost = 2 //Two Points. Yes slightly spamable but considering what people can do with grabs for free this is relatively tame.
+    psi_point_cost = 2 //Two Points. Yes slightly spamable but considering what people can do with grabs for free this is relatively tame.
 
-	var/mob/living/carbon/human/L = get_grabbed_mob(owner)
-	var/obj/item/grab/G = locate() in owner
-	if(!G || !istype(G))
+    var/mob/living/carbon/human/L = get_grabbed_mob(owner)
+    var/obj/item/grab/G = locate() in owner
+    if(!G || !istype(G))
 		usr.show_message(SPAN_DANGER("You can't inflict pain if you are not grabbing anyone."))
 		return
 
-	if(G.state < GRAB_AGGRESSIVE)
+    if(G.state < GRAB_AGGRESSIVE)
 		usr.show_message(SPAN_DANGER("You must have an aggressive grab to inflict pain upon somebody!"))
 		return
 
-	if(pay_power_cost(psi_point_cost))
+    if(pay_power_cost(psi_point_cost))
 		if(check_possibility(TRUE, L))
 			usr.visible_message(
 					SPAN_DANGER("[usr] forcefully presses a hand upon [L] in an attempt to inflict pain upon them!"),

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -25,7 +25,7 @@
     set category = "Psionic powers"
 	set name = "Pain Infliction (2)"
 	set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
-	psi_point_cost = 2 //Two Points. Yes slightly spamable but considering what people can do with grabs for free this is relatively tame. Needs aggressive grab, people with deep psi pools usually invested into that and lack robustness
+	psi_point_cost = 2 //Two Points. Yes slightly spamable but considering what people can do with grabs for free this is relatively tame.
 
 	var/mob/living/carbon/human/L = get_grabbed_mob(owner)
 	var/obj/item/grab/G = locate() in owner

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -21,6 +21,29 @@
 			)
 
 //antiheals people with halloss
+/obj/item/organ/internal/psionic_tumor/proc/pain_infliction()
+	set category = "Psionic powers"
+        set name = "Pain Infliction (2)"
+	set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
+	psi_point_cost = 2 //Two Points. Yes spamable to pain somebody but considering what people can do with grabs for free this is relatively tame. Needs aggressive grab, people with deep psi pools usually invested into that and lack robustness
+
+	var/mob/living/carbon/human/L = get_grabbed_mob(owner)
+	var/obj/item/grab/G = locate() in owner
+	if(!G || !istype(G))
+		usr.show_message(SPAN_DANGER("You can't inflict pain if you are not grabbing anyone."))
+		return
+
+	if(G.state < GRAB_AGGRESSIVE)
+		usr.show_message(SPAN_DANGER("You must have an aggressive grab to inflict pain upon somebody!"))
+		return
+
+	if(pay_power_cost(psi_point_cost))
+		if(check_possibility(TRUE, L))
+			usr.visible_message(
+					SPAN_DANGER("[usr] forcefully presses a hand upon [L] in an attempt to inflict pain upon them!"),
+					SPAN_DANGER("You force your hand on [L] expanding your mind and inflicting pain upon them!")
+					)
+			L.adjustHalLoss(30)
 
 //Heals hunger
 /obj/item/organ/internal/psionic_tumor/proc/psychosomatictransfer()

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -43,7 +43,7 @@
 					SPAN_DANGER("[usr] forcefully presses a hand upon [L] in an attempt to inflict pain upon them!"),
 					SPAN_DANGER("You force your hand on [L] expanding your mind and inflicting pain upon them!")
 					)
-			L.AdjustHalLoss(30)
+			L.adjustHalLoss(30)
 
 //Heals hunger
 /obj/item/organ/internal/psionic_tumor/proc/psychosomatictransfer()

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -23,7 +23,7 @@
 //antiheals people with halloss
 /obj/item/organ/internal/psionic_tumor/proc/pain_infliction()
     set category = "Psionic powers"
-	set name = "Pain Infliction (2)"
+    set name = "Pain Infliction (2)"
 	set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
 	psi_point_cost = 2 //Two Points. Yes slightly spamable but considering what people can do with grabs for free this is relatively tame.
 

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -21,29 +21,6 @@
 			)
 
 //antiheals people with halloss
-/obj/item/organ/internal/psionic_tumor/proc/pain_infliction()
-	set category = "Psionic powers"
-        set name = "Pain Infliction (2)"
-	set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
-	psi_point_cost = 2 //Two Points. Yes spamable to pain somebody but considering what people can do with grabs for free this is relatively tame. Needs aggressive grab, people with deep psi pools usually invested into that and lack robustness
-
-	var/mob/living/carbon/human/L = get_grabbed_mob(owner)
-	var/obj/item/grab/G = locate() in owner
-	if(!G || !istype(G))
-		usr.show_message(SPAN_DANGER("You can't inflict pain if you are not grabbing anyone."))
-		return
-
-	if(G.state < GRAB_AGGRESSIVE)
-		usr.show_message(SPAN_DANGER("You must have an aggressive grab to inflict pain upon somebody!"))
-		return
-
-	if(pay_power_cost(psi_point_cost))
-		if(check_possibility(TRUE, L))
-			usr.visible_message(
-					SPAN_DANGER("[usr] forcefully presses a hand upon [L] in an attempt to inflict pain upon them!"),
-					SPAN_DANGER("You force your hand on [L] expanding your mind and inflicting pain upon them!")
-					)
-			L.adjustHalLoss(30)
 
 //Heals hunger
 /obj/item/organ/internal/psionic_tumor/proc/psychosomatictransfer()

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -42,7 +42,7 @@
 					SPAN_DANGER("[usr] forcefully presses a hand upon [L] in an attempt to inflict pain upon them!"),
 					SPAN_DANGER("You force your hand on [L] expanding your mind and inflicting pain upon them!")
 					)
-			L.adjustHalLoss(50)
+			L.adjustHalLoss(30)
 
 //Heals hunger
 /obj/item/organ/internal/psionic_tumor/proc/psychosomatictransfer()

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -22,6 +22,7 @@
 
 //antiheals people with halloss
 /obj/item/organ/internal/psionic_tumor/proc/pain_infliction()
+    set category = "Psionic powers"
 	set name = "Pain Infliction (2)"
 	set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
 	psi_point_cost = 2 //Two Points. Yes slightly spamable but considering what people can do with grabs for free this is relatively tame. Needs aggressive grab, people with deep psi pools usually invested into that and lack robustness

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -21,7 +21,7 @@
 			)
 
 //antiheals people with halloss
-/obj/item/organ/internal/psionic_tumor/proc/powerword_pain()
+/obj/item/organ/internal/psionic_tumor/proc/pain_infliction()
 	set name = "Pain Infliction (2)"
 	set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
 	psi_point_cost = 2 //Two Points. Yes slightly spamable but considering what people can do with grabs for free this is relatively tame. Needs aggressive grab, people with deep psi pools usually invested into that and lack robustness

--- a/code/modules/psionics/psion_powers/healing_powers.dm
+++ b/code/modules/psionics/psion_powers/healing_powers.dm
@@ -24,7 +24,7 @@
 /obj/item/organ/internal/psionic_tumor/proc/pain_infliction()
     set category = "Psionic powers"
     set name = "Pain Infliction (2)"
-	set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
+    set desc = "Expend two psi points to inflict pain upon whatever person you are currently grabbing in a tight hold."
 	psi_point_cost = 2 //Two Points. Yes slightly spamable but considering what people can do with grabs for free this is relatively tame.
 
 	var/mob/living/carbon/human/L = get_grabbed_mob(owner)


### PR DESCRIPTION
## About The Pull Request

After somehow loosing track last night and talking to Trilby about mind wizard stuff there was the idea floating in the room that psions could be able to do things with pain. So theres that. Ideas were: Pain Transference, Pain Mirror and Pain Infliction.
This PR solely handles "Pain Infliction" or "powerword_pain" in code.

What it does:

If a psion gets an aggressive grab on a person they can inflict pain upon them expending two psi points. Yup. Thats it.

"But Irkalla what the fuck." 

Well if people have deep psi pools and they didn't powerlevel robustness in round to shit they invested into having said psi pools either by picking cog, cog backgrounds, psi point boosting backgrounds locking them out of more interesting choices or by being a cog heavy role which lacks robustness for grabs. So they can disable a single person they get a grab on. Then they are all out of mana and need a potion.  Considering psy regen is slow this makes them able to disable a single person if they somehow manage to get an aggressive grab on them, or somewhat inconvenience them should they lack the psypool.

Yes, I blatantly ripped the code from another psypower and adjusted it.
Yes, Pain Mirror and Transference are still coming but in separate PRs, need to get a good grasp first on how to reduce a value of person and adding said value to another person.

Additionally: Pain Mirror will be either deep maint cube or xenoarch cube, probably deep maint cube but thats beside the point.

Edit: This is ready, Pain Mirror and Pain Transference will need separate PRs since I need to figure out how to make it work without being IrkallaShitcode (Trademarked)


## Changelog
:cl:
add: Psions can now use "Pain Infliction" or rather "Powerword Pain", still not the all powerful "Powerword Naked" the Faceless seem to know.
/:cl:

