### PR TITLE
[Fix] Makes some non-languages non-translatable.

### DIFF
--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -3,7 +3,7 @@
 	name = "Noise"
 	desc = "Noises"
 	key = ""
-	flags = RESTRICTED|NONGLOBAL|INNATE|NO_TALK_MSG|NO_STUTTER
+	flags = RESTRICTED|NONGLOBAL|INNATE|NO_TALK_MSG|NO_STUTTER|NO_TRANSLATE
 	has_written_form = FALSE
 
 /datum/language/noise/format_message(message, verb)

--- a/code/modules/mob/language/monkey.dm
+++ b/code/modules/mob/language/monkey.dm
@@ -10,5 +10,5 @@
 	ask_verb = list("chimpers")
 	exclaim_verb = list("screeches")
 	key = "6"
-	flags = RESTRICTED
+	flags = RESTRICTED | NO_TRANSLATE
 	shorthand = "HM"


### PR DESCRIPTION
## About The Pull Request
Adds the no-translate flag to a few languages that shouldn't be a thing to begin with. I *hate* TG bullshit. Separate PR is going to either gut mice or having to implement a check so say verbs for simple mobs are *no longer translated*. Which if its the latter is a pain in the ass cause there are fringe cases where simple mobs have verbs and are clearly of higher sapience and would still be non-translatable. Actually thats a polaris port and just as I said on discord: Add rudimentary mice language under monkey language dm, then add all the necessities, add RESTRICTED and NO_TRANSLATE flags then use has_lang or equivalent on the mouse mob. 

## Changelog
:cl:
fix: Various non-sapients can no longer be translated by the omni translator.
/:cl:

