### PR TITLE
Adds solar panel upgrade

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -15,18 +15,27 @@
 	var/id = 0
 	health = 10
 	var/obscured = 0 //When we draw are line to the sun, are we blocked by something?
+	var/has_upgraded_range = FALSE //Have we been upgraded?
+	var/obscured_range = 20 //When we draw a line to the sun, how far should the line travel?
 	var/sunfrac = 0 //This is used for maths on how much power were getting, based on were the sun is vs pannel angel
 	var/adir = SOUTH // actual dir
 	var/ndir = SOUTH // target dir
 	var/turn_angle = 0
 	var/obj/machinery/power/solar_control/control = null
 
+/obj/machinery/power/solar/enhanced
+	has_upgraded_range = TRUE
+	obscured_range = 3
+
 /obj/machinery/power/solar/examine(mob/user)
 	..()
 	if(glass_power >= 1) //Basiclly lets make sure
-		to_chat(user, "<span class='info'>The pannel reads that its glass power is at : [glass_power]</span>")
+		to_chat(user, "<span class='info'>The panel reads that its glass power is at : [glass_power] </span>")
 	else
-		to_chat(user, "<span class='info'>The pannel's glass is damage or dirty and generationg : [glass_power] well normal rating is 1x or more!</span>")
+		to_chat(user, "<span class='info'>The panel's glass is damaged or dirty and generating : [glass_power] while a normal rating is 1x or more!</span>")
+
+	if(has_upgraded_range)
+		to_chat(user, "<span class='info'>The glass has been treated with silver.</span>")
 
 /obj/machinery/power/solar/drain_power()
 	return -1
@@ -82,12 +91,27 @@
 			user.visible_message(SPAN_NOTICE("[user] takes the glass off the solar panel."))
 			qdel(src)
 		return
+	else if (istype(I, /obj/item/stack/material) && (I.get_material_name() == MATERIAL_SILVER))
+		if(has_upgraded_range)
+			to_chat(user, SPAN_WARNING("This panel has already been upgraded!"))
+			return
+
+		var/obj/item/stack/material/S = I
+		if(S.use(1))
+			user.visible_message(SPAN_NOTICE("[user] coats the glass with silver."))
+			obscured_range = 3
+			has_upgraded_range = TRUE
+
+		else
+			to_chat(user, SPAN_WARNING("You don't have enough silver!"))
+
+		return
+
 	else if (I)
 		src.add_fingerprint(user)
 		src.health -= I.force
 		src.healthCheck()
 	..()
-
 
 /obj/machinery/power/solar/healthCheck()
 	if (src.health <= 0)
@@ -187,7 +211,7 @@
 	var/ay = y
 	var/turf/T = null
 
-	for(var/i = 1 to 20)		// 20 steps is enough
+	for(var/i = 1 to obscured_range)		// 20 steps by default
 		ax += SSsun.dx	// do step
 		ay += SSsun.dy
 
@@ -263,9 +287,7 @@
 			return
 
 	if(anchored && isturf(loc))
-		log_debug("1")
 		if(istype(I, /obj/item/stack/material) && (I.get_material_name() == MATERIAL_GLASS || I.get_material_name() == MATERIAL_RGLASS || I.get_material_name() == MATERIAL_PLASMAGLASS || I.get_material_name() == MATERIAL_RPLASMAGLASS))
-			log_debug("2")
 			var/obj/item/stack/material/S = I
 			if(S.use(2))
 				glass_type = I.type

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -3305,7 +3305,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/solar,
+/obj/machinery/power/solar/enhanced,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
@@ -5050,7 +5050,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/solar,
+/obj/machinery/power/solar/enhanced,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
 "euK" = (
@@ -8165,7 +8165,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/solar,
+/obj/machinery/power/solar/enhanced,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
@@ -16746,7 +16746,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/solar,
+/obj/machinery/power/solar/enhanced,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/meadow)
 "oMu" = (

--- a/maps/_HunterLodge/map/_Hunting_Lodge.dmm
+++ b/maps/_HunterLodge/map/_Hunting_Lodge.dmm
@@ -742,7 +742,7 @@
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest/hunting_lodge)
 "dP" = (
-/obj/machinery/power/solar,
+/obj/machinery/power/solar/enhanced,
 /obj/structure/cable,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/forest/hunting_lodge)
@@ -1149,7 +1149,7 @@
 /turf/simulated/floor/beach/sand,
 /area/nadezhda/outside/forest/hunting_lodge)
 "fX" = (
-/obj/machinery/power/solar,
+/obj/machinery/power/solar/enhanced,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -1164,7 +1164,7 @@
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "gc" = (
-/obj/machinery/power/solar,
+/obj/machinery/power/solar/enhanced,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -1576,7 +1576,7 @@
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "iB" = (
-/obj/machinery/power/solar,
+/obj/machinery/power/solar/enhanced,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -2975,7 +2975,7 @@
 /turf/simulated/floor/wood,
 /area/nadezhda/outside/forest/hunting_lodge_dark)
 "zY" = (
-/obj/machinery/power/solar,
+/obj/machinery/power/solar/enhanced,
 /obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;


### PR DESCRIPTION
Built solar panels can now be upgraded to only require 3 tiles of unobstructed space to function instead of 20, at the cost of 1 silver per panel.

The Zoo and the Lodge have their solar panel grid upgraded by default.