### PR TITLE
Change missleading setting

### DIFF
--- a/code/game/machinery/tesla_turret.dm
+++ b/code/game/machinery/tesla_turret.dm
@@ -168,7 +168,7 @@ GLOBAL_LIST_INIT(turret_channels, new/list(5))
 	settings[++settings.len] = list("category" = "Target Unauthorized Colonists", "setting" = "check_access", "value" = shock_net.check_access)
 	settings[++settings.len] = list("category" = "Target All Synthetics", "setting" = "check_synth", "value" = shock_net.check_synth)
 	settings[++settings.len] = list("category" = "Target Fauna", "setting" = "check_anomalies", "value" = shock_net.check_anomalies)
-	settings[++settings.len] = list("category" = "Filter out Friendly Fauna", "setting" = "colony_allied_turret", "value" = shock_net.colony_allied_turret)
+	settings[++settings.len] = list("category" = "Filter out Colony Members", "setting" = "colony_allied_turret", "value" = shock_net.colony_allied_turret)
 	settings[++settings.len] = list("category" = "Toggle AI Access", "setting" = "ailock", "value" = shock_net.ailock)
 	data["settings"] = settings
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changed "Filter out Friendly Fauna" to "Filter out Colony Members" for the tesla turret.
This caused endless amounts of confusion since fauna are not humans from a players side of perspective.
Causing them to flip it off when trying to zap rats and the likes but only ending up zapping themself.
