### PR TITLE
Supermatter now tied to radiationSS

### DIFF
--- a/code/controllers/subsystems/radiation.dm
+++ b/code/controllers/subsystems/radiation.dm
@@ -82,8 +82,9 @@ proc/produce_radiation(var/Source, var/Power, var/Range)
 		return
 
 	for(var/mob/living/M in range(Range, Source))
-		M.apply_effect(Power, IRRADIATE)
-		M.updatehealth()
+		if(isInSight(Source, M))
+			M.apply_effect(((Power / 10) * ( 1 / (Range**2) )), IRRADIATE) //inverse square lawed, adjust the Power/10 to tweak this value
+			M.updatehealth()
 		for(var/obj/item/device/geiger/G in M.contents)
 			G.add_rads(Power)
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -265,6 +265,7 @@
 
 		env.merge(removed)
 
+	//This one handles hallucinations
 	for(var/mob/living/carbon/human/H in view(src, min(7, round(sqrt(power/6))))) // If they can see it without mesons on.  Bad on them.
 		if(!istype(H.glasses, /obj/item/clothing/glasses/powered/meson))
 			if (!(istype(H.wearing_rig, /obj/item/rig) && istype(H.wearing_rig.getCurrentGlasses(), /obj/item/clothing/glasses/powered/meson)))
@@ -272,12 +273,7 @@
 				H.adjust_hallucination(effect, 0.25*effect)
 				H.add_side_effect("Headache", 11)
 
-	//adjusted range so that a power of 170 (pretty high) results in 9 tiles, roughly the distance from the core to the engine monitoring room.
-	//note that the rads given at the maximum range is a constant 0.2 - as power increases the maximum range merely increases.
-	for(var/mob/living/l in range(src, round(sqrt(power / 2) / 2)))
-		var/radius = max(get_dist(l, src), 1)
-		var/rads = (power / 10) * ( 1 / (radius**2) )
-		l.apply_effect(rads, IRRADIATE)
+	PulseRadiation(src, power, (round(sqrt(power / 2) / 2)))
 
 	power -= (power/DECAY_FACTOR)**3		//energy losses due to radiation
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Makes the radiationSS now use the inverse square law for propagation of radiation, and makes the supermatter use it instead of doing it on it's own
</summary>
<hr>

- [x] Does it generate radiation?
- [x] Does it make the geiger counter useful with the supermatter?
- [x] Is it obeying the inverse square law?
- [ ] If the SM delams, does it also uses the subsystem? (can't because the SS has no way to apply rads to a whole Z currently)
- [x] Does it affect people? (partial yes, apply_effects seem to be working, but the radiation var on mobs seem to be doing nothing on my local test, like the other pr that changes IRRADIATE to HALOSS in certain gun mods)

Overall it's both a nerf to radiation from far and a buff if you're too close, but the effect on mobs seem to be currently bugged, I will probably have to return to those files and tweak the values in case they cause too much damage to players, or too little once it gets sorted, right now SM is in equal footing with early torch Bay, but walls block it, so avoid being in line of sight of the SM to never get irradiated/hallucinations

	
<hr>
</details>

## Changelog
:cl:
fix: radiation now follows the inverse square law
tweak: supermatter now operates normally under radiationSS instead of it's own, delams are still handled by itself
add: geiger counters now work on active supermatters
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
