### PR TITLE
rework of damage mods

### DIFF
--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -284,20 +284,20 @@
 	..()
 	initial_time = world.time
 	cooldown_time = world.time + 30 MINUTES
-	holder.brute_mod_perk += 0.10
-	holder.burn_mod_perk += 0.10
-	holder.oxy_mod_perk += 0.10
-	holder.toxin_mod_perk += 0.10
+	holder.brute_mod_perk *= 1.10
+	holder.burn_mod_perk *= 1.10
+	holder.oxy_mod_perk *= 1.10
+	holder.toxin_mod_perk *= 1.10
 	holder.stats.changeStat(STAT_ROB, -10)
 	holder.stats.changeStat(STAT_TGH, -10)
 	holder.stats.changeStat(STAT_VIG, -10)
 	H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 0.5, learner = H)
 
 /datum/perk/rezsickness/remove()
-	holder.brute_mod_perk -= 0.10
-	holder.burn_mod_perk -= 0.10
-	holder.oxy_mod_perk -= 0.10
-	holder.toxin_mod_perk -= 0.10
+	holder.brute_mod_perk /= 1.10
+	holder.burn_mod_perk /= 1.10
+	holder.oxy_mod_perk /= 1.10
+	holder.toxin_mod_perk /= 1.10
 	holder.stats.changeStat(STAT_ROB, 10)
 	holder.stats.changeStat(STAT_TGH, 10)
 	holder.stats.changeStat(STAT_VIG, 10)
@@ -311,19 +311,19 @@
 
 /datum/perk/rezsickness/severe/assign(mob/living/carbon/human/H)
 	..()
-	holder.brute_mod_perk += 0.15
-	holder.burn_mod_perk += 0.15
-	holder.oxy_mod_perk += 0.15
-	holder.toxin_mod_perk += 0.15
+	holder.brute_mod_perk *= 1.15
+	holder.burn_mod_perk *= 1.15
+	holder.oxy_mod_perk *= 1.15
+	holder.toxin_mod_perk *= 1.15
 	holder.stats.changeStat(STAT_COG, -15)
 	holder.stats.changeStat(STAT_MEC, -15)
 	holder.stats.changeStat(STAT_BIO, -15)
 
 /datum/perk/rezsickness/severe/remove()
-	holder.brute_mod_perk -= 0.15
-	holder.burn_mod_perk -= 0.15
-	holder.oxy_mod_perk -= 0.15
-	holder.toxin_mod_perk -= 0.15
+	holder.brute_mod_perk /= 1.15
+	holder.burn_mod_perk /= 1.15
+	holder.oxy_mod_perk /= 1.15
+	holder.toxin_mod_perk /= 1.15
 	holder.stats.changeStat(STAT_COG, 15)
 	holder.stats.changeStat(STAT_MEC, 15)
 	holder.stats.changeStat(STAT_BIO, 15)
@@ -336,10 +336,10 @@
 
 /datum/perk/rezsickness/severe/fatal/assign(mob/living/carbon/human/H)
 	..()
-	holder.brute_mod_perk += 0.25
-	holder.burn_mod_perk += 0.25
-	holder.oxy_mod_perk += 0.25
-	holder.toxin_mod_perk += 0.25
+	holder.brute_mod_perk *= 1.25
+	holder.burn_mod_perk *= 1.25
+	holder.oxy_mod_perk *= 1.25
+	holder.toxin_mod_perk *= 1.25
 	holder.stats.changeStat(STAT_ROB, -20)
 	holder.stats.changeStat(STAT_TGH, -20)
 	holder.stats.changeStat(STAT_VIG, -20)
@@ -348,10 +348,10 @@
 	holder.stats.changeStat(STAT_BIO, -20)
 
 /datum/perk/rezsickness/severe/fatal/remove()
-	holder.brute_mod_perk -= 0.25
-	holder.burn_mod_perk -= 0.25
-	holder.oxy_mod_perk -= 0.25
-	holder.toxin_mod_perk -= 0.25
+	holder.brute_mod_perk /= 1.25
+	holder.burn_mod_perk /= 1.25
+	holder.oxy_mod_perk /= 1.25
+	holder.toxin_mod_perk /= 1.25
 	holder.stats.changeStat(STAT_ROB, 20)
 	holder.stats.changeStat(STAT_TGH, 20)
 	holder.stats.changeStat(STAT_VIG, 20)
@@ -381,15 +381,15 @@
 	..()
 	initial_time = world.time
 	cooldown_time = world.time + 30 MINUTES
-	holder.brute_mod_perk += 0.3
-	holder.burn_mod_perk += 0.3
+	holder.brute_mod_perk *= 1.3
+	holder.burn_mod_perk *= 1.3
 	holder.stats.changeStat(STAT_ROB, 30)
 	holder.stats.changeStat(STAT_TGH, -30)
 	holder.stats.changeStat(STAT_VIG, -30)
 
 /datum/perk/racial/slime_rez_sickness/remove()
-	holder.brute_mod_perk -= 0.3
-	holder.burn_mod_perk -= 0.3
+	holder.brute_mod_perk /= 1.3
+	holder.burn_mod_perk /= 1.3
 	holder.stats.changeStat(STAT_ROB, -30)
 	holder.stats.changeStat(STAT_TGH, 30)
 	holder.stats.changeStat(STAT_VIG, 30)

--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -99,12 +99,12 @@
 
 /datum/perk/oddity/harden/assign(mob/living/carbon/human/H)
 	..()
-	holder.brute_mod_perk -= 0.1 // One third of subdermal armor
+	holder.brute_mod_perk *= 0.75 // One third of subdermal armor
 	holder.mob_bomb_defense += 5
 	holder.falls_mod -= 0.2
 
 /datum/perk/oddity/harden/remove()
-	holder.brute_mod_perk += 0.1
+	holder.brute_mod_perk /= 0.75
 	holder.mob_bomb_defense -= 5
 	holder.falls_mod += 0.2
 	..()
@@ -117,14 +117,14 @@
 
 /datum/perk/oddity/thin_skin/assign(mob/living/carbon/human/H)
 	..()
-	holder.brute_mod_perk += 0.1
+	holder.brute_mod_perk *= 1.25
 	holder.mob_bomb_defense -= 5
 	holder.falls_mod += 0.2
 	H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 1, learner = H)
 
 
 /datum/perk/oddity/thin_skin/remove()
-	holder.brute_mod_perk -= 0.1 // One third of subdermal armor
+	holder.brute_mod_perk /= 1.25 // One third of subdermal armor
 	holder.mob_bomb_defense += 5
 	holder.falls_mod -= 0.2
 	..()

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -494,12 +494,12 @@
 
 /datum/perk/chitinarmor/assign(mob/living/carbon/human/H)
 	..()
-	holder.brute_mod_perk -= 0.15 // Reduces total brute damage to +10% **taken** instead of +25%
+	holder.brute_mod_perk *= 0.80 // I need to know what type of stuff people were smoking before my change here
 	holder.mob_bomb_defense += 5
 	holder.falls_mod -= 0.2
 
 /datum/perk/chitinarmor/remove()
-	holder.brute_mod_perk += 0.15
+	holder.brute_mod_perk /= 0.80
 	holder.mob_bomb_defense -= 5
 	holder.falls_mod += 0.2
 	..()

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -397,14 +397,14 @@
 	cooldown_category = "bulwark_of_harmony"
 	effect_time = 1 MINUTES
 	power = 60
-	var/brute_mod_monomial
+	/*var/brute_mod_monomial
 	var/burn_mod_monomial
 	var/toxin_mod_monomial
-	var/oxygen_mod_monomial
+	var/oxygen_mod_monomial*/
 
 /datum/ritual/cruciform/monomial/bulwark_of_harmony/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/cruciform/C)
 
-	brute_mod_monomial = (user.brute_mod_perk * 0.5)
+	/*brute_mod_monomial = (user.brute_mod_perk * 0.5)
 	user.brute_mod_perk -= brute_mod_monomial
 
 	burn_mod_monomial = (user.burn_mod_perk * 0.5)
@@ -414,7 +414,12 @@
 	user.toxin_mod_perk -= toxin_mod_monomial
 
 	oxygen_mod_monomial = (user.oxy_mod_perk * 0.5)
-	user.oxy_mod_perk -= oxygen_mod_monomial
+	user.oxy_mod_perk -= oxygen_mod_monomial*/
+
+	user.brute_mod_perk *= 0.5
+	user.burn_mod_perk *= 0.5
+	user.toxin_mod_perk *= 0.5
+	user.oxy_mod_perk *= 0.5
 
 	user.added_movedelay += 5
 
