### PR TITLE
Chaos intrigration

### DIFF
--- a/code/game/objects/random/mob/greyson.dm
+++ b/code/game/objects/random/mob/greyson.dm
@@ -5,10 +5,7 @@
 	has_postspawn = TRUE
 	late_handling = TRUE //Only used in GP moon base
 	alpha = 128
-
-/obj/random/mob/roomba/item_to_spawn()
-	return pickweight(list(
-				/mob/living/carbon/superior_animal/robot/greyson/roomba = 17,
+	mobs = list(/mob/living/carbon/superior_animal/robot/greyson/roomba = 17,
 				/mob/living/carbon/superior_animal/robot/greyson/roomba/slayer = 15,
 				/mob/living/carbon/superior_animal/robot/greyson/roomba/trip = 10,
 				/mob/living/carbon/superior_animal/robot/greyson/roomba/trip/armored = 3,
@@ -26,12 +23,19 @@
 				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol = 15,
 				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg = 12,
 				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle = 9,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy = 4,
-				/mob/living/carbon/superior_animal/robot/greyson/stalker = 2,
-				/mob/living/carbon/superior_animal/robot/greyson/stalker/dual = 1,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = 3,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = 2
-				))
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy = 4
+				)
+
+/obj/random/mob/roomba/item_to_spawn()
+	if(GLOB.chaos_level > 0) //Higher weights as chaose increase
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/stalker = (2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/stalker/dual = (1 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = (3 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = (2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/roomba/boomba = (4 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 1)
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/sniper/lowestrange = (0.5 * GLOB.chaos_level))
+	return pickweight(mobs)
 
 /obj/random/mob/roomba/post_spawn(var/list/spawns)
 	for(var/mob/living/simple_animal/A in spawns)
@@ -46,42 +50,59 @@
 	name = "random greyson bot (100% Spawns Job based)"
 	has_postspawn = FALSE
 	late_handling = FALSE
-
-/obj/random/mob/roomba/job/item_to_spawn()
-	return pickweight(list(
-				/mob/living/carbon/superior_animal/robot/greyson/roomba = 15,
+	mobs = list(/mob/living/carbon/superior_animal/robot/greyson/roomba = 15,
 				/mob/living/carbon/superior_animal/robot/greyson/custodian = 25,
 				/mob/living/carbon/superior_animal/robot/greyson/custodian/chef = 10,
 				/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer = 15,
 				/mob/living/carbon/superior_animal/robot/greyson/synthetic = 5,
 				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = 1
-				))
+				)
+
+/obj/random/mob/roomba/job/item_to_spawn()
+	if(GLOB.chaos_level > 0) //Higher weights as chaose increase
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = (1 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 1)
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = (0.5 * GLOB.chaos_level))
+
+	return pickweight(mobs)
 
 /obj/random/mob/roomba/melee
 	name = "random greyson bot (100% Spawns melee based)"
 	has_postspawn = FALSE
 	late_handling = FALSE
-
-/obj/random/mob/roomba/melee/item_to_spawn()
-	return pickweight(list(
-				/mob/living/carbon/superior_animal/robot/greyson/roomba = 25,
+	mobs = list(/mob/living/carbon/superior_animal/robot/greyson/roomba = 25,
 				/mob/living/carbon/superior_animal/robot/greyson/roomba/slayer = 20,
 				/mob/living/carbon/superior_animal/robot/greyson/roomba/trip = 15,
 				/mob/living/carbon/superior_animal/robot/greyson/roomba/trip/armored = 10,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/boomba = 7,
 				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical = 10,
 				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical/med = 6,
 				/mob/living/carbon/superior_animal/robot/greyson/roomba/chemical/med/healer = 6,
 				/mob/living/carbon/superior_animal/robot/greyson/custodian = 25,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic = 20,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = 2,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = 1
-				))
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic = 20
+				)
+
+/obj/random/mob/roomba/melee/item_to_spawn()
+	if(GLOB.chaos_level > 0) //Higher weights as chaose increase
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = (2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = (1 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/roomba/boomba = (4 * GLOB.chaos_level))
+
+	return pickweight(mobs)
 
 /obj/random/mob/roomba/range
 	name = "random greyson bot (100% Spawns range based)"
 	has_postspawn = FALSE
 	late_handling = FALSE
+	mobs = list(/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/armored = 7,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba = 12,
+				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/plasma = 8,
+				/mob/living/carbon/superior_animal/robot/greyson/custodian/chef = 12,
+				/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer = 15,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol = 15,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg = 6,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle = 5,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy = 4
+				)
 
 /obj/random/mob/roomba/range/low
 	name = "random greyson bot (10% Spawns range based)"
@@ -90,47 +111,36 @@
 	spawn_nothing_percentage = 90
 
 /obj/random/mob/roomba/range/item_to_spawn()
-	return pickweight(list(
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/armored = 7,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba = 12,
-				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/plasma = 8,
-				/mob/living/carbon/superior_animal/robot/greyson/custodian/chef = 12,
-				/mob/living/carbon/superior_animal/robot/greyson/custodian/engineer = 15,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol = 15,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg = 6,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle = 5,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy = 4,
-				/mob/living/carbon/superior_animal/robot/greyson/stalker = 3,
-				/mob/living/carbon/superior_animal/robot/greyson/stalker/dual = 1
-				))
+	if(GLOB.chaos_level > 0) //Higher weights as chaose increase
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/stalker = (3 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/stalker/dual = (1 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 1)
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/sniper/lowestrange = (0.5 * GLOB.chaos_level))
+
+	return pickweight(mobs)
 
 /obj/random/mob/roomba/mecha
 	name = "random greyson bot (100% Spawns mecha based)"
 	has_postspawn = FALSE
 	late_handling = FALSE
+	mobs = list(/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = 10,
+				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = 1
+				)
 
 /obj/random/mob/roomba/mecha/low
 	name = "random greyson bot (10% Spawns mecha based)"
 	spawn_nothing_percentage = 90
 
 /obj/random/mob/roomba/mecha/item_to_spawn()
-	return pickweight(list(
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley = 10,
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = 1
-				))
+	if(GLOB.chaos_level > 0) //Higher weights as chaose increase
+		mobs += list(/mob/living/carbon/superior_animal/robot/greyson/synthetic/ripley/phazon = (1 * GLOB.chaos_level))
+	return pickweight(mobs)
 
 /obj/random/mob/roomba/combat_class
 	name = "random greyson bot (100% Spawns combat class)"
 	has_postspawn = FALSE
 	late_handling = FALSE
-
-/obj/random/mob/roomba/combat_class/low
-	name = "random greyson bot (10% Spawns combat class)"
-	spawn_nothing_percentage = 90
-
-/obj/random/mob/roomba/combat_class/item_to_spawn()
-	return pickweight(list(
-				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol = 9,
+	mobs = list(/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol = 9,
 				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/esmg = 3,
 				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/rifle = 7,
 				/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/heavy = 4,
@@ -138,4 +148,11 @@
 				/mob/living/carbon/superior_animal/robot/greyson/roomba/gun_ba/armored = 5,
 				/mob/living/carbon/superior_animal/robot/greyson/stalker = 3,
 				/mob/living/carbon/superior_animal/robot/greyson/stalker/dual = 1
-				))
+				)
+
+/obj/random/mob/roomba/combat_class/low
+	name = "random greyson bot (10% Spawns combat class)"
+	spawn_nothing_percentage = 90
+
+/obj/random/mob/roomba/combat_class/item_to_spawn()
+	return pickweight(mobs)

--- a/code/game/objects/random/mob/misc.dm
+++ b/code/game/objects/random/mob/misc.dm
@@ -6,7 +6,7 @@
 	alpha = 128
 
 /obj/random/mob/render/item_to_spawn()
-	return pickweight(list(/mob/living/simple_animal/hostile/render))
+	return /mob/living/simple_animal/hostile/render
 
 /obj/random/mob/render/low_chance
 	name = "low chance render"
@@ -34,14 +34,15 @@
 	name = "random carp"
 	icon_state = "hostilemob-purple"
 	alpha = 128
-
-/obj/random/mob/carp/item_to_spawn()
-	return pickweight(list(/mob/living/simple_animal/hostile/carp = 9,
+	mobs = list(/mob/living/simple_animal/hostile/carp = 9,
 		/mob/living/simple_animal/hostile/carp/baby = 7,
 		/mob/living/simple_animal/hostile/carp/pike = 6,
 		/mob/living/simple_animal/hostile/carp/shark = 2,
 		/mob/living/simple_animal/hostile/carp/greatwhite = 0.5
-		))
+		)
+
+/obj/random/mob/carp/item_to_spawn()
+	return pickweight(mobs)
 
 /obj/random/mob/carp/low_chance
 	name = "low chance random carp"
@@ -55,7 +56,7 @@
 	alpha = 128
 
 /obj/random/mob/croaker/item_to_spawn()
-	return pickweight(list(/mob/living/simple_animal/hostile/retaliate/croakerlord))
+	return /mob/living/simple_animal/hostile/retaliate/croakerlord
 
 /obj/random/mob/croaker/low_chance
 	name = "low chance croaker"
@@ -67,15 +68,15 @@
 	name = "random void wolf"
 	icon_state = "hostilemob-brown"
 	alpha = 128
-
-/obj/random/mob/voidwolf/item_to_spawn()
-	return pickweight(list(
-		/mob/living/carbon/superior_animal/human/voidwolf = 9,
+	mobs = list(/mob/living/carbon/superior_animal/human/voidwolf = 9,
 		/mob/living/carbon/superior_animal/human/voidwolf/fieldtech = 2,
 		/mob/living/carbon/superior_animal/human/voidwolf/ranged = 4,
 		/mob/living/carbon/superior_animal/human/voidwolf/fieldtech/ranged = 4,
 		/mob/living/carbon/superior_animal/human/voidwolf/captain = 0.5
-		))
+		)
+
+/obj/random/mob/voidwolf/item_to_spawn()
+	return pickweight(mobs)
 
 /obj/random/mob/voidwolf/low_chance
 	name = "low chance random void wolf"
@@ -86,16 +87,16 @@
 	name = "random excelsior" //about a 50/50 chance to have a corpse, or an excel agent
 	icon_state = "hostilemob-brown"
 	alpha = 128
-
-/obj/random/mob/excelsior/item_to_spawn()
-	return pickweight(list(
-		/obj/landmark/corpse/excelsior = 10,
+	mobs = list(/obj/landmark/corpse/excelsior = 10,
 		/mob/living/carbon/superior_animal/human/excelsior = 2,
 		/mob/living/carbon/superior_animal/human/excelsior/excel_ppsh = 2,
 		/mob/living/carbon/superior_animal/human/excelsior/excel_ak = 2,
 		/mob/living/carbon/superior_animal/human/excelsior/excel_vintorez = 2,
 		/mob/living/carbon/superior_animal/human/excelsior/excel_drozd = 2
-		))
+		)
+
+/obj/random/mob/excelsior/item_to_spawn()
+	return pickweight()
 
 
 /obj/random/mob/excelsior/low_chance
@@ -108,9 +109,7 @@
 	name = "random psi_monster"
 	icon_state = "hostilemob-brown"
 	alpha = 128
-
-/obj/random/mob/psi_monster/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/psi_monster = 9,
+	mobs = list(/mob/living/carbon/superior_animal/psi_monster = 9,
 				//trash
 				/mob/living/carbon/superior_animal/psi_monster/memory_eater = 8,
 				/mob/living/carbon/superior_animal/psi_monster/thought_melter = 8,
@@ -125,19 +124,29 @@
 				/mob/living/carbon/superior_animal/psi_monster/flesh_behemoth = 2,
 				/mob/living/carbon/superior_animal/psi_monster/mind_gazer = 3,
 				/mob/living/carbon/superior_animal/psi_monster/pus_maggot/ash_wendigo = 4,
-				/mob/living/carbon/superior_animal/psi_monster/cerebral_crusher = 4,
-				/mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly = 2,
-				))
+				/mob/living/carbon/superior_animal/psi_monster/cerebral_crusher = 4
+				)
+
+/obj/random/mob/psi_monster/item_to_spawn()
+	if(GLOB.chaos_level > 0)
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly = (2 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 1)
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly/pitch_horror = (0.5 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 4) //Once admin only
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/ploge = (0.1 * GLOB.chaos_level))
+
+	return pickweight(mobs)
 
 /obj/random/mob/psi_monster_mega_fauna
 	name = "random mega psi monster"
 	icon_state = "hostilemob-brown"
 	alpha = 128
