### PR TITLE
[Removal, Hotfix] Hydrogen Sword EMP interaction removal

### DIFF
--- a/code/game/objects/items/weapons/hydrogen_melee.dm
+++ b/code/game/objects/items/weapons/hydrogen_melee.dm
@@ -95,19 +95,18 @@
 			deactivate()
 		update_icon()
 
-/*
-/obj/item/tool/hydrogen_sword/emp_act(severity)
-	if(active) // Blow up.
-		var/turf/T = get_turf(src)
-		src.visible_message(SPAN_DANGER("[src]'s active magnetic field get disturbed by an EMP, violently exploding and scorching everything nearby!"))
-		explosion(T, 0, 1, 2, 4) // Explode
-		new /obj/effect/explosion(T)
-		for(var/mob/M in view(1, T)) // Burn every mob nearby.
-			to_chat(M, SPAN_DANGER("You feel a wave of heat scorch your body!"))
-			M.take_overall_damage(0, rand(emp_burn_min, emp_burn_max))
-		spawn(20)
-			qdel(src)
-*/
+
+// /obj/item/tool/hydrogen_sword/emp_act(severity)
+//	if(active) // Blow up.
+//		var/turf/T = get_turf(src)
+//		src.visible_message(SPAN_DANGER("[src]'s active magnetic field get disturbed by an EMP, violently exploding and scorching everything nearby!"))
+//		explosion(T, 0, 1, 2, 4) // Explode
+//		new /obj/effect/explosion(T)
+//		for(var/mob/M in view(1, T)) // Burn every mob nearby.
+//			to_chat(M, SPAN_DANGER("You feel a wave of heat scorch your body!"))
+//			M.take_overall_damage(0, rand(emp_burn_min, emp_burn_max))
+//		spawn(20)
+//			qdel(src)
 
 /obj/item/tool/hydrogen_sword/attack(mob/M as mob, mob/living/user as mob)
 	..()

--- a/code/game/objects/items/weapons/hydrogen_melee.dm
+++ b/code/game/objects/items/weapons/hydrogen_melee.dm
@@ -95,7 +95,7 @@
 			deactivate()
 		update_icon()
 
-//
+/*
 /obj/item/tool/hydrogen_sword/emp_act(severity)
 	if(active) // Blow up.
 		var/turf/T = get_turf(src)
@@ -107,7 +107,7 @@
 			M.take_overall_damage(0, rand(emp_burn_min, emp_burn_max))
 		spawn(20)
 			qdel(src)
-//
+*/
 
 /obj/item/tool/hydrogen_sword/attack(mob/M as mob, mob/living/user as mob)
 	..()

--- a/code/game/objects/items/weapons/hydrogen_melee.dm
+++ b/code/game/objects/items/weapons/hydrogen_melee.dm
@@ -95,7 +95,7 @@
 			deactivate()
 		update_icon()
 
-// /obj/item/tool/hydrogen_sword/emp_act(severity)
+ /obj/item/tool/hydrogen_sword/emp_act(severity)
 //	if(active) // Blow up.
 //		var/turf/T = get_turf(src)
 //		src.visible_message(SPAN_DANGER("[src]'s active magnetic field get disturbed by an EMP, violently exploding and scorching everything nearby!"))

--- a/code/game/objects/items/weapons/hydrogen_melee.dm
+++ b/code/game/objects/items/weapons/hydrogen_melee.dm
@@ -95,7 +95,6 @@
 			deactivate()
 		update_icon()
 
-
 // /obj/item/tool/hydrogen_sword/emp_act(severity)
 //	if(active) // Blow up.
 //		var/turf/T = get_turf(src)

--- a/code/game/objects/items/weapons/hydrogen_melee.dm
+++ b/code/game/objects/items/weapons/hydrogen_melee.dm
@@ -95,7 +95,7 @@
 			deactivate()
 		update_icon()
 
- /obj/item/tool/hydrogen_sword/emp_act(severity)
+// /obj/item/tool/hydrogen_sword/emp_act(severity)
 //	if(active) // Blow up.
 //		var/turf/T = get_turf(src)
 //		src.visible_message(SPAN_DANGER("[src]'s active magnetic field get disturbed by an EMP, violently exploding and scorching everything nearby!"))

--- a/code/game/objects/items/weapons/hydrogen_melee.dm
+++ b/code/game/objects/items/weapons/hydrogen_melee.dm
@@ -105,6 +105,7 @@
 		for(var/mob/M in view(1, T)) // Burn every mob nearby.
 			to_chat(M, SPAN_DANGER("You feel a wave of heat scorch your body!"))
 			M.take_overall_damage(0, rand(emp_burn_min, emp_burn_max))
+	qdel(src)
 */
 
 /obj/item/tool/hydrogen_sword/attack(mob/M as mob, mob/living/user as mob)

--- a/code/game/objects/items/weapons/hydrogen_melee.dm
+++ b/code/game/objects/items/weapons/hydrogen_melee.dm
@@ -95,6 +95,7 @@
 			deactivate()
 		update_icon()
 
+//
 /obj/item/tool/hydrogen_sword/emp_act(severity)
 	if(active) // Blow up.
 		var/turf/T = get_turf(src)
@@ -106,6 +107,7 @@
 			M.take_overall_damage(0, rand(emp_burn_min, emp_burn_max))
 		spawn(20)
 			qdel(src)
+//
 
 /obj/item/tool/hydrogen_sword/attack(mob/M as mob, mob/living/user as mob)
 	..()


### PR DESCRIPTION
It crashes the server (or nearly does so) so the part that makes it detonate is commented out. NOTE this is only when hitting certain fringe cases or if an EMP roach detonates while the sword is active. 

## About The Pull Request

Fundamentally broken from the start in case something keeps pulsing EMPs like EMP roaches. An overglorified arc welder does not explode either when I remove its power supply.

Also: Its probably better long term to fix the EMP roach cause it cant be that good that it can perma trigger effects acting on emps.

## Changelog
:cl:
del: Hydrogen Swords no longer explode when EMPed due to it fucking the server.
/:cl:

