### PR TITLE
Greyson turret emp and death fix

### DIFF
--- a/code/game/machinery/os_portable_turret.dm
+++ b/code/game/machinery/os_portable_turret.dm
@@ -181,7 +181,7 @@
 /obj/machinery/power/os_turret/emp_act()
 	..()
 	stat |= EMPED
-	emp_timer_id = addtimer(CALLBACK(src, .proc/emp_off), emp_cooldown, TIMER_STOPPABLE)
+	emp_timer_id = addtimer(CALLBACK(src, .proc/emp_off), emp_cooldown, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE)
 
 /obj/machinery/power/os_turret/bullet_act(obj/item/projectile/proj)
 	var/damage = proj.get_structure_damage()

--- a/code/game/machinery/os_portable_turret.dm
+++ b/code/game/machinery/os_portable_turret.dm
@@ -303,7 +303,7 @@
 		returning_fire = FALSE
 
 /obj/machinery/power/os_turret/proc/shoot(atom/target, def_zone)
-	if(QDELETED(target))
+	if(QDELETED(target) || stat & BROKEN)
 		return
 	set_dir(get_dir(src, target))
 	var/obj/item/projectile/P = new projectile(loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
EMP'ing greyson turrets multiple times now properly resets the timer instead of making several that each trigger an EMP off individually.
Also killing the turret while it is in the middle of it firing will properly stop its burst.