+	mobs = list(/mob/living/carbon/superior_animal/psi_monster/dreaming_king = 1,
+				/mob/living/carbon/superior_animal/psi_monster/dreaming_king/hound_crown =1,
+				)
 
 /obj/random/mob/psi_monster_mega_fauna/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/psi_monster/dreaming_king = 1,
-				/mob/living/carbon/superior_animal/psi_monster/dreaming_king/hound_crown =1,
-				))
+	return pickweight(mobs)
 
 /obj/random/mob/psi_monster/low_chance
 	name = "low chance random psi_monster"
@@ -171,16 +180,14 @@
 	alpha = 128
 
 /obj/random/cluster/psi_monster/maggot_death_gasp/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/psi_monster/pus_maggot/summoned = 1))
+	return /mob/living/carbon/superior_animal/psi_monster/pus_maggot/summoned
 
 //xenomorphs
 /obj/random/mob/xenomorphs
 	name = "random xenomorph"
 	icon_state = "hostilemob-brown"
 	alpha = 128
-
-/obj/random/mob/xenomorphs/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/xenomorph = 9,
+	mobs = list(/mob/living/carbon/superior_animal/xenomorph = 9,
 				//trash
 				/mob/living/carbon/superior_animal/xenomorph/sentinel = 8,
 				/mob/living/carbon/superior_animal/xenomorph/hunter = 8,
@@ -198,10 +205,14 @@
 				/mob/living/carbon/superior_animal/xenomorph/warrior/shrike/screecher = 4,
 				/mob/living/carbon/superior_animal/xenomorph/runner/ravager = 4,
 				/mob/living/carbon/superior_animal/xenomorph/warrior/defiler = 4,
-				/mob/living/carbon/superior_animal/xenomorph/warrior/hivelord = 4,
-				//mega fauna
-				/mob/living/carbon/superior_animal/xenomorph/warrior/praetorian = 1,
-				/mob/living/carbon/superior_animal/xenomorph/warrior/shrike/praetorian/queen = 0.1))
+				/mob/living/carbon/superior_animal/xenomorph/warrior/hivelord = 4)
+
+/obj/random/mob/xenomorphs/item_to_spawn()
+	if(GLOB.chaos_level > 0)
+		mobs += list(/mob/living/carbon/superior_animal/xenomorph/warrior/praetorian = (0.5 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/xenomorph/warrior/shrike/praetorian/queen = (0.1 * GLOB.chaos_level))
+
+	return pickweight(mobs)
 
 /obj/random/mob/xenomorphs/low_chance
 	name = "low chance random xenomorph"
@@ -215,14 +226,13 @@
 	min_amount = 3
 	max_amount = 9
 	spread_range = 0
+	var/list/mobs = list()
 
 /obj/random/cluster/xenomorphs/screacher_removed_and_megafuna
 	name = "random xenomorph without megafana and screecher"
 	icon_state = "hostilemob-brown"
 	alpha = 128
-
-/obj/random/cluster/xenomorphs/screacher_removed_and_megafuna/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/xenomorph = 9,
+	mobs = list(/mob/living/carbon/superior_animal/xenomorph = 9,
 				//trash
 				/mob/living/carbon/superior_animal/xenomorph/sentinel = 8,
 				/mob/living/carbon/superior_animal/xenomorph/hunter = 8,
@@ -238,8 +248,10 @@
 				/mob/living/carbon/superior_animal/xenomorph/warrior/bull/crusher = 4,
 				/mob/living/carbon/superior_animal/xenomorph/runner/ravager = 4,
 				/mob/living/carbon/superior_animal/xenomorph/warrior/defiler = 4,
-				/mob/living/carbon/superior_animal/xenomorph/warrior/hivelord = 4))
+				/mob/living/carbon/superior_animal/xenomorph/warrior/hivelord = 4)
 
+/obj/random/cluster/xenomorphs/screacher_removed_and_megafuna/item_to_spawn()
+	return pickweight(mobs)
 
 /obj/random/cluster/xenomorphs/item_to_spawn()
 	return /obj/random/mob/xenomorphs
@@ -259,14 +271,18 @@
 	name = "random prepper base mob"
 	icon_state = "hostilemob-cyan"
 	alpha = 128
-
-//This is made out of a 100 fo easyer math
-/obj/random/mob/prepper/item_to_spawn()
-	return pickweight(list(/mob/living/simple_animal/hostile/hivebot = 16,
+	mobs = list(/mob/living/simple_animal/hostile/hivebot = 16,
 		/mob/living/simple_animal/hostile/hivebot/range = 12,
 		/mob/living/simple_animal/hostile/republicon = 16,
 		/mob/living/simple_animal/hostile/republicon/range = 8,
-		))
+		)
+
+//This is made out of a 100 fo easyer math
+/obj/random/mob/prepper/item_to_spawn()
+	if(GLOB.chaos_level > 2)
+		mobs += list(/mob/living/carbon/superior_animal/sentinal_seeker = (0.1 * GLOB.chaos_level))
+
+	return pickweight(mobs)
 
 /obj/random/mob/prepper_boss_lowchance
 	name = "low chance sentinel seeker"
@@ -281,11 +297,12 @@
 	name = "random prepper base mob (range only)"
 	icon_state = "hostilemob-blue"
 	alpha = 128
+	mobs = list(/mob/living/simple_animal/hostile/hivebot/range = 3,
+		/mob/living/simple_animal/hostile/republicon/range = 1
+		)
 
 /obj/random/mob/prepper_ranged/item_to_spawn()
-	return pickweight(list(		/mob/living/simple_animal/hostile/hivebot/range = 3,
-		/mob/living/simple_animal/hostile/republicon/range = 1
-		))
+	return pickweight(mobs)
 
 
 //local fauna - surface
@@ -293,15 +310,16 @@
 	name = "random tengolo"
 	icon_state = "hostilemob-brown"
 	alpha = 128
-
-/obj/random/mob/tengolo/item_to_spawn()
-	return pickweight(list(/mob/living/simple_animal/hostile/tengbrute = 20,
+	mobs = list(/mob/living/simple_animal/hostile/tengbrute = 20,
 		/mob/living/simple_animal/hostile/tengstalker = 10,
 		/mob/living/simple_animal/hostile/tengcharge = 20,
 		/mob/living/simple_animal/hostile/hell_pig = 2,
 		/mob/living/simple_animal/hostile/hell_pig/slepnir = 2,
 		/mob/living/simple_animal/hostile/hell_pig/wendigo = 2
-		))
+		)
+
+/obj/random/mob/tengolo/item_to_spawn()
+	return pickweight(mobs)
 
 /obj/random/mob/tengolo/low_chance
 	name = "low chance random tengolo"
@@ -365,15 +383,16 @@
 	name = "random underground mob"
 	icon_state = "hostilemob-brown"
 	alpha = 128
-
-/obj/random/mob/undergroundmob/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/wurm = 20,
+	mobs = list(/mob/living/carbon/superior_animal/wurm = 20,
 		/mob/living/carbon/superior_animal/wurm/silver = 15,
 		/mob/living/carbon/superior_animal/wurm/osmium = 10,
 		/mob/living/simple_animal/hostile/sargoyle = 20,
 		/mob/living/simple_animal/hostile/helldiver = 10,
 		/obj/random/mob/nightmare = 1
-		))
+		)
+
+/obj/random/mob/undergroundmob/item_to_spawn()
+	return pickweight(mobs)
 
 /obj/random/mob/undergroundmob/low_chance
 	name = "low chance random underground mob"
@@ -385,10 +404,11 @@
 	name = "random nightmare"
 	icon_state = "hostilemob-brown"
 	alpha = 128
+	mobs = list(/mob/living/simple_animal/hostile/nightmare = 99,
+			/mob/living/simple_animal/hostile/nightmare/dream_daemon = 1)
 
 /obj/random/mob/nightmare/item_to_spawn()
-	return pickweight(list(/mob/living/simple_animal/hostile/nightmare = 99,
-			/mob/living/simple_animal/hostile/nightmare/dream_daemon = 1)) //If you get this spawn your unlucky
+	return pickweight(mobs) //If you get this spawn your unlucky
 
 /obj/random/mob/nightmare/low_chance
 	name = "low chance nightmare"
@@ -401,9 +421,7 @@
 	name = "random vox"
 	icon_state = "hostilemob-brown"
 	alpha = 128
-
-/obj/random/mob/vox/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/vox = 8,
+	mobs = list(/mob/living/carbon/superior_animal/vox = 8,
 		/mob/living/carbon/superior_animal/vox/posin_thrower = 3,
 		/mob/living/carbon/superior_animal/vox/thrower_spear = 4,
 		/mob/living/carbon/superior_animal/vox/armord = 6,
@@ -411,7 +429,10 @@
 		/mob/living/carbon/superior_animal/vox/ashen = 6,
 		/mob/living/carbon/superior_animal/vox/weak = 10,
 		/mob/living/carbon/superior_animal/vox/rage = 4
-		))
+		)
+
+/obj/random/mob/vox/item_to_spawn()
+	return pickweight(mobs)
 
 /obj/random/mob/vox/low_chance
 	name = "low chance nightmare"

--- a/code/game/objects/random/mob/roach.dm
+++ b/code/game/objects/random/mob/roach.dm
@@ -2,21 +2,27 @@
 	name = "random roach"
 	icon_state = "hostilemob-brown"
 	alpha = 128
-
-/obj/random/mob/roaches/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/roach = 9,
+	mobs = list(/mob/living/carbon/superior_animal/roach = 9,
 				// /mob/living/carbon/superior_animal/roach/fat = 2,
 				/mob/living/carbon/superior_animal/roach/tank = 2,
 				/mob/living/carbon/superior_animal/roach/toxic = 2,
 				/mob/living/carbon/superior_animal/roach/glowing = 2,
 				/mob/living/carbon/superior_animal/roach/nanite = 2,
 				/mob/living/carbon/superior_animal/roach/glowing = 1,
-				/mob/living/carbon/superior_animal/roach/nitro = 0.5,
 				/mob/living/carbon/superior_animal/roach/hunter = 4,
-				/mob/living/carbon/superior_animal/roach/support = 4,
-				/mob/living/carbon/superior_animal/roach/fuhrer = 0.5,
-				/mob/living/carbon/superior_animal/roach/elektromagnetisch = 0.1
-				))
+				/mob/living/carbon/superior_animal/roach/support = 4
+				)
+
+/obj/random/mob/roaches/item_to_spawn()
+	if(GLOB.chaos_level > 0) //Higher weights as chaose increase
+		mobs += list(/mob/living/carbon/superior_animal/roach/fuhrer = (0.5 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 1)
+		mobs += list(/mob/living/carbon/superior_animal/roach/nitro = (0.5 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/roach/elektromagnetisch = (0.1 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 4)
+		mobs += list(/mob/living/carbon/superior_animal/roach/kaiser = (0.1 * GLOB.chaos_level))
+
+	return pickweight(mobs)
 
 /obj/random/mob/roaches/low_chance
 	name = "low chance random roach"

--- a/code/game/objects/random/mob/roach.dm
+++ b/code/game/objects/random/mob/roach.dm
@@ -18,9 +18,10 @@
 		mobs += list(/mob/living/carbon/superior_animal/roach/fuhrer = (0.5 * GLOB.chaos_level))
 	if(GLOB.chaos_level > 1)
 		mobs += list(/mob/living/carbon/superior_animal/roach/nitro = (0.5 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 2)
 		mobs += list(/mob/living/carbon/superior_animal/roach/elektromagnetisch = (0.1 * GLOB.chaos_level))
 	if(GLOB.chaos_level > 4)
-		mobs += list(/mob/living/carbon/superior_animal/roach/kaiser = (0.1 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/roach/kaiser = (0.02 * GLOB.chaos_level)) //0.1 then 0.12 ect ect 
 
 	return pickweight(mobs)
 

--- a/code/game/objects/random/mob/spider.dm
+++ b/code/game/objects/random/mob/spider.dm
@@ -2,28 +2,32 @@
 	name = "random spider"
 	icon_state = "hostilemob-black"
 	alpha = 128
-
-/obj/random/mob/spiders/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/giant_spider = 35,\
+	mobs = list(/mob/living/carbon/superior_animal/giant_spider = 35,\
 				/mob/living/carbon/superior_animal/giant_spider/nurse = 30,\
 				/mob/living/carbon/superior_animal/giant_spider/nurse/midwife = 15,\
 				/mob/living/carbon/superior_animal/giant_spider/nurse/cave_spider = 15,\
 				/mob/living/carbon/superior_animal/giant_spider/nurse/orb_weaver = 14,\
-				/mob/living/carbon/superior_animal/giant_spider/nurse/carrier = 12,\
-				/mob/living/carbon/superior_animal/giant_spider/nurse/queen = 5,\
-				/mob/living/carbon/superior_animal/giant_spider/nurse/recluse = 4,\
-				/mob/living/carbon/superior_animal/giant_spider/plasma = 4,\
-				/mob/living/carbon/superior_animal/giant_spider/tarantula/emperor = 1,\
 				/mob/living/carbon/superior_animal/giant_spider/hunter = 35,\
 				/mob/living/carbon/superior_animal/giant_spider/hunter/cloaker = 20,\
 				/mob/living/carbon/superior_animal/giant_spider/hunter/viper = 15,\
 				/mob/living/carbon/superior_animal/giant_spider/hunter/shocker = 15,\
 				/mob/living/carbon/superior_animal/giant_spider/hunter/pepper = 10,\
 				/mob/living/carbon/superior_animal/giant_spider/tarantula = 10,\
-				/mob/living/carbon/superior_animal/giant_spider/tarantula/ogre = 8,\
 				/mob/living/carbon/superior_animal/giant_spider/tarantula/pit = 8,\
 				/mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing = 6
-				))
+				)
+
+/obj/random/mob/spiders/item_to_spawn()
+	if(GLOB.chaos_level > 0) //Higher weights as chaose increase
+		mobs += list(/mob/living/carbon/superior_animal/giant_spider/nurse/carrier = (8 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/giant_spider/nurse/recluse = (4 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/giant_spider/tarantula/ogre = (6 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 1)
+		mobs += list(/mob/living/carbon/superior_animal/giant_spider/plasma = (2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/giant_spider/nurse/queen = (2 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 2)
+		mobs += list(/mob/living/carbon/superior_animal/giant_spider/tarantula/emperor = (1 * GLOB.chaos_level))
+	return pickweight(mobs)
 
 /obj/random/mob/spiders/low_chance
 	name = "low chance random spider"
@@ -50,24 +54,29 @@
 	name = "random spiderling spider"
 	icon_state = "hostilemob-black"
 	alpha = 128
-
-/obj/random/mob/spiders/spider_ling/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/giant_spider = 35,\
+	mobs = list(/mob/living/carbon/superior_animal/giant_spider = 35,\
 				/mob/living/carbon/superior_animal/giant_spider/nurse = 30,\
 				/mob/living/carbon/superior_animal/giant_spider/nurse/midwife = 15,\
 				/mob/living/carbon/superior_animal/giant_spider/nurse/cave_spider = 15,\
 				/mob/living/carbon/superior_animal/giant_spider/nurse/orb_weaver = 14,\
-				/mob/living/carbon/superior_animal/giant_spider/nurse/queen = 5,\
-				/mob/living/carbon/superior_animal/giant_spider/nurse/recluse = 4,\
-				/mob/living/carbon/superior_animal/giant_spider/plasma = 4,\
-				/mob/living/carbon/superior_animal/giant_spider/tarantula/emperor = 1,\
 				/mob/living/carbon/superior_animal/giant_spider/hunter = 35,\
 				/mob/living/carbon/superior_animal/giant_spider/hunter/cloaker = 20,\
 				/mob/living/carbon/superior_animal/giant_spider/hunter/viper = 15,\
 				/mob/living/carbon/superior_animal/giant_spider/hunter/shocker = 15,\
 				/mob/living/carbon/superior_animal/giant_spider/hunter/pepper = 10,\
 				/mob/living/carbon/superior_animal/giant_spider/tarantula = 10,\
-				/mob/living/carbon/superior_animal/giant_spider/tarantula/ogre = 8,\
 				/mob/living/carbon/superior_animal/giant_spider/tarantula/pit = 8,\
 				/mob/living/carbon/superior_animal/giant_spider/tarantula/burrowing = 6
-				))
+				)
+
+/obj/random/mob/spiders/spider_ling/item_to_spawn()
+	if(GLOB.chaos_level > 0)
+		mobs += list(/mob/living/carbon/superior_animal/giant_spider/nurse/recluse = (4 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/giant_spider/tarantula/ogre = (6 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 1)
+		mobs += list(/mob/living/carbon/superior_animal/giant_spider/plasma = (2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/giant_spider/nurse/queen = (2 * GLOB.chaos_level))
+	if(GLOB.chaos_level > 2)
+		mobs += list(/mob/living/carbon/superior_animal/giant_spider/tarantula/emperor = (1 * GLOB.chaos_level))
+
+	return pickweight(mobs)

--- a/code/game/objects/random/mob/termite.dm
+++ b/code/game/objects/random/mob/termite.dm
@@ -2,14 +2,15 @@
 	name = "random termite that dosnt despawn"
 	icon_state = "hostilemob-brown"
 	alpha = 128
-
-/obj/random/mob/termite_no_despawn/item_to_spawn()
-	return pickweight(list(/mob/living/carbon/superior_animal/termite_no_despawn/iron = 9,
+	mobs = list(/mob/living/carbon/superior_animal/termite_no_despawn/iron = 9,
 				/mob/living/carbon/superior_animal/termite_no_despawn/silver = 5,
 				/mob/living/carbon/superior_animal/termite_no_despawn/plasma = 2,
 				/mob/living/carbon/superior_animal/termite_no_despawn/uranium = 4,
 				/mob/living/carbon/superior_animal/termite_no_despawn/diamond = 1,
-				/mob/living/carbon/superior_animal/termite_no_despawn/osmium = 0.5))
+				/mob/living/carbon/superior_animal/termite_no_despawn/osmium = 0.5)
+
+/obj/random/mob/termite_no_despawn/item_to_spawn()
+	return pickweight(mobs)
 
 /obj/random/mob/termite_no_despawn/low_chance
 	name = "low chance random roach"

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -10,6 +10,9 @@
 	var/late_handling = FALSE
 	invisibility = INVISIBILITY_MAXIMUM	// Hides these spawners from the dmm-tools minimap renderer of SpacemanDMM
 
+/obj/random/mob
+	var/list/mobs = list()
+
 // creates a new object and deletes itself
 /obj/random/Initialize()
 	..()

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/Ploge.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/Ploge.dm
@@ -1,5 +1,5 @@
-//Admin only mob to heck some people up or do events with
-
+//EXSTREAMLY RARE able heck some people up or do events with
+//Requires chaos level 3 or admins
 
 /mob/living/carbon/superior_animal/psi_monster/ploge
 	name = "Ploge"

--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/greyson/types/synthetic.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/greyson/types/synthetic.dm
@@ -77,6 +77,10 @@
 
 	advance = FALSE
 
+/mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/sniper/lowestrange
+	viewRange = 9
+	comfy_range = 9
+
 /mob/living/carbon/superior_animal/robot/greyson/synthetic/epistol/sniper/lowrange //lower performance impact
 	viewRange = 20
 	comfy_range = 20


### PR DESCRIPTION
Chaos level now affects spawning of most *common* mobs (I.e Xenos/Roaches/Spiders/GP)
Higher Chaos level makes "tougher" spawn pools lineally
GP "Sniper" lower range has been added to the GP ranged spawn pool when at higher chaos level
Crimson Jelly and ploge have been added to the Psionic Monster pool when at higher chaos level
EMP roaches and Welder Roaches and even Kaisers have been moved to require higher chaos level before spawning naturally
