### PR TITLE
Gun safety verb no longer brings up a dialogue box

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1015,7 +1015,8 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 		to_chat(user, SPAN_NOTICE("\The [src] is now set to [new_mode.name]."))
 
 /obj/item/gun/proc/toggle_safety(mob/living/user)
-	if(restrict_safety || src != user.get_active_hand())
+	if(restrict_safety)
+		to_chat(user, SPAN_WARNING("This gun does not have a functional safety!"))
 		return
 
 	safety = !safety
@@ -1110,11 +1111,12 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	update_firemode()
 
 /obj/item/gun/proc/toggle_safety_verb()
-	set name = "Toggle gun's safety"
+	set name = "Toggle gun safety"
 	set category = "Object"
 	set src = usr.contents
 
-	var/obj/item/gun/active_firearm = get_active_firearm(usr,FALSE) //safeties shouldn't be restrictive
+	var/obj/item/gun/active_firearm = get_active_firearm(usr, FALSE) //safeties shouldn't be restrictive
+	log_and_message_admins("[active_firearm] is the active firearm")
 
 	if(!active_firearm)
 		return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -760,6 +760,28 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 		offset -= braceable * 3 // Bipod doubles effect
 	return offset
 
+//Support proc. Returns the gun in the active hand. If restrictive is set to FALSE and there's no gun in the active hand, checks the other hand. If both hands have no guns, sends a message to user. Ported from CM for use with gun safety verb
+/obj/item/weapon/gun/proc/get_active_firearm(mob/user, restrictive = TRUE)
+	if(!ishuman(usr))
+		return
+	if(user.incapacitated() || !isturf(usr.loc))
+		to_chat(user, SPAN_WARNING("Not right now."))
+		return
+
+	var/obj/item/weapon/gun/held_item = user.get_active_hand()
+
+	if(!istype(held_item)) // if active hand is not a gun
+		if(restrictive) // if restrictive we return right here
+			to_chat(user, SPAN_WARNING("You need a gun in your active hand to do that!"))
+			return
+		else // else check inactive hand
+			held_item = user.get_inactive_hand()
+			if(!istype(held_item)) // if inactive hand is ALSO not a gun we return
+				to_chat(user, SPAN_WARNING("You need a gun in one of your hands to do that!"))
+				return
+
+	return held_item
+
 //Suicide handling.
 /obj/item/gun/proc/handle_suicide(mob/living/user)
 	if(!ishuman(user))
@@ -1090,7 +1112,14 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 /obj/item/gun/proc/toggle_safety_verb()
 	set name = "Toggle gun's safety"
 	set category = "Object"
-	set src in view(1)
+	set src = usr.contents
+
+	var/obj/item/weapon/gun/active_firearm = get_active_firearm(usr,FALSE) //safeties shouldn't be restrictive
+
+	if(!active_firearm)
+		return
+
+	src = active_firearm
 
 	toggle_safety(usr)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1116,7 +1116,6 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	set src = usr.contents
 
 	var/obj/item/gun/active_firearm = get_active_firearm(usr, FALSE) //safeties shouldn't be restrictive
-	log_and_message_admins("[active_firearm] is the active firearm")
 
 	if(!active_firearm)
 		return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -761,14 +761,14 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	return offset
 
 //Support proc. Returns the gun in the active hand. If restrictive is set to FALSE and there's no gun in the active hand, checks the other hand. If both hands have no guns, sends a message to user. Ported from CM for use with gun safety verb
-/obj/item/weapon/gun/proc/get_active_firearm(mob/user, restrictive = TRUE)
+/obj/item/gun/proc/get_active_firearm(mob/user, restrictive = TRUE)
 	if(!ishuman(usr))
 		return
 	if(user.incapacitated() || !isturf(usr.loc))
 		to_chat(user, SPAN_WARNING("Not right now."))
 		return
 
-	var/obj/item/weapon/gun/held_item = user.get_active_hand()
+	var/obj/item/gun/held_item = user.get_active_hand()
 
 	if(!istype(held_item)) // if active hand is not a gun
 		if(restrictive) // if restrictive we return right here
@@ -1114,7 +1114,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	set category = "Object"
 	set src = usr.contents
 
-	var/obj/item/weapon/gun/active_firearm = get_active_firearm(usr,FALSE) //safeties shouldn't be restrictive
+	var/obj/item/gun/active_firearm = get_active_firearm(usr,FALSE) //safeties shouldn't be restrictive
 
 	if(!active_firearm)
 		return
@@ -1205,18 +1205,18 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 			firemode_stats += list(list("name" = "Fire Delay", "type" = "AnimatedNumber", "value" = F.settings["fire_delay"], "unit" = " ms"))
 		if(F.settings["move_delay"])
 			firemode_stats += list(list("name" = "Move Delay", "type" = "AnimatedNumber", "value" = F.settings["move_delay"], "unit" = " ms"))
-		
+
 		var/list/firemode_info = list(
 			"index" = i,
 			"name" = F.name,
 			"desc" = F.desc,
 			"stats" = firemode_stats
 		)
-		
+
 		if(F.settings["projectile_type"])
 			var/proj_path = F.settings["projectile_type"]
 			firemode_info["projectile"] = ui_data_projectile_stats(new proj_path)
-		
+
 		firemodes_data += list(firemode_info)
 		i += 1
 
@@ -1238,7 +1238,7 @@ For the sake of consistency, I suggest always rounding up on even values when ap
 	. = ..()
 	if(.)
 		return
-	
+
 	switch(action)
 		if("firemode")
 			sel_mode = text2num(params["index"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Gun safety verb no longer makes you choose a gun from a list (and then doesn't work if you choose anything but a gun in your active hand)
</summary>
<hr>

Gun safety verb has long been annoying on every Baycode server except CM because if you have a gun in hand, and a gun on your vest, and you trigger the toggle safety verb, it brings up a list. I ported the proc CM uses to handle that and rewrote the verb so now when you use the verb it checks your active hand, toggles safety if there's a gun there, if there's no gun there it checks your inactive hand and toggles safety, and if there's no guns in your hands it tells you you need a gun in your hands to use it.
<hr>
</details>

## Changelog
:cl:
tweak: Using the toggle-gun-safety verb will no longer bring up a dialogue box and will instead toggle safety for a gun in your hands, preferring the active hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
