### PR TITLE
disallows SI synth to be GM

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -17,7 +17,7 @@
 	minimum_character_age = 25
 	health_modifier = 5
 
-	disallow_species = list(FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
+	disallow_species = list(FORM_SOTSYNTH, FORM_BSSYNTH, FORM_CHURCHSYNTH, FORM_NASHEF)
 	outfit_type = /decl/hierarchy/outfit/job/engineering/exultant
 
 	access = list(


### PR DESCRIPTION
I did a fucky wucky 7 months ago. Allowed SI synths to be GM by total mistake. All better now! Woops! (how did no one notice?) Mini PRs stink but its a important issue so.

Changelog:

Disallows SI synths to be GMs once again. Was permited by mistake.
