### PR TITLE
Lodge SMES Fix

### DIFF
--- a/maps/_HunterLodge/map/_Hunting_Lodge.dmm
+++ b/maps/_HunterLodge/map/_Hunting_Lodge.dmm
@@ -2074,7 +2074,8 @@
 	skill_check = -30
 	},
 /obj/structure/cable/yellow{
-	dir = 1
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/outside/forest/hunting_lodge_dark)


### PR DESCRIPTION
Fixes the wire under the Hunting Lodge Smes to be functional at round start. (Thanks goes to catto for this cause she told me what was wrong)
![Untitled](https://github.com/sojourn-13/sojourn-station/assets/13492089/b0d19493-ff1f-4019-9aa6-e9452756db48)
