### PR TITLE
more advanced mob attacks

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -1,5 +1,5 @@
 // Generic damage proc (slimes and monkeys).
-/atom/proc/attack_generic(mob/user as mob)
+/atom/proc/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	return 0
 
 /*

--- a/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
@@ -52,7 +52,7 @@
 						qdel(A)
 			T.ChangeTurf(type)
 
-/turf/unsimulated/wall/supermatter/attack_generic(mob/user as mob)
+/turf/unsimulated/wall/supermatter/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		return attack_hand(user)
 

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -73,7 +73,7 @@ for reference:
 	maxHealth = material.integrity
 	health = maxHealth
 
-/obj/structure/barricade/attack_generic(mob/user, damage, attack_verb, wallbreaker)
+/obj/structure/barricade/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)
@@ -215,7 +215,7 @@ for reference:
 	var/locked = 0
 //	req_access = list(access_maint_tunnels)
 
-/obj/machinery/deployable/attack_generic(mob/user, damage, attack_verb, wallbreaker)
+/obj/machinery/deployable/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_EMPTY(wedge_icon_cache)
 
 	damage_smoke = TRUE
 
-/obj/machinery/door/airlock/attack_generic(mob/user, damage)
+/obj/machinery/door/airlock/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(stat & (BROKEN|NOPOWER))
 		if(damage >= 10)
 			if(density)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -54,7 +54,7 @@
 /obj/machinery/door/can_prevent_fall()
 	return density
 
-/obj/machinery/door/attack_generic(mob/user, damage)
+/obj/machinery/door/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(damage >= resistance)
 		visible_message(SPAN_DANGER("\The [user] smashes into \the [src]!"))
 		take_damage(damage)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -2209,7 +2209,7 @@ assassination method if you time it right*/
 	return FALSE
 
 
-/obj/mecha/attack_generic(var/mob/user, var/damage, var/attack_message)
+/obj/mecha/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 
 	if(!damage)
 		return 0

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -52,13 +52,13 @@
 		spill()
 		qdel(src)
 
-/obj/item/storage/box/attack_generic(var/mob/user)
+/obj/item/storage/box/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN*2)
 	if (istype(user, /mob/living))
 		var/mob/living/L = user
-		var/damage = L.mob_size ? L.mob_size : MOB_MINISCULE
+		var/size_damage = L.mob_size ? L.mob_size : MOB_MINISCULE
 
-		if (!damage || damage <= 0)
+		if (!size_damage || size_damage <= 0)
 			return
 
 		user.do_attack_animation(src)

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -156,7 +156,7 @@ Freeing yourself is much harder than freeing someone else. Calling for help is a
 		return
 	.=..()
 
-/obj/item/beartrap/attack_generic(var/mob/user, var/damage)
+/obj/item/beartrap/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if (buckled_mob)
 		attempt_release(user)
 		return

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -207,10 +207,10 @@
 		return 0
 	return 1
 
-/obj/structure/attack_generic(var/mob/user, var/damage, var/attack_verb, var/wallbreaker)
-	if(!breakable || !damage || !wallbreaker)
+/obj/structure/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
+	if(!breakable || !damage)
 		return 0
-	visible_message(SPAN_DANGER("[user] [attack_verb] the [src] apart!"))
+	visible_message(SPAN_DANGER("[user] [attack_message] the [src] apart!"))
 	attack_animation(user)
 	spawn(1) qdel(src)
 	return 1

--- a/code/game/objects/structures/alien/alien.dm
+++ b/code/game/objects/structures/alien/alien.dm
@@ -44,8 +44,8 @@
 	..()
 	return
 
-/obj/structure/alien/attack_generic()
-	attack_hand(usr)
+/obj/structure/alien/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
+	attack_hand(user)
 
 /obj/structure/alien/attackby(var/obj/item/W, var/mob/user)
 	health = max(0, health - W.force)

