### PR TITLE
Pulper auto lable and flesh sac fix

### DIFF
--- a/code/modules/genetics/machinery/genetics_extractor.dm
+++ b/code/modules/genetics/machinery/genetics_extractor.dm
@@ -142,6 +142,7 @@
 			var/sample_plates_to_make = occupant_meat_count + occupant_bonus
 			for(var/i=1 to sample_plates_to_make)
 				var/obj/item/genetics/sample/new_sample = new /obj/item/genetics/sample(mob_genes)
+				new_sample.name = "[new_sample.name] ([occupant.name])"
 				new_sample.forceMove(loc)
 
 			src.occupant.attack_log += "\[[time_stamp()]\] Was gibbed by <b>[user]/[user.ckey]</b>" //One shall not simply gib a mob unnoticed!
@@ -169,6 +170,7 @@
 					var/datum/genetics/genetics_holder/meat_genes =  new /datum/genetics/genetics_holder()
 					meat_genes.initializeFromMeat(meat_target)
 					var/obj/item/genetics/sample/new_sample = new /obj/item/genetics/sample(meat_genes)
+					new_sample.name = "[new_sample.name] ([meat_target.name])"
 					new_sample.forceMove(loc)
 
 			meat = list()

--- a/code/modules/genetics/machinery/genetics_items.dm
+++ b/code/modules/genetics/machinery/genetics_items.dm
@@ -431,7 +431,8 @@ A holder for items we make with Genetics. Helps add a visceral element to object
 			for(var/loot_item in loot)
 				if(ispath(loot_item, /obj))
 					var/obj/instanced_item = new loot_item()
-					instanced_item.loc = src.loc
+					var/turf/T = get_turf(src)
+					instanced_item.loc = T.loc
 			qdel(src)
 		else
 			playsound(src.loc, 'sound/effects/splat.ogg', 50, 1)


### PR DESCRIPTION
Pulper now labels its vials.
Flesh sacs now drop their contents on the floor. (If you held it in your hands while cutting it open it would dumb all its stored organs into your body instead of spilling it onto the floor)