### PR TITLE
New tasks + diving tweak

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -277,11 +277,12 @@ var/list/flooring_types
 	if(MOVING_QUICKLY(M))
 		if(M.stats.getPerk(PERK_SURE_STEP))
 			return
+		var/task_level = our_trippah.learnt_tasks.get_task_mastery_level("SLIP_N_DIE")
  // The art of calculating the vectors required to avoid tripping on the metal beams requires big quantities of brain power
-		if(prob(50 - our_trippah.stats.getStat(STAT_COG))) //50 cog makes you unable to trip
+		if(prob(50 - (our_trippah.stats.getStat(STAT_COG)) + task_level)) //50 cog makes you unable to trip, or if you trip alot
 			if(!our_trippah.back)
-				to_chat(our_trippah, SPAN_WARNING("You would have tripped if you didn't balance."))
 				return
+			our_trippah.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/slip_n_die, "SLIP_N_DIE", skill_gained = 1, learner = our_trippah)
 			our_trippah.adjustBruteLoss(5)
 			our_trippah.trip(src, 6)
 			return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -654,7 +654,6 @@ default behaviour is:
 			return
 //End of SoJ edits
 	if(!weakened && _dir)// If true_dir = 0(src isn't moving), doesn't proc.
-		nutrition -= 25 //SOJ EDIT: WE TAKE HUNER
 		if(momentum_dir == _dir)
 			livmomentum = momentum_speed // Set momentum value as soon as possible for stopSliding to work better
 		var/range = 1 //checks for move intent; dive one tile further if on run intent
@@ -671,6 +670,11 @@ default behaviour is:
 		update_lying_buckled_and_verb_status()
 		pass_flags -= PASSTABLE // Jumpn't over them anymore!
 		allow_spin = TRUE
+		if(!species.reagent_tag == IS_SYNTHETIC)
+			var/par_core = learnt_tasks.get_task_mastery_level("PARCORE")
+			var/hunger_to_take = clamp(25 - par_core, 0, 25)
+			nutrition -= hunger_to_take  //SOJ EDIT: WE TAKE HUNER
+			learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/parcore, "PARCORE", skill_gained = range, learner = src)
 
 		// Slide
 		sleep(1.5)

--- a/modular_sojourn/task_master/_task_master_defines.dm
+++ b/modular_sojourn/task_master/_task_master_defines.dm
@@ -10,3 +10,5 @@
 #define TOOL_BREAKER /datum/task_master/task/tool_breaker
 #define PROPER_AREA_SMOKER /datum/task_master/task/proper_area_smoker
 #define POORS /datum/task_master/task/poors
+#define PARCORE /datum/task_master/task/parcore
+#define SLIP_N_DIE /datum/task_master/task/slip_n_die

--- a/modular_sojourn/task_master/task_helpers.dm
+++ b/modular_sojourn/task_master/task_helpers.dm
@@ -21,6 +21,8 @@
 
 /datum/task_master/task/New(mob/living/holding_mob)
 	forwards_refence = holding_mob
+	if(unlocked)
+		level += 1 //Unlocked tasks start at level 1 rather then 0
 	if(forwards_refence)
 		if(gain_text)
 			to_chat(forwards_refence, SPAN_NOTICE("[gain_text]"))

--- a/modular_sojourn/task_master/tasks.dm
+++ b/modular_sojourn/task_master/tasks.dm
@@ -172,3 +172,23 @@
 
 /datum/task_master/task/poors/activate_affect()
 	forwards_refence.stats.addPerk(PERK_FORCEFUL_REJECTION)
+
+//This affect is in diving code directly
+/datum/task_master/task/parcore
+	name = "Acrobatics"
+	key = "PARCORE"
+	desc = "Diving around with after a warmup sure does make it easyer!"
+	gain_text = "Duck n Cover!"
+	level_threshholds = 10
+	alt_scaling_number = 2 // You can dive whenever
+	unlocked = TRUE
+
+//This affect is in plating directly
+/datum/task_master/task/slip_n_die
+	name = "Face planting trips"
+	key = "TRIPS"
+	desc = "Triping sucks, gotta be more careful..."
+	gain_text = "Ouch, my toe"
+	level_threshholds = 1 //You fall down a lot
+	alt_scaling_number = 2 //But it does hurt
+	unlocked = TRUE


### PR DESCRIPTION
Synths when diving no longer have the hunger drain, rejoice FPB buff!
Tripping now gives you a task, that per level directly lowers the tripping odds per level, like a silent cog addition
Diving has a task for lowering hunger cost (upto making it no longer cost hunger) per level
closes #4718