--- a/code/game/objects/structures/burrows.dm
+++ b/code/game/objects/structures/burrows.dm
@@ -681,11 +681,11 @@ percentage is a value in the range 0..1 that determines what portion of this mob
 
 //Mobs that are summoned will walk up and attack this burrow
 //This will suck them in
-/obj/structure/burrow/attack_generic(mob/living/L)
-	if (is_valid(L))
-		enter_burrow(L)
-	if (issuperioranimal(L))//So they don't carry burrow's reference and never qdel
-		var/mob/living/carbon/superior_animal/SA = L
+/obj/structure/burrow/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
+	if (is_valid(user))
+		enter_burrow(user)
+	if (issuperioranimal(user))//So they don't carry burrow's reference and never qdel
+		var/mob/living/carbon/superior_animal/SA = user
 		SA.target_mob = null
 
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -643,13 +643,13 @@
 				add_overlay("[icon_lock]_off")
 				add_overlay(icon_sparking)
 
-/obj/structure/closet/attack_generic(var/mob/user, var/damage, var/attack_message = "destroys", var/wallbreaker)
+/obj/structure/closet/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(damage)
 		damage(damage)
 		attack_animation(user)
 		visible_message(SPAN_DANGER("[user] [attack_message] the [src]!"))
 		return 1
-	if(!damage || !wallbreaker)
+	if(!damage)
 		return
 	attack_animation(user)
 	visible_message(SPAN_DANGER("[user] [attack_message] the [src]!"))

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -12,10 +12,10 @@
 	var/obj/item/tool/fireaxe/fireaxe
 	req_one_access = list(access_heads, access_engine)
 
-/obj/structure/fireaxecabinet/attack_generic(mob/user, damage, attack_verb, wallbreaker)
+/obj/structure/fireaxecabinet/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	attack_animation(user)
 	playsound(user, 'sound/effects/Glasshit.ogg', 50, 1)
-	visible_message(SPAN_DANGER("[user] [attack_verb] \the [src]!"))
+	visible_message(SPAN_DANGER("[user] [attack_message] \the [src]!"))
 	if(damage_threshold > damage)
 		to_chat(user, SPAN_DANGER("Your strike is deflected by the reinforced glass!"))
 		return

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -32,7 +32,7 @@
 	if(reinf_material)
 		.[reinf_material.name] = 2
 
-/obj/structure/girder/attack_generic(var/mob/user, var/damage, var/attack_message = "smashes apart", var/wallbreaker)
+/obj/structure/girder/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)
@@ -301,7 +301,7 @@
 		return
 	return ..()
 
-/obj/structure/girder/attack_generic(var/mob/user, var/damage, var/attack_verb)
+/obj/structure/girder/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -220,7 +220,7 @@
 			healthCheck()
 	..()
 
-/obj/structure/grille/attack_generic(mob/user, damage, attack_verb)
+/obj/structure/grille/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -135,14 +135,14 @@
 	verbs -= /obj/structure/inflatable/verb/hand_deflate
 	deflate()
 
-/obj/structure/inflatable/attack_generic(mob/user, damage, attack_verb)
+/obj/structure/inflatable/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	health -= damage
 	attack_animation(user)
 	if(health <= 0)
-		user.visible_message(SPAN_DANGER("[user] [attack_verb] open the [src]!"))
+		user.visible_message(SPAN_DANGER("[user] [attack_message] open the [src]!"))
 		spawn(1) deflate(1)
 	else
-		user.visible_message(SPAN_DANGER("[user] [attack_verb] at [src]!"))
+		user.visible_message(SPAN_DANGER("[user] [attack_message] at [src]!"))
 	return TRUE
 
 /obj/structure/inflatable/door //Based on mineral door code

--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -489,7 +489,7 @@
 		plant.update_neighbors()
 
 
-/obj/structure/low_wall/attack_generic(mob/user, damage, attack_verb, wallbreaker)
+/obj/structure/low_wall/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -62,7 +62,7 @@
 		visible_message(SPAN_WARNING("[user] hits [src] with [I]!"))
 		playsound(src.loc, 'sound/effects/Glasshit.ogg', 70, 1)
 
-/obj/structure/mirror/attack_generic(var/mob/user, var/damage)
+/obj/structure/mirror/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	attack_animation(user)
 	if(shattered)
 		playsound(src.loc, 'sound/effects/hit_on_shattered_glass.ogg', 70, 1)

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -24,7 +24,7 @@
 	icon_modifier = "grey_"
 	icon_state = "grey_railing0"
 
-/obj/structure/railing/attack_generic(var/mob/user, var/damage, var/attack_verb)
+/obj/structure/railing/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -248,7 +248,7 @@
 							"You hear a knocking sound.")
 	return
 
-/obj/structure/window/attack_generic(var/mob/user, var/damage)
+/obj/structure/window/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)

--- a/code/game/objects/structures/window_spawner.dm
+++ b/code/game/objects/structures/window_spawner.dm
@@ -31,7 +31,7 @@
 /obj/effect/window_lwall_spawn/attack_ghost()
 	attack_generic()
 
-/obj/effect/window_lwall_spawn/attack_generic()
+/obj/effect/window_lwall_spawn/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	activate()
 
 /obj/effect/window_lwall_spawn/Initialize()

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -46,7 +46,7 @@ var/list/mechtoys = list(
 	if(health <= 0)
 		qdel(src)
 
-/obj/structure/plasticflaps/attack_generic(var/mob/user, var/damage, var/attack_message = "smashes", var/wallbreaker)//Occulus Edit
+/obj/structure/plasticflaps/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(damage)
 		damage(damage)
 		attack_animation(user)

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -69,7 +69,7 @@
 
 	try_touch(user, rotting)
 
-/turf/simulated/wall/attack_generic(var/mob/user, var/damage, var/attack_message, var/wallbreaker)
+/turf/simulated/wall/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 
 	radiate()
 	if(!istype(user))
@@ -77,7 +77,7 @@
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	var/rotting = (locate(/obj/effect/overlay/wallrot) in src)
-	if(!damage || !wallbreaker)
+	if(!damage)
 		try_touch(user, rotting)
 		return
 
@@ -85,7 +85,7 @@
 		return success_smash(user)
 
 	if(reinf_material)
-		if((wallbreaker == 2) || (damage >= max(material.hardness,reinf_material.hardness)))
+		if(damage >= max(material.hardness,reinf_material.hardness))
 			return success_smash(user)
 	else if(damage >= material.hardness)
 		return success_smash(user)
@@ -98,7 +98,7 @@
 		to_chat(user, SPAN_WARNING("You don't have the dexterity to do this!"))
 		return
 
-	
+
 	if(!istype(I, /obj/item/mecha_parts/mecha_equipment)) //make sure you're not in a mech
 		if(!istype(user.loc, /turf)) //get the user's location
 			return	//can't do this stuff whilst inside objects and such

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -148,7 +148,7 @@
 					"color" = armorlist[i] > 25 ? (armorlist[i] > 50 ? "good" : "average") : "bad",
 					"unit" = "%"
 				))
-	
+
 	stats["Armor Stats"] = armor_stats
 
 	var/list/equipment_stats = list()
@@ -172,7 +172,7 @@
 		temperature_stats += list(list("name" = "Minimum Temperature", "type" = "AnimatedNumber", "value" = min_cold_protection_temperature, "unit" = " deg K"))
 
 	stats["Temperature Stats"] = temperature_stats
-	
+
 	data["stats"] = stats
 
 	return data
@@ -430,7 +430,7 @@ BLIND     // can't see anything
 	if(!mob_wear_hat(user))
 		return ..()
 
-/obj/item/clothing/head/attack_generic(var/mob/user)
+/obj/item/clothing/head/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(!istype(user) || !mob_wear_hat(user))
 		return ..()
 

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -33,7 +33,7 @@
 /obj/effect/plant/attack_hand(var/mob/user)
 	manual_unbuckle(user)
 
-/obj/effect/plant/attack_generic(var/mob/user)
+/obj/effect/plant/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		manual_unbuckle(user)
 

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -346,7 +346,7 @@
 					return TRUE
 	return FALSE
 
-/obj/machinery/mining/drill/attack_generic(mob/user, damage)
+/obj/machinery/mining/drill/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	user.do_attack_animation(src)
 	visible_message(SPAN_DANGER("\The [user] smashes into \the [src]!"))
 	take_damage(damage)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -341,7 +341,7 @@
 /mob/living/carbon/human/proc/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, inrange, params)
 	return
 
-/mob/living/carbon/human/attack_generic(var/mob/user, var/damage, var/attack_message)
+/mob/living/carbon/human/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 
 	if(!damage || !istype(user))
 		return
@@ -364,7 +364,8 @@
 
 	var/dam_zone = pick(organs_by_name)
 	var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
-	var/dam = damage_through_armor(damage, BRUTE, affecting, ARMOR_MELEE, penetration)
+	var/dam = damage_through_armor(damage = damage, damagetype = damagetype, def_zone = affecting, attack_flag = ARMOR_MELEE, armour_pen = penetration, sharp = sharp, edge = sharp)
+
 	if(dam > 0)
 		affecting.add_autopsy_data("[attack_message] by \a [user]", dam)
 	updatehealth()

--- a/code/modules/mob/living/carbon/superior_animal/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/attack.dm
@@ -17,7 +17,8 @@
 			var/mob/living/carbon/human/target_human = L
 			if(target_human.check_shields(damage, null, src, null, attacktext))
 				return 0
-	. = A.attack_generic(src, damage, attacktext, environment_smash)
+
+	. = A.attack_generic(user = src, damage = damage, attack_message = attacktext, damagetype = melee_damage_type, attack_flag = attacking_armor_type, sharp = melee_sharp, edge = melee_sharp)
 
 	if(.)
 		if (attack_sound && loc && prob(attack_sound_chance))

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -391,7 +391,7 @@
 /mob/living/carbon/superior_animal/proc/pick_armor()
 	return
 
-/mob/living/carbon/superior_animal/attack_generic(mob/user, damage, attack_message)
+/mob/living/carbon/superior_animal/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 
 	if(!damage || !istype(user))
 		return
@@ -401,7 +401,8 @@
 		var/mob/living/L = user
 		penetration = L.armor_penetration
 
-	damage_through_armor(damage, BRUTE, attack_flag=ARMOR_MELEE, armour_pen=penetration)
+	damage_through_armor(damage = damage, damagetype = damagetype, def_zone = null, attack_flag = ARMOR_MELEE, armour_pen = penetration, sharp = sharp, edge = sharp)
+
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked [src.name] ([src.ckey])</font>")
 	src.attack_log += text("\[[time_stamp()]\] <font color='orange'>was attacked by [user.name] ([user.ckey])</font>")
 	src.visible_message(SPAN_DANGER("[user] has [attack_message] [src]!"))

--- a/code/modules/mob/living/carbon/superior_animal/human/stranger.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/stranger.dm
@@ -58,7 +58,7 @@
 	qdel(src)
 	qdel(animation)
 
-/mob/living/carbon/superior_animal/human/stranger/attack_generic(mob/user, damage, attack_message)
+/mob/living/carbon/superior_animal/human/stranger/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	var/mob/living/targetted_mob = (target_mob?.resolve())
 
 	if(!damage || !istype(user))

--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/colony/colony.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/colony/colony.dm
@@ -104,6 +104,7 @@
 	projectiletype = /obj/item/projectile/beam
 	light_range = 5
 	light_color = COLOR_LIGHTING_BLUE_BRIGHT
+	melee_sharp = TRUE //Eswords and welders
 /*
 /mob/living/carbon/superior_animal/human/colony_allie/lonestar_merc
 	name = "Lonestar Corporate Infantryman"
@@ -183,7 +184,7 @@
 
 /mob/living/carbon/superior_animal/human/colony_allie/emp_act(severity)
 	..()
-	if(rapid)
+	if(rapid && egun)
 		rapid = FALSE
 	if(prob(95) && ranged && egun)
 		ranged = FALSE

--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/kriosan/kriosan.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/kriosan/kriosan.dm
@@ -28,6 +28,7 @@
 
 	melee_damage_lower = 10
 	melee_damage_upper = 15
+	melee_sharp = TRUE //claws
 	breath_required_type = 0 // Doesn't need to breath for event atmosphere purposes.
 	breath_poison_type = 0 // Can't be poisoned
 	min_air_pressure = 0 // Doesn't need pressure for event atmosphere purposes.

--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/prisoners/prisoners.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/prisoners/prisoners.dm
@@ -75,6 +75,7 @@
 	melee_damage_upper = 25
 	attacktext = "stabbed"
 	attack_sound = 'sound/weapons/sharphit.ogg'
+	melee_sharp = TRUE //Eswords and welders
 
 /mob/living/carbon/superior_animal/human/prisoner/elite
 	name = "Escaped Convict Looter"

--- a/code/modules/mob/living/carbon/superior_animal/human/subtype/voidwolf/voidwolf.dm
+++ b/code/modules/mob/living/carbon/superior_animal/human/subtype/voidwolf/voidwolf.dm
@@ -12,9 +12,14 @@
 	health = 125
 	melee_damage_lower = 30
 	melee_damage_upper = 30
+
+	melee_sharp = FALSE //Eswords
+	armor_penetration = 30
+
 	breath_required_type = 0 // Doesn't need to breath, in a space suit
 	breath_poison_type = 0 // Can't be poisoned
 	min_air_pressure = 0 // Doesn't need pressure
+
 	attacktext = "slashed"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	meat_amount = 0
@@ -99,6 +104,9 @@
 	attacktext = "burnt"
 	attack_sound = 'sound/items/Welder.ogg'
 	drop_items = list(/obj/item/tool/weldingtool/advanced)
+	melee_sharp = FALSE
+	armor_penetration = 0
+	melee_damage_type = BURN
 
 /*Ranged Void Wolfs*/
 /mob/living/carbon/superior_animal/human/voidwolf/ranged
@@ -122,6 +130,8 @@
 	rounds_left = 16
 	mag_type = /obj/item/cell/medium/high/depleted
 	mags_left = 1
+	melee_sharp = FALSE
+	armor_penetration = 0
 
 /mob/living/carbon/superior_animal/human/voidwolf/ranged/New()
 	..()
@@ -144,6 +154,9 @@
 	rounds_left = 4
 	mag_type = /obj/item/cell/small/high/depleted
 	mags_left = 2
+	melee_sharp = FALSE
+	armor_penetration = 0
+	melee_damage_type = BURN
 
 /mob/living/carbon/superior_animal/human/voidwolf/fieldtech/ranged/New()
 	..()
@@ -161,6 +174,8 @@
 	rapid_fire_shooting_amount = 3
 	projectiletype = /obj/item/projectile/beam
 	drop_items = list(/obj/item/gun/energy/cog)
+	melee_sharp = FALSE
+	armor_penetration = 0
 
 /mob/living/carbon/superior_animal/human/voidwolf/ranged/aerotrooper/New()
 	..()
@@ -185,6 +200,8 @@
 	rounds_left = 8
 	mag_type = /obj/item/cell/small/high/depleted
 	mags_left = 1
+	melee_sharp = TRUE //Eswords
+	armor_penetration = 30
 
 	times_to_get_stat_modifiers = 2 //two prefixes
 
@@ -213,7 +230,8 @@
 	mags_left = 3
 
 	flash_resistances = 20 //no.
-
+	melee_sharp = TRUE //Eswords
+	armor_penetration = 30
 	armor = list(melee = 60, bullet = 55, energy = 50, bomb = 75, bio = 100, rad = 25) //Legitmently their armor
 
 /mob/living/carbon/superior_animal/human/voidwolf/elite/New()
@@ -235,6 +253,8 @@
 
 	rapid_fire_shooting_amount = 5 //we're using the burst 5 mode
 	delay_for_rapid_range = 0.22 SECONDS
+	melee_sharp = FALSE
+	armor_penetration = 0
 
 /obj/item/gun/energy/firestorm/reaver_modded
 
@@ -258,6 +278,8 @@
 	mags_left = 6 //since we fire. FAST
 
 	casingtype = /obj/item/ammo_casing/pistol_35/hv/spent
+	melee_sharp = FALSE
+	armor_penetration = 0
 
 /obj/item/gun/projectile/automatic/c20r/reaver_modded
 
@@ -288,6 +310,8 @@
 	get_stat_modifier = FALSE
 
 	casingtype = /obj/item/ammo_casing/a75/spent
+	melee_sharp = FALSE
+	armor_penetration = 0
 
 /mob/living/carbon/superior_animal/human/voidwolf/elite/gyrojet/New()
 	..()
@@ -305,6 +329,8 @@
 	limited_ammo = FALSE
 	drop_items = list(/obj/item/tool/sword/saber/cutlass, /obj/item/shield/buckler/energy/reaver/damaged,/obj/random/cloth/assault/reaver)
 
+	melee_sharp = TRUE //Eswords
+	armor_penetration = 30
 	var/block_chance = 65
 
 /mob/living/carbon/superior_animal/human/voidwolf/elite/myrmidon/New()

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/bluespace.dm
@@ -84,7 +84,7 @@
 			return FALSE
 	. = ..()
 
-/mob/living/carbon/superior_animal/roach/bluespace/attack_generic(mob/user, damage, attack_message)
+/mob/living/carbon/superior_animal/roach/bluespace/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	var/atom/targetted_mob = (target_mob?.resolve())
 
 	if(!damage || !istype(user))

--- a/code/modules/mob/living/carbon/superior_animal/superior_defines.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_defines.dm
@@ -184,6 +184,15 @@
 	melee_damage_lower = 0
 	melee_damage_upper = 10
 
+	//Type of damage, atm only brute
+	var/melee_damage_type = BRUTE
+	//If are melee attacks are sharp, used for delimming
+	var/melee_sharp = FALSE
+	//If this is set, will ALWAYS hit said lim
+	var/zone_to_always_hit
+	//Used for what type of armor were fighting against
+	var/attacking_armor_type = ARMOR_MELEE
+
 	/// Determines if the mob will target whoever attacked them in the absence of an existing target. Ignores view range.
 	var/react_to_attack = TRUE
 	/// Determines what the mob will fire at if reacting to an attack they can't see. DO NOT MERGE IF NIKO DOES NOT REMOVE THIS COMMENT

--- a/code/modules/mob/living/carbon/superior_animal/superior_defines.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_defines.dm
@@ -188,8 +188,6 @@
 	var/melee_damage_type = BRUTE
 	//If are melee attacks are sharp, used for delimming
 	var/melee_sharp = FALSE
-	//If this is set, will ALWAYS hit said lim
-	var/zone_to_always_hit
 	//Used for what type of armor were fighting against
 	var/attacking_armor_type = ARMOR_MELEE
 

--- a/code/modules/mob/living/carbon/superior_animal/vox/types/vox_types.dm
+++ b/code/modules/mob/living/carbon/superior_animal/vox/types/vox_types.dm
@@ -47,6 +47,7 @@
 	armor = list(melee = 20, bullet = 15, energy = 5, bomb = 50, bio = 0, rad = 0)
 
 	ranged = FALSE
+	armor_penetration = 25
 
 /mob/living/carbon/superior_animal/vox/hider
 	name = "Inuwa kisa"
@@ -93,6 +94,7 @@
 
 	maxHealth = 90
 	health = 90
+	armor_penetration = 35
 
 /mob/living/carbon/superior_animal/vox/weak
 	name = "Yaro mafarauci"
@@ -120,6 +122,7 @@
 	melee_damage_upper = 35
 
 	knock_over_odds = 25
+	armor_penetration = 15
 
 /mob/living/carbon/superior_animal/vox/scout
 	name = "karfe kafafu"

--- a/code/modules/mob/living/carbon/superior_animal/vox/vox.dm
+++ b/code/modules/mob/living/carbon/superior_animal/vox/vox.dm
@@ -28,6 +28,9 @@
 
 	get_stat_modifier = TRUE
 
+	melee_sharp = TRUE //Claws
+	armor_penetration = 5
+
 	allowed_stat_modifiers = list(
 		/datum/stat_modifier/mob/living/carbon/superior_animal/armor/mult/positive/low = 15,
 		/datum/stat_modifier/mob/living/carbon/superior_animal/armor/mult/negative/low = 15,

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/drone.dm
@@ -86,6 +86,8 @@ var/datum/xenomorph/xenomorph_ai
 	)
 
 
+	melee_sharp = TRUE //claws
+	armor_penetration = 15
 
 
 /mob/living/carbon/superior_animal/xenomorph/slip(slipped_on,stun_duration=8)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -374,13 +374,15 @@
 	return 0
 
 // End BS12 momentum-transfer code.
-
-/mob/living/attack_generic(var/mob/user, var/damage, var/attack_message)
+//A **lot** of the arguments for this are dead data used for human/superier mobs
+/mob/living/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 
 	if(!damage || !istype(user))
 		return
-
-	adjustBruteLoss(damage)
+	if(damagetype == BRUTE)
+		adjustBruteLoss(damage)
+	else
+		adjustFireLoss(damage)
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked [src.name] ([src.ckey])</font>")
 	src.attack_log += text("\[[time_stamp()]\] <font color='orange'>was attacked by [user.name] ([user.ckey])</font>")
 	src.visible_message(SPAN_DANGER("[user] has [attack_message] [src]!"))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -872,7 +872,7 @@
 			user.put_in_active_hand(broken_device)
 
 //Robots take half damage from basic attacks.
-/mob/living/silicon/robot/attack_generic(var/mob/user, var/damage, var/attack_message)
+/mob/living/silicon/robot/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	return ..(user,FLOOR(damage * 0.5, 1),attack_message)
 
 /mob/living/silicon/robot/proc/allowed(atom/movable/A)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -755,7 +755,7 @@
 		return
 	speech_buffer.Add(message)
 
-/mob/living/simple_animal/parrot/attack_generic(var/mob/user, var/damage, var/attack_message)
+/mob/living/simple_animal/parrot/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 
 	var/success = ..()
 

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -108,8 +108,8 @@
 		qdel(target)
 	return ..()
 
-/obj/structure/multiz/ladder/attack_generic(var/mob/M)
-	attack_hand(M)
+/obj/structure/multiz/ladder/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
+	attack_hand(user)
 
 /obj/structure/multiz/ladder/proc/throw_through(var/obj/item/C, var/mob/throw_man)
 	if(istype(throw_man,/mob/living/carbon/human))

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -368,7 +368,7 @@
 	if(on != on_gs)
 		on_gs = on
 
-/obj/machinery/light/attack_generic(var/mob/user, var/damage)
+/obj/machinery/light/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(!damage)
 		return
 	if(status == LIGHT_EMPTY||status == LIGHT_BROKEN)

--- a/code/modules/random_map/drop/droppod_doors.dm
+++ b/code/modules/random_map/drop/droppod_doors.dm
@@ -24,7 +24,7 @@
 		return
 	attack_hand(user)
 
-/obj/structure/droppod_door/attack_generic(var/mob/user)
+/obj/structure/droppod_door/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		attack_hand(user)
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -346,7 +346,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// FOOD END
 ////////////////////////////////////////////////////////////////////////////////
-/obj/item/reagent_containers/food/snacks/attack_generic(var/mob/living/user)
+/obj/item/reagent_containers/food/snacks/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(!isanimal(user) && !isalien(user))
 		return
 

--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -266,7 +266,7 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 	playsound(src, "rummage", 50, 1)
 	.=..()
 
-/obj/structure/scrap/attack_generic(mob/user)
+/obj/structure/scrap/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if (isliving(user) && loot)
 		loot.open(user)
 	.=..()

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -139,11 +139,11 @@ Like for example singulo act and whatever.
 	update_icon()
 	update_explosion_resistance()
 
-/obj/effect/shield/attack_generic(var/source, var/damage, var/emote)
+/obj/effect/shield/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	take_damage(damage, SHIELD_DAMTYPE_PHYSICAL, src)
-	if(gen.check_flag(MODEFLAG_OVERCHARGE) && istype(source, /mob/living/))
-		overcharge_shock(source)
-	..(source, damage, emote)
+	if(gen.check_flag(MODEFLAG_OVERCHARGE) && istype(user, /mob/living/))
+		overcharge_shock(user)
+	..(user, damage, attack_message)
 
 
 // Fails shield segments in specific range. Range of 1 affects the shielded turf only.

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -96,7 +96,7 @@ var/list/custom_table_appearance = list(
 		T.update_icon()
 	. = ..()
 
-/obj/structure/table/attack_generic(var/mob/user, var/damage, var/attack_verb, var/wallbreaker)
+/obj/structure/table/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -37,7 +37,7 @@
 /obj/structure/lift/attack_ai(var/mob/user)
 	return attack_hand(user)
 
-/obj/structure/lift/attack_generic(var/mob/user)
+/obj/structure/lift/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	return attack_hand(user)
 
 /obj/structure/lift/attack_hand(var/mob/user)
@@ -174,7 +174,7 @@
 			"name" = floor.name,
 		))
 	data["floors"] = floors
-	
+
 	return data
 
 /obj/structure/lift/panel/ui_act(action, params)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -375,7 +375,7 @@
 /obj/vehicle/proc/update_stats()
 	return
 
-/obj/vehicle/attack_generic(var/mob/user, var/damage, var/attack_message)
+/obj/vehicle/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(!damage)
 		return
 	visible_message(SPAN_DANGER("\The [user] [attack_message] the \the [src]!"))

--- a/modular_sojourn/power_puncher.dm
+++ b/modular_sojourn/power_puncher.dm
@@ -96,7 +96,7 @@
 			take_damage(bomb_scale_six, BRUTE)
 	return
 
-/obj/machinery/power/puncher/attack_generic(mob/user, damage)
+/obj/machinery/power/puncher/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(istype(user))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)

--- a/modular_sojourn/shields.dm
+++ b/modular_sojourn/shields.dm
@@ -116,7 +116,7 @@
 					update_icon()
 					return
 
-/obj/structure/shield_deployed/attack_generic(var/mob/user, var/damage, var/attack_message = "smashes", var/wallbreaker)//Occulus Edit
+/obj/structure/shield_deployed/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
 	if(damage)//Occulus edit
 		damage(damage)//Occulus Edit
 		attack_animation(user)


### PR DESCRIPTION
## About The Pull Request
Voifwolfs that have welders now deal burn based damage in melee
Voidwolfs that have eswords now have esword level AP
Jungle birds, Xenos and other misc mobs now have a little bit more AP
Fixes emping colony-allied ranged mobs that are non-egun being rapid fire disabled 
Allows more advanced melee for superior mobs, such as sharp/different damage types in melee

Standerizes (aka breaks) generic_attack