### PR TITLE
[QOL] Transferring timing parameters (timing and time) from one timer to another timer

### DIFF
--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -112,6 +112,6 @@
         if(secured && timer2.secured)
             timing = timer2.timing
             time = timer2.time
-            to_chat(user, "You transfer the set time from [timer2] to [src].")
+            to_chat(user, "You transfer the timing parameters from [timer2] to [src].")
     else
         ..()

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -105,3 +105,13 @@
 
 	if(usr)
 		attack_self(usr)
+
+/obj/item/device/assembly/timer/attackby(var/obj/item/WIELD, var/mob/user)
+    if(istype(WIELD, /obj/item/device/assembly/timer))
+        var/obj/item/device/assembly/timer/timer2 = WIELD
+        if(secured && timer2.secured)
+            timing = timer2.timing
+            time = timer2.time
+            to_chat(user, "You transfer the set time from [timer2] to [src].")
+    else
+        ..()


### PR DESCRIPTION
## About The Pull Request

An addition that should allow the time settings of one timer to be transferred to another timer. Time matters after all and setting a dozent timers can get very tedious, especially with latency in mind.

Credits:
ExcessiveUseOfCobbleStone from TG for the initial idea and implementation for signalers
DimasW99 for helping with a question and explaining a few things on Eriscode/Sojcode
IrkallaEpsilon (Me) for transferring this from signalers to timers

## Changelog
:cl:
add: Timers can now transfer their timing data by clicking one time with another.
/:cl:


