### PR TITLE
Projectiles go over disposal bins

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -467,6 +467,9 @@
 				visible_message("\The [I] lands in \the [src].")
 			else
 				visible_message("\The [I] bounces off of \the [src]\'s rim!")
+	else if (istype(mover, /obj/item/projectile))
+		return TRUE
+
 	else
 		return ..(mover, target, height, air_group)
 


### PR DESCRIPTION
Projectiles now fly over disposal bins.


----------------


I'm not completely happy with just adding a flat projectile check, but it seems that we don't use the CanPass() "height" variable anywhere in the code for these sorts of purposes, and I don't want to do a code crawl and adjust every single copy-pasted "height=0" in the code.