### PR TITLE
Fullauto runtime

### DIFF
--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -109,7 +109,7 @@
 
 /datum/click_handler/fullauto/proc/shooting_loop()
 
-	if(!owner || !owner.mob || owner.mob.resting)
+	if(!owner || !owner.mob || owner.mob.resting || !reciever)
 		return FALSE
 
 	if(target)

--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -89,7 +89,7 @@
 	receiver.afterattack(target, owner.mob, FALSE)
 
 /datum/click_handler/fullauto/MouseDown(object, location, control, params)
-	if(QDELETED(reciever)
+	if(QDELETED(receiver)
 		Destroy()
 		return FALSE
 	if(!isturf(owner.mob.loc)) // This stops from firing full auto weapons inside closets or in /obj/effect/dummy/chameleon chameleon projector
@@ -112,7 +112,7 @@
 
 /datum/click_handler/fullauto/proc/shooting_loop()
 
-	if(!owner || !owner.mob || owner.mob.resting || !reciever)
+	if(!owner || !owner.mob || owner.mob.resting || !receiver)
 		return FALSE
 
 	if(target)

--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -89,6 +89,9 @@
 	receiver.afterattack(target, owner.mob, FALSE)
 
 /datum/click_handler/fullauto/MouseDown(object, location, control, params)
+	if(QDELETED(reciever)
+		Destroy()
+		return FALSE
 	if(!isturf(owner.mob.loc)) // This stops from firing full auto weapons inside closets or in /obj/effect/dummy/chameleon chameleon projector
 		return FALSE
 	if(time_since_last_init > world.time)

--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -89,7 +89,7 @@
 	receiver.afterattack(target, owner.mob, FALSE)
 
 /datum/click_handler/fullauto/MouseDown(object, location, control, params)
-	if(QDELETED(receiver)
+	if(QDELETED(receiver))
 		Destroy()
 		return FALSE
 	if(!isturf(owner.mob.loc)) // This stops from firing full auto weapons inside closets or in /obj/effect/dummy/chameleon chameleon projector


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I noticed that fullauto still loops when a gun is being deleted like it is for the case of the bluecross lockpick o matic.
This should hopefully stop it looped and delete itself proper since it stopped people from interacting with anything.
Forewarning, I wasn't able to replicate this issue so it may or may not fix it.

If anyone else wants to take a peek at it.
![grafik](https://github.com/sojourn-13/sojourn-station/assets/21098781/368c0d16-b26e-426f-9e5b-ee0f96313497)
![grafik](https://github.com/sojourn-13/sojourn-station/assets/21098781/b7c77e24-5991-4a26-9c25-2565a9c8cfe7)
![grafik](https://github.com/sojourn-13/sojourn-station/assets/21098781/c526da59-4856-415a-9e07-105198b6a0d5)
