### PR TITLE
Remaps the engine chamber to allow for larger engines

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -1395,14 +1395,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/rbreakroom)
-"app" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/nosmoking/small{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "apq" = (
 /obj/machinery/power/breakerbox{
 	RCon_tag = "AI Core Substation Bypass"
@@ -3919,7 +3911,13 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
 "aQO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "aQR" = (
@@ -9135,13 +9133,7 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/workshop)
 "bWI" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "bWL" = (
@@ -14892,11 +14884,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/main/stairwell)
 "dhg" = (
-/obj/effect/floor_decal/industrial/warningred,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "dhi" = (
@@ -16461,7 +16453,6 @@
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/nadezhda/command/tcommsat/computer)
 "dxH" = (
-/obj/structure/table/reinforced,
 /obj/machinery/button/remote/blast_door{
 	id = "guild_lobby";
 	name = "Guild Lobby shutter control";
@@ -16470,6 +16461,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/modular_computer/console/preset/engineering,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/foyer)
 "dxK" = (
@@ -22591,11 +22583,11 @@
 	name = "\improper Clinic"
 	})
 "eKO" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_x = -32;
+	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
+/turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/engine_room)
 "eKU" = (
 /obj/machinery/light{
@@ -24773,13 +24765,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
-"fgW" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "fhb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -25533,8 +25518,14 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/toilet/public)
 "fnU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "foa" = (
@@ -27295,6 +27286,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/engine_room)
 "fHX" = (
@@ -33402,16 +33398,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"gWG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "gWN" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -33557,10 +33543,10 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/prisoncells)
 "gYD" = (
-/obj/effect/floor_decal/industrial/warningred{
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/am_control_unit,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "gYU" = (
@@ -34104,7 +34090,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "heY" = (
@@ -36116,7 +36106,9 @@
 	})
 "hAG" = (
 /obj/effect/floor_decal/industrial/warningred,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "hAT" = (
@@ -38015,7 +38007,7 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters)
 "hUA" = (
-/obj/machinery/power/am_control_unit,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "hUD" = (
@@ -40269,13 +40261,10 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/fitness)
 "ipf" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/danger,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "ipl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -44603,7 +44592,9 @@
 /area/turret_protected/ai_upload)
 "jlP" = (
 /obj/structure/bed/chair/office/dark,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "jlS" = (
@@ -44820,7 +44811,11 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "jny" = (
@@ -65669,7 +65664,6 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
 "nDO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -65693,11 +65687,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "nDX" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -65925,6 +65914,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/engine_room)
 "nGm" = (
@@ -71691,11 +71685,9 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "oOh" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "oOj" = (
@@ -76750,12 +76742,8 @@
 /area/colony)
 "pPc" = (
 /obj/effect/floor_decal/industrial/warningred{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "pPi" = (
@@ -79437,11 +79425,6 @@
 /area/nadezhda/maintenance/surfacenorth)
 "qpV" = (
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -81354,14 +81337,6 @@
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
-"qJT" = (
-/obj/effect/floor_decal/industrial/warningred,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "qKe" = (
 /turf/simulated/wall,
 /area/nadezhda/hallway/surface/section1)
@@ -86405,10 +86380,11 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "rOc" = (
-/obj/machinery/light,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -32
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -89930,15 +89906,14 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
 "sxU" = (
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/box/red/corners{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/box/red/corners{
+/obj/effect/floor_decal/industrial/warningred{
 	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -105426,15 +105401,6 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
-"vFE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "vFL" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -107362,7 +107328,9 @@
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm2)
 "vXX" = (
-/obj/item/modular_computer/console/preset/engineering,
+/obj/item/modular_computer/console/preset/engineering{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/engineering/engine_room)
 "vXZ" = (
@@ -114096,6 +114064,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "xtD" = (
@@ -117683,15 +117656,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "yeh" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "yej" = (
@@ -188946,14 +188913,14 @@ krt
 hrP
 sdp
 vXX
-qON
+gYD
 nDO
 sxU
+pPc
+pPc
+pPc
+aQO
 hrP
-cZb
-cZb
-cZb
-cZb
 cZb
 cZb
 cZb
@@ -189149,13 +189116,13 @@ hrP
 cWv
 nls
 qON
-aQO
 kyK
+oOh
+kyK
+kyK
+kyK
+bWI
 hrP
-cZb
-cZb
-cZb
-tad
 tad
 tad
 tad
@@ -189351,13 +189318,13 @@ xty
 jnu
 heX
 fnU
-fnU
-gWG
+bDQ
+oOh
+kyK
+kyK
+kyK
+dhg
 hrP
-cZb
-cZb
-pDL
-pDL
 pDL
 pDL
 pDL
@@ -189548,18 +189515,18 @@ wpx
 szw
 vrC
 nDX
-ipf
+lkS
 qpV
 yeh
-vFE
-bDQ
+kyK
+diB
 kyK
 oOh
+kyK
+kyK
+kyK
+bWI
 hrP
-pDL
-pDL
-pDL
-pDL
 hKz
 hKz
 pDL
@@ -189753,14 +189720,14 @@ mVx
 fZC
 hrP
 iPz
-bWI
-fgW
-qJT
+kyK
 diB
-hrP
-hrP
-hrP
-hrP
+kyK
+rOc
+ipf
+ipf
+ipf
+hAG
 hrP
 nOS
 hKz
@@ -189953,15 +189920,15 @@ szw
 vHX
 jiu
 krt
-hrP
+eKO
 fkV
-gYD
-aQO
-hAG
+kyK
 diB
-oLe
-aQO
-app
+kyK
+kyK
+kyK
+kyK
+kyK
 hOz
 tIs
 mjh
@@ -190157,12 +190124,12 @@ uPO
 lkS
 hrP
 kld
-pPc
-eKO
-dhg
+kyK
 pJK
-hrP
-aQO
+kyK
+kyK
+kyK
+kyK
 jlP
 hOz
 tIs
@@ -190364,7 +190331,7 @@ hrP
 hrP
 hrP
 hrP
-rOc
+kyK
 hrP
 tIs
 tIs

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -3911,13 +3911,10 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
 "aQO" = (
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warningred,
+/obj/machinery/power/am_control_unit,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "aQR" = (
@@ -9132,10 +9129,6 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/workshop)
-"bWI" = (
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "bWL" = (
 /obj/structure/flora/small/grassa4,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -14885,10 +14878,9 @@
 /area/nadezhda/hallway/main/stairwell)
 "dhg" = (
 /obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -32
+	dir = 8;
+	pixel_x = 32
 	},
-/obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "dhi" = (
@@ -22583,11 +22575,13 @@
 	name = "\improper Clinic"
 	})
 "eKO" = (
-/obj/structure/sign/warning/nosmoking/small{
-	pixel_x = -32;
-	pixel_y = 32
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 1
 	},
-/turf/simulated/wall/r_wall,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "eKU" = (
 /obj/machinery/light{
@@ -24765,6 +24759,12 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
+"fgW" = (
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "fhb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -25211,6 +25211,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -33542,13 +33545,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/prisoncells)
-"gYD" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/power/am_control_unit,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "gYU" = (
 /obj/machinery/door/airlock/mining{
 	name = "Prospector Prep";
@@ -36104,13 +36100,6 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
-"hAG" = (
-/obj/effect/floor_decal/industrial/warningred,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "hAT" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -38008,6 +37997,9 @@
 /area/nadezhda/crew_quarters)
 "hUA" = (
 /obj/machinery/light,
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "hUD" = (
@@ -40261,9 +40253,7 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/fitness)
 "ipf" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
+/obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "ipl" = (
@@ -76740,12 +76730,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/plating/under,
 /area/colony)
-"pPc" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "pPi" = (
 /obj/machinery/door/unpowered/simple/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81337,6 +81321,12 @@
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"qJT" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "qKe" = (
 /turf/simulated/wall,
 /area/nadezhda/hallway/surface/section1)
@@ -86380,9 +86370,7 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "rOc" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/warningred,
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
 	},
@@ -105401,6 +105389,12 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"vFE" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "vFL" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -111077,12 +111071,12 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "wLJ" = (
-/obj/structure/catwalk,
-/obj/structure/sign/warning/nosmoking/small{
-	pixel_x = 32
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
 	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_waste)
+/obj/effect/floor_decal/industrial/warningred,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "wLL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -188514,7 +188508,7 @@ hrP
 hrP
 hrP
 wiT
-wLJ
+nyB
 gSZ
 tip
 cZb
@@ -188712,7 +188706,7 @@ hrP
 cWv
 cIX
 rgg
-oSc
+kyK
 hUA
 hrP
 tip
@@ -188913,13 +188907,13 @@ krt
 hrP
 sdp
 vXX
-gYD
+aQO
 nDO
 sxU
-pPc
-pPc
-pPc
-aQO
+qJT
+qJT
+qJT
+wLJ
 hrP
 cZb
 cZb
@@ -189121,7 +189115,7 @@ oOh
 kyK
 kyK
 kyK
-bWI
+ipf
 hrP
 tad
 tad
@@ -189323,7 +189317,7 @@ oOh
 kyK
 kyK
 kyK
-dhg
+ipf
 hrP
 pDL
 pDL
@@ -189525,7 +189519,7 @@ oOh
 kyK
 kyK
 kyK
-bWI
+ipf
 hrP
 hKz
 hKz
@@ -189723,11 +189717,11 @@ iPz
 kyK
 diB
 kyK
+eKO
+vFE
+vFE
+vFE
 rOc
-ipf
-ipf
-ipf
-hAG
 hrP
 nOS
 hKz
@@ -189920,7 +189914,7 @@ szw
 vHX
 jiu
 krt
-eKO
+hrP
 fkV
 kyK
 diB
@@ -190126,9 +190120,9 @@ hrP
 kld
 kyK
 pJK
-kyK
-kyK
-kyK
+dhg
+oSc
+fgW
 kyK
 jlP
 hOz

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -95536,6 +95536,15 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
+"tIz" = (
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 8
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "tIA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -188910,7 +188919,7 @@ vXX
 aQO
 nDO
 sxU
-qJT
+tIz
 qJT
 qJT
 wLJ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Remaps the engine area and small monitoring room to allow for larger engine configurations
</summary>
<hr>

Guild recently got a few more antimatter pieces which allows them to make larger engines... but their engine room is very firmly designed for a 3x3 engine. This PR remaps the area to support a 5x5, with it able to be made 5x6 relatively easily if the Guild acquires a lot of parts.

![image](https://github.com/sojourn-13/sojourn-station/assets/29682682/a0e3434a-81e7-4db2-88fb-25f408979ad0)

	
<hr>
</details>

## Changelog
:cl:
map: Guild Engine room remapped for larger engines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
