### PR TITLE
CE_BLOODCLOT no longer lethal

### DIFF
--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -132,7 +132,7 @@
 
 /mob/living/carbon/human/proc/handle_heart_blood()
 	var/heart_efficiency = get_organ_efficiency(OP_HEART)
-	var/blood_oxygenation = 0.4 * chem_effects[CE_OXYGENATED] - 0.2 * chem_effects[CE_BLOODCLOT]
+	var/blood_oxygenation = 0.4 * chem_effects[CE_OXYGENATED]
 	var/blood_volume = get_blood_volume() // Percentage.
 
 	// Damaged heart virtually reduces the blood volume, as the blood isn't being pumped properly anymore.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Over the past few weeks I made a silent observation where medical people would be both confused and complain about things like Peridaxon being hyperlethal, causing peoples oxyloss to skyrocket instantly with no obvious signs.

Turns out that both quickclot and peridaxon WILL kill you if injected. In both cases, rendering the chems obsolete. Medical is more content to perform surgery over using peri or simply using a bandage instead of using quickclot. Taking away the purpose of both chems.