### PR TITLE
powercreep round 2 (gives salvager med expert)

### DIFF
--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -141,7 +141,7 @@
 		STAT_VIG = 10,
 		STAT_ROB = 10
 	)
-	perks = list(PERK_JUNKBORN, PERK_STALKER)
+	perks = list(PERK_JUNKBORN, PERK_STALKER, PERK_MEDICAL_EXPERT)
 
 	description = "The Salvager is an informally trained specialist for the prospectors who functions as both an engineer and a doctor.<br>\
 	Your primary role is that of a field medic. Treat and stabilize the wounded on the combat backlines, and evacuate the critically injured.<br>\

--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -119,7 +119,7 @@
 	difficulty = "Medium."
 	noob_name = "Rookie Salvager"
 	alt_titles = list("Sawbones", "Rookie Salvager")
-	alt_perks = list("Sawbones"=list(PERK_MEDICAL_EXPERT, PERK_STALKER), "Junk Technician"=list(PERK_JUNKBORN, PERK_ROBOTICS_EXPERT))
+	//alt_perks = list("Sawbones"=list(PERK_MEDICAL_EXPERT, PERK_STALKER), "Junk Technician"=list(PERK_JUNKBORN, PERK_ROBOTICS_EXPERT))
 	selection_color = "#a7bbc6"
 	initial_balance = 500	//Should be enough to get by with basic meds, tools, and food round-start.
 	wage = WAGE_LABOUR_HAZARD


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	gives salvager the medical expert perk, someone had already attempted this with making sawbones get it as an alt but never seemed to make it work
</summary>
<hr>

	
<hr>
</details>

## Changelog
:cl:
code: adds PERK_MEDICAL_EXPERT to the salvager perk list
code: comments out the nonfunctional attempt to make the alt title get the perk
/:cl:


