### PR TITLE
Surgery Tweaks + Cloathing balance

### DIFF
--- a/code/modules/surgery/robotic_damage.dm
+++ b/code/modules/surgery/robotic_damage.dm
@@ -80,7 +80,7 @@
 
 /datum/surgery_step/robotic/fix_burn
 	allowed_tools = list(/obj/item/stack/cable_coil = 100)
-	required_tool_quality = WORKSOUND_WIRECUTTING
+	required_tool_quality = QUALITY_WIRE_CUTTING
 	duration = 60
 
 /datum/surgery_step/robotic/fix_burn/require_tool_message(mob/living/user)

--- a/code/modules/surgery/robotic_damage.dm
+++ b/code/modules/surgery/robotic_damage.dm
@@ -80,7 +80,7 @@
 
 /datum/surgery_step/robotic/fix_burn
 	allowed_tools = list(/obj/item/stack/cable_coil = 100)
-	difficulty = -70 //We dont have toolmods/stats so this makes it insainly hard to use wire
+	required_tool_quality = WORKSOUND_WIRECUTTING
 	duration = 60
 
 /datum/surgery_step/robotic/fix_burn/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/stack/cable_coil/tool)
@@ -96,22 +96,29 @@
 
 	return FALSE
 
-/datum/surgery_step/robotic/fix_burn/begin_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/cable_coil/tool)
+/datum/surgery_step/robotic/fix_burn/begin_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	user.visible_message(
 		SPAN_NOTICE("[user] begins to [user.stats.getPerk(PERK_ROBOTICS_EXPERT) ? "expertly" : ""] replace damaged wiring in [organ.get_surgery_name()]."),
 		SPAN_NOTICE("You begin to replace damaged wiring in [organ.get_surgery_name()].")
 	)
 
-/datum/surgery_step/robotic/fix_burn/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/cable_coil/tool)
+/datum/surgery_step/robotic/fix_burn/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	user.visible_message(
 		SPAN_NOTICE("[user] finishes [user.stats.getPerk(PERK_ROBOTICS_EXPERT) ? "expertly" : ""] replacing damaged wiring in [organ.get_surgery_name()]."),
 		SPAN_NOTICE("You finish replacing damaged wiring in [organ.get_surgery_name()].")
 	)
-	if(tool.use(3))
+	if(istype(tool, /obj/item/stack/cable_coil))
+		var/obj/item/stack/S = tool
+		S.use(2)
 		if(user.stats.getPerk(PERK_ROBOTICS_EXPERT))
 			organ.heal_damage(0, 50, TRUE)
 		else
 			organ.heal_damage(0,rand(30, 50), TRUE)
+
+	if(user.stats.getPerk(PERK_ROBOTICS_EXPERT))
+		organ.heal_damage(0, 20, TRUE)
+	else
+		organ.heal_damage(0,rand(5, 10), TRUE)
 
 /datum/surgery_step/robotic/fix_burn/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/cable_coil/tool)
 	user.visible_message(

--- a/code/modules/surgery/robotic_damage.dm
+++ b/code/modules/surgery/robotic_damage.dm
@@ -86,17 +86,13 @@
 /datum/surgery_step/robotic/fix_burn/require_tool_message(mob/living/user)
 	to_chat(user, SPAN_WARNING("You need a tool capable of [required_tool_quality] or some some cable coils to complete this step."))
 
-
 /datum/surgery_step/robotic/fix_burn/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
-	if(..() && organ.is_open() && istype(tool))
+	if(BP_IS_ROBOTIC(organ) && organ.is_open() && istype(tool))
 		if(istype(tool, /obj/item/stack/cable_coil))
 			var/obj/item/stack/S = tool
-			if(!S.get_amount() >= 2)
+			if(S.amount < 2)
 				to_chat(user, SPAN_WARNING("You need two or more cable pieces to repair this damage."))
-				return SURGERY_FAILURE
-		if(organ.burn_dam <= 0)
-			to_chat(user, SPAN_NOTICE("The wiring in [organ.get_surgery_name()] is undamaged!"))
-			return SURGERY_FAILURE
+				return
 
 		return TRUE
 

--- a/code/modules/surgery/robotic_damage.dm
+++ b/code/modules/surgery/robotic_damage.dm
@@ -83,11 +83,17 @@
 	required_tool_quality = WORKSOUND_WIRECUTTING
 	duration = 60
 
-/datum/surgery_step/robotic/fix_burn/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/stack/cable_coil/tool)
+/datum/surgery_step/robotic/fix_burn/require_tool_message(mob/living/user)
+	to_chat(user, SPAN_WARNING("You need a tool capable of [required_tool_quality] or some some cable coils to complete this step."))
+
+
+/datum/surgery_step/robotic/fix_burn/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/tool)
 	if(..() && organ.is_open() && istype(tool))
-		if(!tool.get_amount() >= 3)
-			to_chat(user, SPAN_WARNING("You need three or more cable pieces to repair this damage."))
-			return SURGERY_FAILURE
+		if(istype(tool, /obj/item/stack/cable_coil))
+			var/obj/item/stack/S = tool
+			if(!tool.get_amount() >= 2)
+				to_chat(user, SPAN_WARNING("You need two or more cable pieces to repair this damage."))
+				return SURGERY_FAILURE
 		if(organ.burn_dam <= 0)
 			to_chat(user, SPAN_NOTICE("The wiring in [organ.get_surgery_name()] is undamaged!"))
 			return SURGERY_FAILURE

--- a/code/modules/surgery/robotic_damage.dm
+++ b/code/modules/surgery/robotic_damage.dm
@@ -91,7 +91,7 @@
 	if(..() && organ.is_open() && istype(tool))
 		if(istype(tool, /obj/item/stack/cable_coil))
 			var/obj/item/stack/S = tool
-			if(!tool.get_amount() >= 2)
+			if(!S.get_amount() >= 2)
 				to_chat(user, SPAN_WARNING("You need two or more cable pieces to repair this damage."))
 				return SURGERY_FAILURE
 		if(organ.burn_dam <= 0)

--- a/code/modules/surgery/robotic_damage.dm
+++ b/code/modules/surgery/robotic_damage.dm
@@ -80,7 +80,7 @@
 
 /datum/surgery_step/robotic/fix_burn
 	allowed_tools = list(/obj/item/stack/cable_coil = 100)
-
+	difficulty = -70 //We dont have toolmods/stats so this makes it insainly hard to use wire
 	duration = 60
 
 /datum/surgery_step/robotic/fix_burn/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/stack/cable_coil/tool)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -133,6 +133,7 @@
 		return FALSE
 
 	S.begin_step(user, src, tool, target)	//start on it
+
 	var/atom/surgery_target = get_surgery_target()
 	var/success = FALSE
 
@@ -240,7 +241,12 @@
 		difficulty_adjust += -90
 		time_adjust += -130
 
-	if(S.required_tool_quality)
+	var/bypass_normal_tool_check = FALSE
+	for(var/tool_to_check in S.allowed_tools)
+		if(istype(tool, tool_to_check))
+			bypass_normal_tool_check = TRUE
+
+	if(S.required_tool_quality && !bypass_normal_tool_check)
 		success = tool.use_tool_extended(
 			user, surgery_target,
 			S.duration + time_adjust,
@@ -248,7 +254,6 @@
 			S.difficulty + difficulty_adjust,
 			required_stat = S.required_stat
 		)
-
 	else
 		var/wait
 		var/time_bonus = bio_time_bonus(user) // 80 being base duration, whatever value the proc returns will be deducted from the surgical step's duration. - Seb

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -139,13 +139,16 @@
 	var/difficulty_adjust = 0
 	var/time_adjust = 0
 
-	//Cloathing checks: Every lim has cloathing blockers that make surgery harder!
-	if(ishuman(owner))
+	//Clothing checks: Every lim has cloathing blockers that make surgery harder!
+	if(ishuman(owner) && ishuman(user))
 		var/mob/living/carbon/human/H = owner
-		var/sanity_targeting_zone = H.targeted_organ
+		var/mob/living/carbon/human/op = user
+		var/sanity_targeting_zone = op.targeted_organ
+		to_chat(user, SPAN_WARNING("[H.targeted_organ] gets in the way."))
 
 		if(!sanity_targeting_zone)
 			sanity_targeting_zone = BP_TORSO
+		to_chat(user, SPAN_WARNING("[H.targeted_organ] gets in the way."))
 
 		switch(sanity_targeting_zone)
 			if(BP_MOUTH, BP_EYES, BP_HEAD)
@@ -187,7 +190,7 @@
 					to_chat(user, SPAN_WARNING("[H.wear_suit] gets in the way."))
 
 
-			//chest and lower body! ANY uniform but medical scrubs punish us, over-armor pushes us more so
+			//chest and lower body! ANY uniform but medical gown punish us, over-armor pushes us more so
 			if(BP_CHEST, BP_GROIN)
 				if(H.wear_suit)
 					difficulty_adjust += 30