@@ -425,10 +430,14 @@
 
 /datum/ritual/cruciform/monomial/bulwark_of_harmony/proc/discard_effect(mob/living/carbon/human/user, amount)
 	to_chat(user, SPAN_NOTICE("Your body quickens as you slip once more into the flow of normal spacetime."))
-	user.brute_mod_perk += brute_mod_monomial
+	/*user.brute_mod_perk += brute_mod_monomial
 	user.burn_mod_perk += burn_mod_monomial
 	user.toxin_mod_perk += toxin_mod_monomial
-	user.oxy_mod_perk += oxygen_mod_monomial
+	user.oxy_mod_perk += oxygen_mod_monomial*/
+	user.brute_mod_perk /= 0.5
+	user.burn_mod_perk /= 0.5
+	user.toxin_mod_perk /= 0.5
+	user.oxy_mod_perk /= 0.5
 	user.added_movedelay -= 5
 
 //////////////////////////////////////////////////

--- a/code/modules/genetics/mutations/cow_skin.dm
+++ b/code/modules/genetics/mutations/cow_skin.dm
@@ -9,8 +9,8 @@
 
 /datum/genetics/mutation/cow_skin/onMobImplant()
 	..()
-	container.holder.brute_mod_delta *= 0.75
+	container.holder.brute_mod_perk *= 0.75
 
 /datum/genetics/mutation/cow_skin/onMobRemove()
 	..()
-	container.holder.brute_mod_delta /= 0.75
+	container.holder.brute_mod_perk /= 0.75

--- a/code/modules/genetics/mutations/cow_skin.dm
+++ b/code/modules/genetics/mutations/cow_skin.dm
@@ -9,8 +9,8 @@
 
 /datum/genetics/mutation/cow_skin/onMobImplant()
 	..()
-	container.holder.brute_mod_perk -= 0.1
+	container.holder. *= 0.75
 
 /datum/genetics/mutation/cow_skin/onMobRemove()
 	..()
-	container.holder.brute_mod_perk += 0.1
+	container.holder. /= 0.75

--- a/code/modules/genetics/mutations/cow_skin.dm
+++ b/code/modules/genetics/mutations/cow_skin.dm
@@ -9,8 +9,8 @@
 
 /datum/genetics/mutation/cow_skin/onMobImplant()
 	..()
-	container.holder. *= 0.75
+	container.holder.brute_mod_delta *= 0.75
 
 /datum/genetics/mutation/cow_skin/onMobRemove()
 	..()
-	container.holder. /= 0.75
+	container.holder.brute_mod_delta /= 0.75

--- a/code/modules/genetics/mutations/dwarfism.dm
+++ b/code/modules/genetics/mutations/dwarfism.dm
@@ -23,7 +23,7 @@
 
 	//brute_mod_delta = (human_holder.brute_mod_perk * 0.2)
 	//human_holder.brute_mod_perk += brute_mod_delta
-	human_holder.brute_mod_delta *= 1.2
+	human_holder.brute_mod_perk *= 1.2
 
 	//Less need for air
 	//oxy_mod_delta = (human_holder.oxy_mod_perk * 0.2)
@@ -43,7 +43,7 @@
 	human_holder.stats.changeStat(STAT_TGH, 15)
 
 	//human_holder.brute_mod_perk -= brute_mod_delta
-	human_holder.brute_mod_delta /= 1.2
+	human_holder.brute_mod_perk /= 1.2
 
 	//We are normal again, breath more
 	human_holder.oxy_mod_perk /= 0.8

--- a/code/modules/genetics/mutations/dwarfism.dm
+++ b/code/modules/genetics/mutations/dwarfism.dm
@@ -5,8 +5,8 @@
 	desc = "Causes you to become small. VERY small, and more fragile."
 	gain_text = "You feel your body getting smaller, and weaker..."
 	var/old_size
-	var/brute_mod_delta
-	var/oxy_mod_delta
+	//var/brute_mod_delta
+	//var/oxy_mod_delta
 
 /datum/genetics/mutation/dwarfism/onPlayerImplant()
 	if(!..())
@@ -21,27 +21,29 @@
 	human_holder.stats.changeStat(STAT_ROB, -20)
 	human_holder.stats.changeStat(STAT_TGH, -15)
 
-	brute_mod_delta = (human_holder.brute_mod_perk * 0.2)
-	human_holder.brute_mod_perk += brute_mod_delta
+	//brute_mod_delta = (human_holder.brute_mod_perk * 0.2)
+	//human_holder.brute_mod_perk += brute_mod_delta
+	human_holder.brute_mod_delta *= 1.2
 
 	//Less need for air
-	oxy_mod_delta = (human_holder.oxy_mod_perk * 0.2)
-	human_holder.oxy_mod_perk -= oxy_mod_delta
-
+	//oxy_mod_delta = (human_holder.oxy_mod_perk * 0.2)
+	//human_holder.oxy_mod_perk -= oxy_mod_delta
+	human_holder.oxy_mod_perk *= 0.80
 
 /datum/genetics/mutation/dwarfism/onPlayerRemove()
 	if(!..())
 		return
 	var/mob/living/carbon/human/human_holder = container.holder
-	//Smaller
+	//Bigger
 	human_holder.scale_effect = old_size
 	human_holder.update_icons()
 
-	//Weaker
+	//Stronger
 	human_holder.stats.changeStat(STAT_ROB, 20)
 	human_holder.stats.changeStat(STAT_TGH, 15)
 
-	human_holder.brute_mod_perk -= brute_mod_delta
+	//human_holder.brute_mod_perk -= brute_mod_delta
+	human_holder.brute_mod_delta /= 1.2
 
-	//Need less air
-	human_holder.oxy_mod_perk += oxy_mod_delta
+	//We are normal again, breath more
+	human_holder.oxy_mod_perk /= 0.8

--- a/code/modules/genetics/mutations/gigantism.dm
+++ b/code/modules/genetics/mutations/gigantism.dm
@@ -6,8 +6,8 @@
 	gain_text = "You feel your body getting larger, stronger, and slower..."
 	var/old_size
 	var/slowdown_delta
-	var/brute_mod_delta
-	var/oxy_mod_delta
+	//var/brute_mod_delta
+	//var/oxy_mod_delta
 
 /datum/genetics/mutation/gigantism/onPlayerImplant()
 	if(!..())
@@ -22,12 +22,14 @@
 	human_holder.stats.changeStat(STAT_ROB, 20)
 	human_holder.stats.changeStat(STAT_TGH, 15)
 
-	brute_mod_delta = (human_holder.brute_mod_perk * 0.2)
-	human_holder.brute_mod_perk -= brute_mod_delta
+	//brute_mod_delta = (human_holder.brute_mod_perk * 0.2)
+	//human_holder.brute_mod_perk -= brute_mod_delta
+	human_holder.brute_mod_perk *= 0.8 //I am sorry Hex but I was able to gain perma brute mod through your math -DimasW
 
 	//Bigger need for air
-	oxy_mod_delta = (human_holder.oxy_mod_perk * 0.2)
-	human_holder.oxy_mod_perk += oxy_mod_delta
+	//oxy_mod_delta = (human_holder.oxy_mod_perk * 0.2)
+	//human_holder.oxy_mod_perk += oxy_mod_delta
+	human_holder.oxy_mod_perk *= 1.2
 
 	//Slower
 	slowdown_delta = human_holder.slowdown - (human_holder.slowdown * 0.8)
@@ -45,10 +47,12 @@
 	human_holder.stats.changeStat(STAT_ROB, -20)
 	human_holder.stats.changeStat(STAT_TGH, -15)
 
-	human_holder.brute_mod_perk += brute_mod_delta
+	//human_holder.brute_mod_perk += brute_mod_delta
+	human_holder.brute_mod_perk /= 0.8
 
 	//Need less air
-	human_holder.oxy_mod_perk -= oxy_mod_delta
+	//human_holder.oxy_mod_perk -= oxy_mod_delta
+	human_holder.oxy_mod_perk /= 1.2
 
 	//faster
 	human_holder.slowdown -= slowdown_delta

--- a/code/modules/genetics/mutations/thick_fur.dm
+++ b/code/modules/genetics/mutations/thick_fur.dm
@@ -13,15 +13,15 @@
 /datum/genetics/mutation/thick_fur/onPlayerImplant()
 	if(!..())
 		return
-	container.holder.brute_mod_perk -= 0.1
-	container.holder.burn_mod_perk += 0.1
+	container.holder.brute_mod_perk *= 0.75
+	container.holder.burn_mod_perk *= 1.25
 	if(mutation && !(mutation in container.holder.mutations))
 		container.holder.mutations.Add(mutation)
 
 /datum/genetics/mutation/thick_fur/onPlayerRemove()
 	if(!..())
 		return
-	container.holder.brute_mod_perk += 0.1
-	container.holder.burn_mod_perk -= 0.1
+	container.holder.brute_mod_perk /= 0.75
+	container.holder.burn_mod_perk /= 1.25
 	if(mutation && (mutation in container.holder.mutations))
 		container.holder.mutations.Remove(mutation)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -116,7 +116,7 @@
 	var/mod_climb_delay = 1 // delay for climb
 	var/noise_coeff = 1 //noise coefficient
 	var/brute_mod_perk = 1 //this and the ones below adjust various damages via perks
-	var/burn_mod_perk = 1
+	var/burn_mod_perk = 1 //Please make any and all adjustments multiplicative only for all damage mods
 	var/toxin_mod_perk = 1
 	var/oxy_mod_perk = 1
 

--- a/code/modules/reagents/reagents/alchemy.dm
+++ b/code/modules/reagents/reagents/alchemy.dm
@@ -31,9 +31,9 @@
 			return
 	ironskin.mob_bomb_defense += 25
 	ironskin.falls_mod -= 0.4
-	ironskin.brute_mod_perk -= 0.2
-	ironskin.burn_mod_perk += 0.2
-	ironskin.oxy_mod_perk  += 2 //Iron casket
+	ironskin.brute_mod_perk *= 0.65
+	ironskin.burn_mod_perk *= 1.2
+	ironskin.oxy_mod_perk  *= 3 //Iron casket
 
 /datum/reagent/iron_skin_brew/on_mob_delete(mob/living/L)
 	. = ..()
@@ -43,9 +43,9 @@
 	ironskin.mob_bomb_defense -= 25
 	ironskin.falls_mod += 0.4
 	ironskin.Paralyse(3)
-	ironskin.burn_mod_perk -= 0.2
-	ironskin.brute_mod_perk += 0.2
-	ironskin.oxy_mod_perk  -= 2
+	ironskin.burn_mod_perk /= 1.2
+	ironskin.brute_mod_perk /= 0.65
+	ironskin.oxy_mod_perk  /= 3
 
 /datum/reagent/toxin_draft
 	name = "Noxious Sludge"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reworked how damage modifiers are applied to people, making scaling linear instead of being a 1/x curve.
All damage modifiers are now multiplicative instead of additive.

Reasoning: For a while now I noticed that a lot of damage modifiers are tip toeing the line between incredibly small but if stacked enough will utterly break the balance. For example if you have a brute mod of 0.2 from prior stacking, adding another -0.1 from something like cow skin would double your effective HP. Otherwise, it only would be 10% if you had nothing else.
Now that they are multpilied, it is much easier to see how much damage you take less while also preventing the insane stacking. Another reason was that a lot of choices for damage absorbtion by itself were more than just meaningless, the game was encouraging to stack and power game to make any good use out of it.
![grafik](https://github.com/sojourn-13/sojourn-station/assets/21098781/1436c39b-9a7e-4d1e-8f09-2182899dabab)
Of course I did the basic math behind it, coloumn B is our current additive system. You can push it to recieving only 12% but it gets worse since you can exploit resurrection sickness and gigantism to gelow below it. Likewise you can go below it by using the churches abillity.
Coloumn C is the basic unadjusted version of B, 1 - old number
Coloumn D is the manually adjusted rebalance and rebuff of each option since we no longer have to fear insane scaling later on, showing that even with adjusted numbers this is technically a nerf.