### PR TITLE
ADMS requires solid work space

### DIFF
--- a/code/modules/maint_expeditions/adms.dm
+++ b/code/modules/maint_expeditions/adms.dm
@@ -45,15 +45,19 @@
 		return
 
 	if(!use_cell_power())
-		system_error("charge error")//If the battery is dead, shut it down
+		system_error("Charge error")//If the battery is dead, shut it down
 		return
 
 	if(!inserted_disk)
-		system_error("no disk found")
+		system_error("No disk found")
+		return
+
+	if(locate(/turf/simulated/open) in range(5, src))
+		system_error("Surface unsteady")
 		return
 
 	if(inserted_disk.used_capacity >= inserted_disk.max_capacity)
-		system_error("disk full")
+		system_error("Disk full")
 		return
 
 	set_light(2,1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	ADMS will no longer work if there is open space within 5 tiles
</summary>
<hr>

People have learned they can cheese the ADMS by just putting it on a bridge with lots of space and then the mobs will spawn and quickly fall down below. This stops that from happening by checking if there's any open space within 5 tiles and stopping the ADMS if there is.	
<hr>
</details>

## Changelog
:cl:
tweak: ADMS will no longer work if there's open space within 5 tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
