### PR TITLE
[Fix] Fixes broken thermodynamics resulting in critical thermal runaway reactions with plants

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -326,7 +326,7 @@
 	// Handle gas production.
 	if(exude_gasses && exude_gasses.len && !check_only)
 		for(var/gas in exude_gasses)
-			environment.adjust_gas(gas, max(1,round((exude_gasses[gas]*(get_trait(TRAIT_POTENCY)/5))/exude_gasses.len)))
+			environment.adjust_gas_temp(gas, max(1,round((exude_gasses[gas]*(get_trait(TRAIT_POTENCY)/5))/exude_gasses.len)), T20C)
 
 	//Handle temperature change.
 	if(get_trait(TRAIT_ALTER_TEMP) != 0 && !check_only)


### PR DESCRIPTION
Fixes a critical runaway reaction that can occur in fringe cases

## About The Pull Request
So: Picture this: You make a cold box for whatever reason, about 70 K in temperature. You manage to put a plant in there that produces N2O. This plant outputs gas. Sure. Okay. The problem arises that it just creates the gas at the temperature and pressure it is exposed to. This is a massive problem. Not for the low temperature case but for the high temperature case.

Lets say you luck out on strange seed or are a savy scientist wanting to have a miniscule amount of plasma for other research. Now you have a plant producing plasma and oxygen as byproducts (which can roll on lootbox seeds). Sure. Fine. Now that plasma ignites. As it currently is the plant will keep extruding gas at that temperature. If you are really *really* unlucky you roll traits which make it virtually immune to temperature. 

Then you can hook it up to gas harvesting setup and produce infinitely hotter getting gasses due to how our pipe code is set up.

Then you get a nice overflow at some point and you get nAN temperature and pressure for your gas. Anything that touches that is automatically nANed too. 

This PR fixes said fringe case of runaway gas reactions from plants which break thermodynamics in a way I wish I could do. With this PR plants output any gas products at a comfortable 20 °C (Room Temperature) preventing such nonesense. Still useful for reactions mind you. Still increases temperature in very long runs. It just does not nAN in a matter of anywhere between 5-30 minutes.

## Changelog
:cl:
fix: Plants with gas products now produce gasses at 20 °C flat in order to prevent critical thermal runaway reactions
/:cl:

