### PR TITLE
[Feature] Cindarite Voc, a Cindarite language PR

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -47,6 +47,7 @@
 #define IS_TREE 8
 #define IS_OPIFEX 9
 #define IS_NARAMAD 10
+#define IS_CINDARITE 11
 
 #define CE_STABLE			"stable" // Inaprovaline
 #define CE_ANTIBIOTIC		"antibiotic" // Spaceacilin

--- a/code/__DEFINES/species_languages.dm
+++ b/code/__DEFINES/species_languages.dm
@@ -44,6 +44,7 @@
 #define LANGUAGE_SYNTHETIC "Technical Cant"
 #define LANGUAGE_MERP "Narad Pidgin"
 #define LANGUAGE_BLORP "Aulvae Sonet"
+#define LANGUAGE_WEH "Cindarite Voc"
 
 // Special / Antag langauges.
 #define LANGUAGE_MONKEY "Chimpanzee"

--- a/code/modules/goonchat/browserassets/css/browserOutput_override.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_override.css
@@ -63,7 +63,7 @@
 .akula					{color: #f8412c}
 .plant					{color: #882d17}
 .opifex					{color: #e96443}
-.cindarite				{color: #006400}
+.cindarite				{color: #fa7373}
 
 .good                   {color: #4f8529; font-weight: bold;}
 .bad                    {color: #ee0000; font-weight: bold;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_override.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_override.css
@@ -63,6 +63,7 @@
 .akula					{color: #f8412c}
 .plant					{color: #882d17}
 .opifex					{color: #e96443}
+.cindarite				{color: #006400}
 
 .good                   {color: #4f8529; font-weight: bold;}
 .bad                    {color: #ee0000; font-weight: bold;}

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -212,10 +212,10 @@
 	key = "u"
 	has_written_form = TRUE
 	partial_understanding = list(
-		LANGUAGE_COMMON = 20 //Words often get imported into other languages especially if they convey the same information better that and common is the most common language
-		LANGUAGE_YASSARI = 10 //See common
-		LANGUAGE_EURO = 10, //See common
-		LANGUAGE_JANA = 10 //See common
+		LANGUAGE_COMMON = 20 
+		LANGUAGE_YASSARI = 10 
+		LANGUAGE_EURO = 10, 
+		LANGUAGE_JANA = 10 
 	)
 	shorthand = "CRV"
 	space_chance = 50

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -212,8 +212,8 @@
 	key = "u"
 	has_written_form = TRUE
 	partial_understanding = list(
-		LANGUAGE_COMMON = 20 
-		LANGUAGE_YASSARI = 10 
+		LANGUAGE_COMMON = 20, 
+		LANGUAGE_YASSARI = 10, 
 		LANGUAGE_EURO = 10, 
 		LANGUAGE_JANA = 10 
 	)

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -208,7 +208,7 @@
 	speech_verb = list("says", "hisses")
 	ask_verb = list("inquires")
 	exclaim_verb = list("bellows")
-	colour = "rough" //placeholder for now till somebody can explain me how to set this up proper 
+	colour = "cindarite" //placeholder for now till somebody can explain me how to set this up proper 
 	key = "u"
 	has_written_form = TRUE
 	shorthand = "CRV"

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -212,5 +212,5 @@
 	key = "u"
 	has_written_form = TRUE
 	shorthand = "CRV"
-	space_chance = 5
+	space_chance = 50
 	syllables = list("ssa", "zra", "sz", "sssc", "i", "zro", "zii", "zr", "zs", "sz", "ssso", "ol",  "or", "ar", "weh", "ors",  "uuz", "izu", "iso", "e", "a", "u", "lo", "ak", "ssro", "nar", "nra", "nzo", "ee", "li", "ki", "eeh", "ssh", "hssr", "hiissr", "rass", "sie", "lu", "ku", "ri", "bi", "bso", "om", "rro", "siksi", "don", "su", "sss", "ars", "ree", "ssan")

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -211,6 +211,12 @@
 	colour = "cindarite" //placeholder for now till somebody can explain me how to set this up proper 
 	key = "u"
 	has_written_form = TRUE
+	partial_understanding = list(
+		LANGUAGE_COMMON = 20 //Words often get imported into other languages especially if they convey the same information better that and common is the most common language
+		LANGUAGE_YASSARI = 10 //See common
+		LANGUAGE_EURO = 10, //See common
+		LANGUAGE_JANA = 10 //See common
+	)
 	shorthand = "CRV"
 	space_chance = 50
 	syllables = list("ssa", "zra", "sz", "sssc", "i", "zro", "zii", "zr", "zs", "sz", "ssso", "ol",  "or", "ar", "weh", "ors",  "uuz", "izu", "iso", "e", "a", "u", "lo", "ak", "ssro", "nar", "nra", "nzo", "ee", "li", "ki", "eeh", "ssh", "hssr", "hiissr", "rass", "sie", "lu", "ku", "ri", "bi", "bso", "om", "rro", "siksi", "don", "su", "sss", "ars", "ree", "ssan")

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -183,7 +183,6 @@
 	key = "p"
 	has_written_form = FALSE //Hiveminds don't get a written language.
 
-
 //Naramad language. full credit to Yanniert for all of the details herein contained.
 /datum/language/merp
 	name = LANGUAGE_MERP
@@ -201,3 +200,17 @@
 	shorthand = "NP"
 	space_chance = 5
 	syllables = list("Punainen", "Koira", "Tuolla", "Rikas", "syvä", "kivääri", "ulkomaalainen", "ihmisen", "sammakko", "taivaaseen", "Koti", "tilaa",  "sinä", "vastustamaton", "heimo", "klaani",  "kotitalous", "raha", "iso", "pieni", "sairaus", "ruokaa", "alkoholia", "kana", "asevelvollisuus", "alus", "joki", "saari", "ase", "veitsi", "juusto", "pää", "häntää", "taistelevat", "halaamalla", "ystävät", "ystävyys", "kansainyhteisö", "liitto", "aurinko", "missä", "mitä", "kun", "Miten", "siksi", "laulu", "kalastaa", "hämärä", "epäilyttävä", "luottamus", "kusipää", "paskiainen", "ääliö", "munata", "*!*")
+
+//Cindarite language: Lore: Cindarite Voc being a languaged optimized for clear communication. Its function over form having a clear distinct lack of metaphors and emphasizes mostly on relaying any information as optimal as possible due to their upbringing in bunkers on a highly dangerous homeworld. 
+/datum/language/weh
+	name = LANGUAGE_WEH
+	desc = "Cindarite Voc is language emphasizes clear communication with a distinct lack of metaphors and figures of speech to avoid unnecessary missunderstandings. It consists mostly of a combination of various hissing noises and guttural roars. Generations upon generations of living in bunkers on a highly hazardous planet resulted in Cindarite Voc from degrading from a colorful descriptive language to more rigid and functional tool to relay information."
+	speech_verb = list("says", "hisses")
+	ask_verb = list("inquires")
+	exclaim_verb = list("bellows")
+	colour = "rough" //placeholder for now till somebody can explain me how to set this up proper 
+	key = "u"
+	has_written_form = TRUE
+	shorthand = "CRV"
+	space_chance = 5
+	syllables = list("ssa", "zra", "sz", "sssc", "i", "zro", "zii", "zr", "zs", "sz", "ssso", "ol",  "or", "ar", "weh", "ors",  "uuz", "izu", "iso", "e", "a", "u", "lo", "ak", "ssro", "nar", "nra", "nzo", "ee", "li", "ki", "eeh", "ssh", "hssr", "hiissr", "rass", "sie", "lu", "ku", "ri", "bi", "bso", "om", "rro", "siksi", "don", "su", "sss", "ars", "ree", "ssan")

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -425,3 +425,5 @@
 		H.add_language(LANGUAGE_MERP)
 	if(H.species.reagent_tag == IS_SLIME)
 		H.add_language(LANGUAGE_BLORP)
+	if(H.species.reagent_tag == IS_CINDARITE)
+		H.add_language(LANGUAGE_WEH)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -515,6 +515,7 @@
 	name_plural = "Cindarites"
 	default_form = FORM_CINDAR
 	obligate_form = TRUE
+	reagent_tag = IS_CINDARITE
 	unarmed_types = list(/datum/unarmed_attack/punch, /datum/unarmed_attack/stomp,  /datum/unarmed_attack/kick, /datum/unarmed_attack/bite, /datum/unarmed_attack/tail)
 	num_alternate_languages = 2
 	blurb = "no"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -55,6 +55,7 @@
 	add_language(LANGUAGE_SYNTHETIC)
 	add_language(LANGUAGE_MERP)
 	add_language(LANGUAGE_BLORP)
+	add_language(LANGUAGE_WEH)
 	init_id()
 	init_subsystems()
 


### PR DESCRIPTION
Works on local very well, see screenshot below.

## About The Pull Request

Every race currently has an own language, even minor races. Cindarites currently lack that. This PR attempts to fix that.

The idea or lore behind is can be described as follows (WIP):

Cindarites originate from Cindar, which basically boils down to a radioactive deathworld with violent sandstorms containing glass shards. This is definitely not a comfortable environment to be in. They are confined to bunkers for the most part. Communication both inside and outside of bunkers in such an environment is critical and requires a very clear linguistic pattern. The language itself is described as devoid of rhetorical devices such as metaphors, allegories and colorful comparisons. It is optimized for relaying of information here and now. To non-speakers it is a bunch of hisses and bellows, you know typical lizard stuff. Cindarites on Solarian vessels were allowed to keep this language as part of their identity as it seems to help them work far more efficient in their groups. Of course to maximize efficiency with communication and shorten time on talking Cindarites embed acronyms into their own language. This would be something wherein two bunkers, who haven't communicated before, have issues communicating with one another as used acronyms may differ greatly. Could be interesting to see that acted out IC. 

Partial intelligibility to: Common, Jana, Eurolang, Jana. Reason being 1) CDB requested it and thinking about it this morning and it makes lots of sense since 2) import words are common IRL, especially if they convey concepts and information better than what the original word in a language did. 

Translators work obviously as seen with synthetic units. Obviously need some input from lore guys. Also fixed a rogue empty line from the cheese language


https://media.discordapp.net/attachments/860197732689903646/1232687601694146661/image.png?ex=662a5d4a&is=66290bca&hm=ddcd8709db94dd8b40c6a02b7425d1860a8dc92466ddf2fdff6e3555526e1a70&=&format=webp&quality=lossless&width=1199&height=444

Chat color (Thanks to Trilby for that, very pleasant to the eye.)

![image](https://github.com/sojourn-13/sojourn-station/assets/42441793/8f470786-9953-4bde-bd2a-f86727c7c88d)




## Changelog
:cl:
add: Cindarite Language, or Cindarite Voc as it currently is named. Be a Cindarite and pick it.
/:cl:

