### PR TITLE
Make people spawn directly at appropriate locations

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -233,7 +233,6 @@ SUBSYSTEM_DEF(ticker)
 
 	create_characters() //Create player characters and transfer them
 	collect_minds()
-	move_characters_to_spawnpoints()
 	equip_characters()
 
 	CHECK_TICK
@@ -393,9 +392,8 @@ SUBSYSTEM_DEF(ticker)
 			else if(!player.mind.assigned_role)
 				continue
 			else
-				player.create_character()
+				player.create_character(player.mind.assigned_role, FALSE)
 				qdel(player)
-
 
 /datum/controller/subsystem/ticker/proc/collect_minds()
 	for(var/mob/living/player in GLOB.player_list)
@@ -496,10 +494,6 @@ SUBSYSTEM_DEF(ticker)
 			if(!isnewplayer(M))
 				to_chat(M, "Premier role not forced on anyone.")
 
-/datum/controller/subsystem/ticker/proc/move_characters_to_spawnpoints()
-	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		var/datum/spawnpoint/SP = SSjob.get_spawnpoint_for(player.client, player.mind.assigned_role)
-		SP.put_mob(player)
 
 
 /datum/controller/subsystem/ticker/proc/declare_completion()

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -152,6 +152,13 @@
 		M.buckled.set_dir(M.dir)
 	return TRUE
 
+// We will still call put_mob after this
+/datum/spawnpoint/proc/get_turf_for_new_player()
+	var/list/free_locs = get_spawn_locations()
+	if(!LAZYLEN(free_locs))
+		return FALSE
+
+	return get_turf(pick(free_locs))
 
 /**********************
 	Cryostorage Spawning

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -68,9 +68,9 @@
 	qdel(animation)
 	return src
 
-/mob/new_player/AIize()
+/mob/new_player/AIize(move=1)
 	spawning = 1
-	return ..()
+	return ..(move)
 
 /mob/proc/AIize(move=1)
 	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))


### PR DESCRIPTION
## About The Pull Request
This hopefully should make it so that any issues with people all spawning on top of each other at roundstart go away, since the system will now try really really hard to spawn people directly inside the station at the same time as `new`, and then wrassle them around afterwards for like, cryo tubes and the elevator and stuff.

## Changelog
:cl:
tweak: People now spawn directly where they should at roundstart.
/:cl:
