### PR TITLE
Adds armbands to Marshal and Blackshield wardrobes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -207,6 +207,8 @@
 	new /obj/item/clothing/mask/balaclava(src)
 	new /obj/item/clothing/suit/storage/armor/marshal_coat(src)
 	new /obj/item/clothing/suit/storage/armor/marshal_coat(src)
+	new /obj/item/clothing/accessory/armband(src)
+	new /obj/item/clothing/accessory/armband(src)
 
 /obj/structure/closet/wardrobe/militia
 	name = "blackshield wardrobe"
@@ -274,6 +276,11 @@
 	new /obj/item/clothing/glasses/ballistic(src)
 	new /obj/item/clothing/glasses/ballistic(src)
 	new /obj/item/clothing/glasses/ballistic(src)
+	new /obj/item/clothing/accessory/armband/militia(src)
+	new /obj/item/clothing/accessory/armband/militia(src)
+	new /obj/item/clothing/accessory/armband/militia(src)
+	new /obj/item/clothing/accessory/armband/corpsman(src)
+	new /obj/item/clothing/accessory/armband/corpsman(src)
 
 /obj/structure/closet/wardrobe/job/science_white
 	name = "science wardrobe"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Adds militia and security armbands to the Blackshield and Marshal lockers respectively
</summary>
<hr>

Blackshield and Marshals are allowed to wear non-uniform jackets/armor only if they have an armband with their faction's colors on that armor, but none actually spawn on the map, they're only available in loadout. This adds some to the lockers in-game so that players aren't caught without access to them.
<hr>
</details>

## Changelog
:cl:
add: Blackshield and Marshal armbands to their wardrobe lockers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
