### PR TITLE
[balance] New burn-wound medicine

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -74,6 +74,7 @@
 #define CE_DARKSIGHT 		"darksight"	//Vision methods built into a mob.
 #define CE_BRAINHEAL        "neural tissue restoration"
 #define CE_EYEHEAL          "sensory organ regeneration stimulant"
+#define CE_DEBRIDEMENT      "debriding agent" //for fixing burn/necrosis type wounds.
 
 // Chem effects for robotic/assisted organs
 #define CE_MECH_STABLE 		"cooling"

--- a/code/modules/organs/internal/internal_wounds/organic.dm
+++ b/code/modules/organs/internal/internal_wounds/organic.dm
@@ -84,7 +84,7 @@
 /datum/component/internal_wound/organic/burn
 	treatments_item = list(/obj/item/stack/medical/bruise_pack/advanced = 2)
 	treatments_tool = list(QUALITY_CUTTING = FAILCHANCE_NORMAL)
-	treatments_chem = list(CE_STABLE = 1)	// Inaprov will only keep it from killing you
+	treatments_chem = list(CE_STABLE = 1, CE_DEBRIDEMENT = 1)	// Inaprov will only keep it from killing you
 	scar = /datum/component/internal_wound/organic/necrosis_start
 	severity = 0
 	severity_max = 5
@@ -109,6 +109,7 @@
 
 /datum/component/internal_wound/organic/necrosis_start
 	treatments_tool = list(QUALITY_CUTTING = FAILCHANCE_NORMAL)
+	treatments_chem = list(CE_DEBRIDEMENT = 0.5)
 	severity = 0
 	severity_max = 1
 	next_wound = /datum/component/internal_wound/organic/necrosis
@@ -118,7 +119,7 @@
 
 /datum/component/internal_wound/organic/necrosis
 	treatments_tool = list(QUALITY_CUTTING = FAILCHANCE_NORMAL)
-	treatments_chem = list(CE_STABLE = 1)	// Inaprov will only keep it from killing you
+	treatments_chem = list(CE_STABLE = 1, CE_DEBRIDEMENT = 1)	// Inaprov will only keep it from killing you
 	scar = /datum/component/internal_wound/organic/necrosis_start
 	severity = 0
 	severity_max = 3
@@ -241,7 +242,7 @@
 	name = "scar tissue"
 	treatments_item = list()	// No way to treat without an autodoc
 	treatments_tool = list()
-	treatments_chem = list()
+	treatments_chem = list(CE_DEBRIDEMENT = 3) //requires a  high overdose of debridement agent
 	characteristic_flag = IWOUND_CAN_DAMAGE
 	severity = 2
 	severity_max = 2

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -701,6 +701,34 @@ We don't use this but we might find use for it. Porting it since it was updated 
 		if(LAZYLEN(organs_sans_brain_and_bones))
 			create_overdose_wound(pick(organs_sans_brain_and_bones), H, /datum/component/internal_wound/organic/heavy_poisoning)
 
+/datum/reagent/medicine/trypsin
+	name = "Trypsin"
+	id = "trypsin"
+	description = "A synthetic enzyme designed to assist the body in clearing burned and dead flesh from within. Highly painful a typical dose of five units will serve most uses."
+	taste_description = "copper and faint burning"
+	color = "#9c3a33"
+	overdose = 10
+
+/datum/reagent/medicine/trypsin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/list/organs_sans_brain_and_bones = H.internal_organs - H.internal_organs_by_efficiency[BP_BRAIN] - H.internal_organs_by_efficiency[OP_BONE] // Peridaxon shouldn't heal brain or bones
+		for(var/obj/item/organ/I in organs_sans_brain_and_bones)
+			var/list/current_wounds = I.GetComponents(/datum/component/internal_wound)
+			if(LAZYLEN(current_wounds) && !BP_IS_ROBOTIC(I) && prob(75)) //heals only non-robotic organs
+				M.add_chemical_effect(CE_DEBRIDEMENT, dose*0.2) //5 units will provide enough CE_DEBRIDEMENT to actually
+				M.apply_damage(dose*0.5, HALLOSS)
+
+
+/datum/reagent/medicine/trypsin/overdose(mob/living/carbon/M, alien)
+	. = ..()
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/list/organs_sans_brain_and_bones = H.internal_organs - H.internal_organs_by_efficiency[BP_BRAIN] - H.internal_organs_by_efficiency[OP_BONE] // Since it doesn't heal brain/bones it shouldn't damage them too
+		if(LAZYLEN(organs_sans_brain_and_bones))
+			M.take_organ_damage(pick(0,5))
+			M.add_chemical_effect(CE_DEBRIDEMENT, dose*0.1) //a dose of about 20 will give you enough CE_DEBRIDEMENT to clear "permanent" scars. You'll still need to clear the carbonized flesh by hand, however.
+
 /datum/reagent/medicine/ctincture
 	name = "Carpotoxin Tincture"
 	id = "ctincture"

--- a/code/modules/reagents/recipes/recipes.dm
+++ b/code/modules/reagents/recipes/recipes.dm
@@ -117,6 +117,11 @@
 	catalysts = list("plasma" = 5)
 	result_amount = 2
 
+/datum/chemical_reaction/trypsin
+	result = "trypsin"
+	required_reagents = list("carbon" = 1, "sacid" = 1, "dermaline" = 1)
+	result_amount = 1
+
 /datum/chemical_reaction/leporazine
 	result = "leporazine"
 	required_reagents = list("silicon" = 1, "copper" = 1)


### PR DESCRIPTION
Adds a new chem for use in treating internal burns/necrosis.  Created by mixing carbon, sulfuric acid and dermaline. Painful to use, but at least it doesn't require surgery. Trypsin can also be used to treat "permanent" scars but only via overdose- which will cause steady brute wounds similar to kyphotorin(and even more pain). This chem is partly an experiment in chem effect numbers that aren't flat values, but are determined by dose(a number that steadily goes up as you metabolize a reagent.)

Probably works. testing chems and wound shit is a PITA.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
