### PR TITLE
Fixes some tool upgrade intractions

### DIFF
--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -787,7 +787,7 @@
 
 /datum/component/upgrade_removal/proc/attempt_uninstall(var/obj/item/C, var/mob/living/user)
 	if(!isitem(C))
-		return 0
+		return FALSE
 
 	var/obj/item/upgrade_loc = parent
 
@@ -798,7 +798,7 @@
 
 	if(istype(upgrade_loc, /obj/item/clothing))
 		//to_chat(user, SPAN_DANGER("You cannot remove armor upgrades once they've been installed!")) so we dont spawm for suit changing
-		return 1
+		return FALSE
 
 	ASSERT(istype(upgrade_loc))
 	//Removing upgrades from a tool. Very difficult, but passing the check only gets you the perfect result
@@ -809,17 +809,17 @@
 		possibles += "Cancel"
 		var/obj/item/tool_upgrade/toremove = input("Which upgrade would you like to try to remove? The upgrade will probably be destroyed in the process","Removing Upgrades") in possibles
 		if (toremove == "Cancel")
-			return 1
+			return TRUE
 		if(!toremove.can_remove)
 			to_chat(user, SPAN_DANGER("You cannot remove [toremove] once it's been installed!"))
-			return 0
+			return FALSE
 		var/datum/component/item_upgrade/IU = toremove.GetComponent(/datum/component/item_upgrade)
 		if(C.use_tool(user = user, target =  upgrade_loc, base_time = IU.removal_time, required_quality = QUALITY_SCREW_DRIVING, fail_chance = IU.removal_difficulty, required_stat = STAT_MEC))
 			//If you pass the check, then you manage to remove the upgrade intact
 			to_chat(user, SPAN_NOTICE("You successfully remove \the [toremove] while leaving it intact."))
 			LEGACY_SEND_SIGNAL(toremove, COMSIG_REMOVE, upgrade_loc)
 			upgrade_loc.refresh_upgrades()
-			return 1
+			return TRUE
 		else
 			//You failed the check, lets see what happens
 			if(IU.breakable == FALSE)
@@ -833,14 +833,14 @@
 				QDEL_NULL(toremove)
 				upgrade_loc.refresh_upgrades()
 				user.update_action_buttons()
-				return 1
+				return TRUE
 			else if(T && T.degradation) //Because robot tools are unbreakable
 				//otherwise, damage the host tool a bit, and give you another try
 				to_chat(user, SPAN_DANGER("You only managed to damage \the [upgrade_loc], but you can retry."))
 				T.adjustToolHealth(-(5 * T.degradation), user) // inflicting 4 times use damage
 				upgrade_loc.refresh_upgrades()
 				user.update_action_buttons()
-				return 1
+				return TRUE
 	return 0
 
 

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -447,6 +447,7 @@
 	matter = null //magicium
 	clickdelay_offset = -4 //DEFAULT_QUICK_COOLDOWN = 4 so we offset are weapon to quick
 	var/datum/component/rnd_points/point_holder
+	degradation = 0.4 //Used a lot
 
 /obj/item/tool/sword/saber/deconstuctive_rapier/New()
 	..()
@@ -494,6 +495,13 @@
 	reagent_flags = INJECTABLE|TRANSPARENT
 	matter = null //magicium
 	clickdelay_offset = -4 //DEFAULT_QUICK_COOLDOWN = 4 so we offset are weapon to quick
+	degradation = 0.4 //Used a lot
+	var/max_reagents = 30
+
+/obj/item/tool/sword/saber/injection_rapier/refresh_upgrades()
+	..()
+	if(reagents)
+		reagents.maximum_volume = max_reagents
 
 /obj/item/tool/sword/saber/injection_rapier/New()
 	..()

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -448,6 +448,7 @@
 	clickdelay_offset = -4 //DEFAULT_QUICK_COOLDOWN = 4 so we offset are weapon to quick
 	var/datum/component/rnd_points/point_holder
 	degradation = 0.4 //Used a lot
+	embed_mult = 0
 
 /obj/item/tool/sword/saber/deconstuctive_rapier/New()
 	..()
@@ -497,6 +498,7 @@
 	clickdelay_offset = -4 //DEFAULT_QUICK_COOLDOWN = 4 so we offset are weapon to quick
 	degradation = 0.4 //Used a lot
 	var/max_reagents = 30
+	embed_mult = 0
 
 /obj/item/tool/sword/saber/injection_rapier/refresh_upgrades()
 	..()

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -162,17 +162,23 @@ var/global/list/breach_burn_descriptors = list(
 			else if(B.damtype == BURN)
 				burn_damage += B.class
 
-	if(damage >= 3)
-		if(brute_damage >= 3 && brute_damage > burn_damage)
-			name = "punctured [base_name]"
-		else if(burn_damage >= 3 && burn_damage > brute_damage)
-			name = "scorched [base_name]"
-		else
-			name = "damaged [base_name]"
-	else
-		name = "[base_name]"
+	refresh_upgrades() //handles name
 
 	return damage
+
+/obj/item/clothing/suit/space/refresh_upgrades()
+	..()
+	var/edit_name
+	if(damage >= 3)
+		if(brute_damage >= 3 && brute_damage > burn_damage)
+			edit_name = "punctured"
+		else if(burn_damage >= 3 && burn_damage > brute_damage)
+			edit_name = "scorched"
+		else
+			edit_name = "damaged"
+	else
+		name = "[edit_name] [name]"
+
 
 //Handles repairs (and also upgrades).
 
@@ -233,7 +239,7 @@ var/global/list/breach_burn_descriptors = list(
 
 		return
 
-	..()
+	.=..()
 
 /obj/item/clothing/suit/space/examine(mob/user)
 	..(user)

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -280,4 +280,4 @@
 			playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		return
 
-	..()
+	.=..()


### PR DESCRIPTION
## About The Pull Request
Injector Rapier no longer breaks when upgraded
Injector and Deconner Rapier break less often (tool health wise)
Rapiers do not embed anymore as they are rapiers. Not Sabers 
Void suits and armor now have proper returns when upgrades are given to them
**You can now fix voidsuits that are damaged if its upgraded**
close #5038
close #4769