### PR TITLE
Fix nanoui throwing errors when moving away

### DIFF
--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -224,7 +224,9 @@ nanoui is used to open and update nano browser uis
 	var/list/config_data = get_config_data()
 
 	var/list/send_data = list("config" = config_data)
-	send_data["data"] = data
+
+	if(!isnull(data))
+		send_data["data"] = data
 
 	return send_data
 


### PR DESCRIPTION
## About The Pull Request
I didn't notice the subtle behavior change in 411c917941d9deaa5d75f081e17d4baa81f12fb8 where data is no longer checked for isnull() - evidently, this causes nano to scream whenever a UI is out of range

## Changelog
:cl:
fix: NanoUI no longer screams and errors when you walk away from an object
/:cl:
