### PR TITLE
Revert "Make people spawn directly at appropriate locations"

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -233,6 +233,7 @@ SUBSYSTEM_DEF(ticker)
 
 	create_characters() //Create player characters and transfer them
 	collect_minds()
+	move_characters_to_spawnpoints()
 	equip_characters()
 
 	CHECK_TICK
@@ -392,8 +393,9 @@ SUBSYSTEM_DEF(ticker)
 			else if(!player.mind.assigned_role)
 				continue
 			else
-				player.create_character(player.mind.assigned_role, FALSE)
+				player.create_character()
 				qdel(player)
+
 
 /datum/controller/subsystem/ticker/proc/collect_minds()
 	for(var/mob/living/player in GLOB.player_list)
@@ -494,6 +496,10 @@ SUBSYSTEM_DEF(ticker)
 			if(!isnewplayer(M))
 				to_chat(M, "Premier role not forced on anyone.")
 
+/datum/controller/subsystem/ticker/proc/move_characters_to_spawnpoints()
+	for(var/mob/living/carbon/human/player in GLOB.player_list)
+		var/datum/spawnpoint/SP = SSjob.get_spawnpoint_for(player.client, player.mind.assigned_role)
+		SP.put_mob(player)
 
 
 /datum/controller/subsystem/ticker/proc/declare_completion()

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -152,13 +152,6 @@
 		M.buckled.set_dir(M.dir)
 	return TRUE
 
-// We will still call put_mob after this
-/datum/spawnpoint/proc/get_turf_for_new_player()
-	var/list/free_locs = get_spawn_locations()
-	if(!LAZYLEN(free_locs))
-		return FALSE
-
-	return get_turf(pick(free_locs))
 
 /**********************
 	Cryostorage Spawning

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -307,10 +307,12 @@
 
 	SSjob.AssignRole(src, rank, 1)
 	var/datum/job/job = src.mind.assigned_job
+	var/mob/living/character = create_character()	//creates the human and transfers vars and mind
 
 	// AIs don't need a spawnpoint, they must spawn at an empty core
 	if(rank == "AI")
-		var/mob/living/character = AIize(move=0) // AIize the character, but don't move them yet
+
+		character = character.AIize(move=0) // AIize the character, but don't move them yet
 
 			// IsJobAvailable for AI checks that there is an empty core available in this list
 		var/obj/structure/AIcore/deactivated/C = empty_playable_ai_cores[1]
@@ -324,10 +326,9 @@
 		qdel(src)
 		return
 
-	var/list/character_creation = create_character(rank, TRUE)	//creates the human and transfers vars and mind
-	var/mob/living/character = character_creation[1]
-	var/datum/spawnpoint/spawnpoint = character_creation[2]
 
+	var/datum/spawnpoint/spawnpoint = SSjob.get_spawnpoint_for(character.client, rank, late = TRUE)
+	spawnpoint.put_mob(character) // This can fail, and it'll result in the players being left in space and not being teleported to the station. But atleast they'll be equipped. Needs to be fixed so a default case for extreme situations is added.
 	character = SSjob.EquipRank(character, rank) //equips the human
 	equip_custom_items(character)
 	character.lastarea = get_area(loc)
@@ -342,6 +343,8 @@
 			//Grab some data from the character prefs for use in random news procs.
 
 	AnnounceArrival(character, character.mind.assigned_role, spawnpoint.message)	//will not broadcast if there is no message
+
+
 
 	qdel(src)
 
@@ -463,7 +466,7 @@ GLOBAL_VAR_CONST(TGUI_LATEJOIN_EVAC_NONE, "None")
 		late_choices_dialog = new(src)
 	late_choices_dialog.ui_interact(src)
 
-/mob/new_player/proc/create_character(rank, late = FALSE)
+/mob/new_player/proc/create_character()
 	spawning = 1
 	close_spawn_windows()
 
@@ -481,30 +484,20 @@ GLOBAL_VAR_CONST(TGUI_LATEJOIN_EVAC_NONE, "None")
 		chosen_form = GLOB.all_species_form_list[client.prefs.species_form]
 		use_form_name = chosen_form.get_station_variant() //Not used at all but whatever.
 
-	var/datum/spawnpoint/spawnpoint = SSjob.get_spawnpoint_for(client, rank, late)
-	var/turf/initial_loc = spawnpoint.get_turf_for_new_player()
-	if(!initial_loc)
-		// If we can't spawn them at their spawnpoint, try to spawn them at a default
-		spawnpoint = get_spawn_point("Aft Cryogenic Storage")
-		initial_loc = spawnpoint.get_turf_for_new_player()
-		if(!initial_loc)
-			// Finally, give up and spawn them at the lobby screen location
-			initial_loc = loc
-
 	if(chosen_species && use_species_name)
 		// Have to recheck admin due to no usr at roundstart. Latejoins are fine though.
 		if(!is_species_whitelisted(chosen_species) && !has_admin_rights())
 			use_species_name = null
 		if(!is_form_whitelisted(chosen_form) && !has_admin_rights())
 			use_form_name = null
-		new_character = new(initial_loc, use_species_name, use_form_name)
+		new_character = new(loc, use_species_name, use_form_name)
 
 	if(!new_character)
-		new_character = new(initial_loc)
+		new_character = new(loc)
 	if(chosen_species)
 		chosen_species.add_stats(new_character)
 
-	new_character.lastarea = get_area(initial_loc)
+	new_character.lastarea = get_area(loc)
 
 	for(var/lang in client.prefs.alternate_languages)
 		var/datum/language/chosen_language = all_languages[lang]
@@ -565,15 +558,7 @@ GLOBAL_VAR_CONST(TGUI_LATEJOIN_EVAC_NONE, "None")
 	new_character.regenerate_icons()
 	new_character.key = key//Manually transfer the key to log them in
 
-	// Put them into their place properly now
-	spawnpoint = SSjob.get_spawnpoint_for(new_character.client, rank, late)
-	if(!spawnpoint.put_mob(new_character, ignore_environment = !late))
-		// If we can't spawn them at their spawnpoint, try to spawn them at a default
-		spawnpoint = get_spawn_point("Aft Cryogenic Storage")
-		if(!spawnpoint.put_mob(new_character, ignore_environment = !late))
-			log_and_message_admins("[key_name_admin(new_character)] could not find any possible way to spawn and may be stuck in space.")
-
-	return list(new_character, spawnpoint)
+	return new_character
 
 /mob/new_player/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)
 	return 0

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -68,9 +68,9 @@
 	qdel(animation)
 	return src
 
-/mob/new_player/AIize(move=1)
+/mob/new_player/AIize()
 	spawning = 1
-	return ..(move)
+	return ..()
 
 /mob/proc/AIize(move=1)
 	if (HAS_TRANSFORMATION_MOVEMENT_HANDLER(src))


### PR DESCRIPTION
Reverts sojourn-13/sojourn-station#5402

This is triggering some underlying equipment bug that I can't reproduce locally and can't find the source of, and it's a severe issue that causes players inventories to get so fucked up they have to have an admin fix it.