### PR TITLE
Fixes Bulwark of Harmony

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -395,7 +395,7 @@
 	cooldown = TRUE
 	cooldown_time = 30 MINUTES
 	cooldown_category = "bulwark_of_harmony"
-	effect_time = 5 MINUTES
+	effect_time = 1 MINUTES
 	power = 60
 	var/brute_mod_monomial
 	var/burn_mod_monomial
@@ -416,18 +416,20 @@
 	oxygen_mod_monomial = (user.oxy_mod_perk * 0.5)
 	user.oxy_mod_perk -= oxygen_mod_monomial
 
-	user.add_chemical_effect(CE_SLOWDOWN, 5, 1 MINUTES, "monomial_slow")
+	user.added_movedelay += 5
 
 	to_chat(user, SPAN_NOTICE("You feel your body stiffening, your stout refusal to change slowing down the world around you as you remain at a fixed point."))
 	set_personal_cooldown(user)
-	addtimer(CALLBACK(src, .proc/discard_effect, user), src.cooldown_time)
+	addtimer(CALLBACK(src, .proc/discard_effect, user), src.effect_time)
 	return TRUE
 
 /datum/ritual/cruciform/monomial/bulwark_of_harmony/proc/discard_effect(mob/living/carbon/human/user, amount)
-	user.brute_mod_perk -= brute_mod_monomial
-	user.burn_mod_perk -= burn_mod_monomial
-	user.toxin_mod_perk -= toxin_mod_monomial
-	user.oxy_mod_perk -= oxygen_mod_monomial
+	to_chat(user, SPAN_NOTICE("Your body quickens as you slip once more into the flow of normal spacetime."))
+	user.brute_mod_perk += brute_mod_monomial
+	user.burn_mod_perk += burn_mod_monomial
+	user.toxin_mod_perk += toxin_mod_monomial
+	user.oxy_mod_perk += oxygen_mod_monomial
+	user.added_movedelay -= 5
 
 //////////////////////////////////////////////////
 /////////         DIVISOR                /////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes a bug with the Monomial path litany Bulwark of Harmony whereby players become permanently immune to all damage after using the ability.

Also fixes a glitch whereby Bulwark of Harmony slowdown did not last its full intended duration.
<hr>
</details>

## Changelog
:cl:
balance: Reduces Bulwark of Harmony damage reduction to 50%, down from 100%.
balance: Reduces Bulwark of Harmony duration to 1 minute, down from 1 eternity.
balance: Increases Bulwark of Harmony slowdown duration by ~55 seconds, up from one life() tick.
tweak: Added feedback message to user when Bulwark of Harmony expires.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
