### PR TITLE
Makes the excel spawner set the person as excel faction

### DIFF
--- a/code/game/objects/effects/spawners/ghostroles.dm
+++ b/code/game/objects/effects/spawners/ghostroles.dm
@@ -68,6 +68,7 @@
 /obj/effect/mob_spawn/human/exl_civ/special(mob/living/H)
 	var/obj/item/implant/excelsior/E = new /obj/item/implant/excelsior(H)
 	E.install(H, BP_HEAD, H)
+	H.faction = "excelsior"
 
 /obj/effect/mob_spawn/human/exl_civ/armored
 	outfit = /decl/hierarchy/outfit/antagonist/mercenary/excelsior/equipped


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Makes the excel spawners set excel faction on the person spawned
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
tweak: People made by excel spawners will no longer be attacked by excel mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
