### PR TITLE
Fix some miscellaneous startup errors

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -242,7 +242,9 @@ SUBSYSTEM_DEF(garbage)
 	if (level > GC_QUEUE_COUNT)
 		HardDelete(D)
 		return
-	var/gctime = world.time
+	// stuff deleted at compile map init (it happens) would have gc_destroyed = 0, making SSatoms decide to 
+	// initialize them even though they're in our queue, horribly breaking everything
+	var/gctime = world.time || 1
 	var/refid = "\ref[D]"
 
 	D.gc_destroyed = gctime

--- a/code/datums/transformation_types/transform_types.dm
+++ b/code/datums/transformation_types/transform_types.dm
@@ -346,7 +346,7 @@
 	if (copyvaluetarget)
 		src.value_target = to_copy_from.value_target //dont worry, its already in weakref form
 
-/datum/transform_type/proc/update_holder_status(to_be_held_by = holder, to_use_for_values = to_be_held_by)
+/datum/transform_type/proc/update_holder_status(to_be_held_by, to_use_for_values)
 	holder = to_be_held_by
 	value_target = WEAKREF(to_use_for_values)
 

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -21,6 +21,8 @@ var/global/list/image/splatter_cache=list()
 	var/amount = 5
 	var/drytime
 	sanity_damage = 0.25
+	mergeable_decal = TRUE
+	var/should_dry = TRUE
 	// List of are shoe prints we got
 	var/list/shoe_types = list()
 
@@ -58,21 +60,21 @@ var/global/list/image/splatter_cache=list()
 /obj/effect/decal/cleanable/blood/New()
 	..()
 	fall_to_floor()
+
+/obj/effect/decal/cleanable/blood/Initialize()
+	. = ..()
 	update_icon()
 
-	if(istype(src, /obj/effect/decal/cleanable/blood/gibs))
-		return
-	if(type == /obj/effect/decal/cleanable/blood)
-		if(loc && isturf(loc))
-			for(var/obj/effect/decal/cleanable/blood/B in loc)
-				if(B != src)
-					if(B.blood_DNA)
-						blood_DNA |= B.blood_DNA.Copy()
-					if(B.shoe_types)
-						shoe_types |= B.shoe_types.Copy()
-					qdel(B)
-	drytime = world.time + DRYING_TIME * (amount+1)
-	addtimer(CALLBACK(src, .proc/dry), drytime)
+	if(should_dry)
+		drytime = world.time + DRYING_TIME * (amount+1)
+		addtimer(CALLBACK(src, .proc/dry), drytime)
+
+/obj/effect/decal/cleanable/blood/handle_merge_decal(obj/effect/decal/cleanable/blood/merger)
+	. = ..()
+	if(blood_DNA)
+		LAZYOR(merger.blood_DNA, blood_DNA.Copy())
+	if(shoe_types)
+		LAZYOR(merger.shoe_types, shoe_types.Copy())
 
 /obj/effect/decal/cleanable/blood/update_icon()
 	if(basecolor == "rainbow") basecolor = get_random_colour(1)
@@ -200,6 +202,8 @@ var/global/list/image/splatter_cache=list()
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "mgibbl5"
 	random_icon_states = list("gib1", "gib2", "gib3", "gib5", "gib6")
+	mergeable_decal = FALSE
+	should_dry = FALSE
 	var/fleshcolor = "#FFFFFF"
 
 /obj/effect/decal/cleanable/blood/gibs/update_icon()

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -2,6 +2,8 @@
 	layer = ABOVE_NORMAL_TURF_LAYER
 	var/list/random_icon_states = list()
 	random_rotation = 1
+	///When two of these are on a same tile or do we need to merge them into just one?
+	var/mergeable_decal = FALSE
 
 /obj/effect/decal/cleanable/clean_blood(ignore = 0)
 	if(!ignore)
@@ -9,7 +11,24 @@
 		return
 	..()
 
-/obj/effect/decal/cleanable/New()
-	if (random_icon_states && length(src.random_icon_states) > 0)
-		src.icon_state = pick(src.random_icon_states)
-	..()
+/obj/effect/decal/cleanable/Initialize()
+	. = ..()
+	if(random_icon_states && length(random_icon_states) > 0)
+		icon_state = pick(src.random_icon_states)
+	
+	if(loc && isturf(loc))
+		for(var/obj/effect/decal/cleanable/C in loc)
+			if(C != src && C.type == type && !QDELETED(C))
+				if(replace_decal(C))
+					handle_merge_decal(C)
+					return INITIALIZE_HINT_QDEL
+
+/obj/effect/decal/cleanable/proc/replace_decal(obj/effect/decal/cleanable/C) // Returns true if we should give up in favor of the pre-existing decal
+	if(mergeable_decal)
+		return TRUE
+
+/obj/effect/decal/cleanable/proc/handle_merge_decal(obj/effect/decal/cleanable/merger)
+	if(!merger)
+		return
+	if(merger.reagents && reagents)
+		reagents.trans_to(merger, reagents.total_volume)

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -16,9 +16,12 @@
 	if(!(istype(src.loc, /turf/space) || istype(src.loc, /turf/simulated/open) || istype(src.loc, /turf/simulated/floor/hull))) // || istype(src.loc, /turf/simulated/floor/open)
 ///// Z-Level Stuff
 		return INITIALIZE_HINT_QDEL
-	for(var/obj/structure/lattice/LAT in src.loc)
-		if(LAT != src)
-			qdel(LAT)
+	for(var/obj/structure/lattice/LAT in loc)
+		if(LAT == src)
+			continue
+		// commented out cuz we know already it's fucked, whatever
+		// stack_trace("multiple lattices found in ([loc.x], [loc.y], [loc.z])")
+		return INITIALIZE_HINT_QDEL
 	icon = 'icons/obj/smoothlattice.dmi'
 	icon_state = "latticeblank"
 	updateOverlays()

--- a/code/game/turfs/flooring/flooring_effects.dm
+++ b/code/game/turfs/flooring/flooring_effects.dm
@@ -7,12 +7,20 @@
 	icon_state = "scorched1"
 
 /obj/effect/damagedfloor/Initialize()
+	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/damagedfloor/LateInitialize(mapload)
 	var/turf/simulated/floor/F = loc
 	if(istype(F))
 		F.break_tile(1)
 	qdel(src)
 
 /obj/effect/damagedfloor/fire/Initialize()
+	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/damagedfloor/fire/LateInitialize(mapload)
 	var/turf/simulated/floor/F = loc
 	if(istype(F))
 		F.burn_tile()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bunch of random errors that happen on startup, see changelog.

## Changelog
:cl:
fix: Things deleted at roundstart during maploading won't initialize after deletion anymore
fix: Fix qdel failures from /datum/transform_type 
refactor: Cleanable decals handle merging together in a much better way
fix: Blood doesn't qdel anything other than itself at map start anymore (merging means qdeling src instead)
fix: Lattices no longer qdel() in Initialize, similar to decals
fix: Flooring effects use LateInitialize to do their thing and qdel(src) now.
/:cl:
