### PR TITLE
Cargo Favors Shakeup, Kriosan embargo reduction

### DIFF
--- a/code/__DEFINES/trade.dm
+++ b/code/__DEFINES/trade.dm
@@ -32,6 +32,6 @@
 // Export price multipliers
 #define NONEXPORTABLE 0
 #define JUNK 0.1
-#define EXPORTABLE 0.6
+#define EXPORTABLE 0.8
 #define HOCKABLE 0.3		// Term for items being sold to a pawnbroker; means the item can be exported but is not a typical export, sold at 30% value
 #define REFUND 1

--- a/code/modules/trade/datums/trade_stations_presets/1-common/asterstradecapital.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/asterstradecapital.dm
@@ -1,6 +1,6 @@
 /datum/trade_station/asterstradecapital
 	name_pool = list(
-		"FTS 'Solnishko'" = "Free Trade Station 'Solnishko', they're sending a message \"Zdravstvuite, this is the Trade Station 'Solnishko'. We have all of the best products for sale on the frontier! You couldn't get better prices!.\ Everything for sale here, don't be afraid to come aboard and check our wares!\"",
+		"FTS 'Solnishko'" = "Free Trade Station 'Solnishko', they're sending a message \"Zdravstvuite, this is the Trade Station 'Solnishko'. We have all of the best products for sale on the frontier! You couldn't get better prices! \ Everything for sale here, don't be afraid to come aboard and check our wares!\"",
 	)
 	forced_overmap_zone = list(
 		list(24, 26),

--- a/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/caduceus.dm
@@ -120,9 +120,9 @@
 	offer_types = list(
 		/obj/item/organ/internal/scaffold = offer_data_mods("aberrant organ (input, process, output)", 1200, 4, OFFER_ABERRANT_ORGAN, 3),
 		/datum/reagent/medicine/ossisine = offer_data("ossissine bottle (60u)", 2000, 1),
-		/datum/reagent/medicine/bicaridine = offer_data("bicard bottle (60u)", 200, 3),
-		/datum/reagent/medicine/kelotane = offer_data("kelotane bottle (60u)", 200, 3),
-		/datum/reagent/medicine/dylovene = offer_data("dylovene bottle (60u)", 200, 3),
+		/datum/reagent/medicine/bicaridine = offer_data("bicard bottle (60u)", 250, 3),
+		/datum/reagent/medicine/kelotane = offer_data("kelotane bottle (60u)", 250, 3),
+		/datum/reagent/medicine/dylovene = offer_data("dylovene bottle (60u)", 250, 3),
 		/datum/reagent/nanites/uncapped/control_booster_utility = offer_data("Control Booster Utility bottle (60u)", 30000, 1),
 		/datum/reagent/nanites/uncapped/control_booster_combat = offer_data("Control Booster Combat bottle (60u)", 30000, 1)
 		)

--- a/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/hellcat.dm
@@ -102,11 +102,11 @@
 		)
 	)
 	offer_types = list(
-		/obj/item/gun/energy/laser/railgun/pistol = offer_data("\"Myrmidon\" rail pistol or rifle", 5000, 2),
-		/obj/item/tool/shovel/combat = offer_data("combat crovel", 500, 13),
+		/obj/item/gun/energy/laser/railgun/pistol = offer_data("\"Myrmidon\" rail pistol or rifle", 2500, 2),
+		/obj/item/tool/shovel/combat = offer_data("combat crovel", 400, 13),
 		/obj/item/tool_upgrade/armor/melee = offer_data("melee armor plate", 500, 5),
 		/obj/item/tool_upgrade/armor/bullet = offer_data("ballistic armor plate", 1200, 3),
 		/obj/item/tool_upgrade/armor/bomb = offer_data("bomb proofing armor plate", 800, 3),
 		/obj/item/tool_upgrade/armor/energy = offer_data("energy armor plate", 2000, 2),
-		/obj/item/tool/baton/arcwelder = offer_data("arc welder", 1500, 2)
+		/obj/item/tool/baton/arcwelder = offer_data("arc welder", 2000, 2)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/zarya.dm
@@ -103,5 +103,5 @@
 		/obj/item/tool/pickaxe/jackhammer/onestar = offer_data("greyson jackhammer", 1000, 3),
 		/obj/item/tool/screwdriver/combi_driver/onestar = offer_data("greyson combi driver", 1000, 3),
 		/obj/item/tool/weldingtool/onestar  = offer_data("greyson welding tool", 1000, 3),
-		/obj/item/tool_upgrade/augment/repair_nano = offer_data("repair nano", 5000, 1)
+		/obj/item/tool_upgrade/augment/repair_nano = offer_data("repair nano", 1000, 1)
 	)

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/McRonalds.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/McRonalds.dm
@@ -57,6 +57,6 @@
 		/obj/item/reagent_containers/food/snacks/meat/roachmeat/kraftwerk = offer_data("kraftwerk roach meat", 600, 0),
 		/obj/item/reagent_containers/food/snacks/meat/roachmeat/jager = offer_data("seuche roach meat", 350, 0),
 		/obj/item/reagent_containers/food/snacks/meat/roachmeat/fuhrer = offer_data("fuhrer roach meat", 450, 5), //Caps it
