### PR TITLE
Fix the animals translate bug properly

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -71,6 +71,8 @@
 		icon_state = "taperecorder_idle"
 
 /obj/item/device/taperecorder/hear_talk(mob/living/M as mob, msg, var/verb="says", datum/language/speaking=null, speech_volume)
+	if(isanimal(M))
+		return
 	if(speech_volume)
 		msg = "<FONT size='[speech_volume]'>[msg]</FONT>"
 	if(audio_file && recording)

--- a/code/game/objects/items/devices/translators.dm
+++ b/code/game/objects/items/devices/translators.dm
@@ -37,7 +37,7 @@
 		to_chat(user, "<span class='notice'>You disable \the [src].</span>")
 
 /obj/item/device/universal_translator/hear_talk(var/mob/speaker, var/message, var/vrb, var/datum/language/language)
-	if(!listening || !istype(speaker))
+	if(!listening || !istype(speaker) || isanimal(speaker))
 		return
 
 	//Handheld or pocket only.

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -3,7 +3,7 @@
 	name = "Noise"
 	desc = "Noises"
 	key = ""
-	flags = RESTRICTED|NONGLOBAL|INNATE|NO_TALK_MSG|NO_STUTTER|NO_TRANSLATE
+	flags = RESTRICTED|NONGLOBAL|INNATE|NO_TALK_MSG|NO_STUTTER
 	has_written_form = FALSE
 
 /datum/language/noise/format_message(message, verb)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
 #5323 had some issues
Reverts the noise lang change, noise lang must be understandable to everyone, that's it's point
This makes the correct changes to prevent the underlying issue

## Changelog
:cl:
balance: Animals can no longer be tape-recorded or translated.
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
