### PR TITLE
panacea fixes and adjustment

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -368,7 +368,7 @@
 	display_name = "ambrosia panacea"
 	mutants = null
 	evolutions = null
-	chems = list("nutriment"=list(1), "cronexidone"=list(5), "cordradaxon"=list(5,20),"peridaxon"=list(5,20),"respiradoxon"=list(5,20),"vermicetol"=list(5,20),"rezadone"=list(5,20),"quickclot"=list(5,20),"ossissine"=list(5,20))
+	chems = list("nutriment"=list(1), "cronexidone"=list(5), "cordradaxon"=list(5,20),"peridaxon"=list(5,20),"respirodaxon"=list(5,20),"vermicetol"=list(5,20),"rezadone"=list(5,20),"quickclot"=list(5,20),"flossisine"=list(5,20))
 	exude_gasses = list("sleeping_agent" = 4)
 
 /datum/seed/ambrosia/panacea/New()

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -1568,3 +1568,20 @@ We don't use this but we might find use for it. Porting it since it was updated 
 	to_chat(M, SPAN_WARNING("Your stomach groans and aches, you feel as though you might vomit"))
 	if(prob(10 * dose))
 		M.vomit()
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Xenobotany reagents for hard to get plants
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+//Exclusive to Panacea
+/datum/reagent/medicine/ossisine/flora
+	name = "Flossisine"
+	id = "flossisine"
+	description = "A bioengineered natural compound that aids the repairs of broken bones without the side effects of its synthetic version."
+	taste_description = "minty calcium"
+	color = "#298f59"
+	nerve_system_accumulations = 25
+
+/datum/reagent/medicine/ossisine/affect_blood(mob/living/carbon/M, alien, effect_multiplier, var/removed = REM)
+	M.add_chemical_effect(CE_BLOODCLOT, 0.1)
+	M.add_chemical_effect(CE_BONE_MEND, 0.5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes two spelling mistakes in ambrosia panacea for ossisine and respirodaxon.

Adds a new xenobotany exclusive version of ossisine to xenobotany for the panacea plant, replacing its old version.
Flossisine is painless and has only 25 NSA demand.

Reasoning: I always found panacea to be in a really strange spot of it seemingly powerful on paper but barely useful in practise. Usually by the time you are done making this plant with a time investment of like 40 or 30 minutes, medical already has everything mixed and more so. Most often or not they will look at your plant, say cool and forget about it. Mass production of chems never really was its main strenght of xenobotany since medical never needed a mass production to begin with. So elevate xenobotany slightly in its use, I decided to give it a unique reward chem that medical WILL take notice to even if they can still deal with the issue by putting them under a knife. Plus you can eat the plant without going into paincrit which sort of makes it cool. Still dangerous if you overdose accidentially by eating too much.