### PR TITLE
[FIX] [BALANCE] Dartrifle now functioning again + lower capacity fired with darts

### DIFF
--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -32,9 +32,7 @@
 	icon_state = "dart"
 	caliber = "dart"
 	projectile_type = /obj/item/projectile/bullet/chemdart
-
-/obj/item/ammo_casing/chemdart/expend()
-	qdel(src)
+	is_caseless = TRUE
 
 /obj/item/ammo_magazine/chemdart
 	name = "dart cartridge"

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -7,7 +7,7 @@
 	kill_count = 15 //shorter range
 	muzzle_type = null
 	reagent_flags = NO_REACT
-	var/reagent_amount = 15
+	var/reagent_amount = 5
 
 /obj/item/projectile/bullet/chemdart/New()
 	if (!testing)
@@ -67,7 +67,7 @@
 	var/list/beakers = list() //All containers inside the gun.
 	var/list/mixing = list() //Containers being used for mixing.
 	var/max_beakers = 3
-	var/dart_reagent_amount = 15
+	var/dart_reagent_amount = 5
 	var/beaker_type = /obj/item/reagent_containers/glass/beaker
 	var/list/starting_chems = null
 	serial_type = "SI"


### PR DESCRIPTION
## About The Pull Request
Dartrifle was not firing its chemdarts. Worse: It multiplied RECYCLEABLE chemdarts when standing on a spot and firing it allowing for infinite mats on some materials. This makes the darts caseless (they are pneumatically fired and thus dont have propellant) and thus restoring function to the dart rifle.

This also lowers the dart rifles chem payload per dart to 5. Why you ask? Well I am the sole reason why RSG (Rapid Syringe Gun) and analogues are nerfed on any and all codebases to either be single shot, don't apply certain reagents or simply have lower capacity.

Unrelated to this PR: Polytrinic acid is utterly harmless for whatever reason. Need to look into that next

## Changelog
:cl:
fix: Dartrifle now can fire its chemical darts again proper.
balance: Chemdarts now only hold 5u instead of 15
/:cl:


