### PR TITLE
Fix a bunch of runtimes

### DIFF
--- a/code/controllers/subsystems/movement/movement_types.dm
+++ b/code/controllers/subsystems/movement/movement_types.dm
@@ -104,7 +104,7 @@
 
 	lifetime -= old_delay //This needs to be based on work over time, not just time passed
 
-	if(lifetime < 0) //Otherwise lag would make things look really weird
+	if(lifetime < 0 || QDELETED(moving)) //Otherwise lag would make things look really weird
 		qdel(src)
 		return
 

--- a/code/datums/components/clothing_sanity_protection.dm
+++ b/code/datums/components/clothing_sanity_protection.dm
@@ -8,13 +8,13 @@
 	environment_cap_buff = value
 	var/atom/current_parent = parent
 	current_parent.description_info += "This item reduces sanity damage taken from environmental factors. \n"
-	RegisterSignal(current_parent, COMSIG_CLOTH_EQUIPPED, .proc/handle_sanity_buffs)
+	RegisterSignal(current_parent, COMSIG_CLOTH_EQUIPPED, .proc/handle_sanity_buffs, TRUE)
 
 /datum/component/clothing_sanity_protection/proc/handle_sanity_buffs(mob/living/carbon/human/user)
 	var/obj/item/current_parent = parent
 	if(current_parent.is_worn())
 		user.sanity.environment_cap_coeff *= environment_cap_buff
-		RegisterSignal(user, COMSIG_CLOTH_DROPPED, .proc/handle_sanity_debuff)
+		RegisterSignal(user, COMSIG_CLOTH_DROPPED, .proc/handle_sanity_debuff, TRUE)
 		current_user = user
 
 /datum/component/clothing_sanity_protection/proc/handle_sanity_debuff()

--- a/code/datums/perks/backgrounds.dm
+++ b/code/datums/perks/backgrounds.dm
@@ -22,16 +22,20 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	desc = "Your past life has been one of turmoil and extremes and as a result has toughened you up severely. Environmental damage from falling or explosives have less of an effect on your toughened body."
 	icon_state = "bomb" // https://game-icons.net
 
-/datum/perk/space_asshole/assign(mob/living/carbon/human/H)
+/datum/perk/space_asshole/assign(mob/living/L)
 	..()
 	holder.mob_bomb_defense += 25
 	holder.falls_mod -= 0.4
-	holder.sanity.view_damage_threshold += 20
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.view_damage_threshold += 20
 
 /datum/perk/space_asshole/remove()
 	holder.mob_bomb_defense -= 25
 	holder.falls_mod += 0.4
-	holder.sanity.view_damage_threshold -= 20
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.view_damage_threshold -= 20
 	..()
 
 /datum/perk/linguist
@@ -77,7 +81,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	faster. Finally, your rough and tumble movement makes falling from high heights deal a lot less damage compared to others and you will always land on your feet."
 	icon_state = "parkour" //https://game-icons.net/1x1/delapouite/jump-across.html
 
-/datum/perk/parkour/assign(mob/living/carbon/human/H)
+/datum/perk/parkour/assign(mob/living/L)
 	..()
 	holder.mod_climb_delay -= 0.95
 	holder.falls_mod -= 0.8
@@ -105,7 +109,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 
 	var/virtual_scanner = new /obj/item/device/scanner/plant/perk
 
-/datum/perk/greenthumb/assign(mob/living/carbon/human/H)
+/datum/perk/greenthumb/assign(mob/living/L)
 	..()
 	var/obj/item/device/scanner/V = virtual_scanner
 	V.is_virtual = TRUE
@@ -117,16 +121,18 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 			sometimes you won’t take any sanity loss and you can even gain back sanity, or get a boost to your cognition."
 	icon_state = "eye" //https://game-icons.net/1x1/lorc/tear-tracks.html
 
-/datum/perk/nihilist/assign(mob/living/carbon/human/H)
-	if(..())
-		holder.sanity.positive_prob += 30
-		holder.sanity.negative_prob += 20
+/datum/perk/nihilist/assign(mob/living/L)
+	if(..() && ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.sanity.positive_prob += 30
+		H.sanity.negative_prob += 20
 
 /datum/perk/nihilist/remove()
-	if(holder)
-		holder.sanity.positive_prob -= 30
-		holder.sanity.negative_prob -= 20
-		holder.stats.removeTempStat(STAT_COG, "Fate Nihilist")
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.positive_prob -= 30
+		H.sanity.negative_prob -= 20
+		H.stats.removeTempStat(STAT_COG, "Fate Nihilist")
 	..()
 
 /datum/perk/idealist
@@ -144,13 +150,13 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 			Start with an heirloom weapon, higher chance to be on contractor contracts and removed sanity cap. Stay clear of filth and danger."
 
 /datum/perk/noble/assign(mob/living/carbon/human/H)
-	if(!..())
+	if(!..() || !istype(H))
 		return
-	holder.sanity.environment_cap_coeff -= 1
-	if(!holder.name)
-		holder.stats.removePerk(src.type)
+	H.sanity.environment_cap_coeff -= 1
+	if(!H.name)
+		H.stats.removePerk(src.type)
 		return
-	var/turf/T = get_turf(holder)
+	var/turf/T = get_turf(H)
 	var/obj/item/W
 	var/picklist = list( //Total weight sum = 24
 				/obj/item/tool/hammer/mace = 5,
@@ -160,7 +166,7 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 				/obj/item/tool/sword/machete = 4,
 				/obj/item/tool/knife/dagger/ceremonial = 2,)
 
-	if(is_neotheology_disciple(holder)) //If someone's NT, they're likely to spawn with an NT weapon instead
+	if(is_neotheology_disciple(H)) //If someone's NT, they're likely to spawn with an NT weapon instead
 		picklist += list( //Total weight sum = 34
 				/obj/item/tool/sword/nt/longsword = 10,
 				/obj/item/tool/sword/nt/shortsword = 12,
@@ -168,10 +174,10 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 				/obj/item/tool/knife/dagger/nt = 10,)
 
 	W = pickweight(picklist)
-	holder.sanity.valid_inspirations += W
+	H.sanity.valid_inspirations += W
 	W = new W(T)
-	W.desc += " It has been inscribed with the \"[holder.name]\" family name."
-	W.name = "[W] of [holder.name]"
+	W.desc += " It has been inscribed with the \"[H.name]\" family name."
+	W.name = "[W] of [H.name]"
 	var/oddities = rand(2,4) //Will boost 2-4 random stats
 	var/list/stats = ALL_STATS_FOR_LEVEL_UP
 	var/list/final_oddity = list()
@@ -185,11 +191,12 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	W.sanity_damage -= 1
 	W.price_tag += rand(1000, 2500)
 	spawn(1)
-		holder.equip_to_storage_or_drop(W)
+		H.equip_to_storage_or_drop(W)
 
 /datum/perk/noble/remove()
-	if(holder)
-		holder.sanity.environment_cap_coeff += 1
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.environment_cap_coeff += 1
 	..()
 
 /datum/perk/addict
@@ -198,16 +205,20 @@ This is NOT for racial-specific perks, but rather specifically for general backg
 	easily addicted to all of them."
 	icon_state = "chemaddict" // https://game-icons.net/1x1/lorc/overdose.html
 
-/datum/perk/addict/assign(mob/living/carbon/human/H)
+/datum/perk/addict/assign(mob/living/L)
 	..()
-	holder.metabolism_effects.addiction_chance_multiplier = 2
-	holder.metabolism_effects.nsa_bonus += 20
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 2
+		H.metabolism_effects.nsa_bonus += 20
+		H.metabolism_effects.calculate_nsa()
 
 /datum/perk/addict/remove()
-	holder.metabolism_effects.addiction_chance_multiplier = 1
-	holder.metabolism_effects.nsa_bonus -= 20
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 1
+		H.metabolism_effects.nsa_bonus -= 20
+		H.metabolism_effects.calculate_nsa()
 	..()
 
 /datum/perk/no_obfuscation

--- a/code/datums/perks/imprinter_perks.dm
+++ b/code/datums/perks/imprinter_perks.dm
@@ -21,7 +21,7 @@ Chemical Neutralizer - Reduces addiction chance all the way down to 0.1 and incr
 	gain_text = "Your head feels lighter as if huge burden was carried away."
 	lose_text = "Your head starts feeling like a boulder again."
 
-/datum/perk/cognitive_enhancer/assign(mob/living/carbon/human/H)
+/datum/perk/cognitive_enhancer/assign(mob/living/L)
 	..()
 	holder.stats.changeStat(STAT_COG, 30)
 
@@ -35,14 +35,18 @@ Chemical Neutralizer - Reduces addiction chance all the way down to 0.1 and incr
 	gain_text = "You feel unnatural calmness."
 	lose_text = "Your start to crave after things again."
 
-/datum/perk/chemical_neutralizer/assign(mob/living/carbon/human/H)
+/datum/perk/chemical_neutralizer/assign(mob/living/L)
 	..()
-	holder.metabolism_effects.addiction_chance_multiplier = 0.1
-	holder.metabolism_effects.nsa_bonus += 10
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 0.1
+		H.metabolism_effects.nsa_bonus += 10
+		H.metabolism_effects.calculate_nsa()
 
 /datum/perk/chemical_neutralizer/remove()
-	holder.metabolism_effects.addiction_chance_multiplier = 1
-	holder.metabolism_effects.nsa_bonus -= 10
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 1
+		H.metabolism_effects.nsa_bonus -= 10
+		H.metabolism_effects.calculate_nsa()
 	..()

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -11,7 +11,7 @@
 	lose_text = "Your sudden flash of brilliance fades away..."
 	icon_state = "inspiration_active" // https://game-icons.net/1x1/lorc/enlightenment.html
 
-/datum/perk/active_inspiration/assign(mob/living/carbon/human/H)
+/datum/perk/active_inspiration/assign(mob/living/L)
 	..()
 	holder.stats.addTempStat(STAT_COG, 5, INFINITY, "Exotic Inspiration")
 	holder.stats.addTempStat(STAT_MEC, 10, INFINITY, "Exotic Inspiration")
@@ -29,21 +29,25 @@
 	var/old_max_resting = INFINITY
 	var/old_insight_rest_gain_multiplier = 1
 
-/datum/perk/job/artist/assign(mob/living/carbon/human/H)
+/datum/perk/job/artist/assign(mob/living/L)
 	..()
-	old_max_insight = holder.sanity.max_insight
-	old_max_resting = holder.sanity.max_resting
-	old_insight_rest_gain_multiplier = holder.sanity.insight_rest_gain_multiplier
-	holder.sanity.max_insight = 100
-	holder.sanity.insight_gain_multiplier *= 1.5
-	holder.sanity.max_resting = 1
-	holder.sanity.insight_rest_gain_multiplier = 0
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		old_max_insight = H.sanity.max_insight
+		old_max_resting = H.sanity.max_resting
+		old_insight_rest_gain_multiplier = H.sanity.insight_rest_gain_multiplier
+		H.sanity.max_insight = 100
+		H.sanity.insight_gain_multiplier *= 1.5
+		H.sanity.max_resting = 1
+		H.sanity.insight_rest_gain_multiplier = 0
 
 /datum/perk/job/artist/remove()
-	holder.sanity.max_insight += old_max_insight - 100
-	holder.sanity.insight_gain_multiplier /= 1.5
-	holder.sanity.max_resting += old_max_resting - 1
-	holder.sanity.insight_rest_gain_multiplier += old_insight_rest_gain_multiplier
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.max_insight += old_max_insight - 100
+		H.sanity.insight_gain_multiplier /= 1.5
+		H.sanity.max_resting += old_max_resting - 1
+		H.sanity.insight_rest_gain_multiplier += old_insight_rest_gain_multiplier
 	..()
 
 /datum/perk/timeismoney
@@ -77,16 +81,20 @@
 	addicted slightly easier."
 	icon_state = "solborn" // https://game-icons.net/1x1/lorc/overdose.html
 
-/datum/perk/solborn/assign(mob/living/carbon/human/H)
+/datum/perk/solborn/assign(mob/living/L)
 	..()
-	holder.metabolism_effects.addiction_chance_multiplier = 1.2
-	holder.metabolism_effects.nsa_bonus -= 15
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 1.2
+		H.metabolism_effects.nsa_bonus -= 15
+		H.metabolism_effects.calculate_nsa()
 
 /datum/perk/solborn/remove()
-	holder.metabolism_effects.addiction_chance_multiplier = 1
-	holder.metabolism_effects.nsa_bonus += 15
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 1
+		H.metabolism_effects.nsa_bonus += 15
+		H.metabolism_effects.calculate_nsa()
 	..()
 
 /datum/perk/klutz
@@ -94,7 +102,7 @@
 	desc = "You find a lot of tasks a little beyond your ability to perform such is using any type of weaponry, but being accident prone has at least made you used to getting hurt."
 	icon_state = "klutz"
 
-/datum/perk/klutz/assign(mob/living/carbon/human/H)
+/datum/perk/klutz/assign(mob/living/L)
 	..()
 	holder.mutations.Add(CLUMSY)
 
@@ -110,13 +118,15 @@
 	lose_text = "You no longer feel the protection of an obelisk."
 
 
-/datum/perk/active_sanityboost/assign(mob/living/carbon/human/H)
-	if(..())
-		holder.sanity.sanity_passive_gain_multiplier *= 1.5
+/datum/perk/active_sanityboost/assign(mob/living/L)
+	if(..() && ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.sanity_passive_gain_multiplier *= 1.5
 
 /datum/perk/active_sanityboost/remove()
-	if(holder)
-		holder.sanity.sanity_passive_gain_multiplier /= 1.5
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.sanity_passive_gain_multiplier /= 1.5
 	..()
 
 /datum/perk/unfinished_delivery
@@ -142,16 +152,18 @@
 	icon_state = "periodictable"
 	perk_shared_ability = PERK_SHARED_SEE_REAGENTS
 
-/datum/perk/chemist/assign(mob/living/carbon/human/H)
+/datum/perk/chemist/assign(mob/living/L)
 	..()
-	if(holder)
-		holder.metabolism_effects.nsa_mult += 0.25
-		holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.nsa_mult += 0.25
+		H.metabolism_effects.calculate_nsa()
 
 /datum/perk/chemist/chemist/remove()
-	if(holder)
-		holder.metabolism_effects.nsa_mult -= 0.25
-		holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.nsa_mult -= 0.25
+		H.metabolism_effects.calculate_nsa()
 	..()
 
 /datum/perk/alchemist
@@ -160,23 +172,25 @@
 			Your NSA also has been slightly improved due to self experimentation. You can also see all reagents in beakers."
 	perk_shared_ability = PERK_SHARED_SEE_REAGENTS
 
-/datum/perk/alchemist/assign(mob/living/carbon/human/H)
+/datum/perk/alchemist/assign(mob/living/L)
 	..()
-	if(holder)
-		holder.metabolism_effects.nsa_mult += 0.05
-		holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.nsa_mult += 0.05
+		H.metabolism_effects.calculate_nsa()
 
 /datum/perk/alchemist/remove()
-	if(holder)
-		holder.metabolism_effects.nsa_mult -= 0.05
-		holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.nsa_mult -= 0.05
+		H.metabolism_effects.calculate_nsa()
 	..()
 
 /datum/perk/scribe
 	name = "Scribe"
 	desc = "Your ability to turn experiences into words knows no bounds. Paper at this point is hardly able to hold the power of your writing."
 
-/datum/perk/scribe/assign(mob/living/carbon/human/H)
+/datum/perk/scribe/assign(mob/living/L)
 	..()
 	if(holder)
 		holder.sdisabilities|=BLIND
@@ -192,7 +206,7 @@
 	gain_text = "The scroll's smoke fills your eyes. Whats moving in the walls?"
 	lose_text = "Your eyes sting but you don't see the pain anymore."
 
-/datum/perk/cooldown/reveal/assign(mob/living/carbon/human/H)
+/datum/perk/cooldown/reveal/assign(mob/living/L)
 	..()
 	if(holder)
 		//give thermal vision
@@ -218,7 +232,7 @@
 	var/obj/screen/lightOverlay = null
 	icon_state = "night" // https://game-icons.net/1x1/lorc/night-sky.html
 
-/datum/perk/nightcrawler/assign(mob/living/carbon/human/H)
+/datum/perk/nightcrawler/assign(mob/living/L)
 	..()
 	init_sight = holder.additional_darksight
 	init_flash = holder.flash_mod
@@ -241,7 +255,7 @@
 	desc = "Being deadly, easy. Silent? Even easier now. You generate less noise than others."
 	icon_state = "footsteps" // https://game-icons.net
 
-/datum/perk/quiet_as_mouse/assign(mob/living/carbon/human/H)
+/datum/perk/quiet_as_mouse/assign(mob/living/L)
 	..()
 	holder.noise_coeff -= 0.75
 
@@ -259,7 +273,7 @@
 	desc = "Your intense training has perfected your footing, and you're an expert at holding the line. Few things can knock you off balance or push you around."
 	icon_state = "muscular" // https://game-icons.net
 
-/datum/perk/ass_of_concrete/assign(mob/living/carbon/human/H)
+/datum/perk/ass_of_concrete/assign(mob/living/L)
 	..()
 	holder.mob_bump_flag = HEAVY
 
@@ -280,7 +294,7 @@
 	lose_text = "You finally feel like you recovered from the ravages of your body."
 	var/initial_time
 
-/datum/perk/rezsickness/assign(mob/living/carbon/human/H)
+/datum/perk/rezsickness/assign(mob/living/L)
 	..()
 	initial_time = world.time
 	cooldown_time = world.time + 30 MINUTES
@@ -291,7 +305,9 @@
 	holder.stats.changeStat(STAT_ROB, -10)
 	holder.stats.changeStat(STAT_TGH, -10)
 	holder.stats.changeStat(STAT_VIG, -10)
-	H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 0.5, learner = H)
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 0.5, learner = H)
 
 /datum/perk/rezsickness/remove()
 	holder.brute_mod_perk /= 1.10
@@ -309,7 +325,7 @@
 	desc = "You've recently died and have been brought back to life. Your body cannot handle this traumatic experience very well, to the point where you struggle to complete even basic tasks. You better rest in a bed until it subsides before going back to work."
 	icon_state = "severerevivalsickness"
 
-/datum/perk/rezsickness/severe/assign(mob/living/carbon/human/H)
+/datum/perk/rezsickness/severe/assign(mob/living/L)
 	..()
 	holder.brute_mod_perk *= 1.15
 	holder.burn_mod_perk *= 1.15
@@ -334,7 +350,7 @@
 	desc = "You've recently died and have been brought back to life. Your frail constitution can barely handle the process, leaving you utterly physically and mentally wrecked. You better stay in bed for now and rest, or you risk dying even easier than before."
 	icon_state = "fatalrevivalsickness"
 
-/datum/perk/rezsickness/severe/fatal/assign(mob/living/carbon/human/H)
+/datum/perk/rezsickness/severe/fatal/assign(mob/living/L)
 	..()
 	holder.brute_mod_perk *= 1.25
 	holder.burn_mod_perk *= 1.25
@@ -378,7 +394,7 @@
 	var/initial_time
 	icon_state = "slime_rez"
 
-/datum/perk/racial/slime_rez_sickness/assign(mob/living/carbon/human/H)
+/datum/perk/racial/slime_rez_sickness/assign(mob/living/L)
 	..()
 	initial_time = world.time
 	cooldown_time = world.time + 30 MINUTES
@@ -411,7 +427,7 @@
 	desc = "Training by the Artificer's Guild has granted you the knowledge of how to take apart machines in the most efficient way possible, finding materials and supplies most people would miss. This training is taken further the more mechanically skilled or cognitively capable you are."
 	icon_state = "handyman"
 
-/datum/perk/handyman/assign(mob/living/carbon/human/H)
+/datum/perk/handyman/assign(mob/living/L)
 	..()
 
 
@@ -445,7 +461,7 @@
 	desc = "Your formal training and experience in advanced mech construction and complex devices has made you more adept at working with them."
 	icon_state = "roboticsexpert"
 
-/datum/perk/robotics_expert/assign(mob/living/carbon/human/H)
+/datum/perk/robotics_expert/assign(mob/living/L)
 	..()
 
 /datum/perk/robotics_expert/remove()
@@ -466,7 +482,7 @@
 	desc = "Thanks to special and intensive training received in the course of your employment with Blackshield, with all the practice gained in space you feel you can jump from greater heights and know when to duck-and-cover."
 	icon_state = "blackshieldconditioning"
 
-/datum/perk/job/blackshield_conditioning/assign(mob/living/carbon/human/H)
+/datum/perk/job/blackshield_conditioning/assign(mob/living/L)
 	..()
 	holder.mob_bomb_defense += 20
 	holder.falls_mod -= 0.4
@@ -482,18 +498,20 @@
 	icon_state = "roughandtumble"
 	perk_shared_ability = PERK_SHARED_SEE_ILLEGAL_REAGENTS
 
-/datum/perk/job/prospector_conditioning/assign(mob/living/carbon/human/H)
+/datum/perk/job/prospector_conditioning/assign(mob/living/L)
 	..()
-	if(holder)
-		holder.metabolism_effects.addiction_chance_multiplier = 0.1
-		holder.metabolism_effects.nsa_bonus += 25
-		holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 0.1
+		H.metabolism_effects.nsa_bonus += 25
+		H.metabolism_effects.calculate_nsa()
 
 /datum/perk/job/prospector_conditioning/remove()
-	if(holder)
-		holder.metabolism_effects.addiction_chance_multiplier = 1
-		holder.metabolism_effects.nsa_bonus -= 25
-		holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 1
+		H.metabolism_effects.nsa_bonus -= 25
+		H.metabolism_effects.calculate_nsa()
 	..()
 
 /datum/perk/job/butcher
@@ -501,7 +519,7 @@
 	desc = "Your skill as a butcher is unmatched, be it through your training or accumulated field experience. You can harvest additional valuable parts from animals you cut up, nothing shall be wasted."
 	icon_state = "masterbutcher"
 
-/datum/perk/job/butcher/assign(mob/living/carbon/human/H)
+/datum/perk/job/butcher/assign(mob/living/L)
 	..()
 
 /datum/perk/job/butcher/remove()
@@ -527,13 +545,15 @@
 			You can regain sanity by cleaning."
 	icon_state = "neat" // https://game-icons.net/1x1/delapouite/broom.html
 
-/datum/perk/neat/assign(mob/living/carbon/human/H)
-	if(..())
-		holder.sanity.view_damage_threshold += 20
+/datum/perk/neat/assign(mob/living/L)
+	if(..() && ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.view_damage_threshold += 20
 
 /datum/perk/neat/remove()
-	if(holder)
-		holder.sanity.view_damage_threshold -= 20
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.view_damage_threshold -= 20
 	..()
 
 /datum/perk/channeling
@@ -580,7 +600,7 @@
 		/mob/living/carbon/human/proc/codespeak_run_local
 		)
 
-/datum/perk/codespeak/assign(mob/living/carbon/human/H)
+/datum/perk/codespeak/assign(mob/living/L)
 	..()
 	if(holder)
 		holder.verbs += codespeak_procs

--- a/code/datums/perks/nanite_powers.dm
+++ b/code/datums/perks/nanite_powers.dm
@@ -9,11 +9,13 @@
 	var/emped = FALSE				//Whether we are currently being affected by an EMP
 	var/emp_duration = 0			//Duration of EMP effects
 
-/datum/perk/nanite_power/assign(mob/living/carbon/human/H)
+/datum/perk/nanite_power/assign(mob/living/L)
 	. = ..()
-	var/obj/item/organ/internal/nanogate/target_ng = holder.random_organ_by_process(BP_NANOGATE)
-	RegisterSignal(target_ng, COMSIG_NANOGATE_EMP, .proc/on_emp)
-	RegisterSignal(target_ng, COMSIG_NANOGATE_REMOVED, .proc/remove_power)
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		var/obj/item/organ/internal/nanogate/target_ng = H.random_organ_by_process(BP_NANOGATE)
+		RegisterSignal(target_ng, COMSIG_NANOGATE_EMP, .proc/on_emp)
+		RegisterSignal(target_ng, COMSIG_NANOGATE_REMOVED, .proc/remove_power)
 
 //Used for handling behaviors when EMP'd, such as shutting off regeneration or applying negative effects
 //Remember that severity 1 is the strongest EMP

--- a/code/datums/perks/nanogate.dm
+++ b/code/datums/perks/nanogate.dm
@@ -49,7 +49,7 @@
 	icon_state = "naniteskinweave"
 	gain_text = "You feel a dull ache as your nanogate releases newly configured nanites into your body."
 
-/datum/perk/nanite_power/nanite_armor/assign(mob/living/carbon/human/H)
+/datum/perk/nanite_power/nanite_armor/assign(mob/living/L)
 	..()
 	holder.maxHealth += 40
 	holder.health += 40

--- a/code/datums/perks/nepotism.dm
+++ b/code/datums/perks/nepotism.dm
@@ -17,7 +17,7 @@
 	gain_text = "Your body is modified enough already; pushing it further might be bad."
 
 //Genetics is made reliably enough that simply increasing total instability, a dynamically changing value, will be permanent until removed.
-/datum/perk/splicer/assign(mob/living/carbon/human/H)
+/datum/perk/splicer/assign(mob/living/L)
 	..()
 	holder.unnatural_mutations.total_instability += 20
 

--- a/code/datums/perks/oddity.dm
+++ b/code/datums/perks/oddity.dm
@@ -7,13 +7,15 @@
 			Halves sanity loss from seeing people die."
 	icon_state = "survivor" // https://game-icons.net/1x1/lorc/one-eyed.html
 
-/datum/perk/oddity/survivor/assign(mob/living/carbon/human/H)
-	if(..())
-		holder.sanity.death_view_multiplier *= 0.5
+/datum/perk/oddity/survivor/assign(mob/living/L)
+	if(..() && ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.death_view_multiplier *= 0.5
 
 /datum/perk/oddity/survivor/remove()
-	if(holder)
-		holder.sanity.death_view_multiplier *= 2
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.death_view_multiplier *= 2
 	..()
 
 /datum/perk/oddity/inspiring
@@ -22,7 +24,7 @@
 			People around you regain their sanity quicker."
 	icon_state = "inspiringpresence"
 
-/datum/perk/oddity/inspiring/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/inspiring/assign(mob/living/L)
 	if(..())
 		holder.sanity_damage -= 2
 
@@ -45,20 +47,25 @@
 	var/cooldown = 30 MINUTES
 	var/initial_time
 
-/datum/perk/oddity/toxic_revenger/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/toxic_revenger/assign(mob/living/L)
 	..()
 	initial_time = world.time
-	H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 1, learner = H)
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 1, learner = H)
 
 /datum/perk/oddity/toxic_revenger/on_process()
 	if(!..())
 		return
-	if(holder.species.flags & NO_BREATHE || holder.internal)
+	if(!ishuman(holder))
+		return
+	var/mob/living/carbon/human/holder_man = holder
+	if(holder_man.species.flags & NO_BREATHE || holder_man.internal)
 		return
 	if(world.time < initial_time + cooldown)
 		return
 	initial_time = world.time
-	for(var/mob/living/carbon/human/H in viewers(5, holder))
+	for(var/mob/living/carbon/human/H in viewers(5, holder_man))
 		if(H.stat == DEAD || H.internal || H.stats.getPerk(PERK_TOXIC_REVENGER) || H.species.flags & NO_BREATHE)
 			continue
 		if(H.head?.item_flags & BLOCK_GAS_SMOKE_EFFECT || H.wear_mask?.item_flags & BLOCK_GAS_SMOKE_EFFECT || BP_IS_ROBOTIC(H.get_organ(BP_CHEST)))
@@ -86,7 +93,7 @@
 	gain_text = "You feel your pace quickening, your thoughts barely catching up with your stride..."
 	icon_state = "fast" // https://game-icons.net/1x1/delapouite/fast-forward-button.html
 
-/datum/perk/oddity/fast_walker/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/fast_walker/assign(mob/living/L)
 	..()
 	if(holder.stats.getPerk(PERK_FAST_WALKER)) // Prevents stacking the same perk over and over for Emperor spider levels of speed. - Seb
 		return FALSE
@@ -97,7 +104,7 @@
 	gain_text = "After all you've endured, you can't help but feel tougher than normal, your skin feels like iron."
 	icon_state = "riotshield"
 
-/datum/perk/oddity/harden/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/harden/assign(mob/living/L)
 	..()
 	holder.brute_mod_perk *= 0.75 // One third of subdermal armor
 	holder.mob_bomb_defense += 5
@@ -115,12 +122,14 @@
 	gain_text = "You feel yourself growing softer...Did everything always hurt this much?"
 	icon_state = "paper"
 
-/datum/perk/oddity/thin_skin/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/thin_skin/assign(mob/living/L)
 	..()
 	holder.brute_mod_perk *= 1.25
 	holder.mob_bomb_defense -= 5
 	holder.falls_mod += 0.2
-	H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 1, learner = H)
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 1, learner = H)
 
 
 /datum/perk/oddity/thin_skin/remove()
@@ -135,7 +144,7 @@
 	gain_text = "What doesn't kill you, helps you survive it better."
 	icon_state = "alch"
 
-/datum/perk/oddity/better_toxins/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/better_toxins/assign(mob/living/L)
 	..()
 	holder.toxin_mod_perk -= 0.1 //Might be to high...
 
@@ -149,12 +158,14 @@
 	gain_text = "Things just get harder and harder..."
 	icon_state = "shock"
 
-/datum/perk/oddity/shell_shock/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/shell_shock/assign(mob/living/L)
 	..()
 	holder.stats.changeStat(STAT_ROB, -5)
 	holder.stats.changeStat(STAT_TGH, -5)
 	holder.stats.changeStat(STAT_VIG, -5)
-	H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 1, learner = H)
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 1, learner = H)
 
 
 /datum/perk/oddity/shell_shock/remove()
@@ -169,12 +180,14 @@
 	gain_text = "The world is not as clear as it once was."
 	icon_state = "brainrot"
 
-/datum/perk/oddity/failing_mind/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/failing_mind/assign(mob/living/L)
 	..()
 	holder.stats.changeStat(STAT_COG, -5)
 	holder.stats.changeStat(STAT_MEC, -5)
 	holder.stats.changeStat(STAT_BIO, -5)
-	H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 1, learner = H)
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.learnt_tasks.attempt_add_task_mastery(/datum/task_master/task/poors, "POORS", skill_gained = 1, learner = H)
 
 
 /datum/perk/oddity/failing_mind/remove()
@@ -195,7 +208,7 @@
 	gain_text = "The mind can over come any puzzle thrown at it!"
 	icon_state = "brain"
 
-/datum/perk/oddity/sharp_mind/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/sharp_mind/assign(mob/living/L)
 	..()
 	holder.stats.changeStat(STAT_COG, 5)
 	holder.stats.changeStat(STAT_MEC, 5)
@@ -213,7 +226,7 @@
 	gain_text = "The blood pumps, the muscles harden, and your trigger finger feels easier than ever..."
 	icon_state = "muscular"
 
-/datum/perk/oddity/strangth/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/strangth/assign(mob/living/L)
 	..()
 	holder.stats.changeStat(STAT_ROB, 5)
 	holder.stats.changeStat(STAT_TGH, 5)
@@ -230,16 +243,20 @@
 	desc = "The body is able to succumb to many negative affects but the mind can simply ignore them. Getting addicted to things is much harder and you can stomach more chemicals."
 	icon_state = "ironpill" // https://game-icons.net/1x1/lorc/underdose.html
 
-/datum/perk/oddity/iron_will/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/iron_will/assign(mob/living/L)
 	..()
-	holder.metabolism_effects.addiction_chance_multiplier = 0.2
-	holder.metabolism_effects.nsa_bonus += 20
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 0.2
+		H.metabolism_effects.nsa_bonus += 20
+		H.metabolism_effects.calculate_nsa()
 
 /datum/perk/oddity/iron_will/remove()
-	holder.metabolism_effects.addiction_chance_multiplier = 1
-	holder.metabolism_effects.nsa_bonus -= 20
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 1
+		H.metabolism_effects.nsa_bonus -= 20
+		H.metabolism_effects.calculate_nsa()
 	..()
 
 /datum/perk/oddity/mind_of_matter
@@ -247,7 +264,7 @@
 	desc = "The mind protects the body by imposing limits to prevent severe harm to the self. With enough focus, you can push yourself past that limit."
 	icon_state = "ironpill" // https://game-icons.net/1x1/lorc/underdose.html
 
-/datum/perk/oddity/mind_of_matter/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/mind_of_matter/assign(mob/living/L)
 	..()
 	holder.maxHealth += 20
 	holder.health += 20
@@ -265,7 +282,7 @@
 	lose_text = "The reloading from the side is more complicated..."
 	icon_state = "plus_one" // https://game-icons.net/1x1/lorc/gears.html
 
-/datum/perk/oddity/side_loading/assign(mob/living/carbon/human/H)
+/datum/perk/oddity/side_loading/assign(mob/living/L)
 	..()
 	holder.stats.changeStat(STAT_COG, -5)
 	holder.stats.changeStat(STAT_VIG, 5)
@@ -290,7 +307,7 @@
 	var/cooldown = 1 SECONDS // Just to make sure that perk don't go berserk.
 	var/initial_time
 
-/datum/perk/nt_oddity/holy_light/assign(mob/living/carbon/human/H)
+/datum/perk/nt_oddity/holy_light/assign(mob/living/L)
 	..()
 	initial_time = world.time
 
@@ -318,15 +335,16 @@
 	icon_state = "vortex"
 	var/initial_time
 
-/datum/perk/bluespace/assign(mob/living/carbon/human/H)
+/datum/perk/bluespace/assign(mob/living/L)
 	..()
 	initial_time = world.time
 	cooldown_time = world.time + rand(20, 60) MINUTES
 	holder.stats.changeStat(STAT_COG, 5) //We keep this 5 per use
-	if(!H.stats?.getPerk(PERK_SI_SCI) && prob(60))
-		GLOB.bluespace_entropy += rand(80, 150) //You done fucked it up.
-	if(H.stats?.getPerk(PERK_SI_SCI) && prob(50))
-		GLOB.bluespace_entropy -= rand(20, 30) //High odds to do even better!
+	if(holder?.stats)
+		if(!holder.stats.getPerk(PERK_SI_SCI) && prob(60))
+			GLOB.bluespace_entropy += rand(80, 150) //You done fucked it up.
+		if(holder.stats.getPerk(PERK_SI_SCI) && prob(50))
+			GLOB.bluespace_entropy -= rand(20, 30) //High odds to do even better!
 	GLOB.bluespace_entropy -= rand(30, 50)
 
 /datum/perk/bluespace/remove(mob/living/carbon/human/H)
@@ -353,7 +371,7 @@
 	gain_text = "What wondrous possibilities..."
 	icon_state = "tinker"
 
-/datum/perk/guild/blackbox_insight/assign(mob/living/carbon/human/H)
+/datum/perk/guild/blackbox_insight/assign(mob/living/L)
 	..()
 	holder.stats.changeStat(STAT_COG, 15)
 	holder.stats.changeStat(STAT_MEC, 15)
@@ -382,12 +400,14 @@
 	gain_text = "Your mind feels much clearer now."
 	lose_text = "You feel the shadows once more."
 
-/datum/perk/njoy/assign(mob/living/carbon/human/H)
-	if(..())
-		holder.sanity.insight_gain_multiplier *= 0.5
+/datum/perk/njoy/assign(mob/living/L)
+	if(..() && ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.insight_gain_multiplier *= 0.5
 
 /datum/perk/njoy/remove()
-	if(holder)
-		holder.sanity.insight_gain_multiplier *= 2
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.sanity.insight_gain_multiplier *= 2
 	..()
 

--- a/code/datums/perks/perk.dm
+++ b/code/datums/perks/perk.dm
@@ -47,9 +47,9 @@
 /datum/perk
 	var/name = "Perk"
 	var/desc = ""
-	var/icon// = 'icons/effects/perks.dmi'
+	var/icon = 'icons/effects/perks.dmi'
 	var/icon_state = "missing_perk_icon"
-	var/mob/living/carbon/human/holder
+	var/mob/living/holder
 	var/gain_text
 	var/lose_text
 	var/active = TRUE
@@ -86,11 +86,11 @@
 		return FALSE
 	return TRUE
 
-/// Proc called when the perk is assigned to a human. Should be the first thing to be called.
-/datum/perk/proc/assign(mob/living/carbon/human/H)
-	if(istype(H))
+/// Proc called when the perk is assigned to a being. Should be the first thing to be called.
+/datum/perk/proc/assign(mob/living/L)
+	if(istype(L))
 		SHOULD_CALL_PARENT(TRUE)
-		holder = H
+		holder = L
 		RegisterSignal(holder, COMSIG_MOB_LIFE, .proc/on_process)
 		to_chat(holder, SPAN_NOTICE("[gain_text]"))
 		return TRUE

--- a/code/datums/perks/psionic.dm
+++ b/code/datums/perks/psionic.dm
@@ -6,7 +6,7 @@
 	gain_text = "You suddenly get a splitting headache before your vision blurs painfully. By the time its over, you feel like a whole new world of possibilities has opened for you."
 	icon_state = "psionic"
 
-/datum/perk/psion/assign(mob/living/carbon/human/H)
+/datum/perk/psion/assign(mob/living/L)
 	..()
 	holder.maxHealth -=20
 	holder.health -=20
@@ -54,7 +54,7 @@
 	gain_text = "Everything falls into place, all things become clear. You feel stronger, more alert, quicker. You have not attained perfection but you feel you are closer than ever before \
 	and the last mental block you had has been removed, the flood gates of success filling your mind."
 
-/datum/perk/psi_peace_of_the_psion/assign(mob/living/carbon/human/H)
+/datum/perk/psi_peace_of_the_psion/assign(mob/living/L)
 	..()
 	holder.stats.changeStat(STAT_ROB, 10)
 	holder.stats.changeStat(STAT_TGH, 10)

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -33,7 +33,7 @@
 	desc = "All sablekyne are stocky and built wide, your brawny build and low center of gravity gives you exceptional balance. Few beasts can knock you down and not even the strongest men can push you over."
 	icon_state = "muscular" // https://game-icons.net
 
-/datum/perk/brawn/assign(mob/living/carbon/human/H)
+/datum/perk/brawn/assign(mob/living/L)
 	..()
 	holder.mob_bump_flag = HEAVY
 
@@ -72,16 +72,20 @@
 	desc = "A mar'qua's nervous system has long since adapted to the use of stimulants, chemicals, and different toxins. Unlike lesser races, you can handle a wide variety of chemicals before showing any side effects and you'll never become addicted."
 	icon_state = "adaptednervoussystem"
 
-/datum/perk/alien_nerves/assign(mob/living/carbon/human/H)
+/datum/perk/alien_nerves/assign(mob/living/L)
 	..()
-	holder.metabolism_effects.addiction_chance_multiplier = -1
-	holder.metabolism_effects.nsa_bonus += 300
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = -1
+		H.metabolism_effects.nsa_bonus += 300
+		H.metabolism_effects.calculate_nsa()
 
 /datum/perk/alien_nerves/remove()
-	holder.metabolism_effects.addiction_chance_multiplier = 1
-	holder.metabolism_effects.nsa_bonus -= 300
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.addiction_chance_multiplier = 1
+		H.metabolism_effects.nsa_bonus -= 300
+		H.metabolism_effects.calculate_nsa()
 	..()
 
 //////////////////////////////////////Human perks
@@ -434,7 +438,7 @@
 	in your biology and pheromones however make you an enemy to roaches. As a side effect of dealing with spiders so often, you can't be slowed or stuck by webbing."
 	icon_state = "muscular" // https://game-icons.net
 
-/datum/perk/spiderfriend/assign(mob/living/carbon/human/H)
+/datum/perk/spiderfriend/assign(mob/living/L)
 	..()
 	holder.faction = "spiders"
 
@@ -492,7 +496,7 @@
 	desc = "Unlike other caste in the cht'mant hive you are built for combat, while not as naturally tough as other species you can tank a few more blows than your softer insectile brethren."
 	icon_state = "paper"
 
-/datum/perk/chitinarmor/assign(mob/living/carbon/human/H)
+/datum/perk/chitinarmor/assign(mob/living/L)
 	..()
 	holder.brute_mod_perk *= 0.80 // I need to know what type of stuff people were smoking before my change here
 	holder.mob_bomb_defense += 5
@@ -573,7 +577,7 @@
 	desc = "As a Folken, you can use the light to heal wounds, standing in areas of bright light will increase your natural regeneration. Due to your comparitively young age, you heal much faster than older folken."
 	var/replaced = FALSE // Did it replace the normal folken healing?
 
-/datum/perk/folken_healing/young/assign(mob/living/carbon/human/H)
+/datum/perk/folken_healing/young/assign(mob/living/L)
 	..()
 	if(holder.stats.getPerk(PERK_FOLKEN_HEALING)) // Does the user has the folken healing perk?
 		holder.stats.removePerk(PERK_FOLKEN_HEALING) // Remove the old healing.
@@ -777,14 +781,18 @@
 	if(regen_rate  && holder.nutrition > 300 && holder.stat != DEAD) //We lose regen when we are below half max nutrition. Or when we're dead.
 		holder.heal_overall_damage(regen_rate, regen_rate)
 
-/datum/perk/racial/slime_metabolism/assign(mob/living/carbon/human/H)
+/datum/perk/racial/slime_metabolism/assign(mob/living/L)
 	..()
 	holder.toxin_mod_perk -= 0.5
-	holder.metabolism_effects.nsa_bonus += 100
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.nsa_bonus += 100
+		H.metabolism_effects.calculate_nsa()
 
 /datum/perk/racial/slime_metabolism/remove()
 	holder.toxin_mod_perk += 0.5
-	holder.metabolism_effects.nsa_bonus -= 100
-	holder.metabolism_effects.calculate_nsa()
+	if(ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		H.metabolism_effects.nsa_bonus -= 100
+		H.metabolism_effects.calculate_nsa()
 	..()

--- a/code/datums/perks/special.dm
+++ b/code/datums/perks/special.dm
@@ -12,9 +12,6 @@
 	passivePerk = FALSE
 	var/anti_cheat= FALSE
 
-/datum/perk/forceful_rejection/assign(mob/living/carbon/human/H)
-	..()
-
 /datum/perk/forceful_rejection/remove()
 	holder.stats.changeStat(STAT_VIV, -15)
 	if(ishuman(usr))
@@ -68,7 +65,7 @@
 	active = FALSE
 	passivePerk = FALSE
 
-/datum/perk/skill_cap_expanding/assign(mob/living/carbon/human/H)
+/datum/perk/skill_cap_expanding/assign(mob/living/L)
 	..()
 	for(var/stat in ALL_STATS)
 		var/gather_increase = holder.stats.grab_Stat_cap(stat)
@@ -90,7 +87,7 @@
 	active = FALSE
 	passivePerk = FALSE
 
-/datum/perk/skill_cap_addition/assign(mob/living/carbon/human/H)
+/datum/perk/skill_cap_addition/assign(mob/living/L)
 	..()
 	for(var/stat in ALL_STATS)
 		holder.stats.add_Stat_cap(30)

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -75,11 +75,15 @@
 
 		if(loaded_dna)
 			visible_message("<span class='notice'>The printer injects the stored DNA into the biomass.</span>.")
-			O.transplant_data = list()
-			var/mob/living/carbon/C = loaded_dna["donor"]
-			O.transplant_data["species"] =    C.species.name
-			O.transplant_data["blood_type"] = loaded_dna["blood_type"]
-			O.transplant_data["blood_DNA"] =  loaded_dna["blood_DNA"]
+			O.transplant_data = list(
+				"blood_type" = loaded_dna["blood_type"],
+				"blood_DNA" = loaded_dna["blood_DNA"],
+			)
+			var/datum/weakref/ref = loaded_dna["donor"]
+			if(istype(ref))
+				var/mob/living/carbon/C = ref.resolve()
+				if(istype(C))
+					O.transplant_data["species"] =    C.species.name
 
 		visible_message("<span class='info'>The bioprinter spits out a new organ.</span>")
 

--- a/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
+++ b/code/modules/cooking_with_jane/cooking_items/cooking_containers.dm
@@ -116,6 +116,7 @@
 		if(lower_quality_on_fail)
 			for (var/obj/item/contained in contents)
 				contained?:food_quality -= lower_quality_on_fail
+			return
 		else
 			tracker = new /datum/cooking_with_jane/recipe_tracker(src)
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -365,8 +365,8 @@
 	var/dam_zone = pick(organs_by_name)
 	var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
 	var/dam = damage_through_armor(damage = damage, damagetype = damagetype, def_zone = affecting, attack_flag = ARMOR_MELEE, armour_pen = penetration, sharp = sharp, edge = sharp)
-
-	if(dam > 0)
+	// ran_zone might pick a zone that we don't actually have an organ in
+	if(dam > 0 && affecting)
 		affecting.add_autopsy_data("[attack_message] by \a [user]", dam)
 	updatehealth()
 	hit_impact(damage, get_step(user, src))

--- a/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -347,7 +347,7 @@
 	//	loc.assume_air(breath) //by default, exhale
 
 /* this is now handled upwards in living_defense
-/mob/living/carbon/superior_animal/handle_fire(flammable_gas, turf/location)
+/mob/living/carbon/superior_animal/handle_fire()
 	if(never_stimulate_air)
 		if (fire_stacks > 0)
 			ExtinguishMob() //We dont simulate air thus we dont simulate fire

--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -468,7 +468,8 @@
 
 			if (shoot) // should we shoot?
 				if (prepareAttackPrecursor(RANGED_TYPE, TRUE, TRUE, targetted))
-					addtimer(CALLBACK(src, .proc/OpenFire, targetted, trace), delay_for_range)
+					if(!QDELETED(src))
+						addtimer(CALLBACK(src, .proc/OpenFire, targetted, trace), delay_for_range)
 
 			if (advancement_timer <= world.time)  //we dont want to prematurely end a advancing walk
 				if (stat != DEAD)
@@ -586,7 +587,7 @@
 			if (can_burrow && bad_environment)
 				evacuate()
 			//Fire handling , not passing the whole list because thats unefficient.
-			handle_fire(environment.gas["oxygen"], loc)
+			handle_fire()
 		// this one in particular im very unhappy about. every 3 ticks, if a superior mob is dead to something that doesnt directly apply damage, it dies. i hate this.
 		handle_regular_status_updates() // we should probably still do this even if we're dead or something
 		ticks_processed = 0

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -67,7 +67,7 @@
 	handle_chemicals_in_body()
 
 	//Check if we're on fire
-	handle_fire(environment.gas["oxygen"], loc)
+	handle_fire()
 
 	update_pulling()
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -411,7 +411,7 @@
 /mob/living/proc/adjust_fire_stacks(add_fire_stacks) //Adjusting the amount of fire_stacks we have on person
     fire_stacks = CLAMP(fire_stacks + add_fire_stacks, FIRE_MIN_STACKS, FIRE_MAX_STACKS)
 
-/mob/living/proc/handle_fire(flammable_gas, turf/location)
+/mob/living/proc/handle_fire()
 	if(never_stimulate_air)
 		if (fire_stacks > 0)
 			ExtinguishMob() //We dont simulate air thus we dont simulate fire

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -141,6 +141,8 @@ var/global/list/robot_modules = list(
 			//Setting this to be infinity power isnt as good of a fix do to guns that cost power getting endless free shots, so auto charging is better - Trilby
 
 /obj/item/robot_module/proc/Reset(var/mob/living/silicon/robot/R)
+	if(!istype(R))
+		return
 	if(R.actively_resting || R.allow_resting)
 		R.actively_resting = 0
 		R.allow_resting = 0
@@ -334,8 +336,8 @@ var/global/list/robot_modules = list(
 	src.modules += O
 
 	//We are stronk so we get less no knockdowns
-	R.stats.addPerk(PERK_ASS_OF_CONCRETE)
-	R.stats.addPerk(PERK_SI_SCI)
+	R?.stats?.addPerk(PERK_ASS_OF_CONCRETE)
+	R?.stats?.addPerk(PERK_SI_SCI)
 
 	..(R)
 
@@ -460,10 +462,10 @@ var/global/list/robot_modules = list(
 	src.modules += S
 
 	//We know medical care and have all the data on it
-	R.stats.addPerk(PERK_MEDICAL_EXPERT)
-	R.stats.addPerk(PERK_SURGICAL_MASTER)
-	R.stats.addPerk(PERK_ADVANCED_MEDICAL)
-	R.stats.addPerk(PERK_SI_SCI)
+	R?.stats?.addPerk(PERK_MEDICAL_EXPERT)
+	R?.stats?.addPerk(PERK_SURGICAL_MASTER)
+	R?.stats?.addPerk(PERK_ADVANCED_MEDICAL)
+	R?.stats?.addPerk(PERK_SI_SCI)
 
 	..(R)
 
@@ -471,20 +473,20 @@ var/global/list/robot_modules = list(
 
 /obj/item/robot_module/medical/general/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/reagent_containers/syringe/large/S = locate() in src.modules
-	if(S.mode == 2)
-		S.reagents.clear_reagents()
+	if(S && S.mode == 2)
+		S.reagents?.clear_reagents()
 		S.mode = initial(S.mode)
 		S.desc = initial(S.desc)
 		S.update_icon()
 
 	if(src.modules)
 		var/obj/item/reagent_containers/spray/sterilizine/ST = locate() in src.modules //ST for STerilizine
-		ST.reagents.add_reagent("sterilizine", 2 * amount)
+		ST?.reagents?.add_reagent("sterilizine", 2 * amount)
 	..()
 
 	if(src.emag)
 		var/obj/item/reagent_containers/spray/acid/PS = locate() in src.emag
-		PS.reagents.add_reagent("pacid", 2 * amount)
+		PS?.reagents?.add_reagent("pacid", 2 * amount)
 	..()
 
 /obj/item/robot_module/engineering
@@ -637,16 +639,16 @@ var/global/list/robot_modules = list(
 	src.modules += FWT
 
 	//We know guild work and robotics.
-	R.stats.addPerk(PERK_HANDYMAN)
-	R.stats.addPerk(PERK_ROBOTICS_EXPERT)
-	R.stats.addPerk(PERK_SI_SCI)
+	R?.stats?.addPerk(PERK_HANDYMAN)
+	R?.stats?.addPerk(PERK_ROBOTICS_EXPERT)
+	R?.stats?.addPerk(PERK_SI_SCI)
 	..(R)
 
 
 /obj/item/robot_module/engineering/general/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	if(src.modules)
 		var/obj/item/reagent_containers/spray/cleaner/SC = locate() in src.modules //space cleaner
-		SC.reagents.add_reagent("cleaner", 2 * amount)
+		SC?.reagents?.add_reagent("cleaner", 2 * amount)
 	..()
 
 	if(R.HasTrait(CYBORG_TRAIT_EMAGGED))
@@ -747,20 +749,20 @@ var/global/list/robot_modules = list(
 	src.emag += new /obj/item/melee/energy/sword(src)
 
 	//We are stronk so we get less no knockdowns
-	R.stats.addPerk(PERK_ASS_OF_CONCRETE)
-	R.stats.addPerk(PERK_BLOOD_LUST) //Target ME
-	R.stats.addPerk(PERK_SI_SCI)
+	R?.stats?.addPerk(PERK_ASS_OF_CONCRETE)
+	R?.stats?.addPerk(PERK_BLOOD_LUST) //Target ME
+	R?.stats?.addPerk(PERK_SI_SCI)
 
 	..(R)
 
 /obj/item/robot_module/security/defense/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	..()
 	var/obj/item/gun/energy/bsrifle/T = locate() in src.modules
-	if(T.cell.charge < T.cell.maxcharge)
+	if(T && T.cell && (T.cell.charge < T.cell.maxcharge))
 		T.cell.give(T.charge_cost * amount)
 		T.update_icon()
 	else
-		T.charge_tick = 0
+		T?.charge_tick = 0
 
 
 /obj/item/robot_module/security/enforcement
@@ -841,28 +843,28 @@ var/global/list/robot_modules = list(
 	src.emag += new /obj/item/gun/energy/laser/mounted/cyborg(src)
 
 	//We are stronk so we get less no knockdowns
-	R.stats.addPerk(PERK_ASS_OF_CONCRETE)
-	R.stats.addPerk(PERK_BLOOD_LUST) //Target ME
-	R.stats.addPerk(PERK_SI_SCI)
+	R?.stats?.addPerk(PERK_ASS_OF_CONCRETE)
+	R?.stats?.addPerk(PERK_BLOOD_LUST) //Target ME
+	R?.stats?.addPerk(PERK_SI_SCI)
 
 	..(R)
 
 /obj/item/robot_module/security/enforcement/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	..()
 	var/obj/item/gun/energy/taser/mounted/cyborg/T = locate() in src.modules
-	if(T.cell.charge < T.cell.maxcharge)
+	if(T && T.cell && (T.cell.charge < T.cell.maxcharge))
 		T.cell.give(T.charge_cost * amount)
 		T.update_icon()
 	else
-		T.charge_tick = 0
+		T?.charge_tick = 0
 
 	if(R.HasTrait(CYBORG_TRAIT_EMAGGED))
 		var/obj/item/gun/energy/laser/mounted/cyborg/L = locate() in src.modules
-		if(L.cell.charge < L.cell.maxcharge)
+		if(L && L.cell && (L.cell.charge < L.cell.maxcharge))
 			L.cell.give(T.charge_cost * amount)
 			L.update_icon()
 		else
-			L.charge_tick = 0
+			L?.charge_tick = 0
 
 	var/obj/item/tool/baton/robot/B = locate() in src.modules
 	if(B && B.cell)
@@ -947,18 +949,18 @@ var/global/list/robot_modules = list(
 	src.emag += new /obj/item/melee/energy/sword(src)
 
 	//Silent cleaners
-	R.stats.addPerk(PERK_QUIET_AS_MOUSE)
-	R.stats.addPerk(PERK_SI_SCI)
+	R?.stats?.addPerk(PERK_QUIET_AS_MOUSE)
+	R?.stats?.addPerk(PERK_SI_SCI)
 
 	..(R)
 
 /obj/item/robot_module/custodial/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	..()
 	var/obj/item/device/lightreplacer/LR = locate() in src.modules
-	LR.Charge(R, amount)
+	LR?.Charge(R, amount)
 	if(src.emag)
 		var/obj/item/reagent_containers/spray/lube/S = locate() in src.emag
-		S.reagents.add_reagent("lube", 2 * amount)
+		S?.reagents?.add_reagent("lube", 2 * amount)
 
 /obj/item/robot_module/service
 	name = "service robot module"
@@ -1047,7 +1049,6 @@ var/global/list/robot_modules = list(
 	src.emag += new /obj/item/melee/energy/sword(src)
 	src.emag += new /obj/item/stamp/chameleon(src)
 	src.emag += new /obj/item/pen/chameleon(src)
-	..(R)
 
 	var/obj/item/rsf/M = new /obj/item/rsf(src)
 	M.stored_matter = 30
@@ -1064,19 +1065,19 @@ var/global/list/robot_modules = list(
 	src.emag += new /obj/item/reagent_containers/food/drinks/bottle/small/beer_two(src)
 
 	//Seller and cleaner mix, so quite and knowing the deal!
-	R.stats.addPerk(PERK_QUIET_AS_MOUSE)
-	R.stats.addPerk(PERK_MARKET_PROF)
-	R.stats.addPerk(PERK_SI_SCI)
+	R?.stats?.addPerk(PERK_QUIET_AS_MOUSE)
+	R?.stats?.addPerk(PERK_MARKET_PROF)
+	R?.stats?.addPerk(PERK_SI_SCI)
 
 	..(R)
 
 /obj/item/robot_module/service/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	..()
 	var/obj/item/reagent_containers/food/condiment/enzyme/E = locate() in src.modules
-	E.reagents.add_reagent("enzyme", 2 * amount)
+	E?.reagents?.add_reagent("enzyme", 2 * amount)
 	if(src.emag)
 		var/obj/item/reagent_containers/food/drinks/bottle/small/beer_two/B = locate() in src.emag
-		B.reagents.add_reagent("beer2", 2 * amount)
+		B?.reagents?.add_reagent("beer2", 2 * amount)
 
 /obj/item/robot_module/miner
 	name = "miner robot module"
@@ -1153,8 +1154,8 @@ var/global/list/robot_modules = list(
 	src.emag += new /obj/item/melee/energy/sword(src)
 
 	//Seller so quite and knowing the deal!
-	R.stats.addPerk(PERK_MARKET_PROF)
-	R.stats.addPerk(PERK_SI_SCI)
+	R?.stats?.addPerk(PERK_MARKET_PROF)
+	R?.stats?.addPerk(PERK_SI_SCI)
 
 
 	..(R)
@@ -1245,10 +1246,10 @@ var/global/list/robot_modules = list(
 	src.modules += N
 
 	//We know medical and robotics, were a mix.
-	R.stats.addPerk(PERK_MEDICAL_EXPERT)
-	R.stats.addPerk(PERK_SURGICAL_MASTER)
-	R.stats.addPerk(PERK_ROBOTICS_EXPERT)
-	R.stats.addPerk(PERK_SI_SCI)
+	R?.stats?.addPerk(PERK_MEDICAL_EXPERT)
+	R?.stats?.addPerk(PERK_SURGICAL_MASTER)
+	R?.stats?.addPerk(PERK_ROBOTICS_EXPERT)
+	R?.stats?.addPerk(PERK_SI_SCI)
 
 	..(R)
 
@@ -1346,20 +1347,18 @@ var/global/list/robot_modules = list(
 	src.modules += P
 
 	//We know repair work and robotics.
-	R.stats.addPerk(PERK_ROBOTICS_EXPERT)
-	R.stats.addPerk(PERK_SI_SCI)
+	R?.stats?.addPerk(PERK_ROBOTICS_EXPERT)
+	R?.stats?.addPerk(PERK_SI_SCI)
 
 	..(R)
 
 /obj/item/robot_module/drone/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	if(src.modules)
 		var/obj/item/reagent_containers/spray/krag_b_gone/KBG = locate() in src.modules //Krag-B-Gone
-		if(KBG)
-			KBG.reagents.add_reagent("silicate", 2 * amount)
+		KBG?.reagents?.add_reagent("silicate", 2 * amount)
 
 		var/obj/item/device/lightreplacer/LR = locate() in src.modules
-		if(LR)
-			LR.Charge(R, amount)
+		LR?.Charge(R, amount)
 
 	..()
 

--- a/code/modules/modular_computers/hardware/scanners/scanner_price.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner_price.dm
@@ -2,10 +2,12 @@
 	name = "export scanner module"
 	desc = "A module used to check objects against commercial database. Uses NTNet to connect to database."
 
-/obj/item/computer_hardware/scanner/price/can_use_scanner(user, target, proximity)
+/obj/item/computer_hardware/scanner/price/can_use_scanner(user, atom/movable/target, proximity)
+	if(!istype(target))
+		return 0
 	return ..()
 
-/obj/item/computer_hardware/scanner/price/do_on_afterattack(mob/user, atom/target, proximity)
+/obj/item/computer_hardware/scanner/price/do_on_afterattack(mob/user, atom/movable/target, proximity)
 	if(!can_use_scanner(user, target, proximity))
 		return
 	if (!scan_power_use())
@@ -19,4 +21,4 @@
 			driver.data_buffer += "<br>[dat]"
 		if(!SSnano.update_uis(driver.NM))
 			holder2.run_program(driver.filename)
-			driver.NM.nano_ui_interact(user)
+			driver.NM?.nano_ui_interact(user)

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -97,11 +97,12 @@ nanoui is used to open and update nano browser uis
 		ref = nref
 
 	add_common_assets()
-
-	var/datum/asset/nanoui = get_asset_datum(/datum/asset/simple/directories/nanoui)
-	if (nanoui.send(user.client))
-		to_chat(user, span_warning("Currently sending <b>all</b> nanoui assets, please wait!"))
-		user.client.browse_queue_flush() // stall loading nanoui until assets actualy gets sent
+	
+	if(user?.client)
+		var/datum/asset/nanoui = get_asset_datum(/datum/asset/simple/directories/nanoui)
+		if(nanoui.send(user.client))
+			to_chat(user, span_warning("Currently sending <b>all</b> nanoui assets, please wait!"))
+			user.client.browse_queue_flush() // stall loading nanoui until assets actualy gets sent
 
 
 //Do not qdel nanouis. Use close() instead.

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -48,8 +48,6 @@
 	if (!QDELETED(src))
 		for(var/datum/reagent/organic/blood/B in vessel.reagent_list)
 			if(B.id == "blood")
-				B.data = list(	"donor"=src,"viruses"=null,"species"=species.name,"blood_DNA"=dna.unique_enzymes,"blood_colour"= blood_color,"blood_type"=dna.b_type,	\
-								"resistances"=null,"trace_chem"=null, "virus2" = null, "antibodies" = list())
 				B.initialize_data(get_blood_data())
 
 // Takes care blood loss and regeneration
@@ -167,9 +165,11 @@
 /mob/living/carbon/proc/get_blood()
 	var/datum/reagent/organic/blood/res = locate() in vessel.reagent_list //Grab some blood
 	if(res) // Make sure there's some blood at all
-		if(res.data["donor"] != src) //If it's not theirs, then we look for theirs
+		var/datum/weakref/ref = res.data["donor"]
+		if(istype(ref) && ref.resolve() != src)
 			for(var/datum/reagent/organic/blood/D in vessel.reagent_list)
-				if(D.data["donor"] == src)
+				ref = D.data["donor"]
+				if(ref.resolve() == src)
 					return D
 	return res
 

--- a/code/modules/reagents/reagent_containers/glass/beaker.dm
+++ b/code/modules/reagents/reagent_containers/glass/beaker.dm
@@ -28,7 +28,7 @@
 		var/mutable_appearance/lid = mutable_appearance(icon, lid_icon)
 		add_overlay(lid)
 
-	if(reagents.total_volume)
+	if(reagents?.total_volume)
 		var/mutable_appearance/filling = mutable_appearance('icons/obj/reagentfillings.dmi', "[icon_state][get_filling_state()]")
 		filling.color = reagents.get_color()
 		add_overlay(filling)

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -225,7 +225,12 @@
 	if(I.nature != initial(base_type.wound_nature))
 		return
 
-	var/wound_path = pick(subtypesof(base_type))
+	var/wound_path = base_type
+
+	var/list/types = subtypesof(base_type)
+	if(length(types))
+		wound_path = pick(types)
+
 	var/wound_name = "[name] [wound_descriptor]"
 	I.add_wound(wound_path, wound_name)
 	if(!silent && BP_IS_ORGANIC(I) || BP_IS_SLIME(I))

--- a/code/modules/reagents/reagents/core.dm
+++ b/code/modules/reagents/reagents/core.dm
@@ -30,9 +30,15 @@
 /datum/reagent/organic/blood/touch_turf(turf/simulated/T)
 	if(!istype(T) || volume < 3)
 		return TRUE
-	if(!data["donor"] || istype(data["donor"], /mob/living/carbon/human))
+	var/datum/weakref/D = data["donor"]
+	if(!istype(D))
 		blood_splatter(T, src, 1)
-	else if(istype(data["donor"], /mob/living/carbon/alien))
+		return
+	
+	var/mob/living/something = D.resolve()
+	if(istype(something, /mob/living/carbon/human))
+		blood_splatter(T, src, 1)
+	else if(istype(something, /mob/living/carbon/alien))
 		var/obj/effect/decal/cleanable/blood/B = blood_splatter(T, src, 1)
 		if(B)
 			B.blood_DNA["UNKNOWN DNA STRUCTURE"] = "X*"

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -75,14 +75,20 @@
 						if (ID in virusDB)
 							R = virusDB[ID]
 
-						var/mob/living/carbon/human/D = B.data["donor"]
-						pathogen_pool.Add(list(list(\
-							"name" = "[D.get_species()] [B.name]", \
+						var/list/new_data = list(
+							"name" = "[B.name]", \
 							"dna" = B.data["blood_DNA"], \
 							"unique_id" = V.uniqueID, \
 							"reference" = "\ref[V]", \
 							"is_in_database" = !!R, \
-							"record" = "\ref[R]")))
+							"record" = "\ref[R]"
+						)
+						var/datum/weakref/ref = B.data["donor"]
+						if(istype(ref))
+							var/mob/living/carbon/human/D = ref.resolve()
+							if(istype(D))
+								new_data["name"] = "[D.get_species()] [B.name]"
+						pathogen_pool += list(new_data)
 
 				if (pathogen_pool.len > 0)
 					data["pathogen_pool"] = pathogen_pool
@@ -187,8 +193,15 @@
 			P.info += "<hr>"
 
 			for(var/datum/reagent/organic/blood/B in sample.reagents.reagent_list)
-				var/mob/living/carbon/human/D = B.data["donor"]
-				P.info += "<large><u>[D.get_species()] [B.name]:</u></large><br>[B.data["blood_DNA"]]<br>"
+				var/datum/weakref/ref = B.data["donor"]
+				if(istype(ref))
+					var/mob/living/carbon/human/D = ref.resolve()
+					if(istype(D))
+						P.info += "<large><u>[D.get_species()] [B.name]:</u></large><br>[B.data["blood_DNA"]]<br>"
+					else
+						P.info += "<large><u>[B.name]:</u></large><br>[B.data["blood_DNA"]]<br>"
+				else
+					P.info += "<large><u>[B.name]:</u></large><br>[B.data["blood_DNA"]]<br>"
 
 				var/list/virus = B.data["virus2"]
 				P.info += "<u>Pathogens:</u> <br>"


### PR DESCRIPTION
## About The Pull Request
See changelog

## Changelog
:cl:
fix: Runtime when superior mobs move towards qdeleted things
fix: Runtime when adding bad item to a Jane's cooking container
fix: Runtime when superior mobs try to attack after being qdeleted
fix: Runtime when brains in MMis tried to handle being on fire
fix: Runtime when beakers are initialized
fix: Runtime when putting on sanity-protecting gear (it still doesn't work tho)
fix: Runtime when trying to print a blood-matched organ in the bioprinter
fix: Runtime when a mob tries to hit a limb that no longer exists
fix: Runtime when scanning a turf with the export scanner (only movable atoms work)
fix: Runtime when overdosing on plasma
fix: Runtime when opening nanoUI without a client (how?)
fix: Runtime when selecting robot modules
fix: Runtime when robot module has been selected and you try to get perks
fix: A bunch of runtimes when perks are added to non-humans
refactor: Perks no longer expect their holder to be human, just living
/:cl:
