### PR TITLE
deepmaint mobs uniquic attacks

### DIFF
--- a/code/game/objects/random/mob/misc.dm
+++ b/code/game/objects/random/mob/misc.dm
@@ -128,15 +128,15 @@
 				/mob/living/carbon/superior_animal/psi_monster/cerebral_crusher = 4
 				)
 
-//At higher levels we throw in daskvey, they are harder to fight with less
+//At higher levels we throw in CRAZY NOT CONNECTED TO THE REAL CULT daskvey TYPE MOBS, they are harder to fight with less
 /obj/random/mob/psi_monster/item_to_spawn()
 	if(GLOB.chaos_level > 0)
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly = (2 * GLOB.chaos_level))
 
 	if(GLOB.chaos_level > 1)
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly/pitch_horror = (0.5 * GLOB.chaos_level))
-		//mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/weakling/deepmaints_bound = (0.5 * GLOB.chaos_level))
-/* Awaiting Cora's approval!
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/weakling/deepmaints_bound = (0.5 * GLOB.chaos_level))
+
 	if(GLOB.chaos_level > 2)
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/deepmaints_bound = (0.5 * GLOB.chaos_level))
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/cleaver/deepmaints_bound = (0.3 * GLOB.chaos_level))
@@ -148,10 +148,10 @@
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/smg/deepmaints_bound = (0.2 * GLOB.chaos_level))
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/rifle/deepmaints_bound = (0.1 * GLOB.chaos_level))
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/halberd/deepmaints_bound = (0.2 * GLOB.chaos_level))
-*/
+
 	if(GLOB.chaos_level > 4)
-//		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_shooter/deepmaints_bound = (0.2 * GLOB.chaos_level))
-//		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_master/deepmaints_bound = (0.2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_shooter/deepmaints_bound = (0.2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_master/deepmaints_bound = (0.2 * GLOB.chaos_level))
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/ploge = (0.1 * GLOB.chaos_level)) //Once admin only
 
 	return pickweight(mobs)

--- a/code/game/objects/random/mob/misc.dm
+++ b/code/game/objects/random/mob/misc.dm
@@ -128,13 +128,31 @@
 				/mob/living/carbon/superior_animal/psi_monster/cerebral_crusher = 4
 				)
 
