### PR TITLE
Make subsystems report self-init time

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -214,6 +214,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	for (var/datum/controller/subsystem/SS in subsystems)
 		if (SS.flags & SS_NO_INIT || SS.initialized) //Don't init SSs with the correspondig flag or if they already are initialzized
 			continue
+		rustg_time_reset(SS_INIT_TIMER_KEY)
 		SS.Initialize(REALTIMEOFDAY)
 		CHECK_TICK
 	current_ticklimit = TICK_LIMIT_RUNNING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This makes it so the init timer resets between each subsystem, so that when it outputs "initialized within" it'll report the amount of time it actually took to initialize that subsystem, rather than the time at which it finished relative to server start.

![screenshot of the dream daemon output after the change](https://i.tigercat2000.net/2024/05/dreamdaemon_lJcUdzj1IR.png)

## Changelog
:cl:
server: Subsystem Init time output now reports the time the subsystem took to initialize, instead of when it completed relative to the start of init.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
