### PR TITLE
[Balance I guess?] Changes the defunct toxloss component of 2 gun mod to Halloss

### DIFF
--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -296,7 +296,7 @@
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
 		GUN_UPGRADE_DAMAGE_BURN = 10,
-		GUN_UPGRADE_DAMAGE_HALLOSS = 10, //Once again this component was tox before, Tox damage does not exist in erismedIV and wounds are not particularly well thought out as we have seen with unmaker.
+		GUN_UPGRADE_DAMAGE_HALLOSS = 10, // Once again this component was tox before, Tox damage does not exist in erismedIV and wounds are not particularly well thought out as we have seen with unmaker.
 		UPGRADE_BULK = 1
 		)
 	I.req_gun_tags = list(GUN_PROJECTILE, GUN_CALIBRE_9MM)
@@ -533,7 +533,7 @@
 	I.prefix = "honking"
 	I.gun_loc_tag = GUN_TRIGGER
 
-// Add toxin damage to your weapon
+// Add Halloss damage to your weapon
 /obj/item/gun_upgrade/barrel/toxin_coater
 	name = "Soteria \"Scorpion\" neurotoxin coater"
 	desc = "This experimental barrel coates a thin jet of some neurotoxin onto bullets just before they leave the weapon making them more painful to the receiving target. The device is rather unintrusive and does not alter the weapon in any detrimental way."
@@ -545,7 +545,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-	GUN_UPGRADE_DAMAGE_HALLOSS = 5) //I am not entirely sure how well halloss is with the combat rework but at least its not a noob trap that does nothing now
+	GUN_UPGRADE_DAMAGE_HALLOSS = 5) // I am not entirely sure how well halloss is with the combat rework but at least its not a noob trap that does nothing now
 	I.req_gun_tags = list(GUN_PROJECTILE)
 	I.gun_loc_tag = GUN_BARREL
 	I.prefix = "neurotoxic"


### PR DESCRIPTION
Both the Toxin Coater and the Glass Widows toxin damage components are defunct thanks to erismed IV. At least when it comes to pvp. 

## About The Pull Request
One could make an argument to just change it to apply toxic buildup like erismed IV does with roach gas for instance but Erismed IVs wound system isnt that well fleshed out to be honest as it increases in severity no matter how little a wound is. Flat damage numbers are far easier to balance around for gunmods. I also have grown to dislike (partially) broken equipment that is still available for printing and thus wasting materials or time. Glass widow remains 9 mm locked. 

Toxin coater has to compete with better barrel mods like the forged or heavy barrel.

Confirmed on local that halloss applies correctly.

To do in a separate PR: Figure out how to apply L.apply.effects onto guns because that would allow for a bunch of nice shit to work like irradiate (the proper rad barrel in code is not working and I think never really worked to begin with even upstream) or confuse. 

## Changelog
:cl:
tweak: Toxin coater and Glass Widow now apply halloss instead of toxin damage (Toxin damage is defunct, nope its not fixed upstream either :/)
/:cl:


