### PR TITLE
[Removal] Removes partial understanding on monkey for common and for common on monkey

### DIFF
--- a/code/modules/mob/language/monkey.dm
+++ b/code/modules/mob/language/monkey.dm
@@ -2,9 +2,6 @@
 	name = LANGUAGE_MONKEY
 	desc = "Ook ook ook."
 	colour = "monkey"
-	partial_understanding = list(
-		LANGUAGE_COMMON = 5			//hehe le monkey
-	)
 	has_written_form = FALSE //No monke write......
 	speech_verb = list("chimpers")
 	ask_verb = list("chimpers")

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -3,7 +3,6 @@
 	desc = "Most popular language in Canis Majoris constellation, thanks to many USA colonial ships arrived there in distant past."
 	key = "0"
 	partial_understanding = list(
-		LANGUAGE_MONKEY = 5,			//hehe le monkey
 		LANGUAGE_LATIN = 5,
 		LANGUAGE_JANA = 5,
 		LANGUAGE_ROMANA = 10,

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -3,7 +3,7 @@
 	desc = "Most popular language in Canis Majoris constellation, thanks to many USA colonial ships arrived there in distant past."
 	key = "0"
 	partial_understanding = list(
-		LANGUAGE_LATIN = 5
+		LANGUAGE_LATIN = 5,
 		LANGUAGE_JANA = 5,
 		LANGUAGE_ROMANA = 10,
 		LANGUAGE_EURO = 20,

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -3,7 +3,7 @@
 	desc = "Most popular language in Canis Majoris constellation, thanks to many USA colonial ships arrived there in distant past."
 	key = "0"
 	partial_understanding = list(
-		LANGUAGE_LATIN = 5,
+		LANGUAGE_LATIN = 5
 		LANGUAGE_JANA = 5,
 		LANGUAGE_ROMANA = 10,
 		LANGUAGE_EURO = 20,


### PR DESCRIPTION
## About The Pull Request

Both are old references to a gamemode that was merged in 2015 (?) on another codebase for about a month before it got removed. Somehow this reference still exists on many codebases for whatever reason. Theres no instance where a monkey is controlable here outside of certain fringe case events (looking at Carrions turning into one I suppose.). This is basically just a little cleanup.

## Why is this good for the server

- It removes an oversight/pseudofeature from long long ago back when Eriscode was Bay which has no place in our setting.

## Changelog
:cl:
del: Partial understanding on monkey language for common and partial understanding on common for monkey language. Code cleanup basically.
/:cl:

