### PR TITLE
fixes the HEV suit

### DIFF
--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -611,3 +611,32 @@ obj/item/clothing/head/sunhat/verb/toggle_style()
 	desc = "A religious hood that can be colored."
 	icon_state = "general_hood"
 	item_state = "general_hood"
+
+
+/obj/item/clothing/head/hev
+
+	name = "Hazardous Enviroment Protection suit helmet"
+	desc = "A hood that comes with the hazardous protection suit."
+	icon_state = "rad"
+	action_button_name = "Toggle Headlamp"
+	brightness_on = 5
+	light_overlay = "hardhat_light"
+	armor_list = list(
+		melee = 60,
+		bullet = 55,
+		energy = 50,
+		bomb = 75,
+		bio = 100,
+		rad = 100
+	)
+	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
+	body_parts_covered = HEAD|FACE|EARS
+	obscuration = LIGHT_OBSCURATION
+	gas_transfer_coefficient = 0.01
+	permeability_coefficient = 0.01
+	siemens_coefficient = 0.4
+	w_class = ITEM_SIZE_NORMAL
+	item_flags = STOPPRESSUREDAMAGE //hardhat has it? So this gets it to.
+	heat_protection = HEAD
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	price_tag = 1000

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -463,3 +463,31 @@ obj/item/clothing/suit/gownrisque/alt
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	min_cold_protection_temperature = T0C - 20
 	price_tag = 50
+
+/obj/item/clothing/suit/hev
+
+	name = "Hazardous Enviroment Protection suit" //funny reference suit. stronk rare and includes some degree of fire and hazard protection just not a space suit.
+	desc = "An advanced suit designed to protect you from the harshest of enviroments as long as that enviroment is not space. A shame most of it's systems seem broken down..."
+	icon_state = "rad"
+	item_state = "rad_suit"
+	w_class = ITEM_SIZE_BULKY
+	stiffness = LIGHT_STIFFNESS
+	gas_transfer_coefficient = 0.01
+	permeability_coefficient = 0.01
+	siemens_coefficient = 0.4
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	armor_list = list(
+		melee = 60,
+		bullet = 55,
+		energy = 50,
+		bomb = 75,
+		bio = 100,
+		rad = 100
+	)
+	equip_delay = 2 SECONDS
+	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
+	item_flags = COVER_PREVENT_MANIPULATION
+	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+	price_tag = 2000

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -12139,8 +12139,11 @@
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber/yggdrasil/cold{
 	name = "";
-	pixel_x = -135;
-	pixel_y = -50
+	pixel_x = 0;
+	pixel_y = 0;
+	density = 0;
+	alpha = 0;
+	icon_state = "error"
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/abandoned_outpost{

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -21127,11 +21127,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/dungeon/outside/prepper/vault/floor4)
 "nTY" = (
-/obj/item/clothing/head/radiation{
-	armor_list = list("melee" = 60, "bullet" = 55, "energy" = 50, "bomb" = 75, "bio" = 100, "rad" = 100);
-	name = "Hazardous Enviroment Protection suit helmet";
-	desc = "A hood that comes with the hazardous protection suit, comes with a retractable visor for easy nutriment intake"
-	},
+/obj/item/clothing/head/hev,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/abandoned_outpost{
 	name = "Site LIMA-09";
@@ -27416,11 +27412,7 @@
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/asteroid/rogue)
 "rWO" = (
-/obj/item/clothing/suit/radiation{
-	armor_list = list("melee" = 60, "bullet" = 55, "energy" = 50, "bomb" = 75, "bio" = 100, "rad" = 100);
-	name = "Hazardous Enviroment Protection suit";
-	desc = "A suit designed to protect you from the harshest of enviroments."
-	},
+/obj/item/clothing/suit/hev,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/dungeon/outside/abandoned_outpost{
 	name = "Site LIMA-09";


### PR DESCRIPTION
Makes the map edited armor from PR #5460 into a real item.
Combat stats copy pasted. Descs slightly adjusted and included general hazard protection. (heat and gas permeability etc). I've not made any significant balance changes intentionally with the hopes this can be full merged rather then lock up a map file. :3

Changelog: 

Tweaks the HEV suit in the LAMBDA dungeon to be a normal item.  
Fixes one of the coldrasil's (cold atoms tree) being visible.