### PR TITLE
Nerfs Plasma Firestacks

### DIFF
--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -6,7 +6,7 @@
 	damage_types = list(BURN = 28)
 	armor_penetration = 15
 	check_armour = ARMOR_ENERGY
-	fire_stacks = 2 //Blasma
+	fire_stacks = 1 //Blasma
 
 	affective_damage_range = 3
 	affective_ap_range = 5
@@ -33,7 +33,7 @@
 	affective_damage_range = 2
 	affective_ap_range = 3
 	recoil = 10
-	fire_stacks = 3
+	fire_stacks = 1
 
 	damage_types = list(BURN = 30)
 	armor_penetration = 30
@@ -48,7 +48,7 @@
 	affective_damage_range = 1
 	affective_ap_range = 2
 	recoil = 30
-	fire_stacks = 4
+	fire_stacks = 1
 
 /obj/item/projectile/plasma/impact
 	name = "plasma impact bolt"


### PR DESCRIPTION
Plasmaweapon Firestack per hit reduction

## About The Pull Request
The number one reason why any PVP encounter with anyone using plasma just isnt fun. Its actually also ultra boring to use if you are the user in PVP. 

So.. (X times 5+3) per firestack. The dinky soteria plasma applies already 2 stacks. Thats 13 damage per tick DOT. You can roll off 2 stacks per stop drop and roll. Reducing this to 1 cuts down the damage to 8. Still notable but gives you some more time to get the fuck out of dodge.

Worse offenders are church plasma and unbidden plasma. Those apply 4 stacks per hit and are burst fire. This is insanely lethal, stuns you with pain super fast and completely fucks any chance of counterplay. 

The firestack damage equation may need another look so less stacks (you have a little bit of burning going on your clothing) should affect you less while more stacks should affect you more but lets see if the amount of firestack shenanigans can be lowered by making plasma weapon firestacks more sane. 

Plasma weapons have high damage on top of their firestacks soooo..

## Changelog
:cl:
balance: Current attempt to make plasma weapons less of an I win button in PVP. They are okay for PVE still. Any and all plasma weapons that previously applied firestacks now only apply one stack per hit. If it is still a problem a firestack probability may be required.
/:cl:


