### PR TITLE
Pouch "rebalance" 

### DIFF
--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -143,7 +143,7 @@
 	desc = "A mini satchel. Can hold a fair bit, but it won't fit in your pocket"
 	icon_state = "large_generic"
 	item_state = "large_generic"
-	w_class = ITEM_SIZE_NORMAL //This stays a bit bigger do to being WAY more then normal pouches scaling!
+	w_class = ITEM_SIZE_BULKY //This is like a second satchle, is this size for belt/box ect nesting tricks
 	slot_flags = SLOT_BELT | SLOT_DENYPOCKET
 	storage_slots = null //Uses generic capacity
 	max_storage_space = DEFAULT_NORMAL_STORAGE

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -16,9 +16,9 @@
 	attack_verb = list("pouched")
 
 	var/sliding_behavior = FALSE
-	var/interal_bulk = 0 //How much are inside items grows are size
+	var/internal_bulk = 0 //How much are inside items grows are size
 	var/used_storage_space = 0 //How much space is already used in the container, used for growing extra bulk
-	var/free_space_persent = 0 //0 means 100% free space, well 100% means no free space
+	var/free_space_percent = 0 //0 means 100% free space, well 100% means no free space
 	var/plus_extra_bulk = 0    //Used for adding bulk to the item, as the normal var gets overwrote
 
 /obj/item/storage/pouch/verb/toggle_slide()
@@ -61,9 +61,9 @@
 //Little complex at glance but shockingly simple!
 /obj/item/storage/pouch/proc/pouch_size_increase()
 	//Interal bulk is how much over-weight class you store it over with.
-	interal_bulk = 0
+	internal_bulk = 0
 	used_storage_space = 0
-	free_space_persent = 0
+	free_space_percent = 0
 
 	//Cycle through are contents and find everything ever
 	for(var/obj/item/I in contents)
@@ -71,23 +71,23 @@
 		over_filled = I.w_class + I.extra_bulk //Extrabulk for sake of calulations is insainly rough
 		used_storage_space += over_filled
 		if(over_filled > w_class) //If we are item is bigger then are pouch then we get get bigger!
-			interal_bulk += over_filled - w_class
+			internal_bulk += over_filled - w_class
 
 	if(used_storage_space) //Prevents devide by 0
-		free_space_persent = used_storage_space / max_storage_space //20 / 5 = 4
-		free_space_persent *= 100 //To get it to be base 100%
+		free_space_percent = used_storage_space / max_storage_space //20 / 5 = 4
+		free_space_percent *= 100 //To get it to be base 100%
 		//This **LOOKS** harsh but its not, unlike w_class these are lineral numbers not mulitied by silly hidden things
-		switch(free_space_persent)
+		switch(free_space_percent)
 			if(0 to 25)
-				interal_bulk += 1
+				internal_bulk += 1
 			if(25 to 50)
-				interal_bulk += 2
+				internal_bulk += 2
 			if(50 to 75)
-				interal_bulk += 3
+				internal_bulk += 3
 			if(75 to INFINITY)
-				interal_bulk += 4
+				internal_bulk += 4
 
-	extra_bulk = interal_bulk + plus_extra_bulk //This scaling means that if you mix in a-ok items with a few over-big ones they are not all stacking their mauls
+	extra_bulk = internal_bulk + plus_extra_bulk //This scaling means that if you mix in a-ok items with a few over-big ones they are not all stacking their mauls
 	if(extra_bulk < 0)
 		extra_bulk = 0
 	if(istype(loc, /obj/item/storage))

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -104,7 +104,6 @@
 	max_w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_BIOMATTER = 5)
 	level = BELOW_PLATING_LEVEL //We can hide under tiles :D
-	plus_extra_bulk = -3 //Small pouches have EVERY item scale with them, this is simply anti-scaling so that they are not useless
 
 /obj/item/storage/pouch/small_generic/purple
 	icon_state = "small_generic_p"

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -19,6 +19,7 @@
 	var/interal_bulk = 0 //How much are inside items grows are size
 	var/used_storage_space = 0 //How much space is already used in the container, used for growing extra bulk
 	var/free_space_persent = 0 //0 means 100% free space, well 100% means no free space
+	var/plus_extra_bulk = 0    //Used for adding bulk to the item, as the normal var gets overwrote
 
 /obj/item/storage/pouch/verb/toggle_slide()
 	set name = "Toggle Slide"
@@ -42,6 +43,10 @@
 		remove_from_storage(I, T)
 		usr.put_in_hands(I)
 		add_fingerprint(user)
+
+/obj/item/storage/pouch/Initialize(mapload)
+	..()
+	pouch_size_increase() //Do to plus_extra_bulk
 
 /obj/item/storage/pouch/handle_item_insertion(obj/item/W as obj, prevent_warning = FALSE, mob/user, suppress_warning = FALSE)
 	..()
@@ -71,17 +76,20 @@
 	if(used_storage_space) //Prevents devide by 0
 		free_space_persent = used_storage_space / max_storage_space //20 / 5 = 4
 		free_space_persent *= 100 //To get it to be base 100%
+		//This **LOOKS** harsh but its not, unlike w_class these are lineral numbers not mulitied by silly hidden things
 		switch(free_space_persent)
 			if(0 to 25)
-				interal_bulk += 0.5
-			if(25 to 50)
 				interal_bulk += 1
-			if(50 to 75)
-				interal_bulk += 1.5
-			if(75 to INFINITY)
+			if(25 to 50)
 				interal_bulk += 2
+			if(50 to 75)
+				interal_bulk += 3
+			if(75 to INFINITY)
+				interal_bulk += 4
 
-	extra_bulk = interal_bulk //This scaling means that if you mix in a-ok items with a few over-big ones they are not all stacking their mauls
+	extra_bulk = interal_bulk + plus_extra_bulk //This scaling means that if you mix in a-ok items with a few over-big ones they are not all stacking their mauls
+	if(extra_bulk < 0)
+		extra_bulk = 0
 	if(istype(loc, /obj/item/storage))
 		var/obj/item/storage/SO = loc
 		SO.refresh_all() //So we can see are items take up more space and prevent confusion
@@ -96,6 +104,7 @@
 	max_w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_BIOMATTER = 5)
 	level = BELOW_PLATING_LEVEL //We can hide under tiles :D
+	plus_extra_bulk = -3 //Small pouches have EVERY item scale with them, this is simply anti-scaling so that they are not useless
 
 /obj/item/storage/pouch/small_generic/purple
 	icon_state = "small_generic_p"
@@ -116,6 +125,7 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	price_tag = 400
 	level = BELOW_PLATING_LEVEL //As we can
+	plus_extra_bulk = 2 //Anti-quatom scaling with smaller items
 
 /obj/item/storage/pouch/medium_generic/leather
 	icon_state = "medium_leather"
@@ -140,6 +150,7 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	matter = list(MATERIAL_BIOMATTER = 20)
 	price_tag = 800
+	plus_extra_bulk = 4 //Anti-quatom scaling with smaller items
 
 obj/item/storage/pouch/large_generic/advmedic
 	desc = "A mini satchel. Can hold a fair bit, but it won't fit in your pocket. This one is well worn and reeks like the inside of a frontier-chemlab."
@@ -386,6 +397,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 	storage_slots = 1
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_NORMAL
+	plus_extra_bulk = -1
 
 	can_hold = list(
 		/obj/item/gun/projectile/makarov,
@@ -509,6 +521,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_NORMAL
 	sliding_behavior = TRUE // It is by default a quickdraw quiver
+	plus_extra_bulk = -2
 
 	can_hold = list(
 		/obj/item/ammo_casing/arrow,
@@ -551,6 +564,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_BULKY // Just in case a full stack won't fit.
 	sliding_behavior = TRUE // Quickdraw!
+	plus_extra_bulk = -2
 
 	can_hold = list(
 		/obj/item/stack/rods,

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -124,7 +124,7 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	price_tag = 400
 	level = BELOW_PLATING_LEVEL //As we can
-	plus_extra_bulk = 2 //Anti-quatom scaling with smaller items
+	plus_extra_bulk = 1 //Anti-quatom scaling with smaller items
 
 /obj/item/storage/pouch/medium_generic/leather
 	icon_state = "medium_leather"

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -143,14 +143,14 @@
 	desc = "A mini satchel. Can hold a fair bit, but it won't fit in your pocket"
 	icon_state = "large_generic"
 	item_state = "large_generic"
-	w_class = ITEM_SIZE_BULKY //This stays a bit bigger do to being WAY more then normal pouches scaling!
+	w_class = ITEM_SIZE_NORMAL //This stays a bit bigger do to being WAY more then normal pouches scaling!
 	slot_flags = SLOT_BELT | SLOT_DENYPOCKET
 	storage_slots = null //Uses generic capacity
 	max_storage_space = DEFAULT_NORMAL_STORAGE
 	max_w_class = ITEM_SIZE_NORMAL
 	matter = list(MATERIAL_BIOMATTER = 20)
 	price_tag = 800
-	plus_extra_bulk = 4 //Anti-quatom scaling with smaller items
+	plus_extra_bulk = 6 //Anti-quatom scaling with smaller items
 
 obj/item/storage/pouch/large_generic/advmedic
 	desc = "A mini satchel. Can hold a fair bit, but it won't fit in your pocket. This one is well worn and reeks like the inside of a frontier-chemlab."

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -7,7 +7,7 @@
 	price_tag = 100
 	cant_hold = list(/obj/item/storage/pouch) //Pouches in pouches was a misstake
 
-	w_class = ITEM_SIZE_SMALL
+	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_BELT //Pouches can be worn on belt
 	storage_slots = 1
 	max_w_class = ITEM_SIZE_SMALL
@@ -16,6 +16,9 @@
 	attack_verb = list("pouched")
 
 	var/sliding_behavior = FALSE
+	var/interal_bulk = 0 //How much are inside items grows are size
+	var/used_storage_space = 0 //How much space is already used in the container, used for growing extra bulk
+	var/free_space_persent = 0 //0 means 100% free space, well 100% means no free space
 
 /obj/item/storage/pouch/verb/toggle_slide()
 	set name = "Toggle Slide"
@@ -39,6 +42,49 @@
 		remove_from_storage(I, T)
 		usr.put_in_hands(I)
 		add_fingerprint(user)
+
+/obj/item/storage/pouch/handle_item_insertion(obj/item/W as obj, prevent_warning = FALSE, mob/user, suppress_warning = FALSE)
+	..()
+	//Grow when we add in are items
+	pouch_size_increase()
+
+/obj/item/storage/pouch/remove_from_storage(obj/item/W as obj, atom/new_location)
+	..()
+	//So that we can accually shrink when taking items out
+	pouch_size_increase()
+
+//Little complex at glance but shockingly simple!
+/obj/item/storage/pouch/proc/pouch_size_increase()
+	//Interal bulk is how much over-weight class you store it over with.
+	interal_bulk = 0
+	used_storage_space = 0
+	free_space_persent = 0
+
+	//Cycle through are contents and find everything ever
+	for(var/obj/item/I in contents)
+		var/over_filled = 0 //Now we got to get what a REAL w-class is per object
+		over_filled = I.w_class + I.extra_bulk //Extrabulk for sake of calulations is insainly rough
+		used_storage_space += over_filled
+		if(over_filled > w_class) //If we are item is bigger then are pouch then we get get bigger!
+			interal_bulk += over_filled - w_class
+
+	if(used_storage_space) //Prevents devide by 0
+		free_space_persent = used_storage_space / max_storage_space //20 / 5 = 4
+		free_space_persent *= 100 //To get it to be base 100%
+		switch(free_space_persent)
+			if(0 to 25)
+				interal_bulk += 0.5
+			if(25 to 50)
+				interal_bulk += 1
+			if(50 to 75)
+				interal_bulk += 1.5
+			if(75 to INFINITY)
+				interal_bulk += 2
+
+	extra_bulk = interal_bulk //This scaling means that if you mix in a-ok items with a few over-big ones they are not all stacking their mauls
+	if(istype(loc, /obj/item/storage))
+		var/obj/item/storage/SO = loc
+		SO.refresh_all() //So we can see are items take up more space and prevent confusion
 
 /obj/item/storage/pouch/small_generic
 	name = "small generic pouch"
@@ -87,7 +133,7 @@
 	desc = "A mini satchel. Can hold a fair bit, but it won't fit in your pocket"
 	icon_state = "large_generic"
 	item_state = "large_generic"
-	w_class = ITEM_SIZE_BULKY
+	w_class = ITEM_SIZE_BULKY //This stays a bit bigger do to being WAY more then normal pouches scaling!
 	slot_flags = SLOT_BELT | SLOT_DENYPOCKET
 	storage_slots = null //Uses generic capacity
 	max_storage_space = DEFAULT_NORMAL_STORAGE
@@ -194,7 +240,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 	item_state = "engineering_supply"
 
 	storage_slots = 3
-	w_class = ITEM_SIZE_SMALL
+	w_class = ITEM_SIZE_TINY
 	max_w_class = ITEM_SIZE_NORMAL
 
 	can_hold = list(
@@ -224,7 +270,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 	item_state = "janitor_supply"
 
 	storage_slots = 4
-	w_class = ITEM_SIZE_SMALL
+	w_class = ITEM_SIZE_TINY
 	max_w_class = ITEM_SIZE_NORMAL
 
 	can_hold = list(
@@ -244,7 +290,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 	item_state = "ammo"
 
 	storage_slots = 4
-	w_class = ITEM_SIZE_SMALL
+	w_class = ITEM_SIZE_TINY
 	max_w_class = ITEM_SIZE_NORMAL
 
 	can_hold = list(
@@ -259,7 +305,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 	item_state = "flare"
 
 	storage_slots = 7
-	w_class = ITEM_SIZE_NORMAL
+	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_NORMAL
 
 	can_hold = list(
@@ -309,7 +355,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 	item_state = "grow"
 	matter = list(MATERIAL_PLASTIC = 1)
 	storage_slots = 7
-	w_class = ITEM_SIZE_SMALL
+	w_class = ITEM_SIZE_TINY
 	max_w_class = ITEM_SIZE_TINY
 
 	can_hold = list(
@@ -338,7 +384,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 	item_state = "pistol_holster"
 
 	storage_slots = 1
-	w_class = ITEM_SIZE_NORMAL
+	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_NORMAL
 
 	can_hold = list(
@@ -460,7 +506,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 	slot_flags = SLOT_BELT | SLOT_DENYPOCKET
 	matter = list(MATERIAL_BIOMATTER = 10)
 	storage_slots = 4 // 12 arrows
-	w_class = ITEM_SIZE_NORMAL
+	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_NORMAL
 	sliding_behavior = TRUE // It is by default a quickdraw quiver
 
@@ -502,7 +548,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 	slot_flags = SLOT_BELT | SLOT_DENYPOCKET
 	matter = list(MATERIAL_BIOMATTER = 15) // Can hold a full stack of rods.
 	storage_slots = 4
-	w_class = ITEM_SIZE_NORMAL
+	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_BULKY // Just in case a full stack won't fit.
 	sliding_behavior = TRUE // Quickdraw!
 

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -81,11 +81,11 @@
 			if(0 to 25)
 				internal_bulk += 1
 			if(25 to 50)
-				internal_bulk += 2
+				internal_bulk += 1.5
 			if(50 to 75)
-				internal_bulk += 3
+				internal_bulk += 2
 			if(75 to INFINITY)
-				internal_bulk += 4
+				internal_bulk += 2.5
 
 	extra_bulk = internal_bulk + plus_extra_bulk //This scaling means that if you mix in a-ok items with a few over-big ones they are not all stacking their mauls
 	if(extra_bulk < 0)

--- a/code/game/objects/items/weapons/tools/tape.dm
+++ b/code/game/objects/items/weapons/tools/tape.dm
@@ -168,6 +168,10 @@
 	if (!istype(target) || target.anchored)
 		return
 
+	if (istype(src, /obj/item/storage))
+		//dont tape storage items, just put them inside
+		return
+
 	if (target.w_class > ITEM_SIZE_SMALL)
 		to_chat(user, SPAN_WARNING("The [target] is too big to stick with tape!"))
 		return

--- a/code/game/objects/items/weapons/tools/tape.dm
+++ b/code/game/objects/items/weapons/tools/tape.dm
@@ -168,7 +168,7 @@
 	if (!istype(target) || target.anchored)
 		return
 
-	if (istype(src, /obj/item/storage))
+	if (istype(target, /obj/item/storage))
 		//dont tape storage items, just put them inside
 		return
 

--- a/code/modules/mob/inventory/slots.dm
+++ b/code/modules/mob/inventory/slots.dm
@@ -137,6 +137,8 @@
 	req_organ = BP_HEAD
 	req_slot_flags = SLOT_EARS|SLOT_TWOEARS
 	update_proc = /mob/proc/update_inv_ears
+	max_w_class = ITEM_SIZE_TINY
+	resticted_items = list(/obj/item/storage/pouch)
 
 /datum/inventory_slot/ear/can_equip(obj/item/I, mob/living/carbon/human/owner, disable_warning)
 	if(I.slot_flags & SLOT_TWOEARS)
@@ -147,15 +149,11 @@
 /datum/inventory_slot/ear/left
 	name = "Left ear"
 	id = slot_l_ear
-	max_w_class = ITEM_SIZE_TINY
-	resticted_items = list(/obj/item/storage/pouch)
 
 /datum/inventory_slot/ear/right
 	name = "Right ear"
 	id = slot_r_ear
 	req_slot_flags = SLOT_EARS
-	max_w_class = ITEM_SIZE_TINY
-	resticted_items = list(/obj/item/storage/pouch)
 
 /datum/inventory_slot/glasses
 	name = "Glasses"

--- a/code/modules/mob/inventory/slots.dm
+++ b/code/modules/mob/inventory/slots.dm
@@ -16,6 +16,7 @@
 	var/req_slot_flags
 	var/req_type
 	var/max_w_class
+	var/list/resticted_items = list()
 
 /datum/inventory_slot/proc/update_icon(mob/living/owner, redraw)
 	if(update_proc)
@@ -48,7 +49,10 @@
 		return TRUE
 	else if(req_slot_flags && (req_slot_flags & I.slot_flags))
 		return TRUE
-	else if(max_w_class && (I.w_class <= max_w_class))
+	if(max_w_class && (I.w_class <= max_w_class))
+		for(var/check in resticted_items)
+			if(istype(I, check))
+				return FALSE
 		return TRUE
 
 	if(!disable_warning)
@@ -143,13 +147,15 @@
 /datum/inventory_slot/ear/left
 	name = "Left ear"
 	id = slot_l_ear
+	max_w_class = ITEM_SIZE_TINY
+	resticted_items = list(/obj/item/storage/pouch)
 
 /datum/inventory_slot/ear/right
 	name = "Right ear"
 	id = slot_r_ear
 	req_slot_flags = SLOT_EARS
 	max_w_class = ITEM_SIZE_TINY
-
+	resticted_items = list(/obj/item/storage/pouch)
 
 /datum/inventory_slot/glasses
 	name = "Glasses"


### PR DESCRIPTION
Hey hey catto here from back from hell and me and the fallen have been chitchatting before seeking otherworldly advice for tweaking the balance of storage!

Pouches are now "soft storage" for sake of mechanical refence, what that means is that more items put in the more it grows in size well in modular storage.
Pouches default size has been lowered by 1 weight class, some pouches have been given bulk to undo this lowering of class
Putting items of the higher weight class into the soft storage increases its size by the difference 
An exsample
Small pouch is tiny! code wise thats a weight class of 1
You put a medium cell in, thats small and thats a class of 2
so the pouch grows for having an item inside it and then an additional 1 extra bulk for the cell.
This system does NOT prevent you from having big sized pouches in pockets or slotted storage.