+//At higher levels we throw in daskvey, they are harder to fight with less
 /obj/random/mob/psi_monster/item_to_spawn()
 	if(GLOB.chaos_level > 0)
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly = (2 * GLOB.chaos_level))
+
 	if(GLOB.chaos_level > 1)
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly/pitch_horror = (0.5 * GLOB.chaos_level))
-	if(GLOB.chaos_level > 4) //Once admin only
-		mobs += list(/mob/living/carbon/superior_animal/psi_monster/ploge = (0.1 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/weakling/deepmaints_bound = (0.5 * GLOB.chaos_level))
+
+	if(GLOB.chaos_level > 2)
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/deepmaints_bound = (0.5 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/cleaver/deepmaints_bound = (0.3 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/laser/deepmaints_bound = (0.2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/shield/deepmaints_bound = (0.2 * GLOB.chaos_level))
+
+	if(GLOB.chaos_level > 3)
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/plasma/deepmaints_bound = (0.2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/smg/deepmaints_bound = (0.2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/rifle/deepmaints_bound = (0.1 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/halberd/deepmaints_bound = (0.2 * GLOB.chaos_level))
+
+	if(GLOB.chaos_level > 4)
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_shooter/deepmaints_bound = (0.2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_master/deepmaints_bound = (0.2 * GLOB.chaos_level))
+		mobs += list(/mob/living/carbon/superior_animal/psi_monster/ploge = (0.1 * GLOB.chaos_level)) //Once admin only
 
 	return pickweight(mobs)
 

--- a/code/game/objects/random/mob/misc.dm
+++ b/code/game/objects/random/mob/misc.dm
@@ -135,8 +135,8 @@
 
 	if(GLOB.chaos_level > 1)
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/wasonce/crimson_jelly/pitch_horror = (0.5 * GLOB.chaos_level))
-		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/weakling/deepmaints_bound = (0.5 * GLOB.chaos_level))
-
+		//mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/weakling/deepmaints_bound = (0.5 * GLOB.chaos_level))
+/* Awaiting Cora's approval!
 	if(GLOB.chaos_level > 2)
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/deepmaints_bound = (0.5 * GLOB.chaos_level))
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/cleaver/deepmaints_bound = (0.3 * GLOB.chaos_level))
@@ -148,10 +148,10 @@
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/smg/deepmaints_bound = (0.2 * GLOB.chaos_level))
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/rifle/deepmaints_bound = (0.1 * GLOB.chaos_level))
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/halberd/deepmaints_bound = (0.2 * GLOB.chaos_level))
-
+*/
 	if(GLOB.chaos_level > 4)
-		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_shooter/deepmaints_bound = (0.2 * GLOB.chaos_level))
-		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_master/deepmaints_bound = (0.2 * GLOB.chaos_level))
+//		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_shooter/deepmaints_bound = (0.2 * GLOB.chaos_level))
+//		mobs += list(/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_master/deepmaints_bound = (0.2 * GLOB.chaos_level))
 		mobs += list(/mob/living/carbon/superior_animal/psi_monster/ploge = (0.1 * GLOB.chaos_level)) //Once admin only
 
 	return pickweight(mobs)

--- a/code/modules/core_implant/cruciform/machinery/obelisk.dm
+++ b/code/modules/core_implant/cruciform/machinery/obelisk.dm
@@ -32,6 +32,7 @@ GLOBAL_LIST_EMPTY(all_obelisk)
 /obj/machinery/power/nt_obelisk/New()
 	..()
 	GLOB.all_obelisk |= src
+/*
 	var/area/my_area = get_area(src.loc)
 	if(my_area.name == "Deep Maintenance") //Shockingly this is how get area works
 		//In deepmaints we work way worse,
@@ -39,7 +40,7 @@ GLOBAL_LIST_EMPTY(all_obelisk)
 		damage = max(5, damage - 10 - GLOB.chaos_level)
 		max_targets = max(1, max_targets - 1 - GLOB.chaos_level)
 		desc = "[desc] This one is being weaked by the forces in the area"
-
+*/
 /obj/machinery/power/nt_obelisk/Destroy()
 	for(var/i in currently_affected)
 		var/mob/living/carbon/human/H = i

--- a/code/modules/core_implant/cruciform/machinery/obelisk.dm
+++ b/code/modules/core_implant/cruciform/machinery/obelisk.dm
@@ -32,6 +32,13 @@ GLOBAL_LIST_EMPTY(all_obelisk)
 /obj/machinery/power/nt_obelisk/New()
 	..()
 	GLOB.all_obelisk |= src
+	var/area/my_area = get_area(src.loc)
+	if(my_area.name == "Deep Maintenance") //Shockingly this is how get area works
+		//In deepmaints we work way worse,
+		area_radius = max(3, area_radius - 1 - GLOB.chaos_level)
+		damage = max(5, damage - 10 - GLOB.chaos_level)
+		max_targets = max(1, max_targets - 1 - GLOB.chaos_level)
+		desc = "[desc] This one is being weaked by the forces in the area"
 
 /obj/machinery/power/nt_obelisk/Destroy()
 	for(var/i in currently_affected)

--- a/code/modules/hivemind/objects.dm
+++ b/code/modules/hivemind/objects.dm
@@ -6,18 +6,35 @@
 	name = "electrolyzed goo"
 	icon = 'icons/obj/hivemind.dmi'
 	icon_state = "goo_proj"
-	damage_types = list(BURN = 15) //Shot in large amounts and stacks a bit with its toxin damage
+	damage_types = list(BURN = 15) //Shot in large amounts and stacks a bit with its burn damage
 	check_armour = ARMOR_ENERGY //Unlike Bio, it's not either 0% or 100%. Strong Energy armour isn't common, But most of armour has some protection against energy.
 	step_delay = 2
-
+	var/second_hit_damage = 10
 
 /obj/item/projectile/goo/on_hit(atom/target)
 	. = ..()
 	if (!testing)
 		if(isliving(target) && !issilicon(target) )
 			var/mob/living/L = target
-			L.damage_through_armor(10, BURN, attack_flag = ARMOR_RAD)
+			L.damage_through_armor(second_hit_damage, BURN, attack_flag = ARMOR_RAD)
 			if(!(locate(/obj/effect/decal/cleanable/spiderling_remains) in target.loc))
 				var/obj/effect/decal/cleanable/spiderling_remains/goo = new /obj/effect/decal/cleanable/spiderling_remains(target.loc)
-				goo.name = "electrolyzed goo" //from "acrid goo" to "acidic goo", and from "acidic goo" to "electrolyzed goo"
+				goo.name = "[name]" //from "acrid goo" to "acidic goo", and from "acidic goo" to "electrolyzed goo"
 				goo.desc = "An unknown, bubbling liquid. The fumes smell awful with a hint of ozone."
+
+/obj/item/projectile/goo/fast
+	name = "electrolyzed goop"
+	step_delay = 0.5
+
+/obj/item/projectile/goo/fire_starter
+	name = "smoldering goo"
+	fire_stacks = 1
+
+/obj/item/projectile/goo/harder_second_hit
+	name = "sticky goo"
+	second_hit_damage = 15
+
+/obj/item/projectile/goo/heavyer
+	name = "thick electrolyzed goo"
+	damage_types = list(BURN = 20)
+	step_delay = 2.5

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/ai.dm
@@ -66,3 +66,40 @@
 		I.throw_at(get_edge_target_turf(src,pick(alldirs)), rand(1,3), round(30/I.w_class))
 
 	. = ..()
+
+//Chaos intraction
+//Another complx mob that has quite a few bells and whistles!
+/mob/living/carbon/superior_animal/psi_monster/pus_maggot/ash_wendigo/attackby(obj/item/I, mob/user)
+	..()
+	if(GLOB.chaos_level >= 2)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			var/dir_to_oppose = reverse_direction(H.dir)
+			//Ok! the second part of this if statement only applie if we do *not* have locked facing directions!
+			if(!H.psi_blocking > 0 && dir == dir_to_oppose)
+				//This is a bit wierd, so we set ARE direction to where we want to teleport based on WHO HIT US
+				dir = turn(H.dir, -90)
+
+				var/turf/T = get_step(H, dir)
+				if(T && !QDELETED(src)) //Safty so we dont teleport out of quedel
+					forceMove(T)
+					//Ok now turn back to face are foe!
+					dir = reverse_direction(H.dir)
+
+/mob/living/carbon/superior_animal/psi_monster/pus_maggot/ash_wendigo/findTarget(prioritizeCurrent = FALSE)
+	. = ..()
+	if(GLOB.chaos_level >= 2)
+		var/atom/targetted_mob = (target_mob?.resolve())
+		if(ishuman(targetted_mob))
+			var/mob/living/carbon/human/H = targetted_mob
+			var/dir_to_oppose = reverse_direction(H.dir)
+			//Ok! the second part of this if statement only applie if we do *not* have locked facing directions!
+			if(!H.psi_blocking > 0 && dir == dir_to_oppose)
+			//This is a bit wierd, so we set ARE direction to where we want to teleport based on WHO HIT US
+				dir = set_dir(turn(src.dir, -90))
+
+				var/turf/T = get_step(H, dir)
+				if(T && !QDELETED(src)) //Safty so we dont teleport out of quedel
+					forceMove(T)
+					//Ok now turn back to face are foe!
+					dir = reverse_direction(H.dir)

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
@@ -151,9 +151,9 @@
 			var/mob/living/carbon/human/H = A
 			if(!H.psi_blocking > 0)
 				if(istype(H.head, /obj/item/clothing)) //We only knock off hats
-					var/obj/item/clothing/hat
+					var/obj/item/clothing/hat = H.head
 					if(hat.canremove || hat.psi_blocking <= 0)
-						drop_from_inventory(hat)
+						H.drop_from_inventory(hat)
 						visible_message(SPAN_DANGER("[src] steals [H.name]'s [hat]!"))
 	. = ..()
 
@@ -179,9 +179,9 @@
 						H.replace_in_slot(new psionic_mask, slot_wear_mask, skip_covering_check = TRUE)
 
 				else
-					if(istype(H.wear_mask, /obj/item/clothing) && istype(H.wear_mask, /obj/item/clothing/mask/deepmaints_debuff)) //Saved by a masked item!
-						var/obj/item/clothing/mask
+					if(istype(H.wear_mask, /obj/item/clothing) && !istype(H.wear_mask, /obj/item/clothing/mask/deepmaints_debuff)) //Saved by a masked item!
+						var/obj/item/clothing/mask = H.wear_mask
 						if(mask.canremove || mask.psi_blocking <= 0)
-							drop_from_inventory(mask)
+							H.drop_from_inventory(mask)
 							visible_message(SPAN_DANGER("[src] peals off [H.name]'s [mask]!"))
 	. = ..()

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
@@ -220,11 +220,13 @@
 						if(!wielded_l.is_held_twohanded(wielded_l))
 							visible_message(SPAN_DANGER("[src] batters [H.name]'s [wielded_l], making [H.name] unwield [wielded_l]!"))
 							wielded_l.unwield(H)
-				if(knock_out_of_hand) //When not wielding an item we knock it out of your grasp!
-					if(H.get_active_hand())
-						var/obj/fumble = H.get_active_hand()
-						H.drop_from_inventory(fumble)
-						visible_message(SPAN_DANGER("[src] knocks [fumble] out of [H.name]'s grasp!"))
+				//This is insainl powerful and shuld not just happend without choas level being exstreamly high
+				if(GLOB.chaos_level >= 5)
+					if(knock_out_of_hand) //When not wielding an item we knock it out of your grasp!
+						if(H.get_active_hand())
+							var/obj/fumble = H.get_active_hand()
+							H.drop_from_inventory(fumble)
+							visible_message(SPAN_DANGER("[src] knocks [fumble] out of [H.name]'s grasp!"))
 	. = ..()
 
 //To see full affects go to the ai.dm for psi_monsters

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
@@ -126,3 +126,59 @@
 	if(Victim)
 		if(Victim == M)
 			loc = M.loc // simple "attach to head" effect!
+
+
+//Fancy Chaos level attack upgrades
+
+//Memory: the shadow fella, when they attack teleport behind the person, regardless of whats in are way, (like walls n stuff)
+/mob/living/carbon/superior_animal/psi_monster/memory/UnarmedAttack(atom/A, proximity)
+	. = ..()
+
+	if(ismob(A))
+		var/mob/M = A
+		var/RD = reverse_direction(M.dir)
+		dir = M.dir
+
+		if(GLOB.chaos_level >= 2) //Unlocks early as these smucks are trash
+			var/turf/T = get_step(M, RD)
+			if(T)
+				forceMove(T)
+
+//thought and memory police! These two work together at chaos level 2 making them quite tricky
+/mob/living/carbon/superior_animal/psi_monster/thought_melter/UnarmedAttack(atom/A, proximity)
+	if(GLOB.chaos_level >= 2)
+		if(ishuman(A))
+			var/mob/living/carbon/human/H = A
+			if(istype(H.head, /obj/item/clothing)) //We only knock off hats
+				var/obj/item/clothing/hat
+				if(hat.canremove || hat.psi_blocking <= 0)
+					drop_from_inventory(hat)
+					visible_message(SPAN_DANGER("[src] steals [H.name]'s [hat]!"))
+	. = ..()
+
+/mob/living/carbon/superior_animal/psi_monster/memory_eater/UnarmedAttack(atom/A, proximity, repeat_attack = FALSE)
+	if(GLOB.chaos_level >= 2)
+		if(ishuman(A))
+			var/mob/living/carbon/human/H = A
+			if(!istype(H.head, /obj/item/clothing) && !repeat_attack) //if we dont have a hat we attack again!
+				UnarmedAttack(A,proximity,TRUE)
+	. = ..()
+
+//The masked horror!!!!
+/mob/living/carbon/superior_animal/psi_monster/hovering_nightmare/UnarmedAttack(atom/A, proximity)
+	if(GLOB.chaos_level >= 2)
+		if(ishuman(A))
+			var/mob/living/carbon/human/H = A
+
+			if(!H.wear_mask)
+				var/psionic_mask = pick(typesof(/obj/item/clothing/mask/deepmaints_debuff))
+				if(psionic_mask)
+					H.psionic_mask(new mask, slot_wear_mask, skip_covering_check = TRUE)
+
+			else
+				if(istype(H.wear_mask, /obj/item/clothing) && istype(H.wear_mask /obj/item/clothing/mask/deepmaints_debuff)) //Saved by a masked item!
+					var/obj/item/clothing/mask
+					if(mask.canremove || mask.psi_blocking <= 0)
+						drop_from_inventory(mask)
+						visible_message(SPAN_DANGER("[src] peals off [H.name]'s [mask]!"))
+	. = ..()

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
@@ -149,19 +149,21 @@
 	if(GLOB.chaos_level >= 2)
 		if(ishuman(A))
 			var/mob/living/carbon/human/H = A
-			if(istype(H.head, /obj/item/clothing)) //We only knock off hats
-				var/obj/item/clothing/hat
-				if(hat.canremove || hat.psi_blocking <= 0)
-					drop_from_inventory(hat)
-					visible_message(SPAN_DANGER("[src] steals [H.name]'s [hat]!"))
+			if(!H.psi_blocking > 0)
+				if(istype(H.head, /obj/item/clothing)) //We only knock off hats
+					var/obj/item/clothing/hat
+					if(hat.canremove || hat.psi_blocking <= 0)
+						drop_from_inventory(hat)
+						visible_message(SPAN_DANGER("[src] steals [H.name]'s [hat]!"))
 	. = ..()
 
 /mob/living/carbon/superior_animal/psi_monster/memory_eater/UnarmedAttack(atom/A, proximity, repeat_attack = FALSE)
 	if(GLOB.chaos_level >= 2)
 		if(ishuman(A))
 			var/mob/living/carbon/human/H = A
-			if(!istype(H.head, /obj/item/clothing) && !repeat_attack) //if we dont have a hat we attack again!
-				UnarmedAttack(A,proximity,TRUE)
+			if(!H.psi_blocking > 0)
+				if(!istype(H.head, /obj/item/clothing) && !repeat_attack) //if we dont have a hat we attack again!
+					UnarmedAttack(A,proximity,TRUE)
 	. = ..()
 
 //The masked horror!!!!
@@ -170,15 +172,16 @@
 		if(ishuman(A))
 			var/mob/living/carbon/human/H = A
 
-			if(!H.wear_mask)
-				var/psionic_mask = pick(typesof(/obj/item/clothing/mask/deepmaints_debuff))
-				if(psionic_mask)
-					H.replace_in_slot(new psionic_mask, slot_wear_mask, skip_covering_check = TRUE)
+			if(!H.psi_blocking > 0)
+				if(!H.wear_mask)
+					var/psionic_mask = pick(typesof(/obj/item/clothing/mask/deepmaints_debuff))
+					if(psionic_mask)
+						H.replace_in_slot(new psionic_mask, slot_wear_mask, skip_covering_check = TRUE)
 
-			else
-				if(istype(H.wear_mask, /obj/item/clothing) && istype(H.wear_mask, /obj/item/clothing/mask/deepmaints_debuff)) //Saved by a masked item!
-					var/obj/item/clothing/mask
-					if(mask.canremove || mask.psi_blocking <= 0)
-						drop_from_inventory(mask)
-						visible_message(SPAN_DANGER("[src] peals off [H.name]'s [mask]!"))
+				else
+					if(istype(H.wear_mask, /obj/item/clothing) && istype(H.wear_mask, /obj/item/clothing/mask/deepmaints_debuff)) //Saved by a masked item!
+						var/obj/item/clothing/mask
+						if(mask.canremove || mask.psi_blocking <= 0)
+							drop_from_inventory(mask)
+							visible_message(SPAN_DANGER("[src] peals off [H.name]'s [mask]!"))
 	. = ..()

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
@@ -213,15 +213,23 @@
 					var/obj/item/wielded_r = H.r_hand
 					var/obj/item/wielded_l = H.l_hand
 					knock_out_of_hand = FALSE
-					if(!wielded_r.is_held_twohanded(wielded_r))
-						visible_message(SPAN_DANGER("[src] batters [H.name]'s [wielded_r], making [H.name] unwield [wielded_r]!"))
-						wielded_r.unwield(H)
-					if(!wielded_l.is_held_twohanded(wielded_l))
-						visible_message(SPAN_DANGER("[src] batters [H.name]'s [wielded_l], making [H.name] unwield [wielded_l]!"))
-						wielded_l.unwield(H)
-				if(knock_out_of_hand)
+					if(GLOB.chaos_level >= 3) //At level 3 it knocks items from a wielded state out of it!
+						if(!wielded_r.is_held_twohanded(wielded_r))
+							visible_message(SPAN_DANGER("[src] batters [H.name]'s [wielded_r], making [H.name] unwield [wielded_r]!"))
+							wielded_r.unwield(H)
+						if(!wielded_l.is_held_twohanded(wielded_l))
+							visible_message(SPAN_DANGER("[src] batters [H.name]'s [wielded_l], making [H.name] unwield [wielded_l]!"))
+							wielded_l.unwield(H)
+				if(knock_out_of_hand) //When not wielding an item we knock it out of your grasp!
 					if(H.get_active_hand())
 						var/obj/fumble = H.get_active_hand()
 						H.drop_from_inventory(fumble)
 						visible_message(SPAN_DANGER("[src] knocks [fumble] out of [H.name]'s grasp!"))
 	. = ..()
+
+//To see full affects go to the ai.dm for psi_monsters
+/mob/living/carbon/superior_animal/psi_monster/pus_maggot/ash_wendigo/UnarmedAttack(atom/A, proximity)
+	if(ishuman(A))
+		var/mob/living/carbon/human/H = A
+		dir = reverse_direction(H.dir) //face to face comferation (required for how we handle being attacked)
+	..()

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/attack.dm
@@ -173,10 +173,10 @@
 			if(!H.wear_mask)
 				var/psionic_mask = pick(typesof(/obj/item/clothing/mask/deepmaints_debuff))
 				if(psionic_mask)
-					H.psionic_mask(new mask, slot_wear_mask, skip_covering_check = TRUE)
+					H.replace_in_slot(new psionic_mask, slot_wear_mask, skip_covering_check = TRUE)
 
 			else
-				if(istype(H.wear_mask, /obj/item/clothing) && istype(H.wear_mask /obj/item/clothing/mask/deepmaints_debuff)) //Saved by a masked item!
+				if(istype(H.wear_mask, /obj/item/clothing) && istype(H.wear_mask, /obj/item/clothing/mask/deepmaints_debuff)) //Saved by a masked item!
 					var/obj/item/clothing/mask
 					if(mask.canremove || mask.psi_blocking <= 0)
 						drop_from_inventory(mask)

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
@@ -98,7 +98,7 @@
 	var/is_leaching = FALSE
 	var/steal_odds = 0
 	var/stat_to_steal = STAT_VIV
-	var/steal_amount = 1
+	var/steal_amount = -1 //Possitive amounts give stats, and lower the health of the leacher
 	var/mob/living/Victim = null
 
 	var/can_leave = FALSE

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/PsiRobust.dm
@@ -101,3 +101,9 @@
 	mag_drop = FALSE
 	attacktext = "slapped"
 	range_telegraph = "lurks back, getting ready to lob acids at"
+
+/mob/living/carbon/superior_animal/psi_monster/flesh_tower/Initialize(mapload)
+	. = ..()
+	//Proj Upgrade, its a bit random!
+	if(GLOB.chaos_level >= 2)
+		projectiletype = pick(typesof(/obj/item/projectile/goo))

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
@@ -65,11 +65,21 @@
 	//Same armor that they are warning
 	armor = list(melee = 35, bullet = 35, energy = 35, bomb = 30, bio = 100, rad = 50)
 
+/*
+Note about the deepmaints_bound!
+These ones are meant to be only used for chaos level and not for events, or deeper factional ties
+They are soully made and reflavoured to be for PVE.
+*/
+
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/deepmaints_bound
+	name = "Wild Daskveyian Swordsman"
+	desc = "Once a basic footsoldier of the Hand of Daskvey. \
+	Donning the mask of the warrior, the lowest rank of souls receive their sword and begin training for only the safey of their brothers and sisters. \
+	Turned mad from the Kings influence and being rebound to the Deep Maintenance acts on impluse attacking anyone not directly apart of the Daskvey."
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/item/tool/sword/cult/deepmaints, /obj/random/psi/always_spawn)
-
+	color = null
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/daskvey
 	name = "Daskvey"
@@ -193,9 +203,16 @@
 	armor_penetration = 15
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/cleaver/deepmaints_bound
+	name = "Wild Daskveyian Wall Breaker"
+	desc = "Once a basic footsoldier of the Hand of Daskvey. \
+	Donning the mask of the warrior, the agressive souls of former criminals find themselves too enraged to naught but strike their enemies down with furious rage. \
+	Flesh or steel, the axe will smash its way through. \
+	Turned mad from the Kings influence and being rebound to the Deep Maintenance acts on impluse attacking anyone not directly apart of the Daskvey."
+	color = null
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/item/tool/sword/cleaver/cult/deepmaints, /obj/random/psi/always_spawn)
+	color = null
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/plasma
 	name = "Daskveyian Plasma Caster"
@@ -223,6 +240,10 @@
 	armor_penetration = 15
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/plasma/deepmaints_bound
+	name = "Wild Daskveyian Plasma Caster"
+	desc = "Once a trained warrior of the Hand of Daskvey. Carrying a laser gun enhanced by the wielder's mind, they inflict deadly pain on most that obstruct them. \
+	Turned mad from the Kings influence and being rebound to the Deep Maintenance acts on impluse attacking anyone not directly apart of the Daskvey."
+	color = null
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/item/gun/energy/plasma/cassad/cult/deepmaints, /obj/random/psi/always_spawn)
@@ -256,6 +277,10 @@
 	armor_penetration = 15
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/laser/deepmaints_bound
+	name = "Wild Daskveyian Las-Gunner"
+	desc = "Once a trained Gunner of the Hand of Daskvey, their hands clutching a fine laser rifle to burn away that which would threaten them or their fellow followers. \
+	Turned mad from the Kings influence and being rebound to the Deep Maintenance acts on impluse attacking anyone not directly apart of the Daskvey."
+	color = null
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/item/gun/energy/laser/cult/deepmaints, /obj/random/psi/always_spawn)
@@ -299,6 +324,10 @@
 		projectiletype = /obj/item/projectile/bullet/pistol_35
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/smg/deepmaints_bound
+	name = "Wild Daskveyian Assaulter"
+	desc = "Once a mere Gunner of the Hand of Daskvey, still ready to fight, their weapon sprays waves of lead to any that would harm those that they held dear. \
+	Turned mad from the Kings influence and being rebound to the Deep Maintenance acts on impluse attacking anyone not directly apart of the Daskvey."
+	color = null
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/item/gun/projectile/automatic/greasegun/cult/deepmaints, /obj/random/psi/always_spawn)
@@ -342,6 +371,10 @@
 		projectiletype = /obj/item/projectile/bullet/rifle_75
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/rifle/deepmaints_bound
+	name = "Wild Daskveyian Rifleperson"
+	desc = "Once just a basic rifleperson of the Hand of Daskvey. Shadowed behind the mask of the warrior, they lost the peace given to them, yearning freedom once more. \
+	Turned mad from the Kings influence and being rebound to the Deep Maintenance acts on impluse attacking anyone not directly apart of the Daskvey."
+	color = null
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/item/gun/projectile/automatic/sts/rifle/cult/deepmaints, /obj/random/psi/always_spawn)
@@ -379,6 +412,10 @@
 	. = ..()
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/shield/deepmaints_bound
+	name = "Wild Daskveyian Juggernaut "
+	desc = "Once a soul of strength and integrity, recovered from the ravages laid upon it. Still fitted in heavy armor, it protected those in its shadow with unbending steel, for they were once the wall that held back any that seek to harm their kin. \
+	Turned mad from the Kings influence and being rebound to the Deep Maintenance acts on impluse attacking anyone not directly apart of the Daskvey."
+	color = null
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
@@ -403,6 +440,10 @@
 	armor = list(melee = 60, bullet = 60, energy = 60, bomb = 100, bio = 100, rad = 90)
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/halberd/deepmaints_bound
+	name = "Wild Daskveyian Halberdier"
+	desc = "Once a soul of strength and integrity, recovered from the ravages laid upon it. Still fitted in heavy armor, it used to protects those in its shadow with unwavering confidence, for they found what failure means. \
+	Turned mad from the Kings influence and being rebound to the Deep Maintenance acts on impluse attacking anyone not directly apart of the Daskvey."
+	color = null
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
@@ -427,6 +468,10 @@
 	armor = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/weakling/deepmaints_bound
+	name = "Wild Daskveyian Uplifted"
+	desc = "Once A soul uplifted by the Hand of Daskvey, lost and suffering from it's pains, found often in a trance of forgotten memories. \
+	Do to the Kings influence and being rebound to the Deep Maintenance it acts on impluse attacking anyone not directly apart of the Daskvey."
+	color = null
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/random/psi/always_spawn)
@@ -472,6 +517,10 @@
 	..()
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_shooter/deepmaints_bound
+	name = "Wild Daskveyian Cultist "
+	desc = "Once a soul reformed by the Hand of Daskvey, they spend their time occupied with daily routine, trying to fend off the insanity of their own predicament, while better learning their new powers. \
+	Turned mad from the Kings influence and being rebound to the Deep Maintenance acts on impluse attacking anyone not directly apart of the Daskvey."
+	color = null
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
@@ -519,6 +568,12 @@
 	..()
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_master/deepmaints_bound
+	name = "Wild Daskveyian Hand"
+	desc = "A fallen master of the mind, once reformed and guided true by the Hand of Daskvey. \
+	The members of the Hands form the parties of preach leaders, and assistants to the acolytes. \
+	Their knowledge of psionics is of a scholarly level. \
+	Turned mad from the Kings influence and being rebound to the Deep Maintenance acts on impluse attacking anyone not directly apart of the Daskvey."
+	color = null
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn, /obj/random/psi/always_spawn)

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
@@ -65,6 +65,11 @@
 	//Same armor that they are warning
 	armor = list(melee = 35, bullet = 35, energy = 35, bomb = 30, bio = 100, rad = 50)
 
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/deepmaints_bound
+	psionic_respawn = TRUE //Endles fighter
+	can_leave = FALSE
+	drop_items = list(/obj/item/tool/sword/cult/deepmaints, /obj/random/psi/always_spawn)
+
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/daskvey
 	name = "Daskvey"
@@ -187,6 +192,11 @@
 
 	armor_penetration = 15
 
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/cleaver/deepmaints_bound
+	psionic_respawn = TRUE //Endles fighter
+	can_leave = FALSE
+	drop_items = list(/obj/item/tool/sword/cleaver/cult/deepmaints, /obj/random/psi/always_spawn)
+
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/plasma
 	name = "Daskveyian Plasma Caster"
 	desc = "Trained warrior of the Hand of Daskvey. Carrying a laser gun enhanced by the wielder's mind, they inflict deadly pain on any that obstruct the freedom of their cult's members. For freedom is never free."
@@ -211,6 +221,11 @@
 	projectiletype = /obj/item/projectile/plasma/aoe/heat
 
 	armor_penetration = 15
+
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/plasma/deepmaints_bound
+	psionic_respawn = TRUE //Endles fighter
+	can_leave = FALSE
+	drop_items = list(/obj/item/gun/energy/plasma/cassad/cult/deepmaints, /obj/random/psi/always_spawn)
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/laser
 	name = "Daskveyian Las-Gunner"
@@ -239,6 +254,11 @@
 	projectiletype = /obj/item/projectile/beam
 
 	armor_penetration = 15
+
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/laser/deepmaints_bound
+	psionic_respawn = TRUE //Endles fighter
+	can_leave = FALSE
+	drop_items = list(/obj/item/gun/energy/laser/cult/deepmaints, /obj/random/psi/always_spawn)
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/smg
 	name = "Daskveyian Assaulter"
@@ -272,6 +292,17 @@
 
 	armor_penetration = 15
 
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/smg/Initialize(mapload)
+	. = ..()
+	//Proj Upgrade
+	if(GLOB.chaos_level >= 5)
+		projectiletype = /obj/item/projectile/bullet/pistol_35
+
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/smg/deepmaints_bound
+	psionic_respawn = TRUE //Endles fighter
+	can_leave = FALSE
+	drop_items = list(/obj/item/gun/projectile/automatic/greasegun/cult/deepmaints, /obj/random/psi/always_spawn)
+
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/rifle
 	name = "Daskveyian Rifleperson"
 	desc = "A basic rifleperson of the Hand of Daskvey. Shadowed behind the mask of the warrior, they find peace with weapon in hand, for no duty is more important to freedom than to take up arms for it."
@@ -303,6 +334,17 @@
 	mag_type = /obj/item/ammo_magazine/rifle_75/empty
 
 	armor_penetration = 15
+
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/rifle/Initialize(mapload)
+	. = ..()
+	//Proj Upgrade
+	if(GLOB.chaos_level >= 5)
+		projectiletype = /obj/item/projectile/bullet/rifle_75
+
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/rifle/deepmaints_bound
+	psionic_respawn = TRUE //Endles fighter
+	can_leave = FALSE
+	drop_items = list(/obj/item/gun/projectile/automatic/sts/rifle/cult/deepmaints, /obj/random/psi/always_spawn)
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/shield
 	name = "Daskveyian Juggernaut "
@@ -336,6 +378,11 @@
 				L.visible_message(SPAN_DANGER("\the [src] uses its shield to knock over \the [L]!"))
 	. = ..()
 
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/shield/deepmaints_bound
+	psionic_respawn = TRUE //Endles fighter
+	can_leave = FALSE
+	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
+
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/halberd
 	name = "Daskveyian Halberdier"
 	desc = "A soul of strength and integrity, recovered from the ravages laid upon it. Outfitted in heavy armor, it protects those in its shadow with unwavering confidence, for they know what failure means."
@@ -355,6 +402,11 @@
 	armor_penetration = 30
 	armor = list(melee = 60, bullet = 60, energy = 60, bomb = 100, bio = 100, rad = 90)
 
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/halberd/deepmaints_bound
+	psionic_respawn = TRUE //Endles fighter
+	can_leave = FALSE
+	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
+
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/weakling
 	name = "Daskveyian Uplifted"
 	desc = "A soul recently uplifted by the Hand of Daskvey, still lost and recovering from its pains, they find themselves lost in a trance of forgotten memories."
