### PR TITLE
Ditch abiotic checks in scanner/cryo cell, make cryo eject dropped items

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -42,9 +42,6 @@
 	if(src.occupant)
 		to_chat(usr, SPAN_WARNING("The scanner is already occupied!"))
 		return
-	if(usr.abiotic())
-		to_chat(usr, SPAN_WARNING("The subject cannot have abiotic items on."))
-		return
 	set_occupant(usr)
 	src.add_fingerprint(usr)
 	return
@@ -80,9 +77,6 @@
 	if(target.buckled)
 		to_chat(user, SPAN_NOTICE("Unbuckle the subject before attempting to move them."))
 		return
-	if(target.abiotic())
-		to_chat(user, SPAN_NOTICE("Subject cannot have abiotic items on."))
-		return
 	set_occupant(target)
 	src.add_fingerprint(user)
 	return TRUE
@@ -92,9 +86,6 @@
 		return
 	if (src.occupant)
 		to_chat(user, SPAN_WARNING("The scanner is already occupied!"))
-		return
-	if (target.abiotic())
-		to_chat(user, SPAN_WARNING("Subject cannot have abiotic items on."))
 		return
 	if (target.buckled)
 		to_chat(user, SPAN_NOTICE("Unbuckle the subject before attempting to move them."))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -280,12 +280,16 @@
 /obj/machinery/atmospherics/unary/cryo_cell/proc/go_out()
 	if(!( occupant ))
 		return
-	//for(var/obj/O in src)
-	//	O.loc = loc
+	for(var/obj/O in src)
+		if(O == beaker)
+			continue
+		if(O in component_parts)
+			continue
+		O.forceMove(loc)
 	if (occupant.client)
 		occupant.client.eye = occupant.client.mob
 		occupant.client.perspective = MOB_PERSPECTIVE
-	occupant.loc = get_step(loc, SOUTH)	//this doesn't account for walls or anything, but i don't forsee that being a problem.
+	occupant.forceMove(get_step(loc, SOUTH))	//this doesn't account for walls or anything, but i don't forsee that being a problem.
 	if (occupant.bodytemperature < 261 && occupant.bodytemperature >= 70) //Patch by Aranclanos to stop people from taking burn damage after being ejected
 		occupant.bodytemperature = 261									  // Changed to 70 from 140 by Zuhayr due to reoccurance of bug.
 //	occupant.metabslow = 0
@@ -304,9 +308,6 @@
 		return
 	if (occupant)
 		to_chat(usr, SPAN_DANGER("The cryo cell is already occupied!"))
-		return
-	if (M.abiotic())
-		to_chat(usr, SPAN_WARNING("Subject may not have abiotic items on."))
 		return
 	if(!node1)
 		to_chat(usr, SPAN_WARNING("The cell is not correctly connected to its pipe network!"))


### PR DESCRIPTION
## About The Pull Request
This removes the requirement for people being thrown in the scanner or cryo cell to have nothing in their hands (the abiotic() proc).

Tested and made sure that any items that are dropped inside get vomited out with the occupant.

The reason behind this PR is primarily armblades and the like being impossible to remove from hands short of cutting off people's arms, which interferes with medical treatment.

## Changelog
:cl:
tweak: Body Scanner no longer requires empty hands to load
tweak: Cryo Cell no longer requires empty hands to load
/:cl:
