### PR TITLE
[Balance, Buff] Polytrinic Acid lethality  

### DIFF
--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -388,7 +388,6 @@
 	power = 10
 	meltdose = 4
 	metabolism = REM * 2 //should neutralize reasonably fast in your blood if you want it more accurate to reality I can add some metabolites at some point for acids which are usually salts you do not want in your body either
-	strength = 2
 	illegal = TRUE
 	nerve_system_accumulations = 85
 

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -398,8 +398,8 @@
 	M.adjustFireLoss(5 * effect_multiplier) //burns you up rapidly
 	M.take_organ_damage(0.2 * effect_multiplier, 0) //fucks your organs but not as much as dedicated cytotoxins like Lexorin
 	if(prob(50))
-		M.adjustBrainLoss(4) //you injected yourself with acid of course its affects your brain
-	if(prob(20))
+		M.adjustBrainLoss(1) //you injected yourself with acid of course its affects your brain
+	if(prob(5))
 		to_chat(M, SPAN_DANGER("YOUR INSIDES ARE MELTING!!!")) //last but not least tells somebody they got hit by polytrinic
 
 /datum/reagent/toxin/lexorin

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -393,9 +393,8 @@
 	nerve_system_accumulations = 85
 
 /datum/reagent/toxin/polyacid/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	M.adjustToxLoss(rand(3,5) * effect_multiplier)
 	M.adjustOxyLoss(1 * effect_multiplier) //acidic vapors should fuck lungs especially if its probably just trekkified antimony pentafluoride
-	M.adjustFireLoss(5 * effect_multiplier) //burns you up rapidly
+	M.adjustFireLoss(3 * effect_multiplier) //burns you up rapidly
 	M.take_organ_damage(0.2 * effect_multiplier, 0) //fucks your organs but not as much as dedicated cytotoxins like Lexorin
 	if(prob(5))
 		to_chat(M, SPAN_DANGER("YOUR INSIDES ARE MELTING!!!")) //last but not least tells somebody they got hit by polytrinic

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -388,9 +388,20 @@
 	color = "#8E18A9"
 	power = 10
 	meltdose = 4
+	metabolism = REM * 2 //should neutralize reasonably fast in your blood if you want it more accurate to reality I can add some metabolites at some point for acids which are usually salts you do not want in your body either
+	strength = 2
 	illegal = TRUE
-	nerve_system_accumulations = 45
+	nerve_system_accumulations = 85
 
+/datum/reagent/toxin/polyacid/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.adjustToxLoss(rand(3,5) * effect_multiplier)
+	M.adjustOxyLoss(1 * effect_multiplier) //acidic vapors should fuck lungs especially if its probably just trekkified antimony pentafluoride
+	M.adjustBurnLoss(5 * effect_multiplier) //burns you up rapidly
+	M.take_organ_damage(0.2 * effect_multiplier, 0) //fucks your organs but not as much as dedicated cytotoxins like Lexorin
+	if(prob(50))
+		M.adjustBrainLoss(4) //you injected yourself with acid of course its affects your brain
+	if(prob(20))
+		to_chat(M, SPAN_DANGER("YOUR INSIDES ARE MELTING!!!")) //last but not least tells somebody they got hit by polytrinic
 
 /datum/reagent/toxin/lexorin
 	name = "Lexorin"

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -397,7 +397,7 @@
 	M.adjustOxyLoss(1 * effect_multiplier) //acidic vapors should fuck lungs especially if its probably just trekkified antimony pentafluoride
 	M.adjustFireLoss(5 * effect_multiplier) //burns you up rapidly
 	M.take_organ_damage(0.2 * effect_multiplier, 0) //fucks your organs but not as much as dedicated cytotoxins like Lexorin
-	if(prob(50))
+	if(prob(25))
 		M.adjustBrainLoss(1) //you injected yourself with acid of course its affects your brain
 	if(prob(5))
 		to_chat(M, SPAN_DANGER("YOUR INSIDES ARE MELTING!!!")) //last but not least tells somebody they got hit by polytrinic

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -231,7 +231,6 @@
 	taste_mult = 0.6
 	reagent_state = LIQUID
 	color = "#CF3600"
-	strength = 2
 	metabolism = REM/4 //0.05 Cyanide lasts within one day but duh...
 
 /datum/reagent/toxin/cyanide/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
@@ -396,7 +395,7 @@
 /datum/reagent/toxin/polyacid/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.adjustToxLoss(rand(3,5) * effect_multiplier)
 	M.adjustOxyLoss(1 * effect_multiplier) //acidic vapors should fuck lungs especially if its probably just trekkified antimony pentafluoride
-	M.adjustBurnLoss(5 * effect_multiplier) //burns you up rapidly
+	M.adjustFireLoss(5 * effect_multiplier) //burns you up rapidly
 	M.take_organ_damage(0.2 * effect_multiplier, 0) //fucks your organs but not as much as dedicated cytotoxins like Lexorin
 	if(prob(50))
 		M.adjustBrainLoss(4) //you injected yourself with acid of course its affects your brain

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -231,6 +231,7 @@
 	taste_mult = 0.6
 	reagent_state = LIQUID
 	color = "#CF3600"
+	strength = 2
 	metabolism = REM/4 //0.05 Cyanide lasts within one day but duh...
 
 /datum/reagent/toxin/cyanide/affect_blood(mob/living/carbon/M, alien, effect_multiplier)

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -397,8 +397,6 @@
 	M.adjustOxyLoss(1 * effect_multiplier) //acidic vapors should fuck lungs especially if its probably just trekkified antimony pentafluoride
 	M.adjustFireLoss(5 * effect_multiplier) //burns you up rapidly
 	M.take_organ_damage(0.2 * effect_multiplier, 0) //fucks your organs but not as much as dedicated cytotoxins like Lexorin
-	if(prob(25))
-		M.adjustBrainLoss(1) //you injected yourself with acid of course its affects your brain
 	if(prob(5))
 		to_chat(M, SPAN_DANGER("YOUR INSIDES ARE MELTING!!!")) //last but not least tells somebody they got hit by polytrinic
 


### PR DESCRIPTION
Right now you can drink Polytrinic with little consequence.

## About The Pull Request
During dicking around with the dart gun I figured that Polytrinic currently does nothing if its in your blood. Which makes zero sense considering this is the closest thing we got to a super acid. This PR aims to make it more lethal so it isn't a joke item that is currently an illegal substance for no reason.

So what it does: Burns you, causes organ damage, chokes you. It also tells you that your insides are melting because you *will know* when you somehow got a super acid inside of you. Or anything highly corrosive. Can go more into detail about some folks accidentally ramming a syringe loaded with Butyl-Lithium into themself. Thats not a a trivial injury or chemical burn. Neither is this shit.

## Changelog
:cl:
balance: Polytrinic now actually really hurts. Do not do the acid bucket challenge with it. Trust me.
/:cl:

