### PR TITLE
surface transport access patch

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -48072,7 +48072,7 @@
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "shuttle_hatch_bolts";
 	name = "Shuttle Hatch";
-	req_one_access = list(1,19,80)
+	req_one_access = list(1,5,19,80)
 	},
 /obj/machinery/button/remote/airlock{
 	id = "shuttle_hatch_bolts";


### PR DESCRIPTION
-Alters the door on the surface transport to have soteria general access. The medical access it had before didn't work as intended for half of the medical positions. (I.E. lifeline techs)