### PR TITLE
Rebalance recluse to be 2 hit instant death

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -97,7 +97,7 @@
 	icon_living = "recluse"
 	maxHealth = 15
 	health = 15
-	poison_per_bite = 0.5 //Lets not have a classic ss13 traitor chem be used as an instant down when people are lagging. 2 hits for your unfun spider
+	poison_per_bite = 1
 	melee_damage_lower = 3
 	melee_damage_upper = 5
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/spider/recluse

--- a/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
+++ b/code/modules/mob/living/carbon/superior_animal/giant_spider/types/nurse.dm
@@ -97,7 +97,7 @@
 	icon_living = "recluse"
 	maxHealth = 15
 	health = 15
-	poison_per_bite = 1 //1u is all it takes to sleep you, your asleep also dosnt prevet it form attacking you more then once meaning this quit quickly stacks without someones help
+	poison_per_bite = 0.5 //Lets not have a classic ss13 traitor chem be used as an instant down when people are lagging. 2 hits for your unfun spider
 	melee_damage_lower = 3
 	melee_damage_upper = 5
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/spider/recluse

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -311,12 +311,13 @@
 
 /datum/reagent/toxin/zombiepowder/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	..()
-	M.status_flags |= FAKEDEATH
-	M.adjustOxyLoss(0.6 * effect_multiplier)
-	M.Weaken(10)
-	M.silent = max(M.silent, 10)
-	M.tod = world.time
-	M.add_chemical_effect(CE_NOPULSE, 1)
+	if(dose > 1)
+		M.status_flags |= FAKEDEATH
+		M.adjustOxyLoss(0.6 * effect_multiplier)
+		M.Weaken(10)
+		M.silent = max(M.silent, 10)
+		M.tod = world.time
+		M.add_chemical_effect(CE_NOPULSE, 1)
 
 /datum/reagent/toxin/zombiepowder/Destroy()
 	if(holder && holder.my_atom && ismob(holder.my_atom))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Certified salt PR moment. Why do we have an instant death spider with no way to proper counter play? Prob Kaz thought it was funny. Good thing he is no longer around!

Now you need at least two hits to be dead and zombie powder as well requires 1 unit to work, preventing players to cheese super thinned out zombie powder to sleep people indefinetly. So if you do end up lagging into them (Some of us play with a 1 second stutter like me :( ) you don't end up instant dead.