### PR TITLE
[FIX] Vendor sprite icons now properly update when the panel is open and closed

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -327,7 +327,7 @@
 				to_chat(user, SPAN_NOTICE("You [panel_open ? "open" : "close"] the maintenance panel."))
 				cut_overlays()
 				if(panel_open)
-					add_overlay(image(icon, "[icon_type]-panel"))
+					add_overlay(image(icon, "[icon_type]-panel")) //we have to use add_overlay here as opposed to overlay += due to the latter adding another layer onto the icon with each use of the screwdriver
 			return
 
 		if(QUALITY_WELDING)


### PR DESCRIPTION
Ripping out autolathes panel state code for this seems to work rather well.

## About The Pull Request
Iconstates for any vendors were broken due to using += which, thanks to @Dimasw99 checking with VV turns out to add layer upon layer onto a vendor once screwed open but never removed the screwed open state for the sprite.

Taking add_overlay(image(icon, "[icon_type]-panel")), ripped from Autolathe code, fixes this. Tested on local. Ran around opened and closed vendors. Icons now properly display.

Might improve performance slightly as less shit is now stored on the vendor if screwed open.

Credits:
@Dimasw99 for VV checking on what actually fucks up
IrkallaEpsilon (me) for ripping out a working icon state update from autolathe.

To do in separate PRs: Look at telesci.

## Changelog
:cl:
fix: Vendors now show their closed and opened iconstate proper. Do not use overlay+= any further, simply use add_overlay(image(icon, "[icon_type]-panel")) as in this PR for any other iconstate issues with panels etc.
/:cl:


