### PR TITLE
Adds area to SLT helmet alerts, suit sensor changes

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -721,7 +721,8 @@ BLIND     // can't see anything
 /obj/item/clothing/under/New()
 	..()
 	item_state_slots[slot_w_uniform_str] = icon_state //TODO: drop or gonna use it?
-	sensor_mode = 3 // All clothing on tracking by default now.
+	if(isOnStationLevel(src))
+		sensor_mode = 3 // Clothing spawning on colony levels is on tracking by default.
 
 /obj/item/clothing/under/examine(mob/user)
 	..(user)
@@ -774,7 +775,7 @@ BLIND     // can't see anything
 					V.show_message("[usr] sets [src.loc]'s sensors to maximum.", 1)
 
 /obj/item/clothing/under/attackby(var/obj/item/I, var/mob/U)
-	if(I.get_tool_type(usr, list(QUALITY_SCREW_DRIVING), src) && ishuman(U) && !is_sharp(I)) // No setting sensors with knives!
+	if(I.get_tool_type(usr, list(QUALITY_SCREW_DRIVING), src) && ishuman(U))
 		set_sensors(U)
 	else
 		return ..()

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -1804,7 +1804,11 @@
 					continue
 				crewmembers_recently_reported += entry["name"]
 				schedule_memory_cleanup(entry["name"])
-				to_chat(user, SPAN_WARNING("[src] beeps: '[entry["name"]]'s on-suit sensors broadcast an emergency signal. Access monitoring software for details.'"))
+				if((entry["area"]))
+					to_chat(user, SPAN_WARNING("[src] beeps: '[entry["name"]]'s on-suit sensors broadcast an emergency signal from [entry["area"]]. Access monitoring software for details.'"))
+				else
+					to_chat(user, SPAN_WARNING("[src] beeps: '[entry["name"]]'s on-suit sensors broadcast an emergency signal from an unidentified location. Access monitoring software for details.'"))
+
 
 	schedule_scan()
 


### PR DESCRIPTION
The special SLT alert helmets not also print the area the alert came from.

Suit sensors can now be changed with tools that have "SCREWDRIVING" but are also sharp, like knives.

Only clothing that spawns on Station Levels (The colony, the mines, the solars) start with sensors enabled, clothing that spawns outside starts with sensors disabled.