### PR TITLE
injector sword fix + robo tool fixes

### DIFF
--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -502,6 +502,7 @@
 	degradation = 0.4 //Used a lot
 	var/max_reagents = 30
 	embed_mult = 0
+	unacidable = TRUE //So if we do acid injections we dont melt
 
 /obj/item/tool/sword/saber/injection_rapier/refresh_upgrades()
 	..()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -118,6 +118,9 @@ var/global/list/robot_modules = list(
 	spawn() // For future coders , this "corrupts" the USR reference, so for good practice ,don't make the proc use USR if its called with a spawn.
 		R.choose_icon() //Choose icon recurses and blocks new from completing, so spawn it off
 
+	for(var/obj/item/tool/T in modules)
+		T.degradation = 0 //We don't want robot tools breaking
+
 
 /obj/item/robot_module/Initialize()
 	. = ..()


### PR DESCRIPTION
Allows the injector rapier that the CBO gets to be loaded with acid and not melt, this was actually unintended rather then init balance 
Robotic tools in cyborgs/borgs/drones/ect no longer degrade as they have no ways of replacing or fixing them
closes #5288