### PR TITLE
buffs, tweaks and differences in spawning for oddities weapon 

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_EMPTY(atmos_machinery) //All things atmos
 //Jobs and economy
 GLOBAL_LIST_EMPTY(joblist)					//list of all jobstypes, minus borg and AI
 GLOBAL_LIST_EMPTY(all_departments)			//List of all department datums
-var/global/list/department_IDs = list(DEPARTMENT_COMMAND, DEPARTMENT_MEDICAL, DEPARTMENT_ENGINEERING, DEPARTMENT_SCIENCE, 
+var/global/list/department_IDs = list(DEPARTMENT_COMMAND, DEPARTMENT_MEDICAL, DEPARTMENT_ENGINEERING, DEPARTMENT_SCIENCE,
 DEPARTMENT_SECURITY, DEPARTMENT_BLACKSHIELD, DEPARTMENT_LSS, DEPARTMENT_CHURCH, DEPARTMENT_CIVILIAN, DEPARTMENT_PROSPECTOR)
 GLOBAL_LIST_EMPTY(global_corporations)
 
@@ -409,6 +409,9 @@ var/global/list/paramslist_cache = list()
 	return L
 
 
-
-// bee foods
+//Soj changes
+//bee foods
 var/list/bee_food_list = list("harebell", "sunflowers", "thaadra", "telriis", "surik", "vale", "potato", "poppies")
+
+//Used to track repeat odditie weapon spawns, as the name suggests. Currently helps reduce repeats
+GLOBAL_LIST_EMPTY(reapeat_odditie_weapon_spawn)

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -283,6 +283,7 @@
 				/obj/item/gun/projectile/automatic/bastard = 2,
 				/obj/item/gun/projectile/automatic/sts/rifle/blackshield = 2,
 				/obj/item/gun/projectile/automatic/ak47/sa/tac = 1,
+				/obj/item/gun/projectile/automatic/pulse_rifle = 0.1,
 				/obj/item/gun/projectile/shotgun/pump/combat = 3,
 				/obj/item/gun/projectile/shotgun/pug = 2,
 				///obj/item/gun/projectile/gyropistol = 1,

--- a/code/game/objects/random/oddities.dm
+++ b/code/game/objects/random/oddities.dm
@@ -50,16 +50,50 @@
 	spawn_nothing_percentage = 60
 
 /obj/random/oddity_guns
-	name = "random gun oddities"
+	name = "random oddities weapons spawn"
 	icon_state = "techloot-grey"
+	has_postspawn = TRUE
 
 /obj/random/oddity_guns/item_to_spawn()
+	var/item_to_spawn = random_grabber()
+	var/doup_found = FALSE
+	for(var/doup in GLOB.reapeat_odditie_weapon_spawn)
+		if(item_to_spawn in GLOB.reapeat_odditie_weapon_spawn)
+			item_to_spawn = random_grabber() //Roll again
+			doup_found = TRUE
+			break
+
+	if(!doup_found)
+		GLOB.reapeat_odditie_weapon_spawn += item_to_spawn
+
+	return item_to_spawn
+
+/obj/random/oddity_guns/post_spawn(var/list/spawns)
+	for(var/picked_spawn in spawns)
+
+		//The gimmic of this gun is that you can duel wield 2 of them.
+		if(istype(picked_spawn, /obj/item/gun/projectile/clarissa/devil_eye))
+			new /obj/item/gun/projectile/clarissa/devil_eye(src.loc)
+
+		//The gimmic of the of the revolver is that it has a lot of ammo it *can* store, so we give starting ammo
+		if(istype(picked_spawn, /obj/item/gun/projectile/revolver/mistral/elite))
+			new /obj/item/ammo_magazine/ammobox/magnum_40/large(src.loc)
+
+		//The gimmic of the maxim was that its non-exl and powerful, do to powercreep of non-exl maxims we give starting ammo
+		if(istype(picked_spawn, /obj/item/gun/projectile/automatic/maxim/replica))
+			new /obj/item/ammo_magazine/maxim_75(src.loc)
+
+		//Just one of the weakest of the spawns, so we give extra ammo
+		if(istype(picked_spawn, /obj/item/gun/projectile/that_gun))
+			new /obj/item/ammo_magazine/highcap_pistol_35/drum(src.loc)
+	return
+
+/obj/random/oddity_guns/proc/random_grabber()
 	return pickweight(list(
 				//Bullet
 				/obj/item/gun/projectile/deaglebolt = 1,
 				/obj/item/gun/projectile/revolver/mistral/elite = 1,
 				/obj/item/gun/projectile/shotgun/doublebarrel/bluecross_shotgun = 1,
-				/obj/item/gun/projectile/automatic/pulse_rifle = 1,
 				/obj/item/gun/projectile/silenced/rat = 1,
 				/obj/item/gun/projectile/automatic/maxim/replica = 1,
 				/obj/item/gun/projectile/revolver/deacon = 1,

--- a/code/modules/projectiles/guns/oddity_items.dm
+++ b/code/modules/projectiles/guns/oddity_items.dm
@@ -169,10 +169,10 @@
 	name = "\"Devil Eye\" pistol"
 	desc = "An anomalous weapon created by an unknown person (or group?), their work marked by a blue cross, these items are known to vanish and reappear when left alone. \
 			A small red eye has been painted onto the firing pin of this formerly undepowered pistol, this one has been modified with a better feed mechanism to allow \
-			for deadlier shots. Uses 9mm rounds and can take standard pistol magazines, high cap magazines, or submachine gun mags."
+			for deadlier shots. Uses 9mm rounds and can take standard pistol magazines, high cap magazines, or submachine gun mags, even drums!"
 	price_tag = 2000
 	gun_parts = null
-	mag_well = MAG_WELL_PISTOL | MAG_WELL_H_PISTOL | MAG_WELL_SMG
+	mag_well = MAG_WELL_PISTOL | MAG_WELL_H_PISTOL | MAG_WELL_SMG | MAG_WELL_DRUM
 	damage_multiplier = 1.5
 	icon = 'icons/obj/guns/projectile/clarissa.dmi'
 	icon_state = "clarissa"
@@ -387,7 +387,7 @@
 	fire_sound = 'sound/weapons/guns/fire/9mm_pistol.ogg'
 	can_dual = TRUE
 	load_method = MAGAZINE
-	mag_well = MAG_WELL_H_PISTOL|MAG_WELL_PISTOL
+	mag_well = MAG_WELL_PISTOL | MAG_WELL_H_PISTOL | MAG_WELL_DRUM
 	damage_multiplier = 1.25
 	penetration_multiplier = 1
 	gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_9MM, GUN_MAGWELL)
@@ -395,7 +395,8 @@
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,
-		BURST_3_ROUND,
+		BURST_2_ROUND_NOLOSS,
+		BURST_3_ROUND_NOLOSS,
 		)
 	serial_type = "BlueCross"
 


### PR DESCRIPTION

## About The Pull Request
Removes pluse rifle from oddities weapon spawns, its frame was ALREADY in rare loot tables
Adds the pluse rifle to rare gun spawn

Weapon Oddity spawns now will *try* to reroll **once** if said gun has already been spawned by the spawners around the map
This is to help lower **consecutive** repeats

Devil eyes now properly has drum mags loadable
Devil eyes now spawn in pars

Maxin MG now spawns with a pan mag

That gun now has more firemodes, without gun damage loss and can hold any type of pistol mag atm

"\"Elite\" magnum revolver" thing that holds 60 rounds now spawns with a large 10mm box of ammo, so you can actually load it at lest once 