### PR TITLE
[Fix] Icons now update again when an APC is rebooted during the best event in the game

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1020,7 +1020,7 @@
 		//		malfvacate()
 		if("reboot")
 			failure_timer = 0
-			force_update = FALSE
+			force_update = TRUE
 			update_icon()
 			update()
 		//if("emergency_lighting")		we don't have those


### PR DESCRIPTION
Icons of APCs were stuck on bluescreen power outage. Really annoying once you note it. Its also really inconsistent on servers, sometimes the iconstate update works, sometimes it doesn't. Assume that happens because they are changing to another icon state and thus get stuck. Forcing an update upon reboot should fix this.


## About The Pull Request
Fixes APCs not updating icon state and overlays when bluescreened.

Additionally it turns out we do not have a panel overlay for bluescreened APCs. Thats however spritework I guess which is uhghghhghghgkldfgjkghjk

Tested locally:

Went in: Triggered the best event in all of SS13. Went to closest APC. Rebooted APC. Screen changed.

If TMed please report of any abnormalities since thats some really obscure POS code from malf AI back when that was a thing on bay during the stone age. I am not sure if we even *need* that statement as its from ancient rogue AI code that we do not use anymore.

Update: That weird malf AI residual code that I changed the setting to true for: Needed. Commenting it out and rebooting APCs does not work.

So setting this to true allows icon states to update upon reboot.	

## Changelog
:cl:
fix: APC Icons now update again if manually rebooted during the best event ever made; The gridcheck
/:cl:


