### PR TITLE
[bugfix] NO_PAIN flag now actually properly confers pain immunity.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -203,6 +203,11 @@
 /mob/living/carbon/human/setToxLoss()
 	return
 
+/mob/living/carbon/human/adjustHalLoss(amount)
+    if(species.flags & NO_PAIN)
+        return FALSE    //lmao pain
+    ..()
+
 ////////////////////////////////////////////
 
 //Returns a list of damaged organs


### PR DESCRIPTION
Previously, the nopain flag/mutations didn't actually stop you from accumulating halloss(which meant you still suffered all kinds of deleterious effects). This has been fixed. This will also introduce a new issue because some jackalope decided to make it so that shields cause halloss when struck even though halloss is used as pain(not STAMINA). this i will maybe fix later.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
