### PR TITLE
Trash+ map update & Overgrowth

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -1694,11 +1694,6 @@
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
-"asE" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "asL" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window/southleft{
@@ -2245,11 +2240,6 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
-"axJ" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "axS" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/wood/wild4,
@@ -2767,11 +2757,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"aCE" = (
-/obj/item/remains/ribcage,
-/obj/item/clothing/accessory/choker/gold_bell,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "aCI" = (
 /obj/structure/table/standard,
 /obj/random/medical/low_chance,
@@ -3693,6 +3678,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"aNr" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "aNy" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -3736,12 +3725,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
-"aOa" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "aOb" = (
 /obj/item/farmbot_arm_assembly{
 	created_name = "GardenBot";
@@ -4472,11 +4455,6 @@
 "aYl" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/inside_colony)
-"aYn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junkfood/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "aYo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7080,6 +7058,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"bzv" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/portable_atmospherics/hydroponics/soil{
+	layer = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "bzw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7386,11 +7371,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/servist)
-"bDm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/light/tube,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "bDw" = (
 /obj/random/scrap/sparse_even,
 /obj/random/mob/roaches/low_chance,
@@ -7438,15 +7418,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"bDK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/techshop)
 "bDQ" = (
 /obj/effect/floor_decal/industrial/warningred/full,
 /obj/structure/cable/yellow,
@@ -7487,6 +7458,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
+"bEk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "bEn" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -7567,6 +7543,12 @@
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
+"bFl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/device/lighting/toggleable/lamp,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "bFt" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8;
@@ -8598,6 +8580,13 @@
 /obj/structure/barricade,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"bQY" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "bRi" = (
 /obj/effect/floor_decal/industrial/botright/yellow,
 /obj/random/structures,
@@ -10970,9 +10959,10 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/substation/medical)
 "crr" = (
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/beach/sand,
-/area/nadezhda/outside/inside_colony)
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "crs" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -11451,11 +11441,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
-"cxf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/shotgun/pellet/prespawned,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "cxh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_research{
@@ -13955,6 +13940,14 @@
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"cWJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "cWM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13989,11 +13982,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
-"cXc" = (
-/obj/structure/railing,
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "cXf" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -16237,11 +16225,6 @@
 /obj/item/storage/box/flashbangs,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical)
-"duV" = (
-/obj/random/mob/termite_no_despawn,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "duZ" = (
 /obj/machinery/door/airlock/maintenance_cargo{
 	req_one_access = list(50,70,78)
@@ -18221,6 +18204,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"dPB" = (
+/obj/structure/flora/small/busha1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "dPC" = (
 /turf/simulated/shuttle/floor/science{
 	icon_state = "12,4"
@@ -22660,10 +22647,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/captain/quarters)
-"eKY" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "eLa" = (
 /obj/structure/table/steel,
 /obj/structure/salvageable/computer{
@@ -23542,6 +23525,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
+"eTa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "eTd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26250,6 +26238,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"fvz" = (
+/obj/structure/flora/small/busha3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "fvA" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
@@ -28278,11 +28274,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
-"fSY" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "fTa" = (
 /obj/structure/window/reinforced,
 /obj/structure/multiz/stairs/active{
@@ -28411,6 +28402,15 @@
 /obj/effect/floor_decal/border/carpet/orange,
 /turf/simulated/mineral,
 /area/colony)
+"fUw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/techshop)
 "fUB" = (
 /obj/machinery/camera/network/colony_underground{
 	dir = 1
@@ -28465,11 +28465,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"fUZ" = (
-/obj/structure/flora/small/rock3,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "fVe" = (
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
 	pixel_y = 32
@@ -28502,6 +28497,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/network/command,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
 "fVz" = (
@@ -29047,6 +29043,12 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/main/stairwell)
+"gbA" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "gbB" = (
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
@@ -30743,6 +30745,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
+"grx" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "grG" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -30921,14 +30928,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
-"gtE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/trash/candy/proteinbar,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "gtM" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -31699,12 +31701,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/armoryshop)
-"gCw" = (
-/obj/structure/table/woodentable{
-	color = "#9a977b"
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "gCC" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 1;
@@ -32187,6 +32183,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"gJn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "gJp" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/machinery/light,
@@ -34903,6 +34904,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
 "hnn" = (
@@ -35289,11 +35291,6 @@
 /obj/item/stack/cable_coil/yellow,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/hallways)
-"hrz" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "hrA" = (
 /obj/machinery/button/crematorium{
 	pixel_y = 4
@@ -35413,6 +35410,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"hsP" = (
+/obj/structure/railing,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "hsW" = (
 /obj/structure/flora/small/rock3,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -37508,6 +37510,14 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"hMb" = (
+/obj/structure/flora/small/bushb1,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "hMc" = (
 /obj/machinery/light{
 	dir = 4
@@ -38353,6 +38363,7 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/power/shield_generator,
 /obj/structure/cable/blue,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
 "hWL" = (
@@ -38971,6 +38982,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
+"iaZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "ibb" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -39466,8 +39482,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "igp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/lowkeyrandom/low_chance,
+/obj/structure/table/rack,
+/obj/item/trash/material/metal{
+	icon_state = "device0"
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "igt" = (
@@ -40040,16 +40058,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"iml" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "imo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -42873,6 +42881,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/medical/psych)
+"iSk" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "iSn" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -43470,6 +43485,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
 "iZN" = (
@@ -45138,6 +45154,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
+"jpW" = (
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "jqc" = (
 /obj/machinery/light/small,
 /obj/machinery/alarm{
@@ -45146,11 +45166,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/hallways)
-"jqr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "jqw" = (
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/rock,
@@ -45855,6 +45870,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"jwM" = (
+/obj/machinery/atmospherics/unary/vent_pump,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal{
+	icon_state = "metal3"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "jwR" = (
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -47182,10 +47205,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
-"jMt" = (
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "jMx" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -47362,6 +47381,22 @@
 /obj/machinery/door/window/northright,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/podrooms)
+"jNN" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "jNP" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -49448,6 +49483,12 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/gmaster)
+"kkf" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "kkl" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -49809,19 +49850,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
-"knQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "knR" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -49890,12 +49918,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"koB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "koK" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/snacks/twobread,
@@ -50081,6 +50103,16 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"kqn" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "kqu" = (
 /obj/structure/table/standard,
 /obj/item/pen,
@@ -50404,15 +50436,6 @@
 /area/nadezhda/security/nuke_storage{
 	name = "\improper Clinic"
 	})
-"ktZ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "kuc" = (
 /turf/simulated/open,
 /area/nadezhda/maintenance/undergroundfloor2west)
@@ -51794,11 +51817,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/detectives_office)
-"kJi" = (
-/obj/structure/flora/small/busha2,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "kJk" = (
 /obj/structure/bed/chair/sofa/black/right,
 /turf/simulated/floor/wood,
@@ -51910,14 +51928,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"kKy" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/metal{
-	icon_state = "metal3"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "kKF" = (
 /obj/item/modular_computer/console/preset/trade{
 	dir = 1
@@ -52812,13 +52822,6 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"kUT" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "kUX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53124,15 +53127,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
-"kYN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/techshop)
 "kYP" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -53204,11 +53198,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"kZU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "kZY" = (
 /obj/machinery/computer/general_air_control{
 	dir = 1;
@@ -53336,6 +53325,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"lbY" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "lcf" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -53450,6 +53443,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/reception)
+"lcV" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "lcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
@@ -53916,6 +53914,11 @@
 /obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
+"lil" = (
+/obj/item/remains/ribcage,
+/obj/item/clothing/accessory/choker/gold_bell,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "lin" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "16,19"
@@ -54361,11 +54364,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/smc/quarters)
-"loK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/toolbox/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "loL" = (
 /obj/structure/closet/secure_closet/personal/security,
 /obj/effect/floor_decal/industrial/hatch,
@@ -55425,19 +55423,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"lAz" = (
-/obj/structure/flora/small/busha3,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
-"lAB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/remains/mouse,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "lAL" = (
 /obj/structure/flora/ausbushes/genericbush,
 /turf/unsimulated/wall/jungle,
@@ -55450,6 +55435,10 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
+"lBj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "lBk" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -56047,6 +56036,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security)
+"lHw" = (
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "lHA" = (
 /obj/structure/boulder,
 /turf/simulated/mineral,
@@ -56097,14 +56090,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
-"lHX" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "lIb" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -56208,6 +56193,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"lIM" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "lIS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57661,6 +57651,10 @@
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"lYj" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "lYk" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
@@ -59304,14 +59298,14 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
-"mpj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/chips,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "mpm" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/side/f2section1)
+"mpo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "mpw" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light/small{
@@ -59618,6 +59612,8 @@
 	},
 /area/nadezhda/hallway/surface/section1)
 "msh" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/engineering/shield_generator)
 "msm" = (
@@ -59670,6 +59666,13 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/pros/shuttle)
+"mth" = (
+/obj/structure/table/rack,
+/obj/item/trash/material/metal{
+	icon_state = "device3"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "mtj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -63627,6 +63630,13 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
+"nhM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/light/tube,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "nhN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -63953,6 +63963,10 @@
 /obj/random/lowkeyrandom,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
+"nkX" = (
+/obj/structure/railing,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "nlc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64338,6 +64352,11 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/medical/virology)
+"nps" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "npt" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/random/traps/low_chance{
@@ -64567,6 +64586,7 @@
 	dir = 8;
 	pixel_x = 32
 	},
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
 "nrT" = (
@@ -64962,6 +64982,11 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/atmos/surface)
+"nvo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/remains/mouse,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "nvw" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -65751,6 +65776,11 @@
 /obj/item/storage/fancy/crayons,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/captain/quarters)
+"nCV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/toolbox/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "nCY" = (
 /obj/random/tool_upgrade/rare,
 /turf/simulated/floor/plating/under,
@@ -66358,12 +66388,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"nJa" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/contraband/low_chance,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "nJb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66723,6 +66747,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
+"nMo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/techshop)
 "nMq" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/structure/boulder,
@@ -68396,6 +68429,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"odN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/light/tube,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "odW" = (
 /obj/structure/scrap/cloth/large,
 /obj/effect/decal/cleanable/dirt,
@@ -69463,11 +69501,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/crew_quarters/bar)
-"opn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/lighting/toggleable/lamp,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "opp" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
@@ -70315,12 +70348,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
-"oxU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/device/lighting/toggleable/lamp,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "oxW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -70654,11 +70681,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/clownoffice)
-"oAS" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "oAU" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/multiz/ladder/up,
@@ -70681,13 +70703,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"oBe" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/portable_atmospherics/hydroponics/soil{
-	layer = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "oBh" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/candy,
@@ -70890,6 +70905,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
 "oDt" = (
@@ -71335,13 +71352,6 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
-"oHZ" = (
-/obj/structure/table/rack,
-/obj/item/trash/material/metal{
-	icon_state = "device0"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "oIt" = (
 /obj/machinery/papershredder,
 /obj/machinery/light/small{
@@ -73279,13 +73289,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/surgery)
-"pbD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/light/tube,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "pbO" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/random/traps/low_chance{
@@ -73471,6 +73474,10 @@
 "pdW" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
+"pdX" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "pdY" = (
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/nadezhda/engineering/atmos)
@@ -75059,9 +75066,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/sleeper)
-"puS" = (
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "pva" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75329,6 +75333,12 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
+"pxN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "pxW" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/church,
@@ -75824,12 +75834,6 @@
 	icon_state = "9,11"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"pDa" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "pDc" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/slimegun,
@@ -76075,6 +76079,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
+"pFS" = (
+/obj/structure/flora/big/bush3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "pFT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/cluster/spiders,
@@ -76399,10 +76411,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
-"pJO" = (
-/obj/item/remains/ribcage,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "pJT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -77309,10 +77317,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"pRK" = (
-/obj/item/remains/ribcage,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "pRM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -78095,6 +78099,15 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/hallways)
+"pZq" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "pZr" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -78518,6 +78531,11 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qdP" = (
+/obj/structure/flora/big/rocks3,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "qdT" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -78558,11 +78576,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/clownoffice)
-"qee" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "qen" = (
 /obj/effect/floor_decal/industrial/road/warning4,
 /obj/effect/decal/cleanable/dirt,
@@ -78791,6 +78804,11 @@
 	icon_state = "14,1"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"qgR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/shotgun/pellet/prespawned,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "qgT" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/hud/health{
@@ -78840,6 +78858,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"qhq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pen,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "qhu" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
@@ -80878,11 +80901,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"qCR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/pen,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "qCS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -84570,6 +84588,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
+"rrB" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "rrH" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/sign/genetics{
@@ -85526,9 +85548,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "rBK" = (
-/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
+/area/nadezhda/outside/forest)
 "rBL" = (
 /obj/structure/bonfire/permanent,
 /obj/item/material/shard,
@@ -86339,9 +86362,9 @@
 /turf/simulated/open,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "rLy" = (
-/obj/structure/table,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
+/obj/structure/girder,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "rLD" = (
 /obj/machinery/camera/network/colony_surface{
 	dir = 4
@@ -86725,10 +86748,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
-"rOV" = (
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "rPb" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -88429,9 +88448,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
+/obj/item/trash/material/circuit,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "sgY" = (
@@ -88878,6 +88895,7 @@
 /obj/item/stock_parts/smes_coil/super_io,
 /obj/item/stock_parts/smes_coil/super_io,
 /obj/item/stock_parts/smes_coil/super_io,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
 "smq" = (
@@ -90291,6 +90309,11 @@
 /obj/effect/floor_decal/sign/psy,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"syO" = (
+/obj/structure/flora/small/busha2,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "syS" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/big/bush1,
@@ -91867,6 +91890,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
 "sQz" = (
@@ -92506,10 +92530,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/medical/psych)
-"sYB" = (
-/obj/structure/girder,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "sYD" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -92566,6 +92586,7 @@
 	dir = 8
 	},
 /obj/item/modular_computer/console/preset/engineering/rcon,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/engineering/shield_generator)
 "sZo" = (
@@ -92678,14 +92699,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/hallways)
-"sZX" = (
-/obj/structure/flora/small/bushb1,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "tad" = (
 /turf/unsimulated/mineral,
 /area/colony)
@@ -92828,13 +92841,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"tbo" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "tbz" = (
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/grass,
@@ -93613,6 +93619,11 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"tkX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "tkZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -94770,6 +94781,7 @@
 "txT" = (
 /obj/structure/table/standard,
 /obj/item/tool/wrench,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/engineering/shield_generator)
 "txV" = (
@@ -95608,6 +95620,19 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"tFO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "tFQ" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -96019,6 +96044,12 @@
 	},
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
+"tJH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/trash/candy/proteinbar,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "tJI" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/smc/quarters)
@@ -96035,6 +96066,12 @@
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
+"tKe" = (
+/obj/structure/table/woodentable{
+	color = "#9a977b"
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "tKh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -96872,13 +96909,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/absolutism/bioreactor)
-"tRL" = (
-/obj/structure/table/rack,
-/obj/item/trash/material/metal{
-	icon_state = "device3"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "tRU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame/vertical{
@@ -97070,6 +97100,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"tTI" = (
+/obj/structure/flora/small/rock3,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "tTJ" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_x = 32
@@ -98943,6 +98978,11 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/maingate)
+"ulM" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "ulO" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -99314,11 +99354,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"upU" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "upX" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
@@ -99512,16 +99547,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"urL" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/circuit,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "urR" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
@@ -102354,6 +102379,11 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"uUL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/lighting/toggleable/lamp,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "uUN" = (
 /obj/structure/table,
 /obj/effect/spider/stickyweb,
@@ -102810,6 +102840,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"uZV" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "vac" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -105981,6 +106017,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"vIj" = (
+/obj/random/mob/termite_no_despawn,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "vIl" = (
 /obj/structure/table/standard,
 /obj/random/toolbox/low_chance,
@@ -111932,10 +111973,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/hallway/side/f2section1)
-"wRF" = (
-/obj/structure/railing,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "wRG" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/effect/decal/cleanable/dirt,
@@ -113049,7 +113086,7 @@
 /area/nadezhda/outside/forest)
 "xfb" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/table/bench/wooden,
+/obj/structure/flora/big/rocks3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "xfc" = (
@@ -113243,6 +113280,9 @@
 	layer = 1
 	},
 /area/nadezhda/crew_quarters/sleep/bedrooms)
+"xgL" = (
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "xgR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -114418,14 +114458,6 @@
 /obj/item/clothing/head/helmet/bulletproof/ironhammer_thermal,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"xtt" = (
-/obj/structure/flora/big/bush3,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "xty" = (
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -114729,11 +114761,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"xwk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "xwp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -115342,11 +115369,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
-"xBG" = (
-/obj/structure/flora/big/rocks3,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "xBJ" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -115426,6 +115448,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
 "xCo" = (
@@ -115466,10 +115489,6 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
-"xCA" = (
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "xCG" = (
 /obj/structure/table/glass,
 /obj/random/junkfood,
@@ -115876,6 +115895,18 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"xHh" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "xHk" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Post";
@@ -116081,6 +116112,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"xJk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "xJo" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -116271,10 +116307,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/rbreakroom)
 "xKC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
+/obj/structure/table,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "xKJ" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -117889,10 +117924,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/engineering/atmos/surface)
-"ybP" = (
-/obj/structure/flora/small/busha1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "ycd" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -118237,6 +118268,11 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"ygq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/chips,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "ygt" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -177776,9 +177812,9 @@ cIo
 wVV
 wVV
 wVV
-knQ
-knQ
-knQ
+tFO
+tFO
+tFO
 mLu
 cZn
 ucI
@@ -178182,7 +178218,7 @@ yfR
 nkP
 iyl
 iyl
-pDa
+gbA
 tYn
 fHr
 ebO
@@ -178382,9 +178418,9 @@ tnO
 whU
 ebO
 oli
-gtE
-opn
-xKC
+tJH
+uUL
+gJn
 cxN
 rOi
 ebO
@@ -178581,14 +178617,14 @@ sRU
 sRU
 whU
 tnO
-xwk
+tkX
 cCy
 nBz
 cxN
 mSc
-kZU
-igp
-xCA
+iaZ
+eTa
+jpW
 ebO
 qQA
 gSu
@@ -178788,7 +178824,7 @@ cCy
 nBz
 tar
 mXl
-lAB
+nvo
 cxN
 xXM
 ebO
@@ -178985,13 +179021,13 @@ utr
 sRU
 whU
 due
-koB
+pxN
 cCy
 sMN
-igp
+eTa
 qpm
-qee
-mpj
+mpo
+ygq
 wlK
 ebO
 evY
@@ -179392,7 +179428,7 @@ vfn
 liW
 pZA
 bHN
-kYN
+fUw
 oqt
 wdA
 bjf
@@ -179796,7 +179832,7 @@ tQp
 liW
 sEX
 fwY
-bDK
+nMo
 pkg
 vTs
 rvM
@@ -180200,9 +180236,9 @@ laf
 vvx
 cCy
 sMN
-oxU
+bFl
 cuo
-urL
+sgP
 cxN
 bjU
 ebO
@@ -180399,13 +180435,13 @@ ody
 sRU
 whU
 tQp
-xwk
+tkX
 cCy
-tRL
-kKy
+mth
+jwM
 fCf
-sgP
-qee
+xHh
+mpo
 foj
 ebO
 kdn
@@ -180601,13 +180637,13 @@ ody
 sRU
 whU
 tnO
-xwk
+tkX
 cCy
-oHZ
-jqr
+igp
+bEk
 oBN
-iml
-bDm
+kqn
+odN
 bjU
 ebO
 bnh
@@ -180806,7 +180842,7 @@ tnO
 fUB
 ebO
 kDZ
-pbD
+nhM
 ckN
 qJj
 szW
@@ -181009,7 +181045,7 @@ kgK
 aYq
 flW
 iyl
-nJa
+kkf
 iyl
 mDo
 kzx
@@ -207777,14 +207813,14 @@ vSM
 tfW
 eUV
 eUV
-lHX
-lHX
-lHX
+cWJ
+cWJ
+cWJ
 tfW
 eUV
 tfW
-tbo
-tbo
+bQY
+bQY
 tfW
 tfW
 cGa
@@ -208165,7 +208201,7 @@ kOj
 mHv
 tfW
 olX
-duV
+vIj
 tfW
 tfW
 tfW
@@ -208181,16 +208217,16 @@ tfW
 aff
 tfW
 tfW
-jMt
+lHw
 cxU
 vaP
 eUV
-oAS
+rBK
 cxU
 cxU
 tfW
 cxU
-kUT
+iSk
 nhY
 cGa
 iSI
@@ -208392,7 +208428,7 @@ cxU
 tfW
 tfW
 cxU
-kUT
+iSk
 tfW
 tfW
 iSI
@@ -208571,7 +208607,7 @@ cXA
 tfW
 tfW
 tfW
-oBe
+bzv
 fqz
 tfW
 fqz
@@ -208594,7 +208630,7 @@ tfW
 tfW
 bSm
 cxU
-kUT
+iSk
 tfW
 lOm
 iSI
@@ -208783,10 +208819,10 @@ fhp
 tfW
 tfW
 lMN
-wRF
+nkX
 cxU
 tfW
-aCE
+lil
 tfW
 cTB
 tfW
@@ -208796,7 +208832,7 @@ cri
 tfW
 tfW
 cxU
-kUT
+iSk
 tfW
 tfW
 iSI
@@ -208985,9 +209021,9 @@ tfW
 fqz
 fqz
 cTz
-sYB
+rLy
 cxU
-oAS
+rBK
 pCD
 cxU
 cxU
@@ -208998,7 +209034,7 @@ tfW
 tfW
 nhY
 cxU
-kUT
+iSk
 tfW
 tfW
 tfW
@@ -209193,14 +209229,14 @@ eUV
 nhY
 cxU
 pCD
-oAS
+rBK
 eUV
 tfW
-pJO
+aNr
 cXA
 aff
 cxU
-kUT
+iSk
 eRP
 tiO
 tiO
@@ -209390,19 +209426,19 @@ lch
 vDt
 cxU
 tfW
-rOV
+lYj
 lch
 tiO
 cxU
 tfW
-fSY
+lcV
 vaP
 tfW
 tfW
 aff
 aff
 cxU
-kUT
+iSk
 eRP
 eRP
 mYI
@@ -209591,7 +209627,7 @@ tfW
 tfW
 tfW
 tfW
-sYB
+rLy
 cxU
 tfW
 tfW
@@ -209604,7 +209640,7 @@ tfW
 cxU
 cxU
 cxU
-sZX
+hMb
 tfW
 eRP
 nhY
@@ -209782,8 +209818,8 @@ tfW
 tfW
 tfW
 asu
-puS
-rBK
+xgL
+rrB
 qfL
 jsO
 qfL
@@ -209793,11 +209829,11 @@ qfL
 tfW
 cXA
 lch
-cXc
+hsP
 cxU
 cxU
 tfW
-oAS
+rBK
 tfW
 aff
 iqv
@@ -209984,12 +210020,12 @@ tfW
 tfW
 tfW
 tfW
-rBK
+rrB
 vMD
-cxf
+qgR
 xFj
-aYn
-gCw
+xJk
+tKe
 mcB
 qfL
 tfW
@@ -209999,7 +210035,7 @@ tfW
 tfW
 cxU
 cXA
-oAS
+rBK
 cxU
 aff
 tfW
@@ -210186,7 +210222,7 @@ cXA
 fqz
 fqz
 fqz
-hrz
+nps
 gNG
 ugx
 fqx
@@ -210202,7 +210238,7 @@ eUV
 cxU
 cxU
 tfW
-eKY
+pdX
 tfW
 tfW
 olX
@@ -210210,7 +210246,7 @@ oHv
 olX
 olX
 cxU
-kUT
+iSk
 tfW
 tfW
 tfW
@@ -210385,14 +210421,14 @@ rTe
 tfW
 tfW
 iqv
-asE
+ulM
 tfW
 tfW
 sSB
 eOO
 ugx
 cXJ
-qCR
+qhq
 rxh
 qXx
 sSB
@@ -210400,7 +210436,7 @@ tfW
 lch
 lch
 tfW
-kJi
+syO
 tfW
 cxU
 eUV
@@ -210412,7 +210448,7 @@ tfW
 nfC
 tfW
 cxU
-xtt
+pFS
 tfW
 lOm
 dlq
@@ -210581,7 +210617,7 @@ vaP
 tfW
 tfW
 tfW
-ybP
+dPB
 rTe
 cxU
 tfW
@@ -210594,8 +210630,8 @@ qfL
 qfL
 gAr
 qfL
-rLy
-loK
+xKC
+nCV
 bBy
 xfe
 wjb
@@ -210614,7 +210650,7 @@ tfW
 tfW
 kEV
 cxU
-kUT
+iSk
 kEV
 dlq
 kEV
@@ -210796,7 +210832,7 @@ qfL
 vpD
 abI
 qfL
-rLy
+xKC
 ugx
 ugx
 sSB
@@ -210810,13 +210846,13 @@ tfW
 tfW
 aff
 aff
-pRK
+lbY
 tfW
 cxU
 mHv
 mHv
 cxU
-kUT
+iSk
 lOm
 kEV
 syk
@@ -211018,7 +211054,7 @@ cxU
 tfW
 cxU
 cxU
-lAz
+fvz
 ltw
 fdr
 fdr
@@ -211410,16 +211446,16 @@ fqz
 fqz
 tfW
 tfW
-fUZ
+tTI
 tfW
-aOa
+uZV
 tfW
-aOa
-aOa
+uZV
+uZV
 vSM
 nhY
-aOa
-ktZ
+uZV
+pZq
 fdr
 jSt
 uzy
@@ -211800,7 +211836,7 @@ tGU
 tfW
 uTf
 oPz
-xBG
+qdP
 fqz
 tfW
 cGa
@@ -212004,9 +212040,9 @@ uTf
 uTf
 tfW
 cGa
-upU
+grx
 cZD
-axJ
+lIM
 olX
 tfW
 tfW
@@ -219993,8 +220029,8 @@ cwC
 cwC
 pvI
 pFV
-pFV
-pFV
+rIK
+rIK
 cwC
 cwC
 eCT
@@ -220194,8 +220230,8 @@ ufr
 rIK
 tnk
 tnk
-pFV
-xfb
+rIK
+igM
 xfb
 hcX
 wLP
@@ -220393,13 +220429,13 @@ xUV
 ksX
 ksX
 ssS
+rIK
 uit
 uit
 uit
 uit
-uit
-uit
-uit
+pFV
+svK
 pFV
 fFO
 bXS
@@ -220601,8 +220637,8 @@ uit
 uit
 uit
 uit
-uit
-tnk
+pFV
+pFV
 fFO
 fFO
 rIK
@@ -220803,8 +220839,8 @@ uit
 uit
 uit
 uit
-uit
 idr
+rIK
 fFO
 fFO
 rIK
@@ -221005,8 +221041,8 @@ uit
 uit
 uit
 uit
-uit
-tnk
+idr
+pFV
 fFO
 fFO
 rIK
@@ -221201,13 +221237,13 @@ uaC
 ksX
 ksX
 gcR
-crr
+hcX
 uit
 uit
 uit
-uit
-uit
-uit
+rIK
+rIK
+pFV
 rIK
 fFO
 fFO
@@ -221952,8 +221988,8 @@ gBD
 gBD
 pdW
 vvB
-lXt
-lXt
+crr
+lBj
 lXt
 gtD
 pdW
@@ -222558,7 +222594,7 @@ gBD
 gBD
 pdW
 dVU
-jfm
+jNN
 oDs
 uiJ
 nrP

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -456,6 +456,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
+"afc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/lighting/toggleable/lamp,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "aff" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -979,11 +984,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"akK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/pen,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "akM" = (
 /obj/item/clothing/under/excelsior/mixed,
 /obj/item/clothing/under/excelsior/mixed,
@@ -1946,6 +1946,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"auY" = (
+/obj/structure/flora/big/bush3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "ava" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2141,6 +2149,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "awC" = (
@@ -2237,6 +2246,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"axC" = (
+/obj/effect/floor_decal/industrial/box/red,
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "axF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3438,17 +3452,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"aLh" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "aLk" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -3485,10 +3488,6 @@
 /obj/effect/floor_decal/spline/wood,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"aLE" = (
-/obj/structure/flora/big/bush1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "aLJ" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -3659,6 +3658,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/beaker,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "aMU" = (
@@ -4427,11 +4427,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"aXJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "aXP" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -4501,6 +4496,10 @@
 	icon_state = "5,9"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"aYv" = (
+/obj/structure/railing,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "aYx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -4610,15 +4609,6 @@
 /obj/item/device/radio/beacon/bacon,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"aZo" = (
-/obj/item/modular_computer/console/preset/engineering{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "aZp" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -5622,13 +5612,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/techshop)
-"bjg" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "bjj" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1
@@ -6220,6 +6203,7 @@
 	pixel_y = 28
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "bpX" = (
@@ -6238,11 +6222,6 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"bqn" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "bqr" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/steel/monofloor{
@@ -6283,6 +6262,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
+"bqV" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "brc" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/effect/floor_decal/industrial/stand_clear{
@@ -6604,6 +6590,7 @@
 "buA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/steel/violetcorener,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -7090,6 +7077,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"bzs" = (
+/obj/effect/floor_decal/industrial/botright/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner,
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "splatter5"
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "bzt" = (
 /obj/effect/floor_decal/industrial/stand_clear{
 	dir = 8
@@ -7283,6 +7281,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
+"bBD" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/engineering/engine_room)
 "bBF" = (
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
@@ -7437,6 +7439,7 @@
 /obj/machinery/centrifuge{
 	pixel_x = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "bDF" = (
@@ -7457,6 +7460,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"bDP" = (
+/obj/structure/flora/small/rock2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "bDQ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7551,6 +7558,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/main/stairwell)
+"bFa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "bFb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8527,10 +8540,6 @@
 	},
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
-"bPR" = (
-/obj/structure/flora/big/bush1,
-/turf/unsimulated/wall/jungle,
-/area/nadezhda/engineering/engine_room)
 "bPX" = (
 /obj/structure/sink{
 	density = 1;
@@ -8721,11 +8730,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"bSB" = (
-/obj/machinery/camera/network/engineering,
-/obj/effect/floor_decal/industrial/outputgate,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "bSD" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/tool/saw,
@@ -8778,6 +8782,10 @@
 /obj/item/book/manual/nonfiction/suntzu,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"bTf" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "bTj" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -8875,6 +8883,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"bUE" = (
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "bUG" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
@@ -9388,6 +9404,10 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"bZH" = (
+/obj/structure/flora/big/bush3,
+/turf/unsimulated/wall/jungle,
+/area/nadezhda/engineering/engine_room)
 "bZI" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/browndouble,
@@ -10371,6 +10391,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/steel/violetcorener,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -10743,11 +10764,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
-"coE" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/big/bush1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "coG" = (
 /obj/structure/closet/random_miscellaneous,
 /obj/random/contraband,
@@ -10998,8 +11014,11 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/substation/medical)
 "crr" = (
-/obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "crs" = (
@@ -11632,6 +11651,11 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/detectives_office)
+"cyS" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "cyW" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -12573,12 +12597,6 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"cIt" = (
-/obj/effect/floor_decal/industrial/warningdust{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/engine_room)
 "cIE" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall17";
@@ -12701,6 +12719,10 @@
 /obj/structure/sign/warning/caution/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
+"cJN" = (
+/obj/structure/flora/small/grassa4,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "cJP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -13020,15 +13042,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"cNt" = (
-/obj/effect/floor_decal/industrial/warningdust{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/oil{
-	icon_state = "splatter2"
-	},
-/turf/simulated/floor/tiled/steel/monofloor,
-/area/nadezhda/engineering/engine_room)
 "cNy" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -13195,6 +13208,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"cOQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "cOU" = (
 /obj/machinery/door/unpowered/simple/wood/saloon,
 /obj/machinery/door/firedoor,
@@ -13385,6 +13403,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
+"cQs" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/railing,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "cQu" = (
 /obj/structure/flora/big/rocks2,
 /mob/living/simple_animal/chicken,
@@ -13543,6 +13569,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"cRL" = (
+/obj/structure/table/rack,
+/obj/item/trash/material/metal{
+	icon_state = "device0"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "cRS" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -13641,11 +13674,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
-"cSZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/light/tube,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "cTd" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/structure/sign/levels/stairsup{
@@ -13733,13 +13761,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
-"cUh" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/portable_atmospherics/hydroponics/soil{
-	layer = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "cUi" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "serg"
@@ -14400,6 +14421,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
+"dai" = (
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/pond)
 "dak" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/light/small{
@@ -14508,13 +14533,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
-"dbZ" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "dce" = (
 /obj/structure/flora/small/rock3,
 /obj/random/flora/jungle_tree,
@@ -15268,6 +15286,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"dke" = (
+/obj/structure/lattice,
+/obj/structure/girder,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "dkh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/xeno,
@@ -15432,6 +15455,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"dmt" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "dmw" = (
 /obj/structure/salvageable/machine,
 /obj/effect/decal/cleanable/dirt,
@@ -15740,10 +15769,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"dpi" = (
-/obj/structure/railing,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "dpm" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -15848,6 +15873,15 @@
 /obj/structure/closet/crate/secure/weapon/amr,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"dqj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/techshop)
 "dqt" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -17434,10 +17468,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"dGu" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "dGz" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin{
@@ -17456,6 +17486,7 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 24
 	},
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "dGD" = (
@@ -17496,14 +17527,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"dHe" = (
-/obj/effect/floor_decal/industrial/outputgate,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "dHj" = (
 /turf/simulated/floor/reinforced/n20,
 /area/nadezhda/engineering/atmos)
@@ -17982,11 +18005,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"dLZ" = (
-/obj/structure/flora/small/grassb1,
-/obj/random/scrap/sparse_even/low_chance,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "dMh" = (
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/plating/under,
@@ -18419,13 +18437,6 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"dQR" = (
-/obj/structure/lattice,
-/obj/structure/catwalk{
-	icon_state = "catwalk-broken"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "dQU" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "6,0"
@@ -18459,6 +18470,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "dRl" = (
@@ -19049,10 +19061,6 @@
 "dYi" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/barracks)
-"dYj" = (
-/obj/structure/railing,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "dYk" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -19418,9 +19426,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/lab)
 "ebO" = (
-/obj/structure/railing,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "ebP" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -19540,6 +19549,13 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/security/maingate/west)
+"edf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/light/tube,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "edn" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -20087,11 +20103,6 @@
 /mob/living/carbon/superior_animal/giant_spider/nurse,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"eiR" = (
-/obj/structure/flora/small/bushb2,
-/obj/structure/flora/big/bush1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "eiT" = (
 /obj/structure/table/standard,
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
@@ -20285,6 +20296,10 @@
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"ela" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "elk" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
@@ -20820,6 +20835,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"eqc" = (
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "eqe" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -20851,6 +20877,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/medical/virology)
 "eqq" = (
@@ -22513,11 +22540,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/mineral,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"eIT" = (
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/shield_generator)
 "eIU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -23620,11 +23642,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/disposaldrop)
-"eSK" = (
-/obj/item/remains/ribcage,
-/obj/item/clothing/accessory/choker/gold_bell,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "eSP" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23658,6 +23675,10 @@
 /obj/structure/grille,
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/grass/dry,
+/area/nadezhda/outside/forest)
+"eTm" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "eTu" = (
 /obj/structure/disposalpipe/segment{
@@ -24024,6 +24045,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/medical/virology)
 "eXi" = (
@@ -24178,6 +24200,10 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"eYp" = (
+/obj/structure/flora/big/bush1,
+/turf/unsimulated/wall/jungle,
+/area/nadezhda/engineering/engine_room)
 "eYq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -25329,6 +25355,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/sleeper)
+"fkE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/device/lighting/toggleable/lamp,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "fkM" = (
 /obj/effect/floor_decal/industrial/arrows{
 	dir = 1
@@ -25610,10 +25642,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"fno" = (
-/obj/item/remains/ribcage,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "fnq" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/small/grassa1,
@@ -26057,6 +26085,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
+"frI" = (
+/obj/structure/flora/big/rocks2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "frR" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -26629,15 +26661,6 @@
 /obj/random/flora/jungle_tree/low,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"fyO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/techshop)
 "fyR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -26779,6 +26802,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "fAn" = (
@@ -27891,6 +27915,15 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"fMM" = (
+/obj/item/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "fMO" = (
 /obj/effect/floor_decal/industrial/road{
 	dir = 1
@@ -27924,10 +27957,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"fNh" = (
-/obj/structure/girder,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "fNr" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -28149,11 +28178,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/genetics)
-"fQs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/remains/mouse,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "fQv" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -28481,6 +28505,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
+"fUa" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "fUc" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -28745,12 +28774,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"fWS" = (
-/obj/structure/catwalk{
-	icon_state = "catwalk12-0"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "fWY" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -28929,10 +28952,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"fZj" = (
-/obj/item/remains/ribcage,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "fZq" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -29174,13 +29193,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
-"gbM" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "gbO" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Sec Armory";
@@ -29419,17 +29431,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/secrecroom)
-"gdP" = (
-/obj/effect/floor_decal/industrial/botleft/red,
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "gdQ" = (
 /obj/random/scrap/moderate_weighted,
 /turf/simulated/floor/asteroid/dirt,
@@ -29501,17 +29502,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
-"geE" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "geI" = (
 /obj/structure/table/steel,
 /obj/random/credits/low_chance,
@@ -29960,6 +29950,11 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/west)
+"giq" = (
+/obj/structure/flora/small/rock3,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "giu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -30167,6 +30162,14 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate)
+"gkL" = (
+/obj/structure/flora/small/busha3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "gkM" = (
 /obj/structure/table/woodentable,
 /obj/random/toy/plushie_onlycat,
@@ -30881,10 +30884,6 @@
 /obj/item/storage/bag/trash,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"gru" = (
-/obj/structure/flora/small/grassa4,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "grw" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -31240,6 +31239,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
+"gvd" = (
+/obj/structure/flora/small/bushb2,
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "gve" = (
 /obj/structure/table/rack,
 /obj/machinery/door/window/southright{
@@ -31539,6 +31543,7 @@
 /obj/item/storage/box/masks,
 /obj/item/storage/box/gloves,
 /obj/item/storage/box/beakers,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "gyY" = (
@@ -31894,6 +31899,11 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/range)
+"gDq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/chips,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "gDv" = (
 /obj/random/structures/low_chance,
 /obj/structure/catwalk,
@@ -32031,6 +32041,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/courtroom)
+"gER" = (
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate)
 "gFl" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/quartermaster/disposaldrop)
@@ -32303,10 +32317,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"gIS" = (
-/obj/effect/floor_decal/industrial/warningdust,
-/turf/simulated/floor/tiled/steel/monofloor,
-/area/nadezhda/engineering/engine_room)
 "gIY" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -32766,6 +32776,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"gOh" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "gOk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -33082,13 +33099,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"gRB" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "gRC" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/prisoncells{
@@ -33118,11 +33128,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"gRU" = (
-/obj/structure/flora/big/rocks3,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "gSc" = (
 /obj/random/cluster/roaches,
 /turf/simulated/floor/tiled/techmaint,
@@ -33790,6 +33795,16 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/prisoncells)
+"gYJ" = (
+/obj/effect/floor_decal/industrial/botleft/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "gYU" = (
 /obj/machinery/door/airlock/mining{
 	name = "Prospector Prep";
@@ -34178,10 +34193,6 @@
 /obj/random/cluster/spiders,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
-"hdk" = (
-/obj/structure/flora/small/grassb1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "hdo" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable/cyan{
@@ -34296,10 +34307,12 @@
 /obj/random/junkfood/rotten,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"heu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/shield_generator)
+"hep" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "hev" = (
 /obj/machinery/vending/assist,
 /obj/machinery/camera/network/colony_underground,
@@ -34520,6 +34533,14 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"hgM" = (
+/obj/structure/flora/small/bushb1,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "hgO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -35416,6 +35437,10 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"hri" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "hrk" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -35748,6 +35773,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/medical/morgue)
 "huz" = (
+/obj/item/material/shard,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "huF" = (
@@ -35836,6 +35863,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/steel/violetcorener,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -36917,6 +36945,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
+"hGt" = (
+/obj/effect/floor_decal/industrial/warningdust,
+/turf/simulated/floor/tiled/steel/monofloor,
+/area/nadezhda/engineering/engine_room)
 "hGu" = (
 /obj/item/storage/deferred/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -37178,14 +37210,6 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
-"hIv" = (
-/obj/structure/flora/small/bushb1,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "hIw" = (
 /obj/machinery/vending/cart,
 /turf/simulated/floor/wood,
@@ -38067,6 +38091,17 @@
 	icon_state = "15,9"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"hSg" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "hSw" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section6";
@@ -38416,6 +38451,12 @@
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
+"hVv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/trash/candy/proteinbar,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "hVz" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /mob/living/simple_animal/frog{
@@ -38527,6 +38568,10 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
+"hWB" = (
+/obj/structure/bonfire,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/forest)
 "hWL" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop,
@@ -38876,6 +38921,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"hZi" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "hZj" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
@@ -39404,6 +39453,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/sleeper)
+"idY" = (
+/obj/machinery/camera/network/engineering,
+/obj/effect/floor_decal/industrial/outputgate,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "ieb" = (
 /obj/effect/damagedfloor/fire,
 /obj/effect/damagedfloor/fire,
@@ -39641,10 +39695,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "igp" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
+/obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
 "igt" = (
@@ -39838,6 +39889,18 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
+"iiE" = (
+/obj/structure/lattice,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "iiG" = (
 /obj/effect/floor_decal/industrial/box/red,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -40879,6 +40942,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
+"ity" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/steel/violetcorener,
+/area/nadezhda/rnd/circuitlab{
+	name = "Science Expedition prep"
+	})
 "itA" = (
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
@@ -40906,14 +40976,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"itJ" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/metal{
-	icon_state = "metal3"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "itK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41719,11 +41781,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
-"iCv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/chips,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "iCw" = (
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
@@ -41896,13 +41953,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/genetics)
-"iEJ" = (
-/obj/structure/table/rack,
-/obj/item/trash/material/metal{
-	icon_state = "device3"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "iEN" = (
 /obj/machinery/vending/weapon_machine{
 	categories = 3
@@ -42091,6 +42141,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "iHy" = (
@@ -42138,10 +42189,6 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
-"iHJ" = (
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "iHP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
@@ -42214,6 +42261,8 @@
 /area/nadezhda/maintenance/undergroundfloor2north)
 "iIp" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/mucus,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "iIq" = (
@@ -43121,6 +43170,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
+"iSU" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "iSV" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -43874,12 +43928,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
-"jbL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/device/lighting/toggleable/lamp,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "jbO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -44621,13 +44669,6 @@
 /obj/structure/flora/big/bush2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"jiV" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "jiZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -44688,6 +44729,18 @@
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"jjF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
+"jjG" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "jjN" = (
 /obj/machinery/door/airlock/maintenance_common{
 	req_access = list(12)
@@ -44830,15 +44883,6 @@
 /obj/random/cloth/head/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
-"jlj" = (
-/obj/effect/floor_decal/industrial/outputgate,
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/structure/railing,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "jlk" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/structure/sign/levels/stairsup{
@@ -45504,6 +45548,7 @@
 /area/nadezhda/security/maingate)
 "jrD" = (
 /obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -45849,14 +45894,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"juD" = (
-/obj/structure/flora/small/busha3,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "juE" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -46149,6 +46186,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"jxJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/techshop)
 "jxK" = (
 /obj/structure/table/standard,
 /obj/item/mop,
@@ -47044,6 +47090,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/pros/prep)
+"jIc" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "jIe" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/item/genetics/purger,
@@ -47245,6 +47296,19 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/maingate)
+"jKw" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "jKE" = (
 /obj/machinery/door/airlock/sandstone{
 	id_tag = "D1A";
@@ -47404,11 +47468,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
-"jMy" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "jMB" = (
 /obj/structure/table/woodentable,
 /obj/item/hand_labeler,
@@ -48285,6 +48344,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -48423,6 +48483,12 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"jXj" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "jXq" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -49059,6 +49125,15 @@
 "kdQ" = (
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"kdX" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "keb" = (
 /obj/random/mecha_equipment/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -49199,6 +49274,12 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
+"kfr" = (
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/engine_room)
 "kfz" = (
 /obj/structure/bed/chair/office,
 /turf/simulated/floor/beach/sand,
@@ -49234,6 +49315,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
+"kgc" = (
+/obj/structure/flora/small/rock2,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/pond)
 "kge" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -49415,13 +49500,6 @@
 /obj/random/medical_lowcost/low_chance,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
-"khj" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "kho" = (
 /obj/random/tool/advanced,
 /obj/effect/spider/stickyweb,
@@ -50394,6 +50472,10 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/maingate)
+"krF" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "krL" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -50452,10 +50534,6 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"ksv" = (
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "ksF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -50785,11 +50863,6 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"kvM" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "kvR" = (
 /obj/structure/multiz/stairs/enter,
 /turf/simulated/floor/pool,
@@ -50876,13 +50949,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"kwr" = (
-/obj/structure/cable/yellow,
-/obj/effect/floor_decal/industrial/box{
-	color = "f3cbbc"
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/engineering/engine_room)
 "kws" = (
 /obj/structure/flora/small/lavarock1,
 /turf/simulated/floor/asteroid/dirt,
@@ -51244,6 +51310,11 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
+"kzA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/remains/mouse,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "kzJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -51442,6 +51513,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"kBL" = (
+/obj/structure/flora/rock/variant1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "kBO" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint,
@@ -51924,6 +51999,13 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"kGX" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "kHd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -52167,12 +52249,6 @@
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
-"kKP" = (
-/obj/structure/table/woodentable{
-	color = "#9a977b"
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "kKT" = (
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
@@ -52426,6 +52502,11 @@
 "kOB" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/dcave)
+"kOG" = (
+/obj/structure/flora/small/grassb1,
+/obj/random/scrap/sparse_even/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "kOH" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	name = "Bar - Room A"
@@ -52899,6 +52980,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
+"kTy" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "kTC" = (
 /obj/machinery/door/airlock{
 	name = "Toilet"
@@ -53597,6 +53685,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/steel/violetcorener,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -53624,14 +53713,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"lcN" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/structure/railing,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "lcQ" = (
 /obj/item/modular_computer/console/preset/medical/monitor{
 	dir = 4
@@ -53724,14 +53805,6 @@
 	},
 /turf/simulated/wall,
 /area/nadezhda/maintenance/surfaceeast)
-"ldP" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "lea" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -54032,6 +54105,18 @@
 /obj/effect/floor_decal/industrial/box,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"lhg" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/anomaly,
+/obj/item/clothing/head/helmet/space/anomaly,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/rnd/circuitlab{
+	name = "Science Expedition prep"
+	})
 "lhi" = (
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -54806,6 +54891,11 @@
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
+"lqU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/toolbox/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "lqW" = (
 /obj/random/junkfood,
 /turf/simulated/floor/asteroid/dirt,
@@ -55353,6 +55443,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"lxf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "lxj" = (
 /obj/machinery/camera/network/medbay{
 	dir = 1
@@ -55932,13 +56027,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"lDT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/light/tube,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "lDV" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -56029,13 +56117,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
-"lFn" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "lFr" = (
 /obj/effect/floor_decal/industrial/stand_clear/red,
 /obj/machinery/door/window/brigdoor/southleft{
@@ -56545,6 +56626,13 @@
 /obj/structure/table/bar_special,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/bar)
+"lKf" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/portable_atmospherics/hydroponics/soil{
+	layer = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "lKh" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
@@ -56858,11 +56946,6 @@
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"lOv" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warningwhite,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "lOI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -56904,14 +56987,6 @@
 "lOV" = (
 /turf/simulated/floor/wood/wild4,
 /area/colony)
-"lOW" = (
-/obj/structure/flora/big/bush3,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "lOY" = (
 /obj/structure/flora/pottedplant/dead,
 /obj/effect/decal/cleanable/dirt,
@@ -58153,6 +58228,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"mbF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "mbN" = (
 /obj/structure/table/bench/padded,
 /obj/structure/disposalpipe/segment,
@@ -58895,16 +58975,6 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/hallway/side/f2section1)
-"mia" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "mit" = (
 /obj/structure/flora/small/bushc3,
 /obj/random/flora/small_jungle_tree,
@@ -58961,11 +59031,6 @@
 /obj/random/structures,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
-"miV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "miY" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -58982,11 +59047,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"mjc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/toolbox/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "mjd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark/danger,
@@ -59043,11 +59103,6 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
-"mjG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "mjK" = (
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -59518,6 +59573,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
+"mpa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/material/shard,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/medical/virology)
 "mpg" = (
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
@@ -59526,6 +59588,7 @@
 	name = "Expedition prep";
 	req_access = list(5)
 	},
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/steel/violetcorener,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -59697,6 +59760,7 @@
 	dir = 1
 	},
 /obj/structure/closet/l3closet/virology,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "mqL" = (
@@ -59784,7 +59848,7 @@
 "mrI" = (
 /obj/effect/overlay/water/top,
 /obj/effect/overlay/water,
-/turf/simulated/floor/beach/water/shallow,
+/turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/outside/pond)
 "mrJ" = (
 /obj/random/furniture/pottedplant,
@@ -60134,11 +60198,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfaceeast)
-"mvy" = (
-/obj/structure/flora/small/busha2,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "mvB" = (
 /obj/structure/lattice,
 /turf/simulated/floor/fixed/hydrotile,
@@ -60371,13 +60430,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"myn" = (
-/obj/structure/table/rack,
-/obj/item/trash/material/metal{
-	icon_state = "device0"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "myo" = (
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/forest)
@@ -61614,12 +61666,6 @@
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/nadezhda/engineering/atmos)
-"mKJ" = (
-/obj/effect/floor_decal/industrial/warningdust{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/monofloor,
-/area/nadezhda/engineering/engine_room)
 "mKQ" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1;
@@ -61925,6 +61971,14 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"mNY" = (
+/obj/effect/floor_decal/industrial/botright/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "mOc" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -62185,6 +62239,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/bridge)
+"mQb" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "mQk" = (
 /obj/random/closet,
 /obj/machinery/light/small,
@@ -62275,17 +62339,6 @@
 	icon_state = "1,17"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"mRN" = (
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "mRV" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -62910,6 +62963,10 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"mYK" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor/rock,
+/area/colony)
 "mYN" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	external_pressure_bound = 0;
@@ -63059,6 +63116,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
+"mZG" = (
+/obj/structure/flora/small/busha2,
+/obj/random/scrap/sparse_even/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "mZI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -63736,6 +63798,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"nfZ" = (
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/monofloor,
+/area/nadezhda/engineering/engine_room)
 "nga" = (
 /obj/machinery/atmospherics/valve/digital/open{
 	dir = 4;
@@ -64637,12 +64705,6 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/triage_blackshield)
-"npJ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "npN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -65257,6 +65319,7 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/anomaly,
 /obj/item/clothing/head/helmet/space/anomaly,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -65280,6 +65343,10 @@
 /obj/random/medical_lowcost/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
+"nvN" = (
+/obj/structure/flora/small/rock4,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "nvR" = (
 /obj/structure/flora/small/trailrockb5,
 /obj/structure/flora/small/trailrocka1,
@@ -65670,6 +65737,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"nzO" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "nzS" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Core";
@@ -65994,11 +66068,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"nCR" = (
-/obj/structure/lattice,
-/obj/structure/girder,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "nCS" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/table/glass,
@@ -66574,11 +66643,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"nIM" = (
-/obj/structure/flora/small/rock3,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "nIN" = (
 /obj/structure/flora/small/trailrocka5,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -67213,6 +67277,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/lab)
+"nPb" = (
+/obj/random/mob/termite_no_despawn,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "nPc" = (
 /obj/structure/table/bar_special,
 /obj/machinery/chemical_dispenser/beer,
@@ -67296,10 +67365,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"nQc" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "nQd" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/random/scrap/sparse_even,
@@ -67423,6 +67488,9 @@
 	},
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/crew_quarters/dorm3)
+"nRs" = (
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "nRu" = (
 /obj/machinery/light{
 	dir = 8
@@ -67445,6 +67513,16 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
+"nRU" = (
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/item/caution,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "nRZ" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
@@ -67750,6 +67828,15 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"nVz" = (
+/obj/effect/floor_decal/industrial/outputgate,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/railing,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "nVR" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor2west)
@@ -68139,14 +68226,6 @@
 	},
 /turf/simulated/open,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"nYF" = (
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "nYI" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -68357,6 +68436,11 @@
 	icon_state = "2,22"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"oaF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/light/tube,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "oaG" = (
 /obj/machinery/drone_fabricator/ai{
 	desc = "A large automated factory for producing maintenance cyborgs that AIs can use it and control it.";
@@ -68457,6 +68541,11 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/bar)
+"obz" = (
+/obj/effect/floor_decal/industrial/outputgate,
+/obj/structure/railing,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "obE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -68657,6 +68746,7 @@
 /area/nadezhda/crew_quarters/sleep/bedrooms)
 "odD" = (
 /obj/machinery/disease2/incubator,
+/obj/item/ruinedvirusdish,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "odF" = (
@@ -69095,6 +69185,10 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/main/stairwell)
+"oiv" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/engineering/engine_room)
 "oiw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -69525,15 +69619,6 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
-"omo" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "omp" = (
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/crew_quarters/dorm3)
@@ -69964,13 +70049,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"orq" = (
-/obj/effect/floor_decal/industrial/caution{
-	dir = 1
-	},
-/obj/structure/railing,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "orA" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -70260,6 +70338,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "otM" = (
@@ -71190,6 +71269,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"oDL" = (
+/obj/structure/flora/small/busha1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "oDM" = (
 /obj/effect/floor_decal/spline/wood{
 	icon_state = "spline_fancy_cee"
@@ -71733,18 +71816,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/turret_protected/ai)
-"oJv" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "oJx" = (
 /obj/effect/floor_decal/industrial/road/warning3,
 /obj/structure/disposalpipe/segment,
@@ -71960,6 +72031,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/tcommsat/computer)
+"oKP" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "oKU" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/invislight,
@@ -72137,6 +72213,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"oMQ" = (
+/obj/structure/lattice,
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "oNb" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -72206,10 +72289,11 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "oOh" = (
-/obj/effect/floor_decal/industrial/warningdust{
-	dir = 1
+/obj/structure/cable/yellow,
+/obj/effect/floor_decal/industrial/box{
+	color = "f3cbbc"
 	},
-/turf/simulated/floor/tiled/steel/monofloor,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
 "oOj" = (
 /obj/structure/table/woodentable,
@@ -72917,6 +73001,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/robotics)
+"oVj" = (
+/obj/item/remains/ribcage,
+/obj/item/clothing/accessory/choker/gold_bell,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "oVk" = (
 /obj/machinery/cryopod,
 /obj/structure/catwalk,
@@ -73597,6 +73686,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"pcc" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "pcg" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/asteroid/cave)
@@ -73795,12 +73891,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
-"peF" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "peL" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/vending/wallmed/lobby{
@@ -74091,6 +74181,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"phH" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/machinery/floodlight,
+/turf/simulated/floor/rock,
+/area/colony)
 "phJ" = (
 /obj/structure/table/woodentable,
 /obj/random/credits,
@@ -75267,6 +75362,12 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"puu" = (
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/engine_room)
 "pux" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/light{
@@ -75953,17 +76054,6 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/chemistry)
-"pBo" = (
-/obj/effect/floor_decal/industrial/botright/red,
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warningwhite/corner,
-/obj/effect/decal/cleanable/blood/oil{
-	icon_state = "splatter5"
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "pBw" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 4
@@ -76522,11 +76612,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/office)
-"pHN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/lighting/toggleable/lamp,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "pHP" = (
 /obj/structure/mirror,
 /turf/simulated/wall/r_wall,
@@ -76833,6 +76918,22 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"pKZ" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "pLe" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/grass,
@@ -77179,6 +77280,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "pOn" = (
@@ -77510,6 +77613,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/substation/medical)
+"pQX" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "pRb" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -77648,6 +77756,11 @@
 /obj/random/pouch/low_chance,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/armory)
+"pSs" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "pSz" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/bushb1,
@@ -78663,6 +78776,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/disposaldrop)
+"qci" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "qck" = (
 /obj/random/scrap/dense_weighted,
 /obj/effect/decal/cleanable/dirt,
@@ -78914,10 +79039,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/range)
-"qfb" = (
-/obj/machinery/floodlight,
-/turf/simulated/floor/rock,
-/area/colony)
 "qfc" = (
 /obj/structure/flora/big/rocks3,
 /obj/structure/flora/small/bushc2,
@@ -79081,18 +79202,6 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/sleeper)
-"qgU" = (
-/obj/structure/lattice,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk{
-	icon_state = "catwalk-broken"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "qgX" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -79545,6 +79654,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "qlE" = (
@@ -80198,11 +80308,6 @@
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
-"qsh" = (
-/obj/effect/floor_decal/industrial/box/red,
-/obj/effect/decal/cleanable/ash,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "qsl" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/syringe/drugs,
@@ -80411,6 +80516,11 @@
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"quo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "quv" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
@@ -80554,10 +80664,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"qwk" = (
-/obj/structure/flora/big/bush3,
-/turf/unsimulated/wall/jungle,
-/area/nadezhda/engineering/engine_room)
 "qwl" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/random/flora/low_chance,
@@ -80788,11 +80894,6 @@
 /obj/landmark/machinery/input,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/quartermaster/miningdock)
-"qyr" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "qys" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -81190,6 +81291,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"qCW" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/circuit,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "qCX" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
@@ -81675,6 +81786,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera/network/medbay,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "qHp" = (
@@ -82528,11 +82640,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
-"qRG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "qRL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -82908,6 +83015,11 @@
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"qWd" = (
+/obj/structure/flora/big/rocks3,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "qWf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -82974,6 +83086,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/beaker,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "qWL" = (
@@ -83302,6 +83415,13 @@
 	icon_state = "10,18"
 	},
 /area/nadezhda/hallway/surface/section1)
+"rau" = (
+/obj/structure/table/rack,
+/obj/item/trash/material/metal{
+	icon_state = "device3"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "raA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -83635,10 +83755,6 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"reB" = (
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "reC" = (
 /obj/structure/closet/secure_closet/reinforced/RD,
 /obj/structure/noticeboard/research{
@@ -83718,10 +83834,6 @@
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/hallway)
-"rff" = (
-/obj/structure/flora/small/busha1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "rfj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -83823,6 +83935,11 @@
 /obj/structure/plushie/beepsky,
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload)
+"rfH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "rfK" = (
 /obj/random/closet_maintloot,
 /obj/effect/decal/cleanable/dirt,
@@ -83913,6 +84030,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/violetcorener,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -84035,9 +84153,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
-"rhG" = (
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "rhI" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/security/maingate/east)
@@ -84093,6 +84208,7 @@
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset/legacy,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/violetcorener,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -84288,10 +84404,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
-"rkX" = (
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "rlb" = (
 /obj/machinery/body_scanconsole,
 /obj/effect/floor_decal/industrial/hatch,
@@ -84944,11 +85056,6 @@
 /obj/machinery/microwave/burnbarrel,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"rsg" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "rsi" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/hatch,
@@ -85114,12 +85221,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
-"rui" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/contraband/low_chance,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "rul" = (
 /obj/structure/table/standard,
 /obj/item/deck/cards,
@@ -85820,6 +85921,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/servist)
+"rBt" = (
+/obj/structure/railing,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "rBu" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /obj/effect/floor_decal/spline/plain{
@@ -86557,12 +86662,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
-"rKd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/trash/candy/proteinbar,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "rKs" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/hop,
@@ -86663,6 +86762,10 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
+"rLl" = (
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/pond)
 "rLm" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/lab)
@@ -86672,10 +86775,9 @@
 /turf/simulated/open,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "rLy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/table,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "rLD" = (
 /obj/machinery/camera/network/colony_surface{
 	dir = 4
@@ -86844,14 +86946,6 @@
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/hunter_cabin)
-"rMR" = (
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "rMT" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/railing,
@@ -87046,11 +87140,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
-"rOI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/shotgun/pellet/prespawned,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "rON" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -87581,6 +87670,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"rVz" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/pond)
 "rVD" = (
 /obj/effect/step_trigger/surface_to_forest_1_B,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -88251,6 +88345,7 @@
 /obj/structure/table/standard,
 /obj/item/device/camera_film,
 /obj/item/device/camera_film,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -88772,7 +88867,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/circuit,
+/obj/item/trash/material/metal,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "sgY" = (
@@ -88874,6 +88969,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"sis" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pen,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "siu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -89144,6 +89244,11 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
+"slt" = (
+/obj/structure/flora/small/busha2,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "slw" = (
 /obj/structure/sign/warning/xeno/small,
 /turf/simulated/wall/r_wall,
@@ -89757,11 +89862,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"srp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "srr" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /turf/simulated/floor/rock/manmade/road,
@@ -90308,12 +90408,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"svU" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "svV" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -90323,19 +90417,6 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/podrooms)
-"svW" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "svZ" = (
 /obj/structure/table/steel,
 /obj/structure/flora/pottedplant/dead{
@@ -90470,6 +90551,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/ruinedvirusdish,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "sxq" = (
@@ -90961,6 +91043,17 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"sBX" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "sCf" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/small/bushb1,
@@ -91269,6 +91362,12 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_waste)
+"sFz" = (
+/obj/structure/catwalk{
+	icon_state = "catwalk12-0"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "sFH" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/asteroid/grass,
@@ -91409,6 +91508,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
+"sHv" = (
+/obj/random/scrap/sparse_even/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/engineering/engine_room)
 "sHM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -91439,6 +91542,10 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
+"sIf" = (
+/obj/structure/girder,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "sIn" = (
 /obj/machinery/door/airlock/vault{
 	name = "Lonestar Vault";
@@ -93292,6 +93399,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"tcK" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "tdf" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "8,20"
@@ -93546,6 +93658,15 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/security/prisoncells)
+"tfR" = (
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "splatter2"
+	},
+/turf/simulated/floor/tiled/steel/monofloor,
+/area/nadezhda/engineering/engine_room)
 "tfW" = (
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
@@ -93601,6 +93722,10 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/reception)
+"thh" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "thj" = (
 /obj/item/stool,
 /obj/machinery/light/small{
@@ -95743,11 +95868,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"tEm" = (
-/obj/structure/railing,
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "tEs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -95875,6 +95995,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
+"tFp" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "tFu" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -96603,6 +96729,7 @@
 	pixel_x = 31
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/steel/violetcorener,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -97109,6 +97236,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"tQw" = (
+/obj/effect/floor_decal/industrial/outputgate,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "tQD" = (
 /obj/random/mob/spiders,
 /obj/effect/spider/stickyweb,
@@ -97116,6 +97251,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"tQE" = (
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "tQF" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -97209,6 +97348,11 @@
 /obj/machinery/camera/network/church,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"tRF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "tRG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/porta_turret/gate,
@@ -97525,11 +97669,6 @@
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
-"tUK" = (
-/obj/random/mob/termite_no_despawn,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "tUS" = (
 /obj/structure/closet/secure_closet/personal/salvager,
 /obj/machinery/light{
@@ -97713,6 +97852,10 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"tWX" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "tXf" = (
 /obj/structure/sign/misc/techshop,
 /turf/simulated/wall/r_wall,
@@ -98153,22 +98296,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
-"ubp" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/shield_generator)
 "ubv" = (
 /obj/random/closet_tech/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -98784,6 +98911,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/steel/violetcorener,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -98901,13 +99029,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"uhS" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "uhW" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/industrial/hatch,
@@ -100144,7 +100265,7 @@
 /obj/structure/lattice,
 /obj/structure/catwalk,
 /obj/structure/railing/grey{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -100260,14 +100381,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/medical/virology)
-"uxu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "uxw" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/orangedouble,
@@ -100935,6 +101051,10 @@
 "uFe" = (
 /turf/simulated/wall/church,
 /area/nadezhda/absolutism/hallways)
+"uFh" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "uFj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -101506,10 +101626,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"uKY" = (
-/obj/random/scrap/sparse_even/low_chance,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/engineering/engine_room)
 "uLc" = (
 /obj/machinery/door/airlock/maintenance_security{
 	req_access = list(1)
@@ -101781,6 +101897,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/rbreakroom)
+"uMD" = (
+/obj/effect/floor_decal/industrial/botleft/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "uMF" = (
 /turf/simulated/wall/iron,
 /area/nadezhda/maintenance{
@@ -102045,6 +102172,14 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"uPa" = (
+/obj/machinery/atmospherics/unary/vent_pump,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal{
+	icon_state = "metal3"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "uPc" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/meat/corgi,
@@ -102136,11 +102271,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/engine_room)
-"uPQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junkfood/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "uPS" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/atmospherics/unary/vent_pump,
@@ -102526,7 +102656,7 @@
 	dir = 1
 	},
 /obj/structure/railing/grey{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
@@ -103321,11 +103451,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/medical/sleeper)
-"vbB" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/machinery/floodlight,
-/turf/simulated/floor/rock,
-/area/colony)
 "vbH" = (
 /obj/machinery/power/breakerbox{
 	RCon_tag = "Crg Substation Bypass"
@@ -103543,6 +103668,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
+"ver" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "veB" = (
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/secrecroom)
@@ -103835,6 +103967,11 @@
 /obj/structure/sign/faction/excelsior,
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"vhD" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "vhL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -103901,10 +104038,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"vis" = (
-/obj/structure/lattice,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "vit" = (
 /obj/item/oddity/common/paper_bundle,
 /obj/effect/decal/cleanable/dirt,
@@ -104904,10 +105037,6 @@
 /obj/machinery/door/holy/public,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/vectorrooms)
-"vsm" = (
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/engineering/engine_room)
 "vsB" = (
 /obj/structure/table/standard,
 /obj/machinery/power/apc{
@@ -105295,11 +105424,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
-"vvR" = (
-/obj/effect/floor_decal/industrial/outputgate,
-/obj/structure/railing,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "vvV" = (
 /obj/structure/bed/chair/sofa/black/corner{
 	dir = 4;
@@ -105460,6 +105584,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"vxM" = (
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "vxO" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1
@@ -105516,6 +105644,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"vyH" = (
+/obj/structure/lattice,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "vyR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -105707,15 +105839,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"vBD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/techshop)
 "vBE" = (
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /obj/structure/largecrate/animal/cow,
@@ -106160,12 +106283,12 @@
 /obj/effect/floor_decal/industrial/warningdust{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
+/turf/simulated/floor/tiled/steel/monofloor,
 /area/nadezhda/engineering/engine_room)
 "vFL" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/shallow,
+/turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/outside/pond)
 "vFX" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -106691,7 +106814,7 @@
 /area/nadezhda/security/prisoncells)
 "vLb" = (
 /obj/structure/sign/warning/moving_parts{
-	desc = "The service elevator is currently out of order. It will be repaired at the same time the shuttles are. Be sure to enjoy a Lonestar brand vitamin water when taking the stairs.";
+	desc = "An OUT OF ORDER sign";
 	name = "\improper OUT OF ORDER"
 	},
 /turf/simulated/wall/r_wall,
@@ -107314,6 +107437,13 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"vRu" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "vRy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -107416,16 +107546,6 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
-"vSl" = (
-/obj/effect/floor_decal/industrial/botleft/red,
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "vSu" = (
 /obj/structure/catwalk,
 /obj/structure/invislight,
@@ -107711,6 +107831,10 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
 "vUr" = (
@@ -110888,6 +111012,12 @@
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"wAu" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/unsimulated/wall/jungle,
+/area/nadezhda/outside/forest)
 "wAv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -110990,6 +111120,7 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "wBY" = (
 /obj/landmark/mob/carpspawn,
+/obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
 "wCc" = (
@@ -111206,6 +111337,13 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm4)
+"wEi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/tiled/steel/violetcorener,
+/area/nadezhda/rnd/circuitlab{
+	name = "Science Expedition prep"
+	})
 "wEj" = (
 /obj/structure/catwalk,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -111389,6 +111527,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/triage_blackshield)
+"wGA" = (
+/obj/effect/floor_decal/industrial/caution{
+	dir = 1
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "wGG" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/cable/green{
@@ -112531,6 +112676,10 @@
 /obj/structure/bed/chair/sofa/brown/right,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
+"wTv" = (
+/obj/structure/flora/big/rocks2,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/pond)
 "wTC" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -112592,6 +112741,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfacesec)
+"wUs" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "wUt" = (
 /obj/structure/table/bench/wooden,
 /obj/machinery/camera/network/colony_underground{
@@ -112615,16 +112770,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"wUE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "wUF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -112677,6 +112822,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/nadezhda/security/triage_blackshield)
+"wVd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/shotgun/pellet/prespawned,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "wVi" = (
 /obj/effect/floor_decal/border/carpet/orange,
 /turf/simulated/wall,
@@ -112975,6 +113125,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"wXX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/steel/violetcorener,
+/area/nadezhda/rnd/circuitlab{
+	name = "Science Expedition prep"
+	})
 "wYa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/pouch/hardcase_scrap,
@@ -113441,6 +113598,10 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"xew" = (
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "xez" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "2,4"
@@ -116289,6 +116450,12 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/maingate/west)
+"xHo" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "xHt" = (
 /obj/machinery/vending/drip,
 /turf/simulated/floor/tiled/steel/monofloor{
@@ -116672,9 +116839,13 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/rbreakroom)
 "xKC" = (
-/obj/structure/table,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "xKJ" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -116855,14 +117026,6 @@
 /obj/random/cluster/roaches_hoard,
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"xMt" = (
-/obj/effect/floor_decal/industrial/botright/red,
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warningwhite/corner,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "xMv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -116871,12 +117034,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/crew_quarters/bar)
-"xME" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "xMH" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood,
@@ -117732,9 +117889,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xVP" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/engineering/engine_room)
+/obj/structure/table/woodentable{
+	color = "#9a977b"
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "xVR" = (
 /obj/structure/window/reinforced,
 /obj/structure/multiz/stairs/enter{
@@ -117957,16 +118116,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"xYC" = (
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/item/caution,
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "xYI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5;
@@ -117987,6 +118136,7 @@
 /obj/machinery/alarm{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "xYM" = (
@@ -118109,6 +118259,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"xZL" = (
+/obj/structure/flora/small/grassb1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "xZP" = (
 /obj/structure/grille,
 /turf/simulated/floor/asteroid/dirt/burned,
@@ -118365,11 +118519,6 @@
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/robotics)
-"ycS" = (
-/obj/structure/flora/small/busha2,
-/obj/random/scrap/sparse_even/low_chance,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "ycW" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -118568,6 +118717,7 @@
 	name = "West APC";
 	pixel_x = -28
 	},
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
@@ -118639,6 +118789,11 @@
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/techshop)
+"yfV" = (
+/obj/structure/railing,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "yfY" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6,
 /obj/structure/cable/green{
@@ -171930,7 +172085,7 @@ edp
 cPh
 sxn
 bxQ
-bxQ
+mpa
 eqm
 kGd
 oPv
@@ -178202,9 +178357,9 @@ cIo
 wVV
 wVV
 wVV
-svW
-svW
-svW
+jKw
+jKw
+jKw
 mLu
 cZn
 ucI
@@ -178608,7 +178763,7 @@ yfR
 nkP
 iyl
 iyl
-svU
+tFp
 tYn
 fHr
 rBK
@@ -178808,9 +178963,9 @@ tnO
 whU
 rBK
 oli
-rKd
-pHN
-aXJ
+hVv
+afc
+lxf
 cxN
 rOi
 rBK
@@ -179007,14 +179162,14 @@ sRU
 sRU
 whU
 tnO
-rLy
+rfH
 cCy
 nBz
 cxN
 mSc
-miV
-mjG
-iHJ
+jjF
+mbF
+xew
 rBK
 qQA
 gSu
@@ -179214,7 +179369,7 @@ cCy
 nBz
 tar
 mXl
-fQs
+kzA
 cxN
 xXM
 rBK
@@ -179411,13 +179566,13 @@ utr
 sRU
 whU
 due
-uxu
+bFa
 cCy
 sMN
-mjG
+mbF
 qpm
-srp
-iCv
+quo
+gDq
 wlK
 rBK
 evY
@@ -179818,7 +179973,7 @@ vfn
 liW
 pZA
 bHN
-vBD
+dqj
 oqt
 wdA
 bjf
@@ -180222,7 +180377,7 @@ tQp
 liW
 sEX
 fwY
-fyO
+jxJ
 pkg
 vTs
 rvM
@@ -180626,9 +180781,9 @@ laf
 vvx
 cCy
 sMN
-jbL
+fkE
 cuo
-sgP
+qCW
 cxN
 bjU
 rBK
@@ -180825,13 +180980,13 @@ ody
 sRU
 whU
 tQp
-rLy
+rfH
 cCy
-iEJ
-itJ
+rau
+uPa
 fCf
-oJv
-srp
+qci
+quo
 foj
 rBK
 kdn
@@ -181027,13 +181182,13 @@ ody
 sRU
 whU
 tnO
-rLy
+rfH
 cCy
-myn
-qRG
+cRL
+tRF
 oBN
-wUE
-cSZ
+sgP
+oaF
 bjU
 rBK
 bnh
@@ -181232,7 +181387,7 @@ tnO
 fUB
 rBK
 kDZ
-lDT
+edf
 ckN
 qJj
 szW
@@ -181435,7 +181590,7 @@ kgK
 aYq
 flW
 iyl
-rui
+jXj
 iyl
 mDo
 kzx
@@ -189727,17 +189882,17 @@ egv
 egv
 jSf
 bpF
-nCR
-nCR
-xYC
+dke
+dke
+nRU
 vVN
 vVN
 vVN
-dQR
+oMQ
 vVN
 ptD
 vVN
-qfb
+mYK
 pen
 cZb
 cZb
@@ -189751,7 +189906,7 @@ aQO
 nDO
 sxU
 tIz
-cIt
+kfr
 qJT
 wLJ
 hrP
@@ -189932,12 +190087,12 @@ bpF
 xak
 lNB
 tra
-fWS
-mia
-peF
-peF
-peF
-uhS
+sFz
+mQb
+wUs
+wUs
+wUs
+jjG
 jLN
 gGT
 pen
@@ -189950,12 +190105,12 @@ hrP
 cWv
 nls
 qON
-orq
-oOh
-vSl
-lFn
-pBo
-gIS
+wGA
+nfZ
+gYJ
+kGX
+bzs
+hGt
 hrP
 tad
 tad
@@ -190134,12 +190289,12 @@ bpF
 xak
 lNB
 bBk
-fWS
-gRB
+sFz
+vRu
 uCd
 uCd
 uCd
-ebO
+igp
 vVN
 hrP
 hrP
@@ -190153,10 +190308,10 @@ jnu
 heX
 fnU
 bDQ
-kwr
-khj
-qsh
-lOv
+oOh
+bqV
+axC
+pQX
 ipf
 hrP
 pDL
@@ -190333,15 +190488,15 @@ qZA
 egv
 adv
 bpF
-bSB
+idY
 lNB
 bBk
-fWS
-gRB
+sFz
+vRu
 uCd
 uCd
 uCd
-ebO
+igp
 vVN
 hrP
 nxP
@@ -190354,12 +190509,12 @@ qpV
 yeh
 kyK
 diB
-orq
-cNt
-xMt
-dbZ
-gdP
-gIS
+wGA
+tfR
+mNY
+kTy
+uMD
+hGt
 hrP
 hKz
 hKz
@@ -190538,12 +190693,12 @@ bpF
 xak
 lNB
 bBk
-fWS
-gRB
+sFz
+vRu
 uCd
 uCd
 uCd
-ebO
+igp
 vVN
 hrP
 icL
@@ -190556,14 +190711,14 @@ hrP
 iPz
 kyK
 diB
-dpi
+aYv
 eKO
-mKJ
 vFE
-mKJ
+puu
+vFE
 rOc
 hrP
-vsm
+oiv
 hKz
 hKz
 xEi
@@ -190740,12 +190895,12 @@ bpF
 xak
 lNB
 bBk
-fWS
-geE
+sFz
+hSg
 uCd
 uCd
 uCd
-ebO
+igp
 vVN
 hrP
 nxP
@@ -190759,11 +190914,11 @@ fkV
 kyK
 diB
 kyK
-npJ
-npJ
-npJ
-npJ
-aZo
+dmt
+dmt
+dmt
+dmt
+fMM
 tIs
 mjh
 mqO
@@ -190939,15 +191094,15 @@ egv
 jSQ
 jSQ
 bpF
-nCR
-nCR
+dke
+dke
 gIz
 dnd
 mOj
-geE
-igp
-igp
-lcN
+hSg
+gOh
+gOh
+cQs
 vVN
 hrP
 hrP
@@ -191143,10 +191298,10 @@ aPT
 bpF
 cZb
 pen
-vbB
+phH
 gGT
 nZD
-qgU
+iiE
 dnd
 dnd
 dnd
@@ -191170,9 +191325,9 @@ hrP
 tIs
 tIs
 mjh
-reB
+uFh
 hKz
-bPR
+eYp
 hKz
 xEi
 xEi
@@ -191350,7 +191505,7 @@ uVH
 rga
 vVN
 vVN
-dQR
+oMQ
 jLN
 nZD
 hcw
@@ -191369,12 +191524,12 @@ sfC
 oLe
 vVe
 oLe
-xVP
+bBD
 nOS
 mjh
 sfC
 lZr
-dLZ
+kOG
 hKz
 xEi
 xEi
@@ -191550,10 +191705,10 @@ cZb
 cZb
 pen
 jLN
-mia
-peF
-peF
-jiV
+mQb
+wUs
+wUs
+pcc
 vVN
 uLt
 uJL
@@ -191573,7 +191728,7 @@ hrP
 hrP
 ojV
 mjh
-hdk
+xZL
 mjh
 mqO
 bVM
@@ -191582,7 +191737,7 @@ hKz
 hKz
 hKz
 hKz
-qwk
+bZH
 hKz
 xEi
 xEi
@@ -191752,10 +191907,10 @@ cZb
 cZb
 cZb
 vVN
-gRB
+vRu
 uCd
 uCd
-ebO
+igp
 vVN
 uLt
 uLt
@@ -191954,10 +192109,10 @@ cZb
 cZb
 cZb
 vVN
-gRB
+vRu
 uCd
 uCd
-ebO
+igp
 rga
 vVN
 vVN
@@ -191975,17 +192130,17 @@ fvH
 hqv
 hrP
 hrP
-mRN
-uvn
-uvn
-uvn
-uvn
-uvn
-uvn
-uvn
-uvn
-uvn
-uvn
+uSN
+xKC
+xKC
+xKC
+xKC
+xKC
+xKC
+xKC
+xKC
+xKC
+xKC
 mjh
 dOY
 hKz
@@ -192156,14 +192311,14 @@ cZb
 cZb
 cZb
 vVN
-gRB
+vRu
 uCd
 uCd
 uCd
-peF
-peF
-peF
-dHe
+wUs
+wUs
+wUs
+tQw
 vVN
 hqv
 tsV
@@ -192188,7 +192343,7 @@ uCd
 uCd
 uCd
 jMx
-nYF
+bUE
 mjh
 hKz
 xEi
@@ -192358,14 +192513,14 @@ cZb
 cZb
 hrP
 lRi
-gRB
+vRu
 uCd
 uCd
 uCd
 uCd
 uCd
 uCd
-vvR
+obz
 jLN
 hqv
 jDF
@@ -192389,7 +192544,7 @@ uCd
 uCd
 uCd
 uCd
-vis
+vyH
 oIZ
 sfC
 hKz
@@ -192560,14 +192715,14 @@ cZb
 cZb
 cZb
 vVN
-gRB
+vRu
 uCd
 uCd
 uCd
 uCd
 uCd
 uCd
-vvR
+obz
 aWu
 hqv
 ikw
@@ -192591,7 +192746,7 @@ uCd
 uCd
 uCd
 uCd
-vis
+vyH
 bCy
 sfC
 hKz
@@ -192762,14 +192917,14 @@ cZb
 cZb
 uVH
 vVN
-aLh
-igp
-igp
-igp
-igp
-igp
-igp
-jlj
+sBX
+gOh
+gOh
+gOh
+gOh
+gOh
+gOh
+nVz
 vVN
 hqv
 oZW
@@ -192794,8 +192949,8 @@ bGg
 uCd
 uCd
 jMx
-nYF
-ycS
+bUE
+mZG
 hKz
 xEi
 xEi
@@ -192967,7 +193122,7 @@ rga
 vVN
 vVN
 vVN
-dQR
+oMQ
 vVN
 vVN
 vVN
@@ -192985,19 +193140,19 @@ jmo
 hqv
 hrP
 hrP
-uSN
-rMR
-rMR
-rMR
-rMR
-rMR
-rMR
-rMR
-rMR
-rMR
-rMR
+eqc
+uvn
+uvn
+uvn
+uvn
+uvn
+uvn
+uvn
+uvn
+uvn
+uvn
 kCo
-coE
+cyS
 lUl
 xEi
 xEi
@@ -193164,7 +193319,7 @@ tad
 cZb
 cZb
 pen
-vbB
+phH
 gGT
 gGT
 gGT
@@ -193186,17 +193341,17 @@ hqv
 hqv
 hqv
 hrP
-eiR
-uKY
+gvd
+sHv
 nOS
 nOS
-gru
+cJN
 bVM
 sfC
 osj
 sfC
 lZr
-aLE
+vxM
 sfC
 mjh
 lUl
@@ -208203,14 +208358,14 @@ vSM
 tfW
 eUV
 eUV
-ldP
-ldP
-ldP
+crr
+crr
+crr
 tfW
 eUV
 tfW
-bjg
-bjg
+nzO
+nzO
 tfW
 tfW
 cGa
@@ -208591,7 +208746,7 @@ kOj
 mHv
 tfW
 olX
-tUK
+nPb
 tfW
 tfW
 tfW
@@ -208607,16 +208762,16 @@ tfW
 aff
 tfW
 tfW
-rkX
+tQE
 cxU
 vaP
 eUV
-crr
+ebO
 cxU
 cxU
 tfW
 cxU
-gbM
+ver
 nhY
 cGa
 iSI
@@ -208818,7 +208973,7 @@ cxU
 tfW
 tfW
 cxU
-gbM
+ver
 tfW
 tfW
 iSI
@@ -208997,7 +209152,7 @@ cXA
 tfW
 tfW
 tfW
-cUh
+lKf
 fqz
 tfW
 fqz
@@ -209020,7 +209175,7 @@ tfW
 tfW
 bSm
 cxU
-gbM
+ver
 tfW
 lOm
 iSI
@@ -209209,10 +209364,10 @@ fhp
 tfW
 tfW
 lMN
-dYj
+rBt
 cxU
 tfW
-eSK
+oVj
 tfW
 cTB
 tfW
@@ -209222,7 +209377,7 @@ cri
 tfW
 tfW
 cxU
-gbM
+ver
 tfW
 tfW
 iSI
@@ -209411,9 +209566,9 @@ tfW
 fqz
 fqz
 cTz
-fNh
+sIf
 cxU
-crr
+ebO
 pCD
 cxU
 cxU
@@ -209424,7 +209579,7 @@ tfW
 tfW
 nhY
 cxU
-gbM
+ver
 tfW
 tfW
 tfW
@@ -209619,14 +209774,14 @@ eUV
 nhY
 cxU
 pCD
-crr
+ebO
 eUV
 tfW
-fno
+tWX
 cXA
 aff
 cxU
-gbM
+ver
 eRP
 tiO
 tiO
@@ -209816,19 +209971,19 @@ lch
 vDt
 cxU
 tfW
-ksv
+eTm
 lch
 tiO
 cxU
 tfW
-rsg
+iSU
 vaP
 tfW
 tfW
 aff
 aff
 cxU
-gbM
+ver
 eRP
 eRP
 mYI
@@ -210017,7 +210172,7 @@ tfW
 tfW
 tfW
 tfW
-fNh
+sIf
 cxU
 tfW
 tfW
@@ -210030,7 +210185,7 @@ tfW
 cxU
 cxU
 cxU
-hIv
+hgM
 tfW
 eRP
 nhY
@@ -210208,8 +210363,8 @@ tfW
 tfW
 tfW
 asu
-rhG
-dGu
+nRs
+hri
 qfL
 jsO
 qfL
@@ -210219,11 +210374,11 @@ qfL
 tfW
 cXA
 lch
-tEm
+yfV
 cxU
 cxU
 tfW
-crr
+ebO
 tfW
 aff
 iqv
@@ -210410,12 +210565,12 @@ tfW
 tfW
 tfW
 tfW
-dGu
+hri
 vMD
-rOI
+wVd
 xFj
-uPQ
-kKP
+cOQ
+xVP
 mcB
 qfL
 tfW
@@ -210425,7 +210580,7 @@ tfW
 tfW
 cxU
 cXA
-crr
+ebO
 cxU
 aff
 tfW
@@ -210612,7 +210767,7 @@ cXA
 fqz
 fqz
 fqz
-qyr
+pSs
 gNG
 ugx
 fqx
@@ -210628,7 +210783,7 @@ eUV
 cxU
 cxU
 tfW
-nQc
+krF
 tfW
 tfW
 olX
@@ -210636,7 +210791,7 @@ oHv
 olX
 olX
 cxU
-gbM
+ver
 tfW
 tfW
 tfW
@@ -210811,14 +210966,14 @@ rTe
 tfW
 tfW
 iqv
-kvM
+jIc
 tfW
 tfW
 sSB
 eOO
 ugx
 cXJ
-akK
+sis
 rxh
 qXx
 sSB
@@ -210826,7 +210981,7 @@ tfW
 lch
 lch
 tfW
-mvy
+slt
 tfW
 cxU
 eUV
@@ -210838,7 +210993,7 @@ tfW
 nfC
 tfW
 cxU
-lOW
+auY
 tfW
 lOm
 dlq
@@ -211007,7 +211162,7 @@ vaP
 tfW
 tfW
 tfW
-rff
+oDL
 rTe
 cxU
 tfW
@@ -211020,8 +211175,8 @@ qfL
 qfL
 gAr
 qfL
-xKC
-mjc
+rLy
+lqU
 bBy
 xfe
 wjb
@@ -211040,7 +211195,7 @@ tfW
 tfW
 kEV
 cxU
-gbM
+ver
 kEV
 dlq
 kEV
@@ -211222,7 +211377,7 @@ qfL
 vpD
 abI
 qfL
-xKC
+rLy
 ugx
 ugx
 sSB
@@ -211236,13 +211391,13 @@ tfW
 tfW
 aff
 aff
-fZj
+bTf
 tfW
 cxU
 mHv
 mHv
 cxU
-gbM
+ver
 lOm
 kEV
 syk
@@ -211444,7 +211599,7 @@ cxU
 tfW
 cxU
 cxU
-juD
+gkL
 ltw
 fdr
 fdr
@@ -211836,16 +211991,16 @@ fqz
 fqz
 tfW
 tfW
-nIM
+giq
 tfW
-xME
+hep
 tfW
-xME
-xME
+hep
+hep
 vSM
 nhY
-xME
-omo
+hep
+kdX
 fdr
 jSt
 uzy
@@ -212109,7 +212264,7 @@ qJJ
 xxB
 buA
 nau
-jOb
+wXX
 jVq
 qJJ
 iYY
@@ -212226,7 +212381,7 @@ tGU
 tfW
 uTf
 oPz
-gRU
+qWd
 fqz
 tfW
 cGa
@@ -212309,7 +212464,7 @@ jgt
 uSy
 qJJ
 rXV
-jOb
+wXX
 kDc
 jOb
 hAB
@@ -212430,9 +212585,9 @@ uTf
 uTf
 tfW
 cGa
-jMy
+tcK
 cZD
-bqn
+fUa
 olX
 tfW
 tfW
@@ -212511,9 +212666,9 @@ dje
 uSy
 qJJ
 ojE
-jOb
+wEi
 xEo
-jOb
+ity
 kAb
 qJJ
 iYY
@@ -212914,7 +213069,7 @@ piY
 qlT
 uSy
 qJJ
-xxB
+lhg
 mnS
 ckE
 hvN
@@ -216000,8 +216155,8 @@ xRA
 snS
 kGO
 jbb
-cxU
-cxU
+tfW
+tfW
 cxU
 tfW
 tfW
@@ -216204,7 +216359,7 @@ kGO
 jbb
 cNG
 cNG
-cxU
+tfW
 tfW
 tfW
 tfW
@@ -216406,7 +216561,7 @@ kGO
 jbb
 cNG
 cxU
-cxU
+tfW
 tfW
 tfW
 tfW
@@ -216607,7 +216762,7 @@ snS
 kGO
 jbb
 cxU
-cxU
+tfW
 tfW
 tfW
 tfW
@@ -216808,9 +216963,9 @@ nSJ
 gNQ
 nDp
 nxN
+xHo
 cxU
-cxU
-tfW
+kEV
 tfW
 pCD
 aff
@@ -217012,7 +217167,7 @@ vSO
 xRA
 xRA
 fkp
-tfW
+uwP
 tfW
 tfW
 aff
@@ -217217,7 +217372,7 @@ tfW
 tfW
 tfW
 tfW
-tfW
+kEV
 tfW
 tfW
 tfW
@@ -217415,7 +217570,7 @@ fmZ
 fjc
 xRA
 xRA
-cxU
+tfW
 tfW
 kEV
 tfW
@@ -217423,8 +217578,8 @@ olX
 tiO
 tfW
 tfW
-tfW
-tfW
+vaP
+vaP
 tfW
 bSm
 tfW
@@ -217617,17 +217772,17 @@ ycn
 pnV
 xRA
 xRA
-dsj
-dsj
-dsj
+gER
+nZe
+nZe
 dsj
 nZe
 sQo
 sQo
-sQo
-sQo
+lwP
+lwP
 wBY
-sQo
+lwP
 rTq
 rTq
 kKd
@@ -217827,12 +217982,12 @@ dsj
 sQo
 ciR
 lwP
+lwP
+lwP
+lwP
 sQo
-sQo
-sQo
-nDo
-nDo
-nDo
+qMG
+qMG
 sQo
 sQo
 sQo
@@ -218028,12 +218183,12 @@ dis
 dsj
 sQo
 lwP
-wVD
-qMG
-qMG
-dXq
-dXq
-dXq
+lwP
+lwP
+lwP
+sQo
+sQo
+ela
 dXq
 dXq
 dXq
@@ -218230,12 +218385,12 @@ dis
 dsj
 ciR
 wVD
-dZu
-qMG
-qMG
-dXq
-dXq
-dXq
+sQo
+lwP
+sQo
+sQo
+sQo
+ela
 dXq
 dXq
 dXq
@@ -218433,12 +218588,12 @@ dsj
 sQo
 qMG
 dZu
-wVD
+lwP
 lwP
 sQo
-nDo
-nDo
-nDo
+sQo
+sQo
+qMG
 rTq
 rTq
 qMG
@@ -218639,7 +218794,7 @@ lwP
 rTq
 sQo
 sQo
-kKd
+oKP
 sQo
 sQo
 rTq
@@ -218846,8 +219001,8 @@ sQo
 iaO
 sQo
 sQo
-dXq
-qMG
+sQo
+wTv
 sQo
 tfW
 xzG
@@ -219042,15 +219197,15 @@ qMG
 sQo
 sQo
 sQo
-sQo
+rrK
 sQo
 lwP
 sQo
 sQo
 sQo
-dXq
-qMG
+frI
 sQo
+nvN
 tfW
 fqz
 xzG
@@ -219242,7 +219397,7 @@ dZu
 nnz
 qMG
 sQo
-sQo
+frI
 qMG
 rtu
 rtu
@@ -219250,9 +219405,9 @@ lwP
 sQo
 lwP
 sQo
-qMG
-qMG
 sQo
+bDP
+nvN
 tfW
 tym
 fqz
@@ -219449,11 +219604,11 @@ rtu
 vFL
 vFL
 rtu
-kKd
+oKP
+kBL
 sQo
-sQo
-dXq
-qMG
+ela
+bDP
 ezq
 tfW
 tym
@@ -219653,9 +219808,9 @@ vFL
 vFL
 rtu
 ciR
-sQo
-dXq
+rrK
 qMG
+sQo
 rvq
 tfW
 tym
@@ -220056,7 +220211,7 @@ rtu
 vFL
 vFL
 rtu
-emO
+rVz
 sQo
 dXq
 qMG
@@ -220252,8 +220407,8 @@ qQC
 qMG
 dXq
 sQo
-sQo
-qMG
+doc
+dai
 rtu
 vFL
 vFL
@@ -220665,7 +220820,7 @@ vFL
 loh
 ciR
 qMG
-dXq
+ela
 nGh
 tfW
 fqz
@@ -220860,14 +221015,14 @@ dZu
 sQo
 sQo
 sQo
-sQo
+frI
 vFL
 vFL
 vFL
 hYu
-ciR
-qMG
-dXq
+bDP
+bDP
+ela
 sGV
 tfW
 cLN
@@ -221067,9 +221222,9 @@ qMG
 dKA
 hYu
 qMG
+frI
 sQo
-qMG
-dXq
+ela
 gjL
 tfW
 fes
@@ -221266,12 +221421,12 @@ ciR
 ciR
 sQo
 kKd
-qMG
-qMG
+rLl
+kgc
 sQo
 sQo
-qMG
-dXq
+sQo
+ela
 gjL
 tfW
 tfW
@@ -221469,9 +221624,9 @@ ciR
 sQo
 sQo
 sQo
+rrK
 sQo
-sQo
-sQo
+bDP
 qMG
 dXq
 xyC
@@ -221669,7 +221824,7 @@ sQo
 sQo
 sQo
 sQo
-sQo
+doc
 rTq
 rTq
 sQo
@@ -221870,13 +222025,13 @@ qMG
 emO
 sQo
 sQo
-nDo
-nDo
+doc
+thh
 nDo
 sQo
 ciR
-qMG
-dXq
+sQo
+ela
 qMG
 jcr
 tfW
@@ -222071,14 +222226,14 @@ wVD
 qMG
 qMG
 qMG
+sQo
+sQo
 qMG
 qMG
 qMG
 qMG
 qMG
-qMG
-qMG
-dXq
+sQo
 qMG
 sQo
 tfW
@@ -222273,14 +222428,14 @@ gjL
 wVD
 dXq
 dXq
-dXq
-dXq
-dXq
+ela
+ela
+ela
 dXq
 qMG
 qMG
-qMG
-qMG
+sQo
+sQo
 sQo
 sQo
 tfW
@@ -222378,8 +222533,8 @@ gBD
 gBD
 pdW
 vvB
-eIT
-heu
+vhD
+hZi
 lXt
 gtD
 pdW
@@ -222476,10 +222631,10 @@ sQo
 sQo
 sQo
 sQo
-nDo
-nDo
-nDo
+thh
 sQo
+nDo
+doc
 sQo
 sQo
 sQo
@@ -222680,7 +222835,7 @@ sQo
 sQo
 sQo
 sQo
-sQo
+doc
 sQo
 sQo
 sQo
@@ -222984,7 +223139,7 @@ gBD
 gBD
 pdW
 dVU
-ubp
+pKZ
 oDs
 uiJ
 nrP
@@ -231370,8 +231525,8 @@ kOj
 iqg
 iqg
 kOj
-kOj
-kOj
+wAu
+wAu
 kOj
 kOj
 kOj
@@ -231571,10 +231726,10 @@ kOj
 kOj
 kOj
 kOj
-kOj
-kOj
-kOj
-kOj
+wAu
+tfW
+mHv
+wAu
 kOj
 kOj
 kOj
@@ -231773,12 +231928,12 @@ kOj
 kOj
 kOj
 kOj
-kOj
-kOj
+mHv
 tfW
 tfW
+xsx
 kOj
-kOj
+wAu
 kOj
 kOj
 qli
@@ -231975,13 +232130,13 @@ qli
 kOj
 kOj
 kOj
-kOj
+tiO
+tfW
+gho
+hWB
 tfW
 tfW
-tfW
-tfW
-xsx
-xsx
+mHv
 txQ
 qli
 kOj
@@ -232178,10 +232333,10 @@ kOj
 kOj
 kOj
 kOj
-kOj
 tfW
 tfW
-mHv
+tfW
+tfW
 tfW
 gUf
 hyq
@@ -232382,7 +232537,7 @@ kOj
 kOj
 qli
 mHv
-tiO
+tfW
 cxU
 cxU
 oHG

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -203,6 +203,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"aci" = (
+/obj/structure/flora/bush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "acm" = (
 /obj/structure/table/bar_special,
 /obj/item/trash/broken_robot_part,
@@ -766,13 +771,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
-"ail" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "ain" = (
 /obj/machinery/power/port_gen/pacman/diesel/anchored,
 /obj/structure/cable/yellow{
@@ -2209,12 +2207,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"axd" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "axf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2261,6 +2253,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"axs" = (
+/obj/structure/boulder,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "axC" = (
 /obj/effect/floor_decal/industrial/box/red,
 /obj/effect/decal/cleanable/ash,
@@ -2450,6 +2446,9 @@
 "azv" = (
 /obj/structure/flora/small/rock3,
 /obj/structure/invislight,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "azI" = (
@@ -3728,6 +3727,12 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"aNO" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "aNQ" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
@@ -4470,6 +4475,11 @@
 	},
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/medical/reception)
+"aXX" = (
+/obj/structure/railing,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "aYf" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -5527,11 +5537,6 @@
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical)
-"biw" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "biz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5783,11 +5788,6 @@
 /obj/effect/floor_decal/industrial/road/curve4,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"bky" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
@@ -6014,19 +6014,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"boe" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "bog" = (
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"boj" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "bok" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7222,6 +7221,13 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"bAG" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "bAI" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "3,8"
@@ -7233,6 +7239,11 @@
 /obj/landmark/join/start/rd,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/command/cro)
+"bAR" = (
+/obj/structure/flora/small/rock2,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "bAS" = (
 /obj/item/modular_computer/tablet/lease/preset/chemistry,
 /obj/structure/table/standard,
@@ -7616,10 +7627,11 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
 "bFc" = (
-/obj/structure/table/woodentable,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "bFk" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -11139,10 +11151,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "csI" = (
-/obj/random/flora/jungle_tree,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
+/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "csK" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -12510,6 +12522,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"cHA" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/inside_colony)
 "cHC" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -13522,6 +13540,22 @@
 /obj/structure/kitchenspike,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
+"cRg" = (
+/obj/effect/floor_decal/spline/fancy,
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/table/bench/steel,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/security/sechall)
 "cRh" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -14266,6 +14300,15 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/lakeside)
+"cYr" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "cYs" = (
 /obj/random/scrap/sparse_weighted/low_chance,
 /obj/structure/cable/cyan{
@@ -14330,6 +14373,12 @@
 	icon_state = "11,1"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"cZe" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/security/maingate/west)
 "cZf" = (
 /obj/structure/bed/chair/sofa/teal/right{
 	dir = 4
@@ -14466,8 +14515,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
 "dai" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "dak" = (
@@ -16851,12 +16902,6 @@
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"dzg" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "dzr" = (
 /obj/random/medical_lowcost,
 /obj/random/medical_lowcost_handmade,
@@ -16948,9 +16993,8 @@
 /area/shuttle/vasiliy_shuttle_area)
 "dAK" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "dAP" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil/random,
@@ -17753,13 +17797,6 @@
 /obj/item/clothing/under/bathrobe,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
-"dIY" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "dJa" = (
 /obj/structure/sign/misc/rent,
 /turf/simulated/wall/r_wall,
@@ -18653,6 +18690,10 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm3)
+"dSQ" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "dSX" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/effect/decal/cleanable/dirt,
@@ -18995,11 +19036,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfaceeast)
-"dWX" = (
-/obj/structure/flora/bush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "dWZ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -19102,11 +19138,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"dYd" = (
-/obj/random/flora/low_chance,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "dYe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20064,14 +20095,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"ehm" = (
-/obj/structure/flora/small/rock3,
-/obj/structure/invislight,
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "ehp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/chapel,
@@ -20379,12 +20402,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
+"elj" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "elk" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"elo" = (
+/obj/item/ammo_casing,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "elB" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -21739,11 +21771,6 @@
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/lakeside)
-"exq" = (
-/obj/structure/railing,
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "exA" = (
 /obj/effect/spider/stickyweb,
 /obj/random/contraband,
@@ -22512,10 +22539,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/sechall)
-"eHp" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate/east)
 "eHq" = (
 /obj/structure/table/rack,
 /obj/item/towel,
@@ -23000,11 +23023,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"eMA" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "eMB" = (
 /obj/structure/table/glass,
 /obj/item/device/camera,
@@ -23607,10 +23625,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"eRd" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "eRg" = (
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -24537,6 +24551,12 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm2)
+"faD" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/outside/pond)
 "faH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -26184,6 +26204,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
+"frH" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "frI" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/grass,
@@ -26733,11 +26758,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
-"fyz" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "fyB" = (
 /obj/machinery/button/windowtint{
 	id = "serg";
@@ -26915,15 +26935,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"fAp" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/flora/big/bush3{
-	pixel_y = -18
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "fAq" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -27707,6 +27718,11 @@
 	temperature = 80
 	},
 /area/nadezhda/command/tcommsat/computer)
+"fIK" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "fIV" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall22";
@@ -29318,6 +29334,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/armory)
+"gbY" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "gbZ" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/grille,
@@ -31014,6 +31035,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"grQ" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "grR" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -32198,6 +32224,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
+"gFz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "gFC" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
@@ -33294,6 +33325,10 @@
 	icon_state = "11,8"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"gSs" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "gSt" = (
 /obj/item/reagent_containers/glass/fertilizer,
 /obj/item/reagent_containers/glass/fertilizer/ez,
@@ -34116,11 +34151,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"hbk" = (
-/obj/structure/low_wall,
-/obj/structure/flora/big/bush3,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "hbl" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/alarm{
@@ -37061,11 +37091,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/range)
-"hGo" = (
-/obj/item/ammo_casing,
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "hGs" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -37953,12 +37978,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"hNr" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/rock,
-/area/nadezhda/outside/inside_colony)
 "hNs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -38709,11 +38728,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
-"hWz" = (
-/obj/structure/flora/small/rock2,
-/obj/structure/flora/big/bush3,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "hWB" = (
 /obj/structure/bonfire,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -41665,6 +41679,12 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/nadezhda/engineering/atmos)
+"izH" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "izK" = (
 /obj/machinery/atmospherics/pipe/zpipe/up,
 /obj/structure/cable/green{
@@ -41709,6 +41729,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
+"iAm" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "iAp" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "5,1"
@@ -42944,10 +42969,6 @@
 /obj/machinery/sleeper,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
-"iOS" = (
-/obj/random/scrap/sparse_weighted/low_chance,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "iOV" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
@@ -43323,13 +43344,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
-"iSR" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "iSU" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -44691,6 +44705,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
+"jia" = (
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "jic" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -45314,12 +45332,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
-"jnv" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "jny" = (
 /obj/machinery/power/nt_obelisk,
 /obj/machinery/newscaster/directional/north,
@@ -46316,22 +46328,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
-"jwX" = (
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/floor_decal/corner_techfloor_grid,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/table/bench/steel,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/security/sechall)
 "jxb" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/random/traps/low_chance{
@@ -46486,10 +46482,6 @@
 /obj/random/voidsuit/damaged/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/burned_outpost)
-"jzE" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "jzJ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/camera/network/research,
@@ -46636,11 +46628,6 @@
 /obj/structure/closet/secure_closet/personal/detective,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/detectives_office)
-"jBa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/manual/fiction/warandpeace,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "jBc" = (
 /mob/living/simple_animal/soteria_roomba/medical,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -46820,6 +46807,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/tcommsat/computer)
+"jDM" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/outside/pond)
 "jDO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -48823,13 +48816,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/genetics)
-"jZe" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "jZi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/spiders/low_chance,
@@ -49507,10 +49493,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"kfT" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/inside_colony)
 "kfY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -49519,7 +49501,6 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "kgc" = (
-/obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
@@ -50040,12 +50021,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"kkW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/item/flame/lighter/zippo/capitalist,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "kla" = (
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
@@ -51527,6 +51502,11 @@
 /obj/item/remains/mouse,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
+"kzD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/smokable/cigarette/cigar,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "kzJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -52219,6 +52199,13 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/engineering/engine_room)
+"kHc" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/inside_colony)
 "kHd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54497,6 +54484,12 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/hallway/side/f2section1)
+"ljd" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "ljs" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -54944,6 +54937,11 @@
 	icon_state = "10,11"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"lpt" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "lpx" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8;
@@ -56219,6 +56217,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"lDC" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "lDE" = (
 /obj/random/scrap/sparse_even,
 /obj/random/mob/roaches/low_chance,
@@ -56879,10 +56882,6 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"lKn" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "lKx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -57109,13 +57108,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/maingate/east)
-"lNz" = (
-/obj/structure/catwalk,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/pros/shuttle)
 "lNB" = (
 /obj/effect/floor_decal/industrial/inputgate,
 /turf/simulated/floor/fixed/hydrotile,
@@ -57268,11 +57260,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
-"lPr" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate/east)
 "lPt" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -57556,13 +57543,6 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
-"lSe" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "lSh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57661,13 +57641,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
-"lTk" = (
-/obj/structure/flora/big/rocks3,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "lTl" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -59509,6 +59482,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"mlp" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "mlq" = (
 /obj/machinery/disposal,
 /obj/effect/spider/stickyweb,
@@ -60273,6 +60251,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/hallway/surface/section1)
+"mtH" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate/east)
 "mtI" = (
 /obj/machinery/shower{
 	dir = 8
@@ -60546,12 +60528,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"mwH" = (
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "mwL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/coffin,
@@ -61187,11 +61163,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"mDb" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "mDd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61870,6 +61841,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"mJx" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "mJD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -62717,10 +62693,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"mSW" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "mSY" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,1";
@@ -63184,12 +63156,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
-"mYs" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "mYu" = (
 /obj/structure/closet/crate,
 /obj/random/powercell/low_chance,
@@ -65744,12 +65710,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"nxu" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/beach/water/flooded,
-/area/nadezhda/outside/pond)
 "nxx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/cable/yellow{
@@ -66294,6 +66254,12 @@
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"nCy" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "nCA" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
@@ -66915,10 +66881,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
-"nIC" = (
-/obj/structure/boulder,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "nIG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/light/small{
@@ -67017,13 +66979,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"nJp" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush3{
-	pixel_y = -18
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "nJt" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/effect/decal/cleanable/dirt,
@@ -67447,11 +67402,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"nNx" = (
-/obj/structure/railing,
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "nNz" = (
 /obj/machinery/light,
 /obj/machinery/holoposter{
@@ -71725,6 +71675,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"oFA" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "oFI" = (
 /obj/structure/bed/chair/custom/bar_special{
 	dir = 4
@@ -72458,6 +72413,11 @@
 /obj/structure/flora/small/bushc1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/dcave)
+"oMm" = (
+/obj/random/flora/jungle_tree,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "oMq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -76547,15 +76507,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
-"pDm" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/flora/big/bush3{
-	pixel_y = -18
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "pDo" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/stalkybush,
@@ -76649,13 +76600,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/inside_colony)
-"pDW" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/rock,
 /area/nadezhda/outside/inside_colony)
 "pEw" = (
 /obj/structure/bed/psych{
@@ -77622,6 +77566,10 @@
 /obj/item/book/ritual/cruciform,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"pOp" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "pOr" = (
 /obj/machinery/light,
 /obj/machinery/alarm{
@@ -82022,11 +81970,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"qGy" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "qGA" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/simulated/floor/bluegrid{
@@ -83065,13 +83008,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"qSj" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "qSs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -84719,6 +84655,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
+"rkx" = (
+/obj/structure/flora/small/rock3,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "rkA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -85779,10 +85720,6 @@
 /obj/structure/flora/small/grassb2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/main/stairwell)
-"rwR" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "rwS" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/nonfiction/ageofreason,
@@ -86014,6 +85951,13 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"ryz" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "ryA" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -86199,6 +86143,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/surgery)
+"rAr" = (
+/obj/structure/catwalk,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/pros/shuttle)
 "rAx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/wood,
@@ -86227,11 +86178,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"rAW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/mask/smokable/cigarette/cigar,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "rAZ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -87054,11 +87000,6 @@
 /obj/item/caution/cone,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"rKL" = (
-/obj/structure/flora/small/rock3,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "rKU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -87113,9 +87054,9 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
 "rLl" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "rLm" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/lab)
@@ -88021,9 +87962,11 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
 "rVz" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
 "rVD" = (
 /obj/effect/step_trigger/surface_to_forest_1_B,
@@ -88999,6 +88942,10 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"sea" = (
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "seg" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -89476,6 +89423,12 @@
 /obj/structure/closet/secure_closet/armory_explosive,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"sjU" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/inside_colony)
 "sjZ" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -89553,6 +89506,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
+"sla" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/fiction/warandpeace,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "sle" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -89566,11 +89524,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
-"sli" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "slp" = (
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
@@ -90389,6 +90342,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"ssF" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "ssN" = (
 /obj/structure/table/steel,
 /obj/random/lowkeyrandom,
@@ -90701,6 +90660,8 @@
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "svG" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/flame/lighter/zippo/capitalist,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "svJ" = (
@@ -92013,12 +91974,6 @@
 "sJn" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"sJq" = (
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/unsimulated/mineral,
-/area/nadezhda/outside/inside_colony)
 "sJv" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 6
@@ -92230,12 +92185,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/foyer)
-"sLG" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/beach/water/flooded,
-/area/nadezhda/outside/pond)
 "sLH" = (
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/dirt,
@@ -92298,6 +92247,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"sLZ" = (
+/obj/structure/low_wall,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "sMe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -93706,6 +93660,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/rnd/xenobiology)
+"tce" = (
+/obj/structure/flora/big/rocks3,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "tcg" = (
 /obj/machinery/porta_turret{
 	dir = 1
@@ -94194,6 +94155,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
+"thY" = (
+/obj/structure/railing,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "thZ" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "1,6"
@@ -94699,10 +94665,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"tob" = (
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/pond)
 "toe" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/lights/mixed,
@@ -95590,6 +95552,13 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/maingate)
+"txB" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "txD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -96887,6 +96856,10 @@
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
+"tJY" = (
+/obj/random/scrap/sparse_weighted/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "tKh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -96914,11 +96887,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/rnd/xenobiology)
-"tKu" = (
-/obj/structure/railing,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "tKx" = (
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/science{
@@ -97008,6 +96976,11 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
+"tLx" = (
+/obj/random/flora/low_chance,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "tLF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -100148,12 +100121,6 @@
 /mob/living/simple_animal/hostile/dino/tagilla,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
-"upe" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "upo" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -100733,11 +100700,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"uwT" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "uxd" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -106435,6 +106397,10 @@
 "vDw" = (
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"vDC" = (
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/inside_colony)
 "vDE" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -109267,6 +109233,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"wes" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate/east)
 "wew" = (
 /obj/effect/damagedfloor/fire,
 /turf/simulated/floor/asteroid/dirt/burned,
@@ -109541,6 +109512,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/smc/quarters)
+"whK" = (
+/obj/structure/flora/bush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "whM" = (
 /obj/structure/closet/crate/freezer/rations,
 /obj/effect/decal/cleanable/dirt,
@@ -111206,12 +111183,6 @@
 "wyr" = (
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
-"wyt" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/security/maingate/west)
 "wyv" = (
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
@@ -113216,6 +113187,14 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"wUW" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "wVb" = (
 /obj/structure/shuttle_part/escpod{
 	icon_state = "escpodwall9";
@@ -114185,12 +114164,6 @@
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"xgt" = (
-/obj/structure/flora/bush,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "xgv" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/item/contraband/poster/placed/generic/no_erp{
@@ -114630,6 +114603,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/merchant)
+"xkG" = (
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "xkJ" = (
 /obj/structure/table/steel,
 /obj/random/knife/low_chance,
@@ -115168,6 +115146,11 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
+"xqQ" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "xqT" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -117580,6 +117563,13 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/prime)
+"xOA" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "xOE" = (
 /obj/structure/bed/chair/sofa/teal,
 /obj/effect/spider/stickyweb,
@@ -118608,6 +118598,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/robotics)
+"xYT" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "xYV" = (
 /obj/machinery/door/airlock/glass{
 	name = "Tropical Shop"
@@ -118728,10 +118727,6 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"yam" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "yap" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
@@ -118763,6 +118758,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
+"yaH" = (
+/obj/structure/flora/small/rock3,
+/obj/structure/invislight,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "yaI" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/machinery/light/small{
@@ -203838,8 +203838,8 @@ spF
 spF
 spF
 spF
-upe
-upe
+bFc
+bFc
 umT
 gXV
 xRA
@@ -204034,16 +204034,16 @@ spF
 spF
 spF
 spF
-jZe
-jZe
-jZe
-jZe
-jZe
+rVz
+rVz
+rVz
+rVz
+rVz
 pvI
 cLp
 fFO
 fFO
-wyt
+cZe
 xRA
 xRA
 xRA
@@ -204230,22 +204230,22 @@ spF
 spF
 spF
 spF
-jZe
-jZe
-jZe
-jZe
-jZe
-jZe
-jZe
-jzE
-jzE
+rVz
+rVz
+rVz
+rVz
+rVz
+rVz
+rVz
+dSQ
+dSQ
 pFV
 pFV
 pFV
 rIK
 pFV
 pFV
-wyt
+cZe
 xRA
 xRA
 xRA
@@ -204431,20 +204431,20 @@ spF
 spF
 spF
 spF
-jZe
-jZe
-jzE
+rVz
+rVz
+dSQ
 rIK
-mDb
-mDb
-eRd
+fIK
+fIK
+gSs
 pFV
 pvI
 rIK
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
 rIK
 kGO
@@ -204632,22 +204632,22 @@ aYl
 spF
 spF
 spF
-boj
-jZe
-jzE
-eRd
-rLl
-rLl
+wUW
+rVz
+dSQ
+gSs
+kgc
+kgc
 rIK
-rLl
-rLl
-uwT
+kgc
+kgc
+iAm
 pFV
 pFV
 cWF
 rIK
-rLl
-rLl
+kgc
+kgc
 pFV
 qCq
 kGO
@@ -204835,7 +204835,7 @@ spF
 izu
 spF
 wRQ
-eRd
+gSs
 fFO
 pFV
 pvI
@@ -204848,8 +204848,8 @@ vrW
 pFV
 pFV
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
 qCq
 kGO
@@ -205238,8 +205238,8 @@ aYl
 spF
 anq
 spF
-mYs
-iOS
+aNO
+tJY
 fFO
 pFV
 pvI
@@ -205251,8 +205251,8 @@ pFV
 pFV
 pFV
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
 pvI
 qCq
@@ -205437,8 +205437,8 @@ aYl
 aYl
 aYl
 spF
-lTk
-mYs
+tce
+aNO
 bXS
 fFO
 fFO
@@ -205453,7 +205453,7 @@ vrW
 niq
 pFV
 pvI
-dWX
+aci
 pFV
 pFV
 vbq
@@ -205638,9 +205638,9 @@ gBD
 aYl
 aYl
 spF
-iSR
+txB
 bXS
-mSW
+elj
 fFO
 fFO
 fFO
@@ -205651,7 +205651,7 @@ rIK
 rIK
 pFV
 cWF
-rLl
+kgc
 pFV
 pFV
 spa
@@ -205840,21 +205840,21 @@ iYY
 aYl
 aYl
 spF
-iSR
+txB
 cXf
-iOS
+tJY
 fFO
 lVU
 pFV
-hGo
-nNx
+elo
+aXX
 oSE
 fFO
 fFO
 pFV
 vrW
 pFV
-rLl
+kgc
 pFV
 pFV
 pFV
@@ -206042,21 +206042,21 @@ iYY
 aYl
 aYl
 spF
-pDW
-mSW
+kHc
+elj
 fFO
 fFO
 bex
 rIK
 rIK
-exq
+thY
 bXS
 fFO
 fFO
 nIU
 aPg
 hPj
-rLl
+kgc
 pFV
 svK
 pFV
@@ -206251,7 +206251,7 @@ fFO
 fFO
 fFO
 pFV
-tKu
+xkG
 fIj
 fFO
 fFO
@@ -206446,7 +206446,7 @@ iYY
 aYl
 aYl
 spF
-pDW
+kHc
 fFO
 fFO
 cLp
@@ -206648,8 +206648,8 @@ iYY
 aYl
 aYl
 spF
-pDW
-mSW
+kHc
+elj
 lVU
 fFO
 bex
@@ -206663,8 +206663,8 @@ yhP
 aPg
 pFV
 rIK
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
 pFV
@@ -206850,8 +206850,8 @@ iYY
 aYl
 aYl
 spF
-pDW
-mSW
+kHc
+elj
 cLp
 cLp
 fFO
@@ -207052,7 +207052,7 @@ iYY
 aYl
 aYl
 spF
-iSR
+txB
 bXS
 bXS
 fFO
@@ -207254,8 +207254,8 @@ iYY
 aYl
 aYl
 spF
-mSW
-mSW
+elj
+elj
 bXS
 bXS
 fFO
@@ -207265,7 +207265,7 @@ dWS
 bXS
 rIK
 pFV
-hbk
+sLZ
 aPg
 vrW
 pFV
@@ -207457,15 +207457,15 @@ aYl
 aYl
 aYl
 spF
-iSR
-jZe
-jzE
-iOS
+txB
+rVz
+dSQ
+tJY
 fFO
 fFO
 fFO
 fFO
-dIY
+ryz
 rIK
 pFV
 pFV
@@ -207662,10 +207662,10 @@ aYl
 spF
 spF
 spF
-upe
-jzE
+bFc
+dSQ
 fFO
-iOS
+tJY
 fFO
 hPj
 mGO
@@ -207865,7 +207865,7 @@ spF
 aYl
 aYl
 spF
-hNr
+cHA
 aYl
 cwC
 pFV
@@ -208067,8 +208067,8 @@ spF
 spF
 spF
 spF
-upe
-jzE
+bFc
+dSQ
 fFO
 pFV
 pFV
@@ -208268,9 +208268,9 @@ aYl
 spF
 spF
 spF
-lSe
+xOA
 cLp
-jzE
+dSQ
 fFO
 fFO
 pFV
@@ -208471,8 +208471,8 @@ spF
 spF
 spF
 spF
-lSe
-eMA
+xOA
+xqQ
 fFO
 fFO
 cLp
@@ -208674,7 +208674,7 @@ spF
 spF
 spF
 spF
-upe
+bFc
 spF
 spF
 cLp
@@ -209080,7 +209080,7 @@ spF
 spF
 spF
 spF
-hNr
+cHA
 fFO
 rIK
 rIK
@@ -209090,7 +209090,7 @@ rIK
 rIK
 rIK
 rIK
-rLl
+kgc
 bXS
 spa
 kGO
@@ -209282,7 +209282,7 @@ spF
 spF
 spF
 spF
-upe
+bFc
 rIK
 pFV
 rIK
@@ -209477,12 +209477,12 @@ xtc
 xtc
 xtc
 xtc
-lNz
-lNz
-lNz
-lNz
-lNz
-lNz
+rAr
+rAr
+rAr
+rAr
+rAr
+rAr
 xtc
 tdw
 tdw
@@ -209695,7 +209695,7 @@ qlM
 vRM
 rHw
 pFV
-rLl
+kgc
 pFV
 bXS
 cXf
@@ -209896,8 +209896,8 @@ itd
 itd
 cxs
 rHw
-rLl
-rLl
+kgc
+kgc
 fLu
 bXS
 bXS
@@ -210098,7 +210098,7 @@ itd
 itd
 cxs
 rHw
-rLl
+kgc
 vrW
 rIK
 bXS
@@ -214311,10 +214311,10 @@ ntZ
 bro
 hos
 sUh
-kkW
+svG
 pyR
-bFc
-bFc
+csI
+csI
 pHb
 sKl
 ktw
@@ -214510,10 +214510,10 @@ xHa
 rIK
 pHb
 vnF
-svG
-svG
+rLl
+rLl
 kjg
-svG
+rLl
 mTb
 kBt
 dZL
@@ -214712,12 +214712,12 @@ frR
 hcX
 pHb
 eRA
-sli
-svG
+gFz
+rLl
 kjg
-svG
-svG
-rAW
+rLl
+rLl
+kzD
 pqb
 pHb
 bRi
@@ -214917,9 +214917,9 @@ aIM
 aIM
 quv
 kjg
-jBa
+sla
 xeM
-svG
+rLl
 vuN
 pHb
 ffp
@@ -215122,7 +215122,7 @@ spV
 dTD
 pHb
 egN
-bFc
+csI
 pHb
 nRf
 bQD
@@ -216111,7 +216111,7 @@ tYN
 iUn
 uSy
 cOa
-jwX
+cRg
 lej
 acV
 qqM
@@ -219816,7 +219816,7 @@ nnz
 qMG
 sQo
 frI
-tob
+jia
 qMG
 rtu
 lwP
@@ -220222,7 +220222,7 @@ sQo
 sQo
 qMG
 vFL
-nxu
+faD
 vFL
 njk
 ciR
@@ -220424,10 +220424,10 @@ sQo
 rTq
 njk
 vFL
-sLG
+jDM
 vFL
 sQo
-tob
+jia
 sQo
 dXq
 qMG
@@ -220624,7 +220624,7 @@ emO
 dXq
 sQo
 sQo
-tob
+jia
 sQo
 vFL
 vFL
@@ -220829,7 +220829,7 @@ doc
 rrK
 rtu
 vFL
-nxu
+faD
 vFL
 sQo
 ciR
@@ -221193,7 +221193,7 @@ ufr
 rIK
 tnk
 tnk
-rIK
+idr
 igM
 xfb
 hcX
@@ -221232,7 +221232,7 @@ sQo
 sQo
 sQo
 qMG
-nxu
+faD
 vFL
 vFL
 loh
@@ -221392,12 +221392,12 @@ xUV
 ksX
 ksX
 ssS
-rIK
 uit
 uit
 uit
 uit
-pFV
+uit
+uit
 svK
 pFV
 fFO
@@ -221410,7 +221410,7 @@ pFV
 spa
 pFV
 pFV
-dWX
+aci
 pFV
 gcR
 pNi
@@ -221436,7 +221436,7 @@ sQo
 frI
 vFL
 vFL
-nxu
+faD
 hYu
 bDP
 bDP
@@ -221612,8 +221612,8 @@ pFV
 pFV
 rIK
 rIK
-rLl
-dai
+kgc
+lDC
 cpp
 pNi
 lNk
@@ -222017,8 +222017,8 @@ rIK
 rIK
 pFV
 eCL
-rLl
-rVz
+kgc
+mlp
 bXS
 oqZ
 wud
@@ -222200,12 +222200,12 @@ uaC
 ksX
 ksX
 gcR
-hcX
 uit
 uit
 uit
-rIK
-rIK
+uit
+uit
+uit
 pFV
 rIK
 fFO
@@ -222218,9 +222218,9 @@ pFV
 gcR
 pfy
 eCL
-uwT
+iAm
 jez
-rLl
+kgc
 bXS
 oqZ
 oqZ
@@ -222422,7 +222422,7 @@ pFV
 pMh
 mGO
 rIK
-xgt
+whK
 bXS
 bXS
 oqZ
@@ -223027,8 +223027,8 @@ fFO
 pFV
 pFV
 gcR
-rLl
-rLl
+kgc
+kgc
 vrW
 pFV
 foN
@@ -223229,8 +223229,8 @@ fFO
 fFO
 fLu
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
 oxw
@@ -223432,8 +223432,8 @@ fFO
 pFV
 svK
 svK
-rLl
-rLl
+kgc
+kgc
 fFO
 piv
 oqZ
@@ -223634,8 +223634,8 @@ xPA
 pFV
 spa
 svK
-rLl
-csI
+kgc
+oMm
 pFV
 foN
 oqZ
@@ -223836,7 +223836,7 @@ xPA
 pFV
 qoI
 pFV
-rLl
+kgc
 jez
 fFO
 foN
@@ -224037,10 +224037,10 @@ uxZ
 mGO
 pFV
 fLu
-rLl
+kgc
 pFV
-rLl
-rLl
+kgc
+kgc
 piv
 oqZ
 cPj
@@ -224240,9 +224240,9 @@ fFO
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
-dzg
+ljd
 piv
 oqZ
 ilL
@@ -224442,8 +224442,8 @@ xPA
 pFV
 pFV
 vrW
-rLl
-csI
+kgc
+oMm
 rIK
 foN
 gAa
@@ -224644,8 +224644,8 @@ tnk
 pFV
 fLu
 pFV
-rLl
-dAK
+kgc
+oFA
 pFV
 qiM
 oqZ
@@ -224846,7 +224846,7 @@ fFO
 pFV
 huJ
 vbq
-rLl
+kgc
 pFV
 rIK
 piv
@@ -225044,11 +225044,11 @@ pFV
 dce
 pFV
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
 qiM
@@ -225244,12 +225244,12 @@ pFV
 fKS
 fKS
 pFV
-rLl
-dAK
-rLl
+kgc
+oFA
+kgc
 pFV
 fLu
-rLl
+kgc
 igM
 pFV
 rIK
@@ -225447,7 +225447,7 @@ pFV
 pFV
 hcX
 pFV
-dai
+lDC
 pFV
 qPl
 pFV
@@ -225850,11 +225850,11 @@ pFV
 pFV
 rIK
 pFV
-rLl
-rKL
+kgc
+rkx
 pFV
 xGe
-rLl
+kgc
 pFV
 pFV
 pFV
@@ -226051,12 +226051,12 @@ tBq
 pFV
 pFV
 fLu
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
 gcR
@@ -226252,15 +226252,15 @@ vbq
 hcX
 pFV
 pfy
-rLl
-csI
+kgc
+oMm
 pFV
-rVz
-rLl
-rLl
+mlp
+kgc
+kgc
 gcR
 igM
-rLl
+kgc
 igM
 rIK
 piv
@@ -226462,7 +226462,7 @@ gcR
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
 mGO
 tjB
@@ -226664,7 +226664,7 @@ pfy
 pFV
 mGO
 eCL
-kgc
+mJx
 pFV
 dHz
 piv
@@ -227260,9 +227260,9 @@ mGO
 pFV
 pFV
 pFV
-dai
-rLl
-rLl
+lDC
+kgc
+kgc
 pFV
 pFV
 pFV
@@ -227461,18 +227461,18 @@ igM
 pFV
 pFV
 pFV
-rLl
-rVz
-rLl
-rLl
-rLl
+kgc
+mlp
+kgc
+kgc
+kgc
 mGO
 pFV
 pFV
 myK
 rIK
 pvI
-rVz
+mlp
 pFV
 pFV
 wud
@@ -227663,19 +227663,19 @@ pFV
 pFV
 pFV
 pFV
-rLl
-rLl
-rLl
-rLl
-rLl
+kgc
+kgc
+kgc
+kgc
+kgc
 pFV
 pFV
 pFV
 rIK
 rIK
 pFV
-rLl
-rLl
+kgc
+kgc
 pfy
 wud
 oqZ
@@ -227865,19 +227865,19 @@ pFV
 pFV
 pFV
 qPl
-rLl
-rLl
+kgc
+kgc
 pFV
-rVz
-rLl
+mlp
+kgc
 pFV
 pFV
 mGO
 pFV
 pFV
-rLl
-rLl
-rLl
+kgc
+kgc
+kgc
 pFV
 wud
 oqZ
@@ -228066,20 +228066,20 @@ pFV
 pFV
 pFV
 pFV
-rVz
+mlp
 pFV
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
 pFV
 pfy
 fyM
 pFV
-rLl
-dai
-rLl
+kgc
+lDC
+kgc
 bUO
 wud
 oqZ
@@ -228269,7 +228269,7 @@ pfy
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
 pfy
 pFV
@@ -228279,8 +228279,8 @@ igM
 pFV
 pFV
 rIK
-rLl
-rLl
+kgc
+kgc
 pFV
 fFO
 wud
@@ -228471,8 +228471,8 @@ pFV
 pFV
 pFV
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
 pFV
@@ -228482,7 +228482,7 @@ pFV
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
 fFO
 wud
@@ -228674,7 +228674,7 @@ pMh
 pMh
 pFV
 pfy
-rLl
+kgc
 pFV
 qPl
 pFV
@@ -228684,7 +228684,7 @@ pFV
 pFV
 pFV
 rIK
-csI
+oMm
 pFV
 pFV
 wud
@@ -228871,14 +228871,14 @@ mfN
 saN
 pFV
 qPl
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
 pFV
 pFV
@@ -229074,13 +229074,13 @@ bSt
 pFV
 pFV
 pFV
-kgc
+mJx
 pMh
 pFV
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
 pFV
 pFV
@@ -229277,17 +229277,17 @@ pFV
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
 pFV
 fFO
 pFV
 pFV
-rLl
+kgc
 pFV
 pFV
 pFV
@@ -229478,17 +229478,17 @@ bSt
 pMh
 pMh
 pFV
-rLl
+kgc
 pFV
 pFV
 qPl
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
-fyz
+lpt
 pFV
-rLl
+kgc
 pFV
 pFV
 igM
@@ -229680,17 +229680,17 @@ bSt
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
 pFV
-rLl
-rLl
+kgc
+kgc
 jez
-rLl
+kgc
 pFV
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
 mGO
 pFV
@@ -229881,12 +229881,12 @@ mfN
 bSt
 pFV
 pFV
-rLl
+kgc
 jez
 pFV
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
 pFV
@@ -230084,11 +230084,11 @@ rnc
 pFV
 pFV
 fLu
-rLl
+kgc
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
 pFV
 pFV
@@ -230286,12 +230286,12 @@ bSt
 vFX
 bSt
 bSt
-rwR
+pOp
 pFV
 dHz
-fyz
-rLl
-rVz
+lpt
+kgc
+mlp
 pFV
 pFV
 fLu
@@ -230303,7 +230303,7 @@ pFV
 pFV
 pFV
 mGO
-eHp
+mtH
 oqZ
 oGj
 gSS
@@ -230487,7 +230487,7 @@ mfN
 bSt
 bSt
 bSt
-bky
+frH
 bSt
 pFV
 pFV
@@ -230505,7 +230505,7 @@ pMh
 pFV
 pFV
 lPo
-eHp
+mtH
 oqZ
 oGj
 onw
@@ -230689,7 +230689,7 @@ mfN
 bSt
 ccn
 dyf
-rwR
+pOp
 bSt
 pFV
 igM
@@ -230707,7 +230707,7 @@ qPl
 pFV
 pFV
 vbq
-lPr
+wes
 oqZ
 oGj
 onw
@@ -230899,7 +230899,7 @@ igM
 pFV
 igM
 oRK
-rLl
+kgc
 vbq
 pFV
 igM
@@ -231093,14 +231093,14 @@ mfN
 bSt
 bSt
 bSt
-rwR
-rwR
+pOp
+pOp
 pMh
 pFV
 vbq
 pFV
-rVz
-rVz
+mlp
+mlp
 pFV
 tlE
 pFV
@@ -231296,7 +231296,7 @@ aUQ
 bSt
 bSt
 bSt
-rwR
+pOp
 pfy
 dHz
 tlE
@@ -231496,10 +231496,10 @@ gBT
 gBT
 gBT
 gBT
-yam
+sea
 gBT
-rwR
-rLl
+pOp
+kgc
 pFV
 pFV
 pFV
@@ -231507,11 +231507,11 @@ jez
 pFV
 pMh
 pFV
-rLl
-biw
+kgc
+grQ
 pFV
 pFV
-rLl
+kgc
 pFV
 pFV
 pFV
@@ -231701,19 +231701,19 @@ hIM
 hjy
 dKC
 gBT
-rLl
+kgc
 pMh
 pFV
 pFV
 lPo
-rLl
+kgc
 qPl
-rLl
-rLl
+kgc
+kgc
 vbq
 pfy
 pFV
-kgc
+mJx
 pFV
 pFV
 kni
@@ -231902,20 +231902,20 @@ gSR
 gSR
 gSR
 vUx
-mwH
-rLl
-dYd
+ssF
+kgc
+tLx
 mGO
 pFV
 vbq
-dai
+lDC
 pFV
 pFV
-rLl
-qGy
+kgc
+gbY
 vbq
 pFV
-rVz
+mlp
 pFV
 pFV
 pFV
@@ -232105,18 +232105,18 @@ gSR
 gSR
 wAo
 gBT
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
 fLu
-rLl
+kgc
 igM
 pFV
 pFV
@@ -232307,22 +232307,22 @@ gSR
 gSR
 mRx
 gBT
-rLl
+kgc
 pFV
 pFV
 pFV
 pFV
 tzc
 pFV
-rLl
+kgc
 pFV
 igM
-jnv
-rLl
-dai
-vbq
+nCy
 kgc
-fyz
+lDC
+vbq
+mJx
+lpt
 qdc
 oqZ
 oGj
@@ -232508,15 +232508,15 @@ gSR
 gSR
 gSR
 qrl
-lKn
-lKn
-yam
-lKn
-lKn
+dAK
+dAK
+sea
+dAK
+dAK
 gBT
 bSt
 bSt
-rLl
+kgc
 mGO
 pFV
 igM
@@ -232524,7 +232524,7 @@ pFV
 igM
 igM
 pFV
-dai
+lDC
 fXd
 oqZ
 oGj
@@ -232710,13 +232710,13 @@ gSR
 gSR
 lCC
 yjc
-pDm
+cYr
 tQk
 fnK
 fnK
-axd
-axd
-axd
+izH
+izH
+izH
 yjc
 pFV
 pMh
@@ -232724,7 +232724,7 @@ pFV
 vbq
 pFV
 pMh
-rVz
+mlp
 pFV
 nPL
 wud
@@ -232919,14 +232919,14 @@ sTl
 qTf
 kOv
 kOv
-fAp
-rLl
-rLl
+xYT
+kgc
+kgc
 pFV
 igM
 pFV
-rLl
-rVz
+kgc
+mlp
 pFV
 pFV
 wud
@@ -233125,8 +233125,8 @@ rnV
 pFV
 pFV
 pFV
-rLl
-rLl
+kgc
+kgc
 mGO
 tlE
 pFV
@@ -233323,13 +233323,13 @@ iPV
 vjP
 vjP
 gsH
-ail
+boe
 pFV
-rLl
+kgc
 pMh
-rLl
+kgc
 pFV
-biw
+grQ
 pFV
 pFV
 pFV
@@ -233527,14 +233527,14 @@ vjP
 aSZ
 uBR
 pFV
-rLl
+kgc
 dHz
-fyz
-rLl
-rVz
+lpt
+kgc
+mlp
 pFV
 pFV
-dai
+lDC
 hys
 oqZ
 sqf
@@ -233727,15 +233727,15 @@ bGe
 iPV
 vjP
 kOv
-fAp
-kfT
-rLl
+xYT
+vDC
+kgc
 pFV
 fLu
-rLl
+kgc
 igM
 pFV
-rLl
+kgc
 igM
 hys
 oqZ
@@ -234132,13 +234132,13 @@ vjP
 vjP
 aSZ
 uBR
-rLl
+kgc
 mGO
 pFV
-rVz
-rLl
-rVz
+mlp
 kgc
+mlp
+mJx
 pFV
 pFV
 tjB
@@ -234333,7 +234333,7 @@ qyM
 vjP
 vjP
 qTf
-qSj
+bAG
 pFV
 pMh
 pFV
@@ -234535,7 +234535,7 @@ vjP
 vjP
 vjP
 sTl
-ail
+boe
 pFV
 pFV
 pFV
@@ -234544,7 +234544,7 @@ pMh
 pFV
 igM
 pFV
-rLl
+kgc
 fXd
 oqZ
 sqf
@@ -234746,7 +234746,7 @@ pFV
 mGO
 pMh
 pFV
-kgc
+mJx
 piv
 oqZ
 sqf
@@ -234948,7 +234948,7 @@ pFV
 lPo
 pFV
 pFV
-rLl
+kgc
 piv
 oqZ
 sqf
@@ -235145,11 +235145,11 @@ yjc
 pFV
 pFV
 qPl
-rLl
-rLl
+kgc
+kgc
 vbq
 qwl
-rLl
+kgc
 fFO
 wud
 oqZ
@@ -235347,10 +235347,10 @@ spF
 pFV
 pFV
 pFV
-rLl
+kgc
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
 pFV
 bFA
@@ -235546,12 +235546,12 @@ gBD
 sDV
 bXm
 spF
-nIC
+axs
 pFV
-rLl
-rLl
+kgc
+kgc
 pFV
-rLl
+kgc
 tzc
 pFV
 pFV
@@ -235748,8 +235748,8 @@ gBD
 sDV
 bXm
 spF
-nIC
-nIC
+axs
+axs
 pFV
 pFV
 pFV
@@ -235951,12 +235951,12 @@ sDV
 bXm
 spF
 spF
-nIC
+axs
 qPl
 pFV
-nJp
+dai
 pFV
-hWz
+bAR
 aYl
 aYl
 aYl
@@ -236158,7 +236158,7 @@ vvA
 vvA
 hPj
 hcX
-sJq
+sjU
 aYl
 aYl
 aYl
@@ -236358,8 +236358,8 @@ bXm
 bXm
 bXm
 bXm
-ehm
 azv
+yaH
 aYl
 aYl
 aYl

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -176,7 +176,7 @@
 "acb" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table/woodentable,
-/turf/simulated/floor/wood/wild1,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "acc" = (
 /obj/machinery/light/small{
@@ -238,14 +238,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
-"acT" = (
-/obj/effect/floor_decal/rust,
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/grille,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance{
-	name = "Residential District Maintenance"
-	})
 "acV" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/swo/quarters)
@@ -2755,15 +2747,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"aCG" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/item/device/synthesized_instrument/guitar,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "aCI" = (
 /obj/structure/table/standard,
 /obj/random/medical/low_chance,
@@ -3849,9 +3832,11 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
 "aPL" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/random/flora/jungle_tree,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "aPN" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -4649,14 +4634,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"bab" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "bae" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/bushb1,
@@ -5093,7 +5070,6 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/hallway/side/f2section1)
 "beg" = (
-/obj/effect/floor_decal/rust,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance{
@@ -5122,11 +5098,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/command/courtroom)
 "bex" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance{
-	name = "Residential District Maintenance"
-	})
+/obj/item/ammo_casing,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "beG" = (
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/rock,
@@ -5467,11 +5441,6 @@
 "bid" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/server)
-"bif" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "big" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/material/shard,
@@ -5486,10 +5455,8 @@
 	name = "Residential District Maintenance"
 	})
 "bii" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "bil" = (
 /obj/structure/disposaloutlet{
@@ -9581,10 +9548,14 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
 "cbI" = (
-/obj/structure/flora/small/bushb1,
-/obj/structure/flora/big/bush2,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/bed/psych{
+	desc = "It can be a bit noisy, but still serves well.";
+	name = "old bed"
+	},
+/obj/structure/curtain/open/bed{
+	name = "tarnished curtain"
+	},
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "cbM" = (
 /obj/structure/cable/green{
@@ -10607,10 +10578,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"cnr" = (
-/obj/structure/flora/small/bushb1,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "cns" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/cloth,
@@ -12525,10 +12492,6 @@
 	tag = "icon-escpodwall17"
 	},
 /area/shuttle/surface_transport_lz)
-"cIG" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "cII" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13437,15 +13400,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"cRE" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "cRH" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -16589,9 +16543,10 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "dyx" = (
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/plating/under,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/small/rock5,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "dyy" = (
 /obj/machinery/door/airlock/medical{
@@ -17470,10 +17425,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
-"dIg" = (
-/obj/structure/flora/small/bushb3,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "dIj" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,10"
@@ -17690,7 +17641,7 @@
 /obj/structure/table/woodentable,
 /obj/random/junkfood/low_chance,
 /obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/wood/wild1,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "dKg" = (
 /obj/item/trash/liquidfood,
@@ -18633,12 +18584,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
-"dUU" = (
-/obj/structure/girder,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/outside/forest)
 "dVj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -19527,10 +19472,6 @@
 /obj/structure/flora/small/rock4,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/bcave)
-"edZ" = (
-/obj/structure/flora/big/bush1,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "eeb" = (
 /obj/machinery/button/remote/airlock{
 	id = "shuttle_scav_bolts";
@@ -19553,10 +19494,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"eev" = (
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "eey" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22243,7 +22180,9 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
 "eGw" = (
-/turf/simulated/wall/wood_barrel,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "eGz" = (
 /obj/effect/floor_decal/industrial/outline/red,
@@ -23363,7 +23302,8 @@
 	name = "old bed"
 	},
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/wood/wild1,
+/obj/random/gun_parts/low,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "eQJ" = (
 /obj/machinery/camera/network/research,
@@ -27833,8 +27773,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/command/courtroom)
 "fNL" = (
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "fNM" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -28443,11 +28383,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"fVk" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/big/bush1,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "fVl" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/monofloor,
@@ -28523,14 +28458,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/inside_colony)
-"fWu" = (
-/obj/effect/damagedfloor/fire,
-/obj/effect/decal/cleanable/ash,
-/obj/machinery/microwave/burnbarrel,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "fWx" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 1
@@ -28680,11 +28607,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
-"fYw" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "fYz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32559,9 +32481,8 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/west)
 "gNS" = (
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/unsimulated/wall/jungle,
+/obj/structure/flora/big/bush2,
+/turf/simulated/wall/wood_old,
 /area/nadezhda/outside/forest)
 "gNV" = (
 /obj/structure/disposalpipe/segment,
@@ -33179,10 +33100,6 @@
 /obj/structure/flora/small/trailrocka4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/absolutism/chapel)
-"gTX" = (
-/obj/structure/flora/big/bush3,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "gTZ" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "6,2";
@@ -34156,10 +34073,8 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "heY" = (
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/random/gun_parts/low,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "hfa" = (
 /obj/structure/cable/green{
@@ -34330,13 +34245,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
-"hgS" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/big/bush1,
-/obj/structure/flora/small/bushb1,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "hgU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/style,
@@ -35234,8 +35142,8 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "hro" = (
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "hrp" = (
 /obj/structure/railing{
@@ -35318,8 +35226,7 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
 "hsf" = (
-/obj/structure/girder,
-/turf/simulated/floor/plating/under,
+/turf/simulated/wall/wood_old,
 /area/nadezhda/outside/forest)
 "hsg" = (
 /obj/structure/table/rack/shelf,
@@ -36468,10 +36375,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm3)
-"hDv" = (
-/obj/effect/damagedfloor/fire,
-/turf/unsimulated/wall/jungle,
-/area/nadezhda/outside/forest)
 "hDz" = (
 /obj/effect/decal/cleanable/spiderling_remains,
 /obj/effect/spider/stickyweb,
@@ -37928,12 +37831,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
-"hTk" = (
-/obj/structure/flora/small/bushb1,
-/obj/structure/flora/big/bush3,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "hTo" = (
 /obj/structure/table/steel,
 /obj/random/material_resources,
@@ -39464,10 +39361,8 @@
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "igB" = (
-/obj/structure/flora/small/grassb1,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/table/bench/wooden,
+/turf/simulated/wall/wood_old,
 /area/nadezhda/outside/forest)
 "igD" = (
 /obj/effect/floor_decal/spline/plain{
@@ -39597,9 +39492,10 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
 "ihH" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "ihJ" = (
 /obj/structure/catwalk,
@@ -41129,7 +41025,6 @@
 	tag = "icon-danger (WEST)"
 	},
 /obj/effect/decal/cleanable/rubble,
-/obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
@@ -41638,10 +41533,8 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
 "iEe" = (
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/plating/under,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "iEk" = (
 /obj/machinery/petrel_maker,
@@ -42090,8 +41983,11 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
 "iIR" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "iIX" = (
 /obj/structure/table/reinforced,
@@ -42527,11 +42423,6 @@
 /obj/machinery/sleeper,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
-"iOK" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/small/bushb1,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "iOV" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
@@ -45337,8 +45228,11 @@
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/surgery)
 "jrZ" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "jsa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -49948,11 +49842,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"kpF" = (
-/obj/structure/flora/small/grassa4,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "kpI" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/grille/broken,
@@ -51700,10 +51589,8 @@
 /turf/simulated/wall/wood_barrel,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kJa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "kJc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -51990,11 +51877,6 @@
 "kMg" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/substation/cargo)
-"kMr" = (
-/obj/structure/flora/ausbushes/pointybush,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "kMD" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/wall/r_wall,
@@ -52775,11 +52657,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
-"kVC" = (
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "kVE" = (
 /obj/structure/table/woodentable,
 /obj/random/firstaid,
@@ -52976,10 +52853,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
-"kXH" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "kXO" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -54763,7 +54636,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "luh" = (
-/turf/simulated/floor/plating/under,
+/obj/structure/bed/psych{
+	desc = "It can be a bit noisy, but still serves well.";
+	name = "old bed"
+	},
+/obj/structure/curtain/open/bed,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "lui" = (
 /obj/structure/toilet{
@@ -55191,13 +55069,6 @@
 /obj/item/storage/fancy/egg_box,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/crew_quarters/kitchen)
-"lyV" = (
-/obj/structure/flora/big/bush1,
-/obj/structure/flora/small/bushb1,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "lzb" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -55252,7 +55123,11 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
 "lzF" = (
-/mob/living/simple_animal/hostile/snake,
+/mob/living/simple_animal/hostile/snake{
+	faction = "neutral";
+	name = "young viper";
+	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm."
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
 "lzO" = (
@@ -57221,8 +57096,9 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "lUU" = (
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/plating/under,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "lUY" = (
 /obj/structure/table/rack,
@@ -57324,12 +57200,9 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "lVU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "lVY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -59251,9 +59124,11 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/xenobiology)
 "mpP" = (
-/obj/structure/bed/chair,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/big/rocks1,
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "mpR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -60118,9 +59993,8 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "mzI" = (
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "mzJ" = (
@@ -60361,13 +60235,6 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/east)
-"mBL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "mBM" = (
 /obj/structure/table/marble,
 /obj/structure/extinguisher_cabinet{
@@ -61919,12 +61786,9 @@
 	},
 /area/shuttle/surface_transport_lz)
 "mRZ" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "mSb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62706,10 +62570,10 @@
 	name = "Residential District Maintenance"
 	})
 "mZS" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "mZU" = (
 /obj/random/furniture/pottedplant,
@@ -63426,7 +63290,6 @@
 	tag = "icon-danger (WEST)"
 	},
 /obj/effect/decal/cleanable/rubble,
-/obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance{
@@ -65089,12 +64952,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"nyo" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "nyr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
@@ -66759,11 +66616,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
-"nOi" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "nOn" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -67287,13 +67139,6 @@
 /obj/structure/coatrack,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/farm)
-"nUy" = (
-/obj/structure/girder,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/outside/forest)
 "nUD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -68117,14 +67962,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/crew_quarters/pool)
-"oci" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/curtain/open/shower,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/dirt/mud,
-/area/nadezhda/outside/forest)
 "ocq" = (
 /obj/item/modular_computer/console/preset/engineering/alarms{
 	dir = 1
@@ -69107,11 +68944,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/rnd/server)
-"oma" = (
-/obj/structure/flora/ausbushes/pointybush,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "omb" = (
 /obj/random/tool/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -71482,10 +71314,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"oKz" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "oKA" = (
 /obj/item/stack/ore,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -71745,12 +71573,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
-"oNC" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "oNK" = (
 /obj/structure/flora/small/trailrockb1,
 /turf/simulated/floor/rock,
@@ -72263,13 +72085,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfaceeast)
 "oSE" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/small/rock3,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "oSF" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -72508,7 +72326,6 @@
 "oVk" = (
 /obj/machinery/cryopod,
 /obj/structure/catwalk,
-/obj/effect/floor_decal/rust,
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
 	},
@@ -72571,10 +72388,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
-"oVX" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "oVZ" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/hallway/side/f2section1)
@@ -72979,7 +72792,8 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
 "oZO" = (
-/turf/simulated/wall/wood,
+/obj/structure/flora/big/bush1,
+/turf/simulated/wall/wood_old,
 /area/nadezhda/outside/forest)
 "oZR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -74051,7 +73865,6 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
 "plW" = (
-/obj/effect/floor_decal/rust,
 /obj/item/reagent_containers/glass/bucket,
 /obj/random/structures/low_chance,
 /turf/simulated/floor/plating/under,
@@ -75551,7 +75364,6 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/small/trailrocka2,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/effect/floor_decal/rust,
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance{
@@ -76798,7 +76610,7 @@
 "pOC" = (
 /obj/structure/flora/small/grassb1,
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/asteroid/dirt/burned,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "pOI" = (
 /obj/effect/decal/cleanable/rubble,
@@ -77996,7 +77808,6 @@
 "pZL" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/small/trailrocka4,
-/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
@@ -78471,12 +78282,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"qeL" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "qeO" = (
 /obj/structure/railing{
 	dir = 8
@@ -80805,9 +80610,11 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "qDv" = (
-/obj/structure/girder,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/plating/under,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "qDC" = (
 /obj/effect/decal/cleanable/solid_biomass,
@@ -82097,7 +81904,6 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
 "qRR" = (
-/obj/effect/floor_decal/rust,
 /obj/random/closet_maintloot,
 /obj/random/contraband,
 /obj/random/credits,
@@ -82379,10 +82185,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
-"qVc" = (
-/obj/structure/girder,
-/turf/simulated/shuttle/plating,
-/area/nadezhda/outside/forest)
 "qVf" = (
 /obj/machinery/alarm{
 	pixel_y = 32
@@ -83321,8 +83123,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
 "rfo" = (
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/grass,
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "rfq" = (
 /obj/random/cluster/roaches/low_chance,
@@ -83357,9 +83159,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
 "rfB" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/table/bench/wooden,
+/obj/item/device/synthesized_instrument/guitar,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "rfG" = (
 /obj/structure/plushie/beepsky,
@@ -85139,7 +84941,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "ryY" = (
-/turf/simulated/floor/wood/wild1,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/forest)
 "rza" = (
 /obj/machinery/autolathe,
@@ -88089,10 +87893,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "sem" = (
-/obj/structure/flora/big/bush1,
-/obj/structure/flora/small/bushb1,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "sep" = (
 /turf/simulated/floor/carpet,
@@ -90321,12 +90126,6 @@
 /obj/structure/closet/secure_closet/warden,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/armory)
-"sAI" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/pointybush,
-/obj/effect/damagedfloor/fire,
-/turf/unsimulated/wall/jungle,
-/area/nadezhda/outside/forest)
 "sAK" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "15,6";
@@ -92253,9 +92052,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
 "sXm" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/random/flora/small_jungle_tree,
+/obj/structure/flora/big/bush2,
+/turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "sXn" = (
 /obj/structure/cable/green{
@@ -94867,10 +94666,6 @@
 /obj/random/booze/low_chance,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm3)
-"tzW" = (
-/obj/structure/flora/small/bushb3,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "tAg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -95912,10 +95707,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"tKz" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "tKH" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -96966,7 +96757,11 @@
 	},
 /area/shuttle/surface_transport_lz)
 "tUo" = (
-/mob/living/simple_animal/hostile/snake,
+/mob/living/simple_animal/hostile/snake{
+	faction = "neutral";
+	name = "young viper";
+	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm."
+	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/lakeside)
 "tUr" = (
@@ -97461,7 +97256,7 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
 "tZJ" = (
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "tZL" = (
 /obj/machinery/camera/network/colony_underground{
@@ -97592,7 +97387,6 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfacesec)
 "ubg" = (
-/obj/effect/floor_decal/rust,
 /obj/random/closet_maintloot,
 /obj/random/contraband,
 /obj/random/credits,
@@ -99670,8 +99464,9 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
 "uwP" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/small/rock3,
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "uxd" = (
@@ -103616,12 +103411,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/hallways)
-"vld" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "vlh" = (
 /obj/random/structures/os,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -105132,8 +104921,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "vBR" = (
-/obj/random/flora/jungle_tree,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 25;
+	pixel_x = -13;
+	layer = 4.2
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "vBV" = (
 /obj/structure/grille/broken,
@@ -105141,10 +104935,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "vBX" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = -4;
+	layer = 4.2
+	},
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "vCe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -105523,9 +105318,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "vFv" = (
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "vFx" = (
@@ -108025,12 +107821,12 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/crew_quarters/techshop)
 "wdD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/glass/bucket{
-	desc = "It's a bucket. It looks.. stained.";
-	name = "suspicous bucket"
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_x = 6;
+	pixel_y = 18;
+	layer = 4.2
 	},
-/turf/simulated/floor/asteroid/dirt/mud,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "wdH" = (
 /obj/structure/window/reinforced{
@@ -108974,7 +108770,7 @@
 /obj/structure/table/woodentable,
 /obj/random/booze/low_chance,
 /obj/random/gun_handmade/low_chance,
-/turf/simulated/floor/wood/wild1,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "wob" = (
 /obj/structure/barricade,
@@ -109030,9 +108826,12 @@
 /turf/simulated/floor/asteroid/dirt/dark/plough,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "woI" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/grass,
+/mob/living/simple_animal/hostile/snake{
+	faction = "neutral";
+	name = "young viper";
+	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm."
+	},
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "woR" = (
 /obj/machinery/light_switch{
@@ -109629,7 +109428,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "wsJ" = (
-/mob/living/simple_animal/hostile/snake,
+/mob/living/simple_animal/hostile/snake{
+	faction = "neutral";
+	name = "young viper";
+	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm."
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "wsT" = (
@@ -110553,9 +110356,12 @@
 	name = "Residential District Maintenance"
 	})
 "wDQ" = (
-/obj/structure/girder,
-/obj/structure/girder,
-/turf/simulated/floor/plating/under,
+/mob/living/simple_animal/hostile/snake{
+	faction = "neutral";
+	name = "young viper";
+	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm."
+	},
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "wDS" = (
 /obj/structure/disposalpipe/segment{
@@ -111774,12 +111580,10 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
 "wRQ" = (
-/obj/structure/flora/big/bush1,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "wRU" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/effect/decal/cleanable/dirt,
@@ -112433,11 +112237,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"wZp" = (
-/obj/structure/flora/small/rock3,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "wZr" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -113317,10 +113116,10 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "xjS" = (
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/curtain/open/bed{
+	name = "tarnished curtain"
+	},
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "xjU" = (
 /turf/simulated/floor/tiled/dark/golden,
@@ -113754,9 +113553,10 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
 "xoo" = (
-/obj/random/lowkeyrandom/low_chance,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/machinery/microwave/burnbarrel,
+/obj/random/common_oddities/low_chance,
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/wall/wood_old,
 /area/nadezhda/outside/forest)
 "xos" = (
 /obj/structure/flora/small/busha1,
@@ -115010,11 +114810,15 @@
 /turf/simulated/mineral,
 /area/asteroid/cave)
 "xBg" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/big/bush1,
-/obj/structure/flora/small/bushb1,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/bed/psych{
+	desc = "It can be a bit noisy, but still serves well.";
+	name = "old bed"
+	},
+/obj/structure/curtain/open/bed{
+	name = "tarnished curtain"
+	},
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "xBi" = (
 /obj/structure/sink{
@@ -115694,8 +115498,8 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/security/detectives_office)
 "xHK" = (
-/obj/structure/flora/small/bushb2,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "xHM" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -117162,8 +116966,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xWI" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/big/bush2,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "xWK" = (
@@ -185477,7 +185281,7 @@ eBR
 wZE
 cFt
 rWi
-bex
+wZE
 naz
 qZP
 qZP
@@ -187496,7 +187300,7 @@ cZb
 rWi
 kJK
 hua
-acT
+aRq
 hua
 hua
 hua
@@ -203393,7 +203197,7 @@ aYl
 spF
 spF
 spF
-cLp
+rIK
 fFO
 fFO
 pFV
@@ -203595,8 +203399,8 @@ aYl
 spF
 izu
 spF
-cLp
-fFO
+wRQ
+pFV
 fFO
 pFV
 pvI
@@ -203798,7 +203602,7 @@ aYl
 aYl
 aYl
 cwC
-fFO
+spa
 fFO
 pFV
 pFV
@@ -204198,15 +204002,15 @@ aYl
 aYl
 aYl
 oBP
-bXS
+anq
 bXS
 bXS
 fFO
 fFO
 fFO
 pFV
-pFV
-pFV
+rIK
+rIK
 pFV
 pFV
 pFV
@@ -204407,9 +204211,9 @@ fFO
 fFO
 fFO
 fFO
-pFV
+spa
 rIK
-pFV
+rIK
 pFV
 cWF
 pFV
@@ -204605,11 +204409,11 @@ bXS
 cXf
 fFO
 fFO
+lVU
 fFO
-fFO
-fFO
+bex
 dWS
-fIj
+oSE
 fFO
 fFO
 pFV
@@ -204807,7 +204611,7 @@ oBP
 bXS
 fFO
 fFO
-fFO
+bex
 fFO
 fFO
 dWS
@@ -205210,7 +205014,7 @@ oBP
 oBP
 fFO
 fFO
-bif
+cLp
 fFO
 fFO
 fFO
@@ -205411,10 +205215,10 @@ aYl
 oBP
 oBP
 bXS
+lVU
 fFO
-fFO
-fFO
-fFO
+bex
+lVU
 fFO
 dWS
 fIj
@@ -205819,7 +205623,7 @@ bXS
 fFO
 fFO
 fFO
-fFO
+bex
 dWS
 fIj
 fFO
@@ -206020,7 +205824,7 @@ bXS
 bXS
 bXS
 fFO
-fFO
+lVU
 fFO
 dWS
 bXS
@@ -206226,8 +206030,8 @@ fFO
 fFO
 fFO
 fFO
-pFV
-pFV
+rIK
+rIK
 pFV
 pFV
 vrW
@@ -206629,7 +206433,7 @@ oBP
 oBP
 aYl
 cwC
-fFO
+pFV
 pFV
 pFV
 pFV
@@ -206831,7 +206635,7 @@ fFO
 fFO
 fFO
 fFO
-fFO
+pFV
 pFV
 pFV
 mGO
@@ -215368,8 +215172,8 @@ iRG
 iRG
 iRG
 kTO
-rTe
-rTe
+kTO
+kTO
 rTe
 kOj
 kOj
@@ -215569,9 +215373,9 @@ iRG
 iRG
 iRG
 kTO
-rTe
-rTe
-rTe
+ryY
+ryY
+kTO
 rTe
 kOj
 kOj
@@ -215770,12 +215574,12 @@ qWM
 iRG
 iRG
 kTO
-rTe
-mmJ
-mmJ
-cxU
-cxU
-cxU
+kTO
+kTO
+ryY
+ryY
+ryY
+rfo
 kOj
 kOj
 xkT
@@ -215970,17 +215774,17 @@ cCH
 kOj
 kOj
 kOj
+kTO
 kOj
-iGL
-fqz
-kMr
-fqz
-txQ
-tfW
-tfW
-tfW
+toz
+kOj
+ryY
+ryY
+ryY
+wdD
+cXA
 gbc
-tfW
+kOj
 tfW
 tfW
 cXA
@@ -216176,13 +215980,13 @@ kOj
 jBW
 vsS
 aff
-plu
-fqz
-fqz
-tfW
-tfW
-tfW
-tfW
+tlB
+ryY
+ryY
+ryY
+cxU
+oHv
+kOj
 cXA
 ePQ
 tfW
@@ -216378,17 +216182,17 @@ kOj
 kOj
 fqz
 plu
-fqz
-tfW
-bKm
+vBX
+ryY
+bii
 fqz
 txQ
 tfW
-sWJ
+kOj
+vFv
 tfW
-tfW
-tfW
-tfW
+keX
+cXA
 raN
 tfW
 aff
@@ -216580,12 +216384,12 @@ kOj
 iGL
 fqz
 fqz
-fqz
-olX
+woI
+ryY
+ryY
+cxU
 tfW
-tfW
-txQ
-tfW
+sWJ
 aff
 tfW
 tfW
@@ -216783,16 +216587,16 @@ kOj
 bKm
 fqz
 fqz
-tfW
-tfW
-tfW
+cxU
+cxU
+vBR
 vsS
 tfW
 tfW
 oPz
 cXA
 tfW
-rPI
+iIR
 tfW
 tiO
 txQ
@@ -216982,14 +216786,14 @@ kOj
 kOj
 kOj
 jRN
+toz
 fqz
-vsS
-tfW
-tfW
-tfW
+cri
+eGw
+txQ
 tfW
 fqz
-tfW
+sem
 tfW
 tfW
 tfW
@@ -217184,15 +216988,15 @@ kOj
 jBW
 fqz
 fqz
+kOj
 tfW
-tfW
-tfW
+keX
+hsf
 oZO
-oZO
-oZO
-oZO
-oZO
-oZO
+hsf
+hsf
+hsf
+hsf
 tfW
 tfW
 tfW
@@ -217386,19 +217190,19 @@ kOj
 kOj
 fKa
 tfW
+aPL
 tfW
-tfW
-wDQ
-qVc
-eQB
+hsf
+hsf
+fqz
 dKd
 acb
 eQB
-oZO
-oZO
+hsf
+hsf
+sem
 tfW
-tfW
-tfW
+ebv
 ucy
 ucy
 kOj
@@ -217591,13 +217395,13 @@ tfW
 tfW
 tfW
 hsf
+hro
+lOm
+wsJ
+wcY
 tZJ
-tZJ
-tZJ
-ryY
-ryY
 wnV
-oZO
+hsf
 tfW
 tfW
 tfW
@@ -217791,15 +217595,15 @@ fqz
 ucR
 tfW
 tfW
-tfW
+cXA
 hsf
-luh
-luh
+xBg
 tZJ
+mRZ
 tZJ
-tZJ
-eQB
-oZO
+wDQ
+cbI
+hsf
 tfW
 tfW
 tfW
@@ -217993,20 +217797,20 @@ mHv
 tfW
 tfW
 aff
-tfW
 qDv
-lUU
-lUU
-luh
-luh
+hsf
+tZJ
+xHK
+xoo
+rfB
 tZJ
 tZJ
-oZO
+hsf
 tfW
 tfW
 tfW
-jIz
-jIz
+tfW
+tfW
 xkT
 kOj
 kOj
@@ -218196,20 +218000,20 @@ fqz
 tfW
 tfW
 tfW
-dUU
-lUU
-lUU
-lUU
-lUU
-luh
-tZJ
+hsf
+wDQ
+fqz
+igB
+hsf
+fqz
+kJa
 hsf
 tfW
 oPz
 aff
-jIz
-jIz
 tfW
+tfW
+uwP
 kOj
 kOj
 ucy
@@ -218396,21 +218200,21 @@ mHv
 lOm
 fqz
 tfW
-tfW
-tfW
-nUy
-dyx
+cXA
+lOm
+hsf
+heY
 iEe
-lUU
-dyx
-lUU
+cri
+raN
+wDQ
 luh
 hsf
+sem
 tfW
 tfW
-jIz
-jIz
-jIz
+uwP
+tfW
 tiO
 tfW
 tfW
@@ -218594,25 +218398,25 @@ tfW
 xkT
 kOj
 toz
-cXA
-jIz
+iGL
+tfW
 fqz
 tfW
 tfW
 tfW
-nUy
+hsf
+hsf
 lUU
-lUU
+fNL
+fqz
 dyx
-dyx
-dyx
-lUU
+hsf
 hsf
 tfW
 tfW
-oPz
-jIz
-tfW
+jrZ
+kOj
+mZS
 tfW
 tfW
 tfW
@@ -218796,25 +218600,25 @@ jup
 kOj
 kOj
 iUc
-mmJ
-vBR
+kOj
+mHv
 gbc
 tfW
 tfW
-cxU
-lUU
-lUU
-lUU
-lUU
-dyx
-lUU
-qDv
-qDv
-jIz
-jIz
-jIz
-olX
 tfW
+tfW
+hsf
+hsf
+hsf
+xjS
+hsf
+hsf
+qDv
+tfW
+tfW
+uwP
+kOj
+kOj
 tfW
 tfW
 tfW
@@ -218998,24 +218802,24 @@ pQK
 pRX
 kOj
 cCH
-fqz
+toz
 tfW
 tfW
-iIR
+oPz
 tfW
+cXA
 tfW
-tfW
-rfo
+qDv
 cGa
-jIz
-rYV
-tfW
-tfW
-jIz
 tfW
 tfW
 tfW
 tfW
+tfW
+tfW
+tfW
+kOj
+mZS
 tfW
 cXA
 kOj
@@ -219199,25 +219003,25 @@ fqz
 fqz
 kOj
 xkT
-kkF
-fqz
+jBW
+xkT
 aff
-jIz
-cxU
-jIz
+tfW
+tfW
+tfW
 pOC
-jIz
-jIz
-wew
-bIc
-bIc
-obd
+tfW
+tfW
+ebv
+tfW
+tfW
+tfW
 oja
 tfW
-jIz
-jIz
-cGa
-tfW
+uwP
+kOj
+lUR
+kOj
 tfW
 tiO
 kOj
@@ -219402,27 +219206,27 @@ ked
 iGL
 kOj
 kYZ
-fqz
+toz
+kOj
 tfW
-jIz
-jIz
-cxU
-cxU
-eev
-wew
-obd
-kJa
-bIc
-obd
-obd
+tfW
+tfW
+tfW
 cGa
-jIz
-jIz
 tfW
+tfW
+ebv
+tfW
+tfW
+cXA
+cGa
+tfW
+kOj
+mZS
 tfW
 tfW
 kOj
-kOj
+mZS
 tfW
 tfW
 tfW
@@ -219604,24 +219408,24 @@ tfW
 kOj
 iGL
 kOj
-tfW
-cxU
-cxU
-jIz
-oja
-cxU
-jIz
-obd
-mBL
-bIc
-wMi
-kVC
-wew
-tfW
-gTX
 kOj
+tfW
+tfW
+tfW
+vcn
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tiO
+mZS
 cXA
-jIz
+tfW
 tfW
 kOj
 siR
@@ -219806,27 +219610,27 @@ mHv
 iGL
 tfW
 tfW
-jIz
 tfW
-jIz
-cxU
-jIz
-wew
-xoo
-mRZ
-cRE
-lVU
-bIc
-nyo
-igB
-cxU
-cTB
-kOj
 tfW
-jIz
-jIz
+tfW
+cXA
+tfW
+tfW
+tfW
+tfW
+tfW
+cXA
+tfW
+aff
+cAF
+tfW
+mpP
+mZS
+tfW
+tfW
+uwP
 kOj
-kOj
+mZS
 tfW
 tfW
 olX
@@ -220008,24 +219812,24 @@ tfW
 tfW
 tfW
 iGL
-jrZ
-jIz
-jIz
-cxU
-jIz
-wew
-mpP
-oqo
-oqo
-rYV
-wMi
-cxU
-cxU
-cxU
-cxU
-cxU
-jIz
-jIz
+fqz
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
 tiO
 kOj
 kOj
@@ -220210,25 +220014,25 @@ tfW
 xkT
 kOj
 kOj
-jrZ
-cxU
+fqz
 tfW
-jIz
-cIG
-cxU
-mpP
-bIc
-fWu
-kJa
-rYV
-ieb
-cxU
-cxU
-cxU
-cnr
 tfW
-cxU
-cxU
+tfW
+vaP
+cXA
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+nhY
+tfW
+tfW
+tfW
 kOj
 tfW
 tfW
@@ -220412,25 +220216,25 @@ tfW
 kOj
 kOj
 iGL
-jrZ
-cxU
-cxU
-jIz
-jIz
-obd
-mpP
-bIc
-srv
-kJa
-wMi
-ieb
-vld
-jIz
-tfW
-cxU
+fqz
 tfW
 tfW
-cxU
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+bSm
+tfW
+oPz
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
 cXA
 kOj
 tfW
@@ -220615,25 +220419,25 @@ kOj
 kOj
 qit
 fqz
-tzW
+txQ
 sTN
-jIz
-jIz
-cxU
-wew
-bab
-aCG
-rYV
-oqo
-wew
-wew
-wew
-jIz
-cxU
-fNL
-cxU
 tfW
 tfW
+tfW
+tfW
+tfW
+bSm
+iGL
+kOj
+tfW
+tfW
+tfW
+tfW
+tfW
+cXA
+tfW
+tfW
+uwP
 kOj
 tfW
 kEV
@@ -220816,24 +220620,24 @@ pRX
 kOj
 kOj
 hCP
-xfF
-jrZ
-jIz
-jIz
-jIz
-cxU
-wew
-ihH
-oqo
-rYV
-rYV
-obd
-wew
+oUl
+fqz
 tfW
-dIg
 tfW
-oKz
-hro
+tfW
+fqz
+tfW
+fWB
+kOj
+kOj
+ucy
+tfW
+tfW
+tfW
+txQ
+tfW
+aff
+cGa
 tfW
 tfW
 kOj
@@ -221019,23 +220823,23 @@ kOj
 kOj
 kOj
 tfW
-cxU
-tfW
-jIz
-eev
-cxU
-cxU
-jIz
-tKz
-rYV
-rYV
-wew
-jIz
 tfW
 tfW
 tfW
-jIz
-jIz
+cGa
+tfW
+tfW
+kOj
+kOj
+jBW
+cXA
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
 oHv
 tfW
 tfW
@@ -221220,27 +221024,27 @@ kOj
 kOj
 kOj
 xkT
-tlB
-cxU
-cxU
-jIz
-cxU
-cxU
-cxU
-obd
-jIz
-rYV
-rYV
-bIc
-srv
-cxU
+fqz
+tfW
+tfW
+tfW
+tfW
+tfW
+jBW
+kOj
+kOj
+jBW
+tfW
+tfW
+tfW
+tfW
 vgc
 tfW
 tfW
-jIz
-cxU
-srv
-cxU
+tfW
+tfW
+erZ
+tfW
 tfW
 tfW
 tfW
@@ -221425,23 +221229,23 @@ toz
 lOm
 aff
 tfW
-cxU
-cxU
-cxU
-cxU
-obd
-obd
-rYV
-bIc
-srv
-cxU
+tfW
+tfW
+tfW
+kOj
+kOj
+jBW
+hsf
+tfW
+tfW
+tfW
 tfW
 tfW
 tfW
 ePQ
-cxU
-rYV
-cxU
+tfW
+erZ
+tfW
 tfW
 tfW
 vaP
@@ -221625,16 +221429,16 @@ kOj
 dFD
 fqz
 fqz
-kXH
-jIz
-kXH
 tfW
-jIz
-jIz
-jIz
-wew
-oqo
-bIc
+tfW
+tfW
+tfW
+iGL
+kOj
+jBW
+iGL
+tfW
+tfW
 tfW
 tfW
 tfW
@@ -221827,18 +221631,18 @@ kYZ
 fqz
 fqz
 fqz
-olX
 tfW
-kEV
-cxU
-iIR
 tfW
+fqz
+tfW
+jBW
+kOj
 vcn
 tfW
-kJa
-bIc
-eGw
-eGw
+tfW
+tfW
+tfW
+tfW
 qzU
 tfW
 tfW
@@ -222031,17 +221835,17 @@ tfW
 tfW
 tfW
 tfW
+fqz
 tfW
-tfW
+kOj
+jBW
 tfW
 cxU
 tfW
-cxU
-srv
-bIc
-eGw
-oci
-srv
+txQ
+tfW
+tfW
+mzI
 tfW
 cGa
 tfW
@@ -222231,17 +222035,17 @@ tfW
 kOj
 kOj
 fqz
-uwP
-fqz
 tfW
 tfW
 tfW
+hsf
 tfW
+cXA
 cAF
-rfo
-srv
-bIc
-rfo
+tfW
+tfW
+tfW
+tfW
 srv
 tym
 tfW
@@ -222432,18 +222236,18 @@ tym
 tym
 cCH
 toz
-oVX
-jrZ
-jIz
-jIz
-jIz
-cxU
+tfW
+tfW
+cXA
+tfW
+hsf
+tfW
 cGa
-rfo
-rfo
-srv
-srv
-rfo
+tfW
+tfW
+tfW
+tfW
+tfW
 tfW
 tfW
 srv
@@ -222634,21 +222438,21 @@ cxU
 cxU
 kOj
 mzH
-jrZ
-jIz
-cxU
-cxU
 tfW
-wew
-cxU
-woI
 tfW
-srv
-srv
-eGw
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+hsf
+tfW
 rPI
 srv
-wdD
+erZ
 kOj
 kOj
 kOj
@@ -222836,18 +222640,18 @@ hVH
 cxU
 cxU
 aRW
-tlB
-tlB
-cxU
-cxU
-kVC
-wew
-jIz
-obd
-cxU
-srv
-srv
-eGw
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+fqz
+tfW
+tfW
+hsf
+hsf
+tfW
 tfW
 srv
 xkT
@@ -223033,22 +222837,22 @@ ebv
 tfW
 tfW
 nSG
-xfF
-kpF
-oma
-kVC
-mzI
-vFv
-oSE
-mzI
-kVC
-kVC
-hDv
-jIz
-oVX
-cxU
-srv
-srv
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+bSm
+bSm
+fqz
+tfW
+tfW
+tfW
+kOj
+kOj
 tfW
 tfW
 tiO
@@ -223235,23 +223039,23 @@ tfW
 jBW
 kOj
 ndz
-tlB
-rbE
-obd
-wew
-jIz
-toz
-mZS
-ieb
-jIz
-cxU
-obd
-rfo
-wew
-jIz
-rYV
-srv
 tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+kOj
+kOj
+bSm
+tfW
+tfW
+kOj
+kOj
+kOj
+cXA
 tfW
 kOj
 kOj
@@ -223435,25 +223239,25 @@ rqn
 jBW
 iGL
 kOj
-jIz
-kOj
-cxU
-sAI
-ieb
-jIz
-wew
-mZS
-mZS
-wew
-ieb
-ieb
-obd
-gNS
-wew
-jIz
-srv
-srv
 tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+sXm
+kOj
+kOj
+kOj
+gNS
+tfW
+tfW
+kOj
+kOj
+kOj
 tfW
 mHv
 tfW
@@ -223637,24 +223441,24 @@ xkT
 jBW
 kOj
 kOj
-jIz
-jIz
-jIz
-jIz
-wew
-wew
-ieb
-cxU
-cxU
-jIz
-jIz
-obd
-wew
-obd
-jIz
-jIz
-rYV
-srv
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+jBW
+kOj
+kOj
+kOj
+bSm
+fqz
+kOj
+kOj
 tfW
 tfW
 tfW
@@ -223839,29 +223643,29 @@ gcD
 jBW
 kOj
 kOj
-jIz
-jIz
-jIz
-wew
-obd
-obd
-ieb
-jIz
-oVX
-jIz
-wew
-mzI
-jIz
-kVC
-wew
 tfW
-rYV
-rYV
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+kOj
+tfW
+tfW
+tfW
+jBW
+kOj
+iGL
+bSm
+fqz
+fqz
+tfW
 tfW
 tfW
 tiO
 kOj
-kOj
+mZS
 tfW
 tfW
 tfW
@@ -224041,26 +223845,26 @@ fqz
 jBW
 kOj
 kOj
-kOj
-kOj
-jIz
-ieb
-jIz
-ieb
-wew
-vBX
-ieb
-jIz
-wew
-wew
-jIz
-rfo
-wew
-jIz
-rYV
-rYV
 tfW
 tfW
+tfW
+tfW
+tfW
+tfW
+kOj
+kOj
+tfW
+tfW
+tfW
+tfW
+jBW
+jBW
+fqz
+fqz
+tfW
+tfW
+tfW
+tiO
 tfW
 kOj
 kOj
@@ -224245,23 +224049,23 @@ kOj
 kOj
 kOj
 kOj
-kOj
-jIz
-ieb
-ieb
-jIz
-sXm
-mZS
-xjS
-kVC
-ieb
-wZp
-wew
-ieb
-jIz
-rYV
-srv
 tfW
+tfW
+tfW
+kOj
+kOj
+kOj
+tfW
+tfW
+tfW
+cXA
+tfW
+tfW
+tfW
+fqz
+fqz
+cXA
+ihH
 kOj
 kOj
 kOj
@@ -224448,25 +224252,25 @@ kOj
 kOj
 kOj
 kOj
-jIz
-jIz
-wew
-ieb
-jIz
-jrZ
-wew
-obd
-ieb
-jIz
-jIz
-ieb
-jIz
-srv
-srv
 tfW
 kOj
 kOj
 kOj
+kOj
+kOj
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+fqz
+tfW
+uwP
+kOj
+kOj
+mZS
 tfW
 tfW
 tfW
@@ -224652,21 +224456,21 @@ kOj
 kOj
 kOj
 kOj
-jIz
-jIz
-sXm
-nOi
-wew
-obd
-xjS
-wew
-xjS
-ieb
-pmc
-srv
-srv
+kOj
+kOj
+kOj
+kOj
 tfW
-iGL
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+nFW
 kOj
 tfW
 aGD
@@ -224854,19 +224658,19 @@ kOj
 kOj
 kOj
 kOj
-jIz
-fYw
-rfB
-nOi
-sXm
-jIz
-ieb
-wew
-xjS
-obd
+kOj
+kOj
+kOj
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+cXA
 tfW
 srv
-srv
+tfW
 tfW
 tfW
 tfW
@@ -225057,19 +224861,19 @@ kOj
 kOj
 kOj
 kOj
-nOi
-qeL
-jrZ
-jIz
-wew
-wRQ
-wew
-obd
-wew
+kOj
 tfW
-srv
-srv
 tfW
+tfW
+cXA
+tfW
+fqz
+tfW
+tfW
+tfW
+fqz
+xWI
+fqz
 lUx
 tfW
 tfW
@@ -225257,21 +225061,21 @@ rqn
 kOj
 kOj
 kOj
-jIz
-jIz
-nOi
-aPL
-bii
-wew
+kOj
 tfW
-lyV
-cxU
-obd
-wew
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+fqz
+fqz
+tfW
 tfW
 srv
 srv
-tfW
+fqz
 kOj
 kOj
 mHv
@@ -225459,17 +225263,17 @@ kOj
 kOj
 kOj
 kOj
-kOj
-tlB
-heY
-oNC
-nOi
-iOK
-wew
-cbI
-jIz
-wew
-kOj
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+fqz
+fqz
+fqz
+bSm
 tfW
 srv
 srv
@@ -225661,16 +225465,16 @@ kOj
 xkT
 kOj
 cxU
-cxU
-qCP
-tlB
-oVX
-jIz
-xBg
-cxU
-hTk
-jIz
-jIz
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+fqz
+fqz
 kOj
 tfW
 srv
@@ -225866,15 +225670,15 @@ fqz
 fqz
 tlB
 mkR
-mkR
-jIz
-hgS
 tfW
-sem
-jIz
-jIz
+tfW
+tfW
+tfW
+tfW
+tfW
+cXA
 kOj
-tfW
+bSm
 srv
 srv
 tfW
@@ -226069,11 +225873,11 @@ mZf
 vaP
 cxU
 iRu
-mkR
-fVk
-cxU
-jIz
-pGM
+tfW
+tfW
+tfW
+tfW
+bSm
 kOj
 kOj
 tfW
@@ -226271,11 +226075,11 @@ olX
 lEK
 olX
 tfW
-xWI
-pGM
-jIz
-edZ
-xHK
+tfW
+tfW
+tfW
+tfW
+tfW
 jBW
 ucy
 tfW
@@ -226473,10 +226277,10 @@ cxU
 cxU
 cxU
 cxU
-cxU
-jIz
-jIz
-jIz
+tfW
+tfW
+tfW
+tfW
 cxU
 cxU
 cxU

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -2077,6 +2077,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
+"avI" = (
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "avJ" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/catwalk,
@@ -2525,9 +2531,7 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
 "aAA" = (
-/obj/effect/damagedfloor/fire,
-/obj/effect/decal/cleanable/ash,
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/outside/forest)
 "aAH" = (
 /obj/structure/shuttle_part/mining{
@@ -2676,6 +2680,12 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/crew_quarters/dorm3)
+"aBG" = (
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "aBH" = (
 /obj/machinery/papershredder,
 /obj/item/device/radio/intercom{
@@ -3626,7 +3636,8 @@
 /area/colony)
 "aML" = (
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/asteroid/dirt/dark,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "aMM" = (
 /obj/structure/cable/cyan{
@@ -4443,6 +4454,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"aXv" = (
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/campground)
 "aXz" = (
 /obj/item/stool/custom/bar_special,
 /obj/effect/spider/stickyweb,
@@ -5786,6 +5801,11 @@
 /obj/effect/floor_decal/industrial/road/curve4,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"bkt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
@@ -7074,6 +7094,12 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"byU" = (
+/obj/structure/flora/small/grassb4,
+/obj/structure/flora/small/grassb4,
+/obj/structure/flora/big/rocks2,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/forest)
 "byV" = (
 /obj/structure/table/steel,
 /obj/random/credits/low_chance,
@@ -7941,7 +7967,8 @@
 	})
 "bIH" = (
 /obj/item/material/shard/shrapnel/scrap,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "bIL" = (
 /obj/random/furniture/painting,
@@ -11710,9 +11737,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
 "czf" = (
-/obj/item/stack/ore/slag,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/random/firstaid/low_chance,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "czA" = (
 /turf/simulated/shuttle/wall/mining{
@@ -12368,6 +12395,7 @@
 /area/nadezhda/crew_quarters/pool)
 "cFZ" = (
 /obj/structure/door_assembly/door_assembly_eng,
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "cGa" = (
@@ -12802,6 +12830,11 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
+"cKa" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/render,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "cKc" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -13683,8 +13716,8 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "cSk" = (
 /obj/structure/table,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "cSn" = (
 /turf/simulated/wall,
@@ -14338,6 +14371,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"cYP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "cYT" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -14619,6 +14657,11 @@
 /obj/machinery/gibber,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
+"dbT" = (
+/obj/effect/window_lwall_spawn,
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "dbU" = (
 /obj/machinery/light{
 	dir = 4
@@ -18273,6 +18316,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
+"dNV" = (
+/obj/item/scrap_lump,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "dOa" = (
 /obj/item/stool/custom/bar_special,
 /obj/effect/floor_decal/spline/fancy,
@@ -19309,7 +19357,7 @@
 /area/nadezhda/outside/pond)
 "dZv" = (
 /obj/item/scrap_lump,
-/turf/simulated/floor/asteroid/dirt/burned,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "dZw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
@@ -19552,6 +19600,10 @@
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/command/swo/quarters)
+"ebS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "ebT" = (
 /obj/structure/multiz/stairs/enter/bottom,
 /obj/structure/invislight,
@@ -20500,11 +20552,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "emi" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/item/material/shard,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/campground)
 "emo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22035,6 +22085,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"eAI" = (
+/obj/random/spider_trap_burrowing/low_chance,
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "eAK" = (
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
@@ -22110,8 +22167,8 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "eBP" = (
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/random/gun_handmade,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "eBR" = (
 /obj/structure/boulder,
@@ -22574,6 +22631,11 @@
 /mob/living/carbon/superior_animal/roach/elektromagnetisch,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"eHQ" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/simulated/wall,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "eIb" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -25472,6 +25534,12 @@
 /obj/item/device/lighting/toggleable/lamp,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
+"fkF" = (
+/obj/structure/girder,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "fkM" = (
 /obj/effect/floor_decal/industrial/arrows{
 	dir = 1
@@ -27570,7 +27638,8 @@
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/crew_quarters/dorm1)
 "fHw" = (
-/turf/simulated/floor/asteroid/dirt/dark,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "fHy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27815,6 +27884,7 @@
 /area/nadezhda/hallway/surface/section1)
 "fKl" = (
 /obj/structure/firedoor_assembly,
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "fKo" = (
@@ -28897,6 +28967,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"fWU" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "fWY" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -29182,6 +29258,13 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
+"gaq" = (
+/obj/effect/window_lwall_spawn,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "gas" = (
 /obj/machinery/camera/network/engineering{
 	dir = 4
@@ -31048,8 +31131,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
 "gsc" = (
-/obj/random/mob/termite_no_despawn,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "gsh" = (
@@ -31367,6 +31450,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
+"guX" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/outside/forest)
 "gvd" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush1,
@@ -31501,8 +31590,8 @@
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/courtroom)
 "gwu" = (
-/obj/item/stack/ore/slag,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/random/tool/advanced/low_chance,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "gwD" = (
 /turf/simulated/shuttle/floor/mining,
@@ -31746,7 +31835,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "gzw" = (
 /obj/structure/cable/green{
@@ -36527,6 +36616,12 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"hAO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/lighting/toggleable/lantern,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/campground)
 "hAT" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -37315,6 +37410,10 @@
 /obj/item/paper/monitorkey,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/command/cro)
+"hIi" = (
+/mob/living/simple_animal/hostile/render,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "hIk" = (
 /obj/machinery/newscaster{
 	pixel_y = -34
@@ -37751,7 +37850,6 @@
 	name = "Residential District Maintenance"
 	})
 "hLl" = (
-/obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "hLp" = (
@@ -38993,9 +39091,9 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "hYJ" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/campground)
 "hYL" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -39121,9 +39219,9 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "hZt" = (
-/obj/random/cluster/termite_no_despawn,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/dungeon/outside/burned_outpost)
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "hZv" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -40518,8 +40616,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ina" = (
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/dirt,
+/obj/item/remains,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "inc" = (
 /obj/landmark/join/start/roboticist,
@@ -40809,6 +40907,10 @@
 "iqg" = (
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
+/area/nadezhda/outside/forest)
+"iqn" = (
+/obj/structure/flora/small/grassb4,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest)
 "iqo" = (
 /obj/random/scrap/sparse_weighted,
@@ -42756,6 +42858,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"iMe" = (
+/obj/structure/low_wall,
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "iMg" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -42766,8 +42873,7 @@
 /area/nadezhda/outside/inside_colony)
 "iMj" = (
 /obj/item/material/shard/shrapnel/scrap,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "iMl" = (
 /obj/structure/bed/chair/sofa/black/right{
@@ -43676,8 +43782,8 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/farm)
 "iXi" = (
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "iXj" = (
 /obj/structure/cable/cyan{
@@ -44559,6 +44665,10 @@
 /obj/structure/low_wall,
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/atmos)
+"jgE" = (
+/obj/structure/girder,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "jgG" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/reedbush,
@@ -47045,8 +47155,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "jFR" = (
 /obj/item/material/shard/shrapnel,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "jFS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -48347,7 +48456,6 @@
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "jTa" = (
 /obj/structure/table/woodentable,
-/obj/item/device/lighting/toggleable/lamp/green,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/hunter_cabin)
 "jTd" = (
@@ -49031,6 +49139,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"kbg" = (
+/obj/structure/flora/big/bush3,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "kbj" = (
 /obj/structure/table/steel,
 /obj/effect/spider/stickyweb,
@@ -49309,6 +49422,10 @@
 "kdQ" = (
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"kdS" = (
+/obj/structure/barricade,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/campground)
 "kdX" = (
 /obj/structure/railing{
 	dir = 8
@@ -50004,9 +50121,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kkA" = (
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/forest)
 "kkF" = (
 /obj/structure/flora/big/bush2,
 /obj/random/flora/small_jungle_tree,
@@ -50336,6 +50452,16 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"kop" = (
+/obj/structure/girder/displaced,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/hunter_cabin)
 "koq" = (
 /obj/structure/lattice,
 /obj/structure/railing{
@@ -54834,6 +54960,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"loD" = (
+/obj/structure/low_wall,
+/obj/item/material/shard,
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "loI" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -55783,6 +55915,10 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"lyC" = (
+/obj/random/firstaid/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "lyI" = (
 /obj/structure/bed/chair/sofa/black/left{
 	dir = 4
@@ -60386,9 +60522,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
 "muX" = (
-/obj/structure/bed/chair,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/structure/barricade,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "muZ" = (
 /obj/effect/floor_decal/industrial/stand_clear{
 	dir = 4
@@ -64655,9 +64793,9 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "nmw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "nmG" = (
 /obj/random/cluster/termite_no_despawn/low_chance,
@@ -65059,6 +65197,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
+"nrd" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/outside/forest)
 "nrf" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/decal/cleanable/dirt,
@@ -65152,7 +65296,7 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "nsk" = (
 /obj/structure/table,
-/turf/simulated/floor/asteroid/dirt/burned,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "nsp" = (
 /obj/machinery/conveyor_switch{
@@ -66769,6 +66913,10 @@
 /obj/random/structures/low_chance,
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"nHi" = (
+/obj/random/knife/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "nHm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -67934,6 +68082,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"nTD" = (
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "nTH" = (
 /obj/machinery/atmospherics/pipe/zpipe/up,
 /turf/simulated/floor/plating/under,
@@ -69059,7 +69211,8 @@
 /area/nadezhda/engineering/atmos)
 "oeM" = (
 /obj/structure/girder,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "oeR" = (
 /obj/structure/cable/cyan{
@@ -69820,6 +69973,15 @@
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
+"olN" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/railing/grey,
+/obj/structure/flora/big/bush1,
+/obj/structure/girder/displaced,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/hunter_cabin)
 "olX" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -70856,6 +71018,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/janitor)
+"owX" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/item/scrap_lump,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "owZ" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/beach/water/jungle,
@@ -71715,10 +71883,7 @@
 	},
 /area/nadezhda/crew_quarters/sleep/bedrooms)
 "oFV" = (
-/obj/structure/table/woodentable,
-/obj/item/device/lighting/toggleable/lantern,
-/obj/item/device/lighting/toggleable/lantern,
-/turf/simulated/floor/wood/wild5,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/campground)
 "oFY" = (
 /obj/structure/boulder,
@@ -74231,6 +74396,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/security/maingate)
+"pfP" = (
+/obj/effect/window_lwall_spawn,
+/obj/structure/flora/big/bush2,
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "pfU" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -75315,6 +75486,16 @@
 /obj/structure/table/bench/standard,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
+"prt" = (
+/obj/effect/overlay/water,
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_x = 6;
+	pixel_y = 18;
+	layer = 4.2
+	},
+/obj/effect/overlay/water/top,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/outside/forest)
 "pry" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/bed/chair/shuttle{
@@ -77488,6 +77669,11 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/robotics)
+"pNH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/gun_parts/high_end,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "pNJ" = (
 /obj/machinery/hologram/holopad{
 	name = "meeting room holopad two"
@@ -78846,10 +79032,9 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
 "qaG" = (
-/obj/effect/decal/cleanable/generic,
-/obj/random/mob/termite_no_despawn,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/random/gun_parts/frames,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "qaH" = (
 /obj/landmark/join/late/cryo,
@@ -81679,6 +81864,10 @@
 /obj/item/material/shard,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"qDJ" = (
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "qDM" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/autolathe{
@@ -82652,6 +82841,16 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
+"qOm" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/girder/displaced,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/hunter_cabin)
 "qOs" = (
 /obj/structure/table/standard,
 /obj/item/device/defib_kit,
@@ -82768,6 +82967,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"qPH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/lighting/toggleable/lantern,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/campground)
 "qPK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -87309,6 +87513,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"rNk" = (
+/obj/structure/flora/big/rocks2,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/forest)
 "rNq" = (
 /obj/machinery/door/airlock/vault{
 	locked = 1;
@@ -89032,6 +89240,10 @@
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"seR" = (
+/obj/random/gun_parts/frames,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "seT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
@@ -90899,7 +91111,8 @@
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "sxF" = (
-/turf/simulated/floor/asteroid/dirt,
+/obj/random/flora/jungle_tree,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "sxG" = (
 /obj/structure/table/woodentable,
@@ -91692,7 +91905,8 @@
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
 "sFH" = (
-/obj/random/mob/termite_no_despawn,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/random/gun_handmade,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "sFI" = (
@@ -92729,6 +92943,11 @@
 /obj/item/gun/energy/concillium,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/command/prime)
+"sRo" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/render,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "sRD" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -94289,6 +94508,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
+"tiS" = (
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
+/turf/simulated/wall/wood_old,
+/area/nadezhda/dungeon/outside/hunter_cabin)
 "tjc" = (
 /obj/random/mob/termite_no_despawn,
 /obj/effect/decal/cleanable/dirt,
@@ -94706,6 +94931,10 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"toy" = (
+/obj/random/flora/jungle_tree,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/forest)
 "toz" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/unsimulated/wall/jungle,
@@ -95100,6 +95329,10 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"ttA" = (
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/campground)
 "ttG" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -95621,9 +95854,8 @@
 	name = "Interrogation"
 	})
 "tyh" = (
-/obj/random/mob/roaches/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
+/obj/structure/flora/small/grassa4,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "tyl" = (
 /obj/structure/salvageable/computer{
@@ -96194,12 +96426,8 @@
 /turf/simulated/wall,
 /area/nadezhda/maintenance/surfaceeast)
 "tDY" = (
-/obj/structure/table/woodentable,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/reagent_containers/food/snacks/meat/human,
-/obj/item/reagent_containers/food/snacks/meat/roachmeat/panzer,
-/obj/item/reagent_containers/food/snacks/meat/carp,
-/turf/simulated/floor/wood/wild4,
+/obj/structure/table,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/hunter_cabin)
 "tEd" = (
 /obj/structure/disposalpipe/segment,
@@ -96535,7 +96763,8 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "tHe" = (
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "tHg" = (
 /obj/structure/window/reinforced,
@@ -98344,6 +98573,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"tYx" = (
+/obj/structure/flora/big/bush1,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
+/turf/unsimulated/wall/jungle,
+/area/nadezhda/outside/forest)
 "tYB" = (
 /obj/effect/floor_decal/industrial/stand_clear/red,
 /obj/effect/decal/cleanable/dirt,
@@ -98378,6 +98615,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/sechall)
+"tYO" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/render,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "tYP" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lantern/censer,
@@ -99640,6 +99883,11 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
+"ukC" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/item/device/lighting/toggleable/lamp/green,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/dungeon/outside/hunter_cabin)
 "ukF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -99816,6 +100064,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/medical)
+"ulU" = (
+/obj/structure/flora/small/grassb1,
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "umh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -100047,7 +100302,8 @@
 	})
 "uof" = (
 /obj/item/material/shard/plasma,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "uoh" = (
 /obj/structure/lattice,
@@ -100278,7 +100534,8 @@
 /area/nadezhda/security/armory_blackshield)
 "ura" = (
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/item/scrap_lump,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "urc" = (
 /obj/effect/floor_decal/industrial/loading/white,
@@ -100398,9 +100655,8 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
 "use" = (
-/obj/effect/damagedfloor/fire,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel,
+/obj/structure/flora/rock/variant1,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "usi" = (
 /obj/structure/disposalpipe/segment,
@@ -101173,6 +101429,10 @@
 /obj/landmark/join/start/officer,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"uCl" = (
+/obj/structure/flora/small/rock4,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "uCo" = (
 /obj/effect/floor_decal/asteroid,
 /obj/machinery/camera/network/colony_underground,
@@ -103261,6 +103521,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"uVf" = (
+/obj/random/flora/small_jungle_tree,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "uVj" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -104183,9 +104451,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "vfR" = (
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/dungeon/outside/burned_outpost)
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "vfU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -104949,6 +105219,14 @@
 	icon_state = "13,15"
 	},
 /area/nadezhda/quartermaster/miningdock)
+"vnx" = (
+/obj/effect/window_lwall_spawn,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "vnC" = (
 /obj/structure/scrap/poor,
 /obj/effect/decal/cleanable/rubble,
@@ -105229,7 +105507,6 @@
 	name = "empty fuel tank";
 	volume = 0
 	},
-/obj/effect/damagedfloor/fire,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "vqs" = (
@@ -105638,8 +105915,10 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "vuI" = (
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/dark,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "vuN" = (
 /obj/structure/bed/chair/comfy/brown{
@@ -105838,10 +106117,13 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/rnd/rbreakroom)
 "vwo" = (
-/obj/effect/damagedfloor/fire,
-/obj/random/cluster/termite_no_despawn/low_chance,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/dungeon/outside/burned_outpost)
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 25;
+	pixel_x = -13;
+	layer = 4.2
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "vwq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -105897,6 +106179,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"vwN" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/item/scrap_lump,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/outside/forest)
 "vwR" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/shuttle/floor/science{
@@ -106092,6 +106380,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"vzM" = (
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/turf/unsimulated/wall/jungle,
+/area/nadezhda/outside/forest)
 "vzU" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -108063,10 +108357,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/maingate/west)
 "vTp" = (
-/obj/effect/damagedfloor/fire,
-/obj/random/cluster/termite_no_despawn/low_chance,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/dungeon/outside/burned_outpost)
+/obj/structure/flora/big/bush2,
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/campground)
 "vTq" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -110551,6 +110845,7 @@
 /obj/structure/bed,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/filth,
+/obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/hunter_cabin)
 "wrc" = (
@@ -112328,9 +112623,9 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "wLe" = (
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/dungeon/outside/burned_outpost)
+/obj/item/material/shard,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "wLg" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -112986,6 +113281,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"wSu" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = -4;
+	layer = 4.2
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "wSv" = (
 /obj/structure/table/steel,
 /obj/item/device/radio/off{
@@ -116548,6 +116850,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/sleeper)
+"xEe" = (
+/obj/structure/girder,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "xEi" = (
 /turf/simulated/mineral,
 /area/nadezhda/engineering/engine_room)
@@ -119051,6 +119358,10 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm2)
+"ydY" = (
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "yef" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -119088,6 +119399,10 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"yeF" = (
+/obj/item/material/shard/plasma,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "yeH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -119663,7 +119978,6 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
 "ylM" = (
-/obj/structure/multiz/stairs/enter/bottom,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -119674,7 +119988,12 @@
 /obj/item/device/radio/intercom/department/security{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
+/turf/simulated/floor/tiled/dark/gray_platform{
+	icon = 'icons/obj/stairs.dmi';
+	icon_state = "ramptop";
+	name = "stairs";
+	desc = with steps
+	},
 /area/nadezhda/security/maingate)
 "ylO" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -202292,7 +202611,7 @@ rTe
 rTe
 cxU
 tfW
-tfW
+vfR
 tfW
 tfW
 tfW
@@ -202477,12 +202796,12 @@ tfW
 rTe
 tfW
 tfW
-cxU
-cxU
 tfW
 tfW
-cxU
 tfW
+bCJ
+aBG
+bCJ
 mHv
 tfW
 cxU
@@ -202672,7 +202991,9 @@ tfW
 tfW
 tfW
 tfW
-cXA
+uVf
+kOj
+vzM
 tfW
 tfW
 tfW
@@ -202680,16 +203001,14 @@ tfW
 tfW
 tfW
 tfW
+kOj
+kOj
+kOj
 tfW
 tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
+bCJ
+bCJ
+bCJ
 tfW
 tfW
 tfW
@@ -202874,8 +203193,8 @@ tfW
 raN
 raN
 tfW
-tfW
-tfW
+tYx
+kOj
 hHs
 hHs
 hHs
@@ -202889,9 +203208,9 @@ hHs
 hHs
 hHs
 hHs
-tfW
-tfW
-tfW
+kOj
+kOj
+kOj
 tfW
 tfW
 tfW
@@ -202926,13 +203245,13 @@ tfW
 tfW
 tfW
 aff
-tfW
-tfW
+kkA
+rNk
 tfW
 tfW
 aff
+kkF
 kOj
-iGL
 kTO
 "}
 (13,1,3) = {"
@@ -203079,17 +203398,17 @@ tfW
 mHv
 hHs
 hHs
-tHe
+tAD
 uof
-tHe
+tAD
 dZv
 dZv
-tHe
-tHe
+dNV
+iXi
+tAD
+tAD
 fHw
-sxF
-sxF
-sxF
+tAD
 hHs
 hHs
 hHs
@@ -203128,13 +203447,13 @@ tfW
 tfW
 tfW
 mHv
-rNt
-wcY
-tfW
-tfW
+byU
+iqn
+kkA
+mHv
 lMN
-tfW
-iGL
+kOj
+kOj
 kTO
 "}
 (14,1,3) = {"
@@ -203280,18 +203599,18 @@ tfW
 tfW
 hHs
 hHs
-tHe
-tHe
-iXi
-tHe
-tHe
-tHe
-gwu
-tHe
+tAD
+tAD
+tAD
 fHw
-sxF
-sxF
-sxF
+tHe
+tAD
+tAD
+nHi
+seR
+tAD
+tAD
+tAD
 hHs
 vnV
 fgo
@@ -203329,12 +203648,12 @@ tfW
 tfW
 tfW
 tfW
-tfW
-wcY
+kkA
+iqn
 lZz
 lZz
-lfI
-lfI
+dbT
+dbT
 lZz
 lZz
 kTO
@@ -203482,25 +203801,25 @@ tfW
 tfW
 hHs
 dZv
+tAD
+tAD
 gwu
-tHe
-gwu
-ura
-eBP
+tAD
+tAD
 iMj
-vwo
-eBP
+tAD
+tAD
 fHw
-fHw
-sxF
-sxF
+tAD
+tHe
+tAD
 fKl
 pwf
 pwf
 pwf
 pwf
-opX
-gsc
+tYO
+pwf
 hBB
 hHs
 hHs
@@ -203532,7 +203851,7 @@ tfW
 tfW
 tfW
 tfW
-tfW
+kkA
 lZz
 fMZ
 bxG
@@ -203684,17 +204003,17 @@ oPz
 tfW
 hHs
 dZv
-tHe
-tHe
+czf
+qaG
+cSk
 nsk
-nsk
-eBP
+tAD
 eBP
 jFR
-eBP
-wLe
-fHw
-pwf
+tAD
+tAD
+hIi
+ebS
 pwf
 fKl
 pwf
@@ -203710,7 +204029,7 @@ hHs
 tfW
 wcY
 tfW
-tfW
+vfR
 tfW
 wcY
 tfW
@@ -203733,8 +204052,8 @@ aff
 wcY
 kmB
 tfW
-tfW
-tfW
+kkA
+kkA
 lZz
 uii
 cUc
@@ -203885,28 +204204,28 @@ tfW
 tfW
 tfW
 hHs
-tHe
-iXi
-czf
-cSk
-nsk
-tHe
-tHe
-eBP
-eBP
-fHw
 sxF
+iXi
+iXi
+cSk
+cSk
+tAD
+tAD
+tAD
+tAD
+dZv
+tAD
 pwf
 pwf
 fKl
 pwf
-gsc
+pwf
 pwf
 dAg
 jzB
 pwf
 fuT
-tyh
+pwf
 xxU
 hHs
 tfW
@@ -203936,8 +204255,8 @@ wcY
 pCD
 tfW
 tfW
-tfW
-lfI
+toy
+loD
 pls
 cUc
 cUc
@@ -204088,17 +204407,17 @@ tfW
 oPz
 hHs
 nsk
-tHe
-eBP
-eBP
-tHe
-uof
-hZt
-bIH
-tHe
-fHw
 tAD
-sxF
+iXi
+cKa
+iXi
+yeF
+tAD
+bIH
+iXi
+tAD
+tAD
+tAD
 tAD
 fKl
 pwf
@@ -204137,12 +204456,12 @@ tfW
 tfW
 tfW
 tfW
-cxU
-cxU
-lfI
+tfW
+kkA
+gaq
 qGD
 xjM
-bxG
+qPH
 qGD
 lZz
 kTO
@@ -204290,27 +204609,27 @@ mHv
 tfW
 hHs
 nsk
-tHe
-tHe
-tHe
-gwu
-tHe
-tHe
-tHe
-tHe
-fHw
 tAD
-kkA
-kkA
+iXi
+iXi
+tAD
+tAD
+tHe
+iXi
+iXi
+tAD
+tAD
+tAD
+tAD
 hHs
 fLs
 pwf
 pwf
+sRo
 pwf
 pwf
+opX
 pwf
-qaG
-gsc
 vFD
 hHs
 tfW
@@ -204339,9 +204658,9 @@ pCD
 fhp
 oRa
 nmG
-cxU
-hYJ
-kim
+tfW
+wjb
+kdS
 wSD
 bxG
 cUc
@@ -204491,25 +204810,25 @@ tfW
 cri
 tfW
 hHs
+tAD
+tAD
 tHe
+tAD
 ura
-tHe
-tHe
-ura
-tHe
-tHe
-fHw
-fHw
+iXi
+tAD
+iXi
+iXi
 aML
-vfR
-kkA
+tAD
+tAD
 vqq
 hHs
 yhK
+pNH
 pwf
 pwf
 pwf
-gsc
 pwf
 pwf
 pwf
@@ -204539,12 +204858,12 @@ tfW
 tfW
 tfW
 tfW
-cxU
-cxU
-cxU
-cxU
-lfI
-wSD
+tfW
+tfW
+tfW
+tfW
+vTp
+aXv
 bxG
 bxG
 tTd
@@ -204693,18 +205012,18 @@ tfW
 tfW
 tfW
 hHs
-tHe
-tHe
-eBP
-vuI
-vTp
-fHw
-fHw
-fHw
-fHw
-fHw
 tAD
-use
+tAD
+tAD
+fHw
+dZv
+iXi
+iXi
+iXi
+tAD
+tAD
+tAD
+pwf
 vqq
 hHs
 lNQ
@@ -204714,7 +205033,7 @@ oZn
 xba
 fuT
 pwf
-gsc
+pwf
 pwf
 hHs
 tfW
@@ -204739,15 +205058,15 @@ vaP
 vaP
 vaP
 tfW
-cxU
-emi
-emi
-emi
-cxU
-cxU
-lfI
+tfW
+tfW
+xsx
+xsx
+tfW
+tfW
+hYJ
 oFV
-bxG
+hAO
 mRw
 tVX
 lZz
@@ -204895,16 +205214,16 @@ tfW
 tfW
 ebv
 oeM
-fHw
-fHw
-fHw
-fHw
-fHw
-fHw
-fHw
 tAD
-sxF
-sxF
+tAD
+tAD
+tAD
+iXi
+iXi
+tAD
+hIi
+tAD
+tAD
 tAD
 pwf
 hHs
@@ -204920,7 +205239,7 @@ qZO
 cFZ
 hHs
 tfW
-tfW
+ina
 tfW
 wcY
 kOj
@@ -204941,14 +205260,14 @@ vaP
 vaP
 tfW
 tfW
-muX
-cxU
-cxU
-cxU
+tfW
+mHv
 tfW
 tfW
-lfI
-wSD
+tfW
+avI
+lZz
+ttA
 cUc
 bxG
 jlb
@@ -205097,17 +205416,17 @@ olX
 tfW
 tfW
 hHs
-fHw
-fHw
-fHw
-fHw
-sxF
-sxF
 tAD
+use
+tAD
+tHe
+tAD
+tAD
+tyh
 pwf
-sxF
 tAD
-tAD
+seR
+tHe
 pwf
 hHs
 tfW
@@ -205143,10 +205462,10 @@ tfW
 tfW
 tfW
 tfW
-muX
-cxU
+tfW
+tfW
 aAA
-cxU
+tfW
 tfW
 wjb
 kim
@@ -205294,20 +205613,20 @@ tfW
 tfW
 tfW
 tfW
-tfW
+vfR
 iSI
 tfW
 tfW
 hHs
 sxF
-sxF
+tAD
 sFH
-tAD
-sxF
-sxF
-tAD
-pwf
+ydY
+qDJ
+nmw
+uCl
 gsc
+pwf
 pwf
 tAD
 tAD
@@ -205319,9 +205638,9 @@ tfW
 tfW
 tfW
 tfW
+mWZ
 tfW
-tfW
-tfW
+vfR
 tfW
 olX
 tfW
@@ -205343,16 +205662,16 @@ atF
 tfW
 tfW
 tfW
+mHv
 tfW
 tfW
-muX
-cxU
-cxU
-cxU
 tfW
+tfW
+tfW
+wLe
 tfW
 lfI
-wSD
+emi
 bxG
 cUc
 qGD
@@ -205501,18 +205820,18 @@ tfW
 tfW
 tfW
 oeM
-oeM
-sxF
-sxF
-tAD
-pwf
+xEe
 tAD
 tAD
+wSu
+nmw
+nmw
+nmw
+bkt
 pwf
 pwf
 pwf
-pwf
-tAD
+lyC
 hHs
 tfW
 tfW
@@ -205547,13 +205866,13 @@ tfW
 tfW
 dFV
 tfW
-cxU
+tfW
+tfW
 gzu
-gzu
-gzu
-ina
-cxU
-lfI
+tfW
+fhp
+tfW
+loD
 cGg
 bxG
 uUa
@@ -205703,19 +206022,19 @@ bSm
 tfW
 kEV
 tfW
-oeM
-tAD
-pwf
-pwf
+jgE
+fHw
+cYP
+fWU
 nmw
+owX
+vuI
+nmw
+tAD
 pwf
 tAD
 tAD
-tAD
-pwf
-tAD
-tAD
-tAD
+nTD
 tfW
 mHv
 tfW
@@ -205751,11 +206070,11 @@ xwr
 tfW
 tfW
 tfW
-cxU
-cxU
-cxU
-cxU
-lfI
+tfW
+tfW
+tfW
+mHv
+iMe
 lIn
 bxG
 bxG
@@ -205905,19 +206224,19 @@ tfW
 tfW
 tfW
 tfW
-tfW
-tfW
+hZt
+hZt
 hHs
+eHQ
+fkF
+fkF
+eHQ
+muX
+nTD
 hHs
-oeM
-oeM
+jgE
 hHs
-tAD
-tAD
-hHs
-oeM
-hHs
-tAD
+nTD
 tfW
 tfW
 tfW
@@ -205955,8 +206274,8 @@ nmG
 tfW
 tfW
 tfW
-cxU
-cxU
+tfW
+wLe
 lfI
 ejS
 cUc
@@ -206106,23 +206425,23 @@ tfW
 tfW
 tfW
 tfW
-tfW
+ina
 iSI
 tfW
+prt
+ryY
+guX
+ryY
+ryY
+ryY
+vaP
 tfW
 tfW
 tfW
 tfW
 tfW
 tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-cAF
+ulU
 cAF
 tfW
 tfW
@@ -206151,14 +206470,14 @@ tfW
 wsB
 tfW
 tfW
+bSm
 tfW
 tfW
 tfW
 tfW
 tfW
 tfW
-cxU
-cxU
+tfW
 lZz
 lZz
 lfI
@@ -206311,16 +206630,16 @@ tfW
 tfW
 tfW
 tfW
+pQK
+vwN
+ryY
+ryY
+nrd
+vwo
 tfW
-tfW
-tfW
-tfW
-mHv
-tfW
-tfW
-tfW
+ina
 olX
-tfW
+vfR
 tfW
 gbc
 tfW
@@ -206353,14 +206672,14 @@ wcY
 rHf
 tfW
 tfW
+kOj
 tfW
 tfW
 tfW
 tfW
 tfW
 tfW
-tfW
-tfW
+bSm
 lZz
 vCZ
 cUc
@@ -206512,13 +206831,13 @@ tfW
 mHv
 tfW
 tfW
+vfR
 tfW
+vaP
+ryY
+ryY
 tfW
-tfW
-tfW
-tfW
-tfW
-tfW
+vaP
 tfW
 tfW
 tfW
@@ -206555,15 +206874,15 @@ wcY
 wcY
 tfW
 tfW
-tfW
-tfW
-tfW
+jBW
+kOj
+bSm
 tfW
 tfW
 tfW
 tfW
 wcY
-lfI
+pfP
 bPD
 bxG
 cUc
@@ -206710,19 +207029,19 @@ tfW
 tfW
 rPI
 tfW
+bTf
 tfW
 tfW
-tfW
-tfW
+mmJ
 tfW
 iAH
 tfW
+tkB
+vwo
+mWZ
 tfW
-tfW
-tfW
-tfW
-tfW
-tfW
+bCJ
+bCJ
 tfW
 tfW
 tfW
@@ -206757,15 +207076,15 @@ wcY
 pQe
 tfW
 oRa
+wAu
+kOj
+kOj
+bzB
 tfW
 tfW
 tfW
-mHv
-tfW
-tfW
-tfW
-wcY
-lfI
+ygo
+dbT
 kRT
 cUc
 bxG
@@ -206921,7 +207240,7 @@ tfW
 olX
 tfW
 tfW
-tfW
+bCJ
 xkT
 kOj
 kOj
@@ -206960,14 +207279,14 @@ wcY
 tfW
 wcY
 tfW
-tfW
-tfW
+kOj
+kOj
 tfW
 tfW
 tfW
 tfW
 uiM
-lfI
+dbT
 hpv
 cUc
 bxG
@@ -207119,10 +207438,10 @@ tfW
 tfW
 tfW
 tfW
+bTf
 tfW
-tfW
-tfW
-tfW
+vfR
+bCJ
 kOj
 kOj
 kOj
@@ -207162,10 +207481,10 @@ nhY
 tfW
 wcY
 tfW
-tfW
-tfW
-tfW
-tfW
+wAu
+wAu
+kOj
+bSm
 tfW
 wcY
 wcY
@@ -207365,9 +207684,9 @@ atF
 tfW
 tfW
 tfW
-tfW
-tfW
-tfW
+kOj
+kOj
+wAu
 tfW
 wcY
 wcY
@@ -207519,8 +207838,8 @@ tfW
 tfW
 hgy
 iSI
-tfW
-tfW
+bCJ
+bCJ
 tfW
 tfW
 tfW
@@ -207572,11 +207891,11 @@ tfW
 tfW
 tfW
 tfW
-tfW
+jBW
 lZz
 lZz
-lfI
-lfI
+vnx
+dbT
 lZz
 lZz
 kTO
@@ -207718,12 +208037,12 @@ wcY
 wcY
 tfW
 cri
-tfW
-tfW
+bCJ
+bCJ
 mHv
 kOj
 kOj
-tfW
+bCJ
 mHv
 tfW
 keX
@@ -207773,14 +208092,14 @@ tfW
 tfW
 tfW
 bSm
+jBW
+nIa
+jBW
 tfW
-wcY
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
+mHv
+ucy
+kOj
+kOj
 kTO
 "}
 (37,1,3) = {"
@@ -207975,14 +208294,14 @@ tfW
 tfW
 tfW
 tfW
+kOj
+jBW
+kOj
+jBW
 tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
+ihH
+ucy
+kOj
 kTO
 "}
 (38,1,3) = {"
@@ -208179,7 +208498,7 @@ xwr
 tfW
 oRa
 tfW
-tfW
+jBW
 nhY
 iSI
 fbJ
@@ -234621,7 +234940,7 @@ tfW
 tfW
 tfW
 tfW
-cxU
+tfW
 tfW
 tfW
 tfW
@@ -234823,17 +235142,17 @@ tfW
 tfW
 tfW
 tfW
-cxU
-cxU
+tfW
+tfW
 cxU
 cxU
 cxU
 cxU
 tfW
 tfW
-cxU
-cxU
-cxU
+tfW
+tfW
+tfW
 tfW
 tfW
 qZG
@@ -235036,8 +235355,8 @@ cxU
 cxU
 cxU
 cxU
-cxU
-cxU
+tfW
+tfW
 tfW
 tfW
 tfW
@@ -236461,9 +236780,9 @@ tfW
 mHv
 tfW
 tfW
+ebv
 tfW
-tfW
-uTf
+mbZ
 iGL
 kTO
 "}
@@ -236662,11 +236981,11 @@ tfW
 tfW
 tiO
 tfW
-tiO
+kbg
 tfW
 bSm
-tfW
-jBW
+kOj
+kOj
 kTO
 "}
 (180,1,3) = {"
@@ -236863,11 +237182,11 @@ tfW
 tfW
 tfW
 tfW
+ebv
 tfW
-tfW
-tfW
-tfW
-tfW
+mHv
+kOj
+kOj
 kOj
 kTO
 "}
@@ -237066,8 +237385,8 @@ tfW
 tfW
 mHv
 keX
-vRa
-vRa
+kop
+qOm
 vRa
 vRa
 vRa
@@ -237265,10 +237584,10 @@ tfW
 tfW
 tfW
 tfW
+wjb
 tfW
 tfW
-tfW
-vRa
+olN
 tDY
 oOj
 uPc
@@ -237448,9 +237767,9 @@ tfW
 tfW
 tfW
 tfW
-cxU
-cxU
-cxU
+tfW
+tfW
+tfW
 cxU
 cxU
 cxU
@@ -237469,10 +237788,10 @@ tfW
 tfW
 tfW
 mHv
-keX
-vRa
+tfW
+tiS
 dFN
-wjP
+ueY
 rMO
 vRa
 kTO
@@ -237651,6 +237970,8 @@ tfW
 tfW
 tfW
 tfW
+tfW
+tfW
 cxU
 cxU
 cxU
@@ -237659,10 +237980,8 @@ cxU
 cxU
 cxU
 cxU
-cxU
-cxU
-cxU
-cxU
+tfW
+tfW
 tfW
 tfW
 tfW
@@ -237674,7 +237993,7 @@ tfW
 tfW
 vRa
 xwx
-dFN
+ukC
 tSm
 vRa
 kTO
@@ -237854,6 +238173,7 @@ tfW
 tfW
 tfW
 tfW
+tfW
 cxU
 cxU
 cxU
@@ -237862,9 +238182,8 @@ cxU
 cxU
 cxU
 cxU
-cxU
-cxU
-cxU
+tfW
+tfW
 tfW
 tfW
 tfW
@@ -237872,8 +238191,8 @@ tfW
 tfW
 tfW
 iPG
-cxU
-cxU
+tfW
+eAI
 vRa
 jcG
 wjP
@@ -238056,11 +238375,9 @@ tfW
 tfW
 tfW
 tfW
-cxU
-cxU
-cxU
-cxU
-cxU
+tfW
+tfW
+tfW
 cxU
 cxU
 cxU
@@ -238072,13 +238389,15 @@ tfW
 tfW
 tfW
 tfW
+tfW
+wjb
 mHv
 tfW
-cxU
-hYJ
+keX
+tfW
 wmn
 oOO
-ueY
+wjP
 jTa
 vRa
 kTO
@@ -238259,11 +238578,11 @@ tfW
 tfW
 tfW
 tfW
+tfW
+tfW
 cxU
-cxU
-cxU
-cxU
-cxU
+tfW
+tfW
 tfW
 tfW
 tfW
@@ -238276,7 +238595,7 @@ iSI
 tfW
 bSm
 tiO
-cxU
+tfW
 cTB
 vRa
 wrb
@@ -239068,11 +239387,11 @@ tfW
 tfW
 tfW
 tfW
-cxU
 tfW
 tfW
-cxU
-cxU
+tfW
+tfW
+tfW
 tfW
 tfW
 tfW
@@ -239270,10 +239589,10 @@ iSI
 tfW
 tfW
 tfW
-cxU
 tfW
 tfW
-cxU
+tfW
+tfW
 tfW
 tfW
 tfW

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -20982,13 +20982,13 @@
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/podrooms)
 "eqm" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Monkey Containment";
-	req_access = list(39)
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Chem/Viro Labs";
+	req_one_access = list(33,29)
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/medical/virology)
 "eqq" = (
@@ -24138,10 +24138,6 @@
 	name = "Medbay Total Lockdown";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/glass_medical{
-	name = "Chem/Viro Labs";
-	req_one_access = list(33,29)
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24158,6 +24154,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Chem/Viro Labs";
+	req_one_access = list(33,29)
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/medical/virology)
 "eXi" = (
@@ -100731,13 +100731,13 @@
 	name = "Medbay Total Lockdown";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade,
 /obj/machinery/door/airlock/glass_medical{
 	name = "Chem/Viro Labs";
 	req_one_access = list(33,29)
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/medical/virology)
 "uxw" = (

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -1292,6 +1292,8 @@
 	dir = 1;
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
 "anw" = (
@@ -1390,6 +1392,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"apb" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "apk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2289,6 +2298,11 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
+"ayf" = (
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "ayh" = (
 /obj/structure/flora/small/grassa5,
 /obj/random/mob/spiders/low_chance,
@@ -2438,9 +2452,6 @@
 "azv" = (
 /obj/structure/flora/small/rock3,
 /obj/structure/invislight,
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "azI" = (
@@ -3313,7 +3324,7 @@
 /area/nadezhda/maintenance/undergroundfloor2north)
 "aIM" = (
 /obj/item/stool/padded,
-/obj/landmark/join/start/foreigner,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "aIQ" = (
@@ -4010,6 +4021,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
+/obj/landmark/join/start/foreigner,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/pros/shuttle)
 "aRL" = (
@@ -4159,6 +4171,11 @@
 /obj/item/storage/box/monkeycubes,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
+"aUa" = (
+/obj/structure/railing,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "aUc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4193,6 +4210,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/medical/reception)
+"aUC" = (
+/obj/structure/low_wall,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "aUE" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/bushb1,
@@ -5768,6 +5790,10 @@
 /obj/effect/floor_decal/industrial/road/curve4,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"bkt" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
@@ -6302,6 +6328,7 @@
 	name = "Residential District Maintenance"
 	})
 "bro" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/snack,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
@@ -7365,13 +7392,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
-"bCG" = (
-/obj/structure/catwalk,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/pros/shuttle)
 "bCI" = (
 /obj/structure/table/reinforced,
 /obj/item/grenade/chem_grenade/metalfoam,
@@ -7594,10 +7614,11 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
 "bFc" = (
-/obj/structure/table/woodentable,
-/obj/item/clothing/mask/smokable/cigarette/cigar,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "bFk" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -8356,6 +8377,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/medical/morgue)
+"bMB" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "bMF" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
@@ -10701,10 +10727,6 @@
 /obj/structure/scrap/cloth,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
-"cny" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "cnB" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1
@@ -10991,6 +11013,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"crb" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "cri" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/grass,
@@ -11121,10 +11148,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "csI" = (
-/obj/structure/table/woodentable,
-/obj/item/flame/lighter/zippo/capitalist,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "csK" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -11545,6 +11574,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
 "cxw" = (
@@ -12024,6 +12055,12 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/techshop)
+"cCA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/flame/lighter/zippo/capitalist,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "cCD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/machinery/requests_console/preset/command/bc{
@@ -13113,6 +13150,11 @@
 "cOa" = (
 /obj/structure/toilet{
 	dir = 8
+	},
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit{
+	icon_state = "vomit_4"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
@@ -14585,6 +14627,10 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"dcC" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "dcS" = (
 /obj/structure/table/standard,
 /obj/structure/extinguisher_cabinet{
@@ -14941,6 +14987,12 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/inside_colony)
+"dge" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "dgi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15788,6 +15840,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"dph" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate/east)
 "dpm" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -16916,7 +16973,7 @@
 /area/shuttle/vasiliy_shuttle_area)
 "dAK" = (
 /obj/structure/table/woodentable,
-/obj/item/book/manual/fiction/warandpeace,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "dAP" = (
@@ -17114,15 +17171,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"dCP" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/flora/big/bush3{
-	pixel_y = -18
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "dCT" = (
 /obj/structure/flora/small/busha1,
 /obj/random/flora/jungle_tree,
@@ -17223,13 +17271,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/surfaceeast)
-"dEa" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "dEn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19289,6 +19330,8 @@
 /obj/structure/bed/chair/sofa/brown/left{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "dZP" = (
@@ -19527,12 +19570,6 @@
 /area/nadezhda/security/nuke_storage{
 	name = "\improper Clinic"
 	})
-"eck" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/beach/water/flooded,
-/area/nadezhda/outside/pond)
 "ecn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20006,6 +20043,7 @@
 /area/nadezhda/command/fo)
 "egN" = (
 /obj/structure/bed/chair/comfy/brown,
+/obj/effect/decal/cleanable/dirt,
 /obj/landmark/join/start/foreigner,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
@@ -20058,10 +20096,6 @@
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"ehz" = (
-/obj/structure/boulder,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "ehB" = (
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/lakeside)
@@ -21407,11 +21441,6 @@
 /obj/structure/flora/small/grassb3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
-"eut" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "euC" = (
 /obj/structure/closet/crate/secure,
 /obj/random/material_rare/low_chance,
@@ -21452,6 +21481,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
+"euR" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "euT" = (
 /obj/random/structures,
 /obj/effect/decal/cleanable/dirt,
@@ -21500,10 +21535,6 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/nadezhda/command/captain)
-"evS" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "evX" = (
 /obj/machinery/cash_register,
 /obj/structure/table/standard,
@@ -23623,6 +23654,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "eRC" = (
@@ -24720,11 +24752,6 @@
 "fej" = (
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
-"fek" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "fer" = (
 /obj/structure/grille,
 /obj/machinery/light/small{
@@ -25748,6 +25775,9 @@
 "fnK" = (
 /obj/structure/railing/grey{
 	dir = 4
+	},
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -27539,12 +27569,6 @@
 /obj/structure/curtain/open/privacy,
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/medical/sleeper)
-"fHH" = (
-/obj/structure/flora/bush,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "fHI" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/meter,
@@ -30518,11 +30542,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"gou" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "goy" = (
 /obj/machinery/camera/network/cargo{
 	dir = 8
@@ -31464,6 +31483,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"gwR" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "gwV" = (
 /obj/structure/disposalpipe/up{
 	dir = 8
@@ -32198,12 +32222,6 @@
 "gGd" = (
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
-"gGl" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "gGp" = (
 /obj/machinery/bodyscanner,
 /obj/machinery/light,
@@ -34429,13 +34447,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/hallways)
-"heU" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "heX" = (
 /obj/structure/railing{
 	dir = 8
@@ -35268,6 +35279,7 @@
 "hos" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "hox" = (
@@ -38361,6 +38373,13 @@
 /obj/effect/floor_decal/border/carpet/lightblue,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters)
+"hUr" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "hUA" = (
 /obj/machinery/light,
 /obj/structure/closet/wall_mounted/firecloset{
@@ -38901,11 +38920,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"hYw" = (
-/obj/random/flora/jungle_tree,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "hYF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster/directional/north,
@@ -39481,6 +39495,10 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/turret_protected/ai)
+"idb" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "idd" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -41727,6 +41745,8 @@
 "iBg" = (
 /obj/machinery/washing_machine,
 /obj/structure/catwalk,
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/sechall)
 "iBh" = (
@@ -41752,6 +41772,7 @@
 	dir = 4;
 	pixel_x = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
 "iBt" = (
@@ -42443,6 +42464,12 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"iIQ" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "iIR" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/big/bush1{
@@ -44306,8 +44333,7 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/reception)
 "jez" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "jeE" = (
@@ -44736,16 +44762,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"jiI" = (
-/obj/structure/railing,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
-"jiP" = (
-/obj/structure/flora/small/rock3,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "jiQ" = (
 /obj/structure/sign/warning/caution/small{
 	dir = 1
@@ -45378,6 +45394,13 @@
 /obj/item/slime_extract/grey,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/rnd/xenobiology)
+"joG" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "joH" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -45564,13 +45587,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"jrc" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "jre" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/directions/generic{
@@ -47181,6 +47197,11 @@
 /obj/structure/closet/random_milsupply,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"jHU" = (
+/obj/structure/railing,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "jHW" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha3,
@@ -49423,10 +49444,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "kgc" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "kge" = (
 /obj/machinery/light/small{
@@ -49772,6 +49792,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "kju" = (
@@ -49842,10 +49863,6 @@
 /obj/machinery/chem_master,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"kjN" = (
-/obj/structure/flora/big/rocks3,
-/turf/simulated/mineral,
-/area/nadezhda/outside/inside_colony)
 "kjS" = (
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
@@ -50176,6 +50193,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	pixel_y = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
 "knA" = (
@@ -51615,6 +51633,7 @@
 /obj/structure/bed/chair/sofa/brown{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "kBu" = (
@@ -52456,6 +52475,12 @@
 	temperature = 80
 	},
 /area/nadezhda/command/tcommsat/computer)
+"kMb" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "kMe" = (
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -52561,6 +52586,11 @@
 /obj/machinery/power/nt_obelisk,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/command/prime)
+"kNA" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "kNM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/media/jukebox,
@@ -53056,6 +53086,10 @@
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/fo)
+"kSK" = (
+/obj/structure/boulder,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "kSX" = (
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/toilet/public)
@@ -53503,6 +53537,8 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "kYj" = (
@@ -53690,11 +53726,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"lbF" = (
-/obj/structure/railing,
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "lbM" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/decal/cleanable/dirt,
@@ -53959,6 +53990,8 @@
 	dir = 8
 	},
 /obj/structure/table/bench/steel,
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/security/sechall)
 "lew" = (
@@ -55084,6 +55117,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"lrT" = (
+/obj/structure/flora/big/rocks3,
+/turf/simulated/mineral,
+/area/nadezhda/outside/inside_colony)
 "lrX" = (
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/side/f2section1)
@@ -55107,6 +55144,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"lsg" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "lsk" = (
 /obj/structure/table/woodentable,
 /obj/item/device/radio/phone,
@@ -55236,13 +55278,6 @@
 	dir = 4
 	},
 /area/nadezhda/crew_quarters/toilet/public)
-"ltQ" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "ltR" = (
 /obj/machinery/vending/fortune,
 /obj/machinery/light{
@@ -55419,6 +55454,8 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
 "lvC" = (
@@ -55751,6 +55788,11 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/main/stairwell)
+"lzg" = (
+/obj/random/flora/low_chance,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "lzl" = (
 /obj/structure/flora/small/rock3,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -55845,12 +55887,6 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"lBa" = (
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "lBf" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -56090,6 +56126,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"lDj" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "lDk" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/small/bushb1,
@@ -56166,6 +56207,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/medical/reception)
+"lDW" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/inside_colony)
 "lDX" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -57452,6 +57499,13 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"lSf" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "lSh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -62596,6 +62650,7 @@
 /area/shuttle/rocinante_shuttle_area)
 "mTb" = (
 /obj/structure/bed/chair/sofa/brown/corner,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "mTj" = (
@@ -63459,10 +63514,6 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/virology)
-"nbs" = (
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/pond)
 "nbu" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/flora/big/bush1,
@@ -64304,6 +64355,11 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
+"nkj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/fiction/warandpeace,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "nkm" = (
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
@@ -64410,6 +64466,22 @@
 /obj/random/lowkeyrandom,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
+"nkZ" = (
+/obj/effect/floor_decal/spline/fancy,
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/table/bench/steel,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/security/sechall)
 "nlc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65080,6 +65152,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"nsu" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "nsw" = (
 /obj/structure/scrap_cube,
 /obj/structure/catwalk,
@@ -65209,11 +65288,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"ntv" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "ntw" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -65282,6 +65356,8 @@
 /area/nadezhda/maintenance/surfacenorth)
 "ntZ" = (
 /obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "nug" = (
@@ -66978,11 +67054,6 @@
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"nKl" = (
-/obj/structure/railing,
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "nKo" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -67090,6 +67161,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"nLq" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "nLx" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "2,3"
@@ -67660,15 +67737,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
-"nRJ" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/flora/big/bush3{
-	pixel_y = -18
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "nRU" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -68181,11 +68249,6 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/maintenance/surfacesec)
-"nXe" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "nXf" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "4,13"
@@ -69618,6 +69681,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfacesec)
+"okQ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "okV" = (
 /obj/machinery/door/blast/regular/open{
 	id = "genetics2";
@@ -71165,10 +71232,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"oAQ" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "oAR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -74143,6 +74206,11 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"pfA" = (
+/obj/structure/flora/bush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "pfD" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/catwalk,
@@ -75128,6 +75196,8 @@
 /area/nadezhda/security/prisoncells)
 "pqb" = (
 /obj/machinery/newscaster/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "pqe" = (
@@ -75782,6 +75852,10 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"pwL" = (
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "pwQ" = (
 /obj/structure/railing{
 	dir = 4
@@ -75917,11 +75991,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
-"pyp" = (
-/obj/structure/flora/bush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "pyz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -75996,6 +76065,7 @@
 /area/nadezhda/engineering/foyer)
 "pyR" = (
 /obj/structure/bed/chair/sofa/brown/right,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "pzc" = (
@@ -76109,6 +76179,11 @@
 /obj/random/junkfood/onlypizza,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
+"pzZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/smokable/cigarette/cigar,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "pAg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -76394,6 +76469,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/reception)
+"pDh" = (
+/obj/random/flora/jungle_tree,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "pDi" = (
 /obj/structure/table/glass,
 /obj/random/toy,
@@ -76526,6 +76606,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"pEH" = (
+/obj/structure/flora/small/rock3,
+/obj/structure/invislight,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "pEJ" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -76722,11 +76810,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"pGX" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "pHb" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/pros/shuttle)
@@ -76945,10 +77028,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
-"pJQ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate/east)
 "pJT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -79313,12 +79392,6 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"qfS" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "qfU" = (
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -79392,6 +79465,12 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"qha" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/security/maingate/west)
 "qhb" = (
 /obj/machinery/light_switch{
 	pixel_y = 32
@@ -80094,12 +80173,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"qol" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "qon" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80718,6 +80791,8 @@
 /area/nadezhda/crew_quarters/techshop)
 "quv" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "quC" = (
@@ -81598,13 +81673,6 @@
 /obj/item/material/shard,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"qDJ" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "qDM" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/autolathe{
@@ -81704,11 +81772,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"qEJ" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate/east)
 "qEK" = (
 /obj/structure/table/standard,
 /obj/random/lowkeyrandom,
@@ -82141,10 +82204,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
-"qIE" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/inside_colony)
 "qIL" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -82155,13 +82214,6 @@
 /obj/random/material/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"qIR" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "qIU" = (
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -83102,6 +83154,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"qTS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "qTZ" = (
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -84271,6 +84328,12 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/pool)
+"rgL" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/inside_colony)
 "rgP" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -84397,11 +84460,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
-"rhS" = (
-/obj/structure/low_wall,
-/obj/structure/flora/big/bush3,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "rhV" = (
 /obj/structure/table/gamblingtable,
 /obj/item/deck/cards,
@@ -86112,10 +86170,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"rAX" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "rAZ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -86582,6 +86636,11 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"rGx" = (
+/obj/structure/flora/small/rock2,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "rGH" = (
 /obj/machinery/gym/toughness,
 /turf/simulated/floor/tiled/white/gray_perforated,
@@ -86992,11 +87051,10 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
 "rLl" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "rLm" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/lab)
@@ -87392,6 +87450,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
+"rOZ" = (
+/obj/structure/catwalk,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/pros/shuttle)
 "rPb" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -87902,11 +87967,9 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
 "rVz" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/rock,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "rVD" = (
 /obj/effect/step_trigger/surface_to_forest_1_B,
@@ -88882,12 +88945,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"seb" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/beach/water/flooded,
-/area/nadezhda/outside/pond)
 "seg" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -89271,6 +89328,12 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"siS" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/outside/pond)
 "siV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -89689,6 +89752,12 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"snk" = (
+/obj/structure/flora/bush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "snm" = (
 /mob/living/simple_animal/hostile/bear,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -89915,6 +89984,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"spB" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "spC" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -90051,6 +90125,12 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/security/nuke_storage)
+"sqG" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/outside/pond)
 "sqJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -90092,12 +90172,6 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm3)
-"sqY" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/rock,
-/area/nadezhda/outside/inside_colony)
 "srf" = (
 /obj/machinery/light{
 	dir = 4
@@ -90590,6 +90664,7 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "svG" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "svJ" = (
@@ -91240,11 +91315,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
-"sBA" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "sBB" = (
 /obj/structure/railing,
 /obj/structure/catwalk,
@@ -92364,6 +92434,7 @@
 /obj/structure/invislight,
 /obj/structure/invislight,
 /obj/structure/catwalk,
+/obj/landmark/join/start/foreigner,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/pros/shuttle)
 "sOC" = (
@@ -92881,6 +92952,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "sUr" = (
@@ -93047,6 +93119,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
+"sWs" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate/east)
 "sWx" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/structure/cable/cyan{
@@ -93666,11 +93742,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
-"tdp" = (
-/obj/structure/flora/small/rock3,
-/obj/structure/invislight,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "tdq" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Cargo Front Desk";
@@ -95206,6 +95277,11 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
+"tvv" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "tvy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -95644,11 +95720,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/quartermaster/miningdock)
-"tyZ" = (
-/obj/random/flora/low_chance,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "tzc" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/grass,
@@ -96128,6 +96199,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"tEm" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/inside_colony)
 "tEs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -97964,11 +98042,6 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"tVt" = (
-/obj/structure/flora/small/rock2,
-/obj/structure/flora/big/bush3,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "tVv" = (
 /obj/structure/railing,
 /turf/simulated/floor/beach/water/flooded,
@@ -98485,13 +98558,6 @@
 /obj/structure/closet/secure_closet/rare_loot,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"uaJ" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush3{
-	pixel_y = -18
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "uaP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -98784,12 +98850,6 @@
 "udz" = (
 /turf/simulated/mineral,
 /area/nadezhda/quartermaster/miningdock)
-"udC" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/security/maingate/west)
 "udL" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -99060,6 +99120,7 @@
 /area/nadezhda/command/cro)
 "ufP" = (
 /obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "ufR" = (
@@ -100635,12 +100696,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"uxm" = (
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/unsimulated/mineral,
-/area/nadezhda/outside/inside_colony)
 "uxn" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -100867,6 +100922,10 @@
 /obj/structure/flora/small/busha2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"uzA" = (
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/inside_colony)
 "uzG" = (
 /obj/machinery/vending/fitness,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -101050,6 +101109,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
+"uBv" = (
+/obj/structure/flora/small/rock3,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "uBB" = (
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -101085,7 +101149,9 @@
 /obj/structure/railing/grey{
 	dir = 1
 	},
-/obj/structure/flora/small/rock5,
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "uCd" = (
@@ -103629,6 +103695,7 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
 "vaq" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/sechall)
 "vat" = (
@@ -104884,6 +104951,7 @@
 	dir = 1;
 	light_color = "#0892d0"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "vnM" = (
@@ -105083,11 +105151,6 @@
 "vpF" = (
 /turf/simulated/wall,
 /area/nadezhda/hallway/side/f2section1)
-"vpL" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "vpP" = (
 /obj/structure/spider_nest,
 /obj/effect/spider/stickyweb,
@@ -105330,11 +105393,6 @@
 /obj/machinery/door/holy/public,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/vectorrooms)
-"vsw" = (
-/obj/item/ammo_casing,
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "vsB" = (
 /obj/structure/table/standard,
 /obj/machinery/power/apc{
@@ -105570,6 +105628,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
+"vuD" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "vuI" = (
 /obj/effect/damagedfloor/fire,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -105578,6 +105641,7 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/landmark/join/start/foreigner,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
@@ -105829,6 +105893,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"vwC" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "vwR" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/shuttle/floor/science{
@@ -108666,11 +108737,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
-"vZC" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "vZH" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
@@ -108816,6 +108882,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfaceeast)
+"wbd" = (
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "wbe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -108953,10 +109023,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/mineral,
 /area/colony)
-"wct" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "wcu" = (
 /obj/structure/table/standard,
 /obj/item/device/aicard,
@@ -109151,14 +109217,6 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"wem" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "weo" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -111515,6 +111573,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"wCG" = (
+/obj/item/ammo_casing,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "wCM" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/beer,
@@ -111717,11 +111780,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/tactical_blackshield)
-"wER" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "wET" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
@@ -112764,6 +112822,12 @@
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"wQw" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "wQA" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -113094,10 +113158,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"wUB" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "wUF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -113194,11 +113254,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
-"wVE" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "wVF" = (
 /obj/structure/table/rack,
 /obj/item/storage/backpack/industrial{
@@ -113950,6 +114005,8 @@
 	dir = 4;
 	light_color = "#0892d0"
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
 "xeO" = (
@@ -114986,6 +115043,14 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/medical/reception)
+"xpv" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "xpD" = (
 /obj/machinery/camera/network/engineering,
 /obj/effect/decal/cleanable/dirt,
@@ -116295,6 +116360,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"xCg" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "xCk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -117316,6 +117388,10 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"xLN" = (
+/obj/random/scrap/sparse_weighted/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "xLW" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psych Office";
@@ -119137,10 +119213,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
-"yga" = (
-/obj/random/scrap/sparse_weighted/low_chance,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "ygn" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/leafybush,
@@ -203757,8 +203829,8 @@ spF
 spF
 spF
 spF
-qol
-qol
+euR
+euR
 umT
 gXV
 xRA
@@ -203953,16 +204025,16 @@ spF
 spF
 spF
 spF
-qDJ
-qDJ
-qDJ
-qDJ
-qDJ
+nsu
+nsu
+nsu
+nsu
+nsu
 pvI
 cLp
 fFO
 fFO
-udC
+qha
 xRA
 xRA
 xRA
@@ -204149,22 +204221,22 @@ spF
 spF
 spF
 spF
-qDJ
-qDJ
-qDJ
-qDJ
-qDJ
-qDJ
-qDJ
-wct
-wct
+nsu
+nsu
+nsu
+nsu
+nsu
+nsu
+nsu
+idb
+idb
 pFV
 pFV
 pFV
 rIK
 pFV
 pFV
-udC
+qha
 xRA
 xRA
 xRA
@@ -204350,13 +204422,13 @@ spF
 spF
 spF
 spF
-qDJ
-qDJ
-wct
+nsu
+nsu
+idb
 rIK
-vpL
-vpL
-wUB
+spB
+spB
+jez
 pFV
 pvI
 rIK
@@ -204551,16 +204623,16 @@ aYl
 spF
 spF
 spF
-wem
-qDJ
-wct
-wUB
+xpv
+nsu
+idb
+jez
 dai
 dai
 rIK
 dai
 dai
-sBA
+rVz
 pFV
 pFV
 cWF
@@ -204754,7 +204826,7 @@ spF
 izu
 spF
 wRQ
-wUB
+jez
 fFO
 pFV
 pvI
@@ -205155,10 +205227,10 @@ iYY
 aYl
 aYl
 spF
-kjN
+lrT
 spF
-kgc
-yga
+nLq
+xLN
 fFO
 pFV
 pvI
@@ -205357,7 +205429,7 @@ aYl
 aYl
 spF
 anq
-kgc
+nLq
 bXS
 fFO
 fFO
@@ -205372,7 +205444,7 @@ vrW
 niq
 pFV
 pvI
-pyp
+pfA
 pFV
 pFV
 vbq
@@ -205557,9 +205629,9 @@ gBD
 aYl
 aYl
 spF
-dEa
+xCg
 bXS
-rAX
+dcC
 fFO
 fFO
 fFO
@@ -205759,14 +205831,14 @@ iYY
 aYl
 aYl
 spF
-dEa
+xCg
 cXf
-yga
+xLN
 fFO
 lVU
 pFV
-vsw
-nKl
+wCG
+aUa
 oSE
 fFO
 fFO
@@ -205961,14 +206033,14 @@ iYY
 aYl
 aYl
 spF
-rVz
-rAX
+tEm
+dcC
 fFO
 fFO
 bex
 rIK
 rIK
-lbF
+jHU
 bXS
 fFO
 fFO
@@ -206170,7 +206242,7 @@ fFO
 fFO
 fFO
 pFV
-jiI
+ayf
 fIj
 fFO
 fFO
@@ -206365,7 +206437,7 @@ iYY
 aYl
 aYl
 spF
-rVz
+tEm
 fFO
 fFO
 cLp
@@ -206567,8 +206639,8 @@ iYY
 aYl
 aYl
 spF
-rVz
-rAX
+tEm
+dcC
 lVU
 fFO
 bex
@@ -206769,8 +206841,8 @@ iYY
 aYl
 aYl
 spF
-rVz
-rAX
+tEm
+dcC
 cLp
 cLp
 fFO
@@ -206971,7 +207043,7 @@ iYY
 aYl
 aYl
 spF
-dEa
+xCg
 bXS
 bXS
 fFO
@@ -207173,8 +207245,8 @@ iYY
 aYl
 aYl
 spF
-rAX
-rAX
+dcC
+dcC
 bXS
 bXS
 fFO
@@ -207184,7 +207256,7 @@ dWS
 bXS
 rIK
 pFV
-rhS
+aUC
 aPg
 vrW
 pFV
@@ -207376,15 +207448,15 @@ aYl
 aYl
 aYl
 spF
-dEa
-qDJ
-wct
-yga
+xCg
+nsu
+idb
+xLN
 fFO
 fFO
 fFO
 fFO
-heU
+joG
 rIK
 pFV
 pFV
@@ -207581,10 +207653,10 @@ aYl
 spF
 spF
 spF
-qol
-wct
+euR
+idb
 fFO
-yga
+xLN
 fFO
 hPj
 mGO
@@ -207784,7 +207856,7 @@ spF
 aYl
 aYl
 spF
-sqY
+lDW
 aYl
 cwC
 pFV
@@ -207986,8 +208058,8 @@ spF
 spF
 spF
 spF
-qol
-wct
+euR
+idb
 fFO
 pFV
 pFV
@@ -208187,9 +208259,9 @@ aYl
 spF
 spF
 spF
-jrc
+csI
 cLp
-wct
+idb
 fFO
 fFO
 pFV
@@ -208390,8 +208462,8 @@ spF
 spF
 spF
 spF
-jrc
-eut
+csI
+gwR
 fFO
 fFO
 cLp
@@ -208593,7 +208665,7 @@ spF
 spF
 spF
 spF
-qol
+euR
 spF
 spF
 cLp
@@ -208999,7 +209071,7 @@ spF
 spF
 spF
 spF
-sqY
+lDW
 fFO
 rIK
 rIK
@@ -209201,7 +209273,7 @@ spF
 spF
 spF
 spF
-qol
+euR
 rIK
 pFV
 rIK
@@ -209396,12 +209468,12 @@ xtc
 xtc
 xtc
 xtc
-bCG
-bCG
-bCG
-bCG
-bCG
-bCG
+rOZ
+rOZ
+rOZ
+rOZ
+rOZ
+rOZ
 xtc
 tdw
 tdw
@@ -214230,10 +214302,10 @@ ntZ
 bro
 hos
 sUh
-svG
+cCA
 pyR
-bFc
-csI
+dAK
+dAK
 pHb
 sKl
 ktw
@@ -214631,12 +214703,12 @@ frR
 hcX
 pHb
 eRA
-svG
+qTS
 svG
 kjg
 svG
 svG
-svG
+pzZ
 pqb
 pHb
 bRi
@@ -214836,7 +214908,7 @@ aIM
 aIM
 quv
 kjg
-svG
+nkj
 xeM
 svG
 vuN
@@ -216030,7 +216102,7 @@ tYN
 iUn
 uSy
 cOa
-lej
+nkZ
 lej
 acV
 qqM
@@ -219735,7 +219807,7 @@ nnz
 qMG
 sQo
 frI
-nbs
+wbd
 qMG
 rtu
 lwP
@@ -220141,7 +220213,7 @@ sQo
 sQo
 qMG
 vFL
-eck
+sqG
 vFL
 njk
 ciR
@@ -220343,10 +220415,10 @@ sQo
 rTq
 njk
 vFL
-seb
+siS
 vFL
 sQo
-nbs
+wbd
 sQo
 dXq
 qMG
@@ -220543,7 +220615,7 @@ emO
 dXq
 sQo
 sQo
-nbs
+wbd
 sQo
 vFL
 vFL
@@ -220748,7 +220820,7 @@ doc
 rrK
 rtu
 vFL
-eck
+sqG
 vFL
 sQo
 ciR
@@ -221151,7 +221223,7 @@ sQo
 sQo
 sQo
 qMG
-eck
+sqG
 vFL
 vFL
 loh
@@ -221329,7 +221401,7 @@ pFV
 spa
 pFV
 pFV
-pyp
+pfA
 pFV
 gcR
 pNi
@@ -221355,7 +221427,7 @@ sQo
 frI
 vFL
 vFL
-eck
+sqG
 hYu
 bDP
 bDP
@@ -221532,7 +221604,7 @@ pFV
 rIK
 rIK
 dai
-pGX
+lsg
 cpp
 pNi
 lNk
@@ -221937,7 +222009,7 @@ rIK
 pFV
 eCL
 dai
-wVE
+rLl
 bXS
 oqZ
 wud
@@ -222137,8 +222209,8 @@ pFV
 gcR
 pfy
 eCL
-sBA
-vZC
+rVz
+tvv
 dai
 bXS
 oqZ
@@ -222341,7 +222413,7 @@ pFV
 pMh
 mGO
 rIK
-fHH
+snk
 bXS
 bXS
 oqZ
@@ -223554,7 +223626,7 @@ pFV
 spa
 svK
 dai
-hYw
+pDh
 pFV
 foN
 oqZ
@@ -223756,7 +223828,7 @@ pFV
 qoI
 pFV
 dai
-vZC
+tvv
 fFO
 foN
 oqZ
@@ -224161,7 +224233,7 @@ pFV
 pFV
 dai
 pFV
-qfS
+dge
 piv
 oqZ
 ilL
@@ -224362,7 +224434,7 @@ pFV
 pFV
 vrW
 dai
-hYw
+pDh
 rIK
 foN
 gAa
@@ -224564,7 +224636,7 @@ pFV
 fLu
 pFV
 dai
-ntv
+kgc
 pFV
 qiM
 oqZ
@@ -225164,7 +225236,7 @@ fKS
 fKS
 pFV
 dai
-ntv
+kgc
 dai
 pFV
 fLu
@@ -225366,7 +225438,7 @@ pFV
 pFV
 hcX
 pFV
-pGX
+lsg
 pFV
 qPl
 pFV
@@ -225770,7 +225842,7 @@ pFV
 rIK
 pFV
 dai
-jiP
+uBv
 pFV
 xGe
 dai
@@ -226172,9 +226244,9 @@ hcX
 pFV
 pfy
 dai
-hYw
+pDh
 pFV
-wVE
+rLl
 dai
 dai
 gcR
@@ -226583,7 +226655,7 @@ pfy
 pFV
 mGO
 eCL
-wER
+bMB
 pFV
 dHz
 piv
@@ -227179,7 +227251,7 @@ mGO
 pFV
 pFV
 pFV
-pGX
+lsg
 dai
 dai
 pFV
@@ -227381,7 +227453,7 @@ pFV
 pFV
 pFV
 dai
-wVE
+rLl
 dai
 dai
 dai
@@ -227391,7 +227463,7 @@ pFV
 myK
 rIK
 pvI
-wVE
+rLl
 pFV
 pFV
 wud
@@ -227787,7 +227859,7 @@ qPl
 dai
 dai
 pFV
-wVE
+rLl
 dai
 pFV
 pFV
@@ -227985,7 +228057,7 @@ pFV
 pFV
 pFV
 pFV
-wVE
+rLl
 pFV
 pFV
 dai
@@ -227997,7 +228069,7 @@ pfy
 fyM
 pFV
 dai
-pGX
+lsg
 dai
 bUO
 wud
@@ -228603,7 +228675,7 @@ pFV
 pFV
 pFV
 rIK
-hYw
+pDh
 pFV
 pFV
 wud
@@ -228993,7 +229065,7 @@ bSt
 pFV
 pFV
 pFV
-wER
+bMB
 pMh
 pFV
 pFV
@@ -229405,7 +229477,7 @@ dai
 dai
 pFV
 pFV
-jez
+lDj
 pFV
 dai
 pFV
@@ -229604,7 +229676,7 @@ pFV
 pFV
 dai
 dai
-vZC
+tvv
 dai
 pFV
 pFV
@@ -229801,7 +229873,7 @@ bSt
 pFV
 pFV
 dai
-vZC
+tvv
 pFV
 pFV
 dai
@@ -230205,12 +230277,12 @@ bSt
 vFX
 bSt
 bSt
-evS
+bkt
 pFV
 dHz
-jez
+lDj
 dai
-wVE
+rLl
 pFV
 pFV
 fLu
@@ -230222,7 +230294,7 @@ pFV
 pFV
 pFV
 mGO
-pJQ
+sWs
 oqZ
 oGj
 gSS
@@ -230406,7 +230478,7 @@ mfN
 bSt
 bSt
 bSt
-gou
+kNA
 bSt
 pFV
 pFV
@@ -230424,7 +230496,7 @@ pMh
 pFV
 pFV
 lPo
-pJQ
+sWs
 oqZ
 oGj
 onw
@@ -230608,7 +230680,7 @@ mfN
 bSt
 ccn
 dyf
-evS
+bkt
 bSt
 pFV
 igM
@@ -230626,7 +230698,7 @@ qPl
 pFV
 pFV
 vbq
-qEJ
+dph
 oqZ
 oGj
 onw
@@ -231012,14 +231084,14 @@ mfN
 bSt
 bSt
 bSt
-evS
-evS
+bkt
+bkt
 pMh
 pFV
 vbq
 pFV
-wVE
-wVE
+rLl
+rLl
 pFV
 tlE
 pFV
@@ -231215,7 +231287,7 @@ aUQ
 bSt
 bSt
 bSt
-evS
+bkt
 pfy
 dHz
 tlE
@@ -231415,19 +231487,19 @@ gBT
 gBT
 gBT
 gBT
-oAQ
+pwL
 gBT
-evS
+bkt
 dai
 pFV
 pFV
 pFV
-vZC
+tvv
 pFV
 pMh
 pFV
 dai
-nXe
+vuD
 pFV
 pFV
 dai
@@ -231632,7 +231704,7 @@ dai
 vbq
 pfy
 pFV
-wER
+bMB
 pFV
 pFV
 kni
@@ -231821,20 +231893,20 @@ gSR
 gSR
 gSR
 vUx
-lBa
+wQw
 dai
-tyZ
+lzg
 mGO
 pFV
 vbq
-pGX
+lsg
 pFV
 pFV
 dai
-fek
+crb
 vbq
 pFV
-wVE
+rLl
 pFV
 pFV
 pFV
@@ -232236,12 +232308,12 @@ pFV
 dai
 pFV
 igM
-gGl
+kMb
 dai
-pGX
+lsg
 vbq
-wER
-jez
+bMB
+lDj
 qdc
 oqZ
 oGj
@@ -232427,11 +232499,11 @@ gSR
 gSR
 gSR
 qrl
-cny
-cny
-oAQ
-cny
-cny
+okQ
+okQ
+pwL
+okQ
+okQ
 gBT
 bSt
 bSt
@@ -232443,7 +232515,7 @@ pFV
 igM
 igM
 pFV
-pGX
+lsg
 fXd
 oqZ
 oGj
@@ -232629,13 +232701,13 @@ gSR
 gSR
 lCC
 yjc
-dCP
+fnK
 tQk
-ltQ
-ltQ
-fnK
-fnK
-fnK
+hUr
+hUr
+bFc
+bFc
+bFc
 yjc
 pFV
 pMh
@@ -232643,7 +232715,7 @@ pFV
 vbq
 pFV
 pMh
-wVE
+rLl
 pFV
 nPL
 wud
@@ -232838,14 +232910,14 @@ sTl
 qTf
 kOv
 kOv
-nRJ
+uBR
 dai
 dai
 pFV
 igM
 pFV
 dai
-wVE
+rLl
 pFV
 pFV
 wud
@@ -233242,13 +233314,13 @@ iPV
 vjP
 vjP
 gsH
-uBR
+apb
 pFV
 dai
 pMh
 dai
 pFV
-nXe
+vuD
 pFV
 pFV
 pFV
@@ -233444,16 +233516,16 @@ bGe
 iPV
 vjP
 aSZ
-rLl
+iIQ
 pFV
 dai
 dHz
-jez
+lDj
 dai
-wVE
+rLl
 pFV
 pFV
-pGX
+lsg
 hys
 oqZ
 sqf
@@ -233646,8 +233718,8 @@ bGe
 iPV
 vjP
 kOv
-nRJ
-qIE
+uBR
+uzA
 dai
 pFV
 fLu
@@ -233848,7 +233920,7 @@ kYT
 iPV
 vjP
 qxG
-rLl
+iIQ
 gMn
 pFV
 igM
@@ -234050,14 +234122,14 @@ qyM
 vjP
 vjP
 aSZ
-rLl
+iIQ
 dai
 mGO
 pFV
-wVE
+rLl
 dai
-wVE
-wER
+rLl
+bMB
 pFV
 pFV
 tjB
@@ -234252,7 +234324,7 @@ qyM
 vjP
 vjP
 qTf
-qIR
+lSf
 pFV
 pMh
 pFV
@@ -234454,7 +234526,7 @@ vjP
 vjP
 vjP
 sTl
-uBR
+apb
 pFV
 pFV
 pFV
@@ -234656,7 +234728,7 @@ vjP
 vjP
 vjP
 dfF
-rLl
+iIQ
 pFV
 pFV
 pFV
@@ -234665,7 +234737,7 @@ pFV
 mGO
 pMh
 pFV
-wER
+bMB
 piv
 oqZ
 sqf
@@ -234858,7 +234930,7 @@ kZT
 vMw
 arX
 dfF
-rLl
+iIQ
 pFV
 pFV
 pMh
@@ -235465,7 +235537,7 @@ gBD
 sDV
 bXm
 spF
-ehz
+kSK
 pFV
 dai
 dai
@@ -235667,8 +235739,8 @@ gBD
 sDV
 bXm
 spF
-ehz
-ehz
+kSK
+kSK
 pFV
 pFV
 pFV
@@ -235870,12 +235942,12 @@ sDV
 bXm
 spF
 spF
-ehz
+kSK
 qPl
 pFV
-uaJ
+vwC
 pFV
-tVt
+rGx
 aYl
 aYl
 aYl
@@ -236077,7 +236149,7 @@ vvA
 vvA
 hPj
 hcX
-uxm
+rgL
 aYl
 aYl
 aYl
@@ -236277,8 +236349,8 @@ bXm
 bXm
 bXm
 bXm
+pEH
 azv
-tdp
 aYl
 aYl
 aYl

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -908,9 +908,6 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
-"ajy" = (
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "ajH" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -982,6 +979,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"akK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pen,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "akM" = (
 /obj/item/clothing/under/excelsior/mixed,
 /obj/item/clothing/under/excelsior/mixed,
@@ -997,15 +999,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/dorm1)
-"alg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/techshop)
 "alh" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -1175,14 +1168,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"amt" = (
-/obj/effect/floor_decal/industrial/outputgate,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "amx" = (
 /obj/machinery/chemical_dispenser,
 /obj/machinery/light,
@@ -2505,11 +2490,6 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
-"aAi" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "aAv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2860,11 +2840,6 @@
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"aDs" = (
-/obj/effect/floor_decal/industrial/outputgate,
-/obj/structure/railing,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "aDv" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
@@ -3303,12 +3278,6 @@
 "aIE" = (
 /turf/simulated/open,
 /area/nadezhda/outside/scave)
-"aIH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "aIJ" = (
 /obj/machinery/door/airlock/mining{
 	name = "Prospector Prep";
@@ -3469,6 +3438,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"aLh" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "aLk" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -3505,6 +3485,10 @@
 /obj/effect/floor_decal/spline/wood,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"aLE" = (
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "aLJ" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -3729,12 +3713,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"aNO" = (
-/obj/structure/catwalk{
-	icon_state = "catwalk12-0"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "aNQ" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
@@ -4449,6 +4427,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"aXJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "aXP" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -4627,6 +4610,15 @@
 /obj/item/device/radio/beacon/bacon,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"aZo" = (
+/obj/item/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "aZp" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -5630,6 +5622,13 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/techshop)
+"bjg" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "bjj" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1
@@ -6239,6 +6238,11 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"bqn" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "bqr" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/steel/monofloor{
@@ -7282,16 +7286,6 @@
 "bBF" = (
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
-"bBP" = (
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/item/caution,
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "bBQ" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/grille/broken,
@@ -7576,17 +7570,6 @@
 /obj/item/clothing/mask/smokable/cigarette/cigar,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
-"bFh" = (
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "bFk" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -8544,6 +8527,10 @@
 	},
 /turf/open/pool,
 /area/nadezhda/crew_quarters/pool)
+"bPR" = (
+/obj/structure/flora/big/bush1,
+/turf/unsimulated/wall/jungle,
+/area/nadezhda/engineering/engine_room)
 "bPX" = (
 /obj/structure/sink{
 	density = 1;
@@ -8734,6 +8721,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"bSB" = (
+/obj/machinery/camera/network/engineering,
+/obj/effect/floor_decal/industrial/outputgate,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "bSD" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/tool/saw,
@@ -9175,11 +9167,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/command/swo/quarters)
-"bWr" = (
-/obj/random/mob/termite_no_despawn,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "bWx" = (
 /obj/structure/flora/small/lavarock2,
 /obj/structure/flora/small/grassb4,
@@ -9353,13 +9340,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"bYH" = (
-/obj/structure/table/rack,
-/obj/item/trash/material/metal{
-	icon_state = "device3"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "bYI" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -10569,12 +10549,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/tactical_blackshield)
-"cms" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/device/lighting/toggleable/lamp,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "cmt" = (
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
 	pixel_x = 32
@@ -10653,13 +10627,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
-"cna" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "cne" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -10776,6 +10743,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
+"coE" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "coG" = (
 /obj/structure/closet/random_miscellaneous,
 /obj/random/contraband,
@@ -10800,11 +10772,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"coY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/light/tube,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "cpg" = (
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -11031,10 +10998,10 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/substation/medical)
 "crr" = (
-/obj/structure/lattice,
-/obj/structure/girder,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "crs" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -11723,10 +11690,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"czL" = (
-/obj/structure/flora/big/bush1,
-/turf/unsimulated/wall/jungle,
-/area/nadezhda/engineering/engine_room)
 "czM" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/wood/wild4,
@@ -11860,11 +11823,6 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"cBs" = (
-/obj/effect/floor_decal/industrial/box/red,
-/obj/effect/decal/cleanable/ash,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "cBw" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,15"
@@ -12615,6 +12573,12 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"cIt" = (
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/engine_room)
 "cIE" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall17";
@@ -13056,6 +13020,15 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"cNt" = (
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "splatter2"
+	},
+/turf/simulated/floor/tiled/steel/monofloor,
+/area/nadezhda/engineering/engine_room)
 "cNy" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -13668,6 +13641,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
+"cSZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/light/tube,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "cTd" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/structure/sign/levels/stairsup{
@@ -13755,6 +13733,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
+"cUh" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/portable_atmospherics/hydroponics/soil{
+	layer = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "cUi" = (
 /obj/effect/window_lwall_spawn/reinforced/polarized{
 	id = "serg"
@@ -14428,12 +14413,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"dan" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "dap" = (
 /obj/random/scrap/sparse_weighted,
 /obj/effect/decal/cleanable/rubble,
@@ -14529,6 +14508,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"dbZ" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "dce" = (
 /obj/structure/flora/small/rock3,
 /obj/random/flora/jungle_tree,
@@ -15641,17 +15627,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"doo" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "dou" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15765,6 +15740,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"dpi" = (
+/obj/structure/railing,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "dpm" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -17297,10 +17276,6 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
-"dFe" = (
-/obj/structure/lattice,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "dFf" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -17459,6 +17434,10 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"dGu" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "dGz" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin{
@@ -17517,6 +17496,14 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"dHe" = (
+/obj/effect/floor_decal/industrial/outputgate,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "dHj" = (
 /turf/simulated/floor/reinforced/n20,
 /area/nadezhda/engineering/atmos)
@@ -17995,6 +17982,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"dLZ" = (
+/obj/structure/flora/small/grassb1,
+/obj/random/scrap/sparse_even/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "dMh" = (
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/plating/under,
@@ -18427,6 +18419,13 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"dQR" = (
+/obj/structure/lattice,
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "dQU" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "6,0"
@@ -19050,6 +19049,10 @@
 "dYi" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/barracks)
+"dYj" = (
+/obj/structure/railing,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "dYk" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -19415,8 +19418,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/lab)
 "ebO" = (
-/obj/machinery/camera/network/engineering,
-/obj/effect/floor_decal/industrial/outputgate,
+/obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
 "ebP" = (
@@ -19491,10 +19493,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
-"ecp" = (
-/obj/machinery/floodlight,
-/turf/simulated/floor/rock,
-/area/colony)
 "ecu" = (
 /obj/machinery/requests_console/preset/command/wo{
 	pixel_y = 35
@@ -19518,14 +19516,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/range)
-"ecJ" = (
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
 "ecO" = (
 /obj/structure/mopbucket,
 /obj/item/reagent_containers/glass/bucket,
@@ -19594,11 +19584,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
-"edH" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "edJ" = (
 /obj/effect/spider/stickyweb,
@@ -20102,6 +20087,11 @@
 /mob/living/carbon/superior_animal/giant_spider/nurse,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"eiR" = (
+/obj/structure/flora/small/bushb2,
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "eiT" = (
 /obj/structure/table/standard,
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
@@ -22523,6 +22513,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/mineral,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"eIT" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "eIU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -23625,6 +23620,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/disposaldrop)
+"eSK" = (
+/obj/item/remains/ribcage,
+/obj/item/clothing/accessory/choker/gold_bell,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "eSP" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24353,16 +24353,6 @@
 /obj/structure/flora/small/grassb3,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
-"eZA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "eZE" = (
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm3)
@@ -24627,15 +24617,6 @@
 "fdI" = (
 /obj/structure/sign/department/atmos,
 /turf/simulated/wall/r_wall,
-/area/nadezhda/engineering/engine_room)
-"fdJ" = (
-/obj/effect/floor_decal/industrial/warningdust{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/oil{
-	icon_state = "splatter2"
-	},
-/turf/simulated/floor/tiled/steel/monofloor,
 /area/nadezhda/engineering/engine_room)
 "fdN" = (
 /obj/machinery/door/airlock/command{
@@ -25629,6 +25610,10 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"fno" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "fnq" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/small/grassa1,
@@ -26644,6 +26629,15 @@
 /obj/random/flora/jungle_tree/low,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"fyO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/techshop)
 "fyR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -27930,6 +27924,10 @@
 /obj/structure/railing,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"fNh" = (
+/obj/structure/girder,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "fNr" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -28151,6 +28149,11 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/genetics)
+"fQs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/remains/mouse,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "fQv" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -28742,6 +28745,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"fWS" = (
+/obj/structure/catwalk{
+	icon_state = "catwalk12-0"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "fWY" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -28920,6 +28929,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"fZj" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "fZq" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -29161,6 +29174,13 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
+"gbM" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "gbO" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Sec Armory";
@@ -29314,12 +29334,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"gde" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "gdh" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -29405,6 +29419,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/secrecroom)
+"gdP" = (
+/obj/effect/floor_decal/industrial/botleft/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "gdQ" = (
 /obj/random/scrap/moderate_weighted,
 /turf/simulated/floor/asteroid/dirt,
@@ -29476,6 +29501,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"geE" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "geI" = (
 /obj/structure/table/steel,
 /obj/random/credits/low_chance,
@@ -30845,6 +30881,10 @@
 /obj/item/storage/bag/trash,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"gru" = (
+/obj/structure/flora/small/grassa4,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "grw" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -32263,6 +32303,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"gIS" = (
+/obj/effect/floor_decal/industrial/warningdust,
+/turf/simulated/floor/tiled/steel/monofloor,
+/area/nadezhda/engineering/engine_room)
 "gIY" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -32835,10 +32879,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
-"gPr" = (
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "gPx" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/grass,
@@ -33042,6 +33082,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"gRB" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "gRC" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/prisoncells{
@@ -33071,11 +33118,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"gRP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/shotgun/pellet/prespawned,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
+"gRU" = (
+/obj/structure/flora/big/rocks3,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "gSc" = (
 /obj/random/cluster/roaches,
 /turf/simulated/floor/tiled/techmaint,
@@ -34131,6 +34178,10 @@
 /obj/random/cluster/spiders,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
+"hdk" = (
+/obj/structure/flora/small/grassb1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "hdo" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable/cyan{
@@ -34245,6 +34296,10 @@
 /obj/random/junkfood/rotten,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"heu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "hev" = (
 /obj/machinery/vending/assist,
 /obj/machinery/camera/network/colony_underground,
@@ -35105,12 +35160,6 @@
 /obj/machinery/exploration/adms,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"hoq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/trash/candy/proteinbar,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "hos" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -37071,15 +37120,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
-"hHR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/techshop)
 "hHS" = (
 /obj/machinery/button/windowtint{
 	id = "RD";
@@ -37138,6 +37178,14 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
+"hIv" = (
+/obj/structure/flora/small/bushb1,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "hIw" = (
 /obj/machinery/vending/cart,
 /turf/simulated/floor/wood,
@@ -37848,13 +37896,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"hOP" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/portable_atmospherics/hydroponics/soil{
-	layer = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "hPf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -37923,11 +37964,6 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
-"hPP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "hPW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -38431,10 +38467,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
-"hVW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/shield_generator)
 "hVY" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/storage/lunchbox,
@@ -39571,12 +39603,6 @@
 "ifQ" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"ifY" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "igf" = (
 /obj/structure/railing{
 	dir = 8;
@@ -39615,10 +39641,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "igp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/chips,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "igt" = (
 /obj/structure/table/woodentable,
 /obj/random/contraband,
@@ -39722,11 +39750,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"ihi" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/machinery/floodlight,
-/turf/simulated/floor/rock,
-/area/colony)
 "ihr" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -39828,13 +39851,6 @@
 "iiN" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/medical)
-"iiQ" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "iiS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40495,7 +40511,7 @@
 /area/nadezhda/crew_quarters/fitness)
 "ipf" = (
 /obj/effect/floor_decal/industrial/warningdust,
-/turf/simulated/floor/tiled/steel/monofloor,
+/turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/engine_room)
 "ipl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40890,6 +40906,14 @@
 /obj/structure/invislight,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"itJ" = (
+/obj/machinery/atmospherics/unary/vent_pump,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal{
+	icon_state = "metal3"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "itK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41213,11 +41237,6 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"ixo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "ixJ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -41229,10 +41248,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
-"ixM" = (
-/obj/structure/railing,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "ixN" = (
 /obj/structure/table/standard,
 /obj/random/lowkeyrandom/low_chance,
@@ -41704,6 +41719,11 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
+"iCv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/chips,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "iCw" = (
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
@@ -41876,6 +41896,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/genetics)
+"iEJ" = (
+/obj/structure/table/rack,
+/obj/item/trash/material/metal{
+	icon_state = "device3"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "iEN" = (
 /obj/machinery/vending/weapon_machine{
 	categories = 3
@@ -42111,6 +42138,10 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
+"iHJ" = (
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "iHP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
@@ -43843,6 +43874,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
+"jbL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/device/lighting/toggleable/lamp,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "jbO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -43852,15 +43889,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"jbQ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "jbV" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/asteroid/grass,
@@ -44593,6 +44621,13 @@
 /obj/structure/flora/big/bush2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"jiV" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "jiZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -44659,16 +44694,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"jjR" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "jjU" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "3,23"
@@ -44805,6 +44830,15 @@
 /obj/random/cloth/head/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
+"jlj" = (
+/obj/effect/floor_decal/industrial/outputgate,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/railing,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "jlk" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/structure/sign/levels/stairsup{
@@ -45815,6 +45849,14 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"juD" = (
+/obj/structure/flora/small/busha3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "juE" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -47362,6 +47404,11 @@
 /obj/structure/invislight,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
+"jMy" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "jMB" = (
 /obj/structure/table/woodentable,
 /obj/item/hand_labeler,
@@ -47598,11 +47645,6 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"jOn" = (
-/obj/structure/flora/small/rock3,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "jOo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -48723,11 +48765,6 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/security/maingate/east)
-"kaP" = (
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/shield_generator)
 "kaV" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/decal/cleanable/dirt,
@@ -49378,6 +49415,13 @@
 /obj/random/medical_lowcost/low_chance,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"khj" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "kho" = (
 /obj/random/tool/advanced,
 /obj/effect/spider/stickyweb,
@@ -50408,6 +50452,10 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"ksv" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "ksF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -50568,10 +50616,6 @@
 "kuc" = (
 /turf/simulated/open,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"kui" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "kuj" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -50741,6 +50785,11 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"kvM" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "kvR" = (
 /obj/structure/multiz/stairs/enter,
 /turf/simulated/floor/pool,
@@ -50827,6 +50876,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"kwr" = (
+/obj/structure/cable/yellow,
+/obj/effect/floor_decal/industrial/box{
+	color = "f3cbbc"
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/engineering/engine_room)
 "kws" = (
 /obj/structure/flora/small/lavarock1,
 /turf/simulated/floor/asteroid/dirt,
@@ -52111,6 +52167,12 @@
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
+"kKP" = (
+/obj/structure/table/woodentable{
+	color = "#9a977b"
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "kKT" = (
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
@@ -53562,6 +53624,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"lcN" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/railing,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "lcQ" = (
 /obj/item/modular_computer/console/preset/medical/monitor{
 	dir = 4
@@ -53654,6 +53724,14 @@
 	},
 /turf/simulated/wall,
 /area/nadezhda/maintenance/surfaceeast)
+"ldP" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "lea" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -54835,11 +54913,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/quartermaster/miningdock)
-"lsu" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/big/bush1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "lsz" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -55783,11 +55856,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"lCW" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "lDf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -55864,6 +55932,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"lDT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/light/tube,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "lDV" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -55954,6 +56029,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
+"lFn" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "lFr" = (
 /obj/effect/floor_decal/industrial/stand_clear/red,
 /obj/machinery/door/window/brigdoor/southleft{
@@ -56085,13 +56167,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
-"lGt" = (
-/obj/effect/floor_decal/industrial/caution{
-	dir = 1
-	},
-/obj/structure/railing,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "lGv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -56489,11 +56564,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/sechall)
-"lKl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/toolbox/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "lKm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -56750,16 +56820,6 @@
 /obj/machinery/vending/wallmed,
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters)
-"lNZ" = (
-/obj/effect/floor_decal/industrial/botleft/red,
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "lOa" = (
 /obj/structure/table/steel,
 /obj/random/junkfood/rotten/low_chance,
@@ -56798,6 +56858,11 @@
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"lOv" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "lOI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -56839,6 +56904,14 @@
 "lOV" = (
 /turf/simulated/floor/wood/wild4,
 /area/colony)
+"lOW" = (
+/obj/structure/flora/big/bush3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "lOY" = (
 /obj/structure/flora/pottedplant/dead,
 /obj/effect/decal/cleanable/dirt,
@@ -58050,22 +58123,6 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/east)
-"mbk" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/shield_generator)
 "mbm" = (
 /obj/structure/catwalk,
 /obj/structure/extinguisher_cabinet{
@@ -58838,6 +58895,16 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/hallway/side/f2section1)
+"mia" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "mit" = (
 /obj/structure/flora/small/bushc3,
 /obj/random/flora/small_jungle_tree,
@@ -58894,6 +58961,11 @@
 /obj/random/structures,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"miV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "miY" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -58910,6 +58982,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"mjc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/toolbox/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "mjd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark/danger,
@@ -58966,6 +59043,11 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"mjG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "mjK" = (
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -59355,15 +59437,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/crew_quarters/toilet/public)
-"mnE" = (
-/obj/effect/floor_decal/industrial/outputgate,
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/structure/railing,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "mnN" = (
 /obj/machinery/camera/xray/research{
 	dir = 5
@@ -59670,10 +59743,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"mrc" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "mrk" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -60065,6 +60134,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfaceeast)
+"mvy" = (
+/obj/structure/flora/small/busha2,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "mvB" = (
 /obj/structure/lattice,
 /turf/simulated/floor/fixed/hydrotile,
@@ -60297,6 +60371,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"myn" = (
+/obj/structure/table/rack,
+/obj/item/trash/material/metal{
+	icon_state = "device0"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "myo" = (
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/forest)
@@ -61060,12 +61141,6 @@
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"mFK" = (
-/obj/effect/floor_decal/industrial/warningdust{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel/monofloor,
-/area/nadezhda/engineering/engine_room)
 "mFN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61539,6 +61614,12 @@
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/nadezhda/engineering/atmos)
+"mKJ" = (
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/monofloor,
+/area/nadezhda/engineering/engine_room)
 "mKQ" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1;
@@ -61844,11 +61925,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"mNY" = (
-/obj/item/remains/ribcage,
-/obj/item/clothing/accessory/choker/gold_bell,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "mOc" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -62199,6 +62275,17 @@
 	icon_state = "1,17"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"mRN" = (
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "mRV" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -62342,11 +62429,6 @@
 /obj/machinery/chemical_dispenser,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
-"mTm" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "mTn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -63156,13 +63238,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"naS" = (
-/obj/structure/lattice,
-/obj/structure/catwalk{
-	icon_state = "catwalk-broken"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "naZ" = (
 /obj/random/closet_tech/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -64562,6 +64637,12 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/triage_blackshield)
+"npJ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "npN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -64701,11 +64782,6 @@
 /obj/machinery/power/generator,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
-"nrn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "nrr" = (
 /obj/machinery/light{
 	dir = 8
@@ -65918,6 +65994,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"nCR" = (
+/obj/structure/lattice,
+/obj/structure/girder,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "nCS" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/table/glass,
@@ -66493,6 +66574,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"nIM" = (
+/obj/structure/flora/small/rock3,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "nIN" = (
 /obj/structure/flora/small/trailrocka5,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -67210,6 +67296,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"nQc" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "nQd" = (
 /obj/effect/floor_decal/industrial/warningwhite,
 /obj/random/scrap/sparse_even,
@@ -68049,6 +68139,14 @@
 	},
 /turf/simulated/open,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"nYF" = (
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "nYI" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -68610,13 +68708,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/captain/quarters)
-"oeu" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "oev" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/steel,
@@ -69434,6 +69525,15 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
+"omo" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "omp" = (
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/crew_quarters/dorm3)
@@ -69864,16 +69964,19 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"orq" = (
+/obj/effect/floor_decal/industrial/caution{
+	dir = 1
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "orA" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"orD" = (
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "orF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/marble,
@@ -71087,25 +71190,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"oDB" = (
-/obj/structure/lattice,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk{
-	icon_state = "catwalk-broken"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
-"oDL" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "oDM" = (
 /obj/effect/floor_decal/spline/wood{
 	icon_state = "spline_fancy_cee"
@@ -71649,6 +71733,18 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/turret_protected/ai)
+"oJv" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "oJx" = (
 /obj/effect/floor_decal/industrial/road/warning3,
 /obj/structure/disposalpipe/segment,
@@ -71919,14 +72015,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/genetics)
-"oLq" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/structure/railing,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "oLt" = (
 /obj/machinery/door/airlock{
 	id_tag = "toilet21";
@@ -71997,11 +72085,6 @@
 /obj/structure/flora/small/bushc1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/dcave)
-"oMn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junkfood/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "oMq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -72096,17 +72179,6 @@
 "oNS" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/captain)
-"oNT" = (
-/obj/effect/floor_decal/industrial/botleft/red,
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "oOa" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/industrial/outline,
@@ -72134,11 +72206,10 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "oOh" = (
-/obj/structure/cable/yellow,
-/obj/effect/floor_decal/industrial/box{
-	color = "f3cbbc"
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 1
 	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/steel/monofloor,
 /area/nadezhda/engineering/engine_room)
 "oOj" = (
 /obj/structure/table/woodentable,
@@ -73237,14 +73308,6 @@
 	icon_state = "11,20"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"oYU" = (
-/obj/structure/flora/big/bush3,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "oYX" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/structure/disposalpipe/segment{
@@ -73732,6 +73795,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
+"peF" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "peL" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/vending/wallmed/lobby{
@@ -73960,10 +74029,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"pgO" = (
-/obj/item/remains/ribcage,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "pgT" = (
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
@@ -75484,10 +75549,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
-"pxf" = (
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "pxl" = (
 /obj/structure/railing{
 	dir = 4
@@ -75589,11 +75650,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
-"pyy" = (
-/obj/structure/flora/small/busha2,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "pyz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -75897,6 +75953,17 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/chemistry)
+"pBo" = (
+/obj/effect/floor_decal/industrial/botright/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner,
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "splatter5"
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "pBw" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 4
@@ -76455,6 +76522,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/office)
+"pHN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/lighting/toggleable/lamp,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "pHP" = (
 /obj/structure/mirror,
 /turf/simulated/wall/r_wall,
@@ -76622,14 +76694,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"pJU" = (
-/obj/structure/flora/small/bushb1,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "pJW" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -76916,14 +76980,6 @@
 "pMx" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
-"pMK" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/metal{
-	icon_state = "metal3"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "pMM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -78858,6 +78914,10 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/range)
+"qfb" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor/rock,
+/area/colony)
 "qfc" = (
 /obj/structure/flora/big/rocks3,
 /obj/structure/flora/small/bushc2,
@@ -79021,6 +79081,18 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/sleeper)
+"qgU" = (
+/obj/structure/lattice,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "qgX" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -79241,13 +79313,6 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm3)
-"qjh" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "qjm" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -80133,6 +80198,11 @@
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
+"qsh" = (
+/obj/effect/floor_decal/industrial/box/red,
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "qsl" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/syringe/drugs,
@@ -80484,6 +80554,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"qwk" = (
+/obj/structure/flora/big/bush3,
+/turf/unsimulated/wall/jungle,
+/area/nadezhda/engineering/engine_room)
 "qwl" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/random/flora/low_chance,
@@ -80714,6 +80788,11 @@
 /obj/landmark/machinery/input,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/quartermaster/miningdock)
+"qyr" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "qys" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -81828,7 +81907,7 @@
 /obj/effect/floor_decal/industrial/warningdust{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
+/turf/simulated/floor/tiled/steel/monofloor,
 /area/nadezhda/engineering/engine_room)
 "qKe" = (
 /turf/simulated/wall,
@@ -82449,6 +82528,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
+"qRG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "qRL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -82873,17 +82957,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/quartermaster/office)
-"qWC" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "qWI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -83151,13 +83224,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"qZE" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "qZG" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/grass,
@@ -83569,6 +83635,10 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"reB" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "reC" = (
 /obj/structure/closet/secure_closet/reinforced/RD,
 /obj/structure/noticeboard/research{
@@ -83602,12 +83672,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/surfacesec)
-"reN" = (
-/obj/effect/floor_decal/industrial/warningdust{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/engine_room)
 "reP" = (
 /obj/structure/table/woodentable,
 /obj/item/clipboard,
@@ -83654,6 +83718,10 @@
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/hallway)
+"rff" = (
+/obj/structure/flora/small/busha1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "rfj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -83967,6 +84035,9 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
+"rhG" = (
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "rhI" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/security/maingate/east)
@@ -84217,6 +84288,10 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
+"rkX" = (
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "rlb" = (
 /obj/machinery/body_scanconsole,
 /obj/effect/floor_decal/industrial/hatch,
@@ -84869,6 +84944,11 @@
 /obj/machinery/microwave/burnbarrel,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"rsg" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "rsi" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/hatch,
@@ -85034,6 +85114,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"rui" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "rul" = (
 /obj/structure/table/standard,
 /obj/item/deck/cards,
@@ -85134,11 +85220,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
-"rvp" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "rvq" = (
 /obj/structure/flora/small/bushc2,
 /turf/simulated/floor/asteroid/grass,
@@ -85773,11 +85854,7 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "rBK" = (
-/obj/structure/table/rack,
-/obj/item/trash/material/metal{
-	icon_state = "device0"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
+/turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/techshop)
 "rBL" = (
 /obj/structure/bonfire/permanent,
@@ -86480,6 +86557,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
+"rKd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/trash/candy/proteinbar,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "rKs" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/hop,
@@ -86589,13 +86672,10 @@
 /turf/simulated/open,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "rLy" = (
-/obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/nadezhda/engineering/engine_room)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "rLD" = (
 /obj/machinery/camera/network/colony_surface{
 	dir = 4
@@ -86620,11 +86700,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"rLQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "rLR" = (
 /obj/structure/invislight,
 /obj/structure/disposalpipe/segment{
@@ -86769,6 +86844,14 @@
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/hunter_cabin)
+"rMR" = (
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "rMT" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/railing,
@@ -86918,11 +87001,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
-"rOe" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warningwhite,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "rOi" = (
 /obj/machinery/camera/network/colony_underground{
 	dir = 1
@@ -86968,6 +87046,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"rOI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/shotgun/pellet/prespawned,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "rON" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -87973,10 +88056,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
-"rZx" = (
-/obj/structure/railing,
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
 "rZB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -88635,15 +88714,6 @@
 /obj/machinery/reagentgrinder/portable,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
-"sgr" = (
-/obj/item/modular_computer/console/preset/engineering{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "sgt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/contraband/poster/placed/generic/walk{
@@ -89687,6 +89757,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"srp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "srr" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /turf/simulated/floor/rock/manmade/road,
@@ -90233,6 +90308,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"svU" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "svV" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -90242,6 +90323,19 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/podrooms)
+"svW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "svZ" = (
 /obj/structure/table/steel,
 /obj/structure/flora/pottedplant/dead{
@@ -90367,14 +90461,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters)
-"sxh" = (
-/obj/structure/flora/small/busha3,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "sxn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -91283,10 +91369,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical_blackshield)
-"sGT" = (
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "sGV" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/asteroid/grass,
@@ -94359,10 +94441,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"tqJ" = (
-/obj/structure/flora/small/busha1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "tqM" = (
 /obj/random/cluster/termite_no_despawn/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -94558,10 +94636,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"ttF" = (
-/obj/structure/flora/small/grassa4,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "ttG" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -95330,11 +95404,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/crew_quarters/kitchen)
-"tAm" = (
-/obj/structure/flora/big/rocks3,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "tAn" = (
 /obj/machinery/firealarm{
 	pixel_y = 32
@@ -95458,10 +95527,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
-"tBG" = (
-/obj/effect/floor_decal/industrial/warningdust,
-/turf/simulated/floor/tiled/white/techfloor_grid,
-/area/nadezhda/engineering/engine_room)
 "tBO" = (
 /obj/structure/table/standard,
 /obj/machinery/electrolyzer,
@@ -95678,6 +95743,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"tEm" = (
+/obj/structure/railing,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "tEs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -97455,6 +97525,11 @@
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
+"tUK" = (
+/obj/random/mob/termite_no_despawn,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "tUS" = (
 /obj/structure/closet/secure_closet/personal/salvager,
 /obj/machinery/light{
@@ -98078,6 +98153,22 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"ubp" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "ubv" = (
 /obj/random/closet_tech/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -98810,6 +98901,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"uhS" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "uhW" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/industrial/hatch,
@@ -98914,11 +99012,6 @@
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"uiN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "uiU" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/cobweb,
@@ -99332,10 +99425,6 @@
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
-"umV" = (
-/obj/structure/girder,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "umZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -99684,19 +99773,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/foyer)
-"uqP" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "uqW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -100186,6 +100262,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/medical/virology)
+"uxu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "uxw" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/orangedouble,
@@ -100351,13 +100433,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/foyer)
-"uzj" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "uzr" = (
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -100610,13 +100685,6 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "uCd" = (
-/turf/simulated/floor/fixed/hydrotile,
-/area/nadezhda/engineering/engine_room)
-"uCg" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
 "uCi" = (
@@ -101438,6 +101506,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"uKY" = (
+/obj/random/scrap/sparse_even/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/engineering/engine_room)
 "uLc" = (
 /obj/machinery/door/airlock/maintenance_security{
 	req_access = list(1)
@@ -101839,10 +101911,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"uNA" = (
-/obj/item/remains/ribcage,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "uNF" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/warningwhite/full,
@@ -102068,6 +102136,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/engine_room)
+"uPQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "uPS" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/atmospherics/unary/vent_pump,
@@ -102236,11 +102309,6 @@
 "uQS" = (
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/detectives_office)
-"uQW" = (
-/obj/structure/railing,
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "uRa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
@@ -102544,18 +102612,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"uTG" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "uTM" = (
 /obj/structure/sign/warning/server_room,
 /turf/simulated/wall/r_wall,
@@ -102840,14 +102896,6 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
-"uWG" = (
-/obj/effect/floor_decal/industrial/botright/red,
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warningwhite/corner,
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "uWH" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -103273,6 +103321,11 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/medical/sleeper)
+"vbB" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/machinery/floodlight,
+/turf/simulated/floor/rock,
+/area/colony)
 "vbH" = (
 /obj/machinery/power/breakerbox{
 	RCon_tag = "Crg Substation Bypass"
@@ -103848,6 +103901,10 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"vis" = (
+/obj/structure/lattice,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "vit" = (
 /obj/item/oddity/common/paper_bundle,
 /obj/effect/decal/cleanable/dirt,
@@ -104847,6 +104904,10 @@
 /obj/machinery/door/holy/public,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/vectorrooms)
+"vsm" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/engineering/engine_room)
 "vsB" = (
 /obj/structure/table/standard,
 /obj/machinery/power/apc{
@@ -105234,10 +105295,11 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
-"vvU" = (
+"vvR" = (
+/obj/effect/floor_decal/industrial/outputgate,
 /obj/structure/railing,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "vvV" = (
 /obj/structure/bed/chair/sofa/black/corner{
 	dir = 4;
@@ -105532,12 +105594,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"vzT" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/contraband/low_chance,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "vzU" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -105565,11 +105621,6 @@
 	},
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
-"vAw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/pen,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "vAx" = (
 /obj/machinery/light/floor,
 /obj/structure/table/bar_special,
@@ -105656,6 +105707,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"vBD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/techshop)
 "vBE" = (
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /obj/structure/largecrate/animal/cow,
@@ -106100,7 +106160,7 @@
 /obj/effect/floor_decal/industrial/warningdust{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel/monofloor,
+/turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/engine_room)
 "vFL" = (
 /obj/effect/overlay/water,
@@ -106376,11 +106436,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
-"vJl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/remains/mouse,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "vJm" = (
 /obj/structure/lattice,
 /obj/structure/railing,
@@ -107361,6 +107416,16 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"vSl" = (
+/obj/effect/floor_decal/industrial/botleft/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "vSu" = (
 /obj/structure/catwalk,
 /obj/structure/invislight,
@@ -108695,11 +108760,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"weB" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "weI" = (
 /obj/structure/largecrate/animal/welder_roach,
 /obj/effect/decal/cleanable/dirt,
@@ -110105,11 +110165,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"wrQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "wrT" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
@@ -111483,9 +111538,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/disposaldrop)
-"wIn" = (
-/turf/simulated/wall/r_wall,
-/area/nadezhda/crew_quarters/techshop)
 "wIs" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -111600,13 +111652,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"wJj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/light/tube,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "wJm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/network/colony_surface,
@@ -112558,10 +112603,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/merchant)
-"wUw" = (
-/obj/structure/flora/small/grassb1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "wUx" = (
 /obj/machinery/suit_storage_unit,
 /turf/simulated/floor/plating/under,
@@ -112574,6 +112615,16 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"wUE" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "wUF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -113129,11 +113180,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"xaE" = (
-/obj/structure/flora/small/bushb2,
-/obj/structure/flora/big/bush1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "xaF" = (
 /obj/random/oddity_guns,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -113466,10 +113512,6 @@
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/crew_quarters/bar)
-"xfz" = (
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/engineering/engine_room)
 "xfF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -114204,13 +114246,6 @@
 "xmy" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/substation/servist)
-"xmz" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warningwhite{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/monofloor,
-/area/nadezhda/engineering/engine_room)
 "xmD" = (
 /obj/random/furniture/pottedplant,
 /obj/item/contraband/poster/placed/generic/no_erp{
@@ -114790,14 +114825,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
-"xte" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "xtg" = (
 /obj/structure/table/rack/shelf,
 /obj/machinery/door/window/westright{
@@ -115198,11 +115225,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/rbreakroom)
-"xwN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/lighting/toggleable/lamp,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "xwW" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -116079,12 +116101,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/farm)
-"xFk" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "xFl" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -116796,12 +116812,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"xLT" = (
-/obj/structure/table/woodentable{
-	color = "#9a977b"
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "xLW" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psych Office";
@@ -116841,14 +116851,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/podrooms2)
-"xMm" = (
-/obj/structure/flora/big/bush3,
-/turf/unsimulated/wall/jungle,
-/area/nadezhda/engineering/engine_room)
 "xMn" = (
 /obj/random/cluster/roaches_hoard,
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"xMt" = (
+/obj/effect/floor_decal/industrial/botright/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "xMv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -116857,6 +116871,12 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/crew_quarters/bar)
+"xME" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "xMH" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood,
@@ -117334,10 +117354,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
-"xRP" = (
-/obj/structure/flora/big/bush1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/engineering/engine_room)
 "xRR" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -117716,15 +117732,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xVP" = (
-/obj/effect/floor_decal/industrial/botright/red,
-/obj/effect/floor_decal/industrial/warningwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warningwhite/corner,
-/obj/effect/decal/cleanable/blood/oil{
-	icon_state = "splatter5"
-	},
-/turf/simulated/floor/tiled/white/monofloor,
+/obj/structure/catwalk,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
 "xVR" = (
 /obj/structure/window/reinforced,
@@ -117915,12 +117924,6 @@
 /obj/machinery/camera/network/security,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/range)
-"xYn" = (
-/obj/effect/floor_decal/industrial/warningdust{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/monofloor,
-/area/nadezhda/engineering/engine_room)
 "xYp" = (
 /obj/structure/toilet{
 	dir = 1
@@ -117954,6 +117957,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"xYC" = (
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/item/caution,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "xYI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5;
@@ -118352,6 +118365,11 @@
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/robotics)
+"ycS" = (
+/obj/structure/flora/small/busha2,
+/obj/random/scrap/sparse_even/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "ycW" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -178184,9 +178202,9 @@ cIo
 wVV
 wVV
 wVV
-uqP
-uqP
-uqP
+svW
+svW
+svW
 mLu
 cZn
 ucI
@@ -178384,14 +178402,14 @@ oEG
 whU
 tnO
 qDu
-wIn
-wIn
+rBK
+rBK
 cCy
 cCy
 cCy
-wIn
-wIn
-wIn
+rBK
+rBK
+rBK
 mpm
 hmA
 mpm
@@ -178590,10 +178608,10 @@ yfR
 nkP
 iyl
 iyl
-dan
+svU
 tYn
 fHr
-wIn
+rBK
 tAO
 gSu
 iIL
@@ -178788,14 +178806,14 @@ jIQ
 whU
 tnO
 whU
-wIn
+rBK
 oli
-hoq
-xwN
-uiN
+rKd
+pHN
+aXJ
 cxN
 rOi
-wIn
+rBK
 tAO
 gSu
 cAu
@@ -178989,15 +179007,15 @@ sRU
 sRU
 whU
 tnO
-nrn
+rLy
 cCy
 nBz
 cxN
 mSc
-wrQ
-ixo
-pxf
-wIn
+miV
+mjG
+iHJ
+rBK
 qQA
 gSu
 ayv
@@ -179196,10 +179214,10 @@ cCy
 nBz
 tar
 mXl
-vJl
+fQs
 cxN
 xXM
-wIn
+rBK
 tAO
 gSu
 hua
@@ -179393,15 +179411,15 @@ utr
 sRU
 whU
 due
-aIH
+uxu
 cCy
 sMN
-ixo
+mjG
 qpm
-hPP
-igp
+srp
+iCv
 wlK
-wIn
+rBK
 evY
 gSu
 hua
@@ -179602,8 +179620,8 @@ cCy
 nex
 cCy
 cCy
-wIn
-wIn
+rBK
+rBK
 tMC
 gSu
 hua
@@ -179800,12 +179818,12 @@ vfn
 liW
 pZA
 bHN
-alg
+vBD
 oqt
 wdA
 bjf
 pMv
-wIn
+rBK
 tMC
 gSu
 cGW
@@ -180007,7 +180025,7 @@ bNK
 vmC
 tGi
 eyB
-wIn
+rBK
 cAu
 gSu
 mwe
@@ -180204,12 +180222,12 @@ tQp
 liW
 sEX
 fwY
-hHR
+fyO
 pkg
 vTs
 rvM
 nAq
-wIn
+rBK
 cAu
 npF
 jnQ
@@ -180410,8 +180428,8 @@ cCy
 nex
 mpH
 cCy
-wIn
-wIn
+rBK
+rBK
 cAu
 gSu
 gQt
@@ -180608,12 +180626,12 @@ laf
 vvx
 cCy
 sMN
-cms
+jbL
 cuo
 sgP
 cxN
 bjU
-wIn
+rBK
 bnh
 gSu
 rHi
@@ -180807,15 +180825,15 @@ ody
 sRU
 whU
 tQp
-nrn
+rLy
 cCy
-bYH
-pMK
+iEJ
+itJ
 fCf
-uTG
-hPP
+oJv
+srp
 foj
-wIn
+rBK
 kdn
 gSu
 rHi
@@ -181009,15 +181027,15 @@ ody
 sRU
 whU
 tnO
-nrn
+rLy
 cCy
-rBK
-rLQ
+myn
+qRG
 oBN
-eZA
-coY
+wUE
+cSZ
 bjU
-wIn
+rBK
 bnh
 gSu
 eNg
@@ -181212,14 +181230,14 @@ cPd
 wFV
 tnO
 fUB
-wIn
+rBK
 kDZ
-wJj
+lDT
 ckN
 qJj
 szW
 sxI
-wIn
+rBK
 ayv
 gSu
 wSY
@@ -181417,11 +181435,11 @@ kgK
 aYq
 flW
 iyl
-vzT
+rui
 iyl
 mDo
 kzx
-wIn
+rBK
 ayv
 gSu
 wSY
@@ -181616,14 +181634,14 @@ cPd
 tiN
 tnO
 iZA
-wIn
-wIn
-wIn
+rBK
+rBK
+rBK
 eDl
-wIn
-wIn
-wIn
-wIn
+rBK
+rBK
+rBK
+rBK
 vCV
 gSu
 wSY
@@ -189709,17 +189727,17 @@ egv
 egv
 jSf
 bpF
-crr
-crr
-bBP
+nCR
+nCR
+xYC
 vVN
 vVN
 vVN
-naS
+dQR
 vVN
 ptD
 vVN
-ecp
+qfb
 pen
 cZb
 cZb
@@ -189733,8 +189751,8 @@ aQO
 nDO
 sxU
 tIz
+cIt
 qJT
-xYn
 wLJ
 hrP
 cZb
@@ -189914,12 +189932,12 @@ bpF
 xak
 lNB
 tra
-aNO
-jjR
-gde
-gde
-gde
-cna
+fWS
+mia
+peF
+peF
+peF
+uhS
 jLN
 gGT
 pen
@@ -189932,12 +189950,12 @@ hrP
 cWv
 nls
 qON
-lGt
-mFK
-lNZ
-xmz
-xVP
-ipf
+orq
+oOh
+vSl
+lFn
+pBo
+gIS
 hrP
 tad
 tad
@@ -190116,12 +190134,12 @@ bpF
 xak
 lNB
 bBk
-aNO
-oeu
+fWS
+gRB
 uCd
 uCd
 uCd
-rZx
+ebO
 vVN
 hrP
 hrP
@@ -190135,11 +190153,11 @@ jnu
 heX
 fnU
 bDQ
-oOh
-qZE
-cBs
-rOe
-tBG
+kwr
+khj
+qsh
+lOv
+ipf
 hrP
 pDL
 pDL
@@ -190315,15 +190333,15 @@ qZA
 egv
 adv
 bpF
-ebO
+bSB
 lNB
 bBk
-aNO
-oeu
+fWS
+gRB
 uCd
 uCd
 uCd
-rZx
+ebO
 vVN
 hrP
 nxP
@@ -190336,12 +190354,12 @@ qpV
 yeh
 kyK
 diB
-lGt
-fdJ
-uWG
-uzj
-oNT
-ipf
+orq
+cNt
+xMt
+dbZ
+gdP
+gIS
 hrP
 hKz
 hKz
@@ -190520,12 +190538,12 @@ bpF
 xak
 lNB
 bBk
-aNO
-oeu
+fWS
+gRB
 uCd
 uCd
 uCd
-rZx
+ebO
 vVN
 hrP
 icL
@@ -190538,14 +190556,14 @@ hrP
 iPz
 kyK
 diB
-ixM
+dpi
 eKO
+mKJ
 vFE
-reN
-vFE
+mKJ
 rOc
 hrP
-xfz
+vsm
 hKz
 hKz
 xEi
@@ -190722,12 +190740,12 @@ bpF
 xak
 lNB
 bBk
-aNO
-qWC
+fWS
+geE
 uCd
 uCd
 uCd
-rZx
+ebO
 vVN
 hrP
 nxP
@@ -190741,11 +190759,11 @@ fkV
 kyK
 diB
 kyK
-xFk
-xFk
-xFk
-xFk
-sgr
+npJ
+npJ
+npJ
+npJ
+aZo
 tIs
 mjh
 mqO
@@ -190921,15 +190939,15 @@ egv
 jSQ
 jSQ
 bpF
-crr
-crr
+nCR
+nCR
 gIz
 dnd
 mOj
-qWC
-qjh
-qjh
-oLq
+geE
+igp
+igp
+lcN
 vVN
 hrP
 hrP
@@ -191125,10 +191143,10 @@ aPT
 bpF
 cZb
 pen
-ihi
+vbB
 gGT
 nZD
-oDB
+qgU
 dnd
 dnd
 dnd
@@ -191152,9 +191170,9 @@ hrP
 tIs
 tIs
 mjh
-orD
+reB
 hKz
-czL
+bPR
 hKz
 xEi
 xEi
@@ -191332,7 +191350,7 @@ uVH
 rga
 vVN
 vVN
-naS
+dQR
 jLN
 nZD
 hcw
@@ -191351,12 +191369,12 @@ sfC
 oLe
 vVe
 oLe
-nOS
+xVP
 nOS
 mjh
 sfC
 lZr
-wUw
+dLZ
 hKz
 xEi
 xEi
@@ -191532,10 +191550,10 @@ cZb
 cZb
 pen
 jLN
-jjR
-gde
-gde
-uCg
+mia
+peF
+peF
+jiV
 vVN
 uLt
 uJL
@@ -191555,7 +191573,7 @@ hrP
 hrP
 ojV
 mjh
-wUw
+hdk
 mjh
 mqO
 bVM
@@ -191564,7 +191582,7 @@ hKz
 hKz
 hKz
 hKz
-xMm
+qwk
 hKz
 xEi
 xEi
@@ -191734,10 +191752,10 @@ cZb
 cZb
 cZb
 vVN
-oeu
+gRB
 uCd
 uCd
-rZx
+ebO
 vVN
 uLt
 uLt
@@ -191936,10 +191954,10 @@ cZb
 cZb
 cZb
 vVN
-oeu
+gRB
 uCd
 uCd
-rZx
+ebO
 rga
 vVN
 vVN
@@ -191957,7 +191975,7 @@ fvH
 hqv
 hrP
 hrP
-bFh
+mRN
 uvn
 uvn
 uvn
@@ -192138,14 +192156,14 @@ cZb
 cZb
 cZb
 vVN
-oeu
+gRB
 uCd
 uCd
 uCd
-gde
-gde
-gde
-amt
+peF
+peF
+peF
+dHe
 vVN
 hqv
 tsV
@@ -192170,7 +192188,7 @@ uCd
 uCd
 uCd
 jMx
-ecJ
+nYF
 mjh
 hKz
 xEi
@@ -192340,14 +192358,14 @@ cZb
 cZb
 hrP
 lRi
-oeu
+gRB
 uCd
 uCd
 uCd
 uCd
 uCd
 uCd
-aDs
+vvR
 jLN
 hqv
 jDF
@@ -192371,7 +192389,7 @@ uCd
 uCd
 uCd
 uCd
-dFe
+vis
 oIZ
 sfC
 hKz
@@ -192542,14 +192560,14 @@ cZb
 cZb
 cZb
 vVN
-oeu
+gRB
 uCd
 uCd
 uCd
 uCd
 uCd
 uCd
-aDs
+vvR
 aWu
 hqv
 ikw
@@ -192573,7 +192591,7 @@ uCd
 uCd
 uCd
 uCd
-dFe
+vis
 bCy
 sfC
 hKz
@@ -192744,14 +192762,14 @@ cZb
 cZb
 uVH
 vVN
-doo
-qjh
-qjh
-qjh
-qjh
-qjh
-qjh
-mnE
+aLh
+igp
+igp
+igp
+igp
+igp
+igp
+jlj
 vVN
 hqv
 oZW
@@ -192776,8 +192794,8 @@ bGg
 uCd
 uCd
 jMx
-ecJ
-lZr
+nYF
+ycS
 hKz
 xEi
 xEi
@@ -192949,7 +192967,7 @@ rga
 vVN
 vVN
 vVN
-naS
+dQR
 vVN
 vVN
 vVN
@@ -192968,18 +192986,18 @@ hqv
 hrP
 hrP
 uSN
-rLy
-rLy
-rLy
-rLy
-rLy
-rLy
-rLy
-rLy
-rLy
-rLy
+rMR
+rMR
+rMR
+rMR
+rMR
+rMR
+rMR
+rMR
+rMR
+rMR
 kCo
-lsu
+coE
 lUl
 xEi
 xEi
@@ -193146,7 +193164,7 @@ tad
 cZb
 cZb
 pen
-ihi
+vbB
 gGT
 gGT
 gGT
@@ -193168,17 +193186,17 @@ hqv
 hqv
 hqv
 hrP
-xaE
+eiR
+uKY
 nOS
 nOS
-nOS
-ttF
+gru
 bVM
 sfC
 osj
 sfC
 lZr
-xRP
+aLE
 sfC
 mjh
 lUl
@@ -208185,14 +208203,14 @@ vSM
 tfW
 eUV
 eUV
-xte
-xte
-xte
+ldP
+ldP
+ldP
 tfW
 eUV
 tfW
-oDL
-oDL
+bjg
+bjg
 tfW
 tfW
 cGa
@@ -208573,7 +208591,7 @@ kOj
 mHv
 tfW
 olX
-bWr
+tUK
 tfW
 tfW
 tfW
@@ -208589,16 +208607,16 @@ tfW
 aff
 tfW
 tfW
-sGT
+rkX
 cxU
 vaP
 eUV
-aAi
+crr
 cxU
 cxU
 tfW
 cxU
-iiQ
+gbM
 nhY
 cGa
 iSI
@@ -208800,7 +208818,7 @@ cxU
 tfW
 tfW
 cxU
-iiQ
+gbM
 tfW
 tfW
 iSI
@@ -208979,7 +208997,7 @@ cXA
 tfW
 tfW
 tfW
-hOP
+cUh
 fqz
 tfW
 fqz
@@ -209002,7 +209020,7 @@ tfW
 tfW
 bSm
 cxU
-iiQ
+gbM
 tfW
 lOm
 iSI
@@ -209191,10 +209209,10 @@ fhp
 tfW
 tfW
 lMN
-vvU
+dYj
 cxU
 tfW
-mNY
+eSK
 tfW
 cTB
 tfW
@@ -209204,7 +209222,7 @@ cri
 tfW
 tfW
 cxU
-iiQ
+gbM
 tfW
 tfW
 iSI
@@ -209393,9 +209411,9 @@ tfW
 fqz
 fqz
 cTz
-umV
+fNh
 cxU
-aAi
+crr
 pCD
 cxU
 cxU
@@ -209406,7 +209424,7 @@ tfW
 tfW
 nhY
 cxU
-iiQ
+gbM
 tfW
 tfW
 tfW
@@ -209601,14 +209619,14 @@ eUV
 nhY
 cxU
 pCD
-aAi
+crr
 eUV
 tfW
-pgO
+fno
 cXA
 aff
 cxU
-iiQ
+gbM
 eRP
 tiO
 tiO
@@ -209798,19 +209816,19 @@ lch
 vDt
 cxU
 tfW
-gPr
+ksv
 lch
 tiO
 cxU
 tfW
-rvp
+rsg
 vaP
 tfW
 tfW
 aff
 aff
 cxU
-iiQ
+gbM
 eRP
 eRP
 mYI
@@ -209999,7 +210017,7 @@ tfW
 tfW
 tfW
 tfW
-umV
+fNh
 cxU
 tfW
 tfW
@@ -210012,7 +210030,7 @@ tfW
 cxU
 cxU
 cxU
-pJU
+hIv
 tfW
 eRP
 nhY
@@ -210190,8 +210208,8 @@ tfW
 tfW
 tfW
 asu
-ajy
-kui
+rhG
+dGu
 qfL
 jsO
 qfL
@@ -210201,11 +210219,11 @@ qfL
 tfW
 cXA
 lch
-uQW
+tEm
 cxU
 cxU
 tfW
-aAi
+crr
 tfW
 aff
 iqv
@@ -210392,12 +210410,12 @@ tfW
 tfW
 tfW
 tfW
-kui
+dGu
 vMD
-gRP
+rOI
 xFj
-oMn
-xLT
+uPQ
+kKP
 mcB
 qfL
 tfW
@@ -210407,7 +210425,7 @@ tfW
 tfW
 cxU
 cXA
-aAi
+crr
 cxU
 aff
 tfW
@@ -210594,7 +210612,7 @@ cXA
 fqz
 fqz
 fqz
-mTm
+qyr
 gNG
 ugx
 fqx
@@ -210610,7 +210628,7 @@ eUV
 cxU
 cxU
 tfW
-mrc
+nQc
 tfW
 tfW
 olX
@@ -210618,7 +210636,7 @@ oHv
 olX
 olX
 cxU
-iiQ
+gbM
 tfW
 tfW
 tfW
@@ -210793,14 +210811,14 @@ rTe
 tfW
 tfW
 iqv
-weB
+kvM
 tfW
 tfW
 sSB
 eOO
 ugx
 cXJ
-vAw
+akK
 rxh
 qXx
 sSB
@@ -210808,7 +210826,7 @@ tfW
 lch
 lch
 tfW
-pyy
+mvy
 tfW
 cxU
 eUV
@@ -210820,7 +210838,7 @@ tfW
 nfC
 tfW
 cxU
-oYU
+lOW
 tfW
 lOm
 dlq
@@ -210989,7 +211007,7 @@ vaP
 tfW
 tfW
 tfW
-tqJ
+rff
 rTe
 cxU
 tfW
@@ -211003,7 +211021,7 @@ qfL
 gAr
 qfL
 xKC
-lKl
+mjc
 bBy
 xfe
 wjb
@@ -211022,7 +211040,7 @@ tfW
 tfW
 kEV
 cxU
-iiQ
+gbM
 kEV
 dlq
 kEV
@@ -211218,13 +211236,13 @@ tfW
 tfW
 aff
 aff
-uNA
+fZj
 tfW
 cxU
 mHv
 mHv
 cxU
-iiQ
+gbM
 lOm
 kEV
 syk
@@ -211426,7 +211444,7 @@ cxU
 tfW
 cxU
 cxU
-sxh
+juD
 ltw
 fdr
 fdr
@@ -211818,16 +211836,16 @@ fqz
 fqz
 tfW
 tfW
-jOn
+nIM
 tfW
-ifY
+xME
 tfW
-ifY
-ifY
+xME
+xME
 vSM
 nhY
-ifY
-jbQ
+xME
+omo
 fdr
 jSt
 uzy
@@ -212208,7 +212226,7 @@ tGU
 tfW
 uTf
 oPz
-tAm
+gRU
 fqz
 tfW
 cGa
@@ -212412,9 +212430,9 @@ uTf
 uTf
 tfW
 cGa
-edH
+jMy
 cZD
-lCW
+bqn
 olX
 tfW
 tfW
@@ -222360,8 +222378,8 @@ gBD
 gBD
 pdW
 vvB
-kaP
-hVW
+eIT
+heu
 lXt
 gtD
 pdW
@@ -222966,7 +222984,7 @@ gBD
 gBD
 pdW
 dVU
-mbk
+ubp
 oDs
 uiJ
 nrP

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -163,6 +163,16 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "abI" = (
 /obj/random/mob/render/low_chance,
+/obj/effect/floor_decal/corner_oldtile/white,
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
 "abW" = (
@@ -372,6 +382,9 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/science)
+"aey" = (
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "aez" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/tiled/steel/bar_light,
@@ -4333,6 +4346,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"aWF" = (
+/obj/structure/flora/big/bush3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "aWG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5744,6 +5765,15 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics)
+"bkQ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "bkT" = (
 /obj/structure/table/steel,
 /obj/item/oddity/ls/starscope,
@@ -5753,6 +5783,11 @@
 /obj/structure/sign/department/telecoms,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
+"bld" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "ble" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7875,6 +7910,11 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
+"bJf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/toolbox/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "bJk" = (
 /obj/machinery/power/sensor{
 	long_range = 1;
@@ -8556,6 +8596,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/bridge)
+"bRr" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "bRx" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -9772,8 +9816,9 @@
 /area/nadezhda/maintenance/undergroundfloor2north)
 "ceW" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil{
-	color = "#5c463e"
+	layer = 1
 	},
+/obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "ceX" = (
@@ -14431,6 +14476,10 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"dcP" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "dcS" = (
 /obj/structure/table/standard,
 /obj/structure/extinguisher_cabinet{
@@ -14550,6 +14599,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"dec" = (
+/obj/item/remains/ribcage,
+/obj/item/clothing/accessory/choker/gold_bell,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "deh" = (
 /obj/machinery/vending/gamers,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -15568,6 +15622,11 @@
 	},
 /turf/simulated/open,
 /area/nadezhda/outside/scave)
+"doJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "doN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -19269,10 +19328,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/lab)
 "ebO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junkfood/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
+/obj/random/mob/termite_no_despawn,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "ebP" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -24221,6 +24280,14 @@
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/command/fo)
+"eZY" = (
+/obj/structure/flora/small/busha3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "eZZ" = (
 /obj/structure/curtain/open/shower,
 /obj/item/stool,
@@ -26136,8 +26203,19 @@
 	dir = 4;
 	pixel_x = 11
 	},
+/obj/effect/floor_decal/corner_oldtile/white,
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 8
+	},
 /obj/structure/mirror{
-	pixel_x = 28
+	pixel_x = 28;
+	icon_state = "mirror_broke"
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
@@ -31494,6 +31572,10 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"gAT" = (
+/obj/structure/railing,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "gAZ" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -32537,6 +32619,11 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
+"gOn" = (
+/obj/structure/flora/big/rocks3,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "gOx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -38243,6 +38330,12 @@
 /obj/structure/cable/blue,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
+"hWy" = (
+/obj/structure/table/woodentable{
+	color = "#9a977b"
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "hWL" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop,
@@ -39354,9 +39447,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "igp" = (
-/obj/structure/flora/big/rocks3,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "igt" = (
 /obj/structure/table/woodentable,
 /obj/random/contraband,
@@ -48451,6 +48545,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"kbz" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "kbA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -49905,6 +50004,16 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "kqc" = (
 /obj/random/scrap/dense_weighted,
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_oldtile/white,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
 "kqf" = (
@@ -51886,6 +51995,11 @@
 "kMg" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/substation/cargo)
+"kMl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pen,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "kMD" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/wall/r_wall,
@@ -54415,6 +54529,16 @@
 /obj/machinery/shower{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner_oldtile/white,
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
 "lrq" = (
@@ -56600,6 +56724,13 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"lQb" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/portable_atmospherics/hydroponics/soil{
+	layer = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "lQm" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/techmaint,
@@ -59588,6 +59719,16 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "muO" = (
+/obj/effect/floor_decal/corner_oldtile/white,
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
 "muP" = (
@@ -61351,6 +61492,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"mMt" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "mMw" = (
 /obj/machinery/excelsior_boombox,
 /obj/effect/decal/cleanable/dirt,
@@ -66041,6 +66190,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
+"nID" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/shotgun/pellet/prespawned,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "nIG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/light/small{
@@ -69925,6 +70079,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"owt" = (
+/obj/structure/flora/small/busha1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "owx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -70468,6 +70626,14 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
+"oBJ" = (
+/obj/structure/flora/small/bushb1,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "oBN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
@@ -70780,6 +70946,11 @@
 "oFe" = (
 /obj/structure/flora/small/grassb5,
 /turf/unsimulated/wall/jungle,
+/area/nadezhda/outside/forest)
+"oFn" = (
+/obj/structure/flora/small/busha2,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "oFu" = (
 /obj/machinery/computer/arcade,
@@ -73511,6 +73682,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"phH" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "phJ" = (
 /obj/structure/table/woodentable,
 /obj/random/credits,
@@ -78922,6 +79098,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qlu" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "qlD" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -80866,11 +81047,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"qFQ" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "qFS" = (
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/asteroid/grass,
@@ -84601,6 +84777,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"rvA" = (
+/obj/structure/girder,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "rvM" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -85205,10 +85385,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "rBK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/shotgun/pellet/prespawned,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "rBL" = (
 /obj/structure/bonfire/permanent,
 /obj/item/material/shard,
@@ -86019,8 +86200,7 @@
 /turf/simulated/open,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "rLy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/toolbox/low_chance,
+/obj/structure/table,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
 "rLD" = (
@@ -87050,6 +87230,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/security/barracks)
+"rWP" = (
+/obj/structure/flora/small/rock3,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "rWT" = (
 /obj/random/closet/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -87403,12 +87588,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"rZE" = (
-/obj/structure/table/woodentable{
-	color = "#9a977b"
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "rZH" = (
 /obj/random/gun_normal,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -88412,10 +88591,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"skQ" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "skU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -99104,11 +99279,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"urg" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "urn" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -100142,6 +100312,10 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"uEl" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "uEq" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -103906,6 +104080,16 @@
 "vpD" = (
 /obj/structure/toilet,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/floor_decal/corner_oldtile/white,
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
 "vpF" = (
@@ -104230,6 +104414,11 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
+"vtl" = (
+/obj/structure/railing,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "vto" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -106100,6 +106289,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "vMD" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/farm)
 "vME" = (
@@ -106434,6 +106625,13 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
+"vQP" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "vQS" = (
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -108000,6 +108198,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/crew_quarters/toilet/public)
+"wfo" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "wfw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -112541,6 +112743,10 @@
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"xcB" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "xcG" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -113349,11 +113555,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"xlr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/pen,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "xlt" = (
 /obj/effect/decal/cleanable/ash,
 /obj/random/mob/roaches/low_chance,
@@ -115884,9 +116085,12 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/rbreakroom)
 "xKC" = (
-/obj/structure/table,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "xKJ" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -117341,6 +117545,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/smc/quarters)
+"yah" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "yaj" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/big/bush3,
@@ -118022,6 +118231,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/toilet/public)
+"yhX" = (
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "yib" = (
 /obj/structure/table/standard,
 /obj/random/lowkeyrandom,
@@ -206968,9 +207181,9 @@ wcY
 wcY
 olX
 olX
-tfW
-tfW
-tfW
+lch
+lch
+lch
 tfW
 kOj
 kOj
@@ -207384,14 +207597,14 @@ vSM
 tfW
 eUV
 eUV
-eUV
-eUV
-eUV
+mMt
+mMt
+mMt
 tfW
 eUV
 tfW
-tfW
-tfW
+vQP
+vQP
 tfW
 tfW
 cGa
@@ -207567,7 +207780,7 @@ iqg
 xkT
 kOj
 kOj
-tfW
+keX
 tfW
 tfW
 tfW
@@ -207583,14 +207796,14 @@ tfW
 tfW
 tfW
 tfW
-tfW
-tfW
+aff
+aff
 nhY
+cxU
 tfW
 tfW
-tfW
-tfW
-tfW
+vaP
+vaP
 tfW
 cxU
 cxU
@@ -207772,32 +207985,32 @@ kOj
 mHv
 tfW
 olX
-fhp
+ebO
 tfW
 tfW
 tfW
 fhp
 tfW
-tfW
+cXA
 fhp
 tfW
 lMN
 lMN
 tfW
 tfW
+aff
 tfW
 tfW
+yhX
+cxU
+vaP
+eUV
+bld
+cxU
+cxU
 tfW
 cxU
-cxU
-cxU
-cxU
-pCD
-cxU
-cxU
-tfW
-cxU
-tfW
+xKC
 nhY
 cGa
 iSI
@@ -207973,14 +208186,14 @@ tfW
 tfW
 tfW
 tfW
-tfW
-tfW
+fqz
+fqz
 tfW
 fhp
+fqz
+fqz
 tfW
-tfW
-tfW
-tfW
+fqz
 tfW
 tfW
 tfW
@@ -207990,16 +208203,16 @@ tfW
 vSM
 tfW
 vSM
-cxU
+tfW
 pCD
 pCD
 cxU
-cxU
-cxU
-tfW
 tfW
 cxU
 tfW
+tfW
+cxU
+xKC
 tfW
 tfW
 iSI
@@ -208178,30 +208391,30 @@ cXA
 tfW
 tfW
 tfW
+lQb
+fqz
 tfW
-tfW
-tfW
-tfW
-tfW
+fqz
+ceW
 tfW
 tfW
 tfW
 tfW
 lMN
 tfW
+aff
+aff
+aff
 tfW
 tfW
 tfW
-cxU
-cxU
-cxU
 tfW
-cxU
-cxU
+iqv
+tfW
 tfW
 bSm
 cxU
-tfW
+xKC
 tfW
 lOm
 iSI
@@ -208380,30 +208593,30 @@ tfW
 tfW
 asu
 tfW
-tfW
+fqz
+fqz
 ceW
-skQ
-skQ
+fqz
 tfW
 tfW
 fhp
 tfW
 tfW
 lMN
+gAT
+cxU
 tfW
-cxU
-cxU
-cxU
-cxU
+dec
+tfW
 cTB
-cxU
-cxU
-cxU
-hie
+tfW
+cXA
+tfW
+cri
 tfW
 tfW
 cxU
-tfW
+xKC
 tfW
 tfW
 iSI
@@ -208585,27 +208798,27 @@ tfW
 tfW
 tfW
 tfW
-ina
+fhp
+fqz
 tfW
 tfW
-tfW
-tfW
-tfW
+fqz
+fqz
 cTz
+rvA
+cxU
+bld
+pCD
+cxU
+cxU
+eUV
 tfW
-cxU
-pCD
-pCD
-cxU
-cxU
-cxU
-cxU
-cxU
-cxU
+tfW
+tfW
 tfW
 nhY
 cxU
-tfW
+xKC
 tfW
 tfW
 tfW
@@ -208784,30 +208997,30 @@ tfW
 tfW
 tfW
 fhp
+ceW
+fqz
 tfW
-skQ
-skQ
-skQ
-tfW
+ceW
+fqz
 tfW
 fhp
 tfW
 tfW
 tfW
-tfW
 cxU
-tfW
+cxU
+eUV
 nhY
 cxU
-cxU
-cxU
-cxU
-cxU
-cxU
+pCD
+bld
+eUV
+tfW
+wfo
 cXA
 aff
 cxU
-tfW
+xKC
 eRP
 tiO
 tiO
@@ -208984,32 +209197,32 @@ olX
 tfW
 mHv
 tfW
+fqz
+fqz
+fqz
+fqz
 tfW
+cXA
 tfW
-cxU
-tfW
-cxU
-cxU
-cxU
 asu
 tfW
 lch
 vDt
-tfW
-tfW
 cxU
 tfW
+dcP
+lch
 tiO
+cxU
 tfW
-cxU
-cxU
-cxU
-cxU
-cxU
+kbz
+vaP
+tfW
+tfW
 aff
 aff
 cxU
-tfW
+xKC
 eRP
 eRP
 mYI
@@ -209182,6 +209395,14 @@ rTe
 rTe
 tfW
 tfW
+lch
+tfW
+tfW
+fqz
+fqz
+tfW
+tfW
+bSm
 tfW
 tfW
 tfW
@@ -209190,28 +209411,20 @@ tfW
 tfW
 tfW
 tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
-fhp
+rvA
 cxU
 tfW
 tfW
 pCD
+eUV
+tfW
+tfW
+iqv
+tfW
 cxU
 cxU
 cxU
-igp
-cxU
-cxU
-cxU
-cxU
-nhY
+oBJ
 tfW
 eRP
 nhY
@@ -209389,8 +209602,8 @@ tfW
 tfW
 tfW
 asu
-vMD
-vMD
+aey
+uEl
 qfL
 jsO
 qfL
@@ -209400,16 +209613,16 @@ qfL
 tfW
 cXA
 lch
-tfW
+vtl
 cxU
 cxU
 tfW
-pCD
-cxU
+bld
 tfW
-cxU
-cxU
-cxU
+aff
+iqv
+tfW
+tfW
 cxU
 cxU
 tfW
@@ -209591,27 +209804,27 @@ tfW
 tfW
 tfW
 tfW
+uEl
 vMD
-vMD
-rBK
+nID
 xFj
-ebO
-rZE
+doJ
+hWy
 mcB
 qfL
 tfW
-tfW
+iqv
 tfW
 tfW
 tfW
 cxU
+cXA
+bld
+cxU
+aff
 tfW
-pCD
-cxU
 tfW
-cxU
-cxU
-cxU
+tfW
 olX
 cxU
 cxU
@@ -209788,12 +210001,12 @@ rTe
 rTe
 rTe
 tfW
-tfW
+iqv
 cXA
-tfW
-tfW
-tfW
-vMD
+fqz
+fqz
+fqz
+igp
 gNG
 ugx
 fqx
@@ -209805,19 +210018,19 @@ tfW
 fhp
 tfW
 lMN
-tfW
+eUV
 cxU
 cxU
 tfW
-cxU
+bRr
 tfW
-cxU
+tfW
 olX
 oHv
 olX
 olX
 cxU
-tfW
+xKC
 tfW
 tfW
 tfW
@@ -209991,15 +210204,15 @@ rTe
 rTe
 tfW
 tfW
-tfW
-tfW
+iqv
+phH
 tfW
 tfW
 sSB
 eOO
 ugx
 cXJ
-xlr
+kMl
 rxh
 qXx
 sSB
@@ -210007,19 +210220,19 @@ tfW
 lch
 lch
 tfW
-oHv
+oFn
 tfW
 cxU
-tfW
+eUV
 cxU
 tfW
-cxU
-cxU
+cXA
+tfW
 tfW
 nfC
 tfW
 cxU
-tiO
+aWF
 tfW
 lOm
 dlq
@@ -210188,7 +210401,7 @@ vaP
 tfW
 tfW
 tfW
-cxU
+owt
 rTe
 cxU
 tfW
@@ -210201,12 +210414,12 @@ qfL
 qfL
 gAr
 qfL
-xKC
 rLy
+bJf
 bBy
 xfe
 wjb
-tfW
+fqz
 tfW
 fhp
 tfW
@@ -210214,14 +210427,14 @@ tfW
 oHv
 cxU
 cxU
+aff
 tfW
 tfW
-cxU
 tfW
 tfW
 kEV
 cxU
-tfW
+xKC
 kEV
 dlq
 kEV
@@ -210390,12 +210603,12 @@ tfW
 tfW
 tfW
 tfW
-tfW
+cXA
 rTe
 tfW
 tfW
 tfW
-tfW
+fqz
 qfL
 dwc
 nwj
@@ -210403,27 +210616,27 @@ qfL
 vpD
 abI
 qfL
-xKC
+rLy
 ugx
 ugx
 sSB
-tfW
-tfW
+fqz
+fqz
 tfW
 tfW
 tfW
 vSM
 tfW
 tfW
+aff
+aff
+xcB
 tfW
-tfW
-tfW
-cxU
 cxU
 mHv
 mHv
 cxU
-tfW
+xKC
 lOm
 kEV
 syk
@@ -210597,7 +210810,7 @@ tfW
 tfW
 cXA
 tfW
-tfW
+fqz
 qfL
 iXd
 orR
@@ -210609,23 +210822,23 @@ nUo
 lKb
 gkd
 qfL
-cGa
+tfW
 fhp
 fhp
 tfW
 oHv
-tfW
-tfW
-tfW
-tfW
-tfW
-tfW
+cxU
+cxU
+cxU
+cxU
+aff
+aff
 tfW
 cxU
 tfW
 cxU
 cxU
-kEV
+eZY
 ltw
 fdr
 fdr
@@ -210798,8 +211011,8 @@ tfW
 tfW
 tfW
 tfW
-tfW
-tfW
+fqz
+fqz
 qfL
 yjz
 clh
@@ -210811,15 +211024,15 @@ xJC
 vJA
 vJA
 qfL
+fqz
 cGa
-cGa
 tfW
 tfW
-tfW
+cxU
 nhY
-tfW
+cxU
 gbc
-gbc
+bii
 mHv
 tiO
 nhY
@@ -211001,7 +211214,7 @@ iSI
 iSI
 vaP
 tfW
-tfW
+fqz
 qfL
 qfL
 qfL
@@ -211013,20 +211226,20 @@ sSB
 tQf
 sSB
 qfL
-cGa
+fqz
+fqz
 tfW
 tfW
+rWP
 tfW
-gbc
+rBK
 tfW
-tfW
-tfW
-tfW
-tfW
+rBK
+rBK
 vSM
 nhY
-tfW
-tfW
+rBK
+bkQ
 fdr
 jSt
 uzy
@@ -211204,18 +211417,18 @@ qEr
 mZf
 uTf
 bSm
-cGa
+vsS
 tfW
 tfW
 fhp
 tfW
 tfW
-tfW
+iqv
 tfW
 qrS
 tfW
 tfW
-cGa
+fqz
 fhp
 cXA
 tfW
@@ -211406,9 +211619,9 @@ iqg
 tGU
 tfW
 uTf
-eDm
-cGa
-cGa
+oPz
+gOn
+fqz
 tfW
 cGa
 cGa
@@ -211416,8 +211629,8 @@ tfW
 fhp
 tfW
 fhp
-cGa
-cGa
+fqz
+fqz
 tfW
 tfW
 tfW
@@ -211611,15 +211824,15 @@ uTf
 uTf
 tfW
 cGa
-urg
+qlu
+cZD
+yah
 olX
-qFQ
-olX
 tfW
 tfW
-tfW
-cGa
-cGa
+fqz
+fqz
+fqz
 tfW
 tfW
 mHv
@@ -211820,7 +212033,7 @@ fhp
 tfW
 tfW
 tfW
-tfW
+fqz
 tfW
 olX
 olX
@@ -212021,10 +212234,10 @@ tfW
 tfW
 cXA
 tfW
-tfW
+cXA
 tfW
 tiO
-olX
+cZD
 tfW
 tfW
 tfW
@@ -212623,7 +212836,7 @@ kOj
 cXA
 pQK
 olX
-tfW
+cXA
 tfW
 tfW
 olX

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -908,6 +908,9 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
+"ajy" = (
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "ajH" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -994,6 +997,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/dorm1)
+"alg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/techshop)
 "alh" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -1163,6 +1175,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"amt" = (
+/obj/effect/floor_decal/industrial/outputgate,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "amx" = (
 /obj/machinery/chemical_dispenser,
 /obj/machinery/light,
@@ -2485,6 +2505,11 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
+"aAi" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "aAv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2835,6 +2860,11 @@
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"aDs" = (
+/obj/effect/floor_decal/industrial/outputgate,
+/obj/structure/railing,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "aDv" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
@@ -3273,6 +3303,12 @@
 "aIE" = (
 /turf/simulated/open,
 /area/nadezhda/outside/scave)
+"aIH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "aIJ" = (
 /obj/machinery/door/airlock/mining{
 	name = "Prospector Prep";
@@ -3678,10 +3714,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"aNr" = (
-/obj/item/remains/ribcage,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "aNy" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -3697,6 +3729,12 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"aNO" = (
+/obj/structure/catwalk{
+	icon_state = "catwalk12-0"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "aNQ" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
@@ -7058,13 +7096,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"bzv" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/portable_atmospherics/hydroponics/soil{
-	layer = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "bzw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7204,6 +7235,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
 "bBm" = (
@@ -7250,6 +7282,16 @@
 "bBF" = (
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
+"bBP" = (
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/item/caution,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "bBQ" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/grille/broken,
@@ -7302,9 +7344,12 @@
 /area/nadezhda/maintenance/undergroundfloor2north)
 "bCy" = (
 /obj/structure/lattice,
+/obj/structure/invislight,
+/obj/structure/invislight,
 /obj/structure/catwalk,
-/obj/structure/invislight,
-/obj/structure/invislight,
+/obj/structure/railing/grey{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "bCC" = (
@@ -7419,8 +7464,12 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
 "bDQ" = (
-/obj/effect/floor_decal/industrial/warningred/full,
-/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
 "bDX" = (
@@ -7458,11 +7507,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
-"bEk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "bEn" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -7532,6 +7576,17 @@
 /obj/item/clothing/mask/smokable/cigarette/cigar,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
+"bFh" = (
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "bFk" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -7543,12 +7598,6 @@
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
-"bFl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/device/lighting/toggleable/lamp,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "bFt" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8;
@@ -8580,13 +8629,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"bQY" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "bRi" = (
 /obj/effect/floor_decal/industrial/botright/yellow,
 /obj/random/structures,
@@ -9133,6 +9175,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/command/swo/quarters)
+"bWr" = (
+/obj/random/mob/termite_no_despawn,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "bWx" = (
 /obj/structure/flora/small/lavarock2,
 /obj/structure/flora/small/grassb4,
@@ -9306,6 +9353,13 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"bYH" = (
+/obj/structure/table/rack,
+/obj/item/trash/material/metal{
+	icon_state = "device3"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "bYI" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -10515,6 +10569,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/tactical_blackshield)
+"cms" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/device/lighting/toggleable/lamp,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "cmt" = (
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
 	pixel_x = 32
@@ -10593,6 +10653,13 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
+"cna" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "cne" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -10733,6 +10800,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"coY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/light/tube,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "cpg" = (
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -10959,10 +11031,10 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/substation/medical)
 "crr" = (
-/obj/effect/decal/cleanable/filth,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/shield_generator)
+/obj/structure/lattice,
+/obj/structure/girder,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "crs" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -11651,6 +11723,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"czL" = (
+/obj/structure/flora/big/bush1,
+/turf/unsimulated/wall/jungle,
+/area/nadezhda/engineering/engine_room)
 "czM" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/wood/wild4,
@@ -11784,6 +11860,11 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"cBs" = (
+/obj/effect/floor_decal/industrial/box/red,
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "cBw" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,15"
@@ -13940,14 +14021,6 @@
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"cWJ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "cWM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14355,6 +14428,12 @@
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"dan" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "dap" = (
 /obj/random/scrap/sparse_weighted,
 /obj/effect/decal/cleanable/rubble,
@@ -15562,6 +15641,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"doo" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "dou" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17207,6 +17297,10 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
+"dFe" = (
+/obj/structure/lattice,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "dFf" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -18204,10 +18298,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"dPB" = (
-/obj/structure/flora/small/busha1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "dPC" = (
 /turf/simulated/shuttle/floor/science{
 	icon_state = "12,4"
@@ -19325,8 +19415,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/lab)
 "ebO" = (
-/turf/simulated/wall/r_wall,
-/area/nadezhda/crew_quarters/techshop)
+/obj/machinery/camera/network/engineering,
+/obj/effect/floor_decal/industrial/outputgate,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "ebP" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -19399,6 +19491,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
+"ecp" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor/rock,
+/area/colony)
 "ecu" = (
 /obj/machinery/requests_console/preset/command/wo{
 	pixel_y = 35
@@ -19422,6 +19518,14 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/range)
+"ecJ" = (
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "ecO" = (
 /obj/structure/mopbucket,
 /obj/item/reagent_containers/glass/bucket,
@@ -19490,6 +19594,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/burned,
+/area/nadezhda/outside/forest)
+"edH" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "edJ" = (
 /obj/effect/spider/stickyweb,
@@ -22604,13 +22713,11 @@
 	name = "\improper Clinic"
 	})
 "eKO" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 5
 	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/structure/girder,
+/turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "eKU" = (
 /obj/machinery/light{
@@ -23380,6 +23487,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
 	},
+/obj/item/soap,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
 "eQT" = (
@@ -23525,11 +23633,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
-"eTa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "eTd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24250,6 +24353,16 @@
 /obj/structure/flora/small/grassb3,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
+"eZA" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "eZE" = (
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm3)
@@ -24514,6 +24627,15 @@
 "fdI" = (
 /obj/structure/sign/department/atmos,
 /turf/simulated/wall/r_wall,
+/area/nadezhda/engineering/engine_room)
+"fdJ" = (
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "splatter2"
+	},
+/turf/simulated/floor/tiled/steel/monofloor,
 /area/nadezhda/engineering/engine_room)
 "fdN" = (
 /obj/machinery/door/airlock/command{
@@ -26238,14 +26360,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"fvz" = (
-/obj/structure/flora/small/busha3,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "fvA" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
@@ -28402,15 +28516,6 @@
 /obj/effect/floor_decal/border/carpet/orange,
 /turf/simulated/mineral,
 /area/colony)
-"fUw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/techshop)
 "fUB" = (
 /obj/machinery/camera/network/colony_underground{
 	dir = 1
@@ -29043,12 +29148,6 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/main/stairwell)
-"gbA" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "gbB" = (
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
@@ -29215,6 +29314,12 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"gde" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "gdh" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -30745,11 +30850,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
-"grx" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "grG" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -32147,6 +32247,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
 "gIC" = (
@@ -32183,11 +32286,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"gJn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "gJp" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/machinery/light,
@@ -32737,6 +32835,10 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
+"gPr" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "gPx" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/asteroid/grass,
@@ -32969,6 +33071,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"gRP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/shotgun/pellet/prespawned,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "gSc" = (
 /obj/random/cluster/roaches,
 /turf/simulated/floor/tiled/techmaint,
@@ -34998,6 +35105,12 @@
 /obj/machinery/exploration/adms,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"hoq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/trash/candy/proteinbar,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "hos" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -35410,11 +35523,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"hsP" = (
-/obj/structure/railing,
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "hsW" = (
 /obj/structure/flora/small/rock3,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -36963,6 +37071,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
+"hHR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/techshop)
 "hHS" = (
 /obj/machinery/button/windowtint{
 	id = "RD";
@@ -37510,14 +37627,6 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"hMb" = (
-/obj/structure/flora/small/bushb1,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "hMc" = (
 /obj/machinery/light{
 	dir = 4
@@ -37739,6 +37848,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"hOP" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/portable_atmospherics/hydroponics/soil{
+	layer = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "hPf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -37807,6 +37923,11 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
+"hPP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "hPW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -38090,6 +38211,10 @@
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
 	},
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "hUD" = (
@@ -38306,6 +38431,10 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
+"hVW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "hVY" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/storage/lunchbox,
@@ -38825,6 +38954,9 @@
 "iaa" = (
 /obj/machinery/washing_machine,
 /obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
 "iaf" = (
@@ -38982,11 +39114,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
-"iaZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "ibb" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -39444,6 +39571,12 @@
 "ifQ" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"ifY" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "igf" = (
 /obj/structure/railing{
 	dir = 8;
@@ -39482,10 +39615,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "igp" = (
-/obj/structure/table/rack,
-/obj/item/trash/material/metal{
-	icon_state = "device0"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/chips,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "igt" = (
@@ -39591,6 +39722,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"ihi" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/machinery/floodlight,
+/turf/simulated/floor/rock,
+/area/colony)
 "ihr" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -39692,6 +39828,13 @@
 "iiN" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/medical)
+"iiQ" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "iiS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40351,8 +40494,8 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/fitness)
 "ipf" = (
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/effect/floor_decal/industrial/warningdust,
+/turf/simulated/floor/tiled/steel/monofloor,
 /area/nadezhda/engineering/engine_room)
 "ipl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41070,6 +41213,11 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"ixo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "ixJ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -41081,6 +41229,10 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/hydroponics)
+"ixM" = (
+/obj/structure/railing,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "ixN" = (
 /obj/structure/table/standard,
 /obj/random/lowkeyrandom/low_chance,
@@ -42881,13 +43033,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/medical/psych)
-"iSk" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "iSn" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -43707,6 +43852,15 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"jbQ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "jbV" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/asteroid/grass,
@@ -44505,6 +44659,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"jjR" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "jjU" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "3,23"
@@ -45154,10 +45318,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
-"jpW" = (
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "jqc" = (
 /obj/machinery/light/small,
 /obj/machinery/alarm{
@@ -45870,14 +46030,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"jwM" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/metal{
-	icon_state = "metal3"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "jwR" = (
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/dark/monofloor,
@@ -47207,7 +47359,6 @@
 /area/nadezhda/medical/chemistry)
 "jMx" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/invislight,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
@@ -47381,22 +47532,6 @@
 /obj/machinery/door/window/northright,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/podrooms)
-"jNN" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/shield_generator)
 "jNP" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -47463,6 +47598,11 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"jOn" = (
+/obj/structure/flora/small/rock3,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "jOo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -48583,6 +48723,11 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/security/maingate/east)
+"kaP" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "kaV" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/decal/cleanable/dirt,
@@ -49483,12 +49628,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/gmaster)
-"kkf" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/contraband/low_chance,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "kkl" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -50103,16 +50242,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"kqn" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/material/metal,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "kqu" = (
 /obj/structure/table/standard,
 /obj/item/pen,
@@ -50439,6 +50568,10 @@
 "kuc" = (
 /turf/simulated/open,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"kui" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "kuj" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -53325,10 +53458,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"lbY" = (
-/obj/item/remains/ribcage,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "lcf" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -53443,11 +53572,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/reception)
-"lcV" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "lcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
@@ -53914,11 +54038,6 @@
 /obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
-"lil" = (
-/obj/item/remains/ribcage,
-/obj/item/clothing/accessory/choker/gold_bell,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "lin" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "16,19"
@@ -54716,6 +54835,11 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/quartermaster/miningdock)
+"lsu" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "lsz" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -55435,10 +55559,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
-"lBj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/danger,
-/area/nadezhda/engineering/shield_generator)
 "lBk" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -55663,6 +55783,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"lCW" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "lDf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -55960,6 +56085,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
+"lGt" = (
+/obj/effect/floor_decal/industrial/caution{
+	dir = 1
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "lGv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -56036,10 +56168,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security)
-"lHw" = (
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "lHA" = (
 /obj/structure/boulder,
 /turf/simulated/mineral,
@@ -56193,11 +56321,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"lIM" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "lIS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56366,6 +56489,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/sechall)
+"lKl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/toolbox/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "lKm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -56622,6 +56750,16 @@
 /obj/machinery/vending/wallmed,
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters)
+"lNZ" = (
+/obj/effect/floor_decal/industrial/botleft/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "lOa" = (
 /obj/structure/table/steel,
 /obj/random/junkfood/rotten/low_chance,
@@ -57651,10 +57789,6 @@
 /obj/structure/flora/big/rocks3,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"lYj" = (
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "lYk" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
@@ -57916,6 +58050,22 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/east)
+"mbk" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/danger,
+/area/nadezhda/engineering/shield_generator)
 "mbm" = (
 /obj/structure/catwalk,
 /obj/structure/extinguisher_cabinet{
@@ -59205,6 +59355,15 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/crew_quarters/toilet/public)
+"mnE" = (
+/obj/effect/floor_decal/industrial/outputgate,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/railing,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "mnN" = (
 /obj/machinery/camera/xray/research{
 	dir = 5
@@ -59301,11 +59460,6 @@
 "mpm" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/side/f2section1)
-"mpo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "mpw" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light/small{
@@ -59516,6 +59670,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"mrc" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "mrk" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -59666,13 +59824,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/pros/shuttle)
-"mth" = (
-/obj/structure/table/rack,
-/obj/item/trash/material/metal{
-	icon_state = "device3"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "mtj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -60909,6 +61060,12 @@
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"mFK" = (
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/monofloor,
+/area/nadezhda/engineering/engine_room)
 "mFN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61687,6 +61844,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"mNY" = (
+/obj/item/remains/ribcage,
+/obj/item/clothing/accessory/choker/gold_bell,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "mOc" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -62180,6 +62342,11 @@
 /obj/machinery/chemical_dispenser,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
+"mTm" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "mTn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -62989,6 +63156,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"naS" = (
+/obj/structure/lattice,
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "naZ" = (
 /obj/random/closet_tech/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -63630,13 +63804,6 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
-"nhM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/light/tube,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "nhN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -63963,10 +64130,6 @@
 /obj/random/lowkeyrandom,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
-"nkX" = (
-/obj/structure/railing,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "nlc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64352,11 +64515,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/medical/virology)
-"nps" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "npt" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/random/traps/low_chance{
@@ -64543,6 +64701,11 @@
 /obj/machinery/power/generator,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
+"nrn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "nrr" = (
 /obj/machinery/light{
 	dir = 8
@@ -64982,11 +65145,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/atmos/surface)
-"nvo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/remains/mouse,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "nvw" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -65776,11 +65934,6 @@
 /obj/item/storage/fancy/crayons,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/captain/quarters)
-"nCV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/toolbox/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "nCY" = (
 /obj/random/tool_upgrade/rare,
 /turf/simulated/floor/plating/under,
@@ -65893,6 +66046,7 @@
 /area/nadezhda/outside/lakeside)
 "nDO" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/railing,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "nDR" = (
@@ -66747,15 +66901,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
-"nMo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/crew_quarters/techshop)
 "nMq" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/structure/boulder,
@@ -68429,11 +68574,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"odN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/light/tube,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "odW" = (
 /obj/structure/scrap/cloth/large,
 /obj/effect/decal/cleanable/dirt,
@@ -68470,6 +68610,13 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/captain/quarters)
+"oeu" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "oev" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/steel,
@@ -69723,6 +69870,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"orD" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "orF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/marble,
@@ -70936,6 +71087,25 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"oDB" = (
+/obj/structure/lattice,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
+"oDL" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "oDM" = (
 /obj/effect/floor_decal/spline/wood{
 	icon_state = "spline_fancy_cee"
@@ -71432,6 +71602,9 @@
 /obj/structure/lattice,
 /obj/structure/catwalk,
 /obj/structure/invislight,
+/obj/structure/railing/grey{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "oJi" = (
@@ -71746,6 +71919,14 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/genetics)
+"oLq" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/railing,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "oLt" = (
 /obj/machinery/door/airlock{
 	id_tag = "toilet21";
@@ -71816,6 +71997,11 @@
 /obj/structure/flora/small/bushc1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/dcave)
+"oMn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "oMq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -71910,6 +72096,17 @@
 "oNS" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/captain)
+"oNT" = (
+/obj/effect/floor_decal/industrial/botleft/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "oOa" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/industrial/outline,
@@ -71937,10 +72134,11 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "oOh" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
+/obj/structure/cable/yellow,
+/obj/effect/floor_decal/industrial/box{
+	color = "f3cbbc"
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
 "oOj" = (
 /obj/structure/table/woodentable,
@@ -73039,6 +73237,14 @@
 	icon_state = "11,20"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"oYU" = (
+/obj/structure/flora/big/bush3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "oYX" = (
 /obj/effect/window_lwall_spawn/smartspawn/church,
 /obj/structure/disposalpipe/segment{
@@ -73474,10 +73680,6 @@
 "pdW" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
-"pdX" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "pdY" = (
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/nadezhda/engineering/atmos)
@@ -73758,6 +73960,10 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"pgO" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "pgT" = (
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
@@ -75278,6 +75484,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
+"pxf" = (
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "pxl" = (
 /obj/structure/railing{
 	dir = 4
@@ -75333,12 +75543,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"pxN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "pxW" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/church,
@@ -75385,6 +75589,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
+"pyy" = (
+/obj/structure/flora/small/busha2,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "pyz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76079,14 +76288,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
-"pFS" = (
-/obj/structure/flora/big/bush3,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "pFT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/cluster/spiders,
@@ -76421,6 +76622,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"pJU" = (
+/obj/structure/flora/small/bushb1,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "pJW" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -76707,6 +76916,14 @@
 "pMx" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
+"pMK" = (
+/obj/machinery/atmospherics/unary/vent_pump,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal{
+	icon_state = "metal3"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "pMM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -78099,15 +78316,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/hallways)
-"pZq" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "pZr" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -78531,11 +78739,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"qdP" = (
-/obj/structure/flora/big/rocks3,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "qdT" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -78804,11 +79007,6 @@
 	icon_state = "14,1"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"qgR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/shotgun/pellet/prespawned,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "qgT" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/hud/health{
@@ -78858,11 +79056,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
-"qhq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/pen,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "qhu" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/boulder,
@@ -79048,6 +79241,13 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm3)
+"qjh" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "qjm" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
@@ -81625,10 +81825,10 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
 "qJT" = (
-/obj/effect/floor_decal/industrial/warningred{
+/obj/effect/floor_decal/industrial/warningdust{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/engine_room)
 "qKe" = (
 /turf/simulated/wall,
@@ -82673,6 +82873,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/quartermaster/office)
+"qWC" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "qWI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -82940,6 +83151,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qZE" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "qZG" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/grass,
@@ -83384,6 +83602,12 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/maintenance/surfacesec)
+"reN" = (
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/engine_room)
 "reP" = (
 /obj/structure/table/woodentable,
 /obj/item/clipboard,
@@ -84588,10 +84812,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
-"rrB" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "rrH" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/sign/genetics{
@@ -84914,6 +85134,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"rvp" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "rvq" = (
 /obj/structure/flora/small/bushc2,
 /turf/simulated/floor/asteroid/grass,
@@ -85548,10 +85773,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "rBK" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/obj/structure/table/rack,
+/obj/item/trash/material/metal{
+	icon_state = "device0"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "rBL" = (
 /obj/structure/bonfire/permanent,
 /obj/item/material/shard,
@@ -86362,9 +86589,13 @@
 /turf/simulated/open,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "rLy" = (
-/obj/structure/girder,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/obj/structure/lattice,
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
 "rLD" = (
 /obj/machinery/camera/network/colony_surface{
 	dir = 4
@@ -86389,6 +86620,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"rLQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "rLR" = (
 /obj/structure/invislight,
 /obj/structure/disposalpipe/segment{
@@ -86676,11 +86912,16 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "rOc" = (
-/obj/effect/floor_decal/industrial/warningred,
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 4
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/structure/girder,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/nadezhda/engineering/engine_room)
+"rOe" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite,
+/turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/engineering/engine_room)
 "rOi" = (
 /obj/machinery/camera/network/colony_underground{
@@ -87732,6 +87973,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"rZx" = (
+/obj/structure/railing,
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
 "rZB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -88390,6 +88635,15 @@
 /obj/machinery/reagentgrinder/portable,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
+"sgr" = (
+/obj/item/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "sgt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/contraband/poster/placed/generic/walk{
@@ -90113,6 +90367,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters)
+"sxh" = (
+/obj/structure/flora/small/busha3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "sxn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -90205,16 +90467,11 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
 "sxU" = (
-/obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/structure/girder,
+/turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "syf" = (
 /obj/structure/table/steel,
@@ -90309,11 +90566,6 @@
 /obj/effect/floor_decal/sign/psy,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"syO" = (
-/obj/structure/flora/small/busha2,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "syS" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/big/bush1,
@@ -91031,6 +91283,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical_blackshield)
+"sGT" = (
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "sGV" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/asteroid/grass,
@@ -93619,11 +93875,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"tkX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "tkZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -94108,6 +94359,10 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"tqJ" = (
+/obj/structure/flora/small/busha1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "tqM" = (
 /obj/random/cluster/termite_no_despawn/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -94120,6 +94375,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
 "tre" = (
@@ -94302,6 +94558,10 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"ttF" = (
+/obj/structure/flora/small/grassa4,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "ttG" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -95070,6 +95330,11 @@
 /obj/structure/railing,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/crew_quarters/kitchen)
+"tAm" = (
+/obj/structure/flora/big/rocks3,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "tAn" = (
 /obj/machinery/firealarm{
 	pixel_y = 32
@@ -95193,6 +95458,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
+"tBG" = (
+/obj/effect/floor_decal/industrial/warningdust,
+/turf/simulated/floor/tiled/white/techfloor_grid,
+/area/nadezhda/engineering/engine_room)
 "tBO" = (
 /obj/structure/table/standard,
 /obj/machinery/electrolyzer,
@@ -95620,19 +95889,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"tFO" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "tFQ" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -95862,13 +96118,14 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "tIz" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
-	},
 /obj/machinery/camera/network/engineering{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/steel/monofloor,
 /area/nadezhda/engineering/engine_room)
 "tIA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -96044,12 +96301,6 @@
 	},
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
-"tJH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/filth,
-/obj/item/trash/candy/proteinbar,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "tJI" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/smc/quarters)
@@ -96066,12 +96317,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
-"tKe" = (
-/obj/structure/table/woodentable{
-	color = "#9a977b"
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "tKh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -97100,11 +97345,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
-"tTI" = (
-/obj/structure/flora/small/rock3,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "tTJ" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_x = 32
@@ -98674,6 +98914,11 @@
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"uiN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "uiU" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/cobweb,
@@ -98978,11 +99223,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/maingate)
-"ulM" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "ulO" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -99092,6 +99332,10 @@
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
+"umV" = (
+/obj/structure/girder,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "umZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -99440,6 +99684,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/foyer)
+"uqP" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "uqW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -99810,6 +100067,9 @@
 "uvn" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "uvp" = (
@@ -100091,6 +100351,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/foyer)
+"uzj" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "uzr" = (
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -100343,6 +100610,13 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "uCd" = (
+/turf/simulated/floor/fixed/hydrotile,
+/area/nadezhda/engineering/engine_room)
+"uCg" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
 "uCi" = (
@@ -101565,6 +101839,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"uNA" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "uNF" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/warningwhite/full,
@@ -101958,6 +102236,11 @@
 "uQS" = (
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/detectives_office)
+"uQW" = (
+/obj/structure/railing,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "uRa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
@@ -102174,6 +102457,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "uSR" = (
@@ -102258,6 +102544,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"uTG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "uTM" = (
 /obj/structure/sign/warning/server_room,
 /turf/simulated/wall/r_wall,
@@ -102379,11 +102677,6 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
-"uUL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/lighting/toggleable/lamp,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "uUN" = (
 /obj/structure/table,
 /obj/effect/spider/stickyweb,
@@ -102547,6 +102840,14 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
+"uWG" = (
+/obj/effect/floor_decal/industrial/botright/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner,
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "uWH" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -102840,12 +103141,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"uZV" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "vac" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -104939,6 +105234,10 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
+"vvU" = (
+/obj/structure/railing,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "vvV" = (
 /obj/structure/bed/chair/sofa/black/corner{
 	dir = 4;
@@ -105233,6 +105532,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"vzT" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "vzU" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -105260,6 +105565,11 @@
 	},
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
+"vAw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pen,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "vAx" = (
 /obj/machinery/light/floor,
 /obj/structure/table/bar_special,
@@ -105787,10 +106097,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "vFE" = (
-/obj/effect/floor_decal/industrial/warningred{
+/obj/effect/floor_decal/industrial/warningdust{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
+/turf/simulated/floor/tiled/steel/monofloor,
 /area/nadezhda/engineering/engine_room)
 "vFL" = (
 /obj/effect/overlay/water,
@@ -106017,11 +106327,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"vIj" = (
-/obj/random/mob/termite_no_despawn,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "vIl" = (
 /obj/structure/table/standard,
 /obj/random/toolbox/low_chance,
@@ -106071,6 +106376,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
+"vJl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/remains/mouse,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "vJm" = (
 /obj/structure/lattice,
 /obj/structure/railing,
@@ -108385,6 +108695,11 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"weB" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "weI" = (
 /obj/structure/largecrate/animal/welder_roach,
 /obj/effect/decal/cleanable/dirt,
@@ -109790,6 +110105,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"wrQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "wrT" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
@@ -111163,6 +111483,9 @@
 /obj/structure/railing,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/disposaldrop)
+"wIn" = (
+/turf/simulated/wall/r_wall,
+/area/nadezhda/crew_quarters/techshop)
 "wIs" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -111277,6 +111600,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"wJj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/light/tube,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "wJm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/network/colony_surface,
@@ -111480,11 +111810,11 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "wLJ" = (
-/obj/effect/floor_decal/industrial/warningred{
-	dir = 8
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 10
 	},
-/obj/effect/floor_decal/industrial/warningred,
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/structure/girder,
+/turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "wLL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -112228,6 +112558,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/merchant)
+"wUw" = (
+/obj/structure/flora/small/grassb1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "wUx" = (
 /obj/machinery/suit_storage_unit,
 /turf/simulated/floor/plating/under,
@@ -112795,6 +113129,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"xaE" = (
+/obj/structure/flora/small/bushb2,
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "xaF" = (
 /obj/random/oddity_guns,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -113127,6 +113466,10 @@
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/crew_quarters/bar)
+"xfz" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/engineering/engine_room)
 "xfF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -113280,9 +113623,6 @@
 	layer = 1
 	},
 /area/nadezhda/crew_quarters/sleep/bedrooms)
-"xgL" = (
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "xgR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -113864,6 +114204,13 @@
 "xmy" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/substation/servist)
+"xmz" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warningwhite{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "xmD" = (
 /obj/random/furniture/pottedplant,
 /obj/item/contraband/poster/placed/generic/no_erp{
@@ -114443,6 +114790,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
+"xte" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "xtg" = (
 /obj/structure/table/rack/shelf,
 /obj/machinery/door/window/westright{
@@ -114843,6 +115198,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/rbreakroom)
+"xwN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/lighting/toggleable/lamp,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "xwW" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -115719,6 +116079,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/farm)
+"xFk" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "xFl" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -115895,18 +116261,6 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
-"xHh" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "xHk" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Post";
@@ -116112,11 +116466,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"xJk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junkfood/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "xJo" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -116447,6 +116796,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"xLT" = (
+/obj/structure/table/woodentable{
+	color = "#9a977b"
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "xLW" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psych Office";
@@ -116486,6 +116841,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/podrooms2)
+"xMm" = (
+/obj/structure/flora/big/bush3,
+/turf/unsimulated/wall/jungle,
+/area/nadezhda/engineering/engine_room)
 "xMn" = (
 /obj/random/cluster/roaches_hoard,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -116975,6 +117334,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
+"xRP" = (
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/engineering/engine_room)
 "xRR" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -117353,8 +117716,16 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "xVP" = (
-/turf/simulated/mineral,
-/area/nadezhda/engineering/workshop)
+/obj/effect/floor_decal/industrial/botright/red,
+/obj/effect/floor_decal/industrial/warningwhite/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warningwhite/corner,
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "splatter5"
+	},
+/turf/simulated/floor/tiled/white/monofloor,
+/area/nadezhda/engineering/engine_room)
 "xVR" = (
 /obj/structure/window/reinforced,
 /obj/structure/multiz/stairs/enter{
@@ -117544,6 +117915,12 @@
 /obj/machinery/camera/network/security,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/range)
+"xYn" = (
+/obj/effect/floor_decal/industrial/warningdust{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/monofloor,
+/area/nadezhda/engineering/engine_room)
 "xYp" = (
 /obj/structure/toilet{
 	dir = 1
@@ -118268,11 +118645,6 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"ygq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/chips,
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/nadezhda/crew_quarters/techshop)
 "ygt" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -177812,9 +178184,9 @@ cIo
 wVV
 wVV
 wVV
-tFO
-tFO
-tFO
+uqP
+uqP
+uqP
 mLu
 cZn
 ucI
@@ -178012,14 +178384,14 @@ oEG
 whU
 tnO
 qDu
-ebO
-ebO
+wIn
+wIn
 cCy
 cCy
 cCy
-ebO
-ebO
-ebO
+wIn
+wIn
+wIn
 mpm
 hmA
 mpm
@@ -178218,10 +178590,10 @@ yfR
 nkP
 iyl
 iyl
-gbA
+dan
 tYn
 fHr
-ebO
+wIn
 tAO
 gSu
 iIL
@@ -178416,14 +178788,14 @@ jIQ
 whU
 tnO
 whU
-ebO
+wIn
 oli
-tJH
-uUL
-gJn
+hoq
+xwN
+uiN
 cxN
 rOi
-ebO
+wIn
 tAO
 gSu
 cAu
@@ -178617,15 +178989,15 @@ sRU
 sRU
 whU
 tnO
-tkX
+nrn
 cCy
 nBz
 cxN
 mSc
-iaZ
-eTa
-jpW
-ebO
+wrQ
+ixo
+pxf
+wIn
 qQA
 gSu
 ayv
@@ -178824,10 +179196,10 @@ cCy
 nBz
 tar
 mXl
-nvo
+vJl
 cxN
 xXM
-ebO
+wIn
 tAO
 gSu
 hua
@@ -179021,15 +179393,15 @@ utr
 sRU
 whU
 due
-pxN
+aIH
 cCy
 sMN
-eTa
+ixo
 qpm
-mpo
-ygq
+hPP
+igp
 wlK
-ebO
+wIn
 evY
 gSu
 hua
@@ -179230,8 +179602,8 @@ cCy
 nex
 cCy
 cCy
-ebO
-ebO
+wIn
+wIn
 tMC
 gSu
 hua
@@ -179428,12 +179800,12 @@ vfn
 liW
 pZA
 bHN
-fUw
+alg
 oqt
 wdA
 bjf
 pMv
-ebO
+wIn
 tMC
 gSu
 cGW
@@ -179635,7 +180007,7 @@ bNK
 vmC
 tGi
 eyB
-ebO
+wIn
 cAu
 gSu
 mwe
@@ -179832,12 +180204,12 @@ tQp
 liW
 sEX
 fwY
-nMo
+hHR
 pkg
 vTs
 rvM
 nAq
-ebO
+wIn
 cAu
 npF
 jnQ
@@ -180038,8 +180410,8 @@ cCy
 nex
 mpH
 cCy
-ebO
-ebO
+wIn
+wIn
 cAu
 gSu
 gQt
@@ -180236,12 +180608,12 @@ laf
 vvx
 cCy
 sMN
-bFl
+cms
 cuo
 sgP
 cxN
 bjU
-ebO
+wIn
 bnh
 gSu
 rHi
@@ -180435,15 +180807,15 @@ ody
 sRU
 whU
 tQp
-tkX
+nrn
 cCy
-mth
-jwM
+bYH
+pMK
 fCf
-xHh
-mpo
+uTG
+hPP
 foj
-ebO
+wIn
 kdn
 gSu
 rHi
@@ -180637,15 +181009,15 @@ ody
 sRU
 whU
 tnO
-tkX
+nrn
 cCy
-igp
-bEk
+rBK
+rLQ
 oBN
-kqn
-odN
+eZA
+coY
 bjU
-ebO
+wIn
 bnh
 gSu
 eNg
@@ -180840,14 +181212,14 @@ cPd
 wFV
 tnO
 fUB
-ebO
+wIn
 kDZ
-nhM
+wJj
 ckN
 qJj
 szW
 sxI
-ebO
+wIn
 ayv
 gSu
 wSY
@@ -181045,11 +181417,11 @@ kgK
 aYq
 flW
 iyl
-kkf
+vzT
 iyl
 mDo
 kzx
-ebO
+wIn
 ayv
 gSu
 wSY
@@ -181244,14 +181616,14 @@ cPd
 tiN
 tnO
 iZA
-ebO
-ebO
-ebO
+wIn
+wIn
+wIn
 eDl
-ebO
-ebO
-ebO
-ebO
+wIn
+wIn
+wIn
+wIn
 vCV
 gSu
 wSY
@@ -188731,7 +189103,7 @@ bpF
 bpF
 bpF
 bpF
-xVP
+cZb
 bpF
 xro
 eYP
@@ -189143,9 +189515,9 @@ uRk
 uRk
 hrP
 hrP
-cZb
-cZb
-cZb
+gGT
+gGT
+pen
 cZb
 cZb
 cZb
@@ -189337,18 +189709,18 @@ egv
 egv
 jSf
 bpF
+crr
+crr
+bBP
 vVN
 vVN
-jLN
 vVN
-vVN
-vVN
-vVN
+naS
 vVN
 ptD
 vVN
-cZb
-cZb
+ecp
+pen
 cZb
 cZb
 hrP
@@ -189362,7 +189734,7 @@ nDO
 sxU
 tIz
 qJT
-qJT
+xYn
 wLJ
 hrP
 cZb
@@ -189539,18 +189911,18 @@ eOx
 egv
 vnU
 bpF
-vVN
+xak
 lNB
 tra
-uCd
-uCd
-uCd
-uCd
-uCd
-uCd
+aNO
+jjR
+gde
+gde
+gde
+cna
 jLN
-cZb
-cZb
+gGT
+pen
 cZb
 cZb
 hrP
@@ -189560,11 +189932,11 @@ hrP
 cWv
 nls
 qON
-kyK
-oOh
-kyK
-kyK
-kyK
+lGt
+mFK
+lNZ
+xmz
+xVP
 ipf
 hrP
 tad
@@ -189741,15 +190113,15 @@ bWE
 egv
 osG
 bpF
-vVN
+xak
 lNB
 bBk
+aNO
+oeu
 uCd
 uCd
 uCd
-uCd
-uCd
-uCd
+rZx
 vVN
 hrP
 hrP
@@ -189764,10 +190136,10 @@ heX
 fnU
 bDQ
 oOh
-kyK
-kyK
-kyK
-ipf
+qZE
+cBs
+rOe
+tBG
 hrP
 pDL
 pDL
@@ -189943,15 +190315,15 @@ qZA
 egv
 adv
 bpF
-lRi
+ebO
 lNB
 bBk
+aNO
+oeu
 uCd
 uCd
 uCd
-uCd
-uCd
-uCd
+rZx
 vVN
 hrP
 nxP
@@ -189964,11 +190336,11 @@ qpV
 yeh
 kyK
 diB
-kyK
-oOh
-kyK
-kyK
-kyK
+lGt
+fdJ
+uWG
+uzj
+oNT
 ipf
 hrP
 hKz
@@ -190145,15 +190517,15 @@ twX
 egv
 qDM
 bpF
-vVN
+xak
 lNB
 bBk
+aNO
+oeu
 uCd
 uCd
 uCd
-uCd
-uCd
-uCd
+rZx
 vVN
 hrP
 icL
@@ -190166,14 +190538,14 @@ hrP
 iPz
 kyK
 diB
-kyK
+ixM
 eKO
 vFE
-vFE
+reN
 vFE
 rOc
 hrP
-nOS
+xfz
 hKz
 hKz
 xEi
@@ -190347,15 +190719,15 @@ jSQ
 egv
 uSp
 bpF
-jLN
+xak
 lNB
 bBk
+aNO
+qWC
 uCd
 uCd
 uCd
-uCd
-uCd
-uCd
+rZx
 vVN
 hrP
 nxP
@@ -190369,14 +190741,14 @@ fkV
 kyK
 diB
 kyK
-kyK
-kyK
-kyK
-kyK
-hOz
+xFk
+xFk
+xFk
+xFk
+sgr
 tIs
 mjh
-mjh
+mqO
 hKz
 xEi
 xEi
@@ -190549,15 +190921,15 @@ egv
 jSQ
 jSQ
 bpF
-rga
-vVN
+crr
+crr
 gIz
 dnd
 mOj
-uCd
-uCd
-uCd
-uCd
+qWC
+qjh
+qjh
+oLq
 vVN
 hrP
 hrP
@@ -190752,11 +191124,11 @@ iQY
 aPT
 bpF
 cZb
-cZb
-cZb
-cZb
+pen
+ihi
+gGT
 nZD
-dnd
+oDB
 dnd
 dnd
 dnd
@@ -190780,9 +191152,9 @@ hrP
 tIs
 tIs
 mjh
-mjh
+orD
 hKz
-hKz
+czL
 hKz
 xEi
 xEi
@@ -190955,12 +191327,12 @@ bpF
 bpF
 cZb
 cZb
-cZb
-cZb
+pen
+uVH
 rga
 vVN
 vVN
-vVN
+naS
 jLN
 nZD
 hcw
@@ -190982,9 +191354,9 @@ oLe
 nOS
 nOS
 mjh
-mjh
+sfC
 lZr
-mjh
+wUw
 hKz
 xEi
 xEi
@@ -191158,12 +191530,12 @@ tad
 cZb
 cZb
 cZb
-cZb
+pen
 jLN
-uCd
-uCd
-uCd
-uCd
+jjR
+gde
+gde
+uCg
 vVN
 uLt
 uJL
@@ -191183,7 +191555,7 @@ hrP
 hrP
 ojV
 mjh
-mjh
+wUw
 mjh
 mqO
 bVM
@@ -191192,7 +191564,7 @@ hKz
 hKz
 hKz
 hKz
-hKz
+xMm
 hKz
 xEi
 xEi
@@ -191362,10 +191734,10 @@ cZb
 cZb
 cZb
 vVN
+oeu
 uCd
 uCd
-uCd
-uCd
+rZx
 vVN
 uLt
 uLt
@@ -191388,7 +191760,7 @@ bVM
 ixf
 mjh
 mjh
-mjh
+sfC
 rzr
 mjh
 bVM
@@ -191564,10 +191936,10 @@ cZb
 cZb
 cZb
 vVN
+oeu
 uCd
 uCd
-uCd
-uCd
+rZx
 rga
 vVN
 vVN
@@ -191585,7 +191957,7 @@ fvH
 hqv
 hrP
 hrP
-uSN
+bFh
 uvn
 uvn
 uvn
@@ -191766,14 +192138,14 @@ cZb
 cZb
 cZb
 vVN
+oeu
 uCd
 uCd
 uCd
-uCd
-uCd
-uCd
-uCd
-xak
+gde
+gde
+gde
+amt
 vVN
 hqv
 tsV
@@ -191789,7 +192161,7 @@ tCy
 tCy
 uCd
 uCd
-uCd
+bGg
 uCd
 uCd
 bGg
@@ -191798,7 +192170,7 @@ uCd
 uCd
 uCd
 jMx
-uvn
+ecJ
 mjh
 hKz
 xEi
@@ -191968,14 +192340,14 @@ cZb
 cZb
 hrP
 lRi
+oeu
 uCd
 uCd
 uCd
 uCd
 uCd
 uCd
-uCd
-xak
+aDs
 jLN
 hqv
 jDF
@@ -191999,9 +192371,9 @@ uCd
 uCd
 uCd
 uCd
-vVN
+dFe
 oIZ
-mjh
+sfC
 hKz
 xEi
 xEi
@@ -192170,14 +192542,14 @@ cZb
 cZb
 cZb
 vVN
+oeu
 uCd
 uCd
 uCd
 uCd
 uCd
 uCd
-uCd
-xak
+aDs
 aWu
 hqv
 ikw
@@ -192201,9 +192573,9 @@ uCd
 uCd
 uCd
 uCd
-vVN
+dFe
 bCy
-mjh
+sfC
 hKz
 xEi
 xEi
@@ -192370,16 +192742,16 @@ tad
 cZb
 cZb
 cZb
-cZb
+uVH
 vVN
-uCd
-uCd
-uCd
-uCd
-uCd
-uCd
-uCd
-xak
+doo
+qjh
+qjh
+qjh
+qjh
+qjh
+qjh
+mnE
 vVN
 hqv
 oZW
@@ -192396,7 +192768,7 @@ tCy
 uCd
 uCd
 uCd
-uCd
+bGg
 uCd
 uCd
 uCd
@@ -192404,7 +192776,7 @@ bGg
 uCd
 uCd
 jMx
-uvn
+ecJ
 lZr
 hKz
 xEi
@@ -192571,13 +192943,13 @@ cZb
 tad
 cZb
 cZb
-cZb
-cZb
+pen
+uVH
 rga
 vVN
 vVN
 vVN
-vVN
+naS
 vVN
 vVN
 vVN
@@ -192596,18 +192968,18 @@ hqv
 hrP
 hrP
 uSN
-uvn
-uvn
-uvn
-uvn
-uvn
-uvn
-uvn
-uvn
-uvn
-uvn
+rLy
+rLy
+rLy
+rLy
+rLy
+rLy
+rLy
+rLy
+rLy
+rLy
 kCo
-sfC
+lsu
 lUl
 xEi
 xEi
@@ -192773,15 +193145,15 @@ cZb
 tad
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+pen
+ihi
+gGT
+gGT
+gGT
+gGT
+gGT
+gGT
+gGT
 cZb
 cZb
 cZb
@@ -192796,18 +193168,18 @@ hqv
 hqv
 hqv
 hrP
-iek
+xaE
 nOS
 nOS
 nOS
-mjh
+ttF
 bVM
-mjh
+sfC
 osj
-mjh
+sfC
 lZr
-mjh
-mjh
+xRP
+sfC
 mjh
 lUl
 lUl
@@ -192973,20 +193345,20 @@ cZb
 cZb
 cZb
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+pen
+uVH
+uVH
+uVH
+uVH
+uVH
+uVH
+pen
+cZb
+cZb
+cZb
 hqv
 wTh
 xbW
@@ -193174,21 +193546,21 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
 tad
+cZb
+cZb
+cZb
+cZb
+pen
+pen
+pen
+pen
+pen
+pen
+cZb
+cZb
+cZb
+cZb
 hqv
 gsr
 xbW
@@ -193376,21 +193748,21 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
 tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 hqv
 ntT
 oGA
@@ -193578,20 +193950,20 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+tad
+tad
 tad
 hqv
 hqv
@@ -207813,14 +208185,14 @@ vSM
 tfW
 eUV
 eUV
-cWJ
-cWJ
-cWJ
+xte
+xte
+xte
 tfW
 eUV
 tfW
-bQY
-bQY
+oDL
+oDL
 tfW
 tfW
 cGa
@@ -208201,7 +208573,7 @@ kOj
 mHv
 tfW
 olX
-vIj
+bWr
 tfW
 tfW
 tfW
@@ -208217,16 +208589,16 @@ tfW
 aff
 tfW
 tfW
-lHw
+sGT
 cxU
 vaP
 eUV
-rBK
+aAi
 cxU
 cxU
 tfW
 cxU
-iSk
+iiQ
 nhY
 cGa
 iSI
@@ -208428,7 +208800,7 @@ cxU
 tfW
 tfW
 cxU
-iSk
+iiQ
 tfW
 tfW
 iSI
@@ -208607,7 +208979,7 @@ cXA
 tfW
 tfW
 tfW
-bzv
+hOP
 fqz
 tfW
 fqz
@@ -208630,7 +209002,7 @@ tfW
 tfW
 bSm
 cxU
-iSk
+iiQ
 tfW
 lOm
 iSI
@@ -208819,10 +209191,10 @@ fhp
 tfW
 tfW
 lMN
-nkX
+vvU
 cxU
 tfW
-lil
+mNY
 tfW
 cTB
 tfW
@@ -208832,7 +209204,7 @@ cri
 tfW
 tfW
 cxU
-iSk
+iiQ
 tfW
 tfW
 iSI
@@ -209021,9 +209393,9 @@ tfW
 fqz
 fqz
 cTz
-rLy
+umV
 cxU
-rBK
+aAi
 pCD
 cxU
 cxU
@@ -209034,7 +209406,7 @@ tfW
 tfW
 nhY
 cxU
-iSk
+iiQ
 tfW
 tfW
 tfW
@@ -209229,14 +209601,14 @@ eUV
 nhY
 cxU
 pCD
-rBK
+aAi
 eUV
 tfW
-aNr
+pgO
 cXA
 aff
 cxU
-iSk
+iiQ
 eRP
 tiO
 tiO
@@ -209426,19 +209798,19 @@ lch
 vDt
 cxU
 tfW
-lYj
+gPr
 lch
 tiO
 cxU
 tfW
-lcV
+rvp
 vaP
 tfW
 tfW
 aff
 aff
 cxU
-iSk
+iiQ
 eRP
 eRP
 mYI
@@ -209627,7 +209999,7 @@ tfW
 tfW
 tfW
 tfW
-rLy
+umV
 cxU
 tfW
 tfW
@@ -209640,7 +210012,7 @@ tfW
 cxU
 cxU
 cxU
-hMb
+pJU
 tfW
 eRP
 nhY
@@ -209818,8 +210190,8 @@ tfW
 tfW
 tfW
 asu
-xgL
-rrB
+ajy
+kui
 qfL
 jsO
 qfL
@@ -209829,11 +210201,11 @@ qfL
 tfW
 cXA
 lch
-hsP
+uQW
 cxU
 cxU
 tfW
-rBK
+aAi
 tfW
 aff
 iqv
@@ -210020,12 +210392,12 @@ tfW
 tfW
 tfW
 tfW
-rrB
+kui
 vMD
-qgR
+gRP
 xFj
-xJk
-tKe
+oMn
+xLT
 mcB
 qfL
 tfW
@@ -210035,7 +210407,7 @@ tfW
 tfW
 cxU
 cXA
-rBK
+aAi
 cxU
 aff
 tfW
@@ -210222,7 +210594,7 @@ cXA
 fqz
 fqz
 fqz
-nps
+mTm
 gNG
 ugx
 fqx
@@ -210238,7 +210610,7 @@ eUV
 cxU
 cxU
 tfW
-pdX
+mrc
 tfW
 tfW
 olX
@@ -210246,7 +210618,7 @@ oHv
 olX
 olX
 cxU
-iSk
+iiQ
 tfW
 tfW
 tfW
@@ -210421,14 +210793,14 @@ rTe
 tfW
 tfW
 iqv
-ulM
+weB
 tfW
 tfW
 sSB
 eOO
 ugx
 cXJ
-qhq
+vAw
 rxh
 qXx
 sSB
@@ -210436,7 +210808,7 @@ tfW
 lch
 lch
 tfW
-syO
+pyy
 tfW
 cxU
 eUV
@@ -210448,7 +210820,7 @@ tfW
 nfC
 tfW
 cxU
-pFS
+oYU
 tfW
 lOm
 dlq
@@ -210617,7 +210989,7 @@ vaP
 tfW
 tfW
 tfW
-dPB
+tqJ
 rTe
 cxU
 tfW
@@ -210631,7 +211003,7 @@ qfL
 gAr
 qfL
 xKC
-nCV
+lKl
 bBy
 xfe
 wjb
@@ -210650,7 +211022,7 @@ tfW
 tfW
 kEV
 cxU
-iSk
+iiQ
 kEV
 dlq
 kEV
@@ -210846,13 +211218,13 @@ tfW
 tfW
 aff
 aff
-lbY
+uNA
 tfW
 cxU
 mHv
 mHv
 cxU
-iSk
+iiQ
 lOm
 kEV
 syk
@@ -211054,7 +211426,7 @@ cxU
 tfW
 cxU
 cxU
-fvz
+sxh
 ltw
 fdr
 fdr
@@ -211446,16 +211818,16 @@ fqz
 fqz
 tfW
 tfW
-tTI
+jOn
 tfW
-uZV
+ifY
 tfW
-uZV
-uZV
+ifY
+ifY
 vSM
 nhY
-uZV
-pZq
+ifY
+jbQ
 fdr
 jSt
 uzy
@@ -211836,7 +212208,7 @@ tGU
 tfW
 uTf
 oPz
-qdP
+tAm
 fqz
 tfW
 cGa
@@ -212040,9 +212412,9 @@ uTf
 uTf
 tfW
 cGa
-grx
+edH
 cZD
-lIM
+lCW
 olX
 tfW
 tfW
@@ -221988,8 +222360,8 @@ gBD
 gBD
 pdW
 vvB
-crr
-lBj
+kaP
+hVW
 lXt
 gtD
 pdW
@@ -222594,7 +222966,7 @@ gBD
 gBD
 pdW
 dVU
-jNN
+mbk
 oDs
 uiJ
 nrP

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -9771,8 +9771,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "ceW" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/turf/simulated/floor/asteroid/dirt/dust,
+/obj/machinery/portable_atmospherics/hydroponics/soil{
+	color = "#5c463e"
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "ceX" = (
 /obj/machinery/door/airlock/glass,
@@ -10353,7 +10355,9 @@
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
 "clh" = (
-/obj/structure/reagent_dispensers/watertank/huge,
+/obj/structure/reagent_dispensers/watertank/huge{
+	color = "#9a977b"
+	},
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/farm)
 "clk" = (
@@ -14005,8 +14009,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cXJ" = (
-/obj/item/remains/human,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/remains/ribcage,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
 "cXK" = (
@@ -19265,9 +19269,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/lab)
 "ebO" = (
-/obj/structure/bed/double/padded,
-/obj/random/furniture/bedsheetdouble,
-/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
 "ebP" = (
@@ -23017,10 +23020,12 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
 "eOO" = (
-/obj/structure/closet/cabinet,
+/obj/structure/closet/cabinet{
+	color = "#9a977b"
+	},
+/obj/effect/decal/cleanable/cobweb2,
 /obj/random/ammo/shotgun/low_chance,
 /obj/random/gun_shotgun/low_chance,
-/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
 "eOT" = (
@@ -31462,7 +31467,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/science)
 "gAr" = (
-/obj/machinery/door/unpowered/simple/wood,
+/obj/machinery/door/unpowered/simple/wood{
+	color = "#9a977b"
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
 "gAx" = (
@@ -32421,7 +32428,9 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
 "gNG" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	color = "#9a977b"
+	},
 /obj/random/junkfood/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
@@ -45289,12 +45298,12 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "jsO" = (
-/obj/machinery/door/unpowered/simple/wood{
-	name = "Lost Farm"
-	},
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/random/traps/low_chance{
 	spawn_nothing_percentage = 90
+	},
+/obj/machinery/door/unpowered/simple/wood{
+	color = "#9a977b"
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
@@ -56101,6 +56110,7 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "lKb" = (
+/obj/item/paper_bin,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/farm)
 "lKe" = (
@@ -57764,7 +57774,12 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
 "mcB" = (
-/obj/structure/table/woodentable,
+/obj/structure/bed/double/padded{
+	dir = 4
+	},
+/obj/random/furniture/bedsheetdouble{
+	dir = 1
+	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
 "mcC" = (
@@ -64757,7 +64772,9 @@
 	name = "Residential District Maintenance"
 	})
 "nwj" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	color = "#9a977b"
+	},
 /obj/item/tool/shovel/spade,
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/wood/wild4,
@@ -67137,6 +67154,7 @@
 /area/shuttle/rocinante_shuttle_area)
 "nUo" = (
 /obj/structure/coatrack,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/farm)
 "nUD" = (
@@ -69459,7 +69477,9 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
 "orR" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/woodentable{
+	color = "#9a977b"
+	},
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/farm)
 "orT" = (
@@ -78379,7 +78399,7 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "qfL" = (
-/turf/simulated/wall/wood_barrel,
+/turf/simulated/wall/wood_old,
 /area/nadezhda/dungeon/outside/farm)
 "qfM" = (
 /turf/simulated/floor/tiled/steel,
@@ -80846,6 +80866,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"qFQ" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "qFS" = (
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/asteroid/grass,
@@ -85180,9 +85205,10 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "rBK" = (
-/mob/living/simple_animal/jungle_bird,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/shotgun/pellet/prespawned,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "rBL" = (
 /obj/structure/bonfire/permanent,
 /obj/item/material/shard,
@@ -85993,9 +86019,8 @@
 /turf/simulated/open,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "rLy" = (
-/obj/structure/table/woodentable,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/toolbox/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
 "rLD" = (
@@ -87378,6 +87403,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"rZE" = (
+/obj/structure/table/woodentable{
+	color = "#9a977b"
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "rZH" = (
 /obj/random/gun_normal,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -88381,6 +88412,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"skQ" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "skU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -99069,6 +99104,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"urg" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "urn" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -100589,7 +100629,9 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
 "uJn" = (
-/obj/machinery/door/unpowered/simple/wood,
+/obj/machinery/door/unpowered/simple/wood{
+	color = "#9a977b"
+	},
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/farm)
 "uJp" = (
@@ -106058,10 +106100,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "vMD" = (
-/obj/structure/table/woodentable,
-/obj/random/junkfood/low_chance,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/wood/wild5,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/farm)
 "vME" = (
 /obj/structure/cable/green{
@@ -113310,6 +113349,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"xlr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pen,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "xlt" = (
 /obj/effect/decal/cleanable/ash,
 /obj/random/mob/roaches/low_chance,
@@ -115840,8 +115884,7 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/rbreakroom)
 "xKC" = (
-/obj/structure/table/woodentable,
-/obj/random/toolbox/low_chance,
+/obj/structure/table,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
 "xKJ" = (
@@ -207729,14 +207772,14 @@ kOj
 mHv
 tfW
 olX
-tfW
+fhp
 tfW
 tfW
 tfW
 fhp
 tfW
 tfW
-tfW
+fhp
 tfW
 lMN
 lMN
@@ -207933,7 +207976,7 @@ tfW
 tfW
 tfW
 tfW
-tfW
+fhp
 tfW
 tfW
 tfW
@@ -208135,11 +208178,11 @@ cXA
 tfW
 tfW
 tfW
-cxU
-cxU
-cxU
-cxU
-cxU
+tfW
+tfW
+tfW
+tfW
+tfW
 tfW
 tfW
 tfW
@@ -208337,11 +208380,11 @@ tfW
 tfW
 asu
 tfW
-cxU
+tfW
 ceW
-ceW
-ceW
-cxU
+skQ
+skQ
+tfW
 tfW
 fhp
 tfW
@@ -208539,11 +208582,11 @@ tfW
 tfW
 tfW
 tfW
-cxU
-cxU
-cxU
+tfW
+tfW
+tfW
 ina
-cxU
+tfW
 tfW
 tfW
 tfW
@@ -208736,16 +208779,16 @@ cxU
 tfW
 tfW
 tfW
-tfW
+fhp
 tfW
 tfW
 tfW
 fhp
-cxU
-ceW
-ceW
-ceW
-cxU
+tfW
+skQ
+skQ
+skQ
+tfW
 tfW
 fhp
 tfW
@@ -208944,13 +208987,13 @@ tfW
 tfW
 tfW
 cxU
-cxU
+tfW
 cxU
 cxU
 cxU
 asu
 tfW
-tfW
+lch
 vDt
 tfW
 tfW
@@ -209142,12 +209185,6 @@ tfW
 tfW
 tfW
 tfW
-cxU
-cxU
-cxU
-cxU
-cxU
-cxU
 tfW
 tfW
 tfW
@@ -209156,6 +209193,12 @@ tfW
 tfW
 tfW
 tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+fhp
 cxU
 tfW
 tfW
@@ -209344,10 +209387,10 @@ cXA
 tfW
 tfW
 tfW
-cxU
 tfW
-qfL
-qfL
+asu
+vMD
+vMD
 qfL
 jsO
 qfL
@@ -209356,7 +209399,7 @@ qfL
 qfL
 tfW
 cXA
-tfW
+lch
 tfW
 cxU
 cxU
@@ -209546,14 +209589,14 @@ tfW
 tfW
 tfW
 tfW
-rBK
 tfW
-sSB
+tfW
 vMD
-ugx
+vMD
+rBK
 xFj
-ugx
-bBy
+ebO
+rZE
 mcB
 qfL
 tfW
@@ -209748,15 +209791,15 @@ tfW
 tfW
 cXA
 tfW
-cxU
 tfW
-sSB
+tfW
+vMD
 gNG
 ugx
 fqx
 fKx
 udy
-ebO
+qXx
 qfL
 tfW
 fhp
@@ -209950,13 +209993,13 @@ tfW
 tfW
 tfW
 tfW
-cxU
+tfW
 tfW
 sSB
 eOO
 ugx
 cXJ
-ugx
+xlr
 rxh
 qXx
 sSB
@@ -210159,13 +210202,13 @@ qfL
 gAr
 qfL
 xKC
-ugx
+rLy
 bBy
 xfe
 wjb
 tfW
 tfW
-tfW
+fhp
 tfW
 tfW
 oHv
@@ -210360,8 +210403,8 @@ qfL
 vpD
 abI
 qfL
-rLy
-bBy
+xKC
+ugx
 ugx
 sSB
 tfW
@@ -210566,8 +210609,8 @@ nUo
 lKb
 gkd
 qfL
-tfW
-tfW
+cGa
+fhp
 fhp
 tfW
 oHv
@@ -210768,8 +210811,8 @@ xJC
 vJA
 vJA
 qfL
-tfW
-tfW
+cGa
+cGa
 tfW
 tfW
 tfW
@@ -210970,7 +211013,7 @@ sSB
 tQf
 sSB
 qfL
-tfW
+cGa
 tfW
 tfW
 tfW
@@ -211172,8 +211215,8 @@ tfW
 qrS
 tfW
 tfW
-tfW
-tfW
+cGa
+fhp
 cXA
 tfW
 tfW
@@ -211367,14 +211410,14 @@ eDm
 cGa
 cGa
 tfW
-tfW
-tfW
+cGa
+cGa
 tfW
 fhp
 tfW
-tfW
-tfW
-tfW
+fhp
+cGa
+cGa
 tfW
 tfW
 tfW
@@ -211568,15 +211611,15 @@ uTf
 uTf
 tfW
 cGa
+urg
 olX
+qFQ
 olX
-olX
-olX
 tfW
 tfW
 tfW
-tfW
-tfW
+cGa
+cGa
 tfW
 tfW
 mHv
@@ -211773,7 +211816,7 @@ mHv
 ohH
 tfW
 tfW
-tfW
+fhp
 tfW
 tfW
 tfW

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -750,6 +750,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/substation/bridge)
+"aig" = (
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "aij" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
@@ -1282,10 +1287,7 @@
 	})
 "anq" = (
 /obj/structure/flora/big/rocks3,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
+/turf/simulated/mineral,
 /area/nadezhda/outside/inside_colony)
 "anv" = (
 /obj/machinery/firealarm{
@@ -1317,6 +1319,10 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
+"anG" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "anK" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -1392,13 +1398,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"apb" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "apk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2298,11 +2297,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
-"ayf" = (
-/obj/structure/railing,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "ayh" = (
 /obj/structure/flora/small/grassa5,
 /obj/random/mob/spiders/low_chance,
@@ -4058,6 +4052,21 @@
 /obj/random/junkfood/rotten,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"aSj" = (
+/obj/effect/floor_decal/spline/fancy,
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/table/bench/steel,
+/obj/effect/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/security/sechall)
 "aSk" = (
 /obj/structure/table/rack/shelf,
 /obj/item/hand_labeler,
@@ -4171,11 +4180,6 @@
 /obj/item/storage/box/monkeycubes,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
-"aUa" = (
-/obj/structure/railing,
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "aUc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4210,11 +4214,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/medical/reception)
-"aUC" = (
-/obj/structure/low_wall,
-/obj/structure/flora/big/bush3,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "aUE" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/bushb1,
@@ -5790,10 +5789,6 @@
 /obj/effect/floor_decal/industrial/road/curve4,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"bkt" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
@@ -6252,6 +6247,11 @@
 /obj/structure/flora/small/rock3,
 /obj/structure/railing,
 /obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
+"bqo" = (
+/obj/structure/railing,
+/obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "bqr" = (
@@ -7614,11 +7614,10 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
 "bFc" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
+/obj/random/flora/low_chance,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "bFk" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -8377,11 +8376,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/medical/morgue)
-"bMB" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "bMF" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
@@ -8832,6 +8826,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"bTk" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "bTl" = (
 /obj/structure/table/rack/shelf,
 /obj/random/toolbox,
@@ -9774,6 +9773,11 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"ccP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "ccY" = (
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -9787,6 +9791,14 @@
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
+"cdg" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "cdh" = (
 /obj/machinery/atm{
 	dir = 8;
@@ -11013,11 +11025,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"crb" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "cri" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/grass,
@@ -11148,12 +11155,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "csI" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
+/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "csK" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -12055,12 +12060,6 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/techshop)
-"cCA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/item/flame/lighter/zippo/capitalist,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "cCD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/machinery/requests_console/preset/command/bc{
@@ -14485,7 +14484,7 @@
 "dai" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
+/area/nadezhda/security/maingate/east)
 "dak" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/light/small{
@@ -14627,10 +14626,6 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
-"dcC" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "dcS" = (
 /obj/structure/table/standard,
 /obj/structure/extinguisher_cabinet{
@@ -14987,12 +14982,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/cargo,
-/area/nadezhda/outside/inside_colony)
-"dge" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "dgi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15840,11 +15829,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"dph" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate/east)
 "dpm" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -16821,6 +16805,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"dyI" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "dyN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16971,11 +16962,15 @@
 	icon_state = "10,12"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"dAF" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "dAK" = (
-/obj/structure/table/woodentable,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "dAP" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil/random,
@@ -17544,6 +17539,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"dGu" = (
+/obj/structure/low_wall,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "dGz" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin{
@@ -19496,6 +19496,14 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/west)
+"ebL" = (
+/obj/structure/flora/small/rock3,
+/obj/structure/invislight,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "ebN" = (
 /obj/structure/closet/secure_closet/xenoarchaeologist,
 /obj/structure/window/reinforced{
@@ -19620,6 +19628,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
+"ecU" = (
+/obj/item/ammo_casing,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "ecW" = (
 /obj/machinery/camera/network/gate{
 	dir = 10;
@@ -20834,6 +20847,13 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"eoZ" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "epa" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/rock,
@@ -21481,12 +21501,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
-"euR" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "euT" = (
 /obj/random/structures,
 /obj/effect/decal/cleanable/dirt,
@@ -21612,6 +21626,11 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"ewL" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "ewS" = (
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -24670,6 +24689,13 @@
 /obj/item/book/manual/nonfiction/thetranscendentalist,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"fdc" = (
+/obj/structure/catwalk,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/pros/shuttle)
 "fdk" = (
 /turf/simulated/shuttle/floor/science{
 	icon_state = "11,4"
@@ -25775,9 +25801,6 @@
 "fnK" = (
 /obj/structure/railing/grey{
 	dir = 4
-	},
-/obj/structure/flora/big/bush3{
-	pixel_y = -18
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -27395,6 +27418,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
+"fFs" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "fFD" = (
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -28504,6 +28532,15 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
+"fSX" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "fTa" = (
 /obj/structure/window/reinforced,
 /obj/structure/multiz/stairs/active{
@@ -30269,6 +30306,13 @@
 /obj/structure/railing,
 /turf/simulated/open,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
+"gkR" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "gkW" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -31483,11 +31527,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"gwR" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "gwV" = (
 /obj/structure/disposalpipe/up{
 	dir = 8
@@ -34124,6 +34163,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/robotics)
+"hbE" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "hbN" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/stalkybush,
@@ -37896,6 +37940,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"hNd" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "hNf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -38257,6 +38306,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"hTq" = (
+/obj/structure/flora/small/rock2,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "hTt" = (
 /obj/machinery/camera/network/church{
 	dir = 1
@@ -38373,13 +38427,6 @@
 /obj/effect/floor_decal/border/carpet/lightblue,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters)
-"hUr" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "hUA" = (
 /obj/machinery/light,
 /obj/structure/closet/wall_mounted/firecloset{
@@ -39495,10 +39542,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/turret_protected/ai)
-"idb" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "idd" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -39555,6 +39598,13 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
+"idL" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "idS" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
@@ -41100,6 +41150,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"itR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/flame/lighter/zippo/capitalist,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "itU" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -42464,12 +42520,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"iIQ" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "iIR" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/big/bush1{
@@ -42574,6 +42624,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
+"iKO" = (
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
+"iKR" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "iKS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -44284,6 +44344,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"jdV" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "jec" = (
 /obj/structure/railing{
 	dir = 8
@@ -44333,8 +44398,8 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/reception)
 "jez" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
+/obj/structure/boulder,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
 "jeE" = (
 /obj/structure/bed/chair/sofa/black/left{
@@ -44551,6 +44616,11 @@
 /obj/effect/floor_decal/industrial/arrows,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/sechall)
+"jhg" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "jhl" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Sec Armory";
@@ -44762,6 +44832,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"jiF" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "jiQ" = (
 /obj/structure/sign/warning/caution/small{
 	dir = 1
@@ -45394,13 +45471,6 @@
 /obj/item/slime_extract/grey,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/rnd/xenobiology)
-"joG" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "joH" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -46412,6 +46482,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters)
+"jzv" = (
+/obj/structure/flora/bush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "jzw" = (
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/generic,
@@ -46420,6 +46495,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"jzz" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "jzB" = (
 /obj/structure/table/standard,
 /obj/random/cloth/masks/low_chance,
@@ -47197,11 +47278,6 @@
 /obj/structure/closet/random_milsupply,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"jHU" = (
-/obj/structure/railing,
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "jHW" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha3,
@@ -47591,6 +47667,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
+"jMr" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "jMx" = (
 /obj/structure/lattice,
 /obj/structure/invislight,
@@ -49444,9 +49525,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "kgc" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
 "kge" = (
 /obj/machinery/light/small{
@@ -51457,6 +51540,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"kzK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/fiction/warandpeace,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "kzM" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/beach/water/shallow,
@@ -52475,12 +52563,6 @@
 	temperature = 80
 	},
 /area/nadezhda/command/tcommsat/computer)
-"kMb" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "kMe" = (
 /obj/machinery/light/floor,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -52586,11 +52668,6 @@
 /obj/machinery/power/nt_obelisk,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/command/prime)
-"kNA" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "kNM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/media/jukebox,
@@ -53086,10 +53163,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/fo)
-"kSK" = (
-/obj/structure/boulder,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "kSX" = (
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/toilet/public)
@@ -53990,8 +54063,9 @@
 	dir = 8
 	},
 /obj/structure/table/bench/steel,
-/obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/security/sechall)
 "lew" = (
@@ -54101,6 +54175,12 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"lfz" = (
+/obj/structure/flora/bush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "lfE" = (
 /obj/structure/sign/faction/neotheology_cross/gold{
 	pixel_y = -32
@@ -55117,10 +55197,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"lrT" = (
-/obj/structure/flora/big/rocks3,
-/turf/simulated/mineral,
-/area/nadezhda/outside/inside_colony)
 "lrX" = (
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/side/f2section1)
@@ -55144,11 +55220,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
-"lsg" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "lsk" = (
 /obj/structure/table/woodentable,
 /obj/item/device/radio/phone,
@@ -55788,11 +55859,6 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/main/stairwell)
-"lzg" = (
-/obj/random/flora/low_chance,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "lzl" = (
 /obj/structure/flora/small/rock3,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -56126,11 +56192,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"lDj" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "lDk" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/small/bushb1,
@@ -56207,12 +56268,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/medical/reception)
-"lDW" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/rock,
-/area/nadezhda/outside/inside_colony)
 "lDX" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -57295,6 +57350,12 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"lPX" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/inside_colony)
 "lQm" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/techmaint,
@@ -57499,13 +57560,6 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
-"lSf" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "lSh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -59404,6 +59458,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
+"mkT" = (
+/obj/random/flora/jungle_tree,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "mkU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -61417,6 +61476,11 @@
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/xenobiology)
+"mGg" = (
+/obj/structure/flora/small/rock3,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "mGl" = (
 /obj/random/scrap/dense_weighted,
 /obj/structure/table/rack/shelf,
@@ -61853,6 +61917,10 @@
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/nadezhda/engineering/atmos)
+"mKP" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "mKQ" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1;
@@ -64355,11 +64423,6 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
-"nkj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/manual/fiction/warandpeace,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "nkm" = (
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
@@ -64466,22 +64529,6 @@
 /obj/random/lowkeyrandom,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
-"nkZ" = (
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/floor_decal/corner_techfloor_grid,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/table/bench/steel,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/security/sechall)
 "nlc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64842,6 +64889,12 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
+"npf" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/outside/pond)
 "npm" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -65152,13 +65205,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"nsu" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "nsw" = (
 /obj/structure/scrap_cube,
 /obj/structure/catwalk,
@@ -65962,6 +66008,12 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"nzR" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "nzS" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Core";
@@ -67161,12 +67213,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"nLq" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "nLx" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "2,3"
@@ -69681,10 +69727,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfacesec)
-"okQ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "okV" = (
 /obj/machinery/door/blast/regular/open{
 	id = "genetics2";
@@ -71591,6 +71633,12 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
+"oEr" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "oEw" = (
 /obj/structure/closet/secure_closet/personal/miner,
 /obj/item/storage/firstaid/ifak,
@@ -71656,6 +71704,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"oFz" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "oFI" = (
 /obj/structure/bed/chair/custom/bar_special{
 	dir = 4
@@ -74206,11 +74258,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"pfA" = (
-/obj/structure/flora/bush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "pfD" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/catwalk,
@@ -75852,10 +75899,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"pwL" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "pwQ" = (
 /obj/structure/railing{
 	dir = 4
@@ -76179,11 +76222,6 @@
 /obj/random/junkfood/onlypizza,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
-"pzZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/mask/smokable/cigarette/cigar,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "pAg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -76469,11 +76507,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/reception)
-"pDh" = (
-/obj/random/flora/jungle_tree,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "pDi" = (
 /obj/structure/table/glass,
 /obj/random/toy,
@@ -76606,14 +76639,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
-"pEH" = (
-/obj/structure/flora/small/rock3,
-/obj/structure/invislight,
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "pEJ" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -78715,6 +78740,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"pYP" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/outside/pond)
 "pYU" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -79465,12 +79496,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
-"qha" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/security/maingate/west)
 "qhb" = (
 /obj/machinery/light_switch{
 	pixel_y = 32
@@ -82396,6 +82421,11 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/rocinante_shuttle_area)
+"qLi" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "qLk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/cyan{
@@ -83154,11 +83184,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"qTS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "qTZ" = (
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -83697,6 +83722,10 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
+"rax" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "raA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -84328,12 +84357,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/pool)
-"rgL" = (
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/unsimulated/mineral,
-/area/nadezhda/outside/inside_colony)
 "rgP" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -86636,11 +86659,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"rGx" = (
-/obj/structure/flora/small/rock2,
-/obj/structure/flora/big/bush3,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "rGH" = (
 /obj/machinery/gym/toughness,
 /turf/simulated/floor/tiled/white/gray_perforated,
@@ -87051,9 +87069,11 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
 "rLl" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
 "rLm" = (
 /turf/simulated/wall/r_wall,
@@ -87450,13 +87470,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
-"rOZ" = (
-/obj/structure/catwalk,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/pros/shuttle)
 "rPb" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -87967,9 +87980,8 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
 "rVz" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/inside_colony)
 "rVD" = (
 /obj/effect/step_trigger/surface_to_forest_1_B,
@@ -89328,12 +89340,6 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"siS" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/beach/water/flooded,
-/area/nadezhda/outside/pond)
 "siV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -89752,12 +89758,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"snk" = (
-/obj/structure/flora/bush,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "snm" = (
 /mob/living/simple_animal/hostile/bear,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -89984,11 +89984,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"spB" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "spC" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -90125,12 +90120,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/security/nuke_storage)
-"sqG" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/beach/water/flooded,
-/area/nadezhda/outside/pond)
 "sqJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -90360,6 +90349,11 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"ssQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/smokable/cigarette/cigar,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "ssR" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
@@ -91766,6 +91760,10 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
+"sGA" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "sGI" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -93119,10 +93117,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
-"sWs" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate/east)
 "sWx" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/structure/cable/cyan{
@@ -95277,11 +95271,6 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
-"tvv" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "tvy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -96121,6 +96110,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"tDx" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "tDE" = (
 /obj/structure/catwalk,
 /obj/random/junk/low_chance,
@@ -96199,13 +96193,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"tEm" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/rock,
-/area/nadezhda/outside/inside_colony)
 "tEs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -100922,10 +100909,6 @@
 /obj/structure/flora/small/busha2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"uzA" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/inside_colony)
 "uzG" = (
 /obj/machinery/vending/fitness,
 /turf/simulated/floor/tiled/white/gray_platform,
@@ -101109,11 +101092,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
-"uBv" = (
-/obj/structure/flora/small/rock3,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "uBB" = (
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -102426,6 +102404,10 @@
 "uNM" = (
 /obj/effect/floor_decal/industrial/road/straight3,
 /turf/simulated/floor/rock/manmade/road,
+/area/nadezhda/outside/inside_colony)
+"uNN" = (
+/obj/random/scrap/sparse_weighted/low_chance,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
 "uNO" = (
 /turf/simulated/floor/asteroid/grass/dry,
@@ -105628,11 +105610,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
-"vuD" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "vuI" = (
 /obj/effect/damagedfloor/fire,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -105893,13 +105870,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"vwC" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush3{
-	pixel_y = -18
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "vwR" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/shuttle/floor/science{
@@ -107294,6 +107264,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/science)
+"vLN" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "vLR" = (
 /obj/structure/computerframe{
 	anchored = 1;
@@ -107952,6 +107929,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"vSF" = (
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "vSH" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/steel,
@@ -108448,6 +108429,12 @@
 /obj/random/furniture/painting,
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm3)
+"vWn" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "vWA" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -108882,10 +108869,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfaceeast)
-"wbd" = (
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/pond)
 "wbe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -111347,6 +111330,11 @@
 /obj/item/device/lighting/toggleable/lamp,
 /turf/simulated/floor/wood/wild1,
 /area/colony)
+"wAg" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate/east)
 "wAh" = (
 /obj/structure/table/standard,
 /obj/machinery/holoposter{
@@ -111573,11 +111561,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
-"wCG" = (
-/obj/item/ammo_casing,
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "wCM" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/beer,
@@ -111909,7 +111892,6 @@
 /obj/effect/floor_decal/industrial/caution{
 	dir = 1
 	},
-/obj/structure/railing,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
 "wGG" = (
@@ -112822,12 +112804,6 @@
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"wQw" = (
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "wQA" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/white/brown_perforated,
@@ -113503,6 +113479,12 @@
 /obj/item/reagent_containers/dropper,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/crew_quarters/kitchen)
+"wXR" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/inside_colony)
 "wXS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -113568,6 +113550,13 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/armory)
+"wYC" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/inside_colony)
 "wYI" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/industrial/warningwhite{
@@ -113676,6 +113665,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"xaa" = (
+/obj/structure/flora/big/rocks3,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "xac" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 4
@@ -114326,6 +114322,12 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"xhW" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/security/maingate/west)
 "xia" = (
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -115043,14 +115045,6 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/medical/reception)
-"xpv" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "xpD" = (
 /obj/machinery/camera/network/engineering,
 /obj/effect/decal/cleanable/dirt,
@@ -115430,6 +115424,11 @@
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
+"xtH" = (
+/obj/structure/railing,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "xtK" = (
 /obj/random/mob/undergroundmob/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -115838,6 +115837,11 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/robotics)
+"xxn" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "xxy" = (
 /obj/machinery/atmospherics/unary/freezer{
 	icon_state = "freezer"
@@ -116360,13 +116364,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"xCg" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "xCk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -117388,10 +117385,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"xLN" = (
-/obj/random/scrap/sparse_weighted/low_chance,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "xLW" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psych Office";
@@ -118222,6 +118215,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"xVg" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "xVh" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -203829,8 +203828,8 @@ spF
 spF
 spF
 spF
-euR
-euR
+oEr
+oEr
 umT
 gXV
 xRA
@@ -204025,16 +204024,16 @@ spF
 spF
 spF
 spF
-nsu
-nsu
-nsu
-nsu
-nsu
+kgc
+kgc
+kgc
+kgc
+kgc
 pvI
 cLp
 fFO
 fFO
-qha
+xhW
 xRA
 xRA
 xRA
@@ -204221,22 +204220,22 @@ spF
 spF
 spF
 spF
-nsu
-nsu
-nsu
-nsu
-nsu
-nsu
-nsu
-idb
-idb
+kgc
+kgc
+kgc
+kgc
+kgc
+kgc
+kgc
+rax
+rax
 pFV
 pFV
 pFV
 rIK
 pFV
 pFV
-qha
+xhW
 xRA
 xRA
 xRA
@@ -204422,20 +204421,20 @@ spF
 spF
 spF
 spF
-nsu
-nsu
-idb
+kgc
+kgc
+rax
 rIK
-spB
-spB
-jez
+bTk
+bTk
+mKP
 pFV
 pvI
 rIK
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
 rIK
 kGO
@@ -204623,22 +204622,22 @@ aYl
 spF
 spF
 spF
-xpv
-nsu
-idb
-jez
-dai
-dai
+cdg
+kgc
+rax
+mKP
+dAK
+dAK
 rIK
-dai
-dai
-rVz
+dAK
+dAK
+hbE
 pFV
 pFV
 cWF
 rIK
-dai
-dai
+dAK
+dAK
 pFV
 qCq
 kGO
@@ -204826,7 +204825,7 @@ spF
 izu
 spF
 wRQ
-jez
+mKP
 fFO
 pFV
 pvI
@@ -204839,8 +204838,8 @@ vrW
 pFV
 pFV
 pFV
-dai
-dai
+dAK
+dAK
 pFV
 qCq
 kGO
@@ -205227,10 +205226,10 @@ iYY
 aYl
 aYl
 spF
-lrT
+anq
 spF
-nLq
-xLN
+nzR
+uNN
 fFO
 pFV
 pvI
@@ -205242,8 +205241,8 @@ pFV
 pFV
 pFV
 pFV
-dai
-dai
+dAK
+dAK
 pFV
 pvI
 qCq
@@ -205428,8 +205427,8 @@ aYl
 aYl
 aYl
 spF
-anq
-nLq
+xaa
+nzR
 bXS
 fFO
 fFO
@@ -205444,7 +205443,7 @@ vrW
 niq
 pFV
 pvI
-pfA
+jzv
 pFV
 pFV
 vbq
@@ -205629,9 +205628,9 @@ gBD
 aYl
 aYl
 spF
-xCg
+rLl
 bXS
-dcC
+sGA
 fFO
 fFO
 fFO
@@ -205642,7 +205641,7 @@ rIK
 rIK
 pFV
 cWF
-dai
+dAK
 pFV
 pFV
 spa
@@ -205831,21 +205830,21 @@ iYY
 aYl
 aYl
 spF
-xCg
+rLl
 cXf
-xLN
+uNN
 fFO
 lVU
 pFV
-wCG
-aUa
+ecU
+xtH
 oSE
 fFO
 fFO
 pFV
 vrW
 pFV
-dai
+dAK
 pFV
 pFV
 pFV
@@ -206033,21 +206032,21 @@ iYY
 aYl
 aYl
 spF
-tEm
-dcC
+wYC
+sGA
 fFO
 fFO
 bex
 rIK
 rIK
-jHU
+bqo
 bXS
 fFO
 fFO
 nIU
 aPg
 hPj
-dai
+dAK
 pFV
 svK
 pFV
@@ -206242,7 +206241,7 @@ fFO
 fFO
 fFO
 pFV
-ayf
+aig
 fIj
 fFO
 fFO
@@ -206437,7 +206436,7 @@ iYY
 aYl
 aYl
 spF
-tEm
+wYC
 fFO
 fFO
 cLp
@@ -206639,8 +206638,8 @@ iYY
 aYl
 aYl
 spF
-tEm
-dcC
+wYC
+sGA
 lVU
 fFO
 bex
@@ -206654,8 +206653,8 @@ yhP
 aPg
 pFV
 rIK
-dai
-dai
+dAK
+dAK
 pFV
 pFV
 pFV
@@ -206841,8 +206840,8 @@ iYY
 aYl
 aYl
 spF
-tEm
-dcC
+wYC
+sGA
 cLp
 cLp
 fFO
@@ -207043,7 +207042,7 @@ iYY
 aYl
 aYl
 spF
-xCg
+rLl
 bXS
 bXS
 fFO
@@ -207245,8 +207244,8 @@ iYY
 aYl
 aYl
 spF
-dcC
-dcC
+sGA
+sGA
 bXS
 bXS
 fFO
@@ -207256,7 +207255,7 @@ dWS
 bXS
 rIK
 pFV
-aUC
+dGu
 aPg
 vrW
 pFV
@@ -207448,15 +207447,15 @@ aYl
 aYl
 aYl
 spF
-xCg
-nsu
-idb
-xLN
+rLl
+kgc
+rax
+uNN
 fFO
 fFO
 fFO
 fFO
-joG
+eoZ
 rIK
 pFV
 pFV
@@ -207653,10 +207652,10 @@ aYl
 spF
 spF
 spF
-euR
-idb
+oEr
+rax
 fFO
-xLN
+uNN
 fFO
 hPj
 mGO
@@ -207856,7 +207855,7 @@ spF
 aYl
 aYl
 spF
-lDW
+lPX
 aYl
 cwC
 pFV
@@ -208058,8 +208057,8 @@ spF
 spF
 spF
 spF
-euR
-idb
+oEr
+rax
 fFO
 pFV
 pFV
@@ -208259,9 +208258,9 @@ aYl
 spF
 spF
 spF
-csI
+idL
 cLp
-idb
+rax
 fFO
 fFO
 pFV
@@ -208462,8 +208461,8 @@ spF
 spF
 spF
 spF
-csI
-gwR
+idL
+jdV
 fFO
 fFO
 cLp
@@ -208665,7 +208664,7 @@ spF
 spF
 spF
 spF
-euR
+oEr
 spF
 spF
 cLp
@@ -209071,7 +209070,7 @@ spF
 spF
 spF
 spF
-lDW
+lPX
 fFO
 rIK
 rIK
@@ -209081,7 +209080,7 @@ rIK
 rIK
 rIK
 rIK
-dai
+dAK
 bXS
 spa
 kGO
@@ -209273,7 +209272,7 @@ spF
 spF
 spF
 spF
-euR
+oEr
 rIK
 pFV
 rIK
@@ -209468,12 +209467,12 @@ xtc
 xtc
 xtc
 xtc
-rOZ
-rOZ
-rOZ
-rOZ
-rOZ
-rOZ
+fdc
+fdc
+fdc
+fdc
+fdc
+fdc
 xtc
 tdw
 tdw
@@ -209686,7 +209685,7 @@ qlM
 vRM
 rHw
 pFV
-dai
+dAK
 pFV
 bXS
 cXf
@@ -209887,8 +209886,8 @@ itd
 itd
 cxs
 rHw
-dai
-dai
+dAK
+dAK
 fLu
 bXS
 bXS
@@ -210089,7 +210088,7 @@ itd
 itd
 cxs
 rHw
-dai
+dAK
 vrW
 rIK
 bXS
@@ -214302,10 +214301,10 @@ ntZ
 bro
 hos
 sUh
-cCA
+itR
 pyR
-dAK
-dAK
+csI
+csI
 pHb
 sKl
 ktw
@@ -214703,12 +214702,12 @@ frR
 hcX
 pHb
 eRA
-qTS
+ccP
 svG
 kjg
 svG
 svG
-pzZ
+ssQ
 pqb
 pHb
 bRi
@@ -214908,7 +214907,7 @@ aIM
 aIM
 quv
 kjg
-nkj
+kzK
 xeM
 svG
 vuN
@@ -215113,7 +215112,7 @@ spV
 dTD
 pHb
 egN
-dAK
+csI
 pHb
 nRf
 bQD
@@ -216102,8 +216101,8 @@ tYN
 iUn
 uSy
 cOa
-nkZ
 lej
+aSj
 acV
 qqM
 xQK
@@ -219807,7 +219806,7 @@ nnz
 qMG
 sQo
 frI
-wbd
+vSF
 qMG
 rtu
 lwP
@@ -220213,7 +220212,7 @@ sQo
 sQo
 qMG
 vFL
-sqG
+npf
 vFL
 njk
 ciR
@@ -220415,10 +220414,10 @@ sQo
 rTq
 njk
 vFL
-siS
+pYP
 vFL
 sQo
-wbd
+vSF
 sQo
 dXq
 qMG
@@ -220615,7 +220614,7 @@ emO
 dXq
 sQo
 sQo
-wbd
+vSF
 sQo
 vFL
 vFL
@@ -220820,7 +220819,7 @@ doc
 rrK
 rtu
 vFL
-sqG
+npf
 vFL
 sQo
 ciR
@@ -221223,7 +221222,7 @@ sQo
 sQo
 sQo
 qMG
-sqG
+npf
 vFL
 vFL
 loh
@@ -221401,7 +221400,7 @@ pFV
 spa
 pFV
 pFV
-pfA
+jzv
 pFV
 gcR
 pNi
@@ -221427,7 +221426,7 @@ sQo
 frI
 vFL
 vFL
-sqG
+npf
 hYu
 bDP
 bDP
@@ -221603,8 +221602,8 @@ pFV
 pFV
 rIK
 rIK
-dai
-lsg
+dAK
+hNd
 cpp
 pNi
 lNk
@@ -222008,8 +222007,8 @@ rIK
 rIK
 pFV
 eCL
-dai
-rLl
+dAK
+fFs
 bXS
 oqZ
 wud
@@ -222209,9 +222208,9 @@ pFV
 gcR
 pfy
 eCL
-rVz
-tvv
-dai
+hbE
+jMr
+dAK
 bXS
 oqZ
 oqZ
@@ -222413,7 +222412,7 @@ pFV
 pMh
 mGO
 rIK
-snk
+lfz
 bXS
 bXS
 oqZ
@@ -223018,8 +223017,8 @@ fFO
 pFV
 pFV
 gcR
-dai
-dai
+dAK
+dAK
 vrW
 pFV
 foN
@@ -223220,8 +223219,8 @@ fFO
 fFO
 fLu
 pFV
-dai
-dai
+dAK
+dAK
 pFV
 pFV
 oxw
@@ -223423,8 +223422,8 @@ fFO
 pFV
 svK
 svK
-dai
-dai
+dAK
+dAK
 fFO
 piv
 oqZ
@@ -223625,8 +223624,8 @@ xPA
 pFV
 spa
 svK
-dai
-pDh
+dAK
+mkT
 pFV
 foN
 oqZ
@@ -223827,8 +223826,8 @@ xPA
 pFV
 qoI
 pFV
-dai
-tvv
+dAK
+jMr
 fFO
 foN
 oqZ
@@ -224028,10 +224027,10 @@ uxZ
 mGO
 pFV
 fLu
-dai
+dAK
 pFV
-dai
-dai
+dAK
+dAK
 piv
 oqZ
 cPj
@@ -224231,9 +224230,9 @@ fFO
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
-dge
+xVg
 piv
 oqZ
 ilL
@@ -224433,8 +224432,8 @@ xPA
 pFV
 pFV
 vrW
-dai
-pDh
+dAK
+mkT
 rIK
 foN
 gAa
@@ -224635,8 +224634,8 @@ tnk
 pFV
 fLu
 pFV
-dai
-kgc
+dAK
+ewL
 pFV
 qiM
 oqZ
@@ -224837,7 +224836,7 @@ fFO
 pFV
 huJ
 vbq
-dai
+dAK
 pFV
 rIK
 piv
@@ -225035,11 +225034,11 @@ pFV
 dce
 pFV
 pFV
-dai
-dai
+dAK
+dAK
 pFV
-dai
-dai
+dAK
+dAK
 pFV
 pFV
 qiM
@@ -225235,12 +225234,12 @@ pFV
 fKS
 fKS
 pFV
-dai
-kgc
-dai
+dAK
+ewL
+dAK
 pFV
 fLu
-dai
+dAK
 igM
 pFV
 rIK
@@ -225438,7 +225437,7 @@ pFV
 pFV
 hcX
 pFV
-lsg
+hNd
 pFV
 qPl
 pFV
@@ -225841,11 +225840,11 @@ pFV
 pFV
 rIK
 pFV
-dai
-uBv
+dAK
+mGg
 pFV
 xGe
-dai
+dAK
 pFV
 pFV
 pFV
@@ -226042,12 +226041,12 @@ tBq
 pFV
 pFV
 fLu
-dai
-dai
+dAK
+dAK
 pFV
 pFV
-dai
-dai
+dAK
+dAK
 pFV
 pFV
 gcR
@@ -226243,15 +226242,15 @@ vbq
 hcX
 pFV
 pfy
-dai
-pDh
+dAK
+mkT
 pFV
-rLl
-dai
-dai
+fFs
+dAK
+dAK
 gcR
 igM
-dai
+dAK
 igM
 rIK
 piv
@@ -226453,7 +226452,7 @@ gcR
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
 mGO
 tjB
@@ -226655,7 +226654,7 @@ pfy
 pFV
 mGO
 eCL
-bMB
+jhg
 pFV
 dHz
 piv
@@ -227251,9 +227250,9 @@ mGO
 pFV
 pFV
 pFV
-lsg
-dai
-dai
+hNd
+dAK
+dAK
 pFV
 pFV
 pFV
@@ -227452,18 +227451,18 @@ igM
 pFV
 pFV
 pFV
-dai
-rLl
-dai
-dai
-dai
+dAK
+fFs
+dAK
+dAK
+dAK
 mGO
 pFV
 pFV
 myK
 rIK
 pvI
-rLl
+fFs
 pFV
 pFV
 wud
@@ -227654,19 +227653,19 @@ pFV
 pFV
 pFV
 pFV
-dai
-dai
-dai
-dai
-dai
+dAK
+dAK
+dAK
+dAK
+dAK
 pFV
 pFV
 pFV
 rIK
 rIK
 pFV
-dai
-dai
+dAK
+dAK
 pfy
 wud
 oqZ
@@ -227856,19 +227855,19 @@ pFV
 pFV
 pFV
 qPl
-dai
-dai
+dAK
+dAK
 pFV
-rLl
-dai
+fFs
+dAK
 pFV
 pFV
 mGO
 pFV
 pFV
-dai
-dai
-dai
+dAK
+dAK
+dAK
 pFV
 wud
 oqZ
@@ -228057,20 +228056,20 @@ pFV
 pFV
 pFV
 pFV
-rLl
+fFs
 pFV
 pFV
-dai
-dai
+dAK
+dAK
 pFV
 pFV
 pFV
 pfy
 fyM
 pFV
-dai
-lsg
-dai
+dAK
+hNd
+dAK
 bUO
 wud
 oqZ
@@ -228260,7 +228259,7 @@ pfy
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
 pfy
 pFV
@@ -228270,8 +228269,8 @@ igM
 pFV
 pFV
 rIK
-dai
-dai
+dAK
+dAK
 pFV
 fFO
 wud
@@ -228462,8 +228461,8 @@ pFV
 pFV
 pFV
 pFV
-dai
-dai
+dAK
+dAK
 pFV
 pFV
 pFV
@@ -228473,7 +228472,7 @@ pFV
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
 fFO
 wud
@@ -228665,7 +228664,7 @@ pMh
 pMh
 pFV
 pfy
-dai
+dAK
 pFV
 qPl
 pFV
@@ -228675,7 +228674,7 @@ pFV
 pFV
 pFV
 rIK
-pDh
+mkT
 pFV
 pFV
 wud
@@ -228862,14 +228861,14 @@ mfN
 saN
 pFV
 qPl
-dai
-dai
+dAK
+dAK
 pFV
 pFV
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
 pFV
 pFV
@@ -229065,13 +229064,13 @@ bSt
 pFV
 pFV
 pFV
-bMB
+jhg
 pMh
 pFV
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
 pFV
 pFV
@@ -229268,17 +229267,17 @@ pFV
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
 pFV
 fFO
 pFV
 pFV
-dai
+dAK
 pFV
 pFV
 pFV
@@ -229469,17 +229468,17 @@ bSt
 pMh
 pMh
 pFV
-dai
+dAK
 pFV
 pFV
 qPl
-dai
-dai
+dAK
+dAK
 pFV
 pFV
-lDj
+xxn
 pFV
-dai
+dAK
 pFV
 pFV
 igM
@@ -229671,17 +229670,17 @@ bSt
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
 pFV
-dai
-dai
-tvv
-dai
+dAK
+dAK
+jMr
+dAK
 pFV
 pFV
-dai
-dai
+dAK
+dAK
 pFV
 mGO
 pFV
@@ -229872,12 +229871,12 @@ mfN
 bSt
 pFV
 pFV
-dai
-tvv
+dAK
+jMr
 pFV
 pFV
-dai
-dai
+dAK
+dAK
 pFV
 pFV
 pFV
@@ -230075,11 +230074,11 @@ rnc
 pFV
 pFV
 fLu
-dai
+dAK
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
 pFV
 pFV
@@ -230277,12 +230276,12 @@ bSt
 vFX
 bSt
 bSt
-bkt
+oFz
 pFV
 dHz
-lDj
-dai
-rLl
+xxn
+dAK
+fFs
 pFV
 pFV
 fLu
@@ -230294,7 +230293,7 @@ pFV
 pFV
 pFV
 mGO
-sWs
+dai
 oqZ
 oGj
 gSS
@@ -230478,7 +230477,7 @@ mfN
 bSt
 bSt
 bSt
-kNA
+dAF
 bSt
 pFV
 pFV
@@ -230496,7 +230495,7 @@ pMh
 pFV
 pFV
 lPo
-sWs
+dai
 oqZ
 oGj
 onw
@@ -230680,7 +230679,7 @@ mfN
 bSt
 ccn
 dyf
-bkt
+oFz
 bSt
 pFV
 igM
@@ -230698,7 +230697,7 @@ qPl
 pFV
 pFV
 vbq
-dph
+wAg
 oqZ
 oGj
 onw
@@ -230890,7 +230889,7 @@ igM
 pFV
 igM
 oRK
-dai
+dAK
 vbq
 pFV
 igM
@@ -231084,14 +231083,14 @@ mfN
 bSt
 bSt
 bSt
-bkt
-bkt
+oFz
+oFz
 pMh
 pFV
 vbq
 pFV
-rLl
-rLl
+fFs
+fFs
 pFV
 tlE
 pFV
@@ -231287,7 +231286,7 @@ aUQ
 bSt
 bSt
 bSt
-bkt
+oFz
 pfy
 dHz
 tlE
@@ -231487,22 +231486,22 @@ gBT
 gBT
 gBT
 gBT
-pwL
+iKO
 gBT
-bkt
-dai
+oFz
+dAK
 pFV
 pFV
 pFV
-tvv
+jMr
 pFV
 pMh
 pFV
-dai
-vuD
+dAK
+tDx
 pFV
 pFV
-dai
+dAK
 pFV
 pFV
 pFV
@@ -231692,19 +231691,19 @@ hIM
 hjy
 dKC
 gBT
-dai
+dAK
 pMh
 pFV
 pFV
 lPo
-dai
+dAK
 qPl
-dai
-dai
+dAK
+dAK
 vbq
 pfy
 pFV
-bMB
+jhg
 pFV
 pFV
 kni
@@ -231893,20 +231892,20 @@ gSR
 gSR
 gSR
 vUx
-wQw
-dai
-lzg
+vWn
+dAK
+bFc
 mGO
 pFV
 vbq
-lsg
+hNd
 pFV
 pFV
-dai
-crb
+dAK
+qLi
 vbq
 pFV
-rLl
+fFs
 pFV
 pFV
 pFV
@@ -232096,18 +232095,18 @@ gSR
 gSR
 wAo
 gBT
-dai
-dai
+dAK
+dAK
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
-dai
-dai
+dAK
+dAK
 pFV
 fLu
-dai
+dAK
 igM
 pFV
 pFV
@@ -232298,22 +232297,22 @@ gSR
 gSR
 mRx
 gBT
-dai
+dAK
 pFV
 pFV
 pFV
 pFV
 tzc
 pFV
-dai
+dAK
 pFV
 igM
-kMb
-dai
-lsg
+iKR
+dAK
+hNd
 vbq
-bMB
-lDj
+jhg
+xxn
 qdc
 oqZ
 oGj
@@ -232499,15 +232498,15 @@ gSR
 gSR
 gSR
 qrl
-okQ
-okQ
-pwL
-okQ
-okQ
+anG
+anG
+iKO
+anG
+anG
 gBT
 bSt
 bSt
-dai
+dAK
 mGO
 pFV
 igM
@@ -232515,7 +232514,7 @@ pFV
 igM
 igM
 pFV
-lsg
+hNd
 fXd
 oqZ
 oGj
@@ -232701,13 +232700,13 @@ gSR
 gSR
 lCC
 yjc
-fnK
+fSX
 tQk
-hUr
-hUr
-bFc
-bFc
-bFc
+dyI
+dyI
+fnK
+fnK
+fnK
 yjc
 pFV
 pMh
@@ -232715,7 +232714,7 @@ pFV
 vbq
 pFV
 pMh
-rLl
+fFs
 pFV
 nPL
 wud
@@ -232911,13 +232910,13 @@ qTf
 kOv
 kOv
 uBR
-dai
-dai
+dAK
+dAK
 pFV
 igM
 pFV
-dai
-rLl
+dAK
+fFs
 pFV
 pFV
 wud
@@ -233116,8 +233115,8 @@ rnV
 pFV
 pFV
 pFV
-dai
-dai
+dAK
+dAK
 mGO
 tlE
 pFV
@@ -233314,13 +233313,13 @@ iPV
 vjP
 vjP
 gsH
-apb
+vLN
 pFV
-dai
+dAK
 pMh
-dai
+dAK
 pFV
-vuD
+tDx
 pFV
 pFV
 pFV
@@ -233516,16 +233515,16 @@ bGe
 iPV
 vjP
 aSZ
-iIQ
+jzz
 pFV
-dai
+dAK
 dHz
-lDj
-dai
-rLl
+xxn
+dAK
+fFs
 pFV
 pFV
-lsg
+hNd
 hys
 oqZ
 sqf
@@ -233719,14 +233718,14 @@ iPV
 vjP
 kOv
 uBR
-uzA
-dai
+rVz
+dAK
 pFV
 fLu
-dai
+dAK
 igM
 pFV
-dai
+dAK
 igM
 hys
 oqZ
@@ -233920,7 +233919,7 @@ kYT
 iPV
 vjP
 qxG
-iIQ
+jzz
 gMn
 pFV
 igM
@@ -234122,14 +234121,14 @@ qyM
 vjP
 vjP
 aSZ
-iIQ
-dai
+jzz
+dAK
 mGO
 pFV
-rLl
-dai
-rLl
-bMB
+fFs
+dAK
+fFs
+jhg
 pFV
 pFV
 tjB
@@ -234324,7 +234323,7 @@ qyM
 vjP
 vjP
 qTf
-lSf
+gkR
 pFV
 pMh
 pFV
@@ -234526,7 +234525,7 @@ vjP
 vjP
 vjP
 sTl
-apb
+vLN
 pFV
 pFV
 pFV
@@ -234535,7 +234534,7 @@ pMh
 pFV
 igM
 pFV
-dai
+dAK
 fXd
 oqZ
 sqf
@@ -234728,7 +234727,7 @@ vjP
 vjP
 vjP
 dfF
-iIQ
+jzz
 pFV
 pFV
 pFV
@@ -234737,7 +234736,7 @@ pFV
 mGO
 pMh
 pFV
-bMB
+jhg
 piv
 oqZ
 sqf
@@ -234930,7 +234929,7 @@ kZT
 vMw
 arX
 dfF
-iIQ
+jzz
 pFV
 pFV
 pMh
@@ -234939,7 +234938,7 @@ pFV
 lPo
 pFV
 pFV
-dai
+dAK
 piv
 oqZ
 sqf
@@ -235136,11 +235135,11 @@ yjc
 pFV
 pFV
 qPl
-dai
-dai
+dAK
+dAK
 vbq
 qwl
-dai
+dAK
 fFO
 wud
 oqZ
@@ -235338,10 +235337,10 @@ spF
 pFV
 pFV
 pFV
-dai
+dAK
 pFV
-dai
-dai
+dAK
+dAK
 pFV
 pFV
 bFA
@@ -235537,12 +235536,12 @@ gBD
 sDV
 bXm
 spF
-kSK
+jez
 pFV
-dai
-dai
+dAK
+dAK
 pFV
-dai
+dAK
 tzc
 pFV
 pFV
@@ -235739,8 +235738,8 @@ gBD
 sDV
 bXm
 spF
-kSK
-kSK
+jez
+jez
 pFV
 pFV
 pFV
@@ -235942,12 +235941,12 @@ sDV
 bXm
 spF
 spF
-kSK
+jez
 qPl
 pFV
-vwC
+jiF
 pFV
-rGx
+hTq
 aYl
 aYl
 aYl
@@ -236149,7 +236148,7 @@ vvA
 vvA
 hPj
 hcX
-rgL
+wXR
 aYl
 aYl
 aYl
@@ -236349,7 +236348,7 @@ bXm
 bXm
 bXm
 bXm
-pEH
+ebL
 azv
 aYl
 aYl

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -219775,7 +219775,7 @@ tfW
 tfW
 tfW
 tkB
-tfW
+tkB
 tfW
 tfW
 gsI

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -1282,6 +1282,9 @@
 	})
 "anq" = (
 /obj/structure/flora/big/rocks3,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
 "anv" = (
@@ -2435,7 +2438,10 @@
 "azv" = (
 /obj/structure/flora/small/rock3,
 /obj/structure/invislight,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "azI" = (
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -7359,6 +7365,13 @@
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
+"bCG" = (
+/obj/structure/catwalk,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/pros/shuttle)
 "bCI" = (
 /obj/structure/table/reinforced,
 /obj/item/grenade/chem_grenade/metalfoam,
@@ -7619,7 +7632,7 @@
 	dir = 10;
 	network = list("Nadzedha Wall Colony")
 	},
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/east)
 "bFG" = (
 /obj/structure/disposalpipe/segment,
@@ -10688,6 +10701,10 @@
 /obj/structure/scrap/cloth,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
+"cny" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "cnB" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1
@@ -14424,11 +14441,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
 "dai" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/beach/water/flooded,
-/area/nadezhda/outside/pond)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "dak" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/light/small{
@@ -17099,6 +17114,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"dCP" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "dCT" = (
 /obj/structure/flora/small/busha1,
 /obj/random/flora/jungle_tree,
@@ -17199,6 +17223,13 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/surfaceeast)
+"dEa" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "dEn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19496,6 +19527,12 @@
 /area/nadezhda/security/nuke_storage{
 	name = "\improper Clinic"
 	})
+"eck" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/outside/pond)
 "ecn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20021,6 +20058,10 @@
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"ehz" = (
+/obj/structure/boulder,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "ehB" = (
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/lakeside)
@@ -21366,6 +21407,11 @@
 /obj/structure/flora/small/grassb3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
+"eut" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "euC" = (
 /obj/structure/closet/crate/secure,
 /obj/random/material_rare/low_chance,
@@ -21454,6 +21500,10 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/nadezhda/command/captain)
+"evS" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "evX" = (
 /obj/machinery/cash_register,
 /obj/structure/table/standard,
@@ -24670,6 +24720,11 @@
 "fej" = (
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"fek" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "fer" = (
 /obj/structure/grille,
 /obj/machinery/light/small{
@@ -25694,7 +25749,7 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "fnO" = (
 /obj/machinery/door/airlock{
@@ -27484,6 +27539,12 @@
 /obj/structure/curtain/open/privacy,
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/medical/sleeper)
+"fHH" = (
+/obj/structure/flora/bush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "fHI" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/meter,
@@ -30457,6 +30518,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"gou" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "goy" = (
 /obj/machinery/camera/network/cargo{
 	dir = 8
@@ -32132,6 +32198,12 @@
 "gGd" = (
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
+"gGl" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "gGp" = (
 /obj/machinery/bodyscanner,
 /obj/machinery/light,
@@ -32324,6 +32396,7 @@
 "gIY" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "gJa" = (
@@ -34356,6 +34429,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/hallways)
+"heU" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "heX" = (
 /obj/structure/railing{
 	dir = 8
@@ -38781,7 +38861,7 @@
 /obj/item/target/syndicate,
 /obj/item/target/syndicate,
 /obj/structure/closet/crate,
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "hYi" = (
 /turf/simulated/floor/carpet/purcarpet,
@@ -38821,6 +38901,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"hYw" = (
+/obj/random/flora/jungle_tree,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "hYF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster/directional/north,
@@ -44221,8 +44306,9 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/reception)
 "jez" = (
-/obj/structure/flora/big/rocks2,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "jeE" = (
 /obj/structure/bed/chair/sofa/black/left{
@@ -44650,6 +44736,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"jiI" = (
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
+"jiP" = (
+/obj/structure/flora/small/rock3,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "jiQ" = (
 /obj/structure/sign/warning/caution/small{
 	dir = 1
@@ -45468,6 +45564,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"jrc" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "jre" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/directions/generic{
@@ -49320,9 +49423,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "kgc" = (
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/pond)
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "kge" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -49737,6 +49842,10 @@
 /obj/machinery/chem_master,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"kjN" = (
+/obj/structure/flora/big/rocks3,
+/turf/simulated/mineral,
+/area/nadezhda/outside/inside_colony)
 "kjS" = (
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
@@ -53581,6 +53690,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"lbF" = (
+/obj/structure/railing,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "lbM" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/decal/cleanable/dirt,
@@ -55122,6 +55236,13 @@
 	dir = 4
 	},
 /area/nadezhda/crew_quarters/toilet/public)
+"ltQ" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "ltR" = (
 /obj/machinery/vending/fortune,
 /obj/machinery/light{
@@ -55724,6 +55845,12 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"lBa" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "lBf" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -63332,6 +63459,10 @@
 /mob/living/carbon/human/monkey,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/virology)
+"nbs" = (
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "nbu" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/flora/big/bush1,
@@ -65078,6 +65209,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"ntv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "ntw" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -66842,6 +66978,11 @@
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"nKl" = (
+/obj/structure/railing,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "nKo" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -67519,6 +67660,15 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
+"nRJ" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "nRU" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -68031,6 +68181,11 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/maintenance/surfacesec)
+"nXe" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "nXf" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "4,13"
@@ -71010,6 +71165,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"oAQ" = (
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "oAR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -72668,6 +72827,7 @@
 "oRK" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "oRO" = (
@@ -75757,6 +75917,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
+"pyp" = (
+/obj/structure/flora/bush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "pyz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76557,6 +76722,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"pGX" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "pHb" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/pros/shuttle)
@@ -76775,6 +76945,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
+"pJQ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate/east)
 "pJT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -79139,6 +79313,12 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"qfS" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "qfU" = (
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -79914,6 +80094,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"qol" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "qon" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80177,6 +80363,9 @@
 	dir = 1
 	},
 /obj/structure/flora/small/grassb4,
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "qro" = (
@@ -81409,6 +81598,13 @@
 /obj/item/material/shard,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"qDJ" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "qDM" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/autolathe{
@@ -81508,6 +81704,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qEJ" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate/east)
 "qEK" = (
 /obj/structure/table/standard,
 /obj/random/lowkeyrandom,
@@ -81940,6 +82141,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
+"qIE" = (
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/inside_colony)
 "qIL" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -81950,6 +82155,13 @@
 /obj/random/material/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"qIR" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "qIU" = (
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -84185,6 +84397,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
+"rhS" = (
+/obj/structure/low_wall,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "rhV" = (
 /obj/structure/table/gamblingtable,
 /obj/item/deck/cards,
@@ -84720,7 +84937,7 @@
 /obj/structure/railing/grey{
 	dir = 1
 	},
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "rnX" = (
 /obj/structure/disposalpipe/segment{
@@ -85895,6 +86112,10 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"rAX" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "rAZ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -86771,11 +86992,11 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
 "rLl" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/beach/water/flooded,
-/area/nadezhda/outside/pond)
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "rLm" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/lab)
@@ -87680,6 +87901,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"rVz" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/inside_colony)
 "rVD" = (
 /obj/effect/step_trigger/surface_to_forest_1_B,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -88654,6 +88882,12 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"seb" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/outside/pond)
 "seg" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -89858,6 +90092,12 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm3)
+"sqY" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/inside_colony)
 "srf" = (
 /obj/machinery/light{
 	dir = 4
@@ -91000,6 +91240,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
+"sBA" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "sBB" = (
 /obj/structure/railing,
 /obj/structure/catwalk,
@@ -93421,6 +93666,11 @@
 /obj/machinery/newscaster/directional/east,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"tdp" = (
+/obj/structure/flora/small/rock3,
+/obj/structure/invislight,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "tdq" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Cargo Front Desk";
@@ -95394,6 +95644,11 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/quartermaster/miningdock)
+"tyZ" = (
+/obj/random/flora/low_chance,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "tzc" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/grass,
@@ -97220,7 +97475,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "tQp" = (
 /obj/structure/cable/green{
@@ -97709,6 +97964,11 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"tVt" = (
+/obj/structure/flora/small/rock2,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "tVv" = (
 /obj/structure/railing,
 /turf/simulated/floor/beach/water/flooded,
@@ -98225,6 +98485,13 @@
 /obj/structure/closet/secure_closet/rare_loot,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"uaJ" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "uaP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -98517,6 +98784,12 @@
 "udz" = (
 /turf/simulated/mineral,
 /area/nadezhda/quartermaster/miningdock)
+"udC" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/security/maingate/west)
 "udL" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -99549,6 +99822,9 @@
 /area/nadezhda/outside/scave)
 "umT" = (
 /obj/structure/flora/big/rocks1,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
 "umZ" = (
@@ -100359,6 +100635,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"uxm" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/inside_colony)
 "uxn" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -100803,7 +101085,8 @@
 /obj/structure/railing/grey{
 	dir = 1
 	},
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "uCd" = (
 /turf/simulated/floor/fixed/hydrotile,
@@ -104800,6 +105083,11 @@
 "vpF" = (
 /turf/simulated/wall,
 /area/nadezhda/hallway/side/f2section1)
+"vpL" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "vpP" = (
 /obj/structure/spider_nest,
 /obj/effect/spider/stickyweb,
@@ -105042,6 +105330,11 @@
 /obj/machinery/door/holy/public,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/vectorrooms)
+"vsw" = (
+/obj/item/ammo_casing,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "vsB" = (
 /obj/structure/table/standard,
 /obj/machinery/power/apc{
@@ -108373,6 +108666,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"vZC" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "vZH" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
@@ -108655,6 +108953,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/mineral,
 /area/colony)
+"wct" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "wcu" = (
 /obj/structure/table/standard,
 /obj/item/device/aicard,
@@ -108849,6 +109151,14 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"wem" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "weo" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -111407,6 +111717,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/tactical_blackshield)
+"wER" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "wET" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
@@ -112553,6 +112868,10 @@
 "wRQ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/bush2,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "wRU" = (
@@ -112775,6 +113094,10 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"wUB" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "wUF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -112871,6 +113194,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
+"wVE" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "wVF" = (
 /obj/structure/table/rack,
 /obj/item/storage/backpack/industrial{
@@ -118809,6 +119137,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
+"yga" = (
+/obj/random/scrap/sparse_weighted/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "ygn" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/leafybush,
@@ -203425,8 +203757,8 @@ spF
 spF
 spF
 spF
-fFO
-fFO
+qol
+qol
 umT
 gXV
 xRA
@@ -203621,16 +203953,16 @@ spF
 spF
 spF
 spF
-fFO
-fFO
-fFO
-fFO
-fFO
+qDJ
+qDJ
+qDJ
+qDJ
+qDJ
 pvI
 cLp
 fFO
 fFO
-kGO
+udC
 xRA
 xRA
 xRA
@@ -203817,22 +204149,22 @@ spF
 spF
 spF
 spF
-fFO
-fFO
-fFO
-fFO
-fFO
-fFO
-fFO
-fFO
-fFO
+qDJ
+qDJ
+qDJ
+qDJ
+qDJ
+qDJ
+qDJ
+wct
+wct
 pFV
 pFV
 pFV
 rIK
 pFV
 pFV
-kGO
+udC
 xRA
 xRA
 xRA
@@ -204018,20 +204350,20 @@ spF
 spF
 spF
 spF
-cLp
-fFO
-fFO
+qDJ
+qDJ
+wct
 rIK
-pFV
-pFV
-pFV
+vpL
+vpL
+wUB
 pFV
 pvI
 rIK
 pFV
 pFV
 pFV
-rIK
+dai
 pFV
 rIK
 kGO
@@ -204219,22 +204551,22 @@ aYl
 spF
 spF
 spF
+wem
+qDJ
+wct
+wUB
+dai
+dai
 rIK
-fFO
-fFO
-pFV
-pFV
-pFV
-rIK
-pFV
-pFV
-rIK
+dai
+dai
+sBA
 pFV
 pFV
 cWF
 rIK
-pFV
-pFV
+dai
+dai
 pFV
 qCq
 kGO
@@ -204422,7 +204754,7 @@ spF
 izu
 spF
 wRQ
-pFV
+wUB
 fFO
 pFV
 pvI
@@ -204435,8 +204767,8 @@ vrW
 pFV
 pFV
 pFV
-pFV
-pFV
+dai
+dai
 pFV
 qCq
 kGO
@@ -204822,11 +205154,11 @@ gBD
 iYY
 aYl
 aYl
-bXS
-anq
-bXS
-bXS
-fFO
+spF
+kjN
+spF
+kgc
+yga
 fFO
 pFV
 pvI
@@ -204838,8 +205170,8 @@ pFV
 pFV
 pFV
 pFV
-pFV
-pFV
+dai
+dai
 pFV
 pvI
 qCq
@@ -205023,13 +205355,13 @@ gBD
 aYl
 aYl
 aYl
-oBP
+spF
 anq
+kgc
 bXS
-bXS
 fFO
 fFO
-fFO
+pFV
 pFV
 rIK
 rIK
@@ -205040,7 +205372,7 @@ vrW
 niq
 pFV
 pvI
-vrW
+pyp
 pFV
 pFV
 vbq
@@ -205224,21 +205556,21 @@ gBD
 gBD
 aYl
 aYl
-oBP
+spF
+dEa
 bXS
-bXS
-bXS
+rAX
 fFO
 fFO
 fFO
-fFO
+myK
 fFO
 spa
 rIK
 rIK
 pFV
 cWF
-pFV
+dai
 pFV
 pFV
 spa
@@ -205426,22 +205758,22 @@ iYY
 iYY
 aYl
 aYl
-oBP
-bXS
+spF
+dEa
 cXf
-fFO
+yga
 fFO
 lVU
-fFO
-bex
-dWS
+pFV
+vsw
+nKl
 oSE
 fFO
 fFO
 pFV
 vrW
 pFV
-pFV
+dai
 pFV
 pFV
 pFV
@@ -205628,22 +205960,22 @@ iYY
 iYY
 aYl
 aYl
-oBP
-oBP
-bXS
+spF
+rVz
+rAX
 fFO
 fFO
 bex
-fFO
-fFO
-dWS
+rIK
+rIK
+lbF
 bXS
 fFO
 fFO
 nIU
 aPg
-pFV
-pFV
+hPj
+dai
 pFV
 svK
 pFV
@@ -205830,15 +206162,15 @@ iYY
 iYY
 aYl
 aYl
+spF
 oBP
 oBP
-oBP
 fFO
 fFO
 fFO
 fFO
-fFO
-dWS
+pFV
+jiI
 fIj
 fFO
 fFO
@@ -206032,14 +206364,14 @@ iYY
 iYY
 aYl
 aYl
-oBP
-oBP
+spF
+rVz
 fFO
 fFO
 cLp
 fFO
 fFO
-fFO
+myK
 dWS
 bXS
 fFO
@@ -206234,9 +206566,9 @@ iYY
 iYY
 aYl
 aYl
-oBP
-oBP
-bXS
+spF
+rVz
+rAX
 lVU
 fFO
 bex
@@ -206250,8 +206582,8 @@ yhP
 aPg
 pFV
 rIK
-pFV
-pFV
+dai
+dai
 pFV
 pFV
 pFV
@@ -206436,9 +206768,9 @@ iYY
 iYY
 aYl
 aYl
-oBP
-oBP
-bXS
+spF
+rVz
+rAX
 cLp
 cLp
 fFO
@@ -206638,8 +206970,8 @@ iYY
 iYY
 aYl
 aYl
-oBP
-bXS
+spF
+dEa
 bXS
 bXS
 fFO
@@ -206649,7 +206981,7 @@ bex
 dWS
 fIj
 fFO
-fFO
+rIK
 hYc
 aPg
 pFV
@@ -206840,9 +207172,9 @@ gBD
 iYY
 aYl
 aYl
-oBP
-bXS
-bXS
+spF
+rAX
+rAX
 bXS
 bXS
 fFO
@@ -206850,9 +207182,9 @@ lVU
 fFO
 dWS
 bXS
-fFO
-fFO
-aPg
+rIK
+pFV
+rhS
 aPg
 vrW
 pFV
@@ -207043,16 +207375,16 @@ iYY
 aYl
 aYl
 aYl
-oBP
-bXS
+spF
+dEa
+qDJ
+wct
+yga
 fFO
 fFO
 fFO
 fFO
-fFO
-fFO
-fFO
-rIK
+heU
 rIK
 pFV
 pFV
@@ -207246,13 +207578,13 @@ iYY
 iYY
 aYl
 aYl
-bXS
-oBP
+spF
+spF
+spF
+qol
+wct
 fFO
-fFO
-fFO
-fFO
-fFO
+yga
 fFO
 hPj
 mGO
@@ -207448,16 +207780,16 @@ gBD
 iYY
 aYl
 aYl
+spF
+aYl
+aYl
+spF
+sqY
+aYl
 cwC
-aYl
-aYl
-oBP
-oBP
-aYl
-cwC
 pFV
 pFV
-pFV
+rIK
 pFV
 spa
 pFV
@@ -207650,12 +207982,12 @@ iYY
 iYY
 aYl
 aYl
-oBP
-jez
-oBP
-fFO
-fFO
-fFO
+spF
+spF
+spF
+spF
+qol
+wct
 fFO
 pFV
 pFV
@@ -207852,12 +208184,12 @@ iYY
 iYY
 aYl
 aYl
-fFO
-oBP
+spF
+spF
+spF
+jrc
 cLp
-cLp
-cLp
-fFO
+wct
 fFO
 fFO
 pFV
@@ -208058,8 +208390,8 @@ spF
 spF
 spF
 spF
-cLp
-cLp
+jrc
+eut
 fFO
 fFO
 cLp
@@ -208261,7 +208593,7 @@ spF
 spF
 spF
 spF
-fFO
+qol
 spF
 spF
 cLp
@@ -208667,7 +208999,7 @@ spF
 spF
 spF
 spF
-oBP
+sqY
 fFO
 rIK
 rIK
@@ -208677,7 +209009,7 @@ rIK
 rIK
 rIK
 rIK
-pFV
+dai
 bXS
 spa
 kGO
@@ -208869,7 +209201,7 @@ spF
 spF
 spF
 spF
-fFO
+qol
 rIK
 pFV
 rIK
@@ -209064,12 +209396,12 @@ xtc
 xtc
 xtc
 xtc
-xtc
-xtc
-xtc
-xtc
-xtc
-xtc
+bCG
+bCG
+bCG
+bCG
+bCG
+bCG
 xtc
 tdw
 tdw
@@ -209282,7 +209614,7 @@ qlM
 vRM
 rHw
 pFV
-pFV
+dai
 pFV
 bXS
 cXf
@@ -209483,8 +209815,8 @@ itd
 itd
 cxs
 rHw
-pFV
-pFV
+dai
+dai
 fLu
 bXS
 bXS
@@ -209685,7 +210017,7 @@ itd
 itd
 cxs
 rHw
-pFV
+dai
 vrW
 rIK
 bXS
@@ -219403,7 +219735,7 @@ nnz
 qMG
 sQo
 frI
-kgc
+nbs
 qMG
 rtu
 lwP
@@ -219809,7 +220141,7 @@ sQo
 sQo
 qMG
 vFL
-dai
+eck
 vFL
 njk
 ciR
@@ -220011,10 +220343,10 @@ sQo
 rTq
 njk
 vFL
-rLl
+seb
 vFL
 sQo
-kgc
+nbs
 sQo
 dXq
 qMG
@@ -220211,7 +220543,7 @@ emO
 dXq
 sQo
 sQo
-kgc
+nbs
 sQo
 vFL
 vFL
@@ -220416,7 +220748,7 @@ doc
 rrK
 rtu
 vFL
-dai
+eck
 vFL
 sQo
 ciR
@@ -220819,7 +221151,7 @@ sQo
 sQo
 sQo
 qMG
-dai
+eck
 vFL
 vFL
 loh
@@ -220997,7 +221329,7 @@ pFV
 spa
 pFV
 pFV
-vrW
+pyp
 pFV
 gcR
 pNi
@@ -221023,7 +221355,7 @@ sQo
 frI
 vFL
 vFL
-dai
+eck
 hYu
 bDP
 bDP
@@ -221199,8 +221531,8 @@ pFV
 pFV
 rIK
 rIK
-pFV
-pfy
+dai
+pGX
 cpp
 pNi
 lNk
@@ -221604,8 +221936,8 @@ rIK
 rIK
 pFV
 eCL
-pFV
-igM
+dai
+wVE
 bXS
 oqZ
 wud
@@ -221805,9 +222137,9 @@ pFV
 gcR
 pfy
 eCL
-rIK
-mGO
-pFV
+sBA
+vZC
+dai
 bXS
 oqZ
 oqZ
@@ -222009,7 +222341,7 @@ pFV
 pMh
 mGO
 rIK
-nCJ
+fHH
 bXS
 bXS
 oqZ
@@ -222614,8 +222946,8 @@ fFO
 pFV
 pFV
 gcR
-pFV
-pFV
+dai
+dai
 vrW
 pFV
 foN
@@ -222816,8 +223148,8 @@ fFO
 fFO
 fLu
 pFV
-pFV
-pFV
+dai
+dai
 pFV
 pFV
 oxw
@@ -223019,8 +223351,8 @@ fFO
 pFV
 svK
 svK
-pFV
-pFV
+dai
+dai
 fFO
 piv
 oqZ
@@ -223221,8 +223553,8 @@ xPA
 pFV
 spa
 svK
-pFV
-fLu
+dai
+hYw
 pFV
 foN
 oqZ
@@ -223423,8 +223755,8 @@ xPA
 pFV
 qoI
 pFV
-pFV
-mGO
+dai
+vZC
 fFO
 foN
 oqZ
@@ -223624,10 +223956,10 @@ uxZ
 mGO
 pFV
 fLu
+dai
 pFV
-pFV
-pFV
-pFV
+dai
+dai
 piv
 oqZ
 cPj
@@ -223827,9 +224159,9 @@ fFO
 pFV
 pFV
 pFV
+dai
 pFV
-pFV
-uoM
+qfS
 piv
 oqZ
 ilL
@@ -224029,8 +224361,8 @@ xPA
 pFV
 pFV
 vrW
-pFV
-fLu
+dai
+hYw
 rIK
 foN
 gAa
@@ -224231,8 +224563,8 @@ tnk
 pFV
 fLu
 pFV
-pFV
-pFV
+dai
+ntv
 pFV
 qiM
 oqZ
@@ -224433,7 +224765,7 @@ fFO
 pFV
 huJ
 vbq
-pFV
+dai
 pFV
 rIK
 piv
@@ -224631,11 +224963,11 @@ pFV
 dce
 pFV
 pFV
+dai
+dai
 pFV
-pFV
-pFV
-pFV
-pFV
+dai
+dai
 pFV
 pFV
 qiM
@@ -224831,12 +225163,12 @@ pFV
 fKS
 fKS
 pFV
-pFV
-pFV
-pFV
+dai
+ntv
+dai
 pFV
 fLu
-pFV
+dai
 igM
 pFV
 rIK
@@ -225034,7 +225366,7 @@ pFV
 pFV
 hcX
 pFV
-pfy
+pGX
 pFV
 qPl
 pFV
@@ -225437,11 +225769,11 @@ pFV
 pFV
 rIK
 pFV
-pFV
-hcX
+dai
+jiP
 pFV
 xGe
-pFV
+dai
 pFV
 pFV
 pFV
@@ -225638,12 +225970,12 @@ tBq
 pFV
 pFV
 fLu
+dai
+dai
 pFV
 pFV
-pFV
-pFV
-pFV
-pFV
+dai
+dai
 pFV
 pFV
 gcR
@@ -225839,15 +226171,15 @@ vbq
 hcX
 pFV
 pfy
+dai
+hYw
 pFV
-fLu
-pFV
-igM
-pFV
-pFV
+wVE
+dai
+dai
 gcR
 igM
-pFV
+dai
 igM
 rIK
 piv
@@ -226049,7 +226381,7 @@ gcR
 pFV
 pFV
 pFV
-pFV
+dai
 pFV
 mGO
 tjB
@@ -226251,7 +226583,7 @@ pfy
 pFV
 mGO
 eCL
-pMh
+wER
 pFV
 dHz
 piv
@@ -226847,9 +227179,9 @@ mGO
 pFV
 pFV
 pFV
-pfy
-pFV
-pFV
+pGX
+dai
+dai
 pFV
 pFV
 pFV
@@ -227048,18 +227380,18 @@ igM
 pFV
 pFV
 pFV
-pFV
-igM
-pFV
-pFV
-pFV
+dai
+wVE
+dai
+dai
+dai
 mGO
 pFV
 pFV
 myK
 rIK
 pvI
-igM
+wVE
 pFV
 pFV
 wud
@@ -227250,19 +227582,19 @@ pFV
 pFV
 pFV
 pFV
-pFV
-pFV
-pFV
-pFV
-pFV
+dai
+dai
+dai
+dai
+dai
 pFV
 pFV
 pFV
 rIK
 rIK
 pFV
-pFV
-pFV
+dai
+dai
 pfy
 wud
 oqZ
@@ -227452,19 +227784,19 @@ pFV
 pFV
 pFV
 qPl
+dai
+dai
 pFV
-pFV
-pFV
-igM
-pFV
+wVE
+dai
 pFV
 pFV
 mGO
 pFV
 pFV
-pFV
-pFV
-pFV
+dai
+dai
+dai
 pFV
 wud
 oqZ
@@ -227653,20 +227985,20 @@ pFV
 pFV
 pFV
 pFV
-igM
+wVE
 pFV
 pFV
-pFV
-pFV
+dai
+dai
 pFV
 pFV
 pFV
 pfy
 fyM
 pFV
-pFV
-pfy
-pFV
+dai
+pGX
+dai
 bUO
 wud
 oqZ
@@ -227856,7 +228188,7 @@ pfy
 pFV
 pFV
 pFV
-pFV
+dai
 pFV
 pfy
 pFV
@@ -227866,8 +228198,8 @@ igM
 pFV
 pFV
 rIK
-pFV
-pFV
+dai
+dai
 pFV
 fFO
 wud
@@ -228058,8 +228390,8 @@ pFV
 pFV
 pFV
 pFV
-pFV
-pFV
+dai
+dai
 pFV
 pFV
 pFV
@@ -228069,7 +228401,7 @@ pFV
 pFV
 pFV
 pFV
-pFV
+dai
 pFV
 fFO
 wud
@@ -228261,7 +228593,7 @@ pMh
 pMh
 pFV
 pfy
-pFV
+dai
 pFV
 qPl
 pFV
@@ -228271,7 +228603,7 @@ pFV
 pFV
 pFV
 rIK
-fLu
+hYw
 pFV
 pFV
 wud
@@ -228458,14 +228790,14 @@ mfN
 saN
 pFV
 qPl
+dai
+dai
 pFV
 pFV
 pFV
 pFV
 pFV
-pFV
-pFV
-pFV
+dai
 pFV
 pFV
 pFV
@@ -228661,13 +228993,13 @@ bSt
 pFV
 pFV
 pFV
+wER
 pMh
-pMh
 pFV
 pFV
 pFV
 pFV
-pFV
+dai
 pFV
 pFV
 pFV
@@ -228864,17 +229196,17 @@ pFV
 pFV
 pFV
 pFV
+dai
 pFV
 pFV
 pFV
-pFV
-pFV
+dai
 pFV
 pFV
 fFO
 pFV
 pFV
-pFV
+dai
 pFV
 pFV
 pFV
@@ -229065,17 +229397,17 @@ bSt
 pMh
 pMh
 pFV
-pFV
+dai
 pFV
 pFV
 qPl
+dai
+dai
 pFV
 pFV
+jez
 pFV
-pFV
-vbq
-pFV
-pFV
+dai
 pFV
 pFV
 igM
@@ -229267,17 +229599,17 @@ bSt
 pFV
 pFV
 pFV
+dai
 pFV
 pFV
+dai
+dai
+vZC
+dai
 pFV
 pFV
-pFV
-mGO
-pFV
-pFV
-pFV
-pFV
-pFV
+dai
+dai
 pFV
 mGO
 pFV
@@ -229468,12 +229800,12 @@ mfN
 bSt
 pFV
 pFV
-pFV
-mGO
-pFV
-pFV
+dai
+vZC
 pFV
 pFV
+dai
+dai
 pFV
 pFV
 pFV
@@ -229671,11 +230003,11 @@ rnc
 pFV
 pFV
 fLu
+dai
 pFV
 pFV
 pFV
-pFV
-pFV
+dai
 pFV
 pFV
 pFV
@@ -229873,12 +230205,12 @@ bSt
 vFX
 bSt
 bSt
-bSt
+evS
 pFV
 dHz
-vbq
-pFV
-igM
+jez
+dai
+wVE
 pFV
 pFV
 fLu
@@ -229890,7 +230222,7 @@ pFV
 pFV
 pFV
 mGO
-piv
+pJQ
 oqZ
 oGj
 gSS
@@ -230074,7 +230406,7 @@ mfN
 bSt
 bSt
 bSt
-dyf
+gou
 bSt
 pFV
 pFV
@@ -230092,7 +230424,7 @@ pMh
 pFV
 pFV
 lPo
-piv
+pJQ
 oqZ
 oGj
 onw
@@ -230276,7 +230608,7 @@ mfN
 bSt
 ccn
 dyf
-bSt
+evS
 bSt
 pFV
 igM
@@ -230294,7 +230626,7 @@ qPl
 pFV
 pFV
 vbq
-kii
+qEJ
 oqZ
 oGj
 onw
@@ -230486,7 +230818,7 @@ igM
 pFV
 igM
 oRK
-pFV
+dai
 vbq
 pFV
 igM
@@ -230680,14 +231012,14 @@ mfN
 bSt
 bSt
 bSt
-bSt
-bSt
+evS
+evS
 pMh
 pFV
 vbq
 pFV
-igM
-igM
+wVE
+wVE
 pFV
 tlE
 pFV
@@ -230883,7 +231215,7 @@ aUQ
 bSt
 bSt
 bSt
-bSt
+evS
 pfy
 dHz
 tlE
@@ -231079,26 +231411,26 @@ yjc
 bSt
 mfN
 mfN
-fDy
-fDy
-fDy
-fDy
-fDy
-fDy
-bSt
+gBT
+gBT
+gBT
+gBT
+oAQ
+gBT
+evS
+dai
 pFV
 pFV
 pFV
-pFV
-mGO
+vZC
 pFV
 pMh
 pFV
+dai
+nXe
 pFV
-lPo
 pFV
-pFV
-pFV
+dai
 pFV
 pFV
 pFV
@@ -231287,20 +231619,20 @@ pXH
 hIM
 hjy
 dKC
-fDy
-pFV
+gBT
+dai
 pMh
 pFV
 pFV
 lPo
-pFV
+dai
 qPl
-pFV
-pFV
+dai
+dai
 vbq
 pfy
 pFV
-pMh
+wER
 pFV
 pFV
 kni
@@ -231489,20 +231821,20 @@ gSR
 gSR
 gSR
 vUx
-fDy
-pFV
-qPl
+lBa
+dai
+tyZ
 mGO
 pFV
 vbq
-pfy
+pGX
 pFV
 pFV
-pFV
-dHz
+dai
+fek
 vbq
 pFV
-igM
+wVE
 pFV
 pFV
 pFV
@@ -231691,19 +232023,19 @@ gSR
 gSR
 gSR
 wAo
-fDy
+gBT
+dai
+dai
 pFV
 pFV
 pFV
+dai
 pFV
-pFV
-pFV
-pFV
-pFV
-pFV
+dai
+dai
 pFV
 fLu
-pFV
+dai
 igM
 pFV
 pFV
@@ -231893,23 +232225,23 @@ gSR
 gSR
 gSR
 mRx
-fDy
-pFV
+gBT
+dai
 pFV
 pFV
 pFV
 pFV
 tzc
 pFV
-pFV
+dai
 pFV
 igM
-tyN
-pFV
-pfy
+gGl
+dai
+pGX
 vbq
-pMh
-vbq
+wER
+jez
 qdc
 oqZ
 oGj
@@ -232095,15 +232427,15 @@ gSR
 gSR
 gSR
 qrl
-fDy
-fDy
-fDy
-fDy
-fDy
-fDy
+cny
+cny
+oAQ
+cny
+cny
+gBT
 bSt
 bSt
-pFV
+dai
 mGO
 pFV
 igM
@@ -232111,8 +232443,8 @@ pFV
 igM
 igM
 pFV
-pfy
-wud
+pGX
+fXd
 oqZ
 oGj
 onw
@@ -232297,10 +232629,10 @@ gSR
 gSR
 lCC
 yjc
-fnK
+dCP
 tQk
-fnK
-fnK
+ltQ
+ltQ
 fnK
 fnK
 fnK
@@ -232311,7 +232643,7 @@ pFV
 vbq
 pFV
 pMh
-igM
+wVE
 pFV
 nPL
 wud
@@ -232506,14 +232838,14 @@ sTl
 qTf
 kOv
 kOv
-uBR
-pFV
-pFV
-pFV
-igM
-pFV
+nRJ
+dai
+dai
 pFV
 igM
+pFV
+dai
+wVE
 pFV
 pFV
 wud
@@ -232709,11 +233041,11 @@ vjP
 vjP
 gsH
 rnV
-fFO
 pFV
 pFV
 pFV
-pFV
+dai
+dai
 mGO
 tlE
 pFV
@@ -232911,12 +233243,12 @@ vjP
 vjP
 gsH
 uBR
-fFO
 pFV
+dai
 pMh
+dai
 pFV
-pFV
-lPo
+nXe
 pFV
 pFV
 pFV
@@ -233112,16 +233444,16 @@ bGe
 iPV
 vjP
 aSZ
-uBR
-fFO
+rLl
 pFV
+dai
 dHz
-vbq
+jez
+dai
+wVE
 pFV
-igM
 pFV
-pFV
-pfy
+pGX
 hys
 oqZ
 sqf
@@ -233314,15 +233646,15 @@ bGe
 iPV
 vjP
 kOv
-uBR
-fFO
-pFV
+nRJ
+qIE
+dai
 pFV
 fLu
-pFV
+dai
 igM
 pFV
-pFV
+dai
 igM
 hys
 oqZ
@@ -233516,8 +233848,8 @@ kYT
 iPV
 vjP
 qxG
-uBR
-fFO
+rLl
+gMn
 pFV
 igM
 tyN
@@ -233718,14 +234050,14 @@ qyM
 vjP
 vjP
 aSZ
-uBR
-fFO
+rLl
+dai
 mGO
 pFV
-igM
-pFV
-igM
-pMh
+wVE
+dai
+wVE
+wER
 pFV
 pFV
 tjB
@@ -233920,15 +234252,15 @@ qyM
 vjP
 vjP
 qTf
-uBR
-fFO
+qIR
+pFV
 pMh
 pFV
 vbq
 pFV
 igM
 igM
-pFV
+qPl
 pFV
 wud
 gUt
@@ -234123,7 +234455,7 @@ vjP
 vjP
 sTl
 uBR
-fFO
+pFV
 pFV
 pFV
 tlE
@@ -234131,8 +234463,8 @@ pMh
 pFV
 igM
 pFV
-pFV
-wud
+dai
+fXd
 oqZ
 sqf
 onw
@@ -234324,8 +234656,8 @@ vjP
 vjP
 vjP
 dfF
-uBR
-fFO
+rLl
+pFV
 pFV
 pFV
 pFV
@@ -234333,7 +234665,7 @@ pFV
 mGO
 pMh
 pFV
-pMh
+wER
 piv
 oqZ
 sqf
@@ -234526,7 +234858,7 @@ kZT
 vMw
 arX
 dfF
-uBR
+rLl
 pFV
 pFV
 pMh
@@ -234535,7 +234867,7 @@ pFV
 lPo
 pFV
 pFV
-pFV
+dai
 piv
 oqZ
 sqf
@@ -234729,14 +235061,14 @@ yjc
 yjc
 yjc
 yjc
-fFO
+pFV
 pFV
 qPl
-pFV
-pFV
+dai
+dai
 vbq
-pfy
-pFV
+qwl
+dai
 fFO
 wud
 oqZ
@@ -234931,15 +235263,15 @@ gBD
 sDV
 bXm
 spF
-spF
 pFV
 pFV
 pFV
+dai
+pFV
+dai
+dai
 pFV
 pFV
-pFV
-pFV
-fFO
 bFA
 ilL
 sqf
@@ -235133,15 +235465,15 @@ gBD
 sDV
 bXm
 spF
-fFO
+ehz
 pFV
+dai
+dai
 pFV
-pFV
-pFV
-pFV
+dai
 tzc
 pFV
-fFO
+pFV
 rhI
 ilL
 ilL
@@ -235335,14 +235667,14 @@ gBD
 sDV
 bXm
 spF
-fFO
-pFV
+ehz
+ehz
 pFV
 pFV
 pFV
 vtx
-fFO
-fFO
+pFV
+qPl
 obo
 rhI
 ilL
@@ -235538,12 +235870,12 @@ sDV
 bXm
 spF
 spF
-fFO
-fFO
-fFO
-rIK
-fFO
-obo
+ehz
+qPl
+pFV
+uaJ
+pFV
+tVt
 aYl
 aYl
 aYl
@@ -235743,9 +236075,9 @@ vvA
 vvA
 vvA
 vvA
-fFO
-nPL
-aYl
+hPj
+hcX
+uxm
 aYl
 aYl
 aYl
@@ -235946,7 +236278,7 @@ bXm
 bXm
 bXm
 azv
-azv
+tdp
 aYl
 aYl
 aYl

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -1792,6 +1792,12 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
+"ats" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "atw" = (
 /obj/effect/floor_decal/spline/wood,
 /turf/simulated/floor/wood/wild3,
@@ -5619,6 +5625,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
+"bjd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "bjf" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -6276,14 +6287,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
-"bqU" = (
-/obj/structure/flora/big/bush1,
-/obj/structure/flora/big/bush1{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/turf/simulated/mineral,
-/area/nadezhda/outside/scave)
 "bqV" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warningwhite{
@@ -6578,15 +6581,9 @@
 	name = "Residential District Maintenance"
 	})
 "bum" = (
-/mob/living/simple_animal/hostile/snake{
-	faction = "neutral";
-	name = "crimson viper";
-	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm.";
-	color = "#f7140c";
-	maxHealth = 250;
-	health = 250
-	},
-/turf/simulated/floor/rock,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "buo" = (
 /obj/structure/sign/warning/smoking/small,
@@ -7411,10 +7408,10 @@
 	},
 /area/shuttle/vasiliy_shuttle_area)
 "bCJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "bCL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
@@ -7888,10 +7885,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"bIc" = (
-/obj/structure/boulder,
-/turf/simulated/floor/rock,
-/area/nadezhda/outside/forest)
 "bIf" = (
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance{
@@ -12880,6 +12873,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"cLf" = (
+/mob/living/simple_animal/hostile/snake{
+	faction = "neutral";
+	name = "crimson viper";
+	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm.";
+	color = "#f7140c";
+	maxHealth = 250;
+	health = 250
+	},
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/forest)
 "cLm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -19689,12 +19693,12 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/atmos)
 "edF" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -10;
-	pixel_y = -10
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
 	},
-/turf/unsimulated/mineral,
-/area/nadezhda/outside/forest)
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/lakeside)
 "edJ" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/disposalpipe/segment{
@@ -21261,12 +21265,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/engineering/atmos/surface)
 "est" = (
-/obj/structure/lattice,
-/obj/structure/catwalk{
-	icon_state = "catwalk-broken"
-	},
-/turf/simulated/open,
-/area/nadezhda/dungeon/outside/abandoned_outpost)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "esy" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -21570,13 +21572,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"ewk" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	dir = 1;
-	pixel_y = -10
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/abandoned_outpost)
 "ewn" = (
 /obj/structure/boulder,
 /obj/structure/disposalpipe/segment{
@@ -30105,11 +30100,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
-"giB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "giE" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -35139,10 +35129,12 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/sleeper)
 "hlB" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/turf/simulated/mineral,
+/area/nadezhda/outside/scave)
 "hlG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -35787,16 +35779,10 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "htk" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/structure/flora/big/bush1{
-	pixel_x = -15;
-	pixel_y = -25
-	},
-/turf/unsimulated/mineral,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/lakeside)
 "htn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39266,10 +39252,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/maingate)
 "iaB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
+/turf/simulated/mineral,
+/area/nadezhda/outside/scave)
 "iaF" = (
 /mob/living/simple_animal/hostile/jelly/bloat,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -39622,11 +39610,6 @@
 /obj/effect/floor_decal/industrial/outputgate,
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
-"ieb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "iee" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -39874,6 +39857,17 @@
 /obj/structure/flora/small/trailrocka3,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"igB" = (
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/forest)
 "igD" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -40932,12 +40926,12 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "isa" = (
+/obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/big/bush1{
-	pixel_x = -15;
 	pixel_y = -10
 	},
-/turf/simulated/mineral,
-/area/nadezhda/outside/scave)
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "isb" = (
 /obj/structure/table/rack/shelf,
 /obj/item/roller{
@@ -47328,12 +47322,10 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jIz" = (
-/obj/structure/lattice,
-/obj/structure/catwalk{
-	icon_state = "catwalk-broken"
-	},
-/turf/simulated/open,
-/area/nadezhda/outside/scave)
+/obj/random/flora/small_jungle_tree,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "jIA" = (
 /obj/structure/flora/big/bush2,
 /obj/random/flora/jungle_tree,
@@ -54647,6 +54639,7 @@
 "llK" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "llQ" = (
@@ -55866,6 +55859,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
+"lzF" = (
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/forest)
 "lzO" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stock_parts/capacitor/excelsior,
@@ -59552,12 +59548,10 @@
 	name = "Residential District Maintenance"
 	})
 "mmh" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/lakeside)
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "mmj" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
 	dir = 8
@@ -60863,6 +60857,10 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"mAy" = (
+/obj/structure/railing,
+/turf/simulated/floor/beach/sand,
+/area/nadezhda/outside/lakeside)
 "mAD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green,
@@ -61635,11 +61633,6 @@
 /area/nadezhda/maintenance/undergroundfloor2west)
 "mHv" = (
 /obj/random/flora/jungle_tree,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
-"mHC" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "mHE" = (
@@ -64787,11 +64780,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "noj" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/beach/sand,
+/turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/lakeside)
 "nol" = (
 /obj/structure/disposalpipe/segment{
@@ -68500,9 +68489,8 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "nYY" = (
-/obj/structure/flora/big/bush1{
-	pixel_y = -10
-	},
+/obj/effect/decal/cleanable/rubble,
+/obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nYZ" = (
@@ -68741,9 +68729,10 @@
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
 "obd" = (
-/obj/structure/railing,
-/turf/simulated/floor/beach/sand,
-/area/nadezhda/outside/lakeside)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "obl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70180,9 +70169,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
 "oqo" = (
-/obj/structure/flora/big/bush1,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/outside/scave)
+/obj/machinery/microwave/burnbarrel,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/lakeside)
 "oqq" = (
 /obj/structure/closet/secure_closet/personal/orderly,
 /obj/machinery/light{
@@ -75348,11 +75337,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "prJ" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/lattice,
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
 	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/outside/lakeside)
+/turf/simulated/open,
+/area/nadezhda/dungeon/outside/abandoned_outpost)
 "prT" = (
 /obj/structure/table/rack,
 /obj/item/storage/backpack/industrial{
@@ -75366,10 +75356,21 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "prX" = (
-/obj/structure/flora/small/rock5,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/grille{
+	desc = "Keeps the ruffians out. Hopefully.";
+	name = "perimeter fence"
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/security/maingate/west)
 "prZ" = (
 /obj/machinery/door/blast/shutters/glass{
 	name = "Fireplace Cover"
@@ -76798,12 +76799,11 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "pGM" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -10;
-	pixel_y = -10
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/simulated/mineral,
-/area/nadezhda/outside/scave)
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/outside/lakeside)
 "pGS" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -77248,6 +77248,12 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"pLI" = (
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/forest)
 "pLJ" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/big/bush2,
@@ -79689,7 +79695,6 @@
 "qjm" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
-/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "qjo" = (
@@ -80411,6 +80416,10 @@
 /obj/random/ammo,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"qqS" = (
+/obj/structure/boulder,
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/forest)
 "qra" = (
 /obj/structure/table/standard,
 /obj/random/cloth/armor/low_chance,
@@ -85373,10 +85382,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "rsR" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/lakeside)
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -10
+	},
+/turf/simulated/mineral,
+/area/nadezhda/outside/scave)
 "rtf" = (
 /obj/random/structures,
 /turf/simulated/floor/tiled/techmaint,
@@ -88350,9 +88361,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"rYV" = (
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/outside/lakeside)
 "rYX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -93091,10 +93099,12 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "sWc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 1;
+	pixel_y = -10
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/abandoned_outpost)
 "sWd" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/wild3,
@@ -93859,11 +93869,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
 "ten" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	pixel_y = 10
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/abandoned_outpost)
+/area/nadezhda/outside/lakeside)
 "tes" = (
 /obj/structure/showcase{
 	desc = "Ancient robotic frame, that is long deactivated and rusted solid. However, it still strikes am awesome pose, that somehow makes you think of justice and righteousness.";
@@ -94563,14 +94573,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/crew_quarters/hydroponics)
-"tmw" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/flora/big/bush1{
-	pixel_y = -10
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "tmz" = (
 /obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor/tiled/steel,
@@ -96677,6 +96679,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"tIB" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/beach/sand,
+/area/nadezhda/outside/lakeside)
 "tIG" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/machinery/light/small,
@@ -96848,11 +96857,13 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/absolutism/hallways)
 "tJT" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
 	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/outside/lakeside)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "tJY" = (
 /obj/random/scrap/sparse_weighted/low_chance,
 /turf/simulated/floor/asteroid/dirt,
@@ -97972,10 +97983,9 @@
 	},
 /area/shuttle/surface_transport_lz)
 "tUo" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -15
-	},
-/turf/unsimulated/mineral,
+/obj/structure/flora/small/rock5,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "tUr" = (
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -98769,6 +98779,10 @@
 	tag = "icon-escpodwall17"
 	},
 /area/nadezhda/crew_quarters/sleep/bedrooms)
+"ucU" = (
+/obj/structure/flora/big/bush1,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/outside/scave)
 "ucV" = (
 /obj/structure/table/steel,
 /obj/random/lowkeyrandom/low_chance,
@@ -100702,12 +100716,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "uxn" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/flora/big/bush1{
-	pixel_y = -10
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	pixel_y = 10
 	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/abandoned_outpost)
 "uxo" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -109233,8 +109246,13 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/east)
 "wew" = (
-/turf/simulated/floor/rock,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/big/bush1,
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/turf/simulated/mineral,
+/area/nadezhda/outside/scave)
 "wez" = (
 /obj/item/material/shard,
 /obj/item/tool/broken_bottle,
@@ -110138,10 +110156,10 @@
 /turf/simulated/floor/asteroid/dirt/dark/plough,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "woI" = (
-/obj/random/flora/small_jungle_tree,
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/random/junkfood/low_chance,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/area/nadezhda/outside/lakeside)
 "woR" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -110737,9 +110755,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "wsJ" = (
-/obj/machinery/microwave/burnbarrel,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/lakeside)
+/obj/structure/lattice,
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
+	},
+/turf/simulated/open,
+/area/nadezhda/outside/scave)
 "wsT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -111667,13 +111688,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"wDQ" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -15;
-	pixel_y = -25
-	},
-/turf/simulated/mineral,
-/area/nadezhda/outside/scave)
 "wDS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -112401,10 +112415,12 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "wMi" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/random/junkfood/low_chance,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/lakeside)
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/forest)
 "wMl" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "13,0"
@@ -189363,9 +189379,9 @@ qif
 ary
 pJd
 pJd
-jIz
+wsJ
 nfl
-bqU
+wew
 nfl
 hRu
 aIE
@@ -189765,7 +189781,7 @@ aIE
 uhn
 pJd
 pJd
-jIz
+wsJ
 pJd
 pJd
 wtf
@@ -189966,13 +189982,13 @@ hRu
 aIE
 uhn
 pJd
-pGM
+hlB
 wtf
 wtf
 aIE
 aIE
 aIE
-jIz
+wsJ
 hRu
 aIE
 aIE
@@ -190174,7 +190190,7 @@ aIE
 aIE
 aIE
 uhn
-jIz
+wsJ
 hRu
 aIE
 aIE
@@ -190773,7 +190789,7 @@ jsU
 hRu
 aIE
 aIE
-jIz
+wsJ
 drv
 aIE
 aIE
@@ -190980,7 +190996,7 @@ drv
 qif
 qif
 jiQ
-wDQ
+iaB
 xbE
 pJd
 hRu
@@ -191181,9 +191197,9 @@ pJd
 hRu
 aIE
 aIE
-isa
+rsR
 hRu
-pGM
+hlB
 tMB
 hRu
 aIE
@@ -191384,8 +191400,8 @@ hRu
 aIE
 aIE
 paY
-isa
-oqo
+rsR
+ucU
 qif
 hRu
 aIE
@@ -191783,7 +191799,7 @@ hRu
 hRu
 aIE
 aIE
-jIz
+wsJ
 gIC
 aIE
 aIE
@@ -211911,7 +211927,7 @@ kGO
 nYc
 snS
 kGO
-jbb
+prX
 cxU
 cxU
 tfW
@@ -216595,9 +216611,9 @@ kTO
 kTO
 kTO
 kTO
-tUo
-wew
-bum
+pLI
+lzF
+cLf
 kTO
 kOj
 kOj
@@ -216796,9 +216812,9 @@ kTO
 ryY
 ryY
 kTO
-htk
-bIc
-bIc
+igB
+qqS
+qqS
 kTO
 kTO
 kOj
@@ -217000,7 +217016,7 @@ ryY
 ryY
 ryY
 rfo
-edF
+wMi
 kTO
 xkT
 tfW
@@ -218238,7 +218254,7 @@ phr
 gsI
 gsI
 gsI
-obd
+mAy
 lKW
 bZl
 bZl
@@ -218247,7 +218263,7 @@ bZl
 bZl
 bZl
 bZl
-noj
+tIB
 knY
 pVn
 knY
@@ -218440,18 +218456,18 @@ tMW
 gsI
 gsI
 gsI
-rYV
-prJ
-prJ
-prJ
-prJ
-prJ
-prJ
-prJ
-prJ
-rYV
+noj
+pGM
+pGM
+pGM
+pGM
+pGM
+pGM
+pGM
+pGM
+noj
 hPl
-wsJ
+oqo
 lqH
 hPl
 eNc
@@ -218642,19 +218658,19 @@ phr
 gsI
 gsI
 gsI
-rYV
-tJT
-tJT
-tJT
-tJT
-tJT
-tJT
-tJT
-tJT
-rYV
-rsR
+noj
+ten
+ten
+ten
+ten
+ten
+ten
+ten
+ten
+noj
+htk
 cdL
-rsR
+htk
 cdL
 eNc
 bZl
@@ -218844,7 +218860,7 @@ gsI
 gsI
 gsI
 gsI
-obd
+mAy
 lKW
 bZl
 bZl
@@ -218853,7 +218869,7 @@ bZl
 bZl
 dMx
 bZl
-mmh
+edF
 gNN
 sWe
 pLq
@@ -219259,7 +219275,7 @@ bZl
 bZl
 gsI
 qtA
-wMi
+woI
 sWe
 eNc
 eNc
@@ -227350,7 +227366,7 @@ eJk
 ihc
 eJk
 srv
-iaB
+bum
 cxU
 eJk
 eJk
@@ -227747,7 +227763,7 @@ eJk
 eJk
 mMF
 srv
-bCJ
+ats
 srv
 cxU
 srv
@@ -227954,7 +227970,7 @@ tfW
 tfW
 oZR
 cxU
-ieb
+obd
 cxU
 cxU
 asR
@@ -228354,8 +228370,8 @@ tfW
 erZ
 eUV
 szI
-giB
-sWc
+bjd
+est
 fLZ
 erZ
 eUV
@@ -229566,7 +229582,7 @@ qnK
 oVF
 oVF
 rZL
-est
+prJ
 uBg
 gUQ
 dAX
@@ -229968,7 +229984,7 @@ aeb
 crJ
 rLw
 rLw
-est
+prJ
 rLw
 rLw
 uBg
@@ -230565,12 +230581,12 @@ cxU
 cxU
 cxU
 lEs
-llK
+qjm
 tfW
 qZG
 tfW
 tfW
-nYY
+bCJ
 gUQ
 gUQ
 dAX
@@ -230770,9 +230786,9 @@ ovz
 qZG
 tfW
 cXA
-uxn
+isa
 tfW
-hlB
+nYY
 dAX
 gUQ
 dAX
@@ -230981,14 +230997,14 @@ dAX
 dAX
 aeb
 rLw
-ten
-ewk
+uxn
+sWc
 ccE
 qZG
 qZG
 qZG
 cXA
-mHC
+mmh
 eUV
 eUV
 tfW
@@ -231175,18 +231191,18 @@ tfW
 eUV
 fLZ
 eUV
-tmw
+tJT
 tfW
 rLw
 rLw
-est
+prJ
 rLw
 rLw
 rLw
 dAX
 dAX
 gUQ
-mHC
+mmh
 qZG
 qZG
 eUV
@@ -231377,7 +231393,7 @@ qZG
 tfW
 eUV
 eUV
-woI
+jIz
 tfW
 gUQ
 sok
@@ -231780,7 +231796,7 @@ lEs
 tfW
 eUV
 eUV
-uxn
+isa
 qZG
 qZG
 gUQ
@@ -231983,7 +231999,7 @@ wjb
 tfW
 tfW
 tfW
-qjm
+llK
 tfW
 gUQ
 gUQ
@@ -231991,7 +232007,7 @@ gUQ
 gUQ
 gUQ
 gUQ
-est
+prJ
 uBg
 dAX
 gUQ
@@ -232184,7 +232200,7 @@ lEs
 tfW
 qZG
 cXA
-llK
+qjm
 fLZ
 raM
 dAX
@@ -232386,7 +232402,7 @@ ovz
 qZG
 tfW
 qZG
-qjm
+llK
 tfW
 raM
 gUQ
@@ -232539,7 +232555,7 @@ gho
 hWB
 tfW
 tfW
-mHv
+tfW
 txQ
 qli
 kOj
@@ -232606,7 +232622,7 @@ dAX
 dAX
 dAX
 tfW
-woI
+jIz
 tfW
 qZG
 iGL
@@ -232794,7 +232810,7 @@ dAX
 dAX
 gUQ
 rLw
-est
+prJ
 rLw
 rLw
 rLw
@@ -233011,7 +233027,7 @@ dAX
 dAX
 qZG
 eUV
-prX
+tUo
 eUV
 kOj
 kOj
@@ -233213,7 +233229,7 @@ dAX
 dAX
 eUV
 eUV
-woI
+jIz
 tfW
 iGL
 kOj
@@ -233815,7 +233831,7 @@ dAX
 eUV
 eUV
 eUV
-llK
+qjm
 tfW
 tfW
 iEn

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -750,11 +750,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/substation/bridge)
-"aig" = (
-/obj/structure/railing,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "aij" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
@@ -771,6 +766,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
+"ail" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "ain" = (
 /obj/machinery/power/port_gen/pacman/diesel/anchored,
 /obj/structure/cable/yellow{
@@ -1319,10 +1321,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
-"anG" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "anK" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -2211,6 +2209,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"axd" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "axf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4052,21 +4056,6 @@
 /obj/random/junkfood/rotten,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"aSj" = (
-/obj/effect/floor_decal/spline/fancy,
-/obj/effect/floor_decal/corner_techfloor_grid,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/table/bench/steel,
-/obj/effect/spider/stickyweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/security/sechall)
 "aSk" = (
 /obj/structure/table/rack/shelf,
 /obj/item/hand_labeler,
@@ -5538,6 +5527,11 @@
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical)
+"biw" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "biz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5789,6 +5783,11 @@
 /obj/effect/floor_decal/industrial/road/curve4,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"bky" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
@@ -6020,6 +6019,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"boj" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "bok" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6247,11 +6254,6 @@
 /obj/structure/flora/small/rock3,
 /obj/structure/railing,
 /obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
-"bqo" = (
-/obj/structure/railing,
-/obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "bqr" = (
@@ -7614,10 +7616,10 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
 "bFc" = (
-/obj/random/flora/low_chance,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
+/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "bFk" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -8826,11 +8828,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"bTk" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "bTl" = (
 /obj/structure/table/rack/shelf,
 /obj/random/toolbox,
@@ -9773,11 +9770,6 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"ccP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "ccY" = (
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -9791,14 +9783,6 @@
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
-"cdg" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "cdh" = (
 /obj/machinery/atm{
 	dir = 8;
@@ -11155,10 +11139,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "csI" = (
-/obj/structure/table/woodentable,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
+/obj/random/flora/jungle_tree,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "csK" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -14482,9 +14466,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
 "dai" = (
+/obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate/east)
+/area/nadezhda/outside/inside_colony)
 "dak" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/light/small{
@@ -16805,13 +16790,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"dyI" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "dyN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16873,6 +16851,12 @@
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"dzg" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "dzr" = (
 /obj/random/medical_lowcost,
 /obj/random/medical_lowcost_handmade,
@@ -16962,12 +16946,8 @@
 	icon_state = "10,12"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"dAF" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "dAK" = (
+/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
@@ -17539,11 +17519,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"dGu" = (
-/obj/structure/low_wall,
-/obj/structure/flora/big/bush3,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "dGz" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin{
@@ -17778,6 +17753,13 @@
 /obj/item/clothing/under/bathrobe,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
+"dIY" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "dJa" = (
 /obj/structure/sign/misc/rent,
 /turf/simulated/wall/r_wall,
@@ -19013,6 +18995,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfaceeast)
+"dWX" = (
+/obj/structure/flora/bush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "dWZ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -19115,6 +19102,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"dYd" = (
+/obj/random/flora/low_chance,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "dYe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19496,14 +19488,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/west)
-"ebL" = (
-/obj/structure/flora/small/rock3,
-/obj/structure/invislight,
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "ebN" = (
 /obj/structure/closet/secure_closet/xenoarchaeologist,
 /obj/structure/window/reinforced{
@@ -19628,11 +19612,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
-"ecU" = (
-/obj/item/ammo_casing,
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "ecW" = (
 /obj/machinery/camera/network/gate{
 	dir = 10;
@@ -20085,6 +20064,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"ehm" = (
+/obj/structure/flora/small/rock3,
+/obj/structure/invislight,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "ehp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/chapel,
@@ -20847,13 +20834,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"eoZ" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "epa" = (
 /obj/random/mob/termite_no_despawn,
 /turf/simulated/floor/rock,
@@ -21626,11 +21606,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"ewL" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "ewS" = (
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -21764,6 +21739,11 @@
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/lakeside)
+"exq" = (
+/obj/structure/railing,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "exA" = (
 /obj/effect/spider/stickyweb,
 /obj/random/contraband,
@@ -22532,6 +22512,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/sechall)
+"eHp" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate/east)
 "eHq" = (
 /obj/structure/table/rack,
 /obj/item/towel,
@@ -23016,6 +23000,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"eMA" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "eMB" = (
 /obj/structure/table/glass,
 /obj/item/device/camera,
@@ -23618,6 +23607,10 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"eRd" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "eRg" = (
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -24689,13 +24682,6 @@
 /obj/item/book/manual/nonfiction/thetranscendentalist,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"fdc" = (
-/obj/structure/catwalk,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/pros/shuttle)
 "fdk" = (
 /turf/simulated/shuttle/floor/science{
 	icon_state = "11,4"
@@ -25802,6 +25788,7 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "fnO" = (
@@ -26746,6 +26733,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
+"fyz" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "fyB" = (
 /obj/machinery/button/windowtint{
 	id = "serg";
@@ -26923,6 +26915,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"fAp" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "fAq" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -27418,11 +27419,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
-"fFs" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "fFD" = (
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -28532,15 +28528,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
-"fSX" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/flora/big/bush3{
-	pixel_y = -18
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "fTa" = (
 /obj/structure/window/reinforced,
 /obj/structure/multiz/stairs/active{
@@ -30306,13 +30293,6 @@
 /obj/structure/railing,
 /turf/simulated/open,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
-"gkR" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "gkW" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -31848,6 +31828,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/science)
 "gAr" = (
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_oldtile/white{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_oldtile/white,
 /obj/machinery/door/unpowered/simple/wood{
 	color = "#9a977b"
 	},
@@ -34126,6 +34116,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"hbk" = (
+/obj/structure/low_wall,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "hbl" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/alarm{
@@ -34163,11 +34158,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/robotics)
-"hbE" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "hbN" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/stalkybush,
@@ -37071,6 +37061,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/range)
+"hGo" = (
+/obj/item/ammo_casing,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "hGs" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -37940,11 +37935,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"hNd" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "hNf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -37963,6 +37953,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"hNr" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/inside_colony)
 "hNs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -38306,11 +38302,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"hTq" = (
-/obj/structure/flora/small/rock2,
-/obj/structure/flora/big/bush3,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "hTt" = (
 /obj/machinery/camera/network/church{
 	dir = 1
@@ -38718,6 +38709,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
+"hWz" = (
+/obj/structure/flora/small/rock2,
+/obj/structure/flora/big/bush3,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "hWB" = (
 /obj/structure/bonfire,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -39598,13 +39594,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
-"idL" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "idS" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
@@ -41150,12 +41139,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"itR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/item/flame/lighter/zippo/capitalist,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "itU" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -42624,16 +42607,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"iKO" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
-"iKR" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "iKS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -42971,6 +42944,10 @@
 /obj/machinery/sleeper,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
+"iOS" = (
+/obj/random/scrap/sparse_weighted/low_chance,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "iOV" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
@@ -43346,6 +43323,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
+"iSR" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "iSU" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -44344,11 +44328,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"jdV" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "jec" = (
 /obj/structure/railing{
 	dir = 8
@@ -44398,8 +44377,9 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/reception)
 "jez" = (
-/obj/structure/boulder,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "jeE" = (
 /obj/structure/bed/chair/sofa/black/left{
@@ -44616,11 +44596,6 @@
 /obj/effect/floor_decal/industrial/arrows,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/sechall)
-"jhg" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "jhl" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Sec Armory";
@@ -44832,13 +44807,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"jiF" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush3{
-	pixel_y = -18
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "jiQ" = (
 /obj/structure/sign/warning/caution/small{
 	dir = 1
@@ -45346,6 +45314,12 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
+"jnv" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "jny" = (
 /obj/machinery/power/nt_obelisk,
 /obj/machinery/newscaster/directional/north,
@@ -46342,6 +46316,22 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
+"jwX" = (
+/obj/effect/floor_decal/spline/fancy,
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/table/bench/steel,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/security/sechall)
 "jxb" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/random/traps/low_chance{
@@ -46482,11 +46472,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters)
-"jzv" = (
-/obj/structure/flora/bush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "jzw" = (
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/generic,
@@ -46495,18 +46480,16 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"jzz" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "jzB" = (
 /obj/structure/table/standard,
 /obj/random/cloth/masks/low_chance,
 /obj/random/voidsuit/damaged/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"jzE" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "jzJ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/camera/network/research,
@@ -46653,6 +46636,11 @@
 /obj/structure/closet/secure_closet/personal/detective,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/detectives_office)
+"jBa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/fiction/warandpeace,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "jBc" = (
 /mob/living/simple_animal/soteria_roomba/medical,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -47667,11 +47655,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
-"jMr" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "jMx" = (
 /obj/structure/lattice,
 /obj/structure/invislight,
@@ -48840,6 +48823,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/genetics)
+"jZe" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "jZi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/mob/spiders/low_chance,
@@ -49517,6 +49507,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"kfT" = (
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/inside_colony)
 "kfY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -49525,11 +49519,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "kgc" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "kge" = (
 /obj/machinery/light/small{
@@ -50048,6 +50040,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"kkW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/item/flame/lighter/zippo/capitalist,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "kla" = (
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
@@ -51540,11 +51538,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"kzK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/book/manual/fiction/warandpeace,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "kzM" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/beach/water/shallow,
@@ -54063,9 +54056,8 @@
 	dir = 8
 	},
 /obj/structure/table/bench/steel,
+/obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/security/sechall)
 "lew" = (
@@ -54175,12 +54167,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
-"lfz" = (
-/obj/structure/flora/bush,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "lfE" = (
 /obj/structure/sign/faction/neotheology_cross/gold{
 	pixel_y = -32
@@ -56893,6 +56879,10 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"lKn" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "lKx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -57119,6 +57109,13 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/maingate/east)
+"lNz" = (
+/obj/structure/catwalk,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/pros/shuttle)
 "lNB" = (
 /obj/effect/floor_decal/industrial/inputgate,
 /turf/simulated/floor/fixed/hydrotile,
@@ -57271,6 +57268,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"lPr" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/security/maingate/east)
 "lPt" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -57350,12 +57352,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
-"lPX" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/rock,
-/area/nadezhda/outside/inside_colony)
 "lQm" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/techmaint,
@@ -57560,6 +57556,13 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"lSe" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "lSh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57658,6 +57661,13 @@
 /obj/structure/railing,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
+"lTk" = (
+/obj/structure/flora/big/rocks3,
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "lTl" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -59458,11 +59468,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
-"mkT" = (
-/obj/random/flora/jungle_tree,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "mkU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -60541,6 +60546,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"mwH" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "mwL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/coffin,
@@ -61176,6 +61187,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"mDb" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "mDd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61476,11 +61492,6 @@
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/xenobiology)
-"mGg" = (
-/obj/structure/flora/small/rock3,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "mGl" = (
 /obj/random/scrap/dense_weighted,
 /obj/structure/table/rack/shelf,
@@ -61917,10 +61928,6 @@
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/nadezhda/engineering/atmos)
-"mKP" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "mKQ" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1;
@@ -62710,6 +62717,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"mSW" = (
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "mSY" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,1";
@@ -63173,6 +63184,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
+"mYs" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/inside_colony)
 "mYu" = (
 /obj/structure/closet/crate,
 /obj/random/powercell/low_chance,
@@ -64889,12 +64906,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
-"npf" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/beach/water/flooded,
-/area/nadezhda/outside/pond)
 "npm" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -65733,6 +65744,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"nxu" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/outside/pond)
 "nxx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/cable/yellow{
@@ -66008,12 +66025,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"nzR" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "nzS" = (
 /obj/machinery/door/airlock/command{
 	name = "AI Core";
@@ -66904,6 +66915,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
+"nIC" = (
+/obj/structure/boulder,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "nIG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/light/small{
@@ -67002,6 +67017,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"nJp" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "nJt" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/effect/decal/cleanable/dirt,
@@ -67425,6 +67447,11 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"nNx" = (
+/obj/structure/railing,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "nNz" = (
 /obj/machinery/light,
 /obj/machinery/holoposter{
@@ -71633,12 +71660,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
-"oEr" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "oEw" = (
 /obj/structure/closet/secure_closet/personal/miner,
 /obj/item/storage/firstaid/ifak,
@@ -71704,10 +71725,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"oFz" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "oFI" = (
 /obj/structure/bed/chair/custom/bar_special{
 	dir = 4
@@ -76530,6 +76547,15 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"pDm" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/flora/big/bush3{
+	pixel_y = -18
+	},
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "pDo" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/stalkybush,
@@ -76623,6 +76649,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/cargo,
+/area/nadezhda/outside/inside_colony)
+"pDW" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/rock,
 /area/nadezhda/outside/inside_colony)
 "pEw" = (
 /obj/structure/bed/psych{
@@ -78740,12 +78773,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"pYP" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/beach/water/flooded,
-/area/nadezhda/outside/pond)
 "pYU" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -81995,6 +82022,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"qGy" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "qGA" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/simulated/floor/bluegrid{
@@ -82421,11 +82453,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/rocinante_shuttle_area)
-"qLi" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "qLk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/cyan{
@@ -83038,6 +83065,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"qSj" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "qSs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -83722,10 +83756,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
-"rax" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/inside_colony)
 "raA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -85749,6 +85779,10 @@
 /obj/structure/flora/small/grassb2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/main/stairwell)
+"rwR" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "rwS" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/nonfiction/ageofreason,
@@ -86193,6 +86227,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"rAW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/smokable/cigarette/cigar,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "rAZ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -87015,6 +87054,11 @@
 /obj/item/caution/cone,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"rKL" = (
+/obj/structure/flora/small/rock3,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "rKU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -87069,11 +87113,8 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
 "rLl" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt/dust,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "rLm" = (
 /turf/simulated/wall/r_wall,
@@ -87980,8 +88021,9 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
 "rVz" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dark,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
 "rVD" = (
 /obj/effect/step_trigger/surface_to_forest_1_B,
@@ -89524,6 +89566,11 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
+"sli" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/wood,
+/area/nadezhda/pros/shuttle)
 "slp" = (
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
@@ -90349,11 +90396,6 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"ssQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/mask/smokable/cigarette/cigar,
-/turf/simulated/floor/wood,
-/area/nadezhda/pros/shuttle)
 "ssR" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
@@ -91760,10 +91802,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
-"sGA" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "sGI" = (
 /obj/structure/bed/psych{
 	desc = "It can be a bit noisy, but still serves well.";
@@ -91975,6 +92013,12 @@
 "sJn" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"sJq" = (
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/inside_colony)
 "sJv" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 6
@@ -92186,6 +92230,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/foyer)
+"sLG" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/beach/water/flooded,
+/area/nadezhda/outside/pond)
 "sLH" = (
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/dirt,
@@ -94649,6 +94699,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"tob" = (
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/pond)
 "toe" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/lights/mixed,
@@ -96110,11 +96164,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
-"tDx" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "tDE" = (
 /obj/structure/catwalk,
 /obj/random/junk/low_chance,
@@ -96865,6 +96914,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/rnd/xenobiology)
+"tKu" = (
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "tKx" = (
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/science{
@@ -100094,6 +100148,12 @@
 /mob/living/simple_animal/hostile/dino/tagilla,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/pros/foreman)
+"upe" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/inside_colony)
 "upo" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -100673,6 +100733,11 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"uwT" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "uxd" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -101126,9 +101191,6 @@
 "uBR" = (
 /obj/structure/railing/grey{
 	dir = 1
-	},
-/obj/structure/flora/big/bush3{
-	pixel_y = -18
 	},
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
@@ -102404,10 +102466,6 @@
 "uNM" = (
 /obj/effect/floor_decal/industrial/road/straight3,
 /turf/simulated/floor/rock/manmade/road,
-/area/nadezhda/outside/inside_colony)
-"uNN" = (
-/obj/random/scrap/sparse_weighted/low_chance,
-/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
 "uNO" = (
 /turf/simulated/floor/asteroid/grass/dry,
@@ -107264,13 +107322,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/science)
-"vLN" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "vLR" = (
 /obj/structure/computerframe{
 	anchored = 1;
@@ -107929,10 +107980,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"vSF" = (
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/pond)
 "vSH" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/tiled/steel,
@@ -108429,12 +108476,6 @@
 /obj/random/furniture/painting,
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm3)
-"vWn" = (
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/crew_quarters/hydroponics/garden)
 "vWA" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -111165,6 +111206,12 @@
 "wyr" = (
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
+"wyt" = (
+/obj/structure/boulder{
+	pixel_x = -1
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/security/maingate/west)
 "wyv" = (
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
@@ -111330,11 +111377,6 @@
 /obj/item/device/lighting/toggleable/lamp,
 /turf/simulated/floor/wood/wild1,
 /area/colony)
-"wAg" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/security/maingate/east)
 "wAh" = (
 /obj/structure/table/standard,
 /obj/machinery/holoposter{
@@ -113479,12 +113521,6 @@
 /obj/item/reagent_containers/dropper,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/crew_quarters/kitchen)
-"wXR" = (
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/turf/unsimulated/mineral,
-/area/nadezhda/outside/inside_colony)
 "wXS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -113550,13 +113586,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/armory)
-"wYC" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/rock,
-/area/nadezhda/outside/inside_colony)
 "wYI" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/industrial/warningwhite{
@@ -113665,13 +113694,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"xaa" = (
-/obj/structure/flora/big/rocks3,
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/inside_colony)
 "xac" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 4
@@ -114163,6 +114185,12 @@
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"xgt" = (
+/obj/structure/flora/bush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/inside_colony)
 "xgv" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/item/contraband/poster/placed/generic/no_erp{
@@ -114322,12 +114350,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"xhW" = (
-/obj/structure/boulder{
-	pixel_x = -1
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/security/maingate/west)
 "xia" = (
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -115424,11 +115446,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
-"xtH" = (
-/obj/structure/railing,
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "xtK" = (
 /obj/random/mob/undergroundmob/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -115837,11 +115854,6 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/rnd/robotics)
-"xxn" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "xxy" = (
 /obj/machinery/atmospherics/unary/freezer{
 	icon_state = "freezer"
@@ -118215,12 +118227,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
-"xVg" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/inside_colony)
 "xVh" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -118722,6 +118728,10 @@
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"yam" = (
+/obj/structure/flora/small/rock5,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/crew_quarters/hydroponics/garden)
 "yap" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
@@ -191324,7 +191334,7 @@ diB
 kyK
 dmt
 dmt
-dmt
+kyK
 dmt
 fMM
 tIs
@@ -203828,8 +203838,8 @@ spF
 spF
 spF
 spF
-oEr
-oEr
+upe
+upe
 umT
 gXV
 xRA
@@ -204024,16 +204034,16 @@ spF
 spF
 spF
 spF
-kgc
-kgc
-kgc
-kgc
-kgc
+jZe
+jZe
+jZe
+jZe
+jZe
 pvI
 cLp
 fFO
 fFO
-xhW
+wyt
 xRA
 xRA
 xRA
@@ -204220,22 +204230,22 @@ spF
 spF
 spF
 spF
-kgc
-kgc
-kgc
-kgc
-kgc
-kgc
-kgc
-rax
-rax
+jZe
+jZe
+jZe
+jZe
+jZe
+jZe
+jZe
+jzE
+jzE
 pFV
 pFV
 pFV
 rIK
 pFV
 pFV
-xhW
+wyt
 xRA
 xRA
 xRA
@@ -204421,20 +204431,20 @@ spF
 spF
 spF
 spF
-kgc
-kgc
-rax
+jZe
+jZe
+jzE
 rIK
-bTk
-bTk
-mKP
+mDb
+mDb
+eRd
 pFV
 pvI
 rIK
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
 rIK
 kGO
@@ -204622,22 +204632,22 @@ aYl
 spF
 spF
 spF
-cdg
-kgc
-rax
-mKP
-dAK
-dAK
+boj
+jZe
+jzE
+eRd
+rLl
+rLl
 rIK
-dAK
-dAK
-hbE
+rLl
+rLl
+uwT
 pFV
 pFV
 cWF
 rIK
-dAK
-dAK
+rLl
+rLl
 pFV
 qCq
 kGO
@@ -204825,7 +204835,7 @@ spF
 izu
 spF
 wRQ
-mKP
+eRd
 fFO
 pFV
 pvI
@@ -204838,8 +204848,8 @@ vrW
 pFV
 pFV
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
 qCq
 kGO
@@ -205228,8 +205238,8 @@ aYl
 spF
 anq
 spF
-nzR
-uNN
+mYs
+iOS
 fFO
 pFV
 pvI
@@ -205241,8 +205251,8 @@ pFV
 pFV
 pFV
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
 pvI
 qCq
@@ -205427,8 +205437,8 @@ aYl
 aYl
 aYl
 spF
-xaa
-nzR
+lTk
+mYs
 bXS
 fFO
 fFO
@@ -205443,7 +205453,7 @@ vrW
 niq
 pFV
 pvI
-jzv
+dWX
 pFV
 pFV
 vbq
@@ -205628,9 +205638,9 @@ gBD
 aYl
 aYl
 spF
-rLl
+iSR
 bXS
-sGA
+mSW
 fFO
 fFO
 fFO
@@ -205641,7 +205651,7 @@ rIK
 rIK
 pFV
 cWF
-dAK
+rLl
 pFV
 pFV
 spa
@@ -205830,21 +205840,21 @@ iYY
 aYl
 aYl
 spF
-rLl
+iSR
 cXf
-uNN
+iOS
 fFO
 lVU
 pFV
-ecU
-xtH
+hGo
+nNx
 oSE
 fFO
 fFO
 pFV
 vrW
 pFV
-dAK
+rLl
 pFV
 pFV
 pFV
@@ -206032,21 +206042,21 @@ iYY
 aYl
 aYl
 spF
-wYC
-sGA
+pDW
+mSW
 fFO
 fFO
 bex
 rIK
 rIK
-bqo
+exq
 bXS
 fFO
 fFO
 nIU
 aPg
 hPj
-dAK
+rLl
 pFV
 svK
 pFV
@@ -206241,7 +206251,7 @@ fFO
 fFO
 fFO
 pFV
-aig
+tKu
 fIj
 fFO
 fFO
@@ -206436,7 +206446,7 @@ iYY
 aYl
 aYl
 spF
-wYC
+pDW
 fFO
 fFO
 cLp
@@ -206638,8 +206648,8 @@ iYY
 aYl
 aYl
 spF
-wYC
-sGA
+pDW
+mSW
 lVU
 fFO
 bex
@@ -206653,8 +206663,8 @@ yhP
 aPg
 pFV
 rIK
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
 pFV
@@ -206840,8 +206850,8 @@ iYY
 aYl
 aYl
 spF
-wYC
-sGA
+pDW
+mSW
 cLp
 cLp
 fFO
@@ -207042,7 +207052,7 @@ iYY
 aYl
 aYl
 spF
-rLl
+iSR
 bXS
 bXS
 fFO
@@ -207244,8 +207254,8 @@ iYY
 aYl
 aYl
 spF
-sGA
-sGA
+mSW
+mSW
 bXS
 bXS
 fFO
@@ -207255,7 +207265,7 @@ dWS
 bXS
 rIK
 pFV
-dGu
+hbk
 aPg
 vrW
 pFV
@@ -207447,15 +207457,15 @@ aYl
 aYl
 aYl
 spF
-rLl
-kgc
-rax
-uNN
+iSR
+jZe
+jzE
+iOS
 fFO
 fFO
 fFO
 fFO
-eoZ
+dIY
 rIK
 pFV
 pFV
@@ -207652,10 +207662,10 @@ aYl
 spF
 spF
 spF
-oEr
-rax
+upe
+jzE
 fFO
-uNN
+iOS
 fFO
 hPj
 mGO
@@ -207855,7 +207865,7 @@ spF
 aYl
 aYl
 spF
-lPX
+hNr
 aYl
 cwC
 pFV
@@ -208057,8 +208067,8 @@ spF
 spF
 spF
 spF
-oEr
-rax
+upe
+jzE
 fFO
 pFV
 pFV
@@ -208258,9 +208268,9 @@ aYl
 spF
 spF
 spF
-idL
+lSe
 cLp
-rax
+jzE
 fFO
 fFO
 pFV
@@ -208461,8 +208471,8 @@ spF
 spF
 spF
 spF
-idL
-jdV
+lSe
+eMA
 fFO
 fFO
 cLp
@@ -208664,7 +208674,7 @@ spF
 spF
 spF
 spF
-oEr
+upe
 spF
 spF
 cLp
@@ -209070,7 +209080,7 @@ spF
 spF
 spF
 spF
-lPX
+hNr
 fFO
 rIK
 rIK
@@ -209080,7 +209090,7 @@ rIK
 rIK
 rIK
 rIK
-dAK
+rLl
 bXS
 spa
 kGO
@@ -209272,7 +209282,7 @@ spF
 spF
 spF
 spF
-oEr
+upe
 rIK
 pFV
 rIK
@@ -209467,12 +209477,12 @@ xtc
 xtc
 xtc
 xtc
-fdc
-fdc
-fdc
-fdc
-fdc
-fdc
+lNz
+lNz
+lNz
+lNz
+lNz
+lNz
 xtc
 tdw
 tdw
@@ -209685,7 +209695,7 @@ qlM
 vRM
 rHw
 pFV
-dAK
+rLl
 pFV
 bXS
 cXf
@@ -209886,8 +209896,8 @@ itd
 itd
 cxs
 rHw
-dAK
-dAK
+rLl
+rLl
 fLu
 bXS
 bXS
@@ -210088,7 +210098,7 @@ itd
 itd
 cxs
 rHw
-dAK
+rLl
 vrW
 rIK
 bXS
@@ -214301,10 +214311,10 @@ ntZ
 bro
 hos
 sUh
-itR
+kkW
 pyR
-csI
-csI
+bFc
+bFc
 pHb
 sKl
 ktw
@@ -214702,12 +214712,12 @@ frR
 hcX
 pHb
 eRA
-ccP
+sli
 svG
 kjg
 svG
 svG
-ssQ
+rAW
 pqb
 pHb
 bRi
@@ -214907,7 +214917,7 @@ aIM
 aIM
 quv
 kjg
-kzK
+jBa
 xeM
 svG
 vuN
@@ -215112,7 +215122,7 @@ spV
 dTD
 pHb
 egN
-csI
+bFc
 pHb
 nRf
 bQD
@@ -216101,8 +216111,8 @@ tYN
 iUn
 uSy
 cOa
+jwX
 lej
-aSj
 acV
 qqM
 xQK
@@ -219806,7 +219816,7 @@ nnz
 qMG
 sQo
 frI
-vSF
+tob
 qMG
 rtu
 lwP
@@ -220212,7 +220222,7 @@ sQo
 sQo
 qMG
 vFL
-npf
+nxu
 vFL
 njk
 ciR
@@ -220414,10 +220424,10 @@ sQo
 rTq
 njk
 vFL
-pYP
+sLG
 vFL
 sQo
-vSF
+tob
 sQo
 dXq
 qMG
@@ -220614,7 +220624,7 @@ emO
 dXq
 sQo
 sQo
-vSF
+tob
 sQo
 vFL
 vFL
@@ -220819,7 +220829,7 @@ doc
 rrK
 rtu
 vFL
-npf
+nxu
 vFL
 sQo
 ciR
@@ -221222,7 +221232,7 @@ sQo
 sQo
 sQo
 qMG
-npf
+nxu
 vFL
 vFL
 loh
@@ -221400,7 +221410,7 @@ pFV
 spa
 pFV
 pFV
-jzv
+dWX
 pFV
 gcR
 pNi
@@ -221426,7 +221436,7 @@ sQo
 frI
 vFL
 vFL
-npf
+nxu
 hYu
 bDP
 bDP
@@ -221602,8 +221612,8 @@ pFV
 pFV
 rIK
 rIK
-dAK
-hNd
+rLl
+dai
 cpp
 pNi
 lNk
@@ -222007,8 +222017,8 @@ rIK
 rIK
 pFV
 eCL
-dAK
-fFs
+rLl
+rVz
 bXS
 oqZ
 wud
@@ -222208,9 +222218,9 @@ pFV
 gcR
 pfy
 eCL
-hbE
-jMr
-dAK
+uwT
+jez
+rLl
 bXS
 oqZ
 oqZ
@@ -222412,7 +222422,7 @@ pFV
 pMh
 mGO
 rIK
-lfz
+xgt
 bXS
 bXS
 oqZ
@@ -223017,8 +223027,8 @@ fFO
 pFV
 pFV
 gcR
-dAK
-dAK
+rLl
+rLl
 vrW
 pFV
 foN
@@ -223219,8 +223229,8 @@ fFO
 fFO
 fLu
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
 oxw
@@ -223422,8 +223432,8 @@ fFO
 pFV
 svK
 svK
-dAK
-dAK
+rLl
+rLl
 fFO
 piv
 oqZ
@@ -223624,8 +223634,8 @@ xPA
 pFV
 spa
 svK
-dAK
-mkT
+rLl
+csI
 pFV
 foN
 oqZ
@@ -223826,8 +223836,8 @@ xPA
 pFV
 qoI
 pFV
-dAK
-jMr
+rLl
+jez
 fFO
 foN
 oqZ
@@ -224027,10 +224037,10 @@ uxZ
 mGO
 pFV
 fLu
-dAK
+rLl
 pFV
-dAK
-dAK
+rLl
+rLl
 piv
 oqZ
 cPj
@@ -224230,9 +224240,9 @@ fFO
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
-xVg
+dzg
 piv
 oqZ
 ilL
@@ -224432,8 +224442,8 @@ xPA
 pFV
 pFV
 vrW
-dAK
-mkT
+rLl
+csI
 rIK
 foN
 gAa
@@ -224634,8 +224644,8 @@ tnk
 pFV
 fLu
 pFV
+rLl
 dAK
-ewL
 pFV
 qiM
 oqZ
@@ -224836,7 +224846,7 @@ fFO
 pFV
 huJ
 vbq
-dAK
+rLl
 pFV
 rIK
 piv
@@ -225034,11 +225044,11 @@ pFV
 dce
 pFV
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
 qiM
@@ -225234,12 +225244,12 @@ pFV
 fKS
 fKS
 pFV
+rLl
 dAK
-ewL
-dAK
+rLl
 pFV
 fLu
-dAK
+rLl
 igM
 pFV
 rIK
@@ -225437,7 +225447,7 @@ pFV
 pFV
 hcX
 pFV
-hNd
+dai
 pFV
 qPl
 pFV
@@ -225840,11 +225850,11 @@ pFV
 pFV
 rIK
 pFV
-dAK
-mGg
+rLl
+rKL
 pFV
 xGe
-dAK
+rLl
 pFV
 pFV
 pFV
@@ -226041,12 +226051,12 @@ tBq
 pFV
 pFV
 fLu
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
 gcR
@@ -226242,15 +226252,15 @@ vbq
 hcX
 pFV
 pfy
-dAK
-mkT
+rLl
+csI
 pFV
-fFs
-dAK
-dAK
+rVz
+rLl
+rLl
 gcR
 igM
-dAK
+rLl
 igM
 rIK
 piv
@@ -226452,7 +226462,7 @@ gcR
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
 mGO
 tjB
@@ -226654,7 +226664,7 @@ pfy
 pFV
 mGO
 eCL
-jhg
+kgc
 pFV
 dHz
 piv
@@ -227250,9 +227260,9 @@ mGO
 pFV
 pFV
 pFV
-hNd
-dAK
-dAK
+dai
+rLl
+rLl
 pFV
 pFV
 pFV
@@ -227451,18 +227461,18 @@ igM
 pFV
 pFV
 pFV
-dAK
-fFs
-dAK
-dAK
-dAK
+rLl
+rVz
+rLl
+rLl
+rLl
 mGO
 pFV
 pFV
 myK
 rIK
 pvI
-fFs
+rVz
 pFV
 pFV
 wud
@@ -227653,19 +227663,19 @@ pFV
 pFV
 pFV
 pFV
-dAK
-dAK
-dAK
-dAK
-dAK
+rLl
+rLl
+rLl
+rLl
+rLl
 pFV
 pFV
 pFV
 rIK
 rIK
 pFV
-dAK
-dAK
+rLl
+rLl
 pfy
 wud
 oqZ
@@ -227855,19 +227865,19 @@ pFV
 pFV
 pFV
 qPl
-dAK
-dAK
+rLl
+rLl
 pFV
-fFs
-dAK
+rVz
+rLl
 pFV
 pFV
 mGO
 pFV
 pFV
-dAK
-dAK
-dAK
+rLl
+rLl
+rLl
 pFV
 wud
 oqZ
@@ -228056,20 +228066,20 @@ pFV
 pFV
 pFV
 pFV
-fFs
+rVz
 pFV
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
 pFV
 pfy
 fyM
 pFV
-dAK
-hNd
-dAK
+rLl
+dai
+rLl
 bUO
 wud
 oqZ
@@ -228259,7 +228269,7 @@ pfy
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
 pfy
 pFV
@@ -228269,8 +228279,8 @@ igM
 pFV
 pFV
 rIK
-dAK
-dAK
+rLl
+rLl
 pFV
 fFO
 wud
@@ -228461,8 +228471,8 @@ pFV
 pFV
 pFV
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
 pFV
@@ -228472,7 +228482,7 @@ pFV
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
 fFO
 wud
@@ -228664,7 +228674,7 @@ pMh
 pMh
 pFV
 pfy
-dAK
+rLl
 pFV
 qPl
 pFV
@@ -228674,7 +228684,7 @@ pFV
 pFV
 pFV
 rIK
-mkT
+csI
 pFV
 pFV
 wud
@@ -228861,14 +228871,14 @@ mfN
 saN
 pFV
 qPl
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
 pFV
 pFV
@@ -229064,13 +229074,13 @@ bSt
 pFV
 pFV
 pFV
-jhg
+kgc
 pMh
 pFV
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
 pFV
 pFV
@@ -229267,17 +229277,17 @@ pFV
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
 pFV
 fFO
 pFV
 pFV
-dAK
+rLl
 pFV
 pFV
 pFV
@@ -229468,17 +229478,17 @@ bSt
 pMh
 pMh
 pFV
-dAK
+rLl
 pFV
 pFV
 qPl
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
-xxn
+fyz
 pFV
-dAK
+rLl
 pFV
 pFV
 igM
@@ -229670,17 +229680,17 @@ bSt
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
 pFV
-dAK
-dAK
-jMr
-dAK
+rLl
+rLl
+jez
+rLl
 pFV
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
 mGO
 pFV
@@ -229871,12 +229881,12 @@ mfN
 bSt
 pFV
 pFV
-dAK
-jMr
+rLl
+jez
 pFV
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
 pFV
@@ -230074,11 +230084,11 @@ rnc
 pFV
 pFV
 fLu
-dAK
+rLl
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
 pFV
 pFV
@@ -230276,12 +230286,12 @@ bSt
 vFX
 bSt
 bSt
-oFz
+rwR
 pFV
 dHz
-xxn
-dAK
-fFs
+fyz
+rLl
+rVz
 pFV
 pFV
 fLu
@@ -230293,7 +230303,7 @@ pFV
 pFV
 pFV
 mGO
-dai
+eHp
 oqZ
 oGj
 gSS
@@ -230477,7 +230487,7 @@ mfN
 bSt
 bSt
 bSt
-dAF
+bky
 bSt
 pFV
 pFV
@@ -230495,7 +230505,7 @@ pMh
 pFV
 pFV
 lPo
-dai
+eHp
 oqZ
 oGj
 onw
@@ -230679,7 +230689,7 @@ mfN
 bSt
 ccn
 dyf
-oFz
+rwR
 bSt
 pFV
 igM
@@ -230697,7 +230707,7 @@ qPl
 pFV
 pFV
 vbq
-wAg
+lPr
 oqZ
 oGj
 onw
@@ -230889,7 +230899,7 @@ igM
 pFV
 igM
 oRK
-dAK
+rLl
 vbq
 pFV
 igM
@@ -231083,14 +231093,14 @@ mfN
 bSt
 bSt
 bSt
-oFz
-oFz
+rwR
+rwR
 pMh
 pFV
 vbq
 pFV
-fFs
-fFs
+rVz
+rVz
 pFV
 tlE
 pFV
@@ -231286,7 +231296,7 @@ aUQ
 bSt
 bSt
 bSt
-oFz
+rwR
 pfy
 dHz
 tlE
@@ -231486,22 +231496,22 @@ gBT
 gBT
 gBT
 gBT
-iKO
+yam
 gBT
-oFz
-dAK
+rwR
+rLl
 pFV
 pFV
 pFV
-jMr
+jez
 pFV
 pMh
 pFV
-dAK
-tDx
+rLl
+biw
 pFV
 pFV
-dAK
+rLl
 pFV
 pFV
 pFV
@@ -231691,19 +231701,19 @@ hIM
 hjy
 dKC
 gBT
-dAK
+rLl
 pMh
 pFV
 pFV
 lPo
-dAK
+rLl
 qPl
-dAK
-dAK
+rLl
+rLl
 vbq
 pfy
 pFV
-jhg
+kgc
 pFV
 pFV
 kni
@@ -231892,20 +231902,20 @@ gSR
 gSR
 gSR
 vUx
-vWn
-dAK
-bFc
+mwH
+rLl
+dYd
 mGO
 pFV
 vbq
-hNd
+dai
 pFV
 pFV
-dAK
-qLi
+rLl
+qGy
 vbq
 pFV
-fFs
+rVz
 pFV
 pFV
 pFV
@@ -232095,18 +232105,18 @@ gSR
 gSR
 wAo
 gBT
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
 fLu
-dAK
+rLl
 igM
 pFV
 pFV
@@ -232297,22 +232307,22 @@ gSR
 gSR
 mRx
 gBT
-dAK
+rLl
 pFV
 pFV
 pFV
 pFV
 tzc
 pFV
-dAK
+rLl
 pFV
 igM
-iKR
-dAK
-hNd
+jnv
+rLl
+dai
 vbq
-jhg
-xxn
+kgc
+fyz
 qdc
 oqZ
 oGj
@@ -232498,15 +232508,15 @@ gSR
 gSR
 gSR
 qrl
-anG
-anG
-iKO
-anG
-anG
+lKn
+lKn
+yam
+lKn
+lKn
 gBT
 bSt
 bSt
-dAK
+rLl
 mGO
 pFV
 igM
@@ -232514,7 +232524,7 @@ pFV
 igM
 igM
 pFV
-hNd
+dai
 fXd
 oqZ
 oGj
@@ -232700,13 +232710,13 @@ gSR
 gSR
 lCC
 yjc
-fSX
+pDm
 tQk
-dyI
-dyI
 fnK
 fnK
-fnK
+axd
+axd
+axd
 yjc
 pFV
 pMh
@@ -232714,7 +232724,7 @@ pFV
 vbq
 pFV
 pMh
-fFs
+rVz
 pFV
 nPL
 wud
@@ -232909,14 +232919,14 @@ sTl
 qTf
 kOv
 kOv
-uBR
-dAK
-dAK
+fAp
+rLl
+rLl
 pFV
 igM
 pFV
-dAK
-fFs
+rLl
+rVz
 pFV
 pFV
 wud
@@ -233115,8 +233125,8 @@ rnV
 pFV
 pFV
 pFV
-dAK
-dAK
+rLl
+rLl
 mGO
 tlE
 pFV
@@ -233313,13 +233323,13 @@ iPV
 vjP
 vjP
 gsH
-vLN
+ail
 pFV
-dAK
+rLl
 pMh
-dAK
+rLl
 pFV
-tDx
+biw
 pFV
 pFV
 pFV
@@ -233515,16 +233525,16 @@ bGe
 iPV
 vjP
 aSZ
-jzz
+uBR
 pFV
-dAK
+rLl
 dHz
-xxn
-dAK
-fFs
+fyz
+rLl
+rVz
 pFV
 pFV
-hNd
+dai
 hys
 oqZ
 sqf
@@ -233717,15 +233727,15 @@ bGe
 iPV
 vjP
 kOv
-uBR
-rVz
-dAK
+fAp
+kfT
+rLl
 pFV
 fLu
-dAK
+rLl
 igM
 pFV
-dAK
+rLl
 igM
 hys
 oqZ
@@ -233919,7 +233929,7 @@ kYT
 iPV
 vjP
 qxG
-jzz
+uBR
 gMn
 pFV
 igM
@@ -234121,14 +234131,14 @@ qyM
 vjP
 vjP
 aSZ
-jzz
-dAK
+uBR
+rLl
 mGO
 pFV
-fFs
-dAK
-fFs
-jhg
+rVz
+rLl
+rVz
+kgc
 pFV
 pFV
 tjB
@@ -234323,7 +234333,7 @@ qyM
 vjP
 vjP
 qTf
-gkR
+qSj
 pFV
 pMh
 pFV
@@ -234525,7 +234535,7 @@ vjP
 vjP
 vjP
 sTl
-vLN
+ail
 pFV
 pFV
 pFV
@@ -234534,7 +234544,7 @@ pMh
 pFV
 igM
 pFV
-dAK
+rLl
 fXd
 oqZ
 sqf
@@ -234727,7 +234737,7 @@ vjP
 vjP
 vjP
 dfF
-jzz
+uBR
 pFV
 pFV
 pFV
@@ -234736,7 +234746,7 @@ pFV
 mGO
 pMh
 pFV
-jhg
+kgc
 piv
 oqZ
 sqf
@@ -234929,7 +234939,7 @@ kZT
 vMw
 arX
 dfF
-jzz
+uBR
 pFV
 pFV
 pMh
@@ -234938,7 +234948,7 @@ pFV
 lPo
 pFV
 pFV
-dAK
+rLl
 piv
 oqZ
 sqf
@@ -235135,11 +235145,11 @@ yjc
 pFV
 pFV
 qPl
-dAK
-dAK
+rLl
+rLl
 vbq
 qwl
-dAK
+rLl
 fFO
 wud
 oqZ
@@ -235337,10 +235347,10 @@ spF
 pFV
 pFV
 pFV
-dAK
+rLl
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
 pFV
 bFA
@@ -235536,12 +235546,12 @@ gBD
 sDV
 bXm
 spF
-jez
+nIC
 pFV
-dAK
-dAK
+rLl
+rLl
 pFV
-dAK
+rLl
 tzc
 pFV
 pFV
@@ -235738,8 +235748,8 @@ gBD
 sDV
 bXm
 spF
-jez
-jez
+nIC
+nIC
 pFV
 pFV
 pFV
@@ -235941,12 +235951,12 @@ sDV
 bXm
 spF
 spF
-jez
+nIC
 qPl
 pFV
-jiF
+nJp
 pFV
-hTq
+hWz
 aYl
 aYl
 aYl
@@ -236148,7 +236158,7 @@ vvA
 vvA
 hPj
 hcX
-wXR
+sJq
 aYl
 aYl
 aYl
@@ -236348,7 +236358,7 @@ bXm
 bXm
 bXm
 bXm
-ebL
+ehm
 azv
 aYl
 aYl

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -2077,12 +2077,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
-"avI" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -15
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "avJ" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/catwalk,
@@ -2680,12 +2674,6 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/crew_quarters/dorm3)
-"aBG" = (
-/obj/structure/flora/big/bush1{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "aBH" = (
 /obj/machinery/papershredder,
 /obj/item/device/radio/intercom{
@@ -4143,6 +4131,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"aTp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/gun_parts/high_end,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "aTu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
@@ -4454,10 +4447,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"aXv" = (
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/campground)
 "aXz" = (
 /obj/item/stool/custom/bar_special,
 /obj/effect/spider/stickyweb,
@@ -5801,11 +5790,6 @@
 /obj/effect/floor_decal/industrial/road/curve4,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"bkt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
@@ -6879,6 +6863,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
+"bwv" = (
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
+/turf/simulated/wall/wood_old,
+/area/nadezhda/dungeon/outside/hunter_cabin)
 "bwA" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 1
@@ -7094,12 +7084,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"byU" = (
-/obj/structure/flora/small/grassb4,
-/obj/structure/flora/small/grassb4,
-/obj/structure/flora/big/rocks2,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/forest)
 "byV" = (
 /obj/structure/table/steel,
 /obj/random/credits/low_chance,
@@ -9759,6 +9743,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"cci" = (
+/obj/structure/flora/big/bush2,
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/campground)
 "ccn" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/asteroid/grass,
@@ -11737,10 +11726,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
 "czf" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/random/firstaid/low_chance,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/girder/displaced,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
+/area/nadezhda/dungeon/outside/hunter_cabin)
 "czA" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "13,15"
@@ -12830,11 +12824,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
-"cKa" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/render,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "cKc" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -13145,6 +13134,12 @@
 	})
 "cNG" = (
 /obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
+"cNO" = (
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "cNQ" = (
@@ -14371,11 +14366,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"cYP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/big/bush1,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "cYT" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -14657,11 +14647,6 @@
 /obj/machinery/gibber,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/genetics)
-"dbT" = (
-/obj/effect/window_lwall_spawn,
-/obj/structure/barricade,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/campground)
 "dbU" = (
 /obj/machinery/light{
 	dir = 4
@@ -15143,6 +15128,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"dhq" = (
+/obj/effect/window_lwall_spawn,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "dhs" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/table/standard,
@@ -15590,6 +15582,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"dmr" = (
+/obj/random/flora/small_jungle_tree,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "dmt" = (
 /obj/structure/railing{
 	dir = 8
@@ -16183,6 +16183,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"dsK" = (
+/obj/structure/flora/small/rock4,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "dsL" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -18316,11 +18320,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
-"dNV" = (
-/obj/item/scrap_lump,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "dOa" = (
 /obj/item/stool/custom/bar_special,
 /obj/effect/floor_decal/spline/fancy,
@@ -19356,9 +19355,11 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/pond)
 "dZv" = (
-/obj/item/scrap_lump,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
+/area/nadezhda/outside/forest)
 "dZw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -19600,10 +19601,6 @@
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/nadezhda/command/swo/quarters)
-"ebS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "ebT" = (
 /obj/structure/multiz/stairs/enter/bottom,
 /obj/structure/invislight,
@@ -20552,9 +20549,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "emi" = (
-/obj/item/material/shard,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/campground)
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "emo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22085,13 +22084,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"eAI" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/obj/structure/flora/big/bush1{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "eAK" = (
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
@@ -22167,7 +22159,8 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
 "eBP" = (
-/obj/random/gun_handmade,
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/render,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "eBR" = (
@@ -22631,11 +22624,6 @@
 /mob/living/carbon/superior_animal/roach/elektromagnetisch,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"eHQ" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/turf/simulated/wall,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "eIb" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/spline/fancy/three_quarters,
@@ -25534,12 +25522,6 @@
 /obj/item/device/lighting/toggleable/lamp,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
-"fkF" = (
-/obj/structure/girder,
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/shallow,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "fkM" = (
 /obj/effect/floor_decal/industrial/arrows{
 	dir = 1
@@ -25629,6 +25611,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/security/maingate)
+"flF" = (
+/obj/structure/barricade,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "flH" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
@@ -27015,6 +27003,10 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/command/prime)
+"fAt" = (
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "fAw" = (
 /obj/structure/catwalk,
 /obj/structure/barricade,
@@ -27432,6 +27424,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"fEY" = (
+/obj/structure/girder/displaced,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/hunter_cabin)
 "fFg" = (
 /obj/machinery/door/unpowered/simple/wood/saloon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27638,7 +27640,7 @@
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/crew_quarters/dorm1)
 "fHw" = (
-/obj/structure/flora/big/rocks1,
+/obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "fHy" = (
@@ -28967,12 +28969,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"fWU" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/beach/water/shallow,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "fWY" = (
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -29258,13 +29254,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
-"gaq" = (
-/obj/effect/window_lwall_spawn,
-/obj/structure/flora/big/bush1{
-	pixel_x = -15
-	},
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/campground)
 "gas" = (
 /obj/machinery/camera/network/engineering{
 	dir = 4
@@ -30771,6 +30760,12 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/command/gmaster)
+"goU" = (
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/turf/unsimulated/wall/jungle,
+/area/nadezhda/outside/forest)
 "goX" = (
 /obj/random/furniture/pottedplant,
 /obj/effect/decal/cleanable/dirt,
@@ -31131,10 +31126,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
 "gsc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/dungeon/outside/burned_outpost)
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/campground)
 "gsh" = (
 /obj/structure/flora/tree/jungle_small/variant2,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -31450,12 +31444,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
-"guX" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/beach/water/shallow,
-/area/nadezhda/outside/forest)
 "gvd" = (
 /obj/structure/flora/small/bushb2,
 /obj/structure/flora/big/bush1,
@@ -33812,6 +33800,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"gVS" = (
+/obj/effect/overlay/water,
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_x = 6;
+	pixel_y = 18;
+	layer = 4.2
+	},
+/obj/effect/overlay/water/top,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/outside/forest)
 "gWd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -35509,6 +35507,11 @@
 /obj/structure/boulder,
 /turf/simulated/floor/wood/wild4,
 /area/colony)
+"hpe" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/render,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "hpf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -36616,12 +36619,6 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
-"hAO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/lighting/toggleable/lantern,
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/campground)
 "hAT" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -37410,10 +37407,6 @@
 /obj/item/paper/monitorkey,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/command/cro)
-"hIi" = (
-/mob/living/simple_animal/hostile/render,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "hIk" = (
 /obj/machinery/newscaster{
 	pixel_y = -34
@@ -38057,6 +38050,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"hNm" = (
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/campground)
 "hNp" = (
 /obj/structure/railing{
 	dir = 4;
@@ -39091,9 +39088,9 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
 "hYJ" = (
-/obj/structure/barricade,
+/obj/random/firstaid/low_chance,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/campground)
+/area/nadezhda/dungeon/outside/burned_outpost)
 "hYL" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -39219,9 +39216,10 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/vectorrooms)
 "hZt" = (
-/obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/simulated/wall,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "hZv" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -39230,6 +39228,14 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/hallway/surface/section1)
+"hZB" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 25;
+	pixel_x = -13;
+	layer = 4.2
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "hZD" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -40616,7 +40622,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "ina" = (
-/obj/item/remains,
+/obj/structure/flora/small/grassb1,
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "inc" = (
@@ -40907,10 +40916,6 @@
 "iqg" = (
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
-/area/nadezhda/outside/forest)
-"iqn" = (
-/obj/structure/flora/small/grassb4,
-/turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest)
 "iqo" = (
 /obj/random/scrap/sparse_weighted,
@@ -41523,6 +41528,13 @@
 /mob/living/simple_animal/frog,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"iwJ" = (
+/obj/random/spider_trap_burrowing/low_chance,
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "iwT" = (
 /obj/machinery/porta_turret/gate,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -42858,11 +42870,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
-"iMe" = (
-/obj/structure/low_wall,
-/obj/structure/barricade,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/campground)
 "iMg" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -43560,6 +43567,14 @@
 /obj/structure/multiz/ladder/up,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/command/hallway)
+"iUv" = (
+/obj/structure/flora/big/bush1,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
+/turf/unsimulated/wall/jungle,
+/area/nadezhda/outside/forest)
 "iUy" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
@@ -43782,8 +43797,10 @@
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/dungeon/outside/farm)
 "iXi" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "iXj" = (
 /obj/structure/cable/cyan{
@@ -44665,10 +44682,6 @@
 /obj/structure/low_wall,
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/atmos)
-"jgE" = (
-/obj/structure/girder,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "jgG" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/reedbush,
@@ -49139,11 +49152,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"kbg" = (
-/obj/structure/flora/big/bush3,
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "kbj" = (
 /obj/structure/table/steel,
 /obj/effect/spider/stickyweb,
@@ -49422,10 +49430,6 @@
 "kdQ" = (
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"kdS" = (
-/obj/structure/barricade,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/campground)
 "kdX" = (
 /obj/structure/railing{
 	dir = 8
@@ -50052,6 +50056,11 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/gmaster)
+"kkg" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/random/gun_parts/frames,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "kkl" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,23"
@@ -50121,8 +50130,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "kkA" = (
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "kkF" = (
 /obj/structure/flora/big/bush2,
 /obj/random/flora/small_jungle_tree,
@@ -50233,6 +50243,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"kmk" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/outside/forest)
 "kmm" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/random/flora/jungle_tree,
@@ -50452,16 +50468,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"kop" = (
-/obj/structure/girder/displaced,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/hunter_cabin)
 "koq" = (
 /obj/structure/lattice,
 /obj/structure/railing{
@@ -51179,6 +51185,12 @@
 /obj/structure/multiz/stairs/enter,
 /turf/simulated/floor/pool,
 /area/nadezhda/crew_quarters/pool)
+"kvV" = (
+/obj/structure/flora/small/grassb4,
+/obj/structure/flora/small/grassb4,
+/obj/structure/flora/big/rocks2,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/forest)
 "kvZ" = (
 /obj/structure/closet/crate/secure,
 /obj/random/tool/advanced,
@@ -52112,6 +52124,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"kEF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "kEJ" = (
 /obj/structure/table/steel,
 /obj/random/common_oddities/low_chance,
@@ -52361,6 +52377,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics)
+"kIC" = (
+/mob/living/simple_animal/hostile/render,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "kIG" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall8";
@@ -54457,6 +54477,10 @@
 /obj/random/structures,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"lhm" = (
+/obj/structure/flora/small/grassa4,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "lhq" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -54960,12 +54984,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"loD" = (
-/obj/structure/low_wall,
-/obj/item/material/shard,
-/obj/structure/barricade,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/campground)
 "loI" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -55915,10 +55933,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
-"lyC" = (
-/obj/random/firstaid/low_chance,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "lyI" = (
 /obj/structure/bed/chair/sofa/black/left{
 	dir = 4
@@ -60522,10 +60536,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/bridge)
 "muX" = (
+/obj/structure/girder,
 /obj/structure/barricade,
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/shallow,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "muZ" = (
 /obj/effect/floor_decal/industrial/stand_clear{
@@ -60562,6 +60575,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/outside/inside_colony)
+"mvv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/lighting/toggleable/lantern,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/campground)
 "mvx" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -61773,6 +61792,11 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"mHB" = (
+/obj/structure/girder,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "mHE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -62845,6 +62869,10 @@
 /obj/machinery/chemical_dispenser,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
+"mTm" = (
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/campground)
 "mTn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -63883,6 +63911,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"ncL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "ncR" = (
 /obj/machinery/bodyscanner,
 /obj/effect/decal/cleanable/dirt,
@@ -64556,6 +64589,10 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"nkG" = (
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "nkI" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/dcave)
@@ -65197,12 +65234,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
-"nrd" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/small/rock3,
-/turf/simulated/floor/beach/water/shallow,
-/area/nadezhda/outside/forest)
 "nrf" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/decal/cleanable/dirt,
@@ -65312,6 +65343,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"nsv" = (
+/obj/structure/flora/rock/variant1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "nsw" = (
 /obj/structure/scrap_cube,
 /obj/structure/catwalk,
@@ -66913,10 +66948,6 @@
 /obj/random/structures/low_chance,
 /turf/simulated/floor/asteroid/dirt/flood,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"nHi" = (
-/obj/random/knife/low_chance,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "nHm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -67003,6 +67034,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/crew_quarters/fitness)
+"nIg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "nIi" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/random/scrap/sparse_weighted,
@@ -67324,6 +67360,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"nLr" = (
+/obj/effect/window_lwall_spawn,
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "nLx" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "2,3"
@@ -67783,6 +67824,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/security/barracks)
+"nQI" = (
+/obj/structure/flora/big/bush3,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "nQJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -68082,10 +68128,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"nTD" = (
-/obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "nTH" = (
 /obj/machinery/atmospherics/pipe/zpipe/up,
 /turf/simulated/floor/plating/under,
@@ -68541,6 +68583,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate/west)
+"nYe" = (
+/obj/item/scrap_lump,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "nYf" = (
 /obj/structure/table/steel,
 /obj/random/knife/low_chance,
@@ -69211,7 +69258,6 @@
 /area/nadezhda/engineering/atmos)
 "oeM" = (
 /obj/structure/girder,
-/obj/structure/barricade,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "oeR" = (
@@ -69973,15 +70019,6 @@
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
-"olN" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/railing/grey,
-/obj/structure/flora/big/bush1,
-/obj/structure/girder/displaced,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/hunter_cabin)
 "olX" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -71018,12 +71055,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/janitor)
-"owX" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/item/scrap_lump,
-/turf/simulated/floor/beach/water/shallow,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "owZ" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/beach/water/jungle,
@@ -74396,12 +74427,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/security/maingate)
-"pfP" = (
-/obj/effect/window_lwall_spawn,
-/obj/structure/flora/big/bush2,
-/obj/structure/barricade,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/campground)
 "pfU" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -75018,6 +75043,10 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
+"pmF" = (
+/obj/random/flora/jungle_tree,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/forest)
 "pmL" = (
 /obj/effect/decal/weldable/cracks,
 /obj/effect/decal/cleanable/dirt,
@@ -75486,16 +75515,6 @@
 /obj/structure/table/bench/standard,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
-"prt" = (
-/obj/effect/overlay/water,
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_x = 6;
-	pixel_y = 18;
-	layer = 4.2
-	},
-/obj/effect/overlay/water/top,
-/turf/simulated/floor/beach/water/shallow,
-/area/nadezhda/outside/forest)
 "pry" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/bed/chair/shuttle{
@@ -77669,11 +77688,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/robotics)
-"pNH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/gun_parts/high_end,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "pNJ" = (
 /obj/machinery/hologram/holopad{
 	name = "meeting room holopad two"
@@ -77836,6 +77850,11 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/plating/under,
 /area/colony)
+"pPg" = (
+/obj/structure/low_wall,
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "pPi" = (
 /obj/machinery/door/unpowered/simple/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -78962,6 +78981,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"pZw" = (
+/obj/item/material/shard,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/campground)
 "pZx" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
@@ -79032,9 +79055,10 @@
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
 "qaG" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/random/gun_parts/frames,
-/turf/simulated/floor/asteroid/grass,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/render,
+/turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "qaH" = (
 /obj/landmark/join/late/cryo,
@@ -80605,6 +80629,11 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/forest)
+"qqT" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/item/device/lighting/toggleable/lamp/green,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/dungeon/outside/hunter_cabin)
 "qra" = (
 /obj/structure/table/standard,
 /obj/random/cloth/armor/low_chance,
@@ -80980,6 +81009,12 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
+"qut" = (
+/obj/effect/window_lwall_spawn,
+/obj/structure/flora/big/bush2,
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "quv" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt,
@@ -81864,10 +81899,6 @@
 /obj/item/material/shard,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"qDJ" = (
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "qDM" = (
 /obj/structure/table/rack,
 /obj/item/circuitboard/autolathe{
@@ -82141,6 +82172,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"qGh" = (
+/obj/structure/low_wall,
+/obj/item/material/shard,
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "qGo" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -82757,6 +82794,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qNw" = (
+/obj/structure/barricade,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "qNz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -82841,16 +82882,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
-"qOm" = (
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/girder/displaced,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/hunter_cabin)
 "qOs" = (
 /obj/structure/table/standard,
 /obj/item/device/defib_kit,
@@ -82967,11 +82998,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
-"qPH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/device/lighting/toggleable/lantern,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/campground)
 "qPK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -85841,6 +85867,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"rvz" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/item/scrap_lump,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/outside/forest)
 "rvM" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -86570,6 +86602,14 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"rCT" = (
+/obj/effect/window_lwall_spawn,
+/obj/structure/flora/big/bush3{
+	pixel_y = -10
+	},
+/obj/structure/barricade,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/dungeon/outside/campground)
 "rCV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -86720,6 +86760,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/organ_lab)
+"rEH" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/outside/forest)
 "rEJ" = (
 /obj/item/stool,
 /turf/simulated/floor/tiled/dark/cyancorner,
@@ -87513,10 +87559,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"rNk" = (
-/obj/structure/flora/big/rocks2,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/forest)
 "rNq" = (
 /obj/machinery/door/airlock/vault{
 	locked = 1;
@@ -89240,10 +89282,6 @@
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
-"seR" = (
-/obj/random/gun_parts/frames,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "seT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
@@ -91037,6 +91075,10 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"swI" = (
+/obj/random/gun_handmade,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "swN" = (
 /turf/simulated/wall/church_reinforced,
 /area/nadezhda/absolutism/hallways)
@@ -92943,11 +92985,6 @@
 /obj/item/gun/energy/concillium,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/command/prime)
-"sRo" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/render,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "sRD" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -93578,6 +93615,10 @@
 /obj/effect/damagedfloor/rust,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"sZa" = (
+/obj/random/knife/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "sZe" = (
 /obj/machinery/light{
 	dir = 8
@@ -94508,12 +94549,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
-"tiS" = (
-/obj/structure/flora/big/bush1{
-	pixel_y = -10
-	},
-/turf/simulated/wall/wood_old,
-/area/nadezhda/dungeon/outside/hunter_cabin)
+"tiW" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "tjc" = (
 /obj/random/mob/termite_no_despawn,
 /obj/effect/decal/cleanable/dirt,
@@ -94572,6 +94613,12 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"tke" = (
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/item/scrap_lump,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "tkh" = (
 /obj/structure/reagent_dispensers/watertank/huge/derelict,
 /obj/effect/decal/cleanable/dirt,
@@ -94931,10 +94978,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"toy" = (
-/obj/random/flora/jungle_tree,
-/turf/simulated/floor/asteroid/dirt/dark,
-/area/nadezhda/outside/forest)
 "toz" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/unsimulated/wall/jungle,
@@ -95273,6 +95316,10 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/medical/reception)
+"tst" = (
+/obj/structure/flora/big/rocks2,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/forest)
 "tsu" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -95329,10 +95376,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"ttA" = (
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/campground)
 "ttG" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -95854,7 +95897,7 @@
 	name = "Interrogation"
 	})
 "tyh" = (
-/obj/structure/flora/small/grassa4,
+/obj/item/material/shard/plasma,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "tyl" = (
@@ -96235,6 +96278,10 @@
 /obj/machinery/electrolyzer,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"tBU" = (
+/obj/structure/flora/small/grassb4,
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/forest)
 "tCd" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/big/bush3,
@@ -96259,6 +96306,10 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"tCo" = (
+/obj/item/remains,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "tCt" = (
 /obj/structure/mirror{
 	pixel_y = 28
@@ -96763,7 +96814,7 @@
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
 "tHe" = (
-/obj/random/flora/small_jungle_tree,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "tHg" = (
@@ -98573,14 +98624,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"tYx" = (
-/obj/structure/flora/big/bush1,
-/obj/structure/flora/big/bush1{
-	pixel_x = -15;
-	pixel_y = -25
-	},
-/turf/unsimulated/wall/jungle,
-/area/nadezhda/outside/forest)
 "tYB" = (
 /obj/effect/floor_decal/industrial/stand_clear/red,
 /obj/effect/decal/cleanable/dirt,
@@ -98615,12 +98658,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/sechall)
-"tYO" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/render,
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "tYP" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lantern/censer,
@@ -99883,11 +99920,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
-"ukC" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/item/device/lighting/toggleable/lamp/green,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/dungeon/outside/hunter_cabin)
 "ukF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -100064,13 +100096,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/medical)
-"ulU" = (
-/obj/structure/flora/small/grassb1,
-/obj/random/traps/low_chance{
-	spawn_nothing_percentage = 90
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "umh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
@@ -100655,9 +100680,8 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
 "use" = (
-/obj/structure/flora/rock/variant1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
+/turf/simulated/floor/asteroid/dirt/dark,
+/area/nadezhda/outside/forest)
 "usi" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
@@ -101429,10 +101453,6 @@
 /obj/landmark/join/start/officer,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"uCl" = (
-/obj/structure/flora/small/rock4,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "uCo" = (
 /obj/effect/floor_decal/asteroid,
 /obj/machinery/camera/network/colony_underground,
@@ -102837,6 +102857,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"uPC" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/random/firstaid/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "uPD" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -103521,14 +103546,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"uVf" = (
-/obj/random/flora/small_jungle_tree,
-/obj/structure/flora/big/bush1{
-	pixel_x = -15;
-	pixel_y = -25
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "uVj" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -104451,11 +104468,11 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/rnd/xenobiology/xenoflora)
 "vfR" = (
-/obj/random/traps/low_chance{
-	spawn_nothing_percentage = 90
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/obj/structure/girder,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/simulated/floor/beach/water/shallow,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "vfU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -104965,6 +104982,10 @@
 /obj/random/structures/os,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"vli" = (
+/obj/item/material/shard,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "vlm" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /obj/machinery/camera/network/colony_surface{
@@ -105219,14 +105240,6 @@
 	icon_state = "13,15"
 	},
 /area/nadezhda/quartermaster/miningdock)
-"vnx" = (
-/obj/effect/window_lwall_spawn,
-/obj/structure/flora/big/bush3{
-	pixel_y = -10
-	},
-/obj/structure/barricade,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/dungeon/outside/campground)
 "vnC" = (
 /obj/structure/scrap/poor,
 /obj/effect/decal/cleanable/rubble,
@@ -105915,10 +105928,8 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "vuI" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/beach/water/shallow,
+/obj/structure/flora/big/rocks1,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
 "vuN" = (
 /obj/structure/bed/chair/comfy/brown{
@@ -106117,13 +106128,14 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/rnd/rbreakroom)
 "vwo" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 25;
-	pixel_x = -13;
-	layer = 4.2
+/obj/structure/railing/grey{
+	dir = 1
 	},
+/obj/structure/railing/grey,
+/obj/structure/flora/big/bush1,
+/obj/structure/girder/displaced,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/area/nadezhda/dungeon/outside/hunter_cabin)
 "vwq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -106179,12 +106191,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"vwN" = (
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/item/scrap_lump,
-/turf/simulated/floor/beach/water/shallow,
-/area/nadezhda/outside/forest)
 "vwR" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/simulated/shuttle/floor/science{
@@ -106380,12 +106386,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"vzM" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -15
-	},
-/turf/unsimulated/wall/jungle,
-/area/nadezhda/outside/forest)
 "vzU" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 1
@@ -108357,10 +108357,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/security/maingate/west)
 "vTp" = (
-/obj/structure/flora/big/bush2,
-/obj/structure/barricade,
+/obj/item/scrap_lump,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/campground)
+/area/nadezhda/dungeon/outside/burned_outpost)
 "vTq" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -109462,6 +109461,13 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"wdQ" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = -4;
+	layer = 4.2
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "wdZ" = (
 /obj/item/modular_computer/console/preset/medical/monitor{
 	dir = 8
@@ -111983,6 +111989,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"wDO" = (
+/obj/random/gun_parts/frames,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "wDS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -112623,9 +112633,10 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
 "wLe" = (
-/obj/item/material/shard,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/lighting/toggleable/lantern,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/campground)
 "wLg" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -113281,13 +113292,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"wSu" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = -4;
-	layer = 4.2
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "wSv" = (
 /obj/structure/table/steel,
 /obj/item/device/radio/off{
@@ -115238,6 +115242,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"xoi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/big/bush1,
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/dungeon/outside/burned_outpost)
 "xoo" = (
 /obj/machinery/microwave/burnbarrel,
 /obj/effect/decal/cleanable/ash,
@@ -115543,6 +115552,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"xrJ" = (
+/obj/structure/barricade,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/campground)
 "xrN" = (
 /obj/structure/table/marble,
 /obj/random/booze,
@@ -116850,11 +116863,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/sleeper)
-"xEe" = (
-/obj/structure/girder,
-/obj/structure/flora/big/rocks1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "xEi" = (
 /turf/simulated/mineral,
 /area/nadezhda/engineering/engine_room)
@@ -119358,10 +119366,6 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm2)
-"ydY" = (
-/obj/structure/flora/big/bush1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "yef" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -119399,10 +119403,6 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"yeF" = (
-/obj/item/material/shard/plasma,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/burned_outpost)
 "yeH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -119988,12 +119988,9 @@
 /obj/item/device/radio/intercom/department/security{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark/gray_platform{
-	icon = 'icons/obj/stairs.dmi';
-	icon_state = "ramptop";
-	name = "stairs";
-	desc = with steps
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/multiz/stairs,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
 "ylO" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -202611,7 +202608,7 @@ rTe
 rTe
 cxU
 tfW
-vfR
+emi
 tfW
 tfW
 tfW
@@ -202800,7 +202797,7 @@ tfW
 tfW
 tfW
 bCJ
-aBG
+cNO
 bCJ
 mHv
 tfW
@@ -202991,9 +202988,9 @@ tfW
 tfW
 tfW
 tfW
-uVf
+dmr
 kOj
-vzM
+goU
 tfW
 tfW
 tfW
@@ -203193,7 +203190,7 @@ tfW
 raN
 raN
 tfW
-tYx
+iUv
 kOj
 hHs
 hHs
@@ -203201,8 +203198,8 @@ hHs
 hHs
 hHs
 hHs
-oeM
-oeM
+muX
+muX
 hHs
 hHs
 hHs
@@ -203245,8 +203242,8 @@ tfW
 tfW
 tfW
 aff
-kkA
-rNk
+use
+tst
 tfW
 tfW
 aff
@@ -203401,13 +203398,13 @@ hHs
 tAD
 uof
 tAD
-dZv
-dZv
-dNV
-iXi
+vTp
+vTp
+nYe
+tHe
 tAD
 tAD
-fHw
+vuI
 tAD
 hHs
 hHs
@@ -203447,9 +203444,9 @@ tfW
 tfW
 tfW
 mHv
-byU
-iqn
-kkA
+kvV
+tBU
+use
 mHv
 lMN
 kOj
@@ -203602,12 +203599,12 @@ hHs
 tAD
 tAD
 tAD
+vuI
 fHw
-tHe
 tAD
 tAD
-nHi
-seR
+sZa
+wDO
 tAD
 tAD
 tAD
@@ -203648,12 +203645,12 @@ tfW
 tfW
 tfW
 tfW
-kkA
-iqn
+use
+tBU
 lZz
 lZz
-dbT
-dbT
+nLr
+nLr
 lZz
 lZz
 kTO
@@ -203800,7 +203797,7 @@ mHv
 tfW
 tfW
 hHs
-dZv
+vTp
 tAD
 tAD
 gwu
@@ -203809,16 +203806,16 @@ tAD
 iMj
 tAD
 tAD
-fHw
+vuI
 tAD
-tHe
+fHw
 tAD
 fKl
 pwf
 pwf
 pwf
 pwf
-tYO
+qaG
 pwf
 hBB
 hHs
@@ -203851,7 +203848,7 @@ tfW
 tfW
 tfW
 tfW
-kkA
+use
 lZz
 fMZ
 bxG
@@ -204002,18 +203999,18 @@ tfW
 oPz
 tfW
 hHs
-dZv
-czf
-qaG
+vTp
+uPC
+kkg
 cSk
 nsk
 tAD
-eBP
+swI
 jFR
 tAD
 tAD
-hIi
-ebS
+kIC
+kEF
 pwf
 fKl
 pwf
@@ -204029,7 +204026,7 @@ hHs
 tfW
 wcY
 tfW
-vfR
+emi
 tfW
 wcY
 tfW
@@ -204052,8 +204049,8 @@ aff
 wcY
 kmB
 tfW
-kkA
-kkA
+use
+use
 lZz
 uii
 cUc
@@ -204205,15 +204202,15 @@ tfW
 tfW
 hHs
 sxF
-iXi
-iXi
+tHe
+tHe
 cSk
 cSk
 tAD
 tAD
 tAD
 tAD
-dZv
+vTp
 tAD
 pwf
 pwf
@@ -204255,8 +204252,8 @@ wcY
 pCD
 tfW
 tfW
-toy
-loD
+pmF
+qGh
 pls
 cUc
 cUc
@@ -204408,13 +204405,13 @@ oPz
 hHs
 nsk
 tAD
-iXi
-cKa
-iXi
-yeF
+tHe
+eBP
+tHe
+tyh
 tAD
 bIH
-iXi
+tHe
 tAD
 tAD
 tAD
@@ -204457,11 +204454,11 @@ tfW
 tfW
 tfW
 tfW
-kkA
-gaq
+use
+dhq
 qGD
 xjM
-qPH
+wLe
 qGD
 lZz
 kTO
@@ -204610,13 +204607,13 @@ tfW
 hHs
 nsk
 tAD
-iXi
-iXi
-tAD
-tAD
 tHe
-iXi
-iXi
+tHe
+tAD
+tAD
+fHw
+tHe
+tHe
 tAD
 tAD
 tAD
@@ -204625,7 +204622,7 @@ hHs
 fLs
 pwf
 pwf
-sRo
+hpe
 pwf
 pwf
 opX
@@ -204660,7 +204657,7 @@ oRa
 nmG
 tfW
 wjb
-kdS
+xrJ
 wSD
 bxG
 cUc
@@ -204812,20 +204809,20 @@ tfW
 hHs
 tAD
 tAD
-tHe
+fHw
 tAD
 ura
-iXi
+tHe
 tAD
-iXi
-iXi
+tHe
+tHe
 aML
 tAD
 tAD
 vqq
 hHs
 yhK
-pNH
+aTp
 pwf
 pwf
 pwf
@@ -204862,8 +204859,8 @@ tfW
 tfW
 tfW
 tfW
-vTp
-aXv
+cci
+mTm
 bxG
 bxG
 tTd
@@ -205015,11 +205012,11 @@ hHs
 tAD
 tAD
 tAD
-fHw
-dZv
-iXi
-iXi
-iXi
+vuI
+vTp
+tHe
+tHe
+tHe
 tAD
 tAD
 tAD
@@ -205064,9 +205061,9 @@ xsx
 xsx
 tfW
 tfW
-hYJ
+gsc
 oFV
-hAO
+mvv
 mRw
 tVX
 lZz
@@ -205213,15 +205210,15 @@ tfW
 tfW
 tfW
 ebv
-oeM
+muX
 tAD
 tAD
 tAD
 tAD
-iXi
-iXi
+tHe
+tHe
 tAD
-hIi
+kIC
 tAD
 tAD
 tAD
@@ -205239,7 +205236,7 @@ qZO
 cFZ
 hHs
 tfW
-ina
+tCo
 tfW
 wcY
 kOj
@@ -205265,9 +205262,9 @@ mHv
 tfW
 tfW
 tfW
-avI
+dZv
 lZz
-ttA
+hNm
 cUc
 bxG
 jlb
@@ -205417,16 +205414,16 @@ tfW
 tfW
 hHs
 tAD
-use
+nsv
 tAD
-tHe
+fHw
 tAD
 tAD
-tyh
+lhm
 pwf
 tAD
-seR
-tHe
+wDO
+fHw
 pwf
 hHs
 tfW
@@ -205613,7 +205610,7 @@ tfW
 tfW
 tfW
 tfW
-vfR
+emi
 iSI
 tfW
 tfW
@@ -205621,11 +205618,11 @@ hHs
 sxF
 tAD
 sFH
-ydY
-qDJ
+kkA
+nkG
 nmw
-uCl
-gsc
+dsK
+nIg
 pwf
 pwf
 tAD
@@ -205640,7 +205637,7 @@ tfW
 tfW
 mWZ
 tfW
-vfR
+emi
 tfW
 olX
 tfW
@@ -205668,10 +205665,10 @@ tfW
 tfW
 tfW
 tfW
-wLe
+vli
 tfW
 lfI
-emi
+pZw
 bxG
 cUc
 qGD
@@ -205819,19 +205816,19 @@ tfW
 tfW
 tfW
 tfW
-oeM
-xEe
+muX
+mHB
 tAD
 tAD
-wSu
+wdQ
 nmw
 nmw
 nmw
-bkt
+ncL
 pwf
 pwf
 pwf
-lyC
+hYJ
 hHs
 tfW
 tfW
@@ -205872,7 +205869,7 @@ gzu
 tfW
 fhp
 tfW
-loD
+qGh
 cGg
 bxG
 uUa
@@ -206022,19 +206019,19 @@ bSm
 tfW
 kEV
 tfW
-jgE
-fHw
-cYP
-fWU
-nmw
-owX
+oeM
 vuI
+xoi
+tiW
+nmw
+tke
+iXi
 nmw
 tAD
 pwf
 tAD
 tAD
-nTD
+fAt
 tfW
 mHv
 tfW
@@ -206074,7 +206071,7 @@ tfW
 tfW
 tfW
 mHv
-iMe
+pPg
 lIn
 bxG
 bxG
@@ -206224,19 +206221,19 @@ tfW
 tfW
 tfW
 tfW
+qNw
+qNw
+hHs
 hZt
+vfR
+vfR
 hZt
+flF
+fAt
 hHs
-eHQ
-fkF
-fkF
-eHQ
-muX
-nTD
+oeM
 hHs
-jgE
-hHs
-nTD
+fAt
 tfW
 tfW
 tfW
@@ -206275,7 +206272,7 @@ tfW
 tfW
 tfW
 tfW
-wLe
+vli
 lfI
 ejS
 cUc
@@ -206425,12 +206422,12 @@ tfW
 tfW
 tfW
 tfW
-ina
+tCo
 iSI
 tfW
-prt
+gVS
 ryY
-guX
+rEH
 ryY
 ryY
 ryY
@@ -206441,7 +206438,7 @@ tfW
 tfW
 tfW
 tfW
-ulU
+ina
 cAF
 tfW
 tfW
@@ -206631,15 +206628,15 @@ tfW
 tfW
 tfW
 pQK
-vwN
+rvz
 ryY
 ryY
-nrd
-vwo
+kmk
+hZB
 tfW
-ina
+tCo
 olX
-vfR
+emi
 tfW
 gbc
 tfW
@@ -206831,7 +206828,7 @@ tfW
 mHv
 tfW
 tfW
-vfR
+emi
 tfW
 vaP
 ryY
@@ -206882,7 +206879,7 @@ tfW
 tfW
 tfW
 wcY
-pfP
+qut
 bPD
 bxG
 cUc
@@ -207037,7 +207034,7 @@ tfW
 iAH
 tfW
 tkB
-vwo
+hZB
 mWZ
 tfW
 bCJ
@@ -207084,7 +207081,7 @@ tfW
 tfW
 tfW
 ygo
-dbT
+nLr
 kRT
 cUc
 bxG
@@ -207286,7 +207283,7 @@ tfW
 tfW
 tfW
 uiM
-dbT
+nLr
 hpv
 cUc
 bxG
@@ -207440,7 +207437,7 @@ tfW
 tfW
 bTf
 tfW
-vfR
+emi
 bCJ
 kOj
 kOj
@@ -207894,8 +207891,8 @@ tfW
 jBW
 lZz
 lZz
-vnx
-dbT
+rCT
+nLr
 lZz
 lZz
 kTO
@@ -236981,7 +236978,7 @@ tfW
 tfW
 tiO
 tfW
-kbg
+nQI
 tfW
 bSm
 kOj
@@ -237385,8 +237382,8 @@ tfW
 tfW
 mHv
 keX
-kop
-qOm
+fEY
+czf
 vRa
 vRa
 vRa
@@ -237587,7 +237584,7 @@ tfW
 wjb
 tfW
 tfW
-olN
+vwo
 tDY
 oOj
 uPc
@@ -237789,7 +237786,7 @@ tfW
 tfW
 mHv
 tfW
-tiS
+bwv
 dFN
 ueY
 rMO
@@ -237993,7 +237990,7 @@ tfW
 tfW
 vRa
 xwx
-ukC
+qqT
 tSm
 vRa
 kTO
@@ -238192,7 +238189,7 @@ tfW
 tfW
 iPG
 tfW
-eAI
+iwJ
 vRa
 jcG
 wjP

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -382,9 +382,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/science)
-"aey" = (
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "aez" = (
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/tiled/steel/bar_light,
@@ -1697,6 +1694,11 @@
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
+"asE" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "asL" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window/southleft{
@@ -2243,6 +2245,11 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
+"axJ" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/small/grassa1,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "axS" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/wood/wild4,
@@ -2760,6 +2767,11 @@
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"aCE" = (
+/obj/item/remains/ribcage,
+/obj/item/clothing/accessory/choker/gold_bell,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "aCI" = (
 /obj/structure/table/standard,
 /obj/random/medical/low_chance,
@@ -3724,6 +3736,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
+"aOa" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "aOb" = (
 /obj/item/farmbot_arm_assembly{
 	created_name = "GardenBot";
@@ -4346,14 +4364,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"aWF" = (
-/obj/structure/flora/big/bush3,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "aWG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4462,6 +4472,11 @@
 "aYl" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/inside_colony)
+"aYn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "aYo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4476,6 +4491,7 @@
 	id_tag = "FS2";
 	name = "Free Shop 2"
 	},
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/techshop)
 "aYt" = (
@@ -5765,15 +5781,6 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/hydroponics)
-"bkQ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "bkT" = (
 /obj/structure/table/steel,
 /obj/item/oddity/ls/starscope,
@@ -5783,11 +5790,6 @@
 /obj/structure/sign/department/telecoms,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
-"bld" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "ble" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7384,6 +7386,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/servist)
+"bDm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/light/tube,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "bDw" = (
 /obj/random/scrap/sparse_even,
 /obj/random/mob/roaches/low_chance,
@@ -7431,6 +7438,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"bDK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/techshop)
 "bDQ" = (
 /obj/effect/floor_decal/industrial/warningred/full,
 /obj/structure/cable/yellow,
@@ -7752,6 +7768,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/techshop)
 "bHP" = (
@@ -7910,11 +7929,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
-"bJf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/toolbox/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "bJk" = (
 /obj/machinery/power/sensor{
 	long_range = 1;
@@ -8596,10 +8610,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/bridge)
-"bRr" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "bRx" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -11133,9 +11143,6 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/outside/inside_colony)
 "cuo" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -11143,6 +11150,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/light/tube,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "cup" = (
@@ -11442,6 +11451,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"cxf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/shotgun/pellet/prespawned,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "cxh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_research{
@@ -13975,6 +13989,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"cXc" = (
+/obj/structure/railing,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "cXf" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -14476,10 +14495,6 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
-"dcP" = (
-/obj/structure/flora/small/rock1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "dcS" = (
 /obj/structure/table/standard,
 /obj/structure/extinguisher_cabinet{
@@ -14599,11 +14614,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
-"dec" = (
-/obj/item/remains/ribcage,
-/obj/item/clothing/accessory/choker/gold_bell,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "deh" = (
 /obj/machinery/vending/gamers,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -15622,11 +15632,6 @@
 	},
 /turf/simulated/open,
 /area/nadezhda/outside/scave)
-"doJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junkfood/low_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "doN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -16232,6 +16237,11 @@
 /obj/item/storage/box/flashbangs,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical)
+"duV" = (
+/obj/random/mob/termite_no_despawn,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "duZ" = (
 /obj/machinery/door/airlock/maintenance_cargo{
 	req_one_access = list(50,70,78)
@@ -17607,7 +17617,7 @@
 /area/nadezhda/crew_quarters/pool)
 "dJa" = (
 /obj/structure/sign/misc/rent,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/techshop)
 "dJf" = (
 /obj/structure/table/steel,
@@ -19328,10 +19338,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/lab)
 "ebO" = (
-/obj/random/mob/termite_no_despawn,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/turf/simulated/wall/r_wall,
+/area/nadezhda/crew_quarters/techshop)
 "ebP" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -22652,6 +22660,10 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/captain/quarters)
+"eKY" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "eLa" = (
 /obj/structure/table/steel,
 /obj/structure/salvageable/computer{
@@ -24280,14 +24292,6 @@
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/command/fo)
-"eZY" = (
-/obj/structure/flora/small/busha3,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "eZZ" = (
 /obj/structure/curtain/open/shower,
 /obj/item/stool,
@@ -26396,6 +26400,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/techshop)
 "fxl" = (
@@ -28271,6 +28278,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/merchant)
+"fSY" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "fTa" = (
 /obj/structure/window/reinforced,
 /obj/structure/multiz/stairs/active{
@@ -28453,6 +28465,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"fUZ" = (
+/obj/structure/flora/small/rock3,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "fVe" = (
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
 	pixel_y = 32
@@ -30906,6 +30923,12 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
+"gtE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/trash/candy/proteinbar,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "gtM" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -31572,10 +31595,6 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"gAT" = (
-/obj/structure/railing,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "gAZ" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -31680,6 +31699,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/armoryshop)
+"gCw" = (
+/obj/structure/table/woodentable{
+	color = "#9a977b"
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "gCC" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 1;
@@ -32619,11 +32644,6 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
-"gOn" = (
-/obj/structure/flora/big/rocks3,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "gOx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -35269,6 +35289,11 @@
 /obj/item/stack/cable_coil/yellow,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/hallways)
+"hrz" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "hrA" = (
 /obj/machinery/button/crematorium{
 	pixel_y = 4
@@ -38330,12 +38355,6 @@
 /obj/structure/cable/blue,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
-"hWy" = (
-/obj/structure/table/woodentable{
-	color = "#9a977b"
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "hWL" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop,
@@ -39447,10 +39466,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "igp" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
+/obj/effect/decal/cleanable/dirt,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "igt" = (
 /obj/structure/table/woodentable,
 /obj/random/contraband,
@@ -40021,6 +40040,16 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"iml" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "imo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -45117,6 +45146,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/hallways)
+"jqr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "jqw" = (
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/rock,
@@ -47148,6 +47182,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
+"jMt" = (
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "jMx" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -48545,11 +48583,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"kbz" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "kbA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -49776,6 +49809,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
+"knQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "knR" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -49844,6 +49890,12 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"koB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "koK" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/snacks/twobread,
@@ -50352,6 +50404,15 @@
 /area/nadezhda/security/nuke_storage{
 	name = "\improper Clinic"
 	})
+"ktZ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "kuc" = (
 /turf/simulated/open,
 /area/nadezhda/maintenance/undergroundfloor2west)
@@ -51405,8 +51466,8 @@
 	pixel_y = 24;
 	specialfunctions = 4
 	},
-/obj/random/contraband/low_chance,
 /obj/structure/table/rack,
+/obj/item/reagent_containers/syringe,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "kEb" = (
@@ -51733,6 +51794,11 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/detectives_office)
+"kJi" = (
+/obj/structure/flora/small/busha2,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "kJk" = (
 /obj/structure/bed/chair/sofa/black/right,
 /turf/simulated/floor/wood,
@@ -51844,6 +51910,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"kKy" = (
+/obj/machinery/atmospherics/unary/vent_pump,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal{
+	icon_state = "metal3"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "kKF" = (
 /obj/item/modular_computer/console/preset/trade{
 	dir = 1
@@ -51995,11 +52069,6 @@
 "kMg" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/substation/cargo)
-"kMl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/pen,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "kMD" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/wall/r_wall,
@@ -52743,6 +52812,13 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"kUT" = (
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "kUX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53048,6 +53124,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
+"kYN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/crew_quarters/techshop)
 "kYP" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -53119,6 +53204,11 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"kZU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "kZY" = (
 /obj/machinery/computer/general_air_control{
 	dir = 1;
@@ -54271,6 +54361,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/smc/quarters)
+"loK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/toolbox/low_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "loL" = (
 /obj/structure/closet/secure_closet/personal/security,
 /obj/effect/floor_decal/industrial/hatch,
@@ -55330,6 +55425,19 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"lAz" = (
+/obj/structure/flora/small/busha3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
+"lAB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/remains/mouse,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "lAL" = (
 /obj/structure/flora/ausbushes/genericbush,
 /turf/unsimulated/wall/jungle,
@@ -55989,6 +56097,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
+"lHX" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "lIb" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -56724,13 +56840,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
-"lQb" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/portable_atmospherics/hydroponics/soil{
-	layer = 1
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "lQm" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/techmaint,
@@ -59195,6 +59304,11 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"mpj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/chips,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "mpm" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/side/f2section1)
@@ -60558,6 +60672,9 @@
 	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/metal{
+	icon_state = "metal2"
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "mDH" = (
@@ -61492,14 +61609,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"mMt" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "mMw" = (
 /obj/machinery/excelsior_boombox,
 /obj/effect/decal/cleanable/dirt,
@@ -63224,6 +63333,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/techshop)
 "neC" = (
@@ -66190,11 +66300,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
-"nID" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/ammo_casing/shotgun/pellet/prespawned,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/farm)
 "nIG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/light/small{
@@ -66253,6 +66358,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"nJa" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "nJb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69352,6 +69463,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/crew_quarters/bar)
+"opn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/lighting/toggleable/lamp,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "opp" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
@@ -70079,10 +70195,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"owt" = (
-/obj/structure/flora/small/busha1,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "owx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -70203,6 +70315,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cbo)
+"oxU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/device/lighting/toggleable/lamp,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "oxW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -70536,6 +70654,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/clownoffice)
+"oAS" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "oAU" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/multiz/ladder/up,
@@ -70558,6 +70681,13 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"oBe" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/portable_atmospherics/hydroponics/soil{
+	layer = 1
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "oBh" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/candy,
@@ -70626,14 +70756,6 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
-"oBJ" = (
-/obj/structure/flora/small/bushb1,
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "oBN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
@@ -70947,11 +71069,6 @@
 /obj/structure/flora/small/grassb5,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"oFn" = (
-/obj/structure/flora/small/busha2,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "oFu" = (
 /obj/machinery/computer/arcade,
 /obj/effect/decal/cleanable/dirt,
@@ -71218,6 +71335,13 @@
 /area/nadezhda/security/prisoncells{
 	name = "Interrogation"
 	})
+"oHZ" = (
+/obj/structure/table/rack,
+/obj/item/trash/material/metal{
+	icon_state = "device0"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "oIt" = (
 /obj/machinery/papershredder,
 /obj/machinery/light/small{
@@ -73155,6 +73279,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/surgery)
+"pbD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/obj/item/light/tube,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "pbO" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/random/traps/low_chance{
@@ -73682,11 +73813,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"phH" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "phJ" = (
 /obj/structure/table/woodentable,
 /obj/random/credits,
@@ -74933,6 +75059,9 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/sleeper)
+"puS" = (
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/dungeon/outside/farm)
 "pva" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75695,6 +75824,12 @@
 	icon_state = "9,11"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"pDa" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "pDc" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/slimegun,
@@ -76264,6 +76399,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
+"pJO" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "pJT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -77170,6 +77309,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"pRK" = (
+/obj/item/remains/ribcage,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "pRM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -78415,6 +78558,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/clownoffice)
+"qee" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "qen" = (
 /obj/effect/floor_decal/industrial/road/warning4,
 /obj/effect/decal/cleanable/dirt,
@@ -79098,11 +79246,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"qlu" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "qlD" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -79478,9 +79621,6 @@
 	name = "Residential District Maintenance"
 	})
 "qpm" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -80738,6 +80878,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"qCR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pen,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/farm)
 "qCS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
@@ -84777,10 +84922,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
-"rvA" = (
-/obj/structure/girder,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "rvM" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -85385,11 +85526,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
 "rBK" = (
-/obj/structure/railing{
-	dir = 8
-	},
+/obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/area/nadezhda/dungeon/outside/farm)
 "rBL" = (
 /obj/structure/bonfire/permanent,
 /obj/item/material/shard,
@@ -86586,6 +86725,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
+"rOV" = (
+/obj/structure/flora/small/rock1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "rPb" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -87230,11 +87373,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/security/barracks)
-"rWP" = (
-/obj/structure/flora/small/rock3,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "rWT" = (
 /obj/random/closet/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -88291,6 +88429,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "sgY" = (
@@ -91369,7 +91510,6 @@
 /area/nadezhda/security/triage_blackshield)
 "sMN" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/device/lighting/toggleable/lamp,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "sMU" = (
@@ -92366,6 +92506,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/medical/psych)
+"sYB" = (
+/obj/structure/girder,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "sYD" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -92534,6 +92678,14 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/hallways)
+"sZX" = (
+/obj/structure/flora/small/bushb1,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "tad" = (
 /turf/unsimulated/mineral,
 /area/colony)
@@ -92676,6 +92828,13 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"tbo" = (
+/obj/structure/railing{
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "tbz" = (
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/grass,
@@ -96050,6 +96209,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "tMc" = (
@@ -96712,6 +96872,13 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/absolutism/bioreactor)
+"tRL" = (
+/obj/structure/table/rack,
+/obj/item/trash/material/metal{
+	icon_state = "device3"
+	},
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "tRU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame/machine_frame/vertical{
@@ -97198,7 +97365,7 @@
 /area/nadezhda/outside/inside_colony)
 "tXf" = (
 /obj/structure/sign/misc/techshop,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/techshop)
 "tXh" = (
 /obj/structure/table/woodentable,
@@ -97299,6 +97466,7 @@
 	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "tYr" = (
@@ -99146,6 +99314,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"upU" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/random/mob/termite_no_despawn,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "upX" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/rubble,
@@ -99339,6 +99512,16 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"urL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/material/circuit,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "urR" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
@@ -100312,10 +100495,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
-"uEl" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/dungeon/outside/farm)
 "uEq" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -104414,11 +104593,6 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
-"vtl" = (
-/obj/structure/railing,
-/obj/random/mob/termite_no_despawn,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "vto" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -104677,6 +104851,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "vvy" = (
@@ -106625,13 +106800,6 @@
 /obj/random/furniture/pottedplant,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
-"vQP" = (
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "vQS" = (
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -108198,10 +108366,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/crew_quarters/toilet/public)
-"wfo" = (
-/obj/item/remains/ribcage,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "wfw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -108830,11 +108994,11 @@
 /area/nadezhda/command/bridge)
 "wlK" = (
 /obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -32
 	},
+/obj/random/rations/low_chance,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "wlQ" = (
@@ -111768,6 +111932,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/hallway/side/f2section1)
+"wRF" = (
+/obj/structure/railing,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "wRG" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/effect/decal/cleanable/dirt,
@@ -112743,10 +112911,6 @@
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"xcB" = (
-/obj/item/remains/ribcage,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "xcG" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -114254,6 +114418,14 @@
 /obj/item/clothing/head/helmet/bulletproof/ironhammer_thermal,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"xtt" = (
+/obj/structure/flora/big/bush3,
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "xty" = (
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -114557,6 +114729,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"xwk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "xwp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -115165,6 +115342,11 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
+"xBG" = (
+/obj/structure/flora/big/rocks3,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "xBJ" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -115284,6 +115466,10 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"xCA" = (
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "xCG" = (
 /obj/structure/table/glass,
 /obj/random/junkfood,
@@ -116085,12 +116271,10 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/rbreakroom)
 "xKC" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/dark/violetcorener,
+/area/nadezhda/crew_quarters/techshop)
 "xKJ" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -117545,11 +117729,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/smc/quarters)
-"yah" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/small/grassa1,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "yaj" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/big/bush3,
@@ -117710,6 +117889,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/engineering/atmos/surface)
+"ybP" = (
+/obj/structure/flora/small/busha1,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "ycd" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -118027,6 +118210,7 @@
 	id_tag = "FS1";
 	name = "Free Shop 1"
 	},
+/obj/structure/barricade,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/techshop)
 "yfY" = (
@@ -118231,10 +118415,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/toilet/public)
-"yhX" = (
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "yib" = (
 /obj/structure/table/standard,
 /obj/random/lowkeyrandom,
@@ -177596,9 +177776,9 @@ cIo
 wVV
 wVV
 wVV
-wVV
-wVV
-wVV
+knQ
+knQ
+knQ
 mLu
 cZn
 ucI
@@ -177796,17 +177976,17 @@ oEG
 whU
 tnO
 qDu
-eDl
-eDl
+ebO
+ebO
 cCy
 cCy
 cCy
-eDl
-eDl
-eDl
-vpF
+ebO
+ebO
+ebO
+mpm
 hmA
-vpF
+mpm
 pow
 pow
 pow
@@ -178002,10 +178182,10 @@ yfR
 nkP
 iyl
 iyl
-iyl
+pDa
 tYn
 fHr
-eDl
+ebO
 tAO
 gSu
 iIL
@@ -178200,14 +178380,14 @@ jIQ
 whU
 tnO
 whU
-eDl
+ebO
 oli
-cxN
-cxN
-cxN
+gtE
+opn
+xKC
 cxN
 rOi
-eDl
+ebO
 tAO
 gSu
 cAu
@@ -178401,15 +178581,15 @@ sRU
 sRU
 whU
 tnO
-whU
+xwk
 cCy
 nBz
 cxN
 mSc
-cxN
-cxN
-bjU
-eDl
+kZU
+igp
+xCA
+ebO
 qQA
 gSu
 ayv
@@ -178608,10 +178788,10 @@ cCy
 nBz
 tar
 mXl
-cxN
+lAB
 cxN
 xXM
-eDl
+ebO
 tAO
 gSu
 hua
@@ -178805,15 +178985,15 @@ utr
 sRU
 whU
 due
-bbM
+koB
 cCy
 sMN
-cxN
+igp
 qpm
-cxN
-cxN
+qee
+mpj
 wlK
-eDl
+ebO
 evY
 gSu
 hua
@@ -179014,8 +179194,8 @@ cCy
 nex
 cCy
 cCy
-eDl
-eDl
+ebO
+ebO
 tMC
 gSu
 hua
@@ -179212,12 +179392,12 @@ vfn
 liW
 pZA
 bHN
-pZA
+kYN
 oqt
 wdA
 bjf
 pMv
-eDl
+ebO
 tMC
 gSu
 cGW
@@ -179419,7 +179599,7 @@ bNK
 vmC
 tGi
 eyB
-eDl
+ebO
 cAu
 gSu
 mwe
@@ -179616,12 +179796,12 @@ tQp
 liW
 sEX
 fwY
-pZA
+bDK
 pkg
 vTs
 rvM
 nAq
-eDl
+ebO
 cAu
 npF
 jnQ
@@ -179822,8 +180002,8 @@ cCy
 nex
 mpH
 cCy
-eDl
-eDl
+ebO
+ebO
 cAu
 gSu
 gQt
@@ -180020,12 +180200,12 @@ laf
 vvx
 cCy
 sMN
-cxN
+oxU
 cuo
-sgP
+urL
 cxN
 bjU
-eDl
+ebO
 bnh
 gSu
 rHi
@@ -180219,15 +180399,15 @@ ody
 sRU
 whU
 tQp
-whU
+xwk
 cCy
-nBz
-tar
+tRL
+kKy
 fCf
 sgP
-cxN
+qee
 foj
-eDl
+ebO
 kdn
 gSu
 rHi
@@ -180421,15 +180601,15 @@ ody
 sRU
 whU
 tnO
-whU
+xwk
 cCy
-nBz
-cxN
+oHZ
+jqr
 oBN
-sgP
-cxN
+iml
+bDm
 bjU
-eDl
+ebO
 bnh
 gSu
 eNg
@@ -180624,14 +180804,14 @@ cPd
 wFV
 tnO
 fUB
-eDl
+ebO
 kDZ
-ckN
+pbD
 ckN
 qJj
 szW
 sxI
-eDl
+ebO
 ayv
 gSu
 wSY
@@ -180829,11 +181009,11 @@ kgK
 aYq
 flW
 iyl
-iyl
+nJa
 iyl
 mDo
 kzx
-eDl
+ebO
 ayv
 gSu
 wSY
@@ -181028,14 +181208,14 @@ cPd
 tiN
 tnO
 iZA
+ebO
+ebO
+ebO
 eDl
-eDl
-eDl
-eDl
-eDl
-eDl
-eDl
-eDl
+ebO
+ebO
+ebO
+ebO
 vCV
 gSu
 wSY
@@ -207597,14 +207777,14 @@ vSM
 tfW
 eUV
 eUV
-mMt
-mMt
-mMt
+lHX
+lHX
+lHX
 tfW
 eUV
 tfW
-vQP
-vQP
+tbo
+tbo
 tfW
 tfW
 cGa
@@ -207985,7 +208165,7 @@ kOj
 mHv
 tfW
 olX
-ebO
+duV
 tfW
 tfW
 tfW
@@ -208001,16 +208181,16 @@ tfW
 aff
 tfW
 tfW
-yhX
+jMt
 cxU
 vaP
 eUV
-bld
+oAS
 cxU
 cxU
 tfW
 cxU
-xKC
+kUT
 nhY
 cGa
 iSI
@@ -208212,7 +208392,7 @@ cxU
 tfW
 tfW
 cxU
-xKC
+kUT
 tfW
 tfW
 iSI
@@ -208391,7 +208571,7 @@ cXA
 tfW
 tfW
 tfW
-lQb
+oBe
 fqz
 tfW
 fqz
@@ -208414,7 +208594,7 @@ tfW
 tfW
 bSm
 cxU
-xKC
+kUT
 tfW
 lOm
 iSI
@@ -208603,10 +208783,10 @@ fhp
 tfW
 tfW
 lMN
-gAT
+wRF
 cxU
 tfW
-dec
+aCE
 tfW
 cTB
 tfW
@@ -208616,7 +208796,7 @@ cri
 tfW
 tfW
 cxU
-xKC
+kUT
 tfW
 tfW
 iSI
@@ -208805,9 +208985,9 @@ tfW
 fqz
 fqz
 cTz
-rvA
+sYB
 cxU
-bld
+oAS
 pCD
 cxU
 cxU
@@ -208818,7 +208998,7 @@ tfW
 tfW
 nhY
 cxU
-xKC
+kUT
 tfW
 tfW
 tfW
@@ -209013,14 +209193,14 @@ eUV
 nhY
 cxU
 pCD
-bld
+oAS
 eUV
 tfW
-wfo
+pJO
 cXA
 aff
 cxU
-xKC
+kUT
 eRP
 tiO
 tiO
@@ -209210,19 +209390,19 @@ lch
 vDt
 cxU
 tfW
-dcP
+rOV
 lch
 tiO
 cxU
 tfW
-kbz
+fSY
 vaP
 tfW
 tfW
 aff
 aff
 cxU
-xKC
+kUT
 eRP
 eRP
 mYI
@@ -209411,7 +209591,7 @@ tfW
 tfW
 tfW
 tfW
-rvA
+sYB
 cxU
 tfW
 tfW
@@ -209424,7 +209604,7 @@ tfW
 cxU
 cxU
 cxU
-oBJ
+sZX
 tfW
 eRP
 nhY
@@ -209602,8 +209782,8 @@ tfW
 tfW
 tfW
 asu
-aey
-uEl
+puS
+rBK
 qfL
 jsO
 qfL
@@ -209613,11 +209793,11 @@ qfL
 tfW
 cXA
 lch
-vtl
+cXc
 cxU
 cxU
 tfW
-bld
+oAS
 tfW
 aff
 iqv
@@ -209804,12 +209984,12 @@ tfW
 tfW
 tfW
 tfW
-uEl
+rBK
 vMD
-nID
+cxf
 xFj
-doJ
-hWy
+aYn
+gCw
 mcB
 qfL
 tfW
@@ -209819,7 +209999,7 @@ tfW
 tfW
 cxU
 cXA
-bld
+oAS
 cxU
 aff
 tfW
@@ -210006,7 +210186,7 @@ cXA
 fqz
 fqz
 fqz
-igp
+hrz
 gNG
 ugx
 fqx
@@ -210022,7 +210202,7 @@ eUV
 cxU
 cxU
 tfW
-bRr
+eKY
 tfW
 tfW
 olX
@@ -210030,7 +210210,7 @@ oHv
 olX
 olX
 cxU
-xKC
+kUT
 tfW
 tfW
 tfW
@@ -210205,14 +210385,14 @@ rTe
 tfW
 tfW
 iqv
-phH
+asE
 tfW
 tfW
 sSB
 eOO
 ugx
 cXJ
-kMl
+qCR
 rxh
 qXx
 sSB
@@ -210220,7 +210400,7 @@ tfW
 lch
 lch
 tfW
-oFn
+kJi
 tfW
 cxU
 eUV
@@ -210232,7 +210412,7 @@ tfW
 nfC
 tfW
 cxU
-aWF
+xtt
 tfW
 lOm
 dlq
@@ -210401,7 +210581,7 @@ vaP
 tfW
 tfW
 tfW
-owt
+ybP
 rTe
 cxU
 tfW
@@ -210415,7 +210595,7 @@ qfL
 gAr
 qfL
 rLy
-bJf
+loK
 bBy
 xfe
 wjb
@@ -210434,7 +210614,7 @@ tfW
 tfW
 kEV
 cxU
-xKC
+kUT
 kEV
 dlq
 kEV
@@ -210630,13 +210810,13 @@ tfW
 tfW
 aff
 aff
-xcB
+pRK
 tfW
 cxU
 mHv
 mHv
 cxU
-xKC
+kUT
 lOm
 kEV
 syk
@@ -210838,7 +211018,7 @@ cxU
 tfW
 cxU
 cxU
-eZY
+lAz
 ltw
 fdr
 fdr
@@ -211230,16 +211410,16 @@ fqz
 fqz
 tfW
 tfW
-rWP
+fUZ
 tfW
-rBK
+aOa
 tfW
-rBK
-rBK
+aOa
+aOa
 vSM
 nhY
-rBK
-bkQ
+aOa
+ktZ
 fdr
 jSt
 uzy
@@ -211620,7 +211800,7 @@ tGU
 tfW
 uTf
 oPz
-gOn
+xBG
 fqz
 tfW
 cGa
@@ -211824,9 +212004,9 @@ uTf
 uTf
 tfW
 cGa
-qlu
+upU
 cZD
-yah
+axJ
 olX
 tfW
 tfW

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -1793,11 +1793,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
 "ats" = (
-/obj/structure/flora/small/busha3,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -10
+	},
+/turf/simulated/mineral,
+/area/nadezhda/outside/scave)
 "atw" = (
 /obj/effect/floor_decal/spline/wood,
 /turf/simulated/floor/wood/wild3,
@@ -5626,11 +5627,10 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
 "bjd" = (
-/obj/structure/flora/small/grassb1,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/flood,
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "bjf" = (
 /obj/structure/railing/grey{
@@ -6290,11 +6290,12 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
 "bqU" = (
-/obj/structure/flora/small/grassb4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/structure/lattice,
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
+	},
+/turf/simulated/open,
+/area/nadezhda/dungeon/outside/abandoned_outpost)
 "bqV" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warningwhite{
@@ -6589,9 +6590,10 @@
 	name = "Residential District Maintenance"
 	})
 "bum" = (
-/obj/structure/flora/small/grassb4,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/random/junkfood/low_chance,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/lakeside)
 "buo" = (
 /obj/structure/sign/warning/smoking/small,
 /turf/simulated/wall/r_wall,
@@ -7415,8 +7417,10 @@
 	},
 /area/shuttle/vasiliy_shuttle_area)
 "bCJ" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/asteroid/dirt/flood,
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/turf/unsimulated/mineral,
 /area/nadezhda/outside/forest)
 "bCL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
@@ -7891,9 +7895,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "bIc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
+/obj/effect/decal/cleanable/rubble,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "bIf" = (
 /turf/simulated/floor/tiled/techmaint_panels,
@@ -9776,7 +9780,7 @@
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/engineering/atmos/storage)
 "ccE" = (
-/turf/simulated/floor/asteroid/grass/dry,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/abandoned_outpost)
 "ccK" = (
 /obj/machinery/smartfridge/drying_rack,
@@ -12346,7 +12350,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/grille,
 /obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass/dry,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "cFR" = (
 /obj/effect/window_lwall_spawn,
@@ -12884,9 +12888,9 @@
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "cLf" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "cLm" = (
 /obj/machinery/light/small{
@@ -19697,11 +19701,12 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/atmos)
 "edF" = (
-/obj/structure/flora/small/grassb1,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/lakeside)
 "edJ" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/disposalpipe/segment{
@@ -21268,11 +21273,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/engineering/atmos/surface)
 "est" = (
-/obj/structure/flora/small/busha2,
-/obj/random/spider_trap_burrowing/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/dirt/flood,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/big/bush1,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/outside/scave)
 "esy" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -21577,9 +21580,12 @@
 	name = "Residential District Maintenance"
 	})
 "ewk" = (
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/grass/dry,
-/area/nadezhda/outside/forest)
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/beach/sand,
+/area/nadezhda/outside/lakeside)
 "ewn" = (
 /obj/structure/boulder,
 /obj/structure/disposalpipe/segment{
@@ -23786,7 +23792,8 @@
 "eTi" = (
 /obj/structure/grille,
 /obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass/dry,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "eTm" = (
 /obj/structure/flora/small/rock1,
@@ -24800,7 +24807,7 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/grille,
 /obj/structure/barricade,
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "feH" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -27964,7 +27971,8 @@
 /area/nadezhda/crew_quarters/bar)
 "fLZ" = (
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass/dry,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "fMa" = (
 /obj/structure/bed/chair{
@@ -29345,7 +29353,7 @@
 /obj/structure/grille,
 /obj/structure/barricade,
 /obj/structure/barricade,
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "gcf" = (
 /obj/item/clothing/gloves/thick/handmade,
@@ -30106,11 +30114,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
-"giB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/flood,
-/area/nadezhda/outside/forest)
 "giE" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -31428,10 +31431,8 @@
 /area/nadezhda/outside/inside_colony)
 "gvy" = (
 /obj/effect/decal/cleanable/rubble,
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/grille,
-/obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass/dry,
+/obj/structure/flora/big/bush2,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "gvz" = (
 /obj/structure/flora/big/bush2,
@@ -35140,10 +35141,7 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/sleeper)
 "hlB" = (
-/obj/structure/flora/small/busha3,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/turf/simulated/floor/rock,
 /area/nadezhda/outside/forest)
 "hlG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -35471,7 +35469,8 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/grille,
 /obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass/dry,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "hps" = (
 /obj/random/spider_trap/low_chance,
@@ -35787,12 +35786,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
-"htk" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "htn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39261,11 +39254,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/maingate)
-"iaB" = (
-/obj/structure/flora/small/busha2,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "iaF" = (
 /mob/living/simple_animal/hostile/jelly/bloat,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -39619,9 +39607,15 @@
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
 "ieb" = (
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/mob/living/simple_animal/hostile/snake{
+	faction = "neutral";
+	name = "crimson viper";
+	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm.";
+	color = "#f7140c";
+	maxHealth = 250;
+	health = 250
+	},
+/turf/simulated/floor/rock,
 /area/nadezhda/outside/forest)
 "iee" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40932,10 +40926,13 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "isa" = (
-/obj/structure/flora/small/busha2,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/big/bush1,
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/turf/simulated/mineral,
+/area/nadezhda/outside/scave)
 "isb" = (
 /obj/structure/table/rack/shelf,
 /obj/item/roller{
@@ -42093,7 +42090,7 @@
 "iEn" = (
 /obj/structure/flora/small/bushb3,
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass/dry,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "iEq" = (
 /obj/structure/closet/secure_closet/personal/cargotech,
@@ -44829,6 +44826,7 @@
 /obj/structure/sign/warning/caution/small{
 	dir = 1
 	},
+/obj/structure/flora/big/bush1,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/outside/scave)
 "jiR" = (
@@ -47325,8 +47323,12 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jIz" = (
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/turf/simulated/mineral,
+/area/nadezhda/outside/scave)
 "jIA" = (
 /obj/structure/flora/big/bush2,
 /obj/random/flora/jungle_tree,
@@ -53012,7 +53014,8 @@
 "kRl" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt/dust,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "kRq" = (
 /obj/structure/cable/green{
@@ -54639,7 +54642,7 @@
 "llK" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "llQ" = (
 /obj/item/stack/ore,
@@ -55859,13 +55862,10 @@
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
 "lzF" = (
-/mob/living/simple_animal/hostile/snake{
-	faction = "neutral";
-	name = "young viper";
-	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm."
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/lakeside)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "lzO" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stock_parts/capacitor/excelsior,
@@ -58352,7 +58352,7 @@
 "mat" = (
 /obj/structure/barricade,
 /obj/structure/grille,
-/turf/simulated/floor/asteroid/dirt/dust,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "maB" = (
 /obj/effect/spider/stickyweb,
@@ -59552,9 +59552,11 @@
 	name = "Residential District Maintenance"
 	})
 "mmh" = (
-/obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/outside/lakeside)
 "mmj" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
 	dir = 8
@@ -60861,10 +60863,12 @@
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
 "mAy" = (
-/obj/structure/grille,
-/obj/structure/barricade,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
+/turf/simulated/mineral,
+/area/nadezhda/outside/scave)
 "mAD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green,
@@ -61180,11 +61184,6 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"mDn" = (
-/obj/structure/flora/small/busha2,
-/obj/random/flora/jungle_tree,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
 "mDo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
@@ -61643,11 +61642,6 @@
 "mHv" = (
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
-"mHC" = (
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/dirt/burned,
 /area/nadezhda/outside/forest)
 "mHE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -64429,7 +64423,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
 /obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass/dry,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nkI" = (
 /turf/unsimulated/mineral,
@@ -64793,8 +64788,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "noj" = (
-/obj/structure/flora/small/busha3,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/small/rock5,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nol" = (
 /obj/structure/disposalpipe/segment{
@@ -65673,7 +65669,7 @@
 /obj/structure/grille,
 /obj/structure/barricade,
 /obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass/dry,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nwZ" = (
 /obj/structure/shuttle_part/science{
@@ -67851,7 +67847,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/barricade,
 /obj/structure/grille,
-/turf/simulated/floor/asteroid/dirt/dust,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nSW" = (
 /obj/structure/disposalpipe/segment,
@@ -68503,8 +68499,11 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
 "nYY" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/turf/unsimulated/mineral,
 /area/nadezhda/outside/forest)
 "nYZ" = (
 /obj/structure/flora/big/bush1,
@@ -68742,7 +68741,8 @@
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
 "obd" = (
-/obj/effect/damagedfloor/fire,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "obl" = (
@@ -70181,9 +70181,11 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
 "oqo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "oqq" = (
 /obj/structure/closet/secure_closet/personal/orderly,
@@ -73739,7 +73741,7 @@
 "oZR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt/dust,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "oZU" = (
 /obj/structure/disposalpipe/segment,
@@ -75350,9 +75352,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "prJ" = (
-/obj/structure/flora/small/grassb3,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/outside/lakeside)
 "prT" = (
 /obj/structure/table/rack,
 /obj/item/storage/backpack/industrial{
@@ -75366,10 +75370,10 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "prX" = (
-/obj/structure/flora/small/grassb3,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/lakeside)
 "prZ" = (
 /obj/machinery/door/blast/shutters/glass{
 	name = "Fireplace Cover"
@@ -76798,9 +76802,9 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "pGM" = (
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/structure/railing,
+/turf/simulated/floor/beach/sand,
+/area/nadezhda/outside/lakeside)
 "pGS" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -77245,11 +77249,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"pLI" = (
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/small/busha2,
-/turf/unsimulated/wall/jungle,
-/area/nadezhda/outside/forest)
 "pLJ" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/big/bush2,
@@ -78336,6 +78335,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "pVn" = (
 /obj/structure/flora/ausbushes/brflowers,
+/obj/structure/table/bench/wooden,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
 "pVp" = (
@@ -79690,7 +79690,8 @@
 "qjm" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/grass/dry,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "qjo" = (
 /obj/structure/window/reinforced{
@@ -80412,7 +80413,9 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
 "qqS" = (
-/turf/simulated/floor/asteroid/dirt/flood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "qra" = (
 /obj/structure/table/standard,
@@ -83698,7 +83701,7 @@
 /area/nadezhda/hallway/side/f2section1)
 "raM" = (
 /obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "raN" = (
 /obj/structure/flora/small/grassb2,
@@ -85376,9 +85379,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "rsR" = (
-/obj/structure/flora/small/rock5,
-/turf/simulated/floor/asteroid/grass/dry,
-/area/nadezhda/outside/forest)
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 1;
+	pixel_y = -10
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/abandoned_outpost)
 "rtf" = (
 /obj/random/structures,
 /turf/simulated/floor/tiled/techmaint,
@@ -88353,9 +88359,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "rYV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/machinery/microwave/burnbarrel,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/lakeside)
 "rYX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -91097,7 +91103,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
 /obj/structure/barricade,
-/turf/simulated/floor/asteroid/grass/dry,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "szJ" = (
 /obj/effect/floor_decal/industrial/warningwhite{
@@ -93092,10 +93099,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"sWc" = (
-/obj/structure/flora/ausbushes/leafybush,
-/turf/unsimulated/wall/jungle,
-/area/nadezhda/outside/forest)
 "sWd" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/wild3,
@@ -93860,9 +93863,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
 "ten" = (
-/obj/structure/flora/small/busha2,
-/obj/random/flora/jungle_tree,
-/turf/unsimulated/wall/jungle,
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
+/turf/unsimulated/mineral,
 /area/nadezhda/outside/forest)
 "tes" = (
 /obj/structure/showcase{
@@ -94568,7 +94577,7 @@
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/grille,
 /obj/structure/barricade,
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "tmz" = (
 /obj/machinery/smartfridge/secure/extract,
@@ -96650,7 +96659,7 @@
 "tIk" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/small/busha2,
-/turf/simulated/floor/asteroid/dirt,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "tIs" = (
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -96677,8 +96686,9 @@
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
 "tIB" = (
-/obj/structure/flora/small/bushc3,
-/turf/simulated/floor/asteroid/grass/dry,
+/obj/random/flora/small_jungle_tree,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "tIG" = (
 /obj/structure/flora/small/trailrockb2,
@@ -96851,9 +96861,9 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/absolutism/hallways)
 "tJT" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/grille,
-/obj/structure/barricade,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "tJY" = (
@@ -97974,14 +97984,6 @@
 	opacity = 0
 	},
 /area/shuttle/surface_transport_lz)
-"tUo" = (
-/mob/living/simple_animal/hostile/snake{
-	faction = "neutral";
-	name = "young viper";
-	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm."
-	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/lakeside)
 "tUr" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
@@ -98775,9 +98777,11 @@
 	},
 /area/nadezhda/crew_quarters/sleep/bedrooms)
 "ucU" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/asteroid/grass/dry,
-/area/nadezhda/outside/forest)
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	pixel_y = 10
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/abandoned_outpost)
 "ucV" = (
 /obj/structure/table/steel,
 /obj/random/lowkeyrandom/low_chance,
@@ -100711,9 +100715,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "uxn" = (
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt/dust,
-/area/nadezhda/outside/forest)
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/outside/lakeside)
 "uxo" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -109239,9 +109242,12 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/east)
 "wew" = (
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
-/area/nadezhda/outside/forest)
+/obj/structure/lattice,
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
+	},
+/turf/simulated/open,
+/area/nadezhda/outside/scave)
 "wez" = (
 /obj/item/material/shard,
 /obj/item/tool/broken_bottle,
@@ -110145,12 +110151,8 @@
 /turf/simulated/floor/asteroid/dirt/dark/plough,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "woI" = (
-/mob/living/simple_animal/hostile/snake{
-	faction = "neutral";
-	name = "young viper";
-	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm."
-	},
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/rock,
 /area/nadezhda/outside/forest)
 "woR" = (
 /obj/machinery/light_switch{
@@ -110744,14 +110746,6 @@
 "wsF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
-"wsJ" = (
-/mob/living/simple_animal/hostile/snake{
-	faction = "neutral";
-	name = "young viper";
-	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm."
-	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "wsT" = (
@@ -111681,14 +111675,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"wDQ" = (
-/mob/living/simple_animal/hostile/snake{
-	faction = "neutral";
-	name = "young viper";
-	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm."
-	},
-/turf/simulated/floor/wood_old,
-/area/nadezhda/outside/forest)
 "wDS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -112416,10 +112402,12 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "wMi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/damagedfloor/fire,
-/obj/effect/damagedfloor/fire,
-/turf/simulated/floor/asteroid/dirt/burned,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "wMl" = (
 /obj/structure/shuttle_part/science{
@@ -117578,7 +117566,8 @@
 "xOG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/grass/dry,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "xOL" = (
 /obj/effect/floor_decal/industrial/hatch,
@@ -189378,9 +189367,9 @@ qif
 ary
 pJd
 pJd
-pJd
+wew
 nfl
-hRu
+isa
 nfl
 hRu
 aIE
@@ -189780,7 +189769,7 @@ aIE
 uhn
 pJd
 pJd
-pJd
+wew
 pJd
 pJd
 wtf
@@ -189981,13 +189970,13 @@ hRu
 aIE
 uhn
 pJd
-hRu
+jIz
 wtf
 wtf
 aIE
 aIE
 aIE
-pJd
+wew
 hRu
 aIE
 aIE
@@ -190189,7 +190178,7 @@ aIE
 aIE
 aIE
 uhn
-pJd
+wew
 hRu
 aIE
 aIE
@@ -190788,7 +190777,7 @@ jsU
 hRu
 aIE
 aIE
-pJd
+wew
 drv
 aIE
 aIE
@@ -190995,7 +190984,7 @@ drv
 qif
 qif
 jiQ
-hRu
+mAy
 xbE
 pJd
 hRu
@@ -191196,9 +191185,9 @@ pJd
 hRu
 aIE
 aIE
+ats
 hRu
-hRu
-hRu
+jIz
 tMB
 hRu
 aIE
@@ -191399,8 +191388,8 @@ hRu
 aIE
 aIE
 paY
-hRu
-paY
+ats
+est
 qif
 hRu
 aIE
@@ -191797,8 +191786,8 @@ hRu
 hRu
 hRu
 aIE
-uhn
-pJd
+aIE
+wew
 gIC
 aIE
 aIE
@@ -191999,7 +191988,7 @@ hRu
 hRu
 hRu
 aIE
-uhn
+aIE
 pJd
 aIE
 aIE
@@ -216408,10 +216397,10 @@ iRG
 iRG
 iRG
 iRG
-kOj
-kOj
-kOj
-kOj
+kTO
+kTO
+kTO
+kTO
 kOj
 kOj
 tfW
@@ -216457,7 +216446,7 @@ eNc
 eNc
 eNc
 gsI
-tUo
+gsI
 gsI
 gsI
 gsI
@@ -216609,11 +216598,11 @@ iRG
 kTO
 kTO
 kTO
-rTe
-kOj
-kOj
-kOj
-kOj
+kTO
+bCJ
+hlB
+ieb
+kTO
 kOj
 kOj
 tfW
@@ -216811,11 +216800,11 @@ kTO
 ryY
 ryY
 kTO
-rTe
-kOj
-kOj
-kOj
-kOj
+ten
+woI
+woI
+kTO
+kTO
 kOj
 kOj
 fqz
@@ -217015,8 +217004,8 @@ ryY
 ryY
 ryY
 rfo
-kOj
-kOj
+nYY
+kTO
 xkT
 tfW
 cri
@@ -217819,7 +217808,7 @@ kOj
 iGL
 fqz
 fqz
-woI
+ndz
 ryY
 ryY
 cxU
@@ -218253,7 +218242,7 @@ phr
 gsI
 gsI
 gsI
-eNc
+pGM
 lKW
 bZl
 bZl
@@ -218262,7 +218251,7 @@ bZl
 bZl
 bZl
 bZl
-eNc
+ewk
 knY
 pVn
 knY
@@ -218455,18 +218444,18 @@ tMW
 gsI
 gsI
 gsI
-eNc
-lKW
-bZl
-bZl
-bZl
-bZl
-bZl
-bZl
-bZl
-eNc
+uxn
+mmh
+mmh
+mmh
+mmh
+mmh
+mmh
+mmh
+mmh
+uxn
 hPl
-lqH
+rYV
 lqH
 hPl
 eNc
@@ -218657,19 +218646,19 @@ phr
 gsI
 gsI
 gsI
-eNc
-lKW
-bZl
-bZl
-bZl
-bZl
-bZl
-bZl
-bZl
-eNc
+uxn
+prJ
+prJ
+prJ
+prJ
+prJ
+prJ
+prJ
+prJ
+uxn
+prX
 cdL
-cdL
-cdL
+prX
 cdL
 eNc
 bZl
@@ -218832,7 +218821,7 @@ tfW
 hsf
 hro
 lOm
-wsJ
+tfW
 wcY
 tZJ
 wnV
@@ -218859,7 +218848,7 @@ gsI
 gsI
 gsI
 gsI
-eNc
+pGM
 lKW
 bZl
 bZl
@@ -218868,7 +218857,7 @@ bZl
 bZl
 dMx
 bZl
-gsI
+edF
 gNN
 sWe
 pLq
@@ -219036,7 +219025,7 @@ xBg
 tZJ
 mRZ
 tZJ
-wDQ
+tZJ
 cbI
 hsf
 tfW
@@ -219274,7 +219263,7 @@ bZl
 bZl
 gsI
 qtA
-sWe
+bum
 sWe
 eNc
 eNc
@@ -219436,7 +219425,7 @@ tfW
 tfW
 tfW
 hsf
-wDQ
+tZJ
 fqz
 igB
 hsf
@@ -219642,7 +219631,7 @@ heY
 iEe
 cri
 raN
-wDQ
+tZJ
 luh
 hsf
 sem
@@ -224126,7 +224115,7 @@ phr
 phr
 phr
 gsI
-tUo
+gsI
 gsI
 phr
 phr
@@ -224326,7 +224315,7 @@ phr
 phr
 phr
 phr
-lzF
+phr
 phr
 phr
 phr
@@ -224735,7 +224724,7 @@ tfW
 tfW
 cXA
 tfW
-wsJ
+tfW
 tfW
 tfW
 tfW
@@ -225338,10 +225327,10 @@ dlA
 tfW
 tfW
 tfW
-cxU
-cxU
-jIz
-jIz
+tfW
+tfW
+tfW
+tfW
 tfW
 tfW
 tfW
@@ -225539,15 +225528,15 @@ oHv
 tym
 pCD
 tfW
-cxU
-wew
-wew
-obd
-wew
-cxU
 tfW
 tfW
-iGL
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
 kOj
 kOj
 kOj
@@ -225741,15 +225730,15 @@ oLm
 nCw
 tfW
 rjZ
-cxU
-bIc
-jIz
-jIz
-obd
-wew
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
 cxU
 oHv
-ten
+tfW
 kOj
 kOj
 kOj
@@ -225944,15 +225933,15 @@ jsS
 okD
 tfW
 cxU
-giB
-wew
-qqS
-nYY
-ieb
-wew
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
 cxU
-pGM
-jIz
+tfW
+tfW
 kOj
 kOj
 kOj
@@ -226141,20 +226130,20 @@ oHv
 xCl
 kOj
 kOj
-hlB
-ats
+tfW
+tfW
 oHv
 tfW
-cxU
-srv
-bIc
-ieb
-ieb
-obd
-cxU
-jIz
-uzy
-jIz
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
 kOj
 kOj
 kOj
@@ -226342,23 +226331,23 @@ cAF
 oHv
 wQf
 jBW
-wew
-oqo
-noj
-cxU
-qqS
+tfW
+tfW
+tfW
+tfW
+tfW
 tIk
-cxU
+tfW
 uDA
-prX
-prJ
-prJ
-jIz
+tfW
+tfW
+tfW
+tfW
 tfW
 rPI
-sWc
-mDn
-jIz
+tfW
+tfW
+tfW
 kOj
 kOj
 kOj
@@ -226544,24 +226533,24 @@ tfW
 fBh
 erZ
 jBW
-oqo
-jIz
-cxU
-dlA
-qqS
+tfW
+tfW
+tfW
+pCD
+tfW
+wcY
+wcY
 cPL
-cPL
-cPL
-nuk
-bqU
-jIz
-jIz
-jIz
+tfW
+tfW
+tfW
+tfW
+tfW
 rPI
-jIz
-pLI
-isa
-iaB
+tfW
+tfW
+tfW
+tfW
 slP
 kOj
 kOj
@@ -226745,26 +226734,26 @@ tfW
 raN
 oHv
 oHv
-wew
-jIz
-cxU
-cxU
-bCJ
-qqS
-edF
-bjd
-giB
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
 bNi
-qqS
+tfW
 nuk
-bum
-jIz
+tfW
+tfW
 rPI
 tfW
 xDL
 tfW
 tfW
-mmh
+tfW
 wgZ
 duP
 kOj
@@ -226949,24 +226938,24 @@ erZ
 tfW
 fBh
 tfW
-cxU
+tfW
 tfW
 pCD
 fBh
-jIz
-wew
-wMi
-htk
-cLf
-obd
-giB
-wew
-jIz
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
 mbZ
 tfW
 bSm
 tfW
-mHC
+tfW
 oHv
 uzy
 ucy
@@ -227150,10 +227139,10 @@ tfW
 fBh
 erZ
 erZ
-cxU
+tfW
 tfW
 ePQ
-est
+cxU
 cNG
 mkR
 mkR
@@ -227162,9 +227151,9 @@ mkR
 cxU
 cNG
 mkR
-rYV
-rYV
-jIz
+tfW
+tfW
+tfW
 cxU
 cxU
 cNG
@@ -227353,9 +227342,9 @@ srv
 srv
 cxU
 cxU
-qXp
-ihc
-ihc
+cNG
+srv
+mMF
 eJk
 eJk
 eJk
@@ -227364,9 +227353,9 @@ ihc
 eJk
 ihc
 eJk
-eJk
-ihc
-mMF
+srv
+obd
+cxU
 eJk
 eJk
 ihc
@@ -227761,12 +227750,12 @@ ihc
 eJk
 eJk
 mMF
-mMF
-ihc
-mMF
-mMF
-eJk
-mMF
+srv
+tJT
+srv
+cxU
+srv
+cxU
 mMF
 mMF
 mMF
@@ -227956,29 +227945,29 @@ mMF
 mMF
 mMF
 cxU
-uNO
-uNO
-rgB
-rgB
-rgB
-uNO
-uNO
-rgB
-rgB
-mMF
-mMF
-qNz
-uNO
-qNz
-uNO
-uNO
-fLZ
-fLZ
-fLZ
-uNO
-uNO
-uNO
-uNO
+cxU
+cxU
+srv
+srv
+srv
+cxU
+cxU
+erZ
+erZ
+tfW
+tfW
+oZR
+cxU
+lzF
+cxU
+cxU
+asR
+qZG
+qZG
+tfW
+tfW
+tfW
+tfW
 jBW
 bOV
 "}
@@ -228166,21 +228155,21 @@ qNz
 rgB
 wAv
 xOG
-eTi
+lEs
 mat
 nST
 eTi
 hpq
-hpq
-gvy
-gvy
-hpq
-hpq
+ovz
+tmw
+tmw
+ovz
+ovz
 cFN
-gvy
-hpq
-eTi
-eTi
+tmw
+ovz
+lEs
+lEs
 jBW
 kOj
 "}
@@ -228357,32 +228346,32 @@ cxU
 cxU
 cxU
 mkR
-mkR
-uNO
-uNO
-qNz
-uNO
-rgB
-qNz
-uNO
-uNO
-rgB
-uNO
+vaP
+tfW
+tfW
+oZR
+tfW
+erZ
+oZR
+tfW
+tfW
+erZ
+eUV
 szI
-ihc
-eJk
+cLf
+qqS
 fLZ
-rgB
-uNO
-uNO
+erZ
+eUV
+eUV
 fLZ
-uNO
+eUV
 fLZ
-uNO
-uNO
-uNO
-rsR
-fLZ
+eUV
+eUV
+tfW
+lOm
+qZG
 jBW
 kOj
 "}
@@ -228559,21 +228548,21 @@ cxU
 cxU
 cxU
 mkR
-cNG
-uNO
-uNO
-uNO
-uNO
-uNO
-uNO
-uNO
-fLZ
-rgB
-uNO
+pLe
+tfW
+tfW
+tfW
+tfW
+tfW
+tfW
+eUV
+qZG
+erZ
+eUV
 nkv
 oZR
 kRl
-fLZ
+qZG
 dAX
 dAX
 dAX
@@ -228584,7 +228573,7 @@ dAX
 dAX
 dAX
 dAX
-uNO
+tfW
 iGL
 kTO
 "}
@@ -228762,20 +228751,20 @@ cxU
 mkR
 twj
 gbZ
-mAy
-mAy
-hpq
-hpq
+lEs
+lEs
+ovz
+ovz
+lEs
 eTi
 eTi
-eTi
-eTi
-hpq
+lEs
+ovz
 szI
 nwX
 oZR
-uxn
-fLZ
+qZG
+qZG
 dAX
 dAX
 dAX
@@ -228786,7 +228775,7 @@ dAX
 dAX
 dAX
 dAX
-fLZ
+qZG
 xkT
 kTO
 "}
@@ -228963,21 +228952,21 @@ cxU
 cxU
 cxU
 mkR
-mAy
-cxU
-asR
-uNO
-uNO
+lEs
+tfW
+qZG
+tfW
+tfW
+qZG
+eUV
 fLZ
-uNO
-fLZ
-uNO
-fLZ
-uNO
-fLZ
-uxn
-uxn
-fLZ
+eUV
+qZG
+eUV
+qZG
+qZG
+qZG
+qZG
 dAX
 dAX
 dAX
@@ -229165,8 +229154,8 @@ cxU
 cxU
 cxU
 cxU
-mAy
-cxU
+lEs
+tfW
 dAX
 dAX
 dAX
@@ -229190,7 +229179,7 @@ dAX
 dAX
 dAX
 dAX
-uNO
+eUV
 kOj
 kTO
 "}
@@ -229368,7 +229357,7 @@ cxU
 cxU
 cxU
 fev
-cxU
+tfW
 dAX
 dAX
 dAX
@@ -229392,7 +229381,7 @@ dAX
 dAX
 dAX
 dAX
-uNO
+eUV
 ouf
 kTO
 "}
@@ -229570,7 +229559,7 @@ cxU
 cxU
 cxU
 fev
-cxU
+tfW
 dAX
 dAX
 dAX
@@ -229581,7 +229570,7 @@ qnK
 oVF
 oVF
 rZL
-rLw
+bqU
 uBg
 gUQ
 dAX
@@ -229594,7 +229583,7 @@ dAX
 dAX
 dAX
 dAX
-uNO
+eUV
 jBW
 kTO
 "}
@@ -229771,8 +229760,8 @@ cxU
 cxU
 cxU
 cxU
-mAy
-cxU
+lEs
+tfW
 gUQ
 gUQ
 gUQ
@@ -229796,7 +229785,7 @@ dAX
 dAX
 dAX
 dAX
-uNO
+tfW
 rCt
 kTO
 "}
@@ -229974,7 +229963,7 @@ cxU
 cxU
 asR
 tmw
-cxU
+tfW
 dAX
 dAX
 dAX
@@ -229983,7 +229972,7 @@ aeb
 crJ
 rLw
 rLw
-rLw
+bqU
 rLw
 rLw
 uBg
@@ -229998,7 +229987,7 @@ dAX
 dAX
 dAX
 dAX
-fLZ
+qZG
 iGL
 kTO
 "}
@@ -230175,8 +230164,8 @@ cxU
 cxU
 cxU
 cxU
-tJT
-cxU
+ovz
+tfW
 dAX
 dAX
 dAX
@@ -230200,7 +230189,7 @@ dAX
 dAX
 dAX
 dAX
-fLZ
+qZG
 jBW
 kTO
 "}
@@ -230377,8 +230366,8 @@ cxU
 cxU
 cxU
 cxU
-mAy
-asR
+lEs
+qZG
 dAX
 dAX
 dAX
@@ -230402,7 +230391,7 @@ dAX
 dAX
 dAX
 dAX
-fLZ
+qZG
 iGL
 kTO
 "}
@@ -230579,13 +230568,13 @@ cxU
 cxU
 cxU
 cxU
-mAy
+lEs
 llK
-cxU
-asR
-cxU
-cxU
-cxU
+tfW
+qZG
+tfW
+tfW
+bjd
 gUQ
 gUQ
 dAX
@@ -230604,7 +230593,7 @@ dAX
 dAX
 dAX
 dAX
-fLZ
+qZG
 ucy
 kTO
 "}
@@ -230781,13 +230770,13 @@ cxU
 cxU
 cxU
 cxU
-tJT
-asR
-cxU
-cxU
-asR
-cxU
-asR
+ovz
+qZG
+tfW
+cXA
+oqo
+tfW
+bIc
 dAX
 gUQ
 dAX
@@ -230806,7 +230795,7 @@ dAX
 dAX
 dAX
 dAX
-fLZ
+qZG
 jBW
 kTO
 "}
@@ -230983,32 +230972,32 @@ cxU
 cxU
 cxU
 cxU
-mAy
-cxU
-cxU
-asR
-cxU
-asR
-cxU
+lEs
+tfW
+eUV
+qZG
+eUV
+qZG
+tfW
 dAX
 gUQ
 dAX
 dAX
 aeb
 rLw
-dAX
-dAX
+ucU
+rsR
 ccE
-fLZ
-fLZ
-fLZ
-uNO
-fLZ
-uNO
-uNO
-uNO
-fLZ
-tIB
+qZG
+qZG
+qZG
+cXA
+gvy
+eUV
+eUV
+tfW
+qZG
+uTf
 iGL
 kTO
 "}
@@ -231185,32 +231174,32 @@ cxU
 cxU
 cxU
 cxU
-mAy
-cxU
-cxU
-asR
-cxU
-asR
-cxU
+lEs
+tfW
+eUV
+fLZ
+eUV
+wMi
+tfW
 rLw
 rLw
-rLw
+bqU
 rLw
 rLw
 rLw
 dAX
 dAX
 gUQ
+gvy
+qZG
+qZG
+eUV
+fLZ
+qZG
 fLZ
 fLZ
-fLZ
-uNO
-fLZ
-fLZ
-fLZ
-fLZ
-uNO
-uNO
+eUV
+bSm
 xkT
 kTO
 "}
@@ -231387,13 +231376,13 @@ tfW
 cxU
 cxU
 cxU
-mAy
-asR
-cxU
-cxU
-cxU
-cxU
-cxU
+lEs
+qZG
+tfW
+eUV
+eUV
+tIB
+tfW
 gUQ
 sok
 jPU
@@ -231403,16 +231392,16 @@ rLw
 uBg
 dAX
 gUQ
+qZG
+qZG
+tfW
+qZG
+tfW
+eUV
 fLZ
-fLZ
-uNO
-fLZ
-uNO
-uNO
-fLZ
-uNO
-uNO
-uNO
+eUV
+tfW
+tfW
 jBW
 kTO
 "}
@@ -231589,13 +231578,13 @@ tfW
 tfW
 tfW
 cxU
-mAy
-cxU
-cxU
-cxU
-cxU
-asR
-asR
+lEs
+tfW
+eUV
+eUV
+tfW
+fLZ
+qZG
 gUQ
 jPU
 jPU
@@ -231605,17 +231594,17 @@ rLw
 rLw
 dAX
 gUQ
+qZG
+cXA
+qZG
+qZG
+tfW
+tfW
+eUV
 fLZ
-ewk
-fLZ
-fLZ
-uNO
-uNO
-uNO
-fLZ
-uNO
-uNO
-iGL
+bSm
+kOj
+kOj
 kTO
 "}
 (155,1,3) = {"
@@ -231791,13 +231780,13 @@ tfW
 tfW
 tfW
 tfW
-eTi
-cxU
-cxU
-cxU
-asR
-asR
-asR
+lEs
+tfW
+eUV
+eUV
+oqo
+qZG
+qZG
 gUQ
 gHd
 mvP
@@ -231812,11 +231801,11 @@ dAX
 dAX
 dAX
 dAX
-uNO
-uNO
+eUV
+eUV
 fLZ
-uNO
-uNO
+cXA
+kOj
 kOj
 kTO
 "}
@@ -231993,20 +231982,20 @@ tfW
 rrL
 aff
 aff
-eTi
-ucU
-uNO
-uNO
-uNO
-llK
-cxU
+lEs
+wjb
+tfW
+tfW
+tfW
+qjm
+tfW
 gUQ
 gUQ
 gUQ
 gUQ
 gUQ
 gUQ
-rLw
+bqU
 uBg
 dAX
 gUQ
@@ -232014,12 +232003,12 @@ dAX
 dAX
 dAX
 dAX
-uNO
+eUV
 fLZ
-qZG
+fLZ
 tfW
-tfW
-iGL
+jBW
+kOj
 kTO
 "}
 (157,1,3) = {"
@@ -232195,12 +232184,12 @@ aff
 aff
 tfW
 tfW
-eTi
-uNO
+lEs
+tfW
+qZG
+cXA
+llK
 fLZ
-uNO
-qjm
-asR
 raM
 dAX
 dAX
@@ -232216,9 +232205,9 @@ dAX
 dAX
 dAX
 dAX
-uNO
-uNO
 tfW
+eUV
+eUV
 tfW
 uTf
 jBW
@@ -232397,12 +232386,12 @@ tfW
 fqz
 tfW
 fqz
-hpq
-fLZ
-uNO
-fLZ
+ovz
+qZG
+tfW
+qZG
 qjm
-cxU
+tfW
 raM
 gUQ
 gUQ
@@ -232418,7 +232407,7 @@ dAX
 dAX
 dAX
 dAX
-uNO
+tfW
 fLZ
 tfW
 tfW
@@ -232599,8 +232588,8 @@ kYW
 fqz
 fqz
 fqz
-eTi
-uNO
+lEs
+tfW
 dAX
 dAX
 dAX
@@ -232620,8 +232609,8 @@ dAX
 dAX
 dAX
 dAX
-uNO
-uNO
+tfW
+tIB
 tfW
 qZG
 iGL
@@ -232801,15 +232790,15 @@ fqz
 fqz
 fqz
 cXA
-eTi
-uNO
+lEs
+tfW
 dAX
 dAX
 dAX
 dAX
 gUQ
 rLw
-rLw
+bqU
 rLw
 rLw
 rLw
@@ -232822,8 +232811,8 @@ gUQ
 gUQ
 gUQ
 gUQ
-uNO
-uNO
+tfW
+eUV
 tfW
 tfW
 itf
@@ -233003,8 +232992,8 @@ keX
 fqz
 fqz
 tfW
-eTi
-uNO
+lEs
+tfW
 dAX
 dAX
 dAX
@@ -233024,10 +233013,10 @@ dAX
 dAX
 dAX
 dAX
-fLZ
-uNO
-lOm
-tfW
+qZG
+eUV
+noj
+eUV
 kOj
 kOj
 kTO
@@ -233205,7 +233194,7 @@ tfW
 tfW
 fqz
 tfW
-eTi
+lEs
 fLZ
 gUQ
 gUQ
@@ -233226,9 +233215,9 @@ dAX
 dAX
 dAX
 dAX
-uNO
-uNO
-tfW
+eUV
+eUV
+tIB
 tfW
 iGL
 kOj
@@ -233407,7 +233396,7 @@ tfW
 tfW
 fqz
 tfW
-eTi
+lEs
 fLZ
 dAX
 dAX
@@ -233428,9 +233417,9 @@ dAX
 dAX
 dAX
 dAX
-uNO
-uNO
-tfW
+eUV
+eUV
+eUV
 tfW
 iGL
 qYC
@@ -233609,8 +233598,8 @@ tHS
 tfW
 tfW
 mHv
-eTi
-uNO
+lEs
+eUV
 dAX
 dAX
 dAX
@@ -233625,12 +233614,12 @@ gUQ
 uoh
 gUQ
 gUQ
-uNO
-uNO
-uNO
-uNO
-uNO
-fLZ
+tfW
+tfW
+tfW
+tfW
+cXA
+qZG
 fLZ
 tfW
 tfW
@@ -233811,8 +233800,8 @@ tfW
 tfW
 tfW
 bSm
-eTi
-fLZ
+lEs
+qZG
 dAX
 dAX
 dAX
@@ -233827,12 +233816,12 @@ dAX
 gUQ
 dAX
 dAX
-uNO
-uNO
-uNO
-qjm
-uNO
-uNO
+eUV
+eUV
+eUV
+llK
+tfW
+tfW
 iEn
 txQ
 kEV
@@ -234013,29 +234002,29 @@ tfW
 txQ
 txQ
 tfW
-eTi
+lEs
+qZG
+tfW
+eUV
+eUV
+eUV
+eUV
+eUV
+eUV
+eUV
 fLZ
-uNO
-uNO
-uNO
-uNO
-uNO
-uNO
-uNO
-uNO
 fLZ
-fLZ
-uNO
-uNO
-fLZ
-uNO
-uNO
-hpq
-hpq
-eTi
-eTi
-eTi
-hpq
+eUV
+eUV
+qZG
+tfW
+eUV
+ovz
+ovz
+lEs
+lEs
+lEs
+ovz
 lEs
 lEs
 lEs
@@ -234215,23 +234204,23 @@ iSI
 tfW
 tfW
 tfW
-eTi
-eTi
-eTi
-eTi
-eTi
-eTi
-hpq
-hpq
-hpq
-eTi
-eTi
-eTi
-eTi
-eTi
-hpq
-eTi
-hpq
+lEs
+lEs
+lEs
+lEs
+lEs
+lEs
+ovz
+ovz
+ovz
+lEs
+lEs
+lEs
+lEs
+lEs
+ovz
+lEs
+ovz
 ovz
 tfW
 keX

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -1792,13 +1792,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
-"ats" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -15;
-	pixel_y = -10
-	},
-/turf/simulated/mineral,
-/area/nadezhda/outside/scave)
 "atw" = (
 /obj/effect/floor_decal/spline/wood,
 /turf/simulated/floor/wood/wild3,
@@ -5626,12 +5619,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
-"bjd" = (
-/obj/structure/flora/big/bush1{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "bjf" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -6290,12 +6277,13 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
 "bqU" = (
-/obj/structure/lattice,
-/obj/structure/catwalk{
-	icon_state = "catwalk-broken"
+/obj/structure/flora/big/bush1,
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
 	},
-/turf/simulated/open,
-/area/nadezhda/dungeon/outside/abandoned_outpost)
+/turf/simulated/mineral,
+/area/nadezhda/outside/scave)
 "bqV" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warningwhite{
@@ -6590,10 +6578,16 @@
 	name = "Residential District Maintenance"
 	})
 "bum" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/random/junkfood/low_chance,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/lakeside)
+/mob/living/simple_animal/hostile/snake{
+	faction = "neutral";
+	name = "crimson viper";
+	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm.";
+	color = "#f7140c";
+	maxHealth = 250;
+	health = 250
+	},
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/forest)
 "buo" = (
 /obj/structure/sign/warning/smoking/small,
 /turf/simulated/wall/r_wall,
@@ -7417,10 +7411,10 @@
 	},
 /area/shuttle/vasiliy_shuttle_area)
 "bCJ" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -15
-	},
-/turf/unsimulated/mineral,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "bCL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
@@ -7895,9 +7889,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "bIc" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/grass,
+/obj/structure/boulder,
+/turf/simulated/floor/rock,
 /area/nadezhda/outside/forest)
 "bIf" = (
 /turf/simulated/floor/tiled/techmaint_panels,
@@ -12887,11 +12880,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"cLf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "cLm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -19701,12 +19689,12 @@
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/atmos)
 "edF" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
 	},
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/lakeside)
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/forest)
 "edJ" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/disposalpipe/segment{
@@ -21273,9 +21261,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/engineering/atmos/surface)
 "est" = (
-/obj/structure/flora/big/bush1,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/outside/scave)
+/obj/structure/lattice,
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
+	},
+/turf/simulated/open,
+/area/nadezhda/dungeon/outside/abandoned_outpost)
 "esy" = (
 /obj/random/structures/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -21580,12 +21571,12 @@
 	name = "Residential District Maintenance"
 	})
 "ewk" = (
-/obj/structure/railing{
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
 	dir = 1;
-	tag = "icon-railing0 (NORTH)"
+	pixel_y = -10
 	},
-/turf/simulated/floor/beach/sand,
-/area/nadezhda/outside/lakeside)
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/abandoned_outpost)
 "ewn" = (
 /obj/structure/boulder,
 /obj/structure/disposalpipe/segment{
@@ -30114,6 +30105,11 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
+"giB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "giE" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -31431,7 +31427,9 @@
 /area/nadezhda/outside/inside_colony)
 "gvy" = (
 /obj/effect/decal/cleanable/rubble,
-/obj/structure/flora/big/bush2,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/grille,
+/obj/structure/barricade,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "gvz" = (
@@ -35141,7 +35139,9 @@
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/sleeper)
 "hlB" = (
-/turf/simulated/floor/rock,
+/obj/effect/decal/cleanable/rubble,
+/obj/random/flora/small_jungle_tree,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "hlG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -35786,6 +35786,17 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
+"htk" = (
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/forest)
 "htn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39254,6 +39265,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/maingate)
+"iaB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/asteroid/dirt,
+/area/nadezhda/outside/forest)
 "iaF" = (
 /mob/living/simple_animal/hostile/jelly/bloat,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -39607,15 +39623,9 @@
 /turf/simulated/floor/fixed/hydrotile,
 /area/nadezhda/engineering/engine_room)
 "ieb" = (
-/mob/living/simple_animal/hostile/snake{
-	faction = "neutral";
-	name = "crimson viper";
-	desc = "A ferocious, fang-bearing creature that resembles a snake. It seems to be rather calm.";
-	color = "#f7140c";
-	maxHealth = 250;
-	health = 250
-	},
-/turf/simulated/floor/rock,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/rubble,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
 "iee" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -39864,10 +39874,6 @@
 /obj/structure/flora/small/trailrocka3,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"igB" = (
-/obj/structure/table/bench/wooden,
-/turf/simulated/wall/wood_old,
-/area/nadezhda/outside/forest)
 "igD" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -40926,9 +40932,8 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "isa" = (
-/obj/structure/flora/big/bush1,
 /obj/structure/flora/big/bush1{
-	pixel_x = -10;
+	pixel_x = -15;
 	pixel_y = -10
 	},
 /turf/simulated/mineral,
@@ -47323,11 +47328,11 @@
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "jIz" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -10;
-	pixel_y = -10
+/obj/structure/lattice,
+/obj/structure/catwalk{
+	icon_state = "catwalk-broken"
 	},
-/turf/simulated/mineral,
+/turf/simulated/open,
 /area/nadezhda/outside/scave)
 "jIA" = (
 /obj/structure/flora/big/bush2,
@@ -55861,11 +55866,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
-"lzF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/rubble,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
 "lzO" = (
 /obj/structure/table/rack/shelf,
 /obj/item/stock_parts/capacitor/excelsior,
@@ -59553,9 +59553,10 @@
 	})
 "mmh" = (
 /obj/structure/railing{
-	dir = 8
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
 	},
-/turf/simulated/floor/wood/wild5,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/lakeside)
 "mmj" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
@@ -60862,13 +60863,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
-"mAy" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -15;
-	pixel_y = -25
-	},
-/turf/simulated/mineral,
-/area/nadezhda/outside/scave)
 "mAD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green,
@@ -61641,6 +61635,11 @@
 /area/nadezhda/maintenance/undergroundfloor2west)
 "mHv" = (
 /obj/random/flora/jungle_tree,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
+"mHC" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "mHE" = (
@@ -64788,10 +64787,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "noj" = (
-/obj/structure/flora/small/rock5,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/obj/structure/railing{
+	dir = 1;
+	tag = "icon-railing0 (NORTH)"
+	},
+/turf/simulated/floor/beach/sand,
+/area/nadezhda/outside/lakeside)
 "nol" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -68500,10 +68501,9 @@
 /area/nadezhda/maintenance/undergroundfloor2north)
 "nYY" = (
 /obj/structure/flora/big/bush1{
-	pixel_x = -10;
 	pixel_y = -10
 	},
-/turf/unsimulated/mineral,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "nYZ" = (
 /obj/structure/flora/big/bush1,
@@ -68741,10 +68741,9 @@
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
 "obd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/structure/railing,
+/turf/simulated/floor/beach/sand,
+/area/nadezhda/outside/lakeside)
 "obl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70181,12 +70180,9 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
 "oqo" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/flora/big/bush1{
-	pixel_y = -10
-	},
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/obj/structure/flora/big/bush1,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/outside/scave)
 "oqq" = (
 /obj/structure/closet/secure_closet/personal/orderly,
 /obj/machinery/light{
@@ -75353,7 +75349,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "prJ" = (
 /obj/structure/railing{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/lakeside)
@@ -75370,10 +75366,10 @@
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "prX" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/table/bench/wooden,
+/obj/structure/flora/small/rock5,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/lakeside)
+/area/nadezhda/outside/forest)
 "prZ" = (
 /obj/machinery/door/blast/shutters/glass{
 	name = "Fireplace Cover"
@@ -76802,9 +76798,12 @@
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "pGM" = (
-/obj/structure/railing,
-/turf/simulated/floor/beach/sand,
-/area/nadezhda/outside/lakeside)
+/obj/structure/flora/big/bush1{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/turf/simulated/mineral,
+/area/nadezhda/outside/scave)
 "pGS" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -80412,11 +80411,6 @@
 /obj/random/ammo,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"qqS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "qra" = (
 /obj/structure/table/standard,
 /obj/random/cloth/armor/low_chance,
@@ -85379,12 +85373,10 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "rsR" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	dir = 1;
-	pixel_y = -10
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/abandoned_outpost)
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/lakeside)
 "rtf" = (
 /obj/random/structures,
 /turf/simulated/floor/tiled/techmaint,
@@ -88359,8 +88351,7 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "rYV" = (
-/obj/machinery/microwave/burnbarrel,
-/turf/simulated/floor/asteroid/dirt/dust,
+/turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/lakeside)
 "rYX" = (
 /obj/structure/disposalpipe/segment{
@@ -93099,6 +93090,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"sWc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "sWd" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/wood/wild3,
@@ -93863,16 +93859,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
 "ten" = (
-/obj/structure/flora/big/bush1{
-	pixel_x = -10;
-	pixel_y = -10
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	pixel_y = 10
 	},
-/obj/structure/flora/big/bush1{
-	pixel_x = -15;
-	pixel_y = -25
-	},
-/turf/unsimulated/mineral,
-/area/nadezhda/outside/forest)
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/dungeon/outside/abandoned_outpost)
 "tes" = (
 /obj/structure/showcase{
 	desc = "Ancient robotic frame, that is long deactivated and rusted solid. However, it still strikes am awesome pose, that somehow makes you think of justice and righteousness.";
@@ -94574,9 +94565,10 @@
 /area/nadezhda/crew_quarters/hydroponics)
 "tmw" = (
 /obj/effect/decal/cleanable/rubble,
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/grille,
-/obj/structure/barricade,
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "tmz" = (
@@ -96685,11 +96677,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"tIB" = (
-/obj/random/flora/small_jungle_tree,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
 "tIG" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/machinery/light/small,
@@ -96861,11 +96848,11 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/absolutism/hallways)
 "tJT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/forest)
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/outside/lakeside)
 "tJY" = (
 /obj/random/scrap/sparse_weighted/low_chance,
 /turf/simulated/floor/asteroid/dirt,
@@ -97984,6 +97971,12 @@
 	opacity = 0
 	},
 /area/shuttle/surface_transport_lz)
+"tUo" = (
+/obj/structure/flora/big/bush1{
+	pixel_x = -15
+	},
+/turf/unsimulated/mineral,
+/area/nadezhda/outside/forest)
 "tUr" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
@@ -98776,12 +98769,6 @@
 	tag = "icon-escpodwall17"
 	},
 /area/nadezhda/crew_quarters/sleep/bedrooms)
-"ucU" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	pixel_y = 10
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/dungeon/outside/abandoned_outpost)
 "ucV" = (
 /obj/structure/table/steel,
 /obj/random/lowkeyrandom/low_chance,
@@ -100715,8 +100702,12 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
 "uxn" = (
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/outside/lakeside)
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/flora/big/bush1{
+	pixel_y = -10
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/nadezhda/outside/forest)
 "uxo" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -109242,12 +109233,8 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/east)
 "wew" = (
-/obj/structure/lattice,
-/obj/structure/catwalk{
-	icon_state = "catwalk-broken"
-	},
-/turf/simulated/open,
-/area/nadezhda/outside/scave)
+/turf/simulated/floor/rock,
+/area/nadezhda/outside/forest)
 "wez" = (
 /obj/item/material/shard,
 /obj/item/tool/broken_bottle,
@@ -110151,8 +110138,9 @@
 /turf/simulated/floor/asteroid/dirt/dark/plough,
 /area/nadezhda/crew_quarters/hydroponics/garden)
 "woI" = (
-/obj/structure/boulder,
-/turf/simulated/floor/rock,
+/obj/random/flora/small_jungle_tree,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
 "woR" = (
 /obj/machinery/light_switch{
@@ -110748,6 +110736,10 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"wsJ" = (
+/obj/machinery/microwave/burnbarrel,
+/turf/simulated/floor/asteroid/dirt/dust,
+/area/nadezhda/outside/lakeside)
 "wsT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -111675,6 +111667,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"wDQ" = (
+/obj/structure/flora/big/bush1{
+	pixel_x = -15;
+	pixel_y = -25
+	},
+/turf/simulated/mineral,
+/area/nadezhda/outside/scave)
 "wDS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -112402,13 +112401,10 @@
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2west)
 "wMi" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/flora/big/bush1{
-	pixel_y = -10
-	},
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/random/junkfood/low_chance,
 /turf/simulated/floor/asteroid/grass,
-/area/nadezhda/outside/forest)
+/area/nadezhda/outside/lakeside)
 "wMl" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "13,0"
@@ -114926,9 +114922,9 @@
 /area/shuttle/rocinante_shuttle_area)
 "xoo" = (
 /obj/machinery/microwave/burnbarrel,
-/obj/random/common_oddities/low_chance,
 /obj/effect/decal/cleanable/ash,
-/turf/simulated/wall/wood_old,
+/obj/random/common_oddities/low_chance,
+/turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
 "xos" = (
 /obj/structure/flora/small/busha1,
@@ -189367,9 +189363,9 @@ qif
 ary
 pJd
 pJd
-wew
+jIz
 nfl
-isa
+bqU
 nfl
 hRu
 aIE
@@ -189769,7 +189765,7 @@ aIE
 uhn
 pJd
 pJd
-wew
+jIz
 pJd
 pJd
 wtf
@@ -189970,13 +189966,13 @@ hRu
 aIE
 uhn
 pJd
+pGM
+wtf
+wtf
+aIE
+aIE
+aIE
 jIz
-wtf
-wtf
-aIE
-aIE
-aIE
-wew
 hRu
 aIE
 aIE
@@ -190178,7 +190174,7 @@ aIE
 aIE
 aIE
 uhn
-wew
+jIz
 hRu
 aIE
 aIE
@@ -190777,7 +190773,7 @@ jsU
 hRu
 aIE
 aIE
-wew
+jIz
 drv
 aIE
 aIE
@@ -190984,7 +190980,7 @@ drv
 qif
 qif
 jiQ
-mAy
+wDQ
 xbE
 pJd
 hRu
@@ -191185,9 +191181,9 @@ pJd
 hRu
 aIE
 aIE
-ats
+isa
 hRu
-jIz
+pGM
 tMB
 hRu
 aIE
@@ -191388,8 +191384,8 @@ hRu
 aIE
 aIE
 paY
-ats
-est
+isa
+oqo
 qif
 hRu
 aIE
@@ -191787,7 +191783,7 @@ hRu
 hRu
 aIE
 aIE
-wew
+jIz
 gIC
 aIE
 aIE
@@ -216599,9 +216595,9 @@ kTO
 kTO
 kTO
 kTO
-bCJ
-hlB
-ieb
+tUo
+wew
+bum
 kTO
 kOj
 kOj
@@ -216800,9 +216796,9 @@ kTO
 ryY
 ryY
 kTO
-ten
-woI
-woI
+htk
+bIc
+bIc
 kTO
 kTO
 kOj
@@ -217004,7 +217000,7 @@ ryY
 ryY
 ryY
 rfo
-nYY
+edF
 kTO
 xkT
 tfW
@@ -218242,7 +218238,7 @@ phr
 gsI
 gsI
 gsI
-pGM
+obd
 lKW
 bZl
 bZl
@@ -218251,7 +218247,7 @@ bZl
 bZl
 bZl
 bZl
-ewk
+noj
 knY
 pVn
 knY
@@ -218444,18 +218440,18 @@ tMW
 gsI
 gsI
 gsI
-uxn
-mmh
-mmh
-mmh
-mmh
-mmh
-mmh
-mmh
-mmh
-uxn
-hPl
 rYV
+prJ
+prJ
+prJ
+prJ
+prJ
+prJ
+prJ
+prJ
+rYV
+hPl
+wsJ
 lqH
 hPl
 eNc
@@ -218646,19 +218642,19 @@ phr
 gsI
 gsI
 gsI
-uxn
-prJ
-prJ
-prJ
-prJ
-prJ
-prJ
-prJ
-prJ
-uxn
-prX
+rYV
+tJT
+tJT
+tJT
+tJT
+tJT
+tJT
+tJT
+tJT
+rYV
+rsR
 cdL
-prX
+rsR
 cdL
 eNc
 bZl
@@ -218848,7 +218844,7 @@ gsI
 gsI
 gsI
 gsI
-pGM
+obd
 lKW
 bZl
 bZl
@@ -218857,7 +218853,7 @@ bZl
 bZl
 dMx
 bZl
-edF
+mmh
 gNN
 sWe
 pLq
@@ -219263,7 +219259,7 @@ bZl
 bZl
 gsI
 qtA
-bum
+wMi
 sWe
 eNc
 eNc
@@ -219427,8 +219423,8 @@ tfW
 hsf
 tZJ
 fqz
-igB
-hsf
+xHK
+tZJ
 fqz
 kJa
 hsf
@@ -227354,7 +227350,7 @@ eJk
 ihc
 eJk
 srv
-obd
+iaB
 cxU
 eJk
 eJk
@@ -227751,7 +227747,7 @@ eJk
 eJk
 mMF
 srv
-tJT
+bCJ
 srv
 cxU
 srv
@@ -227958,7 +227954,7 @@ tfW
 tfW
 oZR
 cxU
-lzF
+ieb
 cxU
 cxU
 asR
@@ -228161,12 +228157,12 @@ nST
 eTi
 hpq
 ovz
-tmw
-tmw
+gvy
+gvy
 ovz
 ovz
 cFN
-tmw
+gvy
 ovz
 lEs
 lEs
@@ -228358,8 +228354,8 @@ tfW
 erZ
 eUV
 szI
-cLf
-qqS
+giB
+sWc
 fLZ
 erZ
 eUV
@@ -229570,7 +229566,7 @@ qnK
 oVF
 oVF
 rZL
-bqU
+est
 uBg
 gUQ
 dAX
@@ -229962,7 +229958,7 @@ cxU
 cxU
 cxU
 asR
-tmw
+gvy
 tfW
 dAX
 dAX
@@ -229972,7 +229968,7 @@ aeb
 crJ
 rLw
 rLw
-bqU
+est
 rLw
 rLw
 uBg
@@ -230574,7 +230570,7 @@ tfW
 qZG
 tfW
 tfW
-bjd
+nYY
 gUQ
 gUQ
 dAX
@@ -230774,9 +230770,9 @@ ovz
 qZG
 tfW
 cXA
-oqo
+uxn
 tfW
-bIc
+hlB
 dAX
 gUQ
 dAX
@@ -230985,14 +230981,14 @@ dAX
 dAX
 aeb
 rLw
-ucU
-rsR
+ten
+ewk
 ccE
 qZG
 qZG
 qZG
 cXA
-gvy
+mHC
 eUV
 eUV
 tfW
@@ -231179,18 +231175,18 @@ tfW
 eUV
 fLZ
 eUV
-wMi
+tmw
 tfW
 rLw
 rLw
-bqU
+est
 rLw
 rLw
 rLw
 dAX
 dAX
 gUQ
-gvy
+mHC
 qZG
 qZG
 eUV
@@ -231381,7 +231377,7 @@ qZG
 tfW
 eUV
 eUV
-tIB
+woI
 tfW
 gUQ
 sok
@@ -231784,7 +231780,7 @@ lEs
 tfW
 eUV
 eUV
-oqo
+uxn
 qZG
 qZG
 gUQ
@@ -231995,7 +231991,7 @@ gUQ
 gUQ
 gUQ
 gUQ
-bqU
+est
 uBg
 dAX
 gUQ
@@ -232610,7 +232606,7 @@ dAX
 dAX
 dAX
 tfW
-tIB
+woI
 tfW
 qZG
 iGL
@@ -232798,7 +232794,7 @@ dAX
 dAX
 gUQ
 rLw
-bqU
+est
 rLw
 rLw
 rLw
@@ -233015,7 +233011,7 @@ dAX
 dAX
 qZG
 eUV
-noj
+prX
 eUV
 kOj
 kOj
@@ -233217,7 +233213,7 @@ dAX
 dAX
 eUV
 eUV
-tIB
+woI
 tfW
 iGL
 kOj

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -6687,6 +6687,8 @@
 /obj/item/storage/pouch/engineering_tools,
 /obj/item/storage/pouch/engineering_supply,
 /obj/item/storage/toolbox/mechanical,
+/obj/item/stack/material/steel/full,
+/obj/item/stack/rods/random,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/security/armory_blackshield)
 "bvf" = (
@@ -14422,8 +14424,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
 "dai" = (
-/obj/random/flora/small_jungle_tree,
-/turf/simulated/floor/asteroid/dirt,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/outside/pond)
 "dak" = (
 /obj/effect/decal/cleanable/blood,
@@ -17833,7 +17837,7 @@
 	})
 "dKA" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/beach/sand,
+/turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/pond)
 "dKC" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -38808,7 +38812,7 @@
 "hYu" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/beach/sand,
+/turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/pond)
 "hYv" = (
 /obj/machinery/vending/boozeomat{
@@ -49316,8 +49320,8 @@
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
 "kgc" = (
-/obj/structure/flora/small/rock2,
-/turf/simulated/floor/asteroid/dirt,
+/obj/structure/flora/small/rock3,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
 "kge" = (
 /obj/machinery/light/small{
@@ -54600,7 +54604,8 @@
 /area/nadezhda/maintenance/undergroundfloor1north)
 "loh" = (
 /obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/beach/sand,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
 "lol" = (
 /turf/simulated/shuttle/floor/science{
@@ -59848,6 +59853,7 @@
 "mrI" = (
 /obj/effect/overlay/water/top,
 /obj/effect/overlay/water,
+/obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/outside/pond)
 "mrJ" = (
@@ -85132,7 +85138,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/fo)
 "rtu" = (
-/turf/simulated/floor/beach/sand,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
 "rtx" = (
 /obj/machinery/vending/tool,
@@ -86763,8 +86771,10 @@
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
 "rLl" = (
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/dirt,
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/outside/pond)
 "rLm" = (
 /turf/simulated/wall/r_wall,
@@ -87670,11 +87680,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
-"rVz" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/big/bush2,
-/turf/simulated/floor/asteroid/dirt,
-/area/nadezhda/outside/pond)
 "rVD" = (
 /obj/effect/step_trigger/surface_to_forest_1_B,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -209701,7 +209706,7 @@ tfW
 wSc
 tfW
 tfW
-cxU
+tfW
 bzf
 kOj
 kOj
@@ -210306,7 +210311,7 @@ tfW
 tfW
 tfW
 tfW
-cxU
+tfW
 iGL
 kOj
 kOj
@@ -219398,8 +219403,8 @@ nnz
 qMG
 sQo
 frI
+kgc
 qMG
-rtu
 rtu
 lwP
 sQo
@@ -219600,10 +219605,10 @@ qMG
 dXq
 kKd
 sQo
-rtu
+qMG
 vFL
 vFL
-rtu
+njk
 oKP
 kBL
 sQo
@@ -219802,11 +219807,11 @@ qMG
 wNF
 sQo
 sQo
-rtu
+qMG
 vFL
+dai
 vFL
-vFL
-rtu
+njk
 ciR
 rrK
 qMG
@@ -220004,12 +220009,12 @@ qMG
 dXq
 sQo
 rTq
-rtu
+njk
 vFL
+rLl
 vFL
-vFL
-rtu
-qMG
+sQo
+kgc
 sQo
 dXq
 qMG
@@ -220206,12 +220211,12 @@ emO
 dXq
 sQo
 sQo
-qMG
-rtu
+kgc
+sQo
 vFL
 vFL
-rtu
-rVz
+sQo
+rpP
 sQo
 dXq
 qMG
@@ -220408,12 +220413,12 @@ qMG
 dXq
 sQo
 doc
+rrK
+rtu
+vFL
 dai
-rtu
 vFL
-vFL
-vFL
-rtu
+sQo
 ciR
 dXq
 qMG
@@ -220611,11 +220616,11 @@ qMG
 sQo
 sQo
 sQo
-rtu
+qMG
 vFL
 vFL
 mrI
-rtu
+qMG
 rTq
 dXq
 qMG
@@ -220813,8 +220818,8 @@ dZu
 sQo
 sQo
 sQo
-rtu
-vFL
+qMG
+dai
 vFL
 vFL
 loh
@@ -221018,7 +221023,7 @@ sQo
 frI
 vFL
 vFL
-vFL
+dai
 hYu
 bDP
 bDP
@@ -221218,10 +221223,10 @@ sQo
 ciR
 rTq
 sQo
-qMG
+sQo
 dKA
 hYu
-qMG
+sQo
 frI
 sQo
 ela
@@ -221421,8 +221426,8 @@ ciR
 ciR
 sQo
 kKd
-rLl
-kgc
+doc
+bDP
 sQo
 sQo
 sQo
@@ -235746,7 +235751,7 @@ aYl
 aYl
 kTO
 kTO
-mHv
+ucy
 tHS
 tfW
 tfW
@@ -236351,7 +236356,7 @@ iYY
 iYY
 iYY
 kTO
-kOj
+kTO
 ucy
 tfW
 tfW
@@ -236553,8 +236558,8 @@ iYY
 iYY
 iYY
 kTO
-kOj
-kOj
+kTO
+kTO
 tfW
 mHv
 tfW
@@ -236755,8 +236760,8 @@ iYY
 iYY
 iYY
 kTO
-kOj
-kOj
+kTO
+kTO
 nVx
 dbo
 tfW
@@ -237159,8 +237164,8 @@ iPx
 qIy
 gBD
 rTe
-kOj
-kOj
+kTO
+kTO
 kOj
 cXA
 tfW
@@ -237361,7 +237366,7 @@ iYY
 gBD
 gBD
 rTe
-kOj
+kTO
 kOj
 ucy
 vcw


### PR DESCRIPTION
Essentially, adds trashed areas of the colony so people have more tedious chores, as well as overgrown areas outside (and maybe inside!) the colony. This will be updated.

![image](https://github.com/sojourn-13/sojourn-station/assets/76069575/333a4785-9176-4a01-8e50-e1df25e0cb21)
The old hut below gate that was formerly bombed (Now features a snake den with just ONE of them being peaceful.. which one is it?!)