### PR TITLE
[Spellcheck] Fixes grammar on the scrapped positronic brain

### DIFF
--- a/code/game/objects/items/trash_material.dm
+++ b/code/game/objects/items/trash_material.dm
@@ -90,8 +90,8 @@
 	icon_state = "cutlass[rand(3)]"
 
 /obj/item/brokenposi
-	name = "Broken Positronic Brain"
-	desc = "Years upon years of being recycled over and over again this positronic brain ceased all its function. Yet it keeps reappearing in the same spot for some reason. Still contains the same amount of materials" // The Roundstart Posibrain turned into an oddity
+	name = "broken Positronic brain pieces"
+	desc = "Years upon years of being recycled over and over again this positronic brain has ceased all its function and has fallen to pieces. Yet it keeps reappearing in the same spot for some reason like some unnatural corpse. Still contains the same amount of materials." // The Roundstart Posibrain turned into an oddity
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "posibrain"
 	matter = list(MATERIAL_STEEL = 5, MATERIAL_GLASS = 5, MATERIAL_GOLD = 5, MATERIAL_SILVER = 5)

--- a/code/game/objects/items/trash_material.dm
+++ b/code/game/objects/items/trash_material.dm
@@ -91,7 +91,7 @@
 
 /obj/item/brokenposi
 	name = "broken Positronic brain pieces"
-	desc = "Years upon years of being recycled over and over again this positronic brain has ceased all its function and has fallen to pieces. Yet it keeps reappearing in the same spot for some reason like some unnatural corpse. Still contains the same amount of materials." // The Roundstart Posibrain turned into an oddity
+	desc = "Years upon years of being recycled over and over again has seen this positronic brain cease all its function and thus falling to pieces. Yet it keeps reappearing in the same spot for some reason like some unnatural corpse. Still contains the same amount of materials." // The Roundstart Posibrain turned into an oddity
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "posibrain"
 	matter = list(MATERIAL_STEEL = 5, MATERIAL_GLASS = 5, MATERIAL_GOLD = 5, MATERIAL_SILVER = 5)


### PR DESCRIPTION
What it says on the title, can't sleep till this typo and the grammar has been fixed or at least PRed.

## About The Pull Request
It just fixes grammar, typo and some flavor to the reappearing broken posibrain in the description.
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
spellcheck: Fixed a typo and some grammar and added a little bit more flavor to the roundstart broken posibrain
/:cl:

