### PR TITLE
Hardsuit storage module tweaks

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/storage.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/storage.dm
@@ -4,7 +4,6 @@
 	desc = "A series of straps, pouches and internal modifications for a RIGsuit. Has space for quite a few items, though it's a bit bulky and awkward."
 	interface_name = "internal storage compartment"
 	interface_desc = "A storage compartment built directly into the suits back module, accessed through a latching compartment."
-	module_bulk = 0.5 //This gets doubled for stiffness and halved for slowdown.meaning it offers medium stiffness and 0.25 slowdown
 	price_tag = 100
 
 	var/obj/item/storage/internal/container = null
@@ -17,9 +16,17 @@
 	//These vars will be passed onto the storage
 	var/list/can_hold = list() //List of objects which this item can store (if set, it can't store anything else)
 	var/list/cant_hold = list(/obj/item/rig) //List of objects which this item can't store (in effect only if can_hold isn't set)
-	var/max_w_class = ITEM_SIZE_NORMAL //Max size of objects that this object can store (in effect only if can_hold isn't set)
-	var/max_storage_space = DEFAULT_BULKY_STORAGE * 0.7 //This is about a satchel worth of storage.
+	var/max_w_class = ITEM_SIZE_BULKY  //Max size of objects that this object can store (in effect only if can_hold isn't set)
+	var/max_storage_space = DEFAULT_BULKY_STORAGE * 0.5 //This is about a satchel worth of storage
 	var/storage_slots = null //The number of storage slots in this container.
+
+/obj/item/rig_module/storage/large
+	name= "RIG distributed storage system"
+	desc = "A series of straps, pouches and internal modifications for a RIGsuit. This model is distributed across the whole body, and can hold more items but only of a smaller size."
+	interface_name = "large internal storage compartment"
+	interface_desc = "A system of storage integrated into the suits control module."
+	max_w_class = ITEM_SIZE_NORMAL
+	max_storage_space = DEFAULT_BULKY_STORAGE * 0.7
 
 /obj/item/rig_module/storage/med
 	name = "medical storage system"
@@ -142,6 +149,7 @@
 	container.max_storage_space = max_storage_space
 	container.storage_slots = storage_slots
 	container.master_item = src //If its installed immediately after creation this will get set to the rig in install proc
+	container.w_class = w_class
 	.=..()
 /*****************************
 	Installation

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -49,7 +49,7 @@
 	initial_modules = list(
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
-		/obj/item/rig_module/storage/combat
+		/obj/item/rig_module/storage
 		)
 
 /obj/item/clothing/head/helmet/space/rig/combat/ironhammer
@@ -84,7 +84,7 @@
 	initial_modules = list(
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/mounted,
-		/obj/item/rig_module/storage/combat,
+		/obj/item/rig_module/storage,
 		/obj/item/rig_module/device/flash,
 		/obj/item/rig_module/mounted/egun,
 		/obj/item/rig_module/vision/sechud
@@ -224,7 +224,7 @@
 	initial_modules = list(
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/mounted,
-		/obj/item/rig_module/storage/combat,
+		/obj/item/rig_module/storage,
 		/obj/item/rig_module/device/flash,
 		/obj/item/rig_module/mounted/egun,
 		/obj/item/rig_module/vision/sechud
@@ -257,7 +257,7 @@
 	initial_modules = list(
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/mounted,
-		/obj/item/rig_module/storage/combat,
+		/obj/item/rig_module/storage,
 		/obj/item/rig_module/device/flash,
 		/obj/item/rig_module/mounted/egun,
 		/obj/item/rig_module/vision/sechud
@@ -296,7 +296,7 @@
 /obj/item/rig/combat/solfed/equipped
 	initial_modules = list(
 		/obj/item/rig_module/maneuvering_jets,
-		/obj/item/rig_module/storage/combat,
+		/obj/item/rig_module/storage,
 		/obj/item/rig_module/stealth_field,
 		/obj/item/rig_module/modular_injector/combat/preloaded,
 		/obj/item/rig_module/grenade_launcher,

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -162,7 +162,7 @@ Advanced Voidsuit: Guild Master
 		/obj/item/rig_module/device/rcd,
 		/obj/item/rig_module/vision/meson,
 		/obj/item/rig_module/cargo_clamp,
-		/obj/item/rig_module/storage/engi
+		/obj/item/rig_module/storage/large
 		)
 
 /obj/item/clothing/gloves/rig/ce
@@ -212,7 +212,7 @@ Technomancer RIG
 
 /obj/item/rig/techno/equipped
 	initial_modules = list(
-		/obj/item/rig_module/storage/engi,
+		/obj/item/rig_module/storage/large,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/cargo_clamp,
 		)
@@ -367,7 +367,7 @@ Technomancer RIG
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/healthscanner,
 		/obj/item/rig_module/vision/medhud,
-		/obj/item/rig_module/storage/med
+		/obj/item/rig_module/storage/large
 		)
 
 /obj/item/rig/recovery_suit
@@ -406,7 +406,7 @@ Technomancer RIG
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/healthscanner,
 		/obj/item/rig_module/vision/medhud,
-		/obj/item/rig_module/storage/med
+		/obj/item/rig_module/storage/large
 		)
 
 /obj/item/rig/light/ultra_light/cmo
@@ -432,7 +432,7 @@ Technomancer RIG
 		/obj/item/rig_module/modular_injector/medical/preloaded,
 		/obj/item/rig_module/device/healthscanner,
 		/obj/item/rig_module/vision/medhud,
-		/obj/item/rig_module/storage/med
+		/obj/item/rig_module/storage/large
 		)
 
 
@@ -501,5 +501,5 @@ Technomancer RIG
 		/obj/item/rig_module/device/healthscanner,
 		/obj/item/rig_module/modular_injector/medical/preloaded,
 		/obj/item/rig_module/ai_container,
-		/obj/item/rig_module/storage/combat
+		/obj/item/rig_module/storage/large
 		)

--- a/code/modules/research/designs/rigmodules.dm
+++ b/code/modules/research/designs/rigmodules.dm
@@ -93,11 +93,18 @@
 	materials = list(MATERIAL_STEEL = 45, MATERIAL_PLASTIC = 25)
 	category = "RIG"
 
+/datum/design/research/item/storage/large
+	name = "hardsuit distributed storage system"
+	desc = "A system of pouches that has been integrated into a hardsuit."
+	build_path = /obj/item/rig_module/storage/large
+	materials = list(MATERIAL_STEEL = 60, MATERIAL_PLASTIC = 40)
+	category = "RIG"
+
 /datum/design/research/item/storagemed
 	name = "hardsuit medical storage system"
 	desc = "A system of various storage solutions for a RIG. This one is designed for medicine."
 	build_path = /obj/item/rig_module/storage/med
-	materials = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 15)
+	materials = list(MATERIAL_STEEL = 20, MATERIAL_PLASTIC = 15)
 	category = "RIG"
 
 /datum/design/research/item/storagetac

--- a/code/modules/research/nodes/engineering.dm
+++ b/code/modules/research/nodes/engineering.dm
@@ -491,6 +491,7 @@
 	cost = 1875
 
 	unlocks_designs = list(/datum/design/research/item/storage,
+							/datum/design/research/item/storage/large,
 							/datum/design/research/item/storageengi,
 							/datum/design/research/item/storagemed,
 							/datum/design/research/item/storagetac,

--- a/code/modules/trade/datums/trade_stations_presets/2-uncommon/suit_up.dm
+++ b/code/modules/trade/datums/trade_stations_presets/2-uncommon/suit_up.dm
@@ -74,7 +74,8 @@
 			/obj/item/rig_module/storage,
 			/obj/item/rig_module/storage/engi,
 			/obj/item/rig_module/storage/med,
-			/obj/item/rig_module/storage/combat
+			/obj/item/rig_module/storage/combat,
+			/obj/item/rig_module/storage/large
 		)
 	)
 


### PR DESCRIPTION
Rebalances hardsuit storage

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds a new 'large' distributed storage module for hardsuits. This has about the same storage as a satchel, but cannot hold bulky items.

The old storage module has had its overall size reduced, but can hold bulky items.

Both storage modules can now hold appropriately sized containers, similar to a satchel, such as boxes and pouches.

These now replace the old specialized storage modules on all hardsuits. Previous specialized storage modules can still be printed from RnD or ordered from the Suit Up station by Lonestar, if for some reason you prefer them.

Removed slowdown from hardsuit storage modules. It was a lot of slowdown, especially considering most hardsuits have a lot of slowdown anyway.

<hr>
</details>

## Changelog
:cl:
balance: removed hardsuit storage module slowdown
balance: enabled appropriately sized storage items to be placed inside hardsuit storage
balance: Reduced overall size of base hardsuit storage module
add: Added a new version of the hardsuit storage module designed to carry lots of smaller items
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
