### PR TITLE
Refactors warrant projectors and makes them able to print

### DIFF
--- a/code/game/machinery/vendor/weapon_vendors.dm
+++ b/code/game/machinery/vendor/weapon_vendors.dm
@@ -178,6 +178,7 @@
 	req_access = list(access_security)
 	products = list(/obj/item/handcuffs = 8,
 					/obj/item/handcuffs/zipties = 8,
+					/obj/item/device/holowarrant = 5,
 					/obj/item/grenade/flashbang = 8,
 					/obj/item/grenade/chem_grenade/teargas = 8,
 					/obj/item/grenade/frag/stinger = 8,

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -9,9 +9,13 @@
 	throw_range = 10
 	slot_flags = SLOT_BELT|SLOT_POCKET // QOL improvement tbh
 	req_access = list(list(access_heads, access_security))
-	var/boss_name = "Marshals"
-	var/station_name = "The Nadezhda Colony"
+	var/boss_name = "Nadezhda Marshals" //The issuing authority. Can be VVed to make a warrant out to be from another party for whatever reason
+	var/station_name = "Nadezhda Colony" //As above
+	var/language = LANGUAGE_COMMON //More stuff put here so it can theoretically be VVed
 	var/datum/computer_file/data/warrant/active
+	var/output //What we give to paper parser
+	var/header //The header for the paper
+	var/holoheader //The header for the holowarrant
 
 //Examine text
 /obj/item/device/holowarrant/examine(mob/user, distance)
@@ -52,6 +56,54 @@
 			active = W
 	update_icon_status()
 	update_icon()
+	if(active)
+		if(active.fields["arrestsearch"] == "arrest")
+			output = {"
+			<HTML><HEAD><TITLE>[active.fields["namewarrant"]]</TITLE></HEAD>
+			<BODY bgcolor='#ffffff'>Issued under the jurisdiction of the [boss_name]</br>
+			</br>
+			<b>ARREST WARRANT</b></center></br>
+			</br>
+			This document serves as authorization and notice for the arrest of _<u>[active.fields["namewarrant"]]</u>____ for the crime(s) of:</br>[active.fields["charges"]]</br>
+			</br>
+			<b>Jurisdiction:</b> _<u>[station_name]</u>____</br>
+			</br>_<u>[active.fields["auth"]]</u>____</br>
+			<small>Person authorizing arrest</small></br>
+			</BODY></HTML>
+			"}
+
+			header = "Arrest warrant for [active.fields["namewarrant"]]"
+			holoheader = "window=Search warrant for [active.fields["namewarrant"]]"
+
+		if(active.fields["arrestsearch"] ==  "search")
+			output= {"
+			<HTML><HEAD><TITLE>[active.fields["namewarrant"]]</TITLE></HEAD>
+			<BODY bgcolor='#ffffff'>Issued under the jurisdiction of the [boss_name]</br>
+			</br>
+			<b>SEARCH WARRANT</b></center></br>
+			</br>
+			<b>Suspect's/location name: </b>[active.fields["namewarrant"]]</br>
+			</br>
+			<b>For the following reasons: </b> [active.fields["charges"]]</br>
+			</br>
+			<b>Warrant issued by: </b> [active.fields ["auth"]]</br>
+			</br>
+			<b>Jurisdiction:</b> _<u>[station_name]</u>____</br>
+			</br>
+			<center><small><i>The Marshals Officer(s) bearing this Warrant are hereby authorized by the Issuer to conduct a one-time lawful search of the Suspect's person/belongings/premises and/or Department for any items and materials that could be connected to the suspected criminal charges described below, pending an investigation in progress.</br>
+			</br>
+			The Marshals Officer(s) are obligated to remove any and all such items from the Suspect's posession and/or Department and file it as evidence.</br>
+			</br>
+			The Suspect/Departamental staff is expected to offer full co-operation.</br>
+			</br>
+			In the event of the Suspect/Departamental staff attempting to resist/impede this search or flee, they may be taken into custody immediately and charged with appropriate crimes. </br>
+			</br>
+			All confiscated items must be filed and taken to Evidence.</small></i></center></br>
+			</BODY></HTML>
+			"}
+
+			header = "Search warrant for [active.fields["namewarrant"]]"
+			holoheader = "window=Search warrant for [active.fields["namewarrant"]]"
 
 // Use your ID on it to authorize warrants
 /obj/item/device/holowarrant/attackby(obj/item/W, mob/user)
@@ -84,53 +136,14 @@
 /obj/item/device/holowarrant/proc/show_content(mob/user, forceshow)
 	if(!active)
 		return
-	if(active.fields["arrestsearch"] == "arrest")
-		var/output = {"
-		<HTML><HEAD><TITLE>[active.fields["namewarrant"]]</TITLE></HEAD>
-		<BODY bgcolor='#ffffff'><center><large><b>MARSHALS SECURITY Warrant Tracker System</b></large></br>
-		</br>
-		Issued under the jurisdiction of the</br>
-		[boss_name]</br>
-		</br>
-		<b>ARREST WARRANT</b></center></br>
-		</br>
-		This document serves as authorization and notice for the arrest of _<u>[active.fields["namewarrant"]]</u>____ for the crime(s) of:</br>[active.fields["charges"]]</br>
-		</br>
-		In situs: _<u>[station_name]</u>____</br>
-		</br>_<u>[active.fields["auth"]]</u>____</br>
-		<small>Person authorizing arrest</small></br>
-		</BODY></HTML>
-		"}
+	show_browser(user, output, holoheader)
 
-		show_browser(user, output, "window=Warrant for the arrest of [active.fields["namewarrant"]]")
-	if(active.fields["arrestsearch"] ==  "search")
-		var/output= {"
-		<HTML><HEAD><TITLE>Search Warrant: [active.fields["namewarrant"]]</TITLE></HEAD>
-		<BODY bgcolor='#ffffff'><center><large><b>MARSHALS SECURITY Warrant Tracker System</b></large></br>
-		</br>
-		Issued under the jurisdiction of the</br>
-		[boss_name]</br>
-		</br>
-		<b>SEARCH WARRANT</b></center></br>
-		</br>
-		<b>Suspect's/location name: </b>[active.fields["namewarrant"]]</br>
-		</br>
-		<b>For the following reasons: </b> [active.fields["charges"]]</br>
-		</br>
-		<b>Warrant issued by: </b> [active.fields ["auth"]]</br>
-		</br>
-		Jurisdiction: _<u>[station_name]</u>____</br>
-		</br>
-		<center><small><i>The Marshals Officer(s) bearing this Warrant are hereby authorized by the Issuer to conduct a one-time lawful search of the Suspect's person/belongings/premises and/or Department for any items and materials that could be connected to the suspected criminal charges described below, pending an investigation in progress.</br>
-		</br>
-		The Marshals Officer(s) are obligated to remove any and all such items from the Suspect's posession and/or Department and file it as evidence.</br>
-		</br>
-		The Suspect/Departamental staff is expected to offer full co-operation.</br>
-		</br>
-		In the event of the Suspect/Departamental staff attempting to resist/impede this search or flee, they must be taken into custody immediately! </br>
-		</br>
-		All confiscated items must be filed and taken to Evidence!</small></i></center></br>
-		</BODY></HTML>
-		"}
-		show_browser(user, output, "window=Search warrant for [active.fields["namewarrant"]]")
+/obj/item/device/holowarrant/verb/print_warrant()
+	set src in usr.contents
+	set name = "Print Warrant"
+	set desc = "Prints the active warrant."
+	set category = "Object"
 
+	if(!active)
+		return
+	new/obj/item/paper(usr.drop_location(), output, header, language)

--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -160,17 +160,26 @@ LEGACY_RECORD_STRUCTURE(all_warrants, warrant)
 			activewarrant.fields["namewarrant"] = new_name
 			activewarrant.fields["jobwarrant"] = new_job
 
-	if(href_list["editwarrantnamelocation"])
+	if(href_list["editwarrantnamesearch"])
 		. = 1
-		var/new_name = sanitize(input("Please input name or location") as null|text)
+		var/new_name = sanitize(input("Please input name of suspect or location") as null|text)
 		if(CanInteract(user, GLOB.default_state))
 			if (!new_name || !activewarrant)
 				return
 			activewarrant.fields["namewarrant"] = new_name
+			activewarrant.fields["jobwarrant"] = "N/A"
 
 	if(href_list["editwarrantcharges"])
 		. = 1
 		var/new_charges = sanitize(input("Please input charges", "Charges", activewarrant.fields["charges"]) as text|null)
+		if(CanInteract(user, GLOB.default_state))
+			if (!new_charges || !activewarrant)
+				return
+			activewarrant.fields["charges"] = new_charges
+
+	if(href_list["editwarrantsearchreason"])
+		. = 1
+		var/new_charges = sanitize(input("Please input reason for search", "Reason", activewarrant.fields["charges"]) as text|null)
 		if(CanInteract(user, GLOB.default_state))
 			if (!new_charges || !activewarrant)
 				return

--- a/nano/templates/digitalwarrant.tmpl
+++ b/nano/templates/digitalwarrant.tmpl
@@ -57,8 +57,8 @@
 					<tr><td>{{:helper.link('Edit Charges', null, {'editwarrantcharges' : 1})}}
 				{{/if}}
 				{{if data.type == "search"}}
-					<tr><td>{{:helper.link('Edit Name/Location', null, {'editwarrantnamecustom' : 1})}}
-					<tr><td>{{:helper.link('Edit Reason', null, {'editwarrantcharges' : 1})}}	
+					<tr><td>{{:helper.link('Edit Name/Location', null, {'editwarrantnamesearch' : 1})}}
+					<tr><td>{{:helper.link('Edit Reason', null, {'editwarrantsearchreason' : 1})}}
 				{{/if}}
 				<tr><td>{{:helper.link('Authorize', null, {'editwarrantauth' : 1})}}
 				<tr><td>{{:helper.link('Save', null, {'savewarrant' : 1})}}
@@ -85,7 +85,7 @@
 				<td>{{:helper.link('', 'pencil', {'editwarrant' : value.id})}}
 				{{:helper.link('Archive', null, {'sendtoarchive' : value.id})}}
 				{{:helper.link('', 'trash', {'deletewarrant' : value.id})}}</td>
-			{{/for}}		
+			{{/for}}
 		</table>
 	{{/if}}
 	<h2>Search warrants</h2>
@@ -100,7 +100,7 @@
 				<td>{{:helper.link('', 'pencil', {'editwarrant' : value.id})}}
 				{{:helper.link('Archive', null, {'sendtoarchive' : value.id})}}
 				{{:helper.link('', 'trash', {'deletewarrant' : value.id})}}</td>
-			{{/for}}		
+			{{/for}}
 		</table>
 	{{/if}}
 	<h2 style="color:#888888">Archived</h2>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Permits holowarrant projectors to print the warrants, refactors the code, some minor QoL improvements for making search warrants
</summary>
<hr>

Behind the scenes rework of when the warrant projector creates its output, and adds a verb that will print out the warrant (available from Object tab or by right clicking). Additionally makes the warrant program actually use different prompts for search and arrest warrants to improve the quality of life slightly (including not having to input a job for the search warrant).
	
<hr>
</details>

## Changelog
:cl:
tweak: Making a search warrant in the Warrant Assistant program no longer asks for a job
add: Warrant projectors can now print their warrants via a verb accessible by right-clicking or the Object tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