-		/obj/item/reagent_containers/food/snacks/meat/roachmeat/kaiser = offer_data("kaiser roach meat", 5000, 1)
+		/obj/item/reagent_containers/food/snacks/meat/roachmeat/kaiser = offer_data("kaiser roach meat", 2000, 2)
 	)
 

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/advtechno.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/advtechno.dm
@@ -60,10 +60,10 @@
 	offer_types = list(
 		/obj/item/oddity/techno = offer_data("unknown technological part", 1600, 2),
 		/obj/item/tool/crowbar/onestar = offer_data("greyson crowbar", 1500, 3),
-		/obj/item/tool/pickaxe/onestar = offer_data("greyson pickaxe", 1500, 3),
+		/obj/item/tool/pickaxe/onestar = offer_data("greyson pickaxe", 2500, 3),  // Takes diamond to print
 		/obj/item/tool/pickaxe/jackhammer/onestar = offer_data("greyson jackhammer", 1500, 3),
 		/obj/item/tool/screwdriver/combi_driver/onestar = offer_data("greyson combi driver", 2000, 3),
 		/obj/item/tool/weldingtool/onestar  = offer_data("greyson welding tool", 2000, 3),
-		/obj/item/tool_upgrade/augment/repair_nano = offer_data("repair nano", 5000, 1),
+		/obj/item/tool_upgrade/augment/repair_nano = offer_data("repair nano", 1500, 1),
 		/obj/item/organ/external/robotic/one_star = offer_data("greyson external prosthetic", 2700, 4)			// base price: 900
 	)

--- a/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
+++ b/code/modules/trade/datums/trade_stations_presets/4-unique/greyson_ship_alt.dm
@@ -16,8 +16,8 @@
 	automated. It's a wonder it hasn't been raided, but then again its protected by a massive army of still functioning combat drones. This one specializes in a wide variety of interesting goods.")
 	inventory = list(
 		"Sheji pan" = list(
-			/obj/item/computer_hardware/hard_drive/portable/design/onestar/stockparts = good_data("GP Stockpart Disk", list(30, 50), 900),
-			/obj/item/computer_hardware/hard_drive/portable/design/onestar = good_data("GP Tool Disk", list(30, 50), 1200)
+			/obj/item/computer_hardware/hard_drive/portable/design/onestar/stockparts = good_data("GP Stockpart Disk", list(30, 50), 1500),
+			/obj/item/computer_hardware/hard_drive/portable/design/onestar = good_data("GP Tool Disk", list(30, 50), 2000)
 		),
 		"Gongju" = list(
 			/obj/item/tool/crowbar/onestar = custom_good_nameprice("GP Crowbar", list(-100, -50)),


### PR DESCRIPTION
Asides from a minor punctuation fix to Solnishko, this PR does changes the following stations:

Caduceus
- 50 credit buff to the basic medicines it buys, given the public no longer has access to free Bicard-Kelo-Dylo with the recent baseline garden nerfs, this is to make these offers more appealing for SI to fulfill.

Hellcat
- 50% nerf to the rail pistol offer price down to 2500.  Despite the offer's name, it doesn't take rifles, only pistols. This also reels it in to be less than the 3500 hundred at Kaida for the entire rail rifle.
- 500 credit (roughly 33%) buff to arc welder offer price to make it more lucrative for Guild members to produce, alongside rail pistols, so it isn't just a rail-pistol all day every day meta.
- Crovels down from 500 to 400 credits each, given how L.S. generally just produces these inhouse, it was a bit too effective. Could stand to be further adjusted going forward.

Zarya
- Repair Nanos down from 5k to 1k, they were WAY too lucrative for what it takes in resources to print the G.P. toolmods. Hopefully, this results in a variety of greyson tools being exported, instead of just copious crates of nano-repairs.

Nauka? Whichever one's down the path from Zarya.
- Greyson pickaxe from 1500 to 2500 offer price, considering how this takes diamonds to print, it was unreasonable to ever make these alongside the cash cow of Greyson combination drills/welders.
- repair nanos from 5k to 1.5k, same thing as the previous station, but it's further down the station tree, so offers are generally more lucrative, then. Also, has the dynamic of moving a lot of product quicker (nano-repairs) for a lower averaged per item price, or taking longer to do the same thing for the 'full' profit.

Dionis

- Kaiser meat from 5k to 2k offer price, considering how a gibbered/meat spiked Kaiser gave 15 slabs of meat, it was an atrociously lucrative source of credits for the effort it took. Especially if the player was a species not effected by radiation. Also, buffs the potential requested amount from 1 to 2, to go from 150 minutes of potential shackling to a C.T. to a trade console, down to half that, per Kaiser fully butchered. More of a point of contention than one would initially assume.

The weird 2nd Greyson ship that sells the GOODS.

- stock part disk from 900 to 1200, tool disk from 1500 to 2000, to further discourage L.S. from churning out inhouse G.P. tools to export. You can't really effectively export Greyson stockparts but it just felt fitting to bump that up too.

On top of this, this also tweaks a very neglected part of Lonestar! Currently, every item in our server falls under the export good tag, which presently has a 0.6 multiplier applied to it before being sold via the bulk-selling export button. For a variety of reasons (Annoyance of players finding out their loot is worth less than the currently overlooked market professional perk displays, contributors making items/adding prices to items without knowing of the 40% phantom tax, etc. etc.), I've decided that nudging this down to 20% would be more reasonable, given how there's apparently a lore reason for this tariff to be applied. It's been years, whatever chances of an event, arc, or WHATEVER to rectify this icly interestingly has long since passed, given how 95% of players in rotation likely don't even know of this.

===

To put it concisely, kneecaps some of the bit overtly generous offers from other factions, minor buffs to other options to encourage them instead. Tweaks some of the offers LS can do 'in house' to be a bit less efficient. 

Kaisers were considerably too generous, especially with the likely unintended butchering yielding 15 slabs of meat instead of 3/whatever chopping them by hand gives, reels that in.

Tweaks the ambiguous 40% phantom tax that went into the void previously to only be 20% instead. This has the most implications to consider, but considering the 'export' button is generally viewed negatively, this can hopefully work to start reversing the stigma I've witnessed against it. Thankfully, handheld export scanners seem to use the value directly when appraising items.


![image](https://github.com/sojourn-13/sojourn-station/assets/47806118/c0cdac30-475e-4ea2-9301-9e11f1e4cf75)