### PR TITLE
Fix incorrect spawner name

### DIFF
--- a/code/game/objects/random/mob/misc.dm
+++ b/code/game/objects/random/mob/misc.dm
@@ -454,7 +454,7 @@
 	return pickweight(mobs)
 
 /obj/random/mob/vox/low_chance
-	name = "low chance nightmare"
+	name = "low chance vox"
 	icon_state = "hostilemob-brown-low"
 	spawn_nothing_percentage = 50 //Coin flip
 


### PR DESCRIPTION
Changes the incorrectly named "low chance nightmare" vox spawner to "low chance vox".
Only shows up in mapping tools.