### PR TITLE
Market Exspert fix + surplus tag fix

### DIFF
--- a/code/controllers/subsystems/trade.dm
+++ b/code/controllers/subsystems/trade.dm
@@ -306,6 +306,7 @@ SUBSYSTEM_DEF(trade)
 			continue
 		if(!check_attachments(AM, offer_path, attachments, attach_count) || !check_contents(AM, offer_path))		// Check contents after we know it's the same type
 			continue
+
 		. += AM
 
 /datum/controller/subsystem/trade/proc/assess_all_offers(obj/machinery/trade_beacon/sending/beacon)
@@ -338,6 +339,7 @@ SUBSYSTEM_DEF(trade)
 	var/offer_price = text2num(offer_content["price"])
 	if(!exported || length(exported) < offer_amount || !offer_amount)
 		return
+
 
 	exported.Cut(offer_amount + 1)
 
@@ -508,6 +510,9 @@ SUBSYSTEM_DEF(trade)
 							new good_path(C)
 						else
 							var/atom/movable/new_item = senderBeacon.drop(good_path)
+							if(istype(new_item, /obj/item))
+								var/obj/item/T = new_item
+								T.surplus_tag = TRUE
 							invoice_location = new_item.loc
 					if(isnum(index_of_good))
 						station.set_good_amount(category_name, index_of_good, max(0, station.get_good_amount(category_name, index_of_good) - count_of_good))
@@ -538,7 +543,7 @@ SUBSYSTEM_DEF(trade)
 		cost = get_import_cost(thing, station)
 
 	if(thing.surplus_tag)
-		cost -= cost * 0.2
+		cost = cost * 0.1
 
 	if(account)
 		create_log_entry("Individial Sale", account.get_name(), "<li>[thing.name]</li>", cost)
@@ -594,7 +599,7 @@ SUBSYSTEM_DEF(trade)
 			var/export_value = item_price * export_multiplier
 
 			if(item.surplus_tag)
-				item_price -= item_price * 0.2
+				item_price = item_price * 0.1
 
 			if(export_multiplier)
 				invoice_contents_info += "<li>[item.name]</li>"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -234,9 +234,28 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.stats.getPerk(PERK_MARKET_PROF))
-			message += SPAN_NOTICE("\nThis item cost: [get_item_cost()][CREDITS]")
-		if(H.stats.getPerk(PERK_MARKET_PROF) && surplus_tag == TRUE)
-			message += SPAN_NOTICE("\nThis item has a surplus tag and is only worth ten percent its usual value on exports.")
+			message += "\n<blue>Export value: [get_item_cost() * SStrade.get_export_price_multiplier(src)][CREDITS]"
+
+			var/offer_message = "\nThis item is requested at: "
+			var/has_offers = FALSE
+			for(var/datum/trade_station/TS in SStrade.discovered_stations)
+				for(var/path in TS.special_offers)
+					if(istype(src, path))
+						has_offers = TRUE
+						var/list/offer_content = TS.special_offers[path]
+						var/offer_price = offer_content["price"]
+						var/offer_amount = offer_content["amount"]
+						if(offer_amount)
+							offer_message += "[TS.name] ([round(offer_price / offer_amount, 1)][CREDITS] each, [offer_amount] requested), "
+						else
+							offer_message += "[TS.name] (offer fulfilled, awaiting new contract), "
+
+			if(has_offers)
+				offer_message = copytext(offer_message, 1, LAZYLEN(offer_message) - 1)
+				message += SPAN_NOTICE(offer_message)
+
+			if(surplus_tag)
+				message += SPAN_NOTICE("\nThis item has a surplus tag and is only worth ten percent its usual value on exports.")
 
 	return ..(user, distance, "", message)
 


### PR DESCRIPTION
Fixes market exspert perk not really giving you the full idea of how much things would export
Fixes market exspert not telling you about trade deals (This is a fix as it was meant to be ported with cargo reworks)
Fixes imported items not being labled as "Surplus"
Fixes the math of imported items when surplus to be 1/10th the value rather then 9/10ths

NOTE: when filling spec officers, surplus tag isnt checked, this is do to me not being able to find a way to ingore surplus tag for spec officers without it also being unsellable (something i dont want to do)