### PR TITLE
Trivial Favor Title Correction

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/3-rare/mecha.dm
+++ b/code/modules/trade/datums/trade_stations_presets/3-rare/mecha.dm
@@ -76,8 +76,8 @@
 	)
 
 	offer_types = list(
-		/obj/item/mech_ammo_box/scattershot = offer_data("30mm HEAD ammunition box", 350, 5),
-		/obj/item/mech_ammo_box/ultracannon = offer_data("50mm HEAD ammunition box", 350, 5),
+		/obj/item/mech_ammo_box/scattershot = offer_data("50mm HEAD ammunition box", 350, 5),
+		/obj/item/mech_ammo_box/ultracannon = offer_data("30mm HEAD ammunition box", 350, 5),
 		/obj/item/tool_upgrade/reinforcement/plating = offer_data("reinforced plating", 120, 2),
 		/obj/item/gun_upgrade/mechanism/overdrive = offer_data("overdrive chip", 175, 2),
 		/obj/item/cell/large/moebius/nuclear = offer_data("Soteria \"Atomcell 14000L\"", 575, 3)


### PR DESCRIPTION
This has like, no gameplay impact whatsoever. Both ammo boxes are the same, lackluster price, but just had their names swapped around (A single number.)

The game is now playable.

![image](https://github.com/sojourn-13/sojourn-station/assets/47806118/ffc7953d-35fc-4bae-8d4c-61cfc9dc336f)
