### PR TITLE
[Balance, Fix, Spritefix] Corestopper inconsistency fix

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -140,7 +140,7 @@
 	nodamage = TRUE
 	check_armour = ARMOR_ENERGY
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	hitscan = TRUE
+	hitscan = FALSE
 
 /obj/item/projectile/slime_death/on_impact(atom/target)//These two could likely check temp protection on the mob
 	if (!testing)


### PR DESCRIPTION
So. Some gamer set the corestopper to be hitscan.  While this is a very cool idea this has a few nasty implications. The gun deals no damage per say and calls a proc to kill a slime. The gun is supposed to pass through windows if fired. This is very interesting. Unfortunately it makes the gun very inconsistent due to it being hitscan and often functionally useless. Additionally the sprite of the projectile is completely invisible due to hitscan.

## About The Pull Request
This PR:

Sets the corestopper to be a projectile and not a (s)hitscan. This fixes the invisible sprite on the beam, allows it to kill slimes more consistently and most importantly doesnt break half the time you try to shoot them through windows due to clipping somehow on the disposal chute.

Drawbacks to this: Well its no longer hitscan so you have to actually aim. But overall this should hopefully make the gun more usable for people doing xenobiology and stop the relatively frequent "The gun doesnt work at all CRO" which is fair because it often simply does not work due to wonkyness of hitscan paired with window passing and a 0 damage gun.

Tested locally obviously. Works.

## Changelog
:cl:
fix: Fixes the corestoppers projectile being not visible and often not affecting slimes in the slightest by turning it from hitscan into an actual projectile.
/:cl:

