### PR TITLE
Add a warning to 515+ clients that stuff is likely to break

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -256,6 +256,11 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			// log_suspicious_login("Failed Login: [key] - Spoofed byond version")
 			qdel(src)
 
+		// TODO: Remove when 515 is stable
+		if (byond_version >= 515)
+			to_chat(src, span_userdanger("WARNING: This server does not support BYOND versions above 514.1589, but you are running [byond_version].[byond_build]! This is known to cause issues such as UI windows not working!"))
+			to_chat(src, span_danger("Please downgrade to <a href=\"https://secure.byond.com/download/build/514\">BYOND 514.1589</a> or earlier."))
+
 		if (num2text(byond_build) in GLOB.blacklisted_builds)
 			log_access("Failed login: [key] - blacklisted byond version")
 			to_chat(src, span_userdanger("Your version of byond is blacklisted."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds a warning to 515+ clients telling them that stuff is likely to break, because stuff is likely to break.
Remember to remove this when we fix 515 compatibility.

![screenshot showing the warning](https://i.tigercat2000.net/2024/05/dreamseeker_IlzQu2F1Qg.png)


## Changelog
:cl:
tweak: 515 clients now get a warning that they're in for a bad time
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
