### PR TITLE
Revert white mode dsay change

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -270,7 +270,7 @@ em						{font-style: normal;	font-weight: bold;}
 .name					{					font-weight: bold;}
 
 .say					{}
-.deadsay				{color: #3f4041;}
+.deadsay				{color: #5c00e6;}
 .binarysay    			{color: #20c20e; background-color: #000000; display: block;}
 .binarysay a  			{color: #00ff00;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Revert the change to white mode dsay. #5452

While I think the change to darkmode dsay was reasonble since dark blue on black is not a great mix. Changing white modes dsay was not necessery. It actually introduced a new issue in making it look nearly identical to normal say. Example here:
![grafik](https://github.com/sojourn-13/sojourn-station/assets/21098781/4a412e52-79a6-4055-adc1-7730127342b2)