### PR TITLE
Turns the Delay admin verbs into separate start and resume verbs

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -778,22 +778,37 @@ ADMIN_VERB_ADD(/datum/admins/proc/delay, R_SERVER, FALSE)
 /datum/admins/proc/delay()
 	set category = "Server"
 	set desc="Delay the game start/end"
-	set name="Delay"
+	set name="Start/End Delay"
 
 	if(!check_rights(R_SERVER))
 		return
 	if (SSticker.current_state != GAME_STATE_PREGAME && SSticker.current_state != GAME_STATE_STARTUP)
-		SSticker.delay_end = !SSticker.delay_end
-		log_admin("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")
-		message_admins("\blue [key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].", 1)
+		SSticker.delay_end = TRUE
+		log_admin("[key_name(usr)] delayed the round end")
+		message_admins("\blue [key_name(usr)] delayed the round end.", 1)
 		return
-	round_progressing = !round_progressing
-	if (!round_progressing)
-		to_chat(world, "<b>The game start has been delayed.</b>")
-		log_admin("[key_name(usr)] delayed the game.")
-	else
-		to_chat(world, "<b>The game will start soon.</b>")
-		log_admin("[key_name(usr)] removed the delay.")
+
+	round_progressing = FALSE
+	to_chat(world, "<b>The game start has been delayed.</b>")
+	log_admin("[key_name(usr)] delayed the game.")
+
+
+ADMIN_VERB_ADD(/datum/admins/proc/resume, R_SERVER, FALSE)
+/datum/admins/proc/resume()
+	set category = "Server"
+	set desc="Resume the game start/end"
+	set name="Start/End Resume"
+
+	if(!check_rights(R_SERVER))
+		return
+	if (SSticker.current_state != GAME_STATE_PREGAME && SSticker.current_state != GAME_STATE_STARTUP)
+		SSticker.delay_end = FALSE
+		log_admin("[key_name(usr)] has made the round end normally.")
+		message_admins("\blue [key_name(usr)] has made the round end normally.", 1)
+		return
+	round_progressing = TRUE
+	to_chat(world, "<b>The game will start soon.</b>")
+	log_admin("[key_name(usr)] removed the delay.")
 
 ADMIN_VERB_ADD(/datum/admins/proc/adjump, R_SERVER, FALSE)
 /datum/admins/proc/adjump()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Removes the "Delay" Admin verb, replacing it with separate "Start/End Delay" and "Start/End Resume" verbs
</summary>
<hr>

The Delay verb isn't very clear in the fact that it both starts *or* ends a delay period, and if things aren't properly communicated two separate staff can accidentally toggle the delay on and off. This splits it into two distinct, better explained verbs.
	
![image](https://github.com/sojourn-13/sojourn-station/assets/29682682/90e70a8f-a831-4813-8461-2eec37481e41)

<hr>
</details>

## Changelog
:cl:
admin: Turns the Delay admin verbs into separate start and resume verbs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
