### PR TITLE
[Balance, Fix(?), Math, Sanity Check] Rebalances firestacks to use a logistic function

### DIFF
--- a/code/__DEFINES/items_clothing.dm
+++ b/code/__DEFINES/items_clothing.dm
@@ -191,8 +191,8 @@
 
 // Fire.
 #define FIRE_MIN_STACKS          -20
-#define FIRE_MAX_STACKS           25
-#define FIRE_MAX_FIRESUIT_STACKS  20 // If the number of stacks goes above this firesuits won't protect you anymore. If not, you can walk around while on fire like a badass.
+#define FIRE_MAX_STACKS           40
+#define FIRE_MAX_FIRESUIT_STACKS  40 // If the number of stacks goes above this firesuits won't protect you anymore. If not, you can walk around while on fire like a badass.
 
 #define THROWFORCE_SPEED_DIVISOR    5  // The throwing speed value at which the throwforce multiplier is exactly 1.
 #define THROWNOBJ_KNOCKBACK_SPEED   15 // The minumum speed of a w_class 2 thrown object that will cause living mobs it hits to be knocked back. Heavier objects can cause knockback at lower speeds.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -429,7 +429,7 @@
 				adjust_fire_stacks(-1) //This is to simulate some processes that happen during incineration namely sintering and carbonization. Skin is porous. If something is heated pores grow and fuse and thus the surface area decreases. Carbonized skin is far less reactive than uncarbonized. So we have a decrease in surface area and a decrease in reactivity thus it gets harder to be incinerated. Very gamy explanation but thats the gist of it.
 			if(fire_stacks > 40)
 				fire_stacks = 40 //Hardcap to prevent gamers from applying 300 firestacks to a mob or player. That way people dont burn for all eternity.
-			if(fire_stacks == 0)
+			if(fire_stacks <= 0)
 				ExtinguishMob()
 
 /mob/living/fire_act()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -431,8 +431,6 @@
 				adjust_fire_stacks(-1)
 			if(fire_stacks > 26)
 				adjust_fire_stacks(-1) //This is to simulate some processes that happen during incineration namely sintering and carbonization. Skin is porous. If something is heated pores grow and fuse and thus the surface area decreases. Carbonized skin is far less reactive than uncarbonized. So we have a decrease in surface area and a decrease in reactivity thus it gets harder to be incinerated. Very gamy explanation but thats the gist of it.
-			if(fire_stacks > 40)
-				fire_stacks = 40 //2nd check for Hardcap to prevent gamers from applying 300 firestacks to a mob or player by various other exploits bypassing FIRE_MAX_STACKs. That way people dont burn for all eternity.
 			if(fire_stacks <= 0)
 				ExtinguishMob()
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -424,7 +424,11 @@
 			next_onfire_brn = world.time + 50
 			adjustFireLoss(20/(1+(NUM_E**(-0.25*(fire_stacks-10))))) //Logistic function A/(1+(e^(b*(x-y))) --> A the maximum number of burn you can take b the steepness of the curve y the point of inversion and x the number of firestacks. This results in that you may try to go above 30 firestacks but you still 'only' take 20 fire damage per cycle. Who would have thought that math learned 10 years ago is useful.
 			if(prob(40) && fire_stacks > 0) //over time the fire will slowly burn itself out. This is meant to be decently slow so as to not make fire much less dangerous as its purpose is to prevent issues when mobs hit tens of thousands of fireloss. Irkalla edit: I upped the loss chance to 40 so its less feeling like you got napalmed when you just set your coat on fire or something. Fire will still proc wounds and infections. It just wont turbokill you unless you are in an inferno unprotected
-				adjust_fire_stacks(-1) 
+				adjust_fire_stacks(-1)
+			if(fire_stacks > 26)
+				adjust_fire_stacks(-1)
+			if(fire_stacks > 40)
+				fire_stacks = 40
 			if(fire_stacks == 0)
 				ExtinguishMob()
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -424,6 +424,7 @@
 			next_onfire_brn = world.time + 50
 			if(fire_stacks <= 0)
 				ExtinguishMob()
+				return
 			if(fire_stacks > FIRE_MAX_STACKS)
 				fire_stacks = FIRE_MAX_STACKS //Hardcap to prevent gamers from applying 300 firestacks to a mob or player. That way people dont burn for all eternity.
 			adjustFireLoss(20/(1+(NUM_E**(-0.25*(fire_stacks-10))))) //Logistic function A/(1+(e^(b*(x-y))) --> A the maximum number of burn you can take b the steepness of the curve y the point of inversion and x the number of firestacks. This results in that you may try to go above 30 firestacks but you still 'only' take 20 fire damage per cycle. Who would have thought that math learned 10 years ago is useful.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -426,9 +426,9 @@
 			if(prob(40) && fire_stacks > 0) //over time the fire will slowly burn itself out. This is meant to be decently slow so as to not make fire much less dangerous as its purpose is to prevent issues when mobs hit tens of thousands of fireloss. Irkalla edit: I upped the loss chance to 40 so its less feeling like you got napalmed when you just set your coat on fire or something. Fire will still proc wounds and infections. It just wont turbokill you unless you are in an inferno unprotected
 				adjust_fire_stacks(-1)
 			if(fire_stacks > 26)
-				adjust_fire_stacks(-1)
+				adjust_fire_stacks(-1) //This is to simulate some processes that happen during incineration namely sintering and carbonization. Skin is porous. If something is heated pores grow and fuse and thus the surface area decreases. Carbonized skin is far less reactive than uncarbonized. So we have a decrease in surface area and a decrease in reactivity thus it gets harder to be incinerated. Very gamy explanation but thats the gist of it.
 			if(fire_stacks > 40)
-				fire_stacks = 40
+				fire_stacks = 40 //Hardcap to prevent gamers from applying 300 firestacks to a mob or player. That way people dont burn for all eternity.
 			if(fire_stacks == 0)
 				ExtinguishMob()
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -423,14 +423,14 @@
 		if(world.time >= next_onfire_brn)
 			next_onfire_brn = world.time + 50
 			adjustFireLoss(0.33*(NUM_E**(fire_stacks*0.25)) + 3) //This uses an attenuated natural exponential function. The + 3 at the end is there to make sure that you take some damage even at 1 stack. 7 stacks with this function deal about the same damage as 2 firestacks with the old equation also please if you plan to adjust this use wolfram alpha to sanity check your equation, can easily be adjusted to ones desire.
-			if(prob(60) && fire_stacks > 0) //over time the fire will slowly burn itself out. This is meant to be decently slow so as to not make fire much less dangerous as its purpose is to prevent issues when mobs hit tens of thousands of fireloss. Irkalla edit: I upped the loss chance to 40 so its less feeling like you got napalmed when you just set your coat on fire or something
+			if(prob(40) && fire_stacks > 0) //over time the fire will slowly burn itself out. This is meant to be decently slow so as to not make fire much less dangerous as its purpose is to prevent issues when mobs hit tens of thousands of fireloss. Irkalla edit: I upped the loss chance to 40 so its less feeling like you got napalmed when you just set your coat on fire or something
 				adjust_fire_stacks(-1) 
 			if(fire_stacks > 5)
-				adjust_fire_stacks(-2) //This is to simulate carbonization of surface area hence less material to burn
+				adjust_fire_stacks(-1) //This is to simulate carbonization of surface area hence less material to burn
 			if(fire_stacks > 12)
-				adjust_fire_stacks(-3) //Surface reduction from burning
+				adjust_fire_stacks(-2) //Surface reduction from burning
 			if(fire_stacks > 15)
-				adjust_fire_stacks(-4) //Here the efunction begins to pick up and apply damages similar to the ones from the old version
+				adjust_fire_stacks(-3) //Here the efunction begins to pick up and apply damages similar to the ones from the old version
 			if(fire_stacks > 18)
 				fire_stacks = 18 //Softcap to prevent people having thousands upon thousands of burn damage
 			if(fire_stacks == 0)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -422,6 +422,10 @@
 		bodytemperature += round(BODYTEMP_HEATING_MAX*(1-thermal_protection), 1)
 		if(world.time >= next_onfire_brn)
 			next_onfire_brn = world.time + 50
+			if(fire_stacks <= 0)
+				ExtinguishMob()
+			if(fire_stacks > FIRE_MAX_STACKS)
+				fire_stacks = FIRE_MAX_STACKS //Hardcap to prevent gamers from applying 300 firestacks to a mob or player. That way people dont burn for all eternity.
 			adjustFireLoss(20/(1+(NUM_E**(-0.25*(fire_stacks-10))))) //Logistic function A/(1+(e^(b*(x-y))) --> A the maximum number of burn you can take b the steepness of the curve y the point of inversion and x the number of firestacks. This results in that you may try to go above 30 firestacks but you still 'only' take 20 fire damage per cycle. Who would have thought that math learned 10 years ago is useful.
 			if(prob(40) && fire_stacks > 0) //over time the fire will slowly burn itself out. This is meant to be decently slow so as to not make fire much less dangerous as its purpose is to prevent issues when mobs hit tens of thousands of fireloss. Irkalla edit: I upped the loss chance to 40 so its less feeling like you got napalmed when you just set your coat on fire or something. Fire will still proc wounds and infections. It just wont turbokill you unless you are in an inferno unprotected
 				adjust_fire_stacks(-1)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -432,7 +432,7 @@
 			if(fire_stacks > 26)
 				adjust_fire_stacks(-1) //This is to simulate some processes that happen during incineration namely sintering and carbonization. Skin is porous. If something is heated pores grow and fuse and thus the surface area decreases. Carbonized skin is far less reactive than uncarbonized. So we have a decrease in surface area and a decrease in reactivity thus it gets harder to be incinerated. Very gamy explanation but thats the gist of it.
 			if(fire_stacks > 40)
-				fire_stacks = 40 //Hardcap to prevent gamers from applying 300 firestacks to a mob or player. That way people dont burn for all eternity.
+				fire_stacks = 40 //2nd check for Hardcap to prevent gamers from applying 300 firestacks to a mob or player by various other exploits bypassing FIRE_MAX_STACKs. That way people dont burn for all eternity.
 			if(fire_stacks <= 0)
 				ExtinguishMob()
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -418,31 +418,15 @@
 	var/burn_temperature = fire_burn_temperature()
 	var/thermal_protection = get_heat_protection(burn_temperature)
 
-	if (thermal_protection < 1 && bodytemperature < burn_temperature && on_fire && fire_stacks < 20)
+	if (thermal_protection < 1 && bodytemperature < burn_temperature && on_fire)
 		bodytemperature += round(BODYTEMP_HEATING_MAX*(1-thermal_protection), 1)
 		if(world.time >= next_onfire_brn)
 			next_onfire_brn = world.time + 50
-			adjustFireLoss(0.33*(NUM_E**(fire_stacks*0.25)) + 3) //This uses an attenuated natural exponential function. The + 3 at the end is there to make sure that you take some damage even at 1 stack. 7 stacks with this function deal about the same damage as 2 firestacks with the old equation also please if you plan to adjust this use wolfram alpha to sanity check your equation, can easily be adjusted to ones desire.
-			if(prob(40) && fire_stacks > 0) //over time the fire will slowly burn itself out. This is meant to be decently slow so as to not make fire much less dangerous as its purpose is to prevent issues when mobs hit tens of thousands of fireloss. Irkalla edit: I upped the loss chance to 40 so its less feeling like you got napalmed when you just set your coat on fire or something
+			adjustFireLoss(20/(1+(NUM_E**(-0.25*(fire_stacks-10))))) //Logistic function A/(1+(e^(b*(x-y))) --> A the maximum number of burn you can take b the steepness of the curve y the point of inversion and x the number of firestacks. This results in that you may try to go above 30 firestacks but you still 'only' take 20 fire damage per cycle. Who would have thought that math learned 10 years ago is useful.
+			if(prob(40) && fire_stacks > 0) //over time the fire will slowly burn itself out. This is meant to be decently slow so as to not make fire much less dangerous as its purpose is to prevent issues when mobs hit tens of thousands of fireloss. Irkalla edit: I upped the loss chance to 40 so its less feeling like you got napalmed when you just set your coat on fire or something. Fire will still proc wounds and infections. It just wont turbokill you unless you are in an inferno unprotected
 				adjust_fire_stacks(-1) 
-			if(fire_stacks > 5)
-				adjust_fire_stacks(-1) //This is to simulate carbonization of surface area hence less material to burn
-			if(fire_stacks > 12)
-				adjust_fire_stacks(-2) //Surface reduction from burning
-			if(fire_stacks > 15)
-				adjust_fire_stacks(-3) //Here the efunction begins to pick up and apply damages similar to the ones from the old version
-			if(fire_stacks > 18)
-				fire_stacks = 18 //Softcap to prevent people having thousands upon thousands of burn damage
 			if(fire_stacks == 0)
 				ExtinguishMob()
-				
-	if (thermal_protection < 1 && bodytemperature < burn_temperature && on_fire && fire_stacks >= 20) //prevents incendiary grenade abuse for thousands of burn damage due to e function, linear area of function
-		bodytemperature += round(BODYTEMP_HEATING_MAX*(1-thermal_protection), 1)
-		if(world.time >= next_onfire_brn)
-			next_onfire_brn = world.time + 50
-			adjustFireLoss(fire_stacks*3 + 3) //linear scaling from 20 onwards
-			if(fire_stacks >18) //Down to softcap and e-function processing
-				fire_stacks = 18
 
 /mob/living/fire_act()
 	adjust_fire_stacks(2)


### PR DESCRIPTION
So this needs some explanation I suppose.



## About The Pull Request

Firestacks currently are hyperlethal due to the equation for the burn damage being 5*Firestacks+3 with Firestacks from now on referred to as X. So even at 4 firestacks which means being hit ONCE by an incendiary slug you wind up with a DOT of 23 burn per fire process. This is really nasty, rapidly causes infections and wounds and also feels very off. So instead of a really harsh linear scaling I decided to use a logistics function. Its a subtype of an exponential function with some very interesting attributes:

A/1+(e^(-b*(x-s)) 

A is the max value this function can reach (how much burn per processing tick for firestacks, no matter what you do the fire damage you will do at maximum per tick is A. There is no way around it, thats how the function is designed
b steepness scale factor (how harsh we want more firestacks to be, real number)
s = Sigmoid midpoint (point of inversion of function, real number)
x = number of firestacks (how many stacks you got, natural number)

I have to emphasis here that this function might break if one tries to put in complex numbers in there. I doubt byond can do that but in case that can do that. Do not do this.

Also it should be said that one should avoid touching point of inversion/sigmoid. That will mess the function up easily by throwing off on when it inverts and thus shifting slope etc. If adjustments need to be made handle with A or with b. I should be around to make adjustments as well if needed.

This function basically limits damage from firestacks to 20 damage per cycle. So standing in an inferno is a *very* bad idea still. Getting tagged once or twice with a plasma is no longer a death sentence though one should still see a doctor for infections. If one gets hit by current iteration incendiary shotgun shells one should still see a doctor.

Additionally; Heat damage still applies separately. Keep that in mind. Heat damage IS NOT fire_stack damage.

With that the out of the way:

Eq. 1:

f(x) = 20/(1+(e^(-0.25*(x-10)))


X being the number of firestacks somebody holds.
And f(x) obviously being the firedamage you can take.
Again the function is setup in such a way you can take no more than 20 burn damage for a single burn tick.

This is less bloaty than the initial iteration of this PR, more friendly to processing power, future proof unless somebody changes the function of how burnstacks work here and most importantly should not be exploitable because the function converges at 20 for X = 30. So gamers with methods to apply 100 burn stacks will still only do 20 burn per second. Oh. For gamers that think "Sure but they still burn as long." I implemented a maximum number of burn stacks too. So you can no more than 40 burnstacks. So the damage hardcap is 20 burn per tick. The burnstack hardcap is 40.


Was this tested? I spend the better half of the day getting this sorted with a solid amount of testing on local. It works. Sure one can adjust the logistic function a little but so far it looks good:

Extinguishing works.

Low burnstacks are inconvenient and still cause wounds

High burnstack count hurts like fuck

Much saner fire damage.

Incendiary grenades are still turbolethal if you stay in them (Do not do this.

Heres the google plot to describe Eq. 1.

![image](https://github.com/sojourn-13/sojourn-station/assets/42441793/3359bfbe-6c7f-44c2-b8ed-021a728695de)



## Changelog
:cl:
tweak: Makes burn damage less harsh at low firestacks by employing an logistic function for damage. Lethality of fire is still provided while low firestacks (1-4) are FAR less lethal and no more of an instant kill. If this function is tweaked in the future PLEASE use Wolfram Alpha, Google or OriginPro to visualize your function and see if it makes sense. Firestack loss at low firestacks is now somewhat faster, not that it matters because infections and organ wounds will get you regardless. Added a hard cap for firestacks. No more than 40 stacks on a person. Decay of firestacks above 26 is now with 1 firestack per process guaranteed to simulate various surface reduction processes at prolonged burning.
/:cl:


