### PR TITLE
[FIX] Assorted TeleSci Icon Fixes

### DIFF
--- a/code/modules/telesci/relay.dm
+++ b/code/modules/telesci/relay.dm
@@ -73,13 +73,13 @@
 		to_chat(user, "<span class='notice'>\The [src]s crystal slot is empty.")
 
 /obj/machinery/telesci_relay/update_icon()
-	cut_overlays()
+	cut_overlays()	
 	if(panel_open)
-		overlays += "relay-panel"
+		add_overlay("relay-panel")
 	if(checkCrystal())
-		overlays += "relay-powered"
+		add_overlay("relay-powered")
 	if(inUse)
-		overlays += "relay-calculating"
+		add_overlay("relay-calculating")
 
 /obj/machinery/telesci_relay/proc/getCrystalIntegrityPercent()
 	var/percent = stored_crystal.integrity/stored_crystal.max_integrity

--- a/code/modules/telesci/relay.dm
+++ b/code/modules/telesci/relay.dm
@@ -118,12 +118,12 @@
 	bluespace_entropy(2, get_turf(src), TRUE)
 	cut_overlays()
 	if(panel_open)
-		overlays += "relay-panel"
+		add_overlay("relay-panel")
 	if(burntOut)
-		overlays += "relay-fried"
+		add_overlay("relay-fried")
 		addtimer(CALLBACK(src, /atom/proc/update_icon), 4)
 	else
-		overlays += "relay-calculating"
+		add_overlay("relay-calculating")
 		addtimer(CALLBACK(src, /atom/proc/update_icon), 5)
 
 /obj/machinery/telesci_relay/proc/checkCrystal() //Like pingCrystal(), but without risking damage.

--- a/code/modules/telesci/telepads.dm
+++ b/code/modules/telesci/telepads.dm
@@ -94,13 +94,13 @@
 	return ..()
 
 /obj/machinery/telesci_pad/update_icon()
-	cut_overlays()
-	if(!(stat & NOPOWER))
-		overlays += "pad-powered"
-	if(panel_open)
-		overlays += "pad-panel"
-	if(calculating)
-		overlays += "pad-working"
+    cut_overlays()
+    if(!(stat & NOPOWER))
+        add_overlay("pad-powered")
+    if(panel_open)
+        add_overlay("pad-panel")
+    if(calculating)
+        add_overlay("pad-working")
 
 /obj/machinery/telesci_pad/proc/openPortal(x, y, z)
 	if(panel_open)

--- a/code/modules/telesci/teleporter_blocker.dm
+++ b/code/modules/telesci/teleporter_blocker.dm
@@ -52,10 +52,11 @@
 	..()
 
 /obj/machinery/telesci_inhibitor/update_icon()
+	cut_overlays()	
 	if(!(stat & NOPOWER))
-		overlays += "inhibitor-powered"
+		add_overlay("inhibitor-powered")
 	if(panel_open)
-		overlays += "inhibitor-panel"
+		add_overlay("inhibitor-panel")
 
 /obj/machinery/telesci_inhibitor/Destroy()
 	area.tele_inhibitors -= src
@@ -98,7 +99,8 @@
 	amount_extra_blocked = 0
 
 /obj/machinery/telesci_inhibitor/mini/update_icon()
+	cut_overlays()	
 	if(!(stat & NOPOWER))
-		overlays += "minihibitor-powered"
+		add_overlay("minihibitor-powered")
 	if(panel_open)
-		overlays += "minihibitor-panel"
+		add_overlay("minihibitor-panel")


### PR DESCRIPTION
Robust bay autolathe code saving the day again.

## About The Pull Request
Telesci Icon States are currently broken and dont properly update. This fixes icons for the "new" (ca 2022) telesci equipment.

Again overlays+= only adds a layer ontop. It does not clear icons. While add overlay clears up the the icon and returns to initial state.

Tested locally. Working.

Credits:
@Dimasw99 for VV checking what happens with the telesci equipment. 
IrkallaEpsilon (me) for grabbing autolathe iconstate check that was applied to vendor and then applied to here to fix it.
	

## Changelog
:cl:
fix: Fixes telesci iconstate overlays on open panel, inserted crystal etc.
/:cl:


