### PR TITLE
xenoarch loop fix

### DIFF
--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -14,6 +14,7 @@ SUBSYSTEM_DEF(xenoarch)
 	var/list/map_data_list = list()
 
 /datum/controller/subsystem/xenoarch/Initialize(start_timeofday)
+	set background = 1
 	//fill list of map data so we can use it to determine digsite types
 	for(var/obj/map_data/MD in world)
 		if (MD.digsites)
@@ -89,5 +90,7 @@ SUBSYSTEM_DEF(xenoarch)
 	while(artifacts_spawnturf_temp.len > 0)
 		var/turf/simulated/mineral/artifact_turf = pop(artifacts_spawnturf_temp)
 		artifact_turf.artifact_find = new()
+
+	//log_and_message_admins("Xenoarch subsystem as finished creating digsites and anomalies!") Used to test for when it actually finished due to background setting.
 
 	return ..()


### PR DESCRIPTION
Command lines stated xenoarch was being moved to background processing due to fear of looping. 
Set it to background manually so it dosn't complaign about a non existant loop.


![Untitled](https://github.com/sojourn-13/sojourn-station/assets/13492089/90d1a77a-a213-411d-957a-a41f72ebb20a)
![finish](https://github.com/sojourn-13/sojourn-station/assets/13492089/11e5444b-011e-4a1e-96b5-8500e9adc49d)

Still spawns finds, tested with all maps enabled
And added a manual spat message to tell me when its finishing despite being a background process.