### PR TITLE
[Fix] Fixes Inner Peace Church Litany

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -379,7 +379,7 @@
 		if (!(T.Adjacent(get_turf(H))))
 			fail("[H] is beyond your reach..", user, C)
 			return FALSE
-		to_chat(H, "<span class='info'>[User] shares their mountain of of faith as with you as feel calmer and focussed.</span>")
+		to_chat(H, "<span class='info'>As a mountain of of faith is shared with you a senstation of calmness and focus settles in.</span>")
 		H.sanity.changeLevel(40)
 		H.updatehealth()
 		user.sanity.changeLevel(-20)


### PR DESCRIPTION
The entire litany and its target acquisition was fundamentally broken and did not work at all. So I gave it a rewrite to make it work.

## About The Pull Request
What this does: Takes some code from existing litanies (Succour), repurposes it quite a bit. Now the litany is two stage: First it checks if somebody is adjacent to you. If adjacent it begins a channel.

During the channel it checks:

If you are synthetic: It wont proceed
If your target is a synthetic: It won't proceed
If your target moved out of the way: It won't proceed
Else it will proceed.

Local testing conducted with 3 characters: Organic test subject, organic prime and synthetic vector.

Prime casting on vector: Failed
Vector Synthetic casting on either: Failed
Prime casting on organic test subject: Works. Sanity deducted from prime and added to test subject. Goes into cooldown as well.

![image](https://github.com/sojourn-13/sojourn-station/assets/42441793/daf19398-80a1-4ca5-857e-2138b29590cf)

Here a screenshot from debug testing. Don't mind the funny headpat message, it was there for debugging. Its no longer in the code.

Going to push an update immedaitely after for the last bit of flavortext btw.
	
## Changelog
:cl:
fix: Fixes Monomial Inner Peace Litany to now actually work instead of not doing anything.
/:cl:


