### PR TITLE
[Hotfix] Hydrogen Sword EMP effect wont crash the server

### DIFF
--- a/code/game/objects/items/weapons/hydrogen_melee.dm
+++ b/code/game/objects/items/weapons/hydrogen_melee.dm
@@ -104,7 +104,6 @@
 		for(var/mob/M in view(1, T)) // Burn every mob nearby.
 			to_chat(M, SPAN_DANGER("You feel a wave of heat scorch your body!"))
 			M.take_overall_damage(0, rand(emp_burn_min, emp_burn_max))
-		spawn(20)
 			qdel(src)
 
 /obj/item/tool/hydrogen_sword/attack(mob/M as mob, mob/living/user as mob)


### PR DESCRIPTION
Trilby is right, it calls explosion 20 times.


## About The Pull Request

So something was pasted from the Hydrogen grenade clearly. The H2 sword doesnt need to explode 20 times to get the message across. It also crashes the server kinda. This fixes the issue for real this time without commenting out the interaction.

DO NOTE: IF THE H2 GRENADE CAUSES SIMILAR ISSUES REMOVE THE SPAWN 20 COMPONENT.

## Changelog
:cl:
fix: Hydrogen Sword no longer crashes the server if EMPed by a roach
/:cl:

