### PR TITLE
fix markdown calc and rebalance direct sales

### DIFF
--- a/code/controllers/subsystems/trade.dm
+++ b/code/controllers/subsystems/trade.dm
@@ -227,7 +227,7 @@ SUBSYSTEM_DEF(trade)
 		selling_price = price * station.markdown
 
 	if(selling_price > buying_price)
-		selling_price -= selling_price * station.markdown
+		selling_price = buying_price * station.markdown
 
 	. = selling_price
 

--- a/code/controllers/subsystems/trade.dm
+++ b/code/controllers/subsystems/trade.dm
@@ -226,7 +226,7 @@ SUBSYSTEM_DEF(trade)
 	if(selling_price <= 0)
 		selling_price = price * station.markdown
 
-	if(selling_price > buying_price)
+	if(selling_price >= buying_price)
 		selling_price = buying_price * station.markdown
 
 	. = selling_price

--- a/code/modules/trade/datums/_trade_station.dm
+++ b/code/modules/trade/datums/_trade_station.dm
@@ -22,7 +22,7 @@
 	var/list/name_pool = list()
 
 	var/markup = WHOLESALE_GOODS
-	var/markdown = 1			 // Do not increase above 1
+	var/markdown = 0.8			 // If increased above 1, then it turns into an exploit of buy n sell
 	var/favour_purchase_ratio = 0.125  // 8 credits = 1 favour
 
 

--- a/code/modules/trade/datums/_trade_station.dm
+++ b/code/modules/trade/datums/_trade_station.dm
@@ -22,7 +22,7 @@
 	var/list/name_pool = list()
 
 	var/markup = WHOLESALE_GOODS
-	var/markdown = 0.8				 // Default markdown is 20% - SoJ edit they get less markdown.
+	var/markdown = 1			 // Do not increase above 1
 	var/favour_purchase_ratio = 0.125  // 8 credits = 1 favour
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Default markdown multiplier for stations is now 1 - Trilby edit, its 0.8 to avoid exploits still
Fixed the math behind the markdown when markup is below markdown. markdown is now multplied with the current price if markup is lower.

I figured to change the markdown value for all stations to be a proper one to one when you examine your wares or use an export scanner. Making everything a little bit more accessible and less obfuscated.