### PR TITLE
Crusades can now end

### DIFF
--- a/code/game/antagonist/station/inquisitor.dm
+++ b/code/game/antagonist/station/inquisitor.dm
@@ -47,6 +47,15 @@
 	C.make_crusader()
 	return TRUE
 
+/datum/antagonist/inquisitor/remove_antagonist() //Only use this on people whose cruciforms are active
+	var/obj/item/implant/core_implant/cruciform/C = owner.current.get_core_implant(/obj/item/implant/core_implant/cruciform)
+
+	if(!C)
+		return
+	else
+		C.remove_crusader()
+
+	.=..()
 
 /datum/antagonist/inquisitor/greet()
 	if(!owner || !owner.current)

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -207,6 +207,13 @@ var/list/disciples = list()
 	if(security_clearance < CLEARANCE_COMMON)
 		security_clearance = CLEARANCE_COMMON
 
+/obj/item/implant/core_implant/cruciform/proc/remove_crusader()
+	remove_modules(CRUCIFORM_CRUSADER)
+	if(!wearer.stats.getPerk(PERK_CHANNELING)) //If we weren't a roundstart vector, reset us to Scalar status. If the clergy want to re-ordain or give access, they can
+		remove_modules(CRUCIFORM_CLERGY)
+		security_clearance = CLEARANCE_NONE //Vectors will still keep their Prime access, but I can't think of an easy way to check it and it's not a huge deal
+	update_rituals()
+
 /obj/item/implant/core_implant/cruciform/proc/make_inquisitor()
 	add_module(new CRUCIFORM_CLERGY)
 	add_module(new CRUCIFORM_INQUISITOR)

--- a/code/modules/core_implant/cruciform/rituals/crusader.dm
+++ b/code/modules/core_implant/cruciform/rituals/crusader.dm
@@ -140,3 +140,12 @@
 	new /obj/item/clothing/suit/space/void/crusader(usr.loc)
 	set_personal_cooldown(user)
 	return TRUE
+
+/datum/ritual/targeted/cruciform/crusader/end_crusade
+	name = "End Crusade"
+	phrase = "Tempus occidendi, et tempus sanandi; tempus destruendi, et tempus aedificandi." //"A time to kill and a time to heal, a time to tear down and a time to build"
+	desc = "Ends a Crusade, returning the believer to the state they were in when they entered the colony."
+	power = 5 //This is literally a litany to depower yourself, it shouldn't cost much
+
+/datum/ritual/targeted/cruciform/crusader/end_crusade/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C,list/targets)
+	C.remove_crusader()

--- a/code/modules/core_implant/cruciform/rituals/crusader.dm
+++ b/code/modules/core_implant/cruciform/rituals/crusader.dm
@@ -144,7 +144,7 @@
 /datum/ritual/targeted/cruciform/crusader/end_crusade
 	name = "End Crusade"
 	phrase = "Tempus occidendi, et tempus sanandi; tempus destruendi, et tempus aedificandi." //"A time to kill and a time to heal, a time to tear down and a time to build"
-	desc = "Ends a Crusade, returning the believer to the state they were in when they entered the colony."
+	desc = "Ends your Crusade, returning you to the state you were in when you entered the colony."
 	power = 5 //This is literally a litany to depower yourself, it shouldn't cost much
 
 /datum/ritual/targeted/cruciform/crusader/end_crusade/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C,list/targets)

--- a/code/modules/core_implant/cruciform/rituals/crusader.dm
+++ b/code/modules/core_implant/cruciform/rituals/crusader.dm
@@ -144,8 +144,10 @@
 /datum/ritual/targeted/cruciform/crusader/end_crusade
 	name = "End Crusade"
 	phrase = "Tempus occidendi, et tempus sanandi; tempus destruendi, et tempus aedificandi." //"A time to kill and a time to heal, a time to tear down and a time to build"
-	desc = "Ends your Crusade, returning you to the state you were in when you entered the colony."
+	desc = "Ends your Crusade, returning you to the state you were in when you entered the upper levels."
 	power = 5 //This is literally a litany to depower yourself, it shouldn't cost much
 
 /datum/ritual/targeted/cruciform/crusader/end_crusade/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C,list/targets)
-	C.remove_crusader()
+	for(var/datum/antagonist/A in user.mind.antagonist)
+		if(A.id == ROLE_INQUISITOR)
+			A.remove_antagonist()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Gives two ways to end the Crusader protocol
</summary>
<hr>
There is now a litany to end the Crusader protocol once it is no longer needed. It will be mandatory in SOP for certain individuals to use this after the crisis is resolved. Additionally, admins can remove the antag status from a person and the Crusade will end for them. There is not currently a way to do this en masse, but it likely wouldn't be hard to code one.
	
<hr>
</details>

## Changelog
:cl:
add: Crusades can now be ended with a litany or by admins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
