### PR TITLE
reducing the odds of explosive trap spawns in maints and other areas

### DIFF
--- a/code/game/objects/random/traps/traps.dm
+++ b/code/game/objects/random/traps/traps.dm
@@ -5,10 +5,10 @@
 
 /obj/random/traps/item_to_spawn()
 	var/list/possible_traps = list(/obj/structure/wire_splicing = 1,
-	/obj/item/mine/armed = 0.15,
-	/obj/item/mine/improvised/armed = 0.30,
-	/obj/item/beartrap/armed = 0.45,
-	/obj/item/beartrap/makeshift/armed = 0.8)
+	/obj/item/mine/armed = 0.05,
+	/obj/item/mine/improvised/armed = 0.10,
+	/obj/item/beartrap/armed = 0.65,
+	/obj/item/beartrap/makeshift/armed = 0.9)
 
 	//Check that its possible to spawn the chosen trap at this location
 	while (possible_traps.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary> Explosive traps have in general left a bad taste in my mouth, and this can rightfully be considered a salt PR. My main gripe however is that they are simply too **common** for what is supposed to be a semi-secured colony with a dedicated military and security force. The goal of this is to shift the odds to less brutal traps to lessen the chance that someone’s first step into the maintenance tunnels becomes their immediate last and destroys a section of the nearby hall (since there are now trap spawns under basically every maintenance doorway and apparently the kitchen storage too.)
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: Blackshield and Marshals, after numerous complaints from both medical personnel and colonists, have drafted up new IED and ordinance disposal procedures for their teams between shifts. Mines should be less common, though the trappers responsible have simply started placing more mechanical traps instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
