### PR TITLE
Allow Hand Labelers to label a wide variety of things onto equipment.

### DIFF
--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -60,7 +60,7 @@
 	if(mode)
 		to_chat(user, SPAN_NOTICE("You turn on \the [src]."))
 		//Now let them chose the text.
-		var/str = sanitizeName(input(user,"Label text?","Set label",""), MAX_NAME_LEN) //Only A-Z, 1-9 and `-`
+		var/str = sanitizeSafe(input(user,"Label text?","Set label",""), MAX_NAME_LEN)
 		if(!str || !length(str))
 			to_chat(user, SPAN_NOTICE("Invalid text."))
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I enjoy putting bizarre text, emoji's and other things onto my equipment on other servers, and I think this commit will let me do so.
<summary>
	Lets the people put Emoji's onto their equipment.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	Changes the usage Sanitize name Proc for a text input to a sanitize text input on the hand labeler.
<hr>
</details>

## Changelog
:cl:
add: Hand Labelers now can label more then A-Z, 0-9 & -.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
