### PR TITLE
spin fix

### DIFF
--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -324,23 +324,26 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 
 //Deprecated, use SpinAnimation when possible
-/mob/proc/spin(spintime, speed)
-	spawn()
-		var/D = dir
-		while(spintime >= speed)
-			sleep(speed)
-			switch(D)
-				if(NORTH)
-					D = EAST
-				if(SOUTH)
-					D = WEST
-				if(EAST)
-					D = SOUTH
-				if(WEST)
-					D = NORTH
-			set_dir(D)
-			spintime -= speed
-	return
+/mob/proc/spin(var/spintime = 1, var/speed = 1)
+	set waitfor = FALSE
+	if (!spintime || !speed)
+		return
+	spintime = clamp(spintime, 1, 10 SECONDS)
+	speed = clamp(speed, 1, 2 SECONDS)
+	var/D = dir
+	while(spintime >= speed)
+		sleep(speed)
+		switch(D)
+			if(NORTH)
+				D = EAST
+			if(SOUTH)
+				D = WEST
+			if(EAST)
+				D = SOUTH
+			if(WEST)
+				D = NORTH
+		set_dir(D)
+		spintime -= speed
 
 /atom/movable/proc/do_pickup_animation(atom/target, atom/old_loc)
 	set waitfor = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Port spin fix from https://github.com/Baystation12/Baystation12/pull/33885 that would otherwise cause a sleep(0) to loop endlessly if called by just spin()
Kudos to DRD for causing another crash and shame on chefdoggo for being the fool to call it (jk love you)