### PR TITLE
Make nano wait till the UI loads to send updates

### DIFF
--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -59,6 +59,8 @@ nanoui is used to open and update nano browser uis
 	var/list/datum/nanoui/children = list()
 	var/datum/nano_topic_state/state = null
 
+	var/ready_for_updates = FALSE
+
  /**
   * Create a new nanoui instance.
   *
@@ -505,11 +507,12 @@ nanoui is used to open and update nano browser uis
 		return // Closed
 	if (status == STATUS_DISABLED && !force_push)
 		return // Cannot update UI, no visibility
+	if(!ready_for_updates)
+		return // Nano hasn't pinged back to say "im ready and loaded"
 
 	var/list/send_data = get_send_data(data)
 
 //	to_chat(user, list2json_usecache(send_data))// used for debugging //NANO DEBUG HOOK
-
 	user << output(list2params(list(strip_improper(json_encode(send_data)))),"[window_id].browser:receiveUpdateData")
 
  /**
@@ -522,6 +525,10 @@ nanoui is used to open and update nano browser uis
 /datum/nanoui/Topic(href, href_list)
 	update_status(0) // update the status
 	if (status != STATUS_INTERACTIVE || user != usr) // If UI is not interactive or usr calling Topic is not the UI user
+		return
+
+	if(href_list["nano_internal_ready"])
+		ready_for_updates = TRUE
 		return
 
 	// This is used to toggle the nano map ui

--- a/nano/js/nano_utility.js
+++ b/nano/js/nano_utility.js
@@ -64,6 +64,7 @@ $(document).ready(function () {
 	NanoStateManager.init();
 	NanoTemplate.init();
 	NanoBaseHelpers.init();
+	window.location = "byond://" + NanoUtility.generateHref({ "nano_internal_ready": 1 });
 });
 
 if (!Array.prototype.indexOf)


### PR DESCRIPTION
## About The Pull Request
So, I had a hunch, and commented out `user << output(list2params(list(strip_improper(json_encode(send_data)))),"[window_id].browser:receiveUpdateData")` completely...
and what do you know? Never got a white screen error no matter how hard I pressed it.

So, the problem with Nano has been this entire time, that it ends up pushing data before everything has loaded, causing an alert that then stops the rest of the UI from loading.

To fix this, I just took a note from TGUI - Nano now will not push updates to a UI until the UI signals via /Topic that it's loaded and ready. 

With this change, I haven't experienced *a single white screen* from Nano. This might not fix it all, but holy shit it should improve reliability.

## Changelog
:cl:
fix: NanoUI now waits until it's loaded to send data, hopefully completely eliminating whitescreen problems.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