@@ -373,6 +425,11 @@
 
 	armor_penetration = 0
 	armor = list(melee = 0, bullet = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
+
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/weakling/deepmaints_bound
+	psionic_respawn = TRUE //Endles fighter
+	can_leave = FALSE
+	drop_items = list(/obj/random/psi/always_spawn)
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_shooter
 	name = "Daskveyian Cultist "
@@ -413,6 +470,11 @@
 		projectiletype = /obj/item/projectile/kinetic_blast_electro/dangerous
 
 	..()
+
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_shooter/deepmaints_bound
+	psionic_respawn = TRUE //Endles fighter
+	can_leave = FALSE
+	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn)
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_master
 	name = "Daskveyian Hand"
@@ -455,3 +517,8 @@
 	if(prob(10))
 		projectiletype = /obj/item/projectile/kinetic_blast_electro/brutal
 	..()
+
+/mob/living/carbon/superior_animal/psi_monster/daskvey_follower/orb_master/deepmaints_bound
+	psionic_respawn = TRUE //Endles fighter
+	can_leave = FALSE
+	drop_items = list(/obj/random/psi/always_spawn, /obj/random/psi/always_spawn, /obj/random/psi/always_spawn)

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
@@ -212,7 +212,6 @@ They are soully made and reflavoured to be for PVE.
 	psionic_respawn = TRUE //Endles fighter
 	can_leave = FALSE
 	drop_items = list(/obj/item/tool/sword/cleaver/cult/deepmaints, /obj/random/psi/always_spawn)
-	color = null
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/plasma
 	name = "Daskveyian Plasma Caster"

--- a/code/modules/psionics/psionic_items/psi_armor.dm
+++ b/code/modules/psionics/psionic_items/psi_armor.dm
@@ -210,7 +210,7 @@
 	var/pointgranted = 0 //Did we give you your stat?
 	var/pointremoved = 0 //Did we take you your stat?
 	var/pointamounts = 10
-	var/sanity_damage = 5
+	var/damage_to_sanity = 5
 	var/stat_to_change = STAT_VIG
 	color = "#5B0E4F" //spooooky!!!!!
 	matter = list()
@@ -220,13 +220,13 @@
 	if(!pointremoved)
 		victum.stats.changeStat(stat_to_change, -stat_to_change)
 		pointremoved = TRUE
-	victum.sanity.onPsyDamage(sanity_damage)
+	victum.sanity.onPsyDamage(damage_to_sanity)
 	spawn(2)
 	qdel(src)
 
 /obj/item/clothing/mask/deepmaints_debuff/equipped(var/mob/M)
 	.=..()
-	occultist = M
+	victum = M
 	if(!pointgranted)
 		victum.stats.changeStat(stat_to_change, stat_to_change)
 		pointgranted = 1
@@ -238,7 +238,7 @@
 	item_state = "tiki_angry"
 	stat_to_change = STAT_BIO //WHY CANT I INJECT MY NEEEEDLEEEEEEE!!!!!!!!
 
-/obj/item/clothing/mask/deepmaints_debuffi/confused
+/obj/item/clothing/mask/deepmaints_debuff/confused
 	name = "confused psionic mask"
 	desc = "A psionic mask laced into the victum mind. This one doesn't seem very sure of itself."
 	icon_state = "tiki_confused"
@@ -252,5 +252,5 @@
 	icon_state = "tiki_happy"
 	item_state = "tiki_happy"
 	stat_to_change = STAT_VIV
-	sanity_damage = -5 //Should *heal* sanity not damage
+	damage_to_sanity = -5 //Should *heal* sanity not damage
 	pointamounts = 30 //Hope you didnt have combat chems

--- a/code/modules/psionics/psionic_items/psi_armor.dm
+++ b/code/modules/psionics/psionic_items/psi_armor.dm
@@ -202,11 +202,11 @@
 //Deepmaints debuffing ones
 /obj/item/clothing/mask/deepmaints_debuff
 	name = "startled psionic mask"
-	desc = "A psionic mask laced into the victum mind. This one has a shocked expression."
+	desc = "A psionic mask stitched into the victum mind. This one has a shocked expression."
 	icon_state = "tiki_eyebrow"
 	item_state = "tiki_eyebrow"
 
-	var/mob/living/carbon/human/victum
+	var/mob/living/carbon/human/victim
 	var/pointgranted = 0 //Did we give you your stat?
 	var/pointremoved = 0 //Did we take you your stat?
 	var/pointamounts = 10
@@ -218,7 +218,7 @@
 /obj/item/clothing/mask/deepmaints_debuff/dropped()
 	..()
 	if(!pointremoved)
-		victum.stats.changeStat(stat_to_change, -stat_to_change)
+		victim.stats.changeStat(stat_to_change, -stat_to_change)
 		pointremoved = TRUE
 	victum.sanity.onPsyDamage(damage_to_sanity)
 	spawn(2)
@@ -226,21 +226,21 @@
 
 /obj/item/clothing/mask/deepmaints_debuff/equipped(var/mob/M)
 	.=..()
-	victum = M
+	victim = M
 	if(!pointgranted)
-		victum.stats.changeStat(stat_to_change, stat_to_change)
+		victim.stats.changeStat(stat_to_change, stat_to_change)
 		pointgranted = 1
 
 /obj/item/clothing/mask/deepmaints_debuff/angry
 	name = "angry psionic mask"
-	desc = "A psionic mask laced into the victum mind. This one looks furious about something."
+	desc = "A psionic mask stitched into the victim mind. This one looks furious about something."
 	icon_state = "tiki_angry"
 	item_state = "tiki_angry"
 	stat_to_change = STAT_BIO //WHY CANT I INJECT MY NEEEEDLEEEEEEE!!!!!!!!
 
 /obj/item/clothing/mask/deepmaints_debuff/confused
 	name = "confused psionic mask"
-	desc = "A psionic mask laced into the victum mind. This one doesn't seem very sure of itself."
+	desc = "A psionic mask stitched into the victim mind. This one doesn't seem very sure of itself."
 	icon_state = "tiki_confused"
 	item_state = "tiki_confused"
 	stat_to_change = STAT_COG
@@ -248,7 +248,7 @@
 
 /obj/item/clothing/mask/deepmaints_debuff/happy
 	name = "happy psionic mask"
-	desc = "A psionic mask laced into the victum mind. This one is smiling with joy."
+	desc = "A psionic mask stitched into the victim mind. This one is smiling with joy."
 	icon_state = "tiki_happy"
 	item_state = "tiki_happy"
 	stat_to_change = STAT_VIV

--- a/code/modules/psionics/psionic_items/psi_armor.dm
+++ b/code/modules/psionics/psionic_items/psi_armor.dm
@@ -220,7 +220,7 @@
 	if(!pointremoved)
 		victim.stats.changeStat(stat_to_change, -stat_to_change)
 		pointremoved = TRUE
-	victum.sanity.onPsyDamage(damage_to_sanity)
+	victim.sanity.onPsyDamage(damage_to_sanity)
 	spawn(2)
 	qdel(src)
 

--- a/code/modules/psionics/psionic_items/psi_armor.dm
+++ b/code/modules/psionics/psionic_items/psi_armor.dm
@@ -215,10 +215,13 @@
 	color = "#5B0E4F" //spooooky!!!!!
 	matter = list()
 
+//Small intraction you can do!
+//Get the mask, level up to stat cap, take it off, proofit!
+
 /obj/item/clothing/mask/deepmaints_debuff/dropped()
 	..()
 	if(!pointremoved)
-		victim.stats.changeStat(stat_to_change, -stat_to_change)
+		victim.stats.changeStat_withcap(stat_to_change, -pointamounts)
 		pointremoved = TRUE
 	victim.sanity.onPsyDamage(damage_to_sanity)
 	spawn(2)
@@ -228,7 +231,7 @@
 	.=..()
 	victim = M
 	if(!pointgranted)
-		victim.stats.changeStat(stat_to_change, stat_to_change)
+		victim.stats.changeStat_withcap(stat_to_change, pointamounts)
 		pointgranted = 1
 
 /obj/item/clothing/mask/deepmaints_debuff/angry

--- a/code/modules/psionics/psionic_items/psi_armor.dm
+++ b/code/modules/psionics/psionic_items/psi_armor.dm
@@ -198,3 +198,59 @@
 	if(!pointgranted)
 		occultist.stats.changeStat(STAT_COG, 5)
 		pointgranted = 1
+
+//Deepmaints debuffing ones
+/obj/item/clothing/mask/deepmaints_debuff
+	name = "startled psionic mask"
+	desc = "A psionic mask laced into the victum mind. This one has a shocked expression."
+	icon_state = "tiki_eyebrow"
+	item_state = "tiki_eyebrow"
+
+	var/mob/living/carbon/human/victum
+	var/pointgranted = 0 //Did we give you your stat?
+	var/pointremoved = 0 //Did we take you your stat?
+	var/pointamounts = 10
+	var/sanity_damage = 5
+	var/stat_to_change = STAT_VIG
+	color = "#5B0E4F" //spooooky!!!!!
+	matter = list()
+
+/obj/item/clothing/mask/deepmaints_debuff/dropped()
+	..()
+	if(!pointremoved)
+		victum.stats.changeStat(stat_to_change, -stat_to_change)
+		pointremoved = TRUE
+	victum.sanity.onPsyDamage(sanity_damage)
+	spawn(2)
+	qdel(src)
+
+/obj/item/clothing/mask/deepmaints_debuff/equipped(var/mob/M)
+	.=..()
+	occultist = M
+	if(!pointgranted)
+		victum.stats.changeStat(stat_to_change, stat_to_change)
+		pointgranted = 1
+
+/obj/item/clothing/mask/deepmaints_debuff/angry
+	name = "angry psionic mask"
+	desc = "A psionic mask laced into the victum mind. This one looks furious about something."
+	icon_state = "tiki_angry"
+	item_state = "tiki_angry"
+	stat_to_change = STAT_BIO //WHY CANT I INJECT MY NEEEEDLEEEEEEE!!!!!!!!
+
+/obj/item/clothing/mask/deepmaints_debuffi/confused
+	name = "confused psionic mask"
+	desc = "A psionic mask laced into the victum mind. This one doesn't seem very sure of itself."
+	icon_state = "tiki_confused"
+	item_state = "tiki_confused"
+	stat_to_change = STAT_COG
+	pointamounts = 15
+
+/obj/item/clothing/mask/deepmaints_debuff/happy
+	name = "happy psionic mask"
+	desc = "A psionic mask laced into the victum mind. This one is smiling with joy."
+	icon_state = "tiki_happy"
+	item_state = "tiki_happy"
+	stat_to_change = STAT_VIV
+	sanity_damage = -5 //Should *heal* sanity not damage
+	pointamounts = 30 //Hope you didnt have combat chems


### PR DESCRIPTION
At higher chaos level darksie cult mobs can respawn in deepmaints, WAR WAR WAR WARRRRRRRRRRRRRR

At higher chaos levels weaker mobs found in deepmaints will have *uniquic* intractions and attacks!

The following are locked behind chaos level 2
Memorys now teleport behind the person after attacking (even through walls!)
Memory Eater now when not waring a hat will do a 2x attack
thought melter will now rip of hats so that the memory eater can do its 2x attack
hovering nightmares will now rip off your mask (even through your hats) and try and sew on a new one for you! (Lowers stats and on removal deals sanity damage, but on removal gives back the stats it steals)

The Cerebral crusher gets by far the most complex and silly fancy attacks.
If we have a shield, then we deal direct damage to it, trying to kill the shield as fast as possable!
If we are wielding an item? Unwield it
If we dont have any of the above, but still hold an item, drop it (respects can drop)

flesh tower get randomized goo!
Some goo is faster, some deals more damage, some set you on fire!!! WOOO!!!!!

Ash wendigos when you face them and they face you, if agro'ed will teleport to *your left*
If you attack a ash wendigo and it faces you, it teleports to *your left*
When a ash wendigo attacks its target it now will forcefully face them