### PR TITLE
Let Guildees and Ghosts see Machine Parts

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -156,6 +156,21 @@ Class Procs:
 /obj/machinery/Process()//If you dont use process or power why are you here
 	return PROCESS_KILL
 
+/obj/machinery/examine(mob/user, distance, infix, suffix)
+	. = ..()
+
+	if(isghost(user))
+		show_parts(user)
+
+	if(panel_open && get_dist(src, user) <= 2)
+		if((user.stats && user.stats.getPerk(PERK_HANDYMAN)))
+			show_parts(user)
+
+/obj/machinery/proc/show_parts(mob/user)
+	to_chat(user, SPAN_NOTICE("\The [src] contains the following parts:"))
+	for(var/obj/item/C in component_parts)
+		to_chat(user, SPAN_NOTICE("\t[C.name]"))
+
 /obj/machinery/emp_act(severity)
 	if(use_power && !stat)
 		use_power(7500/severity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ghosts and anyone with PERK_HANDYMAN (Guild Adept/Guild Master) can now see what components are inside of a machine, provided (for humans):

A) the maintenance panel is open
B) they are within two tiles

This is basically just to make it easier to know what's going on inside a machine when you aren't in possession of the one CRPED the guild gets. For example, to plan ahead of time what you'll need to load the RPED with.

![standing distance](https://i.tigercat2000.net/2024/05/dreamseeker_uT90WxlM3z.png)
![description](https://i.tigercat2000.net/2024/05/dreamseeker_EWZE95weQa.png)

## Changelog
:cl:
balance: Guild Members can now see machine parts when they are within two tiles of the machine and the maintenance panel is open.
add: Ghosts can now see machine parts
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
