### PR TITLE
Mobs targeting turrets

### DIFF
--- a/code/game/machinery/os_portable_turret.dm
+++ b/code/game/machinery/os_portable_turret.dm
@@ -203,6 +203,12 @@
 				return		// Don't shoot other turrets
 		try_shoot(proj_start_turf)
 
+/obj/machinery/power/os_turret/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
+	if(!damage)
+		return 0
+	attack_animation(user)
+	take_damage(damage)
+
 /obj/machinery/power/os_turret/attackby(obj/item/I, mob/user)
 	var/mec_or_cog = max(user.stats.getStat(STAT_MEC), user.stats.getStat(STAT_COG))
 

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -496,6 +496,12 @@ var/list/turret_icons
 	if(health <= 0)
 		die()	//the death process :(
 
+/obj/machinery/porta_turret/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
+	if(!damage)
+		return 0
+	attack_animation(user)
+	take_damage(damage)
+
 /obj/machinery/porta_turret/bullet_act(obj/item/projectile/Proj)
 	var/damage = Proj.get_structure_damage()
 

--- a/code/game/machinery/tesla_turret.dm
+++ b/code/game/machinery/tesla_turret.dm
@@ -446,6 +446,12 @@ GLOBAL_LIST_INIT(turret_channels, new/list(5))
 	if(health <= 0)
 		die()	//the death process :(
 
+/obj/machinery/tesla_turret/attack_generic(mob/user, damage, attack_message, damagetype = BRUTE, attack_flag = ARMOR_MELEE, sharp = FALSE, edge = FALSE)
+	if(!damage)
+		return 0
+	attack_animation(user)
+	take_damage(damage)
+
 /obj/machinery/tesla_turret/bullet_act(obj/item/projectile/Proj)
 	var/damage = Proj.get_structure_damage()
 

--- a/code/modules/mob/living/carbon/superior_animal/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/ai.dm
@@ -30,13 +30,25 @@
 
 	var/turf/our_turf = get_turf(src)
 	if (our_turf) //If we're not in anything, continue
-		for(var/mob/living/target_mob as anything in hearers(src, viewRange)) //as anything works because isvalid has a isliving check, change if necessary
-			if (isValidAttackTarget(target_mob))
+		for(var/mob/living/target_mob in hearers(src, viewRange)) //as anything : Removed do optimization
+			if(isValidAttackTarget(target_mob))
 				if(target_mob.target_dummy && prioritize_dummies) //Target me over anyone else
 					return target_mob
 				filteredTargets += target_mob
 
-		for (var/obj/mecha/M as anything in GLOB.mechas_list)
+		for(var/obj/machinery/tesla_turret/tesla_turret in view(src, viewRange))
+			if(isValidAttackTarget(tesla_turret))
+				filteredTargets += tesla_turret
+
+		for(var/obj/machinery/porta_turret/porta_turret in view(src, viewRange))
+			if(isValidAttackTarget(porta_turret))
+				filteredTargets += porta_turret
+
+		for(var/obj/machinery/power/os_turret/os_turret in view(src, viewRange))
+			if(isValidAttackTarget(os_turret))
+				filteredTargets += os_turret
+
+		for(var/obj/mecha/M in GLOB.mechas_list)
 			//As goofy as this looks its more optimized as were not looking at every mech outside are z-level if they are around us. - Trilby
 			if(M.z == z)
 				if(get_dist(src, M) <= viewRange)
@@ -140,6 +152,36 @@
 		if (can_see(src, O, get_dist(src, O))) //can we even see it?
 			var/obj/mecha/M = O
 			return isValidAttackTarget(M.occupant)
+
+	if (istype(O, /obj/machinery/tesla_turret))
+		var/obj/machinery/tesla_turret/TT = O
+		if(TT.stat & (BROKEN | NOPOWER))
+			return FALSE
+		if(TT.colony_allied_turret && friendly_to_colony) //dont target your own turret unless they are haywire
+			return FALSE
+		if(!TT.colony_allied_turret && !friendly_to_colony) //its on are side!
+			return FALSE
+		return TRUE
+
+	if (istype(O, /obj/machinery/power/os_turret))
+		var/obj/machinery/power/os_turret/OST = O
+		if(OST.faction_iff == faction) //What are you doing fool?!
+			return FALSE
+		if(OST.stat & (BROKEN | NOPOWER))
+			return FALSE
+		if(!OST.should_target_players && friendly_to_colony) //dont target your own turret unless they are haywire
+			return FALSE
+		return TRUE
+
+	if (istype(O, /obj/machinery/porta_turret))
+		var/obj/machinery/porta_turret/PO = O
+		if(PO.faction_iff == faction) //What are you doing fool?!
+			return FALSE
+		if(PO.stat & (BROKEN | NOPOWER))
+			return FALSE
+		if(PO.colony_allied_turret && friendly_to_colony)
+			return FALSE
+		return TRUE
 
 	return FALSE
 

--- a/code/modules/mob/living/carbon/superior_animal/ai.dm
+++ b/code/modules/mob/living/carbon/superior_animal/ai.dm
@@ -181,6 +181,9 @@
 			return FALSE
 		if(PO.colony_allied_turret && friendly_to_colony)
 			return FALSE
+		//So we dont try and attack turrets that are not attacking us
+		if(!PO.colony_allied_turret && !friendly_to_colony)
+			return FALSE
 		return TRUE
 
 	return FALSE


### PR DESCRIPTION
Turrets that target a mob now will be targeted by the mob its targeting
Only expiation is church ones as they dont break
Tweaks how mobs view living as anything rather then strick type
Should be an optimization, might break something
