### PR TITLE
bluecross Lockpick o matic anti lag measures

### DIFF
--- a/code/modules/projectiles/guns/oddity_items.dm
+++ b/code/modules/projectiles/guns/oddity_items.dm
@@ -260,7 +260,7 @@
 			A \"presumebly\" endless supply of slaught-o-matics when drawn. You are never really able to tell when and how a new one takes its place when you draw one."
 	price_tag = 4000
 	var/spam_protection = 10 //The amount of guns we currently store
-	var/spam_protection_delay = 1 SECOND //How fast we recharge our storage
+	var/spam_protection_delay = 2 SECOND //How fast we recharge our storage
 	var/stored = 10
 
 /obj/item/clothing/accessory/holster/bluecross/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The lockpick o matic holster now holds 10 charges that recharge every second to prevent spam
The lockpick o matics despawn after a minute, making it a limit of 70 guns at a time when drawing constantly
The bullet type has been changed to caseless, damage mult, AP and recoil has been adjusted to compensate
Using the out of ammo special now stuns non humans. Bonus style!