### PR TITLE
Changes LSS ERT to an IAA

### DIFF
--- a/code/datums/outfits/jobs/ghostroles.dm
+++ b/code/datums/outfits/jobs/ghostroles.dm
@@ -39,9 +39,15 @@
 	glasses = /obj/item/clothing/glasses/hud/health
 	shoes = /obj/item/clothing/shoes/reinforced/medical
 	back = /obj/item/storage/backpack/satchel/medical
-	backpack_contents = list(/obj/item/storage/firstaid/soteria = 1, /obj/item/gun/projectile/automatic/c20r/sci/preloaded = 1, \
-							/obj/item/gun_upgrade/trigger/dnalock = 1, /obj/item/gun_upgrade/muzzle/silencer = 1, /obj/item/bodybag/cryobag = 2, \
-							/obj/item/storage/firstaid/blackshield/large = 1, /obj/item/storage/firstaid/surgery/si = 1, /obj/item/roller/compact  = 1, /obj/item/device/defib_kit/compact/combat/adv/loaded = 1)
+	backpack_contents = list(/obj/item/storage/firstaid/soteria = 1,
+							/obj/item/gun/projectile/automatic/c20r/sci/preloaded = 1,
+							/obj/item/gun_upgrade/trigger/dnalock = 1,
+							/obj/item/gun_upgrade/muzzle/silencer = 1,
+							/obj/item/bodybag/cryobag = 2,
+							/obj/item/storage/firstaid/blackshield/large = 1,
+							/obj/item/storage/firstaid/surgery/si = 1,
+							/obj/item/roller/compact  = 1,
+							/obj/item/device/defib_kit/compact/combat/adv/loaded = 1)
 	id_slot = slot_wear_id
 	id_type =  /obj/item/card/id/syndicate/ert/medical_ert
 
@@ -110,11 +116,9 @@
 	id_type =  /obj/item/card/id/syndicate/ert/aa/guild_ert
 
 /decl/hierarchy/outfit/lss_ert
-	name = "Auditor"
-	l_ear = /obj/item/device/radio/headset/headset_com
-	head = /obj/item/clothing/head/helmet/technomancersuit //Looks good enuff and has good armor I guess
+	name = "Internal Affairs Agent"
+	l_ear = /obj/item/device/radio/headset/heads/merchant
 	uniform = /obj/item/clothing/under/suit_jacket/executive
-	suit = /obj/item/clothing/suit/storage/cargovest
 	r_pocket = /obj/item/device/t_scanner/advanced
 	pda_type = /obj/item/modular_computer/pda/heads
 	glasses = /obj/item/clothing/glasses/sunglasses/big

--- a/code/game/objects/effects/spawners/ghostroles.dm
+++ b/code/game/objects/effects/spawners/ghostroles.dm
@@ -190,17 +190,16 @@
 
 /obj/effect/mob_spawn/human/lonestar_ert
 	name = "deployment sleeper"
-	desc = "A sleeper, with an unconscious body inside. The occupant seems to be an Auditor."
+	desc = "A sleeper, with an unconscious body inside. The occupant seems to be a Lonestar IA Agent."
 	mob_name = "a human"
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "sleeper_1"
 	outfit = /decl/hierarchy/outfit/lss_ert
-	ghost_role_perks = list(PERK_SI_SCI, PERK_CHEMIST, PERK_SURE_STEP, PERK_TRUE_NAME)
-	short_desc = "You are an Auditor."
-	flavour_text = "The upper colony has done something thats not upto code, whether it be LSS, SI or any other department your job is to look into any matter that HC tells you about. \
-	You're not a cop, you're not medical personal you're here to correct some papers not criminals."
-	assignedrole = "Guild Emergency Personnel"
-	title = "Guild Emergency Personnel"
+	ghost_role_perks = list(PERK_NO_OBFUSCATION, PERK_MARKET_PROF, PERK_TRUE_NAME)
+	short_desc = "You are an Internal Affairs Agent."
+	flavour_text = "Lonestar's surface operations have run into some troubles, and your job is to handle them. Speak to those involved, make decisions, keep the profits flowing."
+	assignedrole = "Lonestar Internal Affairs Agent"
+	title = "Lonestar Internal Affairs Agent"
 	stat_modifiers = list(
 		STAT_ROB = 45,
 		STAT_TGH = 45,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Changes the Lonestar ERT to be an Internal Affairs Agent rather than an Auditor
</summary>
<hr>

It was kinda weird to have an Auditor as the one who handles when CEOs are acting out of line in things other than their numbers not matching up, so changing it over to IAA makes more sense. Also tweaks their uniform to not have weird guild things.	
<hr>
</details>

## Changelog
:cl:
tweak: Lonestar ERT is now an IAA rather than an Auditor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
