### PR TITLE
Xenobiology QOL

### DIFF
--- a/code/modules/projectiles/guns/energy/misc/slimegun.dm
+++ b/code/modules/projectiles/guns/energy/misc/slimegun.dm
@@ -7,7 +7,7 @@
 	item_state = "slimepistol"
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 6, MATERIAL_SILVER = 3)
 	price_tag = 500
-	charge_cost = 100
+	charge_cost = 20
 	fire_sound = 'sound/weapons/energy/Taser.ogg'
 	suitable_cell = /obj/item/cell/small
 	cell_type = /obj/item/cell/small

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -4132,6 +4132,7 @@
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
+/obj/item/gun/energy/slimegun,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "aUc" = (
@@ -20878,16 +20879,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "erv" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/slime_compresser,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
 "erE" = (
@@ -75589,10 +75585,6 @@
 /area/shuttle/vasiliy_shuttle_area)
 "pDc" = (
 /obj/structure/table/reinforced,
-/obj/machinery/slime_dye_vat{
-	pixel_x = 1;
-	pixel_y = 5
-	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "pDd" = (
@@ -77038,6 +77030,11 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -32
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/slime_dye_vat{
+	pixel_x = 1;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)


### PR DESCRIPTION
Added a slime grinder to Xenobiology along with a round start corestopper.

Lowered the firing charge of the corestopper from 100 to 20 (1/5th)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
