### PR TITLE
MegaSeed Servitor for Lodge

### DIFF
--- a/code/game/machinery/vendor/food_vendors.dm
+++ b/code/game/machinery/vendor/food_vendors.dm
@@ -227,6 +227,77 @@
 					 )
 	auto_price = FALSE
 
+/obj/machinery/vending/hydroseeds/lodge
+	name = "MegaSeed Servitor"
+	desc = "When you need seeds fast!"
+	product_slogans = "This is where the seeds live, git you some!;Hands down the best seed selection on the colony!;Also certain mushroom varieties available, more for experts! Get certified today!;Seeds? We got you covered.;Remember: Glowshrooms are bad for you.;I'm legally advised to tell you that Nettles are poisonous."
+	product_ads = "We like plants!;Grow some crops!;Grow, baby, growww!;Aw h'yeah son!;Just like your ancestors!"
+	icon_state = "seeds"
+	always_open = TRUE
+	can_stock = list(/obj/item/seeds)
+
+	products = list(
+					/obj/item/seeds/ambrosiarobusto = 3,
+					/obj/item/seeds/appleseed = 3,
+					/obj/item/seeds/bananaseed = 3,
+					/obj/item/seeds/berryseed = 3,
+					/obj/item/seeds/blueberryseed = 3,
+					/obj/item/seeds/brootseed = 2,
+					/obj/item/seeds/cabbageseed = 3,
+					/obj/item/seeds/carrotseed = 3,
+					/obj/item/seeds/chantermycelium = 3,
+					/obj/item/seeds/cherryseed = 3,
+					/obj/item/seeds/chiliseed = 3,
+					/obj/item/seeds/cinnamonseed = 2,
+					/obj/item/seeds/cocoapodseed = 3,
+					/obj/item/seeds/cornseed = 3,
+					/obj/item/seeds/eggplantseed = 3,
+					/obj/item/seeds/gelthi = 2,
+					/obj/item/seeds/grapeseed = 3,
+					/obj/item/seeds/grassseed = 3,
+					/obj/item/seeds/lemonseed = 3,
+					/obj/item/seeds/limeseed = 3,
+					/obj/item/seeds/mintseed = 2,
+					/obj/item/seeds/mtearseed = 2,
+					/obj/item/seeds/orangeseed = 3,
+					/obj/item/seeds/peanutseed = 3,
+					/obj/item/seeds/pineappleseed = 2,
+					/obj/item/seeds/plastiseed = 3,
+					/obj/item/seeds/plumpmycelium = 2,
+					/obj/item/seeds/poppyseed = 3,
+					/obj/item/seeds/potatoseed = 3,
+					/obj/item/seeds/pumpkinseed = 3,
+					/obj/item/seeds/riceseed = 3,
+					/obj/item/seeds/shandseed = 2,
+					/obj/item/seeds/soyaseed = 3,
+					/obj/item/seeds/strawberryseed = 3,
+					/obj/item/seeds/sugarcaneseed = 3,
+					/obj/item/seeds/sunflowerseed = 3,
+					/obj/item/seeds/thaadra = 2,
+					/obj/item/seeds/thaadra = 3,
+					/obj/item/seeds/tomatoseed = 3,
+					/obj/item/seeds/towermycelium = 3,
+					/obj/item/seeds/watermelonseed = 3,
+					/obj/item/seeds/wheatseed = 3,
+					/obj/item/seeds/whitebeetseed = 3,
+					)
+
+	contraband = list(
+					/obj/item/seeds/amanitamycelium = 2,
+					/obj/item/seeds/amauri = 2,
+					/obj/item/seeds/ambrosiavulgarisseed = 2,
+					/obj/item/seeds/glowshroom = 2,
+					/obj/item/seeds/jurlmah = 2,
+					/obj/item/seeds/libertymycelium = 2,
+					/obj/item/seeds/nettleseed = 2,
+					/obj/item/seeds/reishimycelium = 2,
+					/obj/item/seeds/reishimycelium = 2,
+					/obj/item/seeds/surik = 2,
+					/obj/item/seeds/telriis = 2,
+					/obj/item/seeds/vale = 2,
+					 )
+	auto_price = FALSE
+
 /**
  * Populate hydroseeds product_records
  *

--- a/maps/_HunterLodge/map/_Hunting_Lodge.dmm
+++ b/maps/_HunterLodge/map/_Hunting_Lodge.dmm
@@ -850,9 +850,7 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "eo" = (
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
-	},
+/obj/machinery/vending/hydroseeds/lodge,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "er" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Gives Lodge the same seeds they've had before Xenobotany tweaks by making an independent version of the MegaSeed Servitor with the same seeds they had prior
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
Add: MegaSeed Servitor independent for lodge
Change: Changes MegaSeed Servitor at lodge to independent Lodge version

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
