### PR TITLE
[Balance] Unmaker can no longer fit on the Firestorm

### DIFF
--- a/code/modules/projectiles/guns/energy/laser/firestorm.dm
+++ b/code/modules/projectiles/guns/energy/laser/firestorm.dm
@@ -19,6 +19,7 @@
 	init_recoil = CARBINE_RECOIL(0.2)
 	projectile_type = /obj/item/projectile/beam
 	cell_type = /obj/item/cell/small
+	blacklist_upgrades = list(/obj/item/gun_upgrade/mechanism/greyson_master_catalyst = TRUE)
 	charge_cost = 40
 	gun_tags = list(GUN_LASER, GUN_ENERGY, GUN_SCOPE)
 	init_firemodes = list(


### PR DESCRIPTION
Blacklists Unmaker from Firestorm SMG

## About The Pull Request

I don't know why this still fits on there. This gun has the highest firerate of all energy weapons and it can still fit this thing. Additionally the gun is really really small. Currently contender of highest DPS gun. This hopefully knocks it back down.

I am not joking. This turns a mid weapon into a 300 DPS monstrosity that you can dual wield.  


## Changelog
:cl:
balance: Unmakers no longer fit Fierstorm.
/:cl:


