### PR TITLE
Councilors are no longer required for game start

### DIFF
--- a/code/game/gamemodes/storyteller.dm
+++ b/code/game/gamemodes/storyteller.dm
@@ -77,27 +77,24 @@ GLOBAL_DATUM(storyteller, /datum/storyteller)
 		return TRUE
 
 	var/engineer = FALSE
-	var/command = FALSE
+	//var/command = FALSE
 	var/single_person = FALSE
 	for(var/mob/new_player/player in GLOB.player_list)
 		if(player.ready && player.mind)
 			single_person = TRUE
-			if(player.mind.assigned_role in list(JOBS_COMMAND))
-				command = TRUE
+			//if(player.mind.assigned_role in list(JOBS_COMMAND))
+				//command = TRUE
 			if(player.mind.assigned_role in list(JOBS_ENGINEERING))
 				engineer = TRUE
-			if(command && engineer)
 				return TRUE
+			//if(command && engineer)
+				//return TRUE
 
 	var/tcol = "#ffaa00"
 
 	if(announce)
-		if(!engineer && !command)
-			to_chat(world, "<b><font color='[tcol]'>A Council Member and Guild Member are required to start the round.</font></b>")
-		else if(!engineer)
+		if(!engineer)
 			to_chat(world, "<b><font color='[tcol]'>A Guild Member is required to start the round.</font></b>")
-		else if(!command)
-			to_chat(world, "<b><font color='[tcol]'>A Council Member is required to start the round.</font></b>")
 
 	if(!single_person)
 		to_chat(world, "<b><font color='[tcol]'>A single ready player is required to start the round.</font></b>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Removes the requirement for a Councilor to start the game
</summary>
<hr>

Requiring a Councilor doesn't actually provide much benefit... there isn't all that much that the colony regularly needs where a single Council member is key. Requiring a Councilor does, however, lead to folks feeling obligated to change their job to suit the needs of the storyteller, and as often as not cryoing out at the first opportunity. Requiring Guild is fine because setting up power is actually important, and someone joining in as Guild and cryoing out a bit later doesn't use any one-time equipment kits or similar that complicate future people joining in that role.	
<hr>
</details>

## Changelog
:cl:
tweak: Game start no longer requires a member of Command
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
