### PR TITLE
[QOL] Frequency Transfer for Signallers

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -103,6 +103,15 @@
 			set_freq(input_freq)
 		return 1
 
+/obj/item/device/assembly/signaler/attackby(var/obj/item/WIELD, var/mob/user)
+    if(istype(WIELD, /obj/item/device/assembly/signaler))
+        var/obj/item/assembly/signaler/signaler2 = WIELD
+        if(secured && signaler2.secured)
+            code = signaler2.code
+            set_frequency(signaler2.frequency)
+            to_chat(user, "You transfer the frequency and code of [signaler2] to [src].")
+    else
+        ..()
 
 /obj/item/device/assembly/signaler/proc/signal()
 	if(!radio_connection)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -105,7 +105,7 @@
 
 /obj/item/device/assembly/signaler/attackby(var/obj/item/WIELD, var/mob/user)
     if(istype(WIELD, /obj/item/device/assembly/signaler))
-        var/obj/item/assembly/signaler/signaler2 = WIELD
+        var/obj/item/device/assembly/signaler/signaler2 = WIELD
         if(secured && signaler2.secured)
             code = signaler2.code
             set_frequency(signaler2.frequency)


### PR DESCRIPTION
QOL improvement for all kinds of singalers for all kinds of assemblies

## About The Pull Request
This adds a method of transferring frequency and code from one remote to another. Click with the active remote on the other signaler. Useful for all kinds of assemblies, from infrared assemblies to proximity alarms to anything else you can think off.

Credit goes to: 
1.  ExcessiveUseOfCobblestone for the initial conception on TG.
2. DimasW99 for handling Eriscode/Sojcode related questions and some fixing relating to vars on how to transition this feature.
3. Me (IrkallaEpsilon) getting it moved over and initial work/fixes.

Tested and working

## Changelog
:cl:
add: Remote signal devices frequency and code can now be paired by clicking on eachother.
/:cl:

