### PR TITLE
Borg inventory patch

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -38,6 +38,8 @@
 	R.modtype = initial(R.modtype)
 
 	R.notify_ai(ROBOT_NOTIFICATION_MODULE_RESET, R.module.name)
+	if(R.shown_robot_modules)
+		R.toggle_show_robot_modules() //fix for borgs fucking their inventory windows up by reseting with it open.
 	R.module.Reset(R)
 	R.module = null
 	R.updatename("Default")


### PR DESCRIPTION
Borg inventories will now auto close on module reset.
This prevents a visual glitch that would cause previous module items to be permanently pasted across the screen.
