### PR TITLE
Underplating tripping checks higher of vig or cog

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -278,7 +278,8 @@ var/list/flooring_types
 		if(M.stats.getPerk(PERK_SURE_STEP))
 			return
  // The art of calculating the vectors required to avoid tripping on the metal beams requires big quantities of brain power
-		if(prob(50 - our_trippah.stats.getStat(STAT_COG))) //50 cog makes you unable to trip
+ // The truly aware can smell the rolled ankle's unwashed bald spot and dodge it like they dodged the draft
+		if(prob(50 - max(our_trippah.stats.getStat(STAT_COG), our_trippah.stats.getStat(STAT_VIG)))) //50 cog or vig makes you unable to trip
 			if(!our_trippah.back)
 				to_chat(our_trippah, SPAN_WARNING("You would have tripped if you didn't balance."))
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request

</summary>
<hr>
Encourages build diversity by allowing another stat as a potential trip bypass, allowing more characters to take interesting backgrounds that aren't Former Scavenger.

The higher of vigilance or cognition is used to determine trip chance. Dumb melee builds can WEEP.

Gives an additional reason to not dump vigilance, since doing so is kindof all the rage right now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
balance: Vigilance allows the user to avoid tripping on underplating.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