@@ -198,7 +201,7 @@
 					if(!istype(H.w_uniform, /obj/item/clothing/under/medigown))
 						time_adjust += 10
 						to_chat(user, SPAN_WARNING("[H.w_uniform] takes additional time to operate through."))
-					//Proper scrubs = better, DO THIS!!!
+					//Proper gown = better, DO THIS!!!
 					else
 						difficulty_adjust += -25
 						time_adjust += -25

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -220,9 +220,9 @@
 
 		//For if a user is doing 'surgery' on their own prosthetic bodypart
 		//this is VERY complicated work to do with perfect sightlines and ergonomics - let alone without these.
-		//Thus we add properly now a 50% increase to non-experts difficulty when self surgerying 
+		//Thus we add properly now a 5 increase to non-experts difficulty when self surgerying but make it take way longer burning more cell/fuel/ect
 		if(nature == MODIFICATION_SILICON && !user.stats.getPerk(PERK_ROBOTICS_EXPERT))
-			difficulty_adjust += 35
+			difficulty_adjust += 5
 			time_adjust += 20
 
 		//Chtmants feel no pain, and are pretty used to working on ourselves due to metal paranoia. Still slightly worse than letting someone else do, due to limited ability to see inside

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -220,9 +220,10 @@
 
 		//For if a user is doing 'surgery' on their own prosthetic bodypart
 		//this is VERY complicated work to do with perfect sightlines and ergonomics - let alone without these.
+		//Thus we add properly now a 50% increase to non-experts difficulty when self surgerying 
 		if(nature == MODIFICATION_SILICON && !user.stats.getPerk(PERK_ROBOTICS_EXPERT))
-			difficulty_adjust += 70
-			time_adjust += 40
+			difficulty_adjust += 35
+			time_adjust += 20
 
 		//Chtmants feel no pain, and are pretty used to working on ourselves due to metal paranoia. Still slightly worse than letting someone else do, due to limited ability to see inside
 		if(user.stats.getPerk(PERK_SCUTTLEBUG || PERK_ICHOR || PERK_CHITINARMOR))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -157,14 +157,20 @@
 					to_chat(user, SPAN_WARNING("[H.head] gets in the way."))
 
 				if(H.wear_mask)
-					if(!istype(H.wear_mask, /obj/item/clothing/mask/breath/medical))
-						difficulty_adjust += 15
-						time_adjust += 10
-						to_chat(user, SPAN_WARNING("[H.wear_mask] gets in the way."))
+					var/allowed_mask = TRUE
 					//Proper mask = better
-					else
+					if(istype(H.wear_mask, /obj/item/clothing/mask/breath/medical))
 						difficulty_adjust += -10
 						time_adjust += -5
+						allowed_mask = TRUE
+					//Opifiex masks dont encure a punishment, but cant really get the benifits eather!
+					if(istype(H.wear_mask, /obj/item/clothing/mask/gas/opifex) || istype(H.wear_mask, /obj/item/clothing/mask/opifex_no_mask))
+						allowed_mask = TRUE
+					if(!allowed_mask)
+						to_chat(user, SPAN_WARNING("[H.wear_mask] gets in the way."))
+						difficulty_adjust += -10
+						time_adjust += -5
+
 
 			//Arms and hands, waring an over suit is less punishing then gloves
 			if(BP_R_ARM, BP_L_ARM, BP_L_HAND, BP_R_HAND)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -144,11 +144,9 @@
 		var/mob/living/carbon/human/H = owner
 		var/mob/living/carbon/human/op = user
 		var/sanity_targeting_zone = op.targeted_organ
-		to_chat(user, SPAN_WARNING("[H.targeted_organ] gets in the way."))
 
 		if(!sanity_targeting_zone)
 			sanity_targeting_zone = BP_TORSO
-		to_chat(user, SPAN_WARNING("[H.targeted_organ] gets in the way."))
 
 		switch(sanity_targeting_zone)
 			if(BP_MOUTH, BP_EYES, BP_HEAD)


### PR DESCRIPTION
Surgery debuffs and buffs now stack rather then set (this likely was a bug and not actually indented) 
Doing surgery on someone (or yourself) now takes account to what clothing the person is waring, generally doing surgery through clothing is harder and takes slightly longer.
Robotic burn repair now can use wirecutters and costs 1 less coil
Using wire cutters to repair burn simply heals less then coil but is easier as its a proper tool 
Fixes doing self robotic surgery counting as a 100% more difficult, now doing 5 more difficulty and takes much longer