### PR TITLE
Small mob size audit, kitchen spike mob size limit

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -30,7 +30,7 @@
 				return
 	visible_message(SPAN_DANGER("[user] is trying to force \the [target] onto \the [src]!"))
 	if(do_after(user, 80))
-		if(spike(target))
+		if(spike(user, target))
 			visible_message(SPAN_DANGER("[user] has forced [target] onto \the [src], killing them instantly!"))
 			target.damage_through_armor(201, BRUTE, BP_CHEST)
 			for(var/obj/item/thing in target)
@@ -41,7 +41,7 @@
 		return FALSE
 
 
-/obj/structure/kitchenspike/proc/spike(mob/living/victim)
+/obj/structure/kitchenspike/proc/spike(mob/user, mob/living/victim)
 
 	if(!istype(victim))
 		return FALSE
@@ -55,12 +55,18 @@
 		var/mob/living/simple_animal/animal = victim
 		if(!ispath(animal.meat_type, /obj/item/reagent_containers/food/snacks/meat))
 			return FALSE
+		if(animal.mob_size > MOB_MEDIUM)
+			to_chat(user, SPAN_WARNING("The [animal] will not fit!"))
+			return FALSE
 		meat_type = animal.meat_type
 		icon_state = "spike_Monkey"
 		meat = animal.meat_amount
 	else if (issuperioranimal(victim))
 		var/mob/living/carbon/superior_animal/s_animal = victim
 		if(!ispath(s_animal.meat_type, /obj/item/reagent_containers/food/snacks/meat))
+			return FALSE
+		if(s_animal.mob_size > MOB_MEDIUM)
+			to_chat(user, SPAN_WARNING("The [s_animal] will not fit!"))
 			return FALSE
 		meat_type = s_animal.meat_type
 		icon_state = "spike_Monkey"

--- a/code/modules/genetics/creatures/wasonce.dm
+++ b/code/modules/genetics/creatures/wasonce.dm
@@ -47,7 +47,7 @@ Has ability of every roach.
 	melee_damage_upper = 35
 	attack_sound = 'sound/xenomorph/alien_footstep_charge1.ogg'
 	move_to_delay = 6
-	mob_size =  3  // The same as Hivemind Tyrant
+	mob_size =  MOB_LARGE  // The same as Hivemind Tyrant
 	status_flags = 0
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 	phaser = TRUE //WERE REALLLLL

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -7,7 +7,7 @@
 	pass_flags = PASSTABLE
 	health = 100
 	maxHealth = 100
-	mob_size = 4
+	mob_size = MOB_MEDIUM
 
 	var/adult_form
 	var/dead_icon

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/psi_monster.dm
@@ -31,7 +31,6 @@
 	overkill_dust = 0
 	contaminant_immunity = TRUE
 	never_stimulate_air = TRUE
-	mob_size = 3 // Can't contain that which isn't actually real.
 
 	move_to_delay = 2
 	turns_per_move = 6

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/kaiser.dm
@@ -24,7 +24,7 @@ Has ability of every roach.
 	melee_damage_lower = 20
 	melee_damage_upper = 35
 	move_to_delay = 4.5 //we're fast despite our size, many legs move us quick! otherwise, it's too easy to kite us.
-	mob_size =  3  // The same as Hivemind Tyrant
+	mob_size = MOB_LARGE  // The same as Hivemind Tyrant
 	status_flags = 0
 	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -15,7 +15,6 @@
 	stop_automated_movement = 1
 	friendly = "pinches"
 	faction = "pond"
-	mob_size = 5
 	leather_amount = 0
 	bones_amount = 0
 	var/obj/item/inventory_head
@@ -61,7 +60,6 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "stomps"
-	mob_size = 3
 	faction = "pond"
 	density = 0
 	wander = 1
@@ -98,7 +96,6 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "stomps"
-	mob_size = 3
 	faction = "neutral"
 	colony_friend = TRUE
 	friendly_to_colony = TRUE
@@ -115,7 +112,6 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "stomps"
-	mob_size = 3
 	faction = "pond"
 	density = 0
 	colony_friend = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/big.dm
+++ b/code/modules/mob/living/simple_animal/hostile/big.dm
@@ -58,7 +58,6 @@
 	meat_amount = 6
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/primal
 	can_burrow = FALSE
-	mob_size = 3
 	leather_amount = 16
 	bones_amount = 20
 	has_special_parts = TRUE
@@ -211,7 +210,6 @@
 	attack_sound = 'sound/xenomorph/alien_bite1.ogg'
 	alpha = 30
 	faction = "stalker"
-	mob_size = 3
 	leather_amount = 0 //No actual skin
 	bones_amount = 30 //Lots of bone-like chitin
 	has_special_parts = TRUE
@@ -283,7 +281,6 @@
 	speak_emote = list("looses a rumbling croak.", "grumbles quietly.")
 	attack_sound = 'sound/xenomorph/alien_bite2.ogg'
 	faction = "pond"
-	mob_size = 3
 	wander = 1
 	meat_amount = 10 //extra thicc
 	leather_amount = 20
@@ -336,7 +333,6 @@
 	speak_emote = list("emits a challenging roar!", "stomps the ground angrily.")
 	attack_sound = 'sound/xenomorph/alien_bite2.ogg'
 	faction = "tengolo_berserker"
-	mob_size =  3  // The same as Hivemind Tyrant
 	wander = 1
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/pork
 	meat_amount = 8

--- a/code/modules/mob/living/simple_animal/hostile/huntersprey.dm
+++ b/code/modules/mob/living/simple_animal/hostile/huntersprey.dm
@@ -35,7 +35,7 @@
 	meat_amount = 6
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/primal
 	can_burrow = FALSE
-	mob_size =  3  // The same as Hivemind Tyrant
+	mob_size = MOB_LARGE
 	attack_sound = 'sound/xenomorph/alien_bite2.ogg'
 	sanity_damage = 3
 
@@ -374,7 +374,7 @@
 	var/nocooldown = 0 //If set to 1, we don't use cooldowns.
 	rapid = 1
 	can_burrow = FALSE
-	mob_size =  3  // The same as Hivemind Tyrant
+	mob_size = MOB_LARGE
 
 /mob/living/simple_animal/hostile/poporavtomat/ex_act(severity, target)
 	switch (severity)

--- a/code/modules/mob/living/simple_animal/hostile/misc.dm
+++ b/code/modules/mob/living/simple_animal/hostile/misc.dm
@@ -19,7 +19,7 @@
 	emote_see = list("paws the ground.","shakes its mane.","stomps.")
 	emote_hear = list("snuffles")
 	meat_amount = 3
-	mob_size = 10
+	mob_size = MOB_MEDIUM
 	resistance = 8
 	has_special_parts = TRUE
 	special_parts = list(/obj/item/animal_part/wolf_tooth)
@@ -45,7 +45,7 @@
 	emote_hear = list("snuffles")
 	pass_flags = PASSTABLE
 	density = 0
-	mob_size = 3
+	mob_size = MOB_SMALL
 	has_special_parts = TRUE
 	special_parts = list(/obj/item/animal_part/wolf_tooth)
 	clone_difficulty = CLONE_EASY
@@ -69,7 +69,7 @@
 	speak_chance = 5
 	speak = list("Shuhn","Shrunnph?","Shunpf")
 	emote_see = list("scratches the ground.","shakes out it's mane.","tinkles gently.")
-	mob_size = 5
+	mob_size = MOB_MEDIUM
 	resistance = 3
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/pork
 	meat_amount = 6 //Pigs are known for giving meat
@@ -83,7 +83,7 @@
 	icon_living = "yithian"
 	icon_dead = "yithian_dead"
 	density = 0
-	mob_size = 2
+	mob_size = MOB_TINY
 	sanity_damage = -1
 
 /mob/living/simple_animal/tindalos
@@ -93,7 +93,7 @@
 	icon_living = "tindalos"
 	icon_dead = "tindalos_dead"
 	density = 0
-	mob_size = 1.5
+	mob_size = MOB_TINY
 	sanity_damage = -1
 
 /mob/living/simple_animal/schlorgo
@@ -105,7 +105,7 @@
 	icon_dead = "schlorgo_dead"
 	pass_flags = PASSTABLE
 	density = 0
-	mob_size = 2
+	mob_size = MOB_SMALL
 	//Schlorgo is a fucking mess
 	inherent_mutations = list(MUTATION_DWARFISM, MUTATION_NO_PAIN, MUTATION_UNBALANCED, MUTATION_IMBECILE, MUTATION_TOURETTES)
 	sanity_damage = -1
@@ -207,7 +207,7 @@
 	emote_hear = list("snuffles")
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/pork // Since half warthog.
 	meat_amount = 3
-	mob_size = 10
+	mob_size = MOB_MEDIUM
 	resistance = 5
 	leather_amount = 4
 	bones_amount = 4
@@ -238,7 +238,7 @@
 	emote_see = list("paws the ground.","shakes its mane.","stomps.")
 	emote_hear = list("snuffles")
 	meat_amount = 3
-	mob_size = 10
+	mob_size = MOB_MEDIUM
 	resistance = 5
 	pixel_x = -16
 	leather_amount = 4
@@ -271,7 +271,7 @@
 	emote_hear = list("snuffles")
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/pork // Since half warthog, and its evolutions are pig-oriented. Don't make me code/sprite venison meat next, please... - Seb
 	meat_amount = 3
-	mob_size = 10
+	mob_size = MOB_MEDIUM
 	resistance = 3
 	leather_amount = 4
 	bones_amount = 4
@@ -307,7 +307,7 @@
 	emote_hear = list("chitters.")
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/pork
 	meat_amount = 2 // Undomesticated, and underfed compared to a lodge cerberus, thus less meat.
-	mob_size = 5
+	mob_size = MOB_SMALL
 	resistance = 10
 	sanity_damage = -1
 	//Feed to lead
@@ -352,7 +352,7 @@
 	emote_see = list("flutters its wings.","twitches its antenna.","stomps.")
 	emote_hear = list("gronks.")
 	meat_amount = 3
-	mob_size = 20
+	mob_size = MOB_MEDIUM
 	resistance = 15
 
 // Credit to scar#1579 for the sprite.
@@ -383,6 +383,6 @@
 	meat_amount = 3
 	leather_amount = 6
 	bones_amount = 6
-	mob_size = 20
+	mob_size = MOB_MEDIUM
 	has_special_parts = TRUE
 	special_parts = list(/obj/item/animal_part/tahca_antler)


### PR DESCRIPTION
Several copy-pasted mob size vars were adjusted to be more sensible and to use defines whenever possible.

Meatspikes can now only fit up to MOB_MEDIUM size creatures.