### PR TITLE
marshal break room fix

### DIFF
--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -12547,6 +12547,10 @@
 /obj/random/mob/vox/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/colony/exposedsun/pastgate)
+"lfd" = (
+/obj/structure/invislight,
+/turf/simulated/mineral/planet,
+/area/nadezhda/dungeon/outside/prepper)
 "lfg" = (
 /obj/random/junk,
 /obj/random/junk,
@@ -80168,7 +80172,7 @@ nxY
 rHY
 rHY
 wDE
-kQB
+lfd
 kQB
 qHH
 qHH

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -12259,6 +12259,9 @@
 	narrate = "A great, massive structure. Rotting and decayed, though seemingly maintained to some minimum, the whole vault feels as if it could collapse around you at any moment, the shuffling of steel-clad boots echoes through the halls.";
 	name = "Abandoned Bunker"
 	})
+"kQB" = (
+/turf/simulated/mineral/planet,
+/area/nadezhda/dungeon/outside/prepper)
 "kQG" = (
 /obj/structure/closet/onestar/tier1/mineral,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -22816,6 +22819,14 @@
 /obj/structure/scrap/guns/large,
 /obj/structure/scrap/guns/large,
 /turf/simulated/floor/tiled/dark,
+/area/nadezhda/dungeon/outside/prepper)
+"tYC" = (
+/obj/random/cluster/spiders/low_chance,
+/obj/item/hand_tele/handmade,
+/obj/random/cloth/armor,
+/obj/random/pack/gun_loot,
+/obj/item/remains/human,
+/turf/simulated/mineral/planet,
 /area/nadezhda/dungeon/outside/prepper)
 "tZg" = (
 /obj/random/mob/vox,
@@ -79948,7 +79959,7 @@ nxY
 rHY
 wDE
 wDE
-wDE
+tYC
 wDE
 qHH
 qHH
@@ -80157,8 +80168,8 @@ nxY
 rHY
 rHY
 wDE
-wDE
-wDE
+kQB
+kQB
 qHH
 qHH
 chp
@@ -80364,10 +80375,10 @@ nxY
 nxY
 nxY
 rHY
+rHY
+rHY
 tml
-rHY
-rHY
-rHY
+tml
 gbQ
 gbQ
 jSh
@@ -80574,10 +80585,10 @@ nxY
 nxY
 rHY
 tml
-tml
 rHY
-gbQ
-gbQ
+rHY
+tml
+tml
 gbQ
 ojX
 ojX
@@ -80786,7 +80797,7 @@ tml
 tml
 naj
 naj
-naj
+qxe
 hRL
 wFt
 wFt

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -173,10 +173,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/prepper/vault/entryway)
-"ajn" = (
-/obj/random/cluster/spiders/low_chance,
-/turf/unsimulated/mineral,
-/area/nadezhda/dungeon/outside/prepper)
 "ajQ" = (
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -79952,7 +79948,7 @@ nxY
 rHY
 wDE
 wDE
-ajn
+wDE
 wDE
 qHH
 qHH

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -24646,8 +24646,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "East APC";
-	pixel_x = 28;
-	operating = 0
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Someone copy pasted a maints APC into the marshals break room, making it off by default.
Also remove a random spider spawner inside the walls.
![grafik](https://github.com/sojourn-13/sojourn-station/assets/21098781/ac2507de-edcf-4723-b635-a24210a2ef43)
