### PR TITLE
Makes the Church vendor no longer custom

### DIFF
--- a/code/game/machinery/vendor/weapon_vendors.dm
+++ b/code/game/machinery/vendor/weapon_vendors.dm
@@ -318,8 +318,9 @@
 					/obj/item/computer_hardware/hard_drive/portable/design/nt/basic_utility/public = 100,
 					/obj/item/tool/knife/neotritual = 250,
 					/obj/item/gun/matter/launcher/nt_sprayer = 500)
-	custom_vendor = TRUE // So they can sell pouches and other printed goods, if they bother to stock them
+	//custom_vendor = TRUE // So they can sell pouches and other printed goods, if they bother to stock them - Turns out they just abuse it to get free stuff, and they just make a custom vendor if they want to sell
 
+/* We don't actually use this code at all, check_NT is hardcoded to always return true, so why run the proc every time?
 /obj/machinery/vending/theomat/proc/check_NT(mob/user)
 	var/bingo = TRUE //SoJ tweak, were always true, sadly for us church likes non-churchies (lame I know)
 	if(ishuman(user))
@@ -352,6 +353,7 @@
 /obj/machinery/vending/theomat/try_to_buy(obj/item/W, var/datum/data/vending_product/R, var/mob/user)
 	if(check_NT(user))
 		..()
+*/
 
 /obj/machinery/vending/serbomat
 	name = "From Serbia with love"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Makes the Church vendor no longer a custom vendor that can be unlocked with an ID
</summary>
<hr>

It was made such back on Eris so that the Church could be cool and sell stuff with it, but they only use it to gain free things. They can and do just set up a new custom vendor for selling stuff to the public.	

Also removes a proc that was checked any time someone interacted with the Church vending machine but would only ever return one value because the Church wants to sell.
<hr>
</details>

## Changelog
:cl:
tweak: The Church vendor is no longer a custom vendor that can be used for free goodies by any Vector
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
