### PR TITLE
[Balancing] Lowers cooldown of Aulvaes limb regen

### DIFF
--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -744,8 +744,8 @@
 /* This is the old code for this perk, it does not work but it's left for postereity. Feel free to remove if you please - CDB
 /datum/perk/racial/limb_regen
 	name = "Gelatinous Regeneration"
-	desc = "Spend nutrition to regenerate lost limbs, albeit without fully fixing your injuries."
-	var/cooldown = 30 MINUTES
+	desc = "Spend nutrition to regenerate a lost limb, albeit without fully fixing your injuries."
+	var/cooldown = 5 MINUTES
 	passivePerk = FALSE
 	var/nutrition_cost = 300
 

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -664,7 +664,7 @@
 	desc = "By expending an extraordinary amount of energy you can kick your natural regeneration into high-gear, regenerating limbs and improving healing. \
 	This process must be done slowly and carefuly to avoid the risk of DNA damage and thus slows you down and limits consciousness."
 	icon_state = "hypermytosis"
-	var/cooldown = 30 MINUTES
+	var/cooldown = 5 MINUTES
 	passivePerk = FALSE
 	var/nutrition_cost = 450
 
@@ -745,7 +745,7 @@
 /datum/perk/racial/limb_regen
 	name = "Gelatinous Regeneration"
 	desc = "Spend nutrition to regenerate a lost limb, albeit without fully fixing your injuries."
-	var/cooldown = 5 MINUTES
+	var/cooldown = 30 MINUTES
 	passivePerk = FALSE
 	var/nutrition_cost = 300
 

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -744,7 +744,7 @@
 /* This is the old code for this perk, it does not work but it's left for postereity. Feel free to remove if you please - CDB
 /datum/perk/racial/limb_regen
 	name = "Gelatinous Regeneration"
-	desc = "Spend nutrition to regenerate a lost limb, albeit without fully fixing your injuries."
+	desc = "Spend nutrition to regenerate lost limbs, albeit without fully fixing your injuries."
 	var/cooldown = 30 MINUTES
 	passivePerk = FALSE
 	var/nutrition_cost = 300


### PR DESCRIPTION


## About The Pull Request
A simple PR of lowering the Aulvaes limb regen from the insane 30 minutes to 5. This ability is not spamable anyhow due to needing 300 nutrients per use and it also is not a full heal. Also CDB kindly asked for a buff on slime limb regen in terms of a cooldown reduction.

## Changelog
:cl:
balance: Aulvae Limb Regen from 30 minutes down to 5. 
/:cl:

