### PR TITLE
Colony atmos pass + more maintenance

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -99,12 +99,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
-"aba" = (
-/obj/structure/closet/wall_mounted/emcloset{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "abj" = (
 /obj/structure/bed/chair/sofa/black/left{
 	dir = 4
@@ -189,12 +183,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"abY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/tool/advanced/onestar/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "acb" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table/woodentable,
@@ -650,11 +638,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"agV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ahf" = (
 /obj/structure/bed/chair/sofa/black/corner{
 	dir = 8;
@@ -1642,6 +1625,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"arr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/lathe_disk/any_gun/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ary" = (
 /obj/structure/lattice,
 /obj/structure/railing,
@@ -1700,15 +1690,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"asi" = (
-/obj/structure/table/rack,
-/obj/structure/curtain/medical,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/organ/internal/optical_sensor,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "asn" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -1876,13 +1857,6 @@
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"atI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "atX" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4
@@ -2017,11 +1991,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
-"auT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/lowkeyrandom,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ava" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2565,10 +2534,6 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
-"aAr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aAv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3290,10 +3255,9 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/forest)
-"aHC" = (
-/obj/machinery/door/window/northleft,
-/obj/structure/curtain/black,
-/turf/simulated/floor/wood/wild5,
+"aHx" = (
+/obj/structure/janitorialcart,
+/turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "aHF" = (
 /obj/machinery/disposal/deliveryChute{
@@ -3415,9 +3379,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
-"aIT" = (
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aIV" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -3502,11 +3463,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/janitor)
-"aKo" = (
-/obj/random/cluster/roaches/lower_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aKu" = (
 /obj/structure/boulder{
 	pixel_x = -1
@@ -3514,6 +3470,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
+"aKw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aKG" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -3722,6 +3683,13 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/colony)
+"aMH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aML" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -3811,6 +3779,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"aNp" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aNy" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -4347,11 +4320,6 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"aUR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/termite_no_despawn/lower_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aVm" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 8
@@ -4544,6 +4512,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"aXg" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/welding,
+/obj/item/storage/belt,
+/obj/item/clothing/head/welding,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aXu" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -4798,10 +4774,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"aZK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "bab" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest)
@@ -4912,19 +4884,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cro)
+"bbc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/spiders/low_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bbf" = (
 /mob/living/simple_animal/chicken{
 	name = "Commander Clucky"
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
-"bbk" = (
-/obj/structure/curtain/open/bed{
-	name = "Privacy curtain"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bbn" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "3,0"
@@ -5376,7 +5346,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/multiz/stairs/enter{
+/obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
 	},
 /turf/simulated/floor/wood/wild3,
@@ -5484,6 +5454,11 @@
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
+"bgt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bgB" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -6166,6 +6141,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"bnC" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A3";
+	name = "D1-A3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bnF" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -7158,6 +7141,11 @@
 /obj/item/storage/bag/xenobio,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
+"bxj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bxt" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
@@ -7631,6 +7619,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"bCS" = (
+/obj/structure/table/glass,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bCU" = (
 /obj/effect/floor_decal/industrial/warningred,
 /obj/structure/extinguisher_cabinet{
@@ -7772,11 +7765,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
-"bEA" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/roach/roachling,
-/turf/simulated/floor/plating,
-/area/colony)
 "bEE" = (
 /obj/item/remains/mouse,
 /turf/simulated/floor/asteroid/grass,
@@ -8027,11 +8015,6 @@
 /obj/landmark/join/late/cyborg,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"bHw" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/rig_module/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bHA" = (
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/asteroid/grass,
@@ -8164,6 +8147,13 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"bIK" = (
+/obj/machinery/vending/engivend,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bIL" = (
 /obj/random/furniture/painting,
 /turf/simulated/wall,
@@ -8767,7 +8757,9 @@
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
-"bOx" = (
+"bOO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "bOV" = (
@@ -8996,11 +8988,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"bSh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "bSj" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Front Desk";
@@ -9050,6 +9037,12 @@
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/outside/inside_colony)
+"bSN" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/rig/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bSP" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/bushb1,
@@ -9686,6 +9679,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"bZk" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/autolathe/mechfab/loaded,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bZl" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -10003,6 +10001,11 @@
 "cco" = (
 /turf/unsimulated/mask,
 /area/nadezhda/dungeon/outside/trashcave)
+"ccw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/eastright,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ccx" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -10060,10 +10063,10 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
-"cdi" = (
+"cdm" = (
+/obj/structure/bed/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/spider_shadow_trap,
-/turf/simulated/floor/tiled/dark/monofloor,
+/turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "cdB" = (
 /obj/structure/catwalk,
@@ -10179,6 +10182,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/clownoffice)
+"ceF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ceJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10545,16 +10554,14 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
-"ciK" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ciM" = (
 /obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"ciN" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ciP" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/railing,
@@ -11136,13 +11143,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/absolutism/skyyard)
-"coP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/lathe_disk/any_gun/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "coS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11268,6 +11268,19 @@
 	icon_state = "10,18"
 	},
 /area/nadezhda/engineering/engine_room)
+"cqg" = (
+/obj/structure/closet/crate/secure/large,
+/obj/item/organ/internal/bone/head/robotic,
+/obj/item/organ/internal/bone/l_arm/robotic,
+/obj/item/organ/internal/bone/l_leg/robotic,
+/obj/item/organ/internal/bone/r_arm/robotic,
+/obj/item/organ/internal/bone/r_leg/robotic,
+/obj/item/organ/internal/bone/chest/robotic,
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "splatter2"
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cqi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12189,6 +12202,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"cAE" = (
+/mob/living/bot/cleanbot,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cAF" = (
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
@@ -13093,6 +13110,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
+"cJn" = (
+/obj/machinery/microwave/burnbarrel,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cJq" = (
 /obj/structure/catwalk,
 /obj/random/cluster/spiders/low_chance,
@@ -13686,6 +13707,10 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/virology)
+"cPi" = (
+/obj/random/science/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cPj" = (
 /obj/structure/low_wall,
 /obj/machinery/door/blast/shutters/glass{
@@ -13917,12 +13942,6 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
-"cRB" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/material_resources,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cRC" = (
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -14141,9 +14160,6 @@
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
-"cTD" = (
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cTG" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/machinery/light/small,
@@ -14556,6 +14572,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
+"cXw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cXx" = (
 /obj/random/flora/small_jungle_tree,
 /obj/random/flora/jungle_tree,
@@ -14713,6 +14733,16 @@
 	},
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/medical/reception)
+"cYU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/northleft,
+/obj/machinery/door/window/southleft,
+/obj/machinery/cash_register{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cYZ" = (
 /obj/structure/table/rack,
 /obj/random/tank,
@@ -14790,14 +14820,6 @@
 "cZu" = (
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
-"cZx" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cZC" = (
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
@@ -15013,11 +15035,6 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/turret_protected/ai)
-"dcK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/eastright,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dcS" = (
 /obj/structure/table/standard,
 /obj/structure/extinguisher_cabinet{
@@ -15582,11 +15599,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
-"dih" = (
-/obj/machinery/mech_recharger,
-/obj/random/mecha/low_chance,
-/turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dil" = (
 /obj/machinery/bioprinter/prosthetics,
 /obj/machinery/camera/network/research{
@@ -15771,13 +15783,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/crew_quarters/bar)
-"dkw" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dky" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
@@ -15852,6 +15857,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
+"dlo" = (
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/mineral,
+/area/colony)
 "dlq" = (
 /obj/structure/flora/small/rock5,
 /obj/structure/flora/small/busha3,
@@ -15879,14 +15888,6 @@
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
-"dlW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall_mounted{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/flour,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dlY" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -16289,6 +16290,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"dpn" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/roach/roachling,
+/turf/simulated/floor/plating,
+/area/colony)
 "dpw" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -16420,14 +16426,6 @@
 "dqN" = (
 /turf/simulated/floor/reinforced/nitrogen,
 /area/nadezhda/engineering/atmos)
-"dqQ" = (
-/obj/random/booze,
-/obj/random/junkfood/onlypizza,
-/obj/random/junkfood/onlyburger,
-/obj/random/junkfood,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "drb" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/light{
@@ -16530,13 +16528,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"drY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/sofa{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dsd" = (
 /obj/structure/catwalk,
 /obj/random/structures,
@@ -16909,6 +16900,13 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"dvs" = (
+/obj/machinery/door/airlock/maintenance_common,
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
+	},
+/turf/space,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dvu" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -18162,6 +18160,13 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"dHP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dIe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18333,19 +18338,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"dJq" = (
-/obj/structure/closet/crate/secure/large,
-/obj/item/organ/internal/bone/head/robotic,
-/obj/item/organ/internal/bone/l_arm/robotic,
-/obj/item/organ/internal/bone/l_leg/robotic,
-/obj/item/organ/internal/bone/r_arm/robotic,
-/obj/item/organ/internal/bone/r_leg/robotic,
-/obj/item/organ/internal/bone/chest/robotic,
-/obj/effect/decal/cleanable/blood/oil{
-	icon_state = "splatter2"
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dJx" = (
 /obj/structure/table/woodentable,
 /obj/machinery/recharger,
@@ -18453,11 +18445,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"dKn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dKy" = (
 /obj/structure/flora/small/trailrocka4,
 /obj/effect/decal/cleanable/dirt,
@@ -18917,6 +18904,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/security/barracks)
+"dOX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet_tech/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dOY" = (
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
@@ -19018,6 +19010,16 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"dQa" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "dQf" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/beach/sand,
@@ -19157,6 +19159,14 @@
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"dRG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dRK" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -19398,13 +19408,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
-"dUl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dUo" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -19506,6 +19509,12 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"dWc" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dWf" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_x = 32
@@ -19626,6 +19635,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfaceeast)
+"dWX" = (
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dWZ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -19707,6 +19720,11 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm2)
+"dXF" = (
+/obj/random/booze/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dXR" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -20262,16 +20280,20 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"edk" = (
-/obj/structure/reagent_dispensers/bidon,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "edn" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/inside_colony)
+"edo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "edp" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/virology)
@@ -20305,13 +20327,6 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/atmos)
-"edz" = (
-/obj/machinery/vending/engivend,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "edF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
@@ -20888,15 +20903,6 @@
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
-"ejg" = (
-/obj/machinery/optable,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ejh" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -21016,11 +21022,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"eks" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ekv" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -21216,6 +21217,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"emU" = (
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "emV" = (
 /obj/item/book/manual/fiction/littlewomen,
 /obj/item/book/manual/fiction/aroundtheworld,
@@ -21589,6 +21595,12 @@
 /obj/random/cluster/tengolo,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
+"epU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "epW" = (
 /obj/structure/table/standard,
 /obj/item/device/integrated_electronics/debugger{
@@ -21910,6 +21922,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/engineering/atmos/surface)
+"esq" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "est" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/grey,
@@ -22634,14 +22652,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
-"eAj" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/makeshift_grinder,
-/obj/effect/decal/cleanable/cobweb{
-	dir = 4
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eAm" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section3";
@@ -23158,14 +23168,6 @@
 /obj/structure/curtain/open/privacy,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
-"eGP" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/welding,
-/obj/item/storage/belt,
-/obj/item/clothing/head/welding,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eGR" = (
 /obj/structure/railing,
 /obj/structure/disposalpipe/segment{
@@ -23431,6 +23433,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"eJU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eJW" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
@@ -24243,11 +24250,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
-"eQo" = (
-/obj/random/booze/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eQp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -24656,6 +24658,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"eVq" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/costume/body_animals,
+/obj/random/costume/body_generic,
+/obj/random/costume/body_halloween,
+/obj/random/costume/head_animals,
+/obj/random/costume/head_generic,
+/obj/random/costume/head_halloween,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eVv" = (
 /obj/structure/multiz/stairs/enter{
 	dir = 8
@@ -25397,6 +25409,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"fbF" = (
+/obj/structure/table/standard,
+/obj/item/storage/freezer/medical,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fbJ" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/small/busha1,
@@ -25419,11 +25436,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"fcl" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fcq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/sofa/black/corner{
@@ -25463,13 +25475,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"fdq" = (
-/obj/structure/table/reinforced,
-/obj/item/device/makeshift_electrolyser,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fdr" = (
 /obj/structure/flora/small/busha3,
 /turf/unsimulated/wall/jungle,
@@ -26103,14 +26108,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/maingate/west)
-"fjd" = (
-/obj/structure/table/rack/shelf,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/computer_hardware/hard_drive/portable/advanced/shady,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fjo" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -26489,6 +26486,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"fmy" = (
+/obj/machinery/vending/assist,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fmz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26533,6 +26537,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"fmL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fmO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -26861,6 +26871,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"fpx" = (
+/obj/machinery/door/window/northleft,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fpz" = (
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled/white/techfloor_grid,
@@ -26902,6 +26917,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"fqa" = (
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fqc" = (
 /obj/structure/table/marble,
 /obj/random/toy/plushie_onlycorgi,
@@ -26975,6 +26993,13 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"fqW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/miningdock)
 "fqZ" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -27032,6 +27057,11 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"frS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "frV" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/wood/random,
@@ -27217,6 +27247,11 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
+"fun" = (
+/obj/structure/table/standard,
+/obj/item/storage/pill_bottle/tramadol,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fuG" = (
 /obj/random/spider_trap_burrowing,
 /obj/effect/decal/cleanable/dirt,
@@ -27705,13 +27740,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/bar)
-"fzs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/material/kitchen/utensil/fork,
-/obj/item/stack/rods/random,
-/turf/simulated/floor/plating,
-/area/colony)
 "fzw" = (
 /obj/machinery/conveyor/south{
 	id = "mining_internal"
@@ -28566,10 +28594,6 @@
 /obj/item/book/manual/fiction/littlewomen,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"fIA" = (
-/mob/living/bot/cleanbot,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fII" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,10"
@@ -28774,6 +28798,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
+"fLm" = (
+/obj/structure/curtain/open/bed{
+	name = "Privacy curtain"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fLq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -28833,6 +28864,12 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
+"fLU" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/cheap/elbrus4kk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fLZ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -29062,11 +29099,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"fOs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet_tech/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fOK" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable/cyan{
@@ -29350,10 +29382,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
-"fSj" = (
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fSm" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -29860,6 +29888,10 @@
 	temperature = 80
 	},
 /area/nadezhda/command/tcommsat/computer)
+"fXR" = (
+/obj/random/cluster/termite_no_despawn_hoard,
+/turf/unsimulated/mineral,
+/area/colony)
 "fXT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
@@ -30251,11 +30283,7 @@
 	name = "Residential District Maintenance"
 	})
 "gbE" = (
-/obj/machinery/vending/assist,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "gbL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -30430,6 +30458,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"gdk" = (
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gdo" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1;
@@ -30889,11 +30921,6 @@
 /obj/machinery/alarm{
 	pixel_y = 32
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28
-	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "ghd" = (
@@ -30981,6 +31008,12 @@
 /obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
+"ghJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "ghL" = (
 /obj/structure/table/rack/shelf,
 /obj/random/melee/low_chance,
@@ -31025,6 +31058,11 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/west)
+"gip" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "giu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -31088,6 +31126,13 @@
 /obj/machinery/autolathe/mechfab/loaded,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
+"gjr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gjs" = (
 /obj/effect/spider/stickyweb,
 /obj/machinery/light/small{
@@ -31423,10 +31468,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"gmU" = (
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "gmZ" = (
 /obj/structure/shuttle_part/science{
@@ -31891,9 +31932,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
-"gqE" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gqN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -32304,7 +32342,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/multiz/stairs/enter{
+/obj/structure/multiz/stairs/enter/bottom{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -32522,6 +32560,9 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"gwQ" = (
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gwV" = (
 /obj/structure/disposalpipe/up{
 	dir = 8
@@ -32606,13 +32647,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/hallway)
-"gxu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gxw" = (
 /obj/structure/window/basic{
 	dir = 8
@@ -33022,9 +33056,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/armoryshop)
-"gCq" = (
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gCC" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 1;
@@ -33078,6 +33109,11 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/range)
+"gDj" = (
+/obj/structure/closet/cabinet,
+/obj/random/booze,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gDv" = (
 /obj/random/structures/low_chance,
 /obj/structure/catwalk,
@@ -33342,6 +33378,11 @@
 /obj/item/mine/old/armed,
 /turf/simulated/floor/rock,
 /area/colony)
+"gGI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gGN" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -33663,6 +33704,10 @@
 /obj/random/material/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"gKI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gKN" = (
 /obj/structure/boulder{
 	pixel_x = -1
@@ -33762,6 +33807,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/tcommsat/computer)
+"gLS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gLT" = (
 /obj/item/storage/deferred/crate/alcohol,
 /obj/effect/decal/cleanable/dirt,
@@ -34061,6 +34111,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
+"gOJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gOS" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -34390,6 +34445,10 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"gRN" = (
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gSc" = (
 /obj/random/cluster/roaches,
 /turf/simulated/floor/tiled/techmaint,
@@ -34627,13 +34686,6 @@
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"gTQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gTS" = (
 /obj/machinery/holoposter{
 	pixel_x = 32
@@ -34931,6 +34983,13 @@
 	},
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"gWD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gWK" = (
 /obj/effect/floor_decal/corner_oldtile,
 /obj/effect/floor_decal/corner_oldtile{
@@ -35050,24 +35109,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
-"gXT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	dir = 4
-	},
-/obj/machinery/door/window/northright{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/barricade,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/crew_quarters/techshop)
 "gXV" = (
 /turf/simulated/mineral,
 /area/nadezhda/security/maingate/west)
@@ -35322,10 +35363,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"hbp" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hbs" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/mineral,
@@ -35527,6 +35564,11 @@
 /obj/random/cluster/spiders,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
+"hdn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "hdo" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable/cyan{
@@ -35752,6 +35794,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"hfI" = (
+/obj/machinery/door/unpowered/simple/wood,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hfO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -36088,6 +36134,10 @@
 /obj/item/clothing/accessory/magatama,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
+"hjP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hjS" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/structure/cable/cyan{
@@ -36208,14 +36258,6 @@
 /obj/structure/sign/directions/room4,
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"hkQ" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A2";
-	name = "D1-A2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hkT" = (
 /obj/structure/sign/faction/neotheology_cross/gold{
 	pixel_y = -32
@@ -36654,11 +36696,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"hpn" = (
-/obj/structure/table/standard,
-/obj/item/storage/freezer/medical,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hpq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/grille,
@@ -36962,6 +36999,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"hsI" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hsW" = (
 /obj/structure/flora/small/rock3,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -37112,6 +37154,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"hug" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/mecha_equipment/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hui" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -38017,6 +38065,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"hDg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "hDn" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -38286,6 +38342,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"hFB" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/rig_module/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hFG" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/effect/decal/cleanable/dirt,
@@ -38348,6 +38409,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"hGy" = (
+/obj/machinery/optable,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hGB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -39266,6 +39336,15 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
+"hNx" = (
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/structure/bedsheetbin,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hNy" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/dirt,
@@ -39279,6 +39358,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/tactical_blackshield)
+"hNQ" = (
+/obj/effect/floor_decal/industrial/caution{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "hNT" = (
 /obj/machinery/light,
 /obj/structure/table/bar_special,
@@ -39405,12 +39490,6 @@
 "hPE" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/surfacesec)
-"hPJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bench/glass,
-/obj/structure/curtain/red,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hPL" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 4
@@ -39811,6 +39890,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
+"hUY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hVb" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -39972,6 +40056,12 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
+"hWj" = (
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hWs" = (
 /obj/structure/mirror{
 	pixel_y = -28
@@ -40105,6 +40195,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/medical/reception)
+"hXt" = (
+/obj/random/cluster/slimes,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hXB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -40674,11 +40768,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"ibF" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/autolathe/mechfab/loaded,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ibG" = (
 /obj/item/modular_computer/console/preset/command,
 /obj/item/device/radio/intercom{
@@ -41147,12 +41236,6 @@
 /obj/structure/flora/small/trailrocka3,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"igw" = (
-/obj/machinery/door/window/southleft,
-/obj/machinery/door/window/northleft,
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "igB" = (
 /obj/structure/railing{
 	dir = 8
@@ -41236,11 +41319,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
-"ihb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ihc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -41317,6 +41395,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
+"iin" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iip" = (
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/armory)
@@ -41370,25 +41458,10 @@
 	},
 /turf/simulated/open,
 /area/asteroid/cave)
-"ijh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1;
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ijl" = (
 /obj/item/weldpack/canister,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"ijn" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ijo" = (
 /obj/structure/table/marble,
 /obj/machinery/cooking_with_jane/grill,
@@ -41609,6 +41682,10 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/mineral,
 /area/colony)
+"ilm" = (
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ilq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/scrap/dense_weighted/low_chance,
@@ -41653,6 +41730,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"ilG" = (
+/obj/item/reagent_containers/syringe/drugs,
+/obj/item/reagent_containers/pill/floorpill,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ilH" = (
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 4;
@@ -41932,6 +42014,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"inO" = (
+/obj/structure/table/rack/shelf,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/computer_hardware/hard_drive/portable/advanced/shady,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"inQ" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "inU" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -42626,6 +42726,11 @@
 	icon_state = "1,21"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"ivi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ivk" = (
 /obj/item/reagent_containers/dropper{
 	pixel_y = -4
@@ -42685,12 +42790,6 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"ivN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/mecha_equipment/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ivP" = (
 /obj/random/mob/spiders/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -42972,11 +43071,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"izh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "izj" = (
 /obj/structure/bed{
 	dir = 4
@@ -43990,10 +44084,6 @@
 	icon_state = "10,15"
 	},
 /area/nadezhda/rnd/docking)
-"iJQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iKj" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -44157,6 +44247,15 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/server)
+"iLZ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/bodybags,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/random/circuitboard/low_chance,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iMd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -44588,14 +44687,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"iQt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iQv" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -44653,6 +44744,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"iRj" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iRl" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "4,1"
@@ -44705,11 +44801,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
-"iRS" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iRT" = (
 /obj/structure/spider_nest,
 /obj/effect/decal/cleanable/dirt,
@@ -44789,6 +44880,13 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
+"iSK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iSN" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -44855,11 +44953,6 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/side/f2section1)
-"iTN" = (
-/obj/structure/closet/random_miscellaneous,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iUc" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/rock5,
@@ -45047,6 +45140,11 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"iVF" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/surgery,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iVJ" = (
 /obj/structure/catwalk,
 /obj/random/scrap/dense_weighted/low_chance,
@@ -45107,15 +45205,6 @@
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
-"iWA" = (
-/obj/machinery/firealarm{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel_reinforced,
-/obj/structure/bedsheetbin,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iWC" = (
 /obj/structure/table/glass,
 /obj/random/scrap/dense_even,
@@ -45518,6 +45607,16 @@
 /obj/random/dungeon_gun_mods,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"jbe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/northleft,
+/obj/machinery/cash_register{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jbo" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/alarm{
@@ -45783,6 +45882,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
+"jdC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jdE" = (
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor2north)
@@ -46035,6 +46138,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/prisoncells)
+"jgq" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil/random,
+/obj/item/device/robotanalyzer,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jgt" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -46381,6 +46490,9 @@
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"jjL" = (
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jjN" = (
 /obj/machinery/door/airlock/maintenance_common{
 	req_access = list(12)
@@ -46744,6 +46856,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
+"jnh" = (
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jni" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -46774,6 +46889,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"jnm" = (
+/obj/structure/closet/wall_mounted/emcloset{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jno" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -47340,10 +47461,6 @@
 /obj/structure/flora/small/bushb3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"jsz" = (
-/obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jsE" = (
 /obj/structure/flora/small/grassb2,
 /obj/structure/flora/ausbushes/brflowers,
@@ -47647,6 +47764,13 @@
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"jvq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jvw" = (
 /obj/machinery/light{
 	dir = 1
@@ -47756,11 +47880,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cro)
-"jwD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jwF" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/asteroid/grass,
@@ -49006,14 +49125,6 @@
 /obj/item/paper_bin,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/security/detectives_office)
-"jLs" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28
-	},
-/turf/simulated/floor/wood/wild3,
-/area/nadezhda/command/merchant)
 "jLw" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -49655,6 +49766,11 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"jRo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jRr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49718,6 +49834,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"jRV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/open/shower/closed,
+/turf/simulated/floor/plating,
+/area/colony)
 "jRZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -50170,6 +50291,11 @@
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"jWG" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/mat_katana,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jWI" = (
 /obj/structure/window/reinforced,
 /obj/structure/multiz/stairs/active/bottom{
@@ -50215,12 +50341,6 @@
 /obj/item/reagent_containers/syringe/drugs,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"jXK" = (
-/obj/structure/curtain/open/bed{
-	name = "Privacy curtain"
-	},
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jXL" = (
 /obj/structure/table/standard,
 /obj/item/device/radio/off,
@@ -50493,6 +50613,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"kas" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kau" = (
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -50541,11 +50667,6 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/security/maingate/east)
-"kaU" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kaV" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/decal/cleanable/dirt,
@@ -51228,14 +51349,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
-"khI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "khK" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -51461,6 +51574,12 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/engineering/engine_room)
+"kkm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/double/padded,
+/obj/random/furniture/bedsheetdouble,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kkr" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -51633,14 +51752,6 @@
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/surfaceeast)
-"klX" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A3";
-	name = "D1-A3"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kme" = (
 /obj/machinery/light{
 	dir = 4
@@ -51709,11 +51820,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
-"kmR" = (
-/obj/structure/bonfire,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "kmZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -52267,16 +52373,19 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"ksu" = (
+/obj/random/booze,
+/obj/random/junkfood/onlypizza,
+/obj/random/junkfood/onlyburger,
+/obj/random/junkfood,
+/obj/structure/closet/secure_closet/freezer,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ksF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"ksG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ksJ" = (
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
@@ -52795,17 +52904,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"kxv" = (
-/obj/machinery/door/airlock/maintenance_cargo,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"kxx" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junkfood,
-/obj/random/junkfood,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kxz" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/fitness)
@@ -53276,25 +53374,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"kBF" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "kBO" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint,
@@ -53392,6 +53471,12 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"kDe" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kDh" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -53803,6 +53888,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"kHC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/spider_shadow_trap,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kHD" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/floor_decal/spline/plain/three_quarters,
@@ -53814,23 +53904,27 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"kHO" = (
+/obj/structure/boulder,
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kHW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
-"kIq" = (
-/obj/machinery/door/window/eastright,
-/obj/structure/curtain/medical,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kIz" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics)
+"kIA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/highsecurity,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kIG" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall8";
@@ -53894,6 +53988,11 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/nadezhda/security/barracks)
+"kJx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kJC" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
@@ -54652,12 +54751,6 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/lakeside)
-"kRQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kRT" = (
 /obj/landmark/costume/maid,
 /obj/structure/table/rack,
@@ -54712,6 +54805,13 @@
 /obj/item/storage/firstaid/ifak,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
+"kSq" = (
+/obj/machinery/door/window/eastright,
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kSr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54741,6 +54841,11 @@
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/fo)
+"kSS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kSX" = (
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/toilet/public)
@@ -54784,23 +54889,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
-"kTw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kTC" = (
 /obj/machinery/door/airlock{
 	name = "Toilet"
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/surfacesec)
-"kTG" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kTH" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -54918,18 +55012,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
-"kVg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/storage/freezer,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/snacks/meat/monkey,
-/obj/item/reagent_containers/food/snacks/meat/monkey,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kVl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/security{
@@ -55042,6 +55124,28 @@
 	icon_state = "1,20"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"kVZ" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
+"kWf" = (
+/obj/structure/table/rack/shelf,
+/obj/item/modular_computer/wrist,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kWg" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -55299,23 +55403,6 @@
 /obj/structure/flora/small/rock5,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"kZd" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "kZq" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -55366,13 +55453,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
-"lab" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "laf" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -55392,13 +55472,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"lam" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lan" = (
 /obj/random/cluster/spiders/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -55686,6 +55759,14 @@
 	icon_state = "4,8"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"ldz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ldA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -56180,6 +56261,12 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"ljy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/tool/advanced/onestar/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ljL" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = 32
@@ -56867,6 +56954,9 @@
 "lrX" = (
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/side/f2section1)
+"lrZ" = (
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lsd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57152,6 +57242,14 @@
 /obj/random/junkfood/onlyburger,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/dcave)
+"lvd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/tool/knife/butch,
+/obj/item/material/kitchen/rollingpin,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
@@ -57610,11 +57708,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/smc/quarters)
-"lAc" = (
-/obj/structure/bed,
-/obj/item/handcuffs/fuzzy,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lAo" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = 32
@@ -57631,11 +57724,6 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"lAZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lBf" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -57910,6 +57998,10 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"lDl" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lDu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -58055,6 +58147,11 @@
 "lEP" = (
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/medical/sleeper)
+"lES" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lET" = (
 /obj/item/remains/human,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -58559,10 +58656,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"lJO" = (
-/obj/random/cluster/slimes,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lJZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -58741,6 +58834,13 @@
 "lMk" = (
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
+"lMm" = (
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lMp" = (
 /obj/structure/flora/ausbushes/fernybush,
 /mob/living/simple_animal/jungle_bird,
@@ -58915,6 +59015,10 @@
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"lOB" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lOI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -59079,6 +59183,12 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"lPX" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lQm" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/techmaint,
@@ -59392,11 +59502,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"lTq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "lTv" = (
 /obj/machinery/light/small{
@@ -59736,6 +59841,11 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"lWC" = (
+/obj/structure/bonfire,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "lWE" = (
 /obj/structure/disposalpipe/sortjunction/wildcard{
 	dir = 8
@@ -59874,6 +59984,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"lXJ" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lXP" = (
 /obj/machinery/door/airlock/security,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -59913,6 +60028,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
+"lYn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "lYp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -60583,11 +60705,6 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
-"mfd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mfg" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section4";
@@ -61746,6 +61863,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"mqy" = (
+/obj/structure/table/bench/glass,
+/obj/structure/curtain/red,
+/obj/effect/decal/cleanable/vomit,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mqA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61816,11 +61939,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"mrf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/loading/red,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mrk" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -61929,12 +62047,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/engineering/shield_generator)
-"msk" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil/random,
-/obj/item/device/robotanalyzer,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "msm" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
@@ -61972,6 +62084,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"msJ" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "msL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_panels,
@@ -62201,6 +62317,12 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"mvp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/random/cluster/spiders,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mvs" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable/cyan{
@@ -62336,13 +62458,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"mwD" = (
-/obj/structure/closet/wall_mounted{
-	pixel_x = -32
-	},
-/obj/item/storage/box/drinkingglasses,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mwL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/coffin,
@@ -63110,6 +63225,13 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"mEv" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mEx" = (
 /obj/structure/catwalk,
 /obj/machinery/craftingstation,
@@ -63575,6 +63697,18 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"mIj" = (
+/obj/structure/table/rack,
+/obj/structure/curtain/medical,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/organ/external/robotic/junktech/r_leg,
+/obj/item/organ/external/robotic/junktech/r_arm,
+/obj/item/organ/external/robotic/junktech/l_leg,
+/obj/item/organ/external/robotic/junktech/l_arm,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mIl" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "6,10"
@@ -63602,13 +63736,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"mIz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mIJ" = (
 /obj/structure/table/standard,
 /obj/item/virusdish/random,
@@ -63670,10 +63797,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/maingate/west)
-"mJk" = (
-/obj/structure/janitorialcart,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mJn" = (
 /obj/item/device/radio/intercom/department/security{
 	pixel_x = 30
@@ -63889,11 +64012,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
-"mLC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mLG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5;
@@ -64353,6 +64471,13 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
+"mPD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mPF" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/effect/decal/cleanable/dirt,
@@ -64869,10 +64994,6 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/podrooms2)
-"mWI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mWK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -65333,11 +65454,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"mZO" = (
-/obj/structure/table/standard,
-/obj/item/storage/pill_bottle/tramadol,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mZS" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -66071,6 +66187,15 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"ngY" = (
+/obj/structure/table/rack,
+/obj/structure/curtain/medical,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/organ/internal/optical_sensor,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ngZ" = (
 /obj/random/mob/croaker/low_chance,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -66287,14 +66412,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/security/maingate)
-"njz" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A20";
-	name = "D1-A20"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "njI" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
@@ -66628,6 +66745,11 @@
 /obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"nmE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nmG" = (
 /obj/random/cluster/termite_no_despawn/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -66776,6 +66898,14 @@
 /mob/living/simple_animal/frog,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"not" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "noA" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos/surface)
@@ -66848,17 +66978,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
-"npd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/curtain/open,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "npe" = (
 /obj/machinery/atm{
 	pixel_y = 32
@@ -67501,10 +67620,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
-"nuR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nuS" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -67757,6 +67872,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"nxF" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nxJ" = (
 /obj/machinery/vending/gamers,
 /turf/simulated/floor/tiled/techmaint,
@@ -67906,6 +68026,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/hut_cell1)
+"nyK" = (
+/obj/machinery/mech_recharger,
+/obj/random/mecha/low_chance,
+/turf/simulated/floor/plating,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nyO" = (
 /obj/machinery/recharger,
 /obj/random/tool_upgrade/low_chance,
@@ -68456,6 +68581,9 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/west)
+"nDt" = (
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nDv" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/foyer)
@@ -68706,6 +68834,15 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
+"nFG" = (
+/obj/structure/table/reinforced,
+/obj/item/device/makeshift_centrifuge,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nFI" = (
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp,
@@ -68737,12 +68874,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/outside/inside_colony)
-"nGg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/obj/random/cluster/spiders,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nGh" = (
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
@@ -68806,6 +68937,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
+"nGT" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nGY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68880,11 +69017,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
-"nHv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nHw" = (
 /obj/structure/salvageable/data,
 /turf/simulated/floor/bluegrid{
@@ -68930,14 +69062,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"nHU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/obj/random/cluster/spiders,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nIa" = (
 /obj/structure/flora/small/grassb4,
 /turf/unsimulated/wall/jungle,
@@ -68964,6 +69088,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
+"nIB" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A20";
+	name = "D1-A20"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nIG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/light/small{
@@ -69232,6 +69364,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacesec)
+"nKH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nKM" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/machinery/floodlight,
@@ -69441,6 +69577,18 @@
 /obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
+"nMM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/storage/freezer,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nMO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -71064,6 +71212,13 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/crew_quarters/pool)
+"ocf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oci" = (
 /obj/structure/railing{
 	dir = 4;
@@ -71465,6 +71620,11 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/shuttle/surface_transport_lz)
+"ogj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ogo" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall23";
@@ -71727,6 +71887,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"oiZ" = (
+/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/northleft,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oja" = (
 /obj/structure/flora/small/bushc2,
 /turf/simulated/floor/asteroid/dirt,
@@ -71766,6 +71932,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"ojr" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ojt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72135,11 +72305,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"omI" = (
-/obj/item/reagent_containers/syringe/drugs,
-/obj/item/reagent_containers/pill/floorpill,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "omO" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/table/bench/wooden,
@@ -72277,6 +72442,13 @@
 /obj/effect/window_lwall_spawn/smartspawnplasma,
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai_upload)
+"ooA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/material/kitchen/utensil/fork,
+/obj/item/stack/rods/random,
+/turf/simulated/floor/plating,
+/area/colony)
 "ooF" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -72802,6 +72974,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
+"otw" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "otx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -72959,6 +73135,12 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
+"ovm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cabinet,
+/obj/random/booze,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ovn" = (
 /obj/effect/decal/cleanable/rubble,
 /mob/living/simple_animal/hostile/jelly/bloat,
@@ -72986,6 +73168,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"ovw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/common_oddities/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ovz" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/grille,
@@ -73123,6 +73313,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"owM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "owQ" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -73380,12 +73575,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
-"ozC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "ozH" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = -32
@@ -73434,6 +73623,12 @@
 /obj/structure/table/bar_special,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm1)
+"ozY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oAo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair{
@@ -73833,11 +74028,6 @@
 /obj/random/gun_parts/low,
 /turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
-"oDG" = (
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oDM" = (
 /obj/effect/floor_decal/spline/wood{
 	icon_state = "spline_fancy_cee"
@@ -73953,6 +74143,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/dorm1)
+"oER" = (
+/obj/structure/closet/wall_mounted{
+	pixel_x = -32
+	},
+/obj/item/storage/box/drinkingglasses,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oET" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -74047,6 +74244,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/inside_colony)
+"oGf" = (
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oGj" = (
 /obj/structure/low_wall,
 /obj/machinery/door/blast/shutters/glass{
@@ -74806,11 +75007,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
-"oNB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oNC" = (
 /obj/structure/flora/small/grassa1,
 /turf/simulated/floor/asteroid/grass,
@@ -75239,6 +75435,10 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/security/barracks)
+"oRT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "oRU" = (
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/techmaint,
@@ -75292,11 +75492,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
-"oSk" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/mineral,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oSl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -75385,9 +75580,6 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/medical/ward)
-"oSV" = (
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oSW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75652,16 +75844,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
-"oVT" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/costume/body_animals,
-/obj/random/costume/body_generic,
-/obj/random/costume/body_halloween,
-/obj/random/costume/head_animals,
-/obj/random/costume/head_generic,
-/obj/random/costume/head_halloween,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oVX" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/bush1,
@@ -75846,10 +76028,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
-"oXD" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oXM" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -77067,6 +77245,11 @@
 /obj/landmark/join/start/foreman,
 /turf/simulated/floor/carpet,
 /area/nadezhda/pros/foreman)
+"pkd" = (
+/obj/structure/closet/random_miscellaneous,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pkg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77089,11 +77272,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
-"pko" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pky" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -77448,12 +77626,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"poG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "poN" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -77802,11 +77974,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"psf" = (
+"psl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
+/turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "psn" = (
 /obj/machinery/door/window/eastleft,
@@ -78395,6 +78565,11 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
+"pxJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pxW" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/church,
@@ -78620,11 +78795,6 @@
 /obj/random/junkfood/onlypizza,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
-"pAb" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/mat_katana,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pAg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -79403,10 +79573,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
-"pIO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pJd" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -79502,6 +79668,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"pJU" = (
+/obj/structure/bed,
+/obj/item/handcuffs/fuzzy,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pJW" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -81565,13 +81736,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
-"qcB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "qcQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -81957,6 +82121,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"qhd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/sofa{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qhh" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -82408,14 +82579,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"qlv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/revolver/handmade,
-/obj/item/clothing/accessory/duster/bloodred,
-/obj/item/ammo_magazine/ammobox/pistol_35/scrap,
-/turf/simulated/floor/plating,
-/area/colony)
 "qlD" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -82508,12 +82671,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"qmx" = (
-/obj/effect/floor_decal/industrial/caution{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "qmz" = (
 /obj/machinery/door/holy{
 	name = "Church"
@@ -82888,6 +83045,10 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"qqv" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qqw" = (
 /obj/structure/table/standard,
 /obj/random/pack/tech_loot,
@@ -82906,6 +83067,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"qqD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qqF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -83854,11 +84019,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/detectives_office)
-"qAs" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qAA" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/dirt,
@@ -83885,6 +84045,24 @@
 "qAM" = (
 /turf/simulated/floor/reinforced/airmix,
 /area/nadezhda/engineering/atmos)
+"qAN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	dir = 4
+	},
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/barricade,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/crew_quarters/techshop)
 "qAQ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/structure/cable/yellow{
@@ -84550,6 +84728,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
+"qGX" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/credits/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qHa" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/effect/window_lwall_spawn/reinforced,
@@ -85085,6 +85269,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"qNi" = (
+/obj/random/cluster/roaches/lower_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qNn" = (
 /obj/machinery/power/hydroelectric_control,
 /obj/structure/cable/yellow,
@@ -85266,12 +85455,6 @@
 /obj/random/flora/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"qPr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qPu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85353,6 +85536,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"qPX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qQa" = (
 /obj/structure/scrap/poor,
 /obj/effect/decal/cleanable/dirt,
@@ -85606,6 +85794,11 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"qSP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qSQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -85730,6 +85923,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"qUq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qUD" = (
 /obj/structure/closet/crate/secure,
 /obj/item/flame/lighter/zippo/gold,
@@ -86290,6 +86494,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/hallway/side/f2section1)
+"raF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/random/cluster/spiders,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "raM" = (
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/asteroid/grass,
@@ -86547,9 +86759,6 @@
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
-"rdD" = (
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rdP" = (
 /obj/machinery/vending/gym,
 /obj/structure/sign/warning/nosmoking/small{
@@ -86909,6 +87118,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/crew_quarters)
+"rgl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/revolver/handmade,
+/obj/item/clothing/accessory/duster/bloodred,
+/obj/item/ammo_magazine/ammobox/pistol_35/scrap,
+/turf/simulated/floor/plating,
+/area/colony)
 "rgm" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -87003,11 +87220,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
-"rhm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain/red,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rhv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87847,6 +88059,14 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"rqr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 1;
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rqu" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -87854,6 +88074,25 @@
 /obj/item/circuitboard/puncher,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"rqB" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "rqF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -88609,6 +88848,10 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/quartermaster/miningdock)
+"ryC" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ryI" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -88835,11 +89078,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/west)
-"rBc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rBi" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -88862,6 +89100,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/servist)
+"rBq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/glass,
+/obj/structure/curtain/red,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rBu" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /obj/effect/floor_decal/spline/plain{
@@ -89136,13 +89380,6 @@
 "rEh" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/absolutism/hallways)
-"rEo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/miningdock)
 "rEq" = (
 /obj/random/cluster/termite_no_despawn/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -89193,6 +89430,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
+"rEV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rFc" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -89605,13 +89849,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/detectives_office)
-"rJG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rJJ" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -89778,11 +90015,6 @@
 "rLm" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/lab)
-"rLp" = (
-/obj/structure/table/glass,
-/obj/structure/curtain/black,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rLw" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -89943,6 +90175,11 @@
 /mob/living/simple_animal/jungle_bird,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"rMH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet_maintloot,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rMJ" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -90231,12 +90468,6 @@
 /obj/effect/floor_decal/industrial/road/straight4,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"rPs" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rPB" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/machinery/newscaster/directional/north,
@@ -90293,17 +90524,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
-"rQh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/eastright,
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rQk" = (
 /obj/machinery/door/window{
 	dir = 8
@@ -90327,12 +90547,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
-"rQq" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/oddity/common/paper_bundle,
-/obj/machinery/door/window/eastright,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rQC" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -90650,6 +90864,10 @@
 /obj/item/storage/firstaid/adv,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/sleeper)
+"rUm" = (
+/obj/machinery/door/airlock/maintenance_cargo,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rUv" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -90753,15 +90971,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"rVs" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/bodybags,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/random/circuitboard/low_chance,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rVt" = (
 /obj/structure/girder,
 /turf/simulated/floor/asteroid/grass,
@@ -90821,13 +91030,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
-"rVX" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rVY" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -90930,6 +91132,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/captain/quarters)
+"rWX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rWZ" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -91094,12 +91301,6 @@
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/dorm4)
-"rYk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rYp" = (
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/dirt,
@@ -91426,15 +91627,16 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"saQ" = (
-/obj/machinery/autolathe/loaded,
-/obj/effect/floor_decal/industrial/warning{
+"saU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/eastright,
+/obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "sbc" = (
 /obj/machinery/light/small,
@@ -92425,6 +92627,11 @@
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/maintenance/surfacesec)
+"slK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/lowkeyrandom,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "slM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -92652,13 +92859,6 @@
 /obj/effect/decal/mecha_wreckage/hoverpod,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/pros/shuttle)
-"snM" = (
-/obj/machinery/door/airlock/maintenance_common,
-/obj/random/traps/low_chance{
-	spawn_nothing_percentage = 90
-	},
-/turf/space,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "snS" = (
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -92817,10 +93017,6 @@
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"spg" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "spm" = (
 /obj/structure/cyberplant,
 /obj/effect/decal/cleanable/rubble,
@@ -93027,11 +93223,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"sri" = (
-/obj/structure/table/rack/shelf,
-/obj/item/modular_computer/wrist,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "srr" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /turf/simulated/floor/rock/manmade/road,
@@ -93132,10 +93323,6 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
-"srV" = (
-/obj/random/science/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "srX" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt,
@@ -94216,12 +94403,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
-"sBC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/cabinet,
-/obj/random/booze,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sBF" = (
 /obj/structure/railing,
 /obj/structure/multiz/stairs/enter/bottom{
@@ -94450,6 +94631,11 @@
 /obj/item/device/lighting/toggleable/lamp/green,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"sEv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/red,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sEA" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet,
@@ -94460,11 +94646,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/crew_quarters/bar)
-"sEC" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sEF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -95254,11 +95435,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
-"sNE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sNJ" = (
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/dirt,
@@ -96361,12 +96537,10 @@
 	name = "Residential District Maintenance"
 	})
 "sZK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "sZL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -96738,6 +96912,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"tdU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tdW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/turcarpet,
@@ -96809,6 +96988,12 @@
 /obj/structure/closet/l3closet/janitor,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/janitor)
+"tey" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "teI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -96942,6 +97127,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"tgo" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tgt" = (
 /obj/structure/table/standard,
 /obj/machinery/light/small{
@@ -98057,6 +98246,12 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"ttx" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/material_resources,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ttG" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -99471,11 +99666,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
-"tGw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/spiders/low_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tGy" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "15,8"
@@ -99517,6 +99707,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/lab)
+"tHh" = (
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tHo" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -99834,6 +100028,13 @@
 	},
 /turf/simulated/open,
 /area/nadezhda/outside/scave)
+"tKg" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A20";
+	name = "D1-A20"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tKh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -100214,10 +100415,6 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/forest)
-"tNG" = (
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tNJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera/network/research{
@@ -101069,6 +101266,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"tVz" = (
+/obj/machinery/door/airlock/maintenance_interior{
+	name = "Hotel Desk"
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tVB" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -101076,6 +101279,21 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"tVE" = (
+/obj/machinery/autolathe/loaded,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"tVF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tVO" = (
 /obj/effect/window_lwall_spawn,
 /obj/structure/flora/big/bush3{
@@ -101116,11 +101334,6 @@
 /obj/random/cloth/suit/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
-"tVZ" = (
-/obj/structure/bed/chair/office/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tWc" = (
 /obj/structure/table/standard,
 /obj/item/extinguisher,
@@ -101338,6 +101551,13 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
+"tYq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tYr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable/cyan{
@@ -101777,6 +101997,13 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"ucz" = (
+/obj/item/device/radio/intercom{
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ucI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -101938,11 +102165,6 @@
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/inside_colony)
-"udX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uec" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Disposals";
@@ -101952,20 +102174,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/disposaldrop)
-"uek" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"uep" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ues" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -102086,6 +102294,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/range)
+"ufj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ufk" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -102441,12 +102653,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"uhT" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uhW" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/industrial/hatch,
@@ -102592,11 +102798,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/sleeper)
-"ujt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ujx" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /turf/simulated/open,
@@ -103096,12 +103297,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"unM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "unO" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/effect/decal/cleanable/dirt,
@@ -103224,10 +103419,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/command/tcommsat/computer)
-"upp" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "upq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -103517,6 +103708,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/colony)
+"usp" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "usq" = (
 /obj/item/remains/unathi,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -103758,12 +103956,6 @@
 "uvs" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/turret_protected/ai_upload)
-"uvw" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/cheap/elbrus4kk,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uvJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -103789,11 +103981,6 @@
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
-"uvZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain/open/shower/closed,
-/turf/simulated/floor/plating,
-/area/colony)
 "uwc" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -104582,10 +104769,6 @@
 "uFe" = (
 /turf/simulated/wall/church,
 /area/nadezhda/absolutism/hallways)
-"uFg" = (
-/obj/random/cluster/termite_no_despawn_hoard,
-/turf/unsimulated/mineral,
-/area/colony)
 "uFj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -104840,6 +105023,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfaceeast)
+"uHM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uHQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -105007,18 +105197,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/servist)
-"uIZ" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/rig/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uJg" = (
 /obj/machinery/light_switch{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"uJi" = (
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uJn" = (
 /obj/machinery/door/unpowered/simple/wood{
 	color = "#9a977b"
@@ -105705,12 +105893,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"uOY" = (
-/obj/structure/boulder,
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uPc" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/meat/corgi,
@@ -105781,13 +105963,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"uPM" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A20";
-	name = "D1-A20"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uPO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -106006,6 +106181,13 @@
 /obj/machinery/newscaster/directional/south,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"uRj" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uRk" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -106938,10 +107120,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/cryo)
-"vaz" = (
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vaH" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -107274,6 +107452,13 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
+"veH" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood,
+/obj/random/junkfood,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "veL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -107427,6 +107612,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
+"vfW" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vfY" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -107448,6 +107637,11 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"vgg" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vgm" = (
 /obj/structure/railing{
 	dir = 8
@@ -107618,15 +107812,6 @@
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
-"via" = (
-/obj/structure/table/reinforced,
-/obj/item/device/makeshift_centrifuge,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vib" = (
 /obj/structure/table/reinforced,
 /obj/item/genetics/mut_injector,
@@ -108601,12 +108786,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
-"vrq" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vrt" = (
 /obj/structure/closet/jcloset,
 /obj/machinery/camera/network/colony_underground,
@@ -108688,10 +108867,6 @@
 /obj/machinery/door/holy/public,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/vectorrooms)
-"vso" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vsB" = (
 /obj/structure/table/standard,
 /obj/machinery/power/apc{
@@ -108963,6 +109138,9 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
+"vuU" = (
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vuY" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -109468,6 +109646,11 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"vAJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading/red,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vAL" = (
 /obj/machinery/door/unpowered/simple/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -109531,6 +109714,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"vBQ" = (
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vBR" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/barricade,
@@ -110562,6 +110749,12 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"vLw" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/oddity/common/paper_bundle,
+/obj/machinery/door/window/eastright,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vLC" = (
 /obj/item/tool/broken_bottle,
 /obj/effect/spider/stickyweb,
@@ -111150,11 +111343,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
-"vRv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vRy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -111183,16 +111371,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
-"vRD" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "vRF" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -111638,10 +111816,6 @@
 /obj/landmark/join/start/smc,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
-"vUQ" = (
-/obj/machinery/microwave/burnbarrel,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vUS" = (
 /obj/structure/salvageable/machine,
 /obj/effect/decal/cleanable/dirt,
@@ -112767,6 +112941,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"wgo" = (
+/obj/structure/table/steel,
+/obj/random/powercell/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wgu" = (
 /obj/structure/table/woodentable,
 /obj/item/stamp/hos2,
@@ -112950,6 +113129,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"wio" = (
+/obj/structure/curtain/open/bed{
+	name = "Privacy curtain"
+	},
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wiq" = (
 /obj/machinery/atmospherics/valve/digital{
 	dir = 4;
@@ -113135,12 +113320,6 @@
 /obj/random/mob/excelsior,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"wkl" = (
-/obj/machinery/door/airlock/maintenance_interior{
-	name = "Hotel Desk"
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wkp" = (
 /obj/structure/table/bench/steel,
 /obj/effect/spider/stickyweb,
@@ -113149,6 +113328,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"wkq" = (
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/common_oddities/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wkt" = (
 /obj/machinery/camera/network/medbay{
 	dir = 8
@@ -113206,14 +113392,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"wkK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/tool/knife/butch,
-/obj/item/material/kitchen/rollingpin,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wlg" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -113510,6 +113688,14 @@
 /obj/random/gun_handmade/low_chance,
 /turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
+"wnZ" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A2";
+	name = "D1-A2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wob" = (
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
@@ -113756,13 +113942,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"wpF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wpG" = (
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm3)
@@ -114133,6 +114312,12 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"wse" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "wsj" = (
 /obj/structure/sink{
 	dir = 8;
@@ -114186,6 +114371,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
+"wsR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wsT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -114225,6 +114415,11 @@
 /obj/structure/closet/secure_closet/personal/engineering_personal,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"wtF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/simple/wood,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wtK" = (
 /obj/structure/boulder,
 /obj/machinery/door/airlock/maintenance_common,
@@ -114437,6 +114632,10 @@
 "wwv" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm4)
+"wwC" = (
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wwG" = (
 /obj/random/material/low_chance,
 /obj/structure/catwalk,
@@ -114882,12 +115081,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/outside/inside_colony)
-"wBb" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/credits/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wBj" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/colony_surface,
@@ -115250,10 +115443,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"wEY" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wFg" = (
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/beach/sand,
@@ -115398,11 +115587,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/side/f2section1)
-"wGZ" = (
-/obj/structure/closet/cabinet,
-/obj/random/booze,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wHe" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -116157,12 +116341,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
-"wPd" = (
-/obj/structure/table/bench/glass,
-/obj/structure/curtain/red,
-/obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wPf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -116731,6 +116909,10 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"wUY" = (
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wVb" = (
 /obj/structure/shuttle_part/escpod{
 	icon_state = "escpodwall9";
@@ -117135,16 +117317,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"wYU" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/curtain/open,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wZp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -117167,6 +117339,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"wZs" = (
+/obj/structure/reagent_dispensers/bidon,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wZu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -117398,18 +117574,6 @@
 "xbW" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
-"xbX" = (
-/obj/structure/table/rack,
-/obj/structure/curtain/medical,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/organ/external/robotic/junktech/r_leg,
-/obj/item/organ/external/robotic/junktech/r_arm,
-/obj/item/organ/external/robotic/junktech/l_leg,
-/obj/item/organ/external/robotic/junktech/l_arm,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xca" = (
 /obj/structure/flora/small/trailrocka3,
 /obj/structure/railing,
@@ -117452,6 +117616,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"xcN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xcR" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/small/busha1,
@@ -117535,9 +117707,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
-"xes" = (
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xev" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/drinkingglasses,
@@ -117573,11 +117742,6 @@
 /mob/living/simple_animal/hostile/diyaab,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"xeT" = (
-/obj/structure/table/steel,
-/obj/random/powercell/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xfb" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/big/rocks3,
@@ -117778,6 +117942,12 @@
 	layer = 1
 	},
 /area/nadezhda/crew_quarters/sleep/bedrooms)
+"xgM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/employment,
+/obj/random/credits/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xgR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -118361,14 +118531,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
-"xmu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "xmy" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/substation/servist)
@@ -118493,11 +118655,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
-"xnR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "xnW" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1
@@ -120244,10 +120401,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/vectorrooms)
-"xES" = (
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xET" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -120288,10 +120441,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/farm)
-"xFk" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xFl" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -120345,6 +120494,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"xFN" = (
+/obj/structure/table/reinforced,
+/obj/item/device/makeshift_electrolyser,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xFQ" = (
 /obj/structure/table/steel,
 /obj/random/lowkeyrandom/low_chance,
@@ -120744,11 +120900,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"xJB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet_maintloot,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xJC" = (
 /obj/random/furniture/pottedplant,
 /obj/effect/decal/cleanable/cobweb2,
@@ -120787,12 +120938,6 @@
 	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"xJQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/double/padded,
-/obj/random/furniture/bedsheetdouble,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xJW" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -121475,10 +121620,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/medical/sleeper)
-"xRc" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xRe" = (
 /obj/effect/shuttle_landmark/skipjack_colony,
 /turf/simulated/floor/asteroid/dirt,
@@ -121739,6 +121880,11 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/xenobiology)
+"xTH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xTO" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/lighting/toggleable/lamp,
@@ -121905,6 +122051,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"xVu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/termite_no_despawn/lower_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xVB" = (
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/beach/sand,
@@ -122019,6 +122170,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
+"xWy" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/makeshift_grinder,
+/obj/effect/decal/cleanable/cobweb{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xWz" = (
 /obj/random/scrap/dense_weighted,
 /obj/effect/spider/stickyweb,
@@ -122307,12 +122466,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"xZy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xZK" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "11,0"
@@ -123178,12 +123331,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"yjP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "yjR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -149951,7 +150098,7 @@ jIg
 kJV
 eAy
 oax
-jLs
+frb
 clN
 gBw
 vpm
@@ -150569,7 +150716,7 @@ kUx
 kUx
 kUx
 aFa
-rEo
+fqW
 qxo
 hax
 nzT
@@ -183242,9 +183389,9 @@ cvn
 mjZ
 vmZ
 hSX
-bSh
-kBF
-vRD
+hdn
+rqB
+dQa
 sCN
 sCN
 sCN
@@ -183263,9 +183410,9 @@ aOb
 lif
 sRU
 sRU
-bSh
-kBF
-poG
+hdn
+rqB
+wse
 cCy
 nBz
 cxN
@@ -183875,7 +184022,7 @@ cvc
 dJa
 cCy
 cCy
-gXT
+qAN
 cCy
 cCy
 nCK
@@ -189715,7 +189862,7 @@ whU
 eMU
 whU
 whU
-qcB
+lYn
 nUF
 wnJ
 tIQ
@@ -189917,7 +190064,7 @@ iBR
 nVZ
 iBR
 iBR
-kZd
+kVZ
 iBR
 iBR
 iBR
@@ -190119,7 +190266,7 @@ whU
 qwB
 whU
 whU
-xmu
+hDg
 bbM
 rkA
 ilF
@@ -191305,7 +191452,7 @@ hLD
 uTo
 wEB
 wEB
-cZb
+dlo
 cZb
 vpF
 czA
@@ -194127,12 +194274,12 @@ cZb
 cZb
 cZb
 wEB
-ibF
-mrf
-eGP
-jsz
-qPr
-pko
+bZk
+vAJ
+aXg
+dWX
+kDe
+tdU
 wEB
 wEB
 wEB
@@ -194140,8 +194287,8 @@ wEB
 wEB
 tTB
 vJX
-uhT
-uhT
+esq
+esq
 wEB
 wEB
 wEB
@@ -194329,12 +194476,12 @@ cZb
 cZb
 cZb
 wEB
-msk
-eks
-iJQ
-cZx
-cTD
-iJQ
+jgq
+lES
+qqD
+not
+gwQ
+qqD
 wEB
 iKp
 jWI
@@ -194343,9 +194490,9 @@ wEB
 pOR
 avz
 rsN
-uhT
+esq
 wiO
-fcl
+iRj
 wEB
 cZb
 cZb
@@ -194531,12 +194678,12 @@ wEB
 wEB
 wEB
 wEB
-fjd
-cTD
-iJQ
-unM
-rJG
-xRc
+inO
+gwQ
+qqD
+tey
+uHM
+qqv
 wEB
 iVg
 nXu
@@ -194545,9 +194692,9 @@ wEB
 snr
 kSY
 wEB
-fcl
-fcl
-yjP
+iRj
+iRj
+ceF
 wEB
 cZb
 cZb
@@ -194725,20 +194872,20 @@ cZb
 cZb
 cZb
 wEB
-kxx
-aAr
-psf
-psf
-sri
+veH
+hjP
+ozY
+ozY
+kWf
 wEB
-srV
-iJQ
-cTD
-mfd
-lam
-mfd
-khI
-dih
+cPi
+qqD
+gwQ
+frS
+dHP
+frS
+edo
+nyK
 wEB
 lVS
 lVS
@@ -194747,9 +194894,9 @@ snr
 pQH
 pQH
 wEB
-coP
-auT
-rYk
+arr
+slK
+kas
 wEB
 cZb
 cZb
@@ -194927,20 +195074,20 @@ cZb
 cZb
 cZb
 wEB
-pAb
-rdD
-nGg
-aAr
-aAr
+jWG
+nDt
+mvp
+hjP
+hjP
 wEB
-iJQ
-cTD
-iJQ
-cTD
-iJQ
-unM
-iJQ
-cTD
+qqD
+gwQ
+qqD
+gwQ
+qqD
+tey
+qqD
+gwQ
 wEB
 lVS
 lVS
@@ -194949,9 +195096,9 @@ lTo
 qBj
 snr
 wEB
-kTw
-aUR
-ihb
+kJx
+xVu
+eJU
 wEB
 cZb
 cZb
@@ -195018,7 +195165,7 @@ kyK
 diB
 kyK
 kyK
-qmx
+hNQ
 kyK
 fbS
 sAU
@@ -195129,22 +195276,22 @@ cZb
 cZb
 cZb
 wEB
-uIZ
-aAr
-mLC
-nHv
-uep
+bSN
+hjP
+aKw
+kSS
+iin
 wEB
-iJQ
-iJQ
-tNG
-vrq
-rVs
-saQ
-gbE
-edz
+qqD
+qqD
+ilm
+lPX
+iLZ
+tVE
+fmy
+bIK
 wEB
-uhT
+esq
 wiO
 wEB
 wEB
@@ -195152,13 +195299,13 @@ wEB
 wEB
 wEB
 wEB
-uPM
+tKg
 wEB
 wEB
-fcl
-fcl
-fcl
-fcl
+iRj
+iRj
+iRj
+iRj
 cZb
 cZb
 cZb
@@ -195331,36 +195478,36 @@ cZb
 cZb
 cZb
 wEB
-bHw
-aAr
-upp
-dkw
-rQq
+hFB
+hjP
+otw
+uRj
+vLw
 wEB
-snM
-wEB
-wEB
+dvs
 wEB
 wEB
 wEB
 wEB
 wEB
 wEB
-fcl
-fcl
-ksG
+wEB
+wEB
+iRj
+iRj
+gip
 pQH
 pQH
-iQt
+ldz
 pQH
 snr
-gqE
+ciN
 snr
 pQH
-gxu
+gWD
 snr
-fcl
-fcl
+iRj
+iRj
 cZb
 cZb
 cZb
@@ -195533,34 +195680,34 @@ cZb
 cZb
 cZb
 wEB
-cRB
-aAr
-aAr
-dUl
-cdi
-oNB
+ttx
+hjP
+hjP
+iSK
+kHC
+nmE
 snr
-gxu
-fcl
-oSk
-fcl
-pIO
+gWD
+iRj
+nxF
+iRj
+ufj
 lVS
-mIz
-bOx
+aMH
+gbE
 lVS
-pIO
+ufj
 wEB
 wEB
-njz
-wEB
-wEB
-wEB
-hkQ
+nIB
 wEB
 wEB
 wEB
-klX
+wnZ
+wEB
+wEB
+wEB
+bnC
 wEB
 wEB
 cZb
@@ -195735,35 +195882,35 @@ cZb
 cZb
 cZb
 wEB
-wBb
-aAr
-psf
-rdD
-drY
+qGX
+hjP
+ozY
+nDt
+qhd
 wEB
-kxv
-wEB
-wEB
+rUm
 wEB
 wEB
 wEB
 wEB
 wEB
 wEB
-aba
-wpF
 wEB
-kTw
-mWI
-dqQ
 wEB
-kTw
-mWI
-dqQ
+jnm
+gjr
 wEB
-kTw
-mWI
-dqQ
+kJx
+psl
+ksu
+wEB
+kJx
+psl
+ksu
+wEB
+kJx
+psl
+ksu
 wEB
 cZb
 cZb
@@ -195937,35 +196084,35 @@ cZb
 cZb
 cZb
 wEB
-oVT
-aAr
-nHU
-aAr
-drY
+eVq
+hjP
+raF
+hjP
+qhd
 wEB
-oSV
-oSV
-rPs
-oSV
-oSV
+vuU
+vuU
+nGT
+vuU
+vuU
 wEB
-iTN
-uek
-wkl
-lAZ
-gmU
+pkd
+gKI
+tVz
+qPX
+wUY
 wEB
-ivN
-vaz
-xJB
+hug
+tgo
+rMH
 wEB
-xeT
-tGw
-ujt
+wgo
+bbc
+owM
 wEB
-abY
-mWI
-fOs
+ljy
+psl
+dOX
 wEB
 cZb
 cZb
@@ -196139,35 +196286,35 @@ cZb
 cZb
 cZb
 wEB
-dJq
-aAr
-psf
-aAr
-xFk
+cqg
+hjP
+ozY
+hjP
+gRN
 wEB
-mJk
-sEC
-edk
-fIA
-oDG
+aHx
+vgg
+wZs
+cAE
+emU
 wEB
-ijn
-eQo
+usp
+dXF
 wEB
-atI
+rEV
 lVS
 wEB
-rQh
-mWI
-kTG
+saU
+psl
+hWj
 wEB
-rQh
-mWI
-lab
+saU
+psl
+ocf
 wEB
-rQh
-lJO
-lab
+saU
+hXt
+ocf
 wEB
 cZb
 cZb
@@ -196343,33 +196490,33 @@ cZb
 wEB
 wEB
 wEB
+sju
+wwC
+sju
+sju
+sju
+sju
 wEB
 wEB
 wEB
 wEB
+ucz
+cdm
+oiZ
+tHh
+gbE
 wEB
+qUq
+rqr
+kkm
 wEB
+qUq
+rqr
+kkm
 wEB
-wEB
-wEB
-wEB
-rVX
-tVZ
-igw
-fSj
-bOx
-wEB
-npd
-ijh
-xJQ
-wEB
-npd
-ijh
-xJQ
-wEB
-wYU
-ijh
-xJQ
+inQ
+rqr
+kkm
 wEB
 cZb
 cZb
@@ -196545,20 +196692,20 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+sju
+jdC
+ovw
+mPD
+lMm
+sju
+dpn
+rgl
+lWC
 wEB
-bEA
-qlv
-kmR
+hNx
+fLU
 wEB
-iWA
-uvw
-wEB
-udX
+bOO
 lVS
 wEB
 wEB
@@ -196747,32 +196894,32 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-wEB
-xnR
-ozC
-fzs
+sju
+jdC
+xTH
+xTH
+jdC
+sju
+sZK
+ghJ
+ooA
 wEB
 wEB
 wEB
 wEB
 lVS
-bOx
-rLp
-mwD
-eAj
+gbE
+bCS
+oER
+xWy
 wEB
-wkK
-kVg
-vUQ
+lvd
+nMM
+cJn
 wEB
-mZO
-iRS
-ejg
+fun
+iVF
+hGy
 wEB
 cZb
 cZb
@@ -196949,32 +197096,32 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-wEB
-aZK
-xnR
-ozC
-aZK
-xnR
-xnR
-uvZ
-bOx
+sju
+jdC
+dRG
+mPD
+ovw
+sju
+oRT
+sZK
+ghJ
+oRT
+sZK
+sZK
+jRV
+gbE
 lVS
-rLp
-xES
-fdq
+bCS
+lOB
+xFN
 wEB
-dlW
-rBc
-oXD
+xcN
+jRo
+lDl
 wEB
-hpn
-aKo
-kRQ
+fbF
+qNi
+fmL
 wEB
 cZb
 cZb
@@ -197151,11 +197298,11 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+sju
+jdC
+xTH
+rWX
+fqa
 sju
 sju
 sju
@@ -197164,19 +197311,19 @@ sju
 sju
 sju
 sju
-kaU
 lVS
-aHC
-aIT
-via
+lVS
+fpx
+jnh
+nFG
 wEB
-dKn
-dKn
-dcK
+wsR
+wsR
+ccw
 wEB
-lTq
-lTq
-xes
+gOJ
+gOJ
+jjL
 wEB
 cZb
 cZb
@@ -197353,32 +197500,32 @@ tad
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-rsN
-xZy
-sNE
+sju
+mPD
+mPD
+mPD
+jdC
+sju
+xgM
+vfW
+jbe
+ogj
+vBQ
+jvq
+wtF
+ivi
+hUY
 wEB
 wEB
 wEB
 wEB
-hPJ
-wPd
-rhm
+rBq
+mqy
+sEv
 wEB
-kIq
-asi
-xbX
+kSq
+ngY
+mIj
 wEB
 wEB
 wEB
@@ -197555,21 +197702,21 @@ tad
 tad
 tad
 tad
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-wEB
-fcl
-pIO
+sju
+jdC
+jdC
+jdC
+fqa
+sju
+dWc
+jdC
+qSP
+uJi
+epU
+msJ
+sju
+iRj
+ufj
 lVS
 lVS
 lVS
@@ -197577,13 +197724,13 @@ lVS
 lVS
 lVS
 lVS
-gTQ
-vRv
-bOx
+tYq
+bgt
+gbE
 lVS
-agV
-agV
-agV
+gGI
+gGI
+gGI
 cZb
 cZb
 cZb
@@ -197757,32 +197904,32 @@ tad
 tad
 tad
 tad
-tad
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+sju
+lMm
+wkq
+dRG
+jdC
+kIA
+xTH
+tVF
+cYU
+vBQ
+ogj
+jvq
+hfI
+iRj
+iRj
 wEB
-fcl
-fcl
-wEB
-vso
-wEB
-wEB
-bbk
+ojr
 wEB
 wEB
-jXK
+fLm
 wEB
 wEB
-jXK
+wio
+wEB
+wEB
+wio
 wEB
 wEB
 rsN
@@ -197959,33 +198106,33 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+sju
+sju
+sju
+sju
+sju
+sju
+sju
+sju
+sju
+sju
+sju
+sju
+sju
+hsI
+kHO
 wEB
-kaU
-uOY
+ryC
+aNp
 wEB
-wEY
-qAs
+oGf
+ovm
 wEB
-hbp
-sBC
+gLS
+gDj
 wEB
-jwD
-wGZ
-wEB
-jwD
-sBC
+gLS
+ovm
 wEB
 cZb
 cZb
@@ -198173,21 +198320,21 @@ cZb
 cZb
 cZb
 cZb
+rsN
+nKH
+pxJ
 wEB
-lVS
-lVS
+mEv
+aNp
 wEB
-sZK
-qAs
+cXw
+pJU
 wEB
-nuR
-lAc
+lrZ
+lXJ
 wEB
-gCq
-ciK
-wEB
-omI
-ciK
+ilG
+lXJ
 wEB
 cZb
 cZb
@@ -198376,8 +198523,8 @@ cZb
 cZb
 cZb
 wEB
-lVS
-bOx
+nKH
+gdk
 wEB
 wEB
 wEB
@@ -198578,8 +198725,8 @@ cZb
 cZb
 cZb
 wEB
-lVS
-spg
+pxJ
+gdk
 wEB
 cZb
 cZb
@@ -198780,8 +198927,8 @@ cZb
 cZb
 cZb
 wEB
-bOx
-bOx
+gbE
+gbE
 wEB
 cZb
 cZb
@@ -198982,7 +199129,7 @@ cZb
 cZb
 cZb
 wEB
-bOx
+gbE
 lVS
 wEB
 cZb
@@ -199588,8 +199735,8 @@ cZb
 cZb
 cZb
 wEB
-bOx
-bOx
+gbE
+gbE
 wEB
 cZb
 cZb
@@ -199778,7 +199925,7 @@ tad
 tad
 tad
 tad
-uFg
+fXR
 tad
 tad
 tad
@@ -199791,7 +199938,7 @@ cZb
 cZb
 wEB
 lVS
-bOx
+gbE
 wEB
 cZb
 cZb
@@ -199993,7 +200140,7 @@ cZb
 cZb
 wEB
 lVS
-izh
+bxj
 wEB
 cZb
 cZb
@@ -200396,7 +200543,7 @@ cZb
 cZb
 cZb
 wEB
-bOx
+gbE
 lVS
 wEB
 cZb
@@ -200599,7 +200746,7 @@ cZb
 cZb
 wEB
 wiO
-agV
+gGI
 wEB
 cZb
 cZb

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -99,6 +99,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
+"aba" = (
+/obj/structure/closet/wall_mounted/emcloset{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "abj" = (
 /obj/structure/bed/chair/sofa/black/left{
 	dir = 4
@@ -183,6 +189,12 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"abY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/tool/advanced/onestar/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "acb" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table/woodentable,
@@ -638,6 +650,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"agV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ahf" = (
 /obj/structure/bed/chair/sofa/black/corner{
 	dir = 8;
@@ -1458,8 +1475,7 @@
 /area/nadezhda/absolutism/bioreactor)
 "apI" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -1684,6 +1700,15 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"asi" = (
+/obj/structure/table/rack,
+/obj/structure/curtain/medical,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/organ/internal/optical_sensor,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "asn" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -1851,6 +1876,13 @@
 /obj/structure/flora/small/grassb4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"atI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "atX" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4
@@ -1985,6 +2017,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"auT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/lowkeyrandom,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ava" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2017,12 +2054,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 1;
-	icon_state = "box_corners_red"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/box/red/corners{
-	dir = 4;
-	icon_state = "box_corners_red"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
@@ -2530,6 +2565,10 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
+"aAr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aAv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3251,6 +3290,11 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/forest)
+"aHC" = (
+/obj/machinery/door/window/northleft,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aHF" = (
 /obj/machinery/disposal/deliveryChute{
 	name = "trash chute"
@@ -3371,6 +3415,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
+"aIT" = (
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aIV" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 1
@@ -3455,6 +3502,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/janitor)
+"aKo" = (
+/obj/random/cluster/roaches/lower_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aKu" = (
 /obj/structure/boulder{
 	pixel_x = -1
@@ -4137,9 +4189,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
@@ -4297,6 +4347,11 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"aUR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/termite_no_despawn/lower_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aVm" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 8
@@ -4743,6 +4798,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"aZK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "bab" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest)
@@ -4859,6 +4918,13 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
+"bbk" = (
+/obj/structure/curtain/open/bed{
+	name = "Privacy curtain"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bbn" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "3,0"
@@ -7706,6 +7772,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
+"bEA" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/roach/roachling,
+/turf/simulated/floor/plating,
+/area/colony)
 "bEE" = (
 /obj/item/remains/mouse,
 /turf/simulated/floor/asteroid/grass,
@@ -7956,6 +8027,11 @@
 /obj/landmark/join/late/cyborg,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
+"bHw" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/rig_module/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bHA" = (
 /obj/structure/flora/small/lavarock2,
 /turf/simulated/floor/asteroid/grass,
@@ -8691,6 +8767,9 @@
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
+"bOx" = (
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bOV" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/big/bush2,
@@ -8917,6 +8996,11 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"bSh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "bSj" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Front Desk";
@@ -9095,7 +9179,12 @@
 /area/nadezhda/crew_quarters/pool)
 "bUs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall/r_wall,
+/obj/machinery/door/airlock/command{
+	name = "Surface Operations Manager's Office";
+	req_access = list(41);
+	id_tag = "ceodoor"
+	},
+/turf/simulated/floor/carpet,
 /area/nadezhda/command/merchant)
 "bUu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9971,6 +10060,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
+"cdi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/spider_shadow_trap,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cdB" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/security{
@@ -10451,6 +10545,11 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
+"ciK" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ciM" = (
 /obj/structure/table/standard,
 /obj/effect/decal/cleanable/dirt,
@@ -10996,6 +11095,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "coy" = (
@@ -11033,6 +11136,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/absolutism/skyyard)
+"coP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/lathe_disk/any_gun/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "coS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12027,8 +12137,7 @@
 /area/nadezhda/maintenance/undergroundfloor1south)
 "czW" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -12295,6 +12404,7 @@
 /area/nadezhda/maintenance/undergroundfloor1west)
 "cCy" = (
 /obj/effect/window_lwall_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/techshop)
 "cCD" = (
@@ -13029,8 +13139,7 @@
 	dir = 8
 	},
 /obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
@@ -13808,6 +13917,12 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
+"cRB" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/material_resources,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cRC" = (
 /obj/random/closet_tech/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -14026,6 +14141,9 @@
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
+"cTD" = (
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cTG" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/machinery/light/small,
@@ -14672,6 +14790,14 @@
 "cZu" = (
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
+"cZx" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cZC" = (
 /obj/structure/flora/small/busha2,
 /turf/simulated/floor/asteroid/grass,
@@ -14887,6 +15013,11 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/turret_protected/ai)
+"dcK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/eastright,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dcS" = (
 /obj/structure/table/standard,
 /obj/structure/extinguisher_cabinet{
@@ -15451,6 +15582,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
+"dih" = (
+/obj/machinery/mech_recharger,
+/obj/random/mecha/low_chance,
+/turf/simulated/floor/plating,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dil" = (
 /obj/machinery/bioprinter/prosthetics,
 /obj/machinery/camera/network/research{
@@ -15635,6 +15771,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/crew_quarters/bar)
+"dkw" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dky" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
@@ -15736,6 +15879,14 @@
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"dlW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dlY" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -16269,6 +16420,14 @@
 "dqN" = (
 /turf/simulated/floor/reinforced/nitrogen,
 /area/nadezhda/engineering/atmos)
+"dqQ" = (
+/obj/random/booze,
+/obj/random/junkfood/onlypizza,
+/obj/random/junkfood/onlyburger,
+/obj/random/junkfood,
+/obj/structure/closet/secure_closet/freezer,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "drb" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/light{
@@ -16371,6 +16530,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"drY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/sofa{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dsd" = (
 /obj/structure/catwalk,
 /obj/random/structures,
@@ -16720,8 +16886,7 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
@@ -18168,6 +18333,19 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"dJq" = (
+/obj/structure/closet/crate/secure/large,
+/obj/item/organ/internal/bone/head/robotic,
+/obj/item/organ/internal/bone/l_arm/robotic,
+/obj/item/organ/internal/bone/l_leg/robotic,
+/obj/item/organ/internal/bone/r_arm/robotic,
+/obj/item/organ/internal/bone/r_leg/robotic,
+/obj/item/organ/internal/bone/chest/robotic,
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "splatter2"
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dJx" = (
 /obj/structure/table/woodentable,
 /obj/machinery/recharger,
@@ -18275,6 +18453,11 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"dKn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dKy" = (
 /obj/structure/flora/small/trailrocka4,
 /obj/effect/decal/cleanable/dirt,
@@ -19215,6 +19398,13 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
+"dUl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dUo" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -20072,6 +20262,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"edk" = (
+/obj/structure/reagent_dispensers/bidon,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "edn" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -20111,6 +20305,13 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/atmos)
+"edz" = (
+/obj/machinery/vending/engivend,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "edF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
@@ -20687,6 +20888,15 @@
 	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/nadezhda/engineering/atmos)
+"ejg" = (
+/obj/machinery/optable,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ejh" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -20806,6 +21016,11 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
+"eks" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ekv" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -22419,6 +22634,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"eAj" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/makeshift_grinder,
+/obj/effect/decal/cleanable/cobweb{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eAm" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section3";
@@ -22935,6 +23158,14 @@
 /obj/structure/curtain/open/privacy,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"eGP" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/welding,
+/obj/item/storage/belt,
+/obj/item/clothing/head/welding,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eGR" = (
 /obj/structure/railing,
 /obj/structure/disposalpipe/segment{
@@ -23290,7 +23521,6 @@
 /obj/effect/floor_decal/industrial/warningdust{
 	dir = 5
 	},
-/obj/structure/girder,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "eKU" = (
@@ -24013,6 +24243,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/absolutism/bioreactor)
+"eQo" = (
+/obj/random/booze/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eQp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -25184,6 +25419,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"fcl" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fcq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair/sofa/black/corner{
@@ -25223,6 +25463,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"fdq" = (
+/obj/structure/table/reinforced,
+/obj/item/device/makeshift_electrolyser,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fdr" = (
 /obj/structure/flora/small/busha3,
 /turf/unsimulated/wall/jungle,
@@ -25856,6 +26103,14 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/maingate/west)
+"fjd" = (
+/obj/structure/table/rack/shelf,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/computer_hardware/hard_drive/portable/advanced/shady,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fjo" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -27450,6 +27705,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/bar)
+"fzs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/material/kitchen/utensil/fork,
+/obj/item/stack/rods/random,
+/turf/simulated/floor/plating,
+/area/colony)
 "fzw" = (
 /obj/machinery/conveyor/south{
 	id = "mining_internal"
@@ -28304,6 +28566,10 @@
 /obj/item/book/manual/fiction/littlewomen,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"fIA" = (
+/mob/living/bot/cleanbot,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fII" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,10"
@@ -28796,6 +29062,11 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"fOs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet_tech/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fOK" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable/cyan{
@@ -29079,6 +29350,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"fSj" = (
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fSm" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -29976,9 +30251,12 @@
 	name = "Residential District Maintenance"
 	})
 "gbE" = (
-/obj/structure/railing,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
+/obj/machinery/vending/assist,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gbL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 10
@@ -30611,6 +30889,11 @@
 /obj/machinery/alarm{
 	pixel_y = 32
 	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28
+	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "ghd" = (
@@ -31141,6 +31424,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"gmU" = (
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gmZ" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "1,3"
@@ -31604,6 +31891,9 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
+"gqE" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gqN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -32316,6 +32606,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/hallway)
+"gxu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gxw" = (
 /obj/structure/window/basic{
 	dir = 8
@@ -32725,6 +33022,9 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/armoryshop)
+"gCq" = (
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gCC" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 1;
@@ -33621,8 +33921,7 @@
 "gNH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -34328,6 +34627,13 @@
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"gTQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gTS" = (
 /obj/machinery/holoposter{
 	pixel_x = 32
@@ -34744,6 +35050,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
+"gXT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	dir = 4
+	},
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/barricade,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/crew_quarters/techshop)
 "gXV" = (
 /turf/simulated/mineral,
 /area/nadezhda/security/maingate/west)
@@ -34930,6 +35254,9 @@
 	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
 "haB" = (
@@ -34994,6 +35321,10 @@
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"hbp" = (
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "hbs" = (
 /obj/effect/decal/cleanable/rubble,
@@ -35877,6 +36208,14 @@
 /obj/structure/sign/directions/room4,
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"hkQ" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A2";
+	name = "D1-A2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hkT" = (
 /obj/structure/sign/faction/neotheology_cross/gold{
 	pixel_y = -32
@@ -36315,6 +36654,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"hpn" = (
+/obj/structure/table/standard,
+/obj/item/storage/freezer/medical,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hpq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/grille,
@@ -39061,6 +39405,12 @@
 "hPE" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/surfacesec)
+"hPJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/glass,
+/obj/structure/curtain/red,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hPL" = (
 /obj/structure/multiz/stairs/enter/bottom{
 	dir = 4
@@ -40324,6 +40674,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"ibF" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/autolathe/mechfab/loaded,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ibG" = (
 /obj/item/modular_computer/console/preset/command,
 /obj/item/device/radio/intercom{
@@ -40792,6 +41147,12 @@
 /obj/structure/flora/small/trailrocka3,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"igw" = (
+/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/northleft,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "igB" = (
 /obj/structure/railing{
 	dir = 8
@@ -40875,6 +41236,11 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"ihb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ihc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -41004,10 +41370,25 @@
 	},
 /turf/simulated/open,
 /area/asteroid/cave)
+"ijh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 1;
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ijl" = (
 /obj/item/weldpack/canister,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"ijn" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ijo" = (
 /obj/structure/table/marble,
 /obj/machinery/cooking_with_jane/grill,
@@ -41698,7 +42079,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
 "ipH" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -42303,6 +42685,12 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"ivN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/mecha_equipment/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ivP" = (
 /obj/random/mob/spiders/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -42584,6 +42972,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"izh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "izj" = (
 /obj/structure/bed{
 	dir = 4
@@ -43597,6 +43990,10 @@
 	icon_state = "10,15"
 	},
 /area/nadezhda/rnd/docking)
+"iJQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iKj" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -44191,6 +44588,14 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"iQt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iQv" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -44300,6 +44705,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
+"iRS" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/surgery,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iRT" = (
 /obj/structure/spider_nest,
 /obj/effect/decal/cleanable/dirt,
@@ -44445,6 +44855,11 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/side/f2section1)
+"iTN" = (
+/obj/structure/closet/random_miscellaneous,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iUc" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/small/rock5,
@@ -44661,8 +45076,7 @@
 /area/nadezhda/engineering/atmos)
 "iWc" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -44693,6 +45107,15 @@
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
+"iWA" = (
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/structure/bedsheetbin,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iWC" = (
 /obj/structure/table/glass,
 /obj/random/scrap/dense_even,
@@ -46445,6 +46868,9 @@
 "jof" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/yellowdouble,
+/obj/machinery/alarm{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/merchant)
 "joh" = (
@@ -46696,8 +47122,7 @@
 /area/nadezhda/medical/cryo)
 "jqU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -46915,6 +47340,10 @@
 /obj/structure/flora/small/bushb3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"jsz" = (
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jsE" = (
 /obj/structure/flora/small/grassb2,
 /obj/structure/flora/ausbushes/brflowers,
@@ -47327,6 +47756,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cro)
+"jwD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jwF" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/asteroid/grass,
@@ -48572,6 +49006,14 @@
 /obj/item/paper_bin,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/security/detectives_office)
+"jLs" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "West APC";
+	pixel_x = -28
+	},
+/turf/simulated/floor/wood/wild3,
+/area/nadezhda/command/merchant)
 "jLw" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -48785,8 +49227,7 @@
 "jNd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -49774,6 +50215,12 @@
 /obj/item/reagent_containers/syringe/drugs,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"jXK" = (
+/obj/structure/curtain/open/bed{
+	name = "Privacy curtain"
+	},
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jXL" = (
 /obj/structure/table/standard,
 /obj/item/device/radio/off,
@@ -50094,6 +50541,11 @@
 	},
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/security/maingate/east)
+"kaU" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kaV" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/decal/cleanable/dirt,
@@ -50776,6 +51228,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"khI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "khK" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -51173,6 +51633,14 @@
 /obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/surfaceeast)
+"klX" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A3";
+	name = "D1-A3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kme" = (
 /obj/machinery/light{
 	dir = 4
@@ -51241,6 +51709,11 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
+"kmR" = (
+/obj/structure/bonfire,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "kmZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -51799,6 +52272,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"ksG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ksJ" = (
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
@@ -52317,6 +52795,17 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"kxv" = (
+/obj/machinery/door/airlock/maintenance_cargo,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"kxx" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood,
+/obj/random/junkfood,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kxz" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/fitness)
@@ -52787,6 +53276,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"kBF" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "kBO" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint,
@@ -53312,6 +53820,13 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
+"kIq" = (
+/obj/machinery/door/window/eastright,
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kIz" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -54137,6 +54652,12 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/outside/lakeside)
+"kRQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kRT" = (
 /obj/landmark/costume/maid,
 /obj/structure/table/rack,
@@ -54263,12 +54784,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
+"kTw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kTC" = (
 /obj/machinery/door/airlock{
 	name = "Toilet"
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/surfacesec)
+"kTG" = (
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kTH" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -54386,6 +54918,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"kVg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/storage/freezer,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kVl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/security{
@@ -54755,6 +55299,23 @@
 /obj/structure/flora/small/rock5,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"kZd" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "kZq" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -54805,6 +55366,13 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/engineering/atmos/surface)
+"lab" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "laf" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -54824,6 +55392,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"lam" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lan" = (
 /obj/random/cluster/spiders/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -57035,6 +57610,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/smc/quarters)
+"lAc" = (
+/obj/structure/bed,
+/obj/item/handcuffs/fuzzy,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lAo" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = 32
@@ -57051,6 +57631,11 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"lAZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lBf" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -57974,6 +58559,10 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"lJO" = (
+/obj/random/cluster/slimes,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lJZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -58342,12 +58931,6 @@
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/courtroom)
 "lON" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 32
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -58809,6 +59392,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"lTq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "lTv" = (
 /obj/machinery/light/small{
@@ -59995,6 +60583,11 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/hallway/surface/section1)
+"mfd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mfg" = (
 /obj/machinery/button/remote/blast_door{
 	id = "section4";
@@ -61048,6 +61641,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/crew_quarters/techshop)
 "mpK" = (
@@ -61222,6 +61816,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"mrf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading/red,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mrk" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -61330,6 +61929,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/engineering/shield_generator)
+"msk" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil/random,
+/obj/item/device/robotanalyzer,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "msm" = (
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
@@ -61731,6 +62336,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"mwD" = (
+/obj/structure/closet/wall_mounted{
+	pixel_x = -32
+	},
+/obj/item/storage/box/drinkingglasses,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mwL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/coffin,
@@ -62990,6 +63602,13 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"mIz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mIJ" = (
 /obj/structure/table/standard,
 /obj/item/virusdish/random,
@@ -63051,6 +63670,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/maingate/west)
+"mJk" = (
+/obj/structure/janitorialcart,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mJn" = (
 /obj/item/device/radio/intercom/department/security{
 	pixel_x = 30
@@ -63266,6 +63889,11 @@
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/security/hut_cell1)
+"mLC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mLG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5;
@@ -64241,6 +64869,10 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/crew_quarters/podrooms2)
+"mWI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mWK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -64701,6 +65333,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"mZO" = (
+/obj/structure/table/standard,
+/obj/item/storage/pill_bottle/tramadol,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mZS" = (
 /obj/structure/flora/small/busha2,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -65650,6 +66287,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/security/maingate)
+"njz" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A20";
+	name = "D1-A20"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "njI" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
@@ -66203,6 +66848,17 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
+"npd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "npe" = (
 /obj/machinery/atm{
 	pixel_y = 32
@@ -66845,6 +67501,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
+"nuR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nuS" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -68077,6 +68737,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/outside/inside_colony)
+"nGg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/random/cluster/spiders,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nGh" = (
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
@@ -68214,6 +68880,11 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"nHv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nHw" = (
 /obj/structure/salvageable/data,
 /turf/simulated/floor/bluegrid{
@@ -68259,6 +68930,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"nHU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/random/cluster/spiders,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nIa" = (
 /obj/structure/flora/small/grassb4,
 /turf/unsimulated/wall/jungle,
@@ -69367,8 +70046,7 @@
 	tag = "icon-railing0 (EAST)"
 	},
 /obj/structure/railing{
-	dir = 1;
-	icon_state = "railing0"
+	dir = 1
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
@@ -71457,6 +72135,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"omI" = (
+/obj/item/reagent_containers/syringe/drugs,
+/obj/item/reagent_containers/pill/floorpill,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "omO" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/table/bench/wooden,
@@ -72697,6 +73380,12 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"ozC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "ozH" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = -32
@@ -73144,6 +73833,11 @@
 /obj/random/gun_parts/low,
 /turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
+"oDG" = (
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oDM" = (
 /obj/effect/floor_decal/spline/wood{
 	icon_state = "spline_fancy_cee"
@@ -74112,6 +74806,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
+"oNB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oNC" = (
 /obj/structure/flora/small/grassa1,
 /turf/simulated/floor/asteroid/grass,
@@ -74593,6 +75292,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"oSk" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oSl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -74681,6 +75385,9 @@
 	},
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/medical/ward)
+"oSV" = (
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oSW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74945,6 +75652,16 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"oVT" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/costume/body_animals,
+/obj/random/costume/body_generic,
+/obj/random/costume/body_halloween,
+/obj/random/costume/head_animals,
+/obj/random/costume/head_generic,
+/obj/random/costume/head_halloween,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oVX" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/bush1,
@@ -75129,6 +75846,10 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
+"oXD" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oXM" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -76368,6 +77089,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
+"pko" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pky" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -76722,6 +77448,12 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"poG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "poN" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -77070,6 +77802,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"psf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "psn" = (
 /obj/machinery/door/window/eastleft,
 /obj/machinery/door/window/brigdoor/westright{
@@ -77882,6 +78620,11 @@
 /obj/random/junkfood/onlypizza,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
+"pAb" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/mat_katana,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pAg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -78660,6 +79403,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"pIO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pJd" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -80818,6 +81565,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
+"qcB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "qcQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -81654,6 +82408,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qlv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/revolver/handmade,
+/obj/item/clothing/accessory/duster/bloodred,
+/obj/item/ammo_magazine/ammobox/pistol_35/scrap,
+/turf/simulated/floor/plating,
+/area/colony)
 "qlD" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -81746,6 +82508,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qmx" = (
+/obj/effect/floor_decal/industrial/caution{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "qmz" = (
 /obj/machinery/door/holy{
 	name = "Church"
@@ -83086,6 +83854,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/security/detectives_office)
+"qAs" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qAA" = (
 /obj/structure/boulder,
 /obj/effect/decal/cleanable/dirt,
@@ -84493,6 +85266,12 @@
 /obj/random/flora/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"qPr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qPu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85651,8 +86430,7 @@
 "rcb" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/engineering/atmos)
@@ -85769,6 +86547,9 @@
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
+"rdD" = (
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rdP" = (
 /obj/machinery/vending/gym,
 /obj/structure/sign/warning/nosmoking/small{
@@ -86222,6 +87003,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
+"rhm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/red,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rhv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88049,6 +88835,11 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/west)
+"rBc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rBi" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -88345,6 +89136,13 @@
 "rEh" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/absolutism/hallways)
+"rEo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/miningdock)
 "rEq" = (
 /obj/random/cluster/termite_no_despawn/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -88807,6 +89605,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/security/detectives_office)
+"rJG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rJJ" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -88973,6 +89778,11 @@
 "rLm" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/rnd/lab)
+"rLp" = (
+/obj/structure/table/glass,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rLw" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -89312,7 +90122,6 @@
 /obj/effect/floor_decal/industrial/warningdust{
 	dir = 6
 	},
-/obj/structure/girder,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "rOi" = (
@@ -89422,6 +90231,12 @@
 /obj/effect/floor_decal/industrial/road/straight4,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"rPs" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rPB" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/machinery/newscaster/directional/north,
@@ -89478,6 +90293,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"rQh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/eastright,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rQk" = (
 /obj/machinery/door/window{
 	dir = 8
@@ -89501,6 +90327,12 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
+"rQq" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/oddity/common/paper_bundle,
+/obj/machinery/door/window/eastright,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rQC" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -89921,6 +90753,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"rVs" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/bodybags,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/random/circuitboard/low_chance,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rVt" = (
 /obj/structure/girder,
 /turf/simulated/floor/asteroid/grass,
@@ -89980,6 +90821,13 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
+"rVX" = (
+/obj/item/device/radio/intercom{
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rVY" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -90246,6 +91094,12 @@
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters/dorm4)
+"rYk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rYp" = (
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/dirt,
@@ -90572,6 +91426,16 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"saQ" = (
+/obj/machinery/autolathe/loaded,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sbc" = (
 /obj/machinery/light/small,
 /obj/machinery/light_switch{
@@ -91788,6 +92652,13 @@
 /obj/effect/decal/mecha_wreckage/hoverpod,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/pros/shuttle)
+"snM" = (
+/obj/machinery/door/airlock/maintenance_common,
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
+	},
+/turf/space,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "snS" = (
 /obj/structure/grille{
 	desc = "Keeps the ruffians out. Hopefully.";
@@ -91946,6 +92817,10 @@
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"spg" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "spm" = (
 /obj/structure/cyberplant,
 /obj/effect/decal/cleanable/rubble,
@@ -92152,6 +93027,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"sri" = (
+/obj/structure/table/rack/shelf,
+/obj/item/modular_computer/wrist,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "srr" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /turf/simulated/floor/rock/manmade/road,
@@ -92252,6 +93132,10 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"srV" = (
+/obj/random/science/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "srX" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt,
@@ -92948,7 +93832,6 @@
 /obj/effect/floor_decal/industrial/warningdust{
 	dir = 9
 	},
-/obj/structure/girder,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "syf" = (
@@ -93333,6 +94216,12 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"sBC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cabinet,
+/obj/random/booze,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sBF" = (
 /obj/structure/railing,
 /obj/structure/multiz/stairs/enter/bottom{
@@ -93571,6 +94460,11 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/crew_quarters/bar)
+"sEC" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sEF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -94360,6 +95254,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
+"sNE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sNJ" = (
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/dirt,
@@ -95462,14 +96361,12 @@
 	name = "Residential District Maintenance"
 	})
 "sZK" = (
-/obj/machinery/alarm{
-	pixel_y = 32
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sZL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -98574,6 +99471,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
+"tGw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/spiders/low_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tGy" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "15,8"
@@ -99050,7 +99952,6 @@
 /obj/structure/table/standard,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/danger,
@@ -99313,6 +100214,10 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/forest)
+"tNG" = (
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tNJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera/network/research{
@@ -100211,6 +101116,11 @@
 /obj/random/cloth/suit/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/campground)
+"tVZ" = (
+/obj/structure/bed/chair/office/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tWc" = (
 /obj/structure/table/standard,
 /obj/item/extinguisher,
@@ -101028,6 +101938,11 @@
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/inside_colony)
+"udX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uec" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Disposals";
@@ -101037,6 +101952,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/disposaldrop)
+"uek" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"uep" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ues" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -101512,6 +102441,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"uhT" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uhW" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/industrial/hatch,
@@ -101657,6 +102592,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/sleeper)
+"ujt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ujx" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /turf/simulated/open,
@@ -102156,6 +103096,12 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"unM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "unO" = (
 /obj/machinery/door/airlock/maintenance_common,
 /obj/effect/decal/cleanable/dirt,
@@ -102278,6 +103224,10 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/command/tcommsat/computer)
+"upp" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "upq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -102808,6 +103758,12 @@
 "uvs" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/turret_protected/ai_upload)
+"uvw" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/cheap/elbrus4kk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uvJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -102833,6 +103789,11 @@
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/shuttle/surface_transport_lz)
+"uvZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/open/shower/closed,
+/turf/simulated/floor/plating,
+/area/colony)
 "uwc" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -103621,6 +104582,10 @@
 "uFe" = (
 /turf/simulated/wall/church,
 /area/nadezhda/absolutism/hallways)
+"uFg" = (
+/obj/random/cluster/termite_no_despawn_hoard,
+/turf/unsimulated/mineral,
+/area/colony)
 "uFj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -104042,6 +105007,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/servist)
+"uIZ" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/rig/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uJg" = (
 /obj/machinery/light_switch{
 	pixel_y = 32
@@ -104734,6 +105705,12 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"uOY" = (
+/obj/structure/boulder,
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uPc" = (
 /obj/structure/table/woodentable,
 /obj/item/reagent_containers/food/snacks/meat/corgi,
@@ -104804,6 +105781,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"uPM" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A20";
+	name = "D1-A20"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uPO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -105954,6 +106938,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/cryo)
+"vaz" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vaH" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -106005,7 +106993,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -106631,6 +107618,15 @@
 /obj/random/structures,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
+"via" = (
+/obj/structure/table/reinforced,
+/obj/item/device/makeshift_centrifuge,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vib" = (
 /obj/structure/table/reinforced,
 /obj/item/genetics/mut_injector,
@@ -107605,6 +108601,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
+"vrq" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vrt" = (
 /obj/structure/closet/jcloset,
 /obj/machinery/camera/network/colony_underground,
@@ -107686,6 +108688,10 @@
 /obj/machinery/door/holy/public,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/vectorrooms)
+"vso" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vsB" = (
 /obj/structure/table/standard,
 /obj/machinery/power/apc{
@@ -110144,6 +111150,11 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
+"vRv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vRy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -110172,6 +111183,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"vRD" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "vRF" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -110617,6 +111638,10 @@
 /obj/landmark/join/start/smc,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
+"vUQ" = (
+/obj/machinery/microwave/burnbarrel,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vUS" = (
 /obj/structure/salvageable/machine,
 /obj/effect/decal/cleanable/dirt,
@@ -112110,6 +113135,12 @@
 /obj/random/mob/excelsior,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"wkl" = (
+/obj/machinery/door/airlock/maintenance_interior{
+	name = "Hotel Desk"
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wkp" = (
 /obj/structure/table/bench/steel,
 /obj/effect/spider/stickyweb,
@@ -112168,15 +113199,21 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 4;
-	icon_state = "box_corners_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/box/white/corners{
-	dir = 1;
-	icon_state = "box_corners_white"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"wkK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/tool/knife/butch,
+/obj/item/material/kitchen/rollingpin,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wlg" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -112719,6 +113756,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"wpF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wpG" = (
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm3)
@@ -112779,8 +113823,7 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
@@ -113156,7 +114199,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall/r_wall,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/quartermaster/miningdock)
 "wtf" = (
 /obj/structure/railing{
@@ -113838,6 +114882,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/outside/inside_colony)
+"wBb" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/credits/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wBj" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/colony_surface,
@@ -114200,6 +115250,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"wEY" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wFg" = (
 /obj/structure/flora/small/bushb3,
 /turf/simulated/floor/beach/sand,
@@ -114344,6 +115398,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/side/f2section1)
+"wGZ" = (
+/obj/structure/closet/cabinet,
+/obj/random/booze,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wHe" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -114796,7 +115855,6 @@
 /obj/effect/floor_decal/industrial/warningdust{
 	dir = 10
 	},
-/obj/structure/girder,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
 "wLL" = (
@@ -115099,6 +116157,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/absolutism/bioreactor)
+"wPd" = (
+/obj/structure/table/bench/glass,
+/obj/structure/curtain/red,
+/obj/effect/decal/cleanable/vomit,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wPf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -116071,6 +117135,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"wYU" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wZp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -116324,6 +117398,18 @@
 "xbW" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
+"xbX" = (
+/obj/structure/table/rack,
+/obj/structure/curtain/medical,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/organ/external/robotic/junktech/r_leg,
+/obj/item/organ/external/robotic/junktech/r_arm,
+/obj/item/organ/external/robotic/junktech/l_leg,
+/obj/item/organ/external/robotic/junktech/l_arm,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xca" = (
 /obj/structure/flora/small/trailrocka3,
 /obj/structure/railing,
@@ -116449,6 +117535,9 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
+"xes" = (
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xev" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/drinkingglasses,
@@ -116484,6 +117573,11 @@
 /mob/living/simple_animal/hostile/diyaab,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"xeT" = (
+/obj/structure/table/steel,
+/obj/random/powercell/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xfb" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/big/rocks3,
@@ -117267,6 +118361,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
+"xmu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "xmy" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/substation/servist)
@@ -117391,6 +118493,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
+"xnR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "xnW" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1
@@ -118977,8 +120084,7 @@
 /area/shuttle/rocinante_shuttle_area)
 "xDn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
@@ -119138,6 +120244,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/absolutism/vectorrooms)
+"xES" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xET" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -119178,6 +120288,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/dungeon/outside/farm)
+"xFk" = (
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xFl" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -119630,6 +120744,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"xJB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet_maintloot,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xJC" = (
 /obj/random/furniture/pottedplant,
 /obj/effect/decal/cleanable/cobweb2,
@@ -119668,6 +120787,12 @@
 	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"xJQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/double/padded,
+/obj/random/furniture/bedsheetdouble,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xJW" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -120350,6 +121475,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/medical/sleeper)
+"xRc" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xRe" = (
 /obj/effect/shuttle_landmark/skipjack_colony,
 /turf/simulated/floor/asteroid/dirt,
@@ -121178,6 +122307,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"xZy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xZK" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "11,0"
@@ -122043,6 +123178,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"yjP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "yjR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -148810,7 +149951,7 @@ jIg
 kJV
 eAy
 oax
-frb
+jLs
 clN
 gBw
 vpm
@@ -149428,7 +150569,7 @@ kUx
 kUx
 kUx
 aFa
-qxo
+rEo
 qxo
 hax
 nzT
@@ -182101,9 +183242,9 @@ cvn
 mjZ
 vmZ
 hSX
-whU
-tnO
-mAJ
+bSh
+kBF
+vRD
 sCN
 sCN
 sCN
@@ -182122,9 +183263,9 @@ aOb
 lif
 sRU
 sRU
-whU
-tnO
-est
+bSh
+kBF
+poG
 cCy
 nBz
 cxN
@@ -182734,7 +183875,7 @@ cvc
 dJa
 cCy
 cCy
-nex
+gXT
 cCy
 cCy
 nCK
@@ -188574,7 +189715,7 @@ whU
 eMU
 whU
 whU
-whU
+qcB
 nUF
 wnJ
 tIQ
@@ -188776,7 +189917,7 @@ iBR
 nVZ
 iBR
 iBR
-iBR
+kZd
 iBR
 iBR
 iBR
@@ -188978,7 +190119,7 @@ whU
 qwB
 whU
 whU
-bbM
+xmu
 bbM
 rkA
 ilF
@@ -189163,7 +190304,7 @@ mpm
 mpm
 mpm
 mpm
-sZK
+bwI
 vCe
 ghk
 vpF
@@ -192985,13 +194126,13 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+ibF
+mrf
+eGP
+jsz
+qPr
+pko
 wEB
 wEB
 wEB
@@ -192999,11 +194140,11 @@ wEB
 wEB
 tTB
 vJX
-wiO
-cZb
-cZb
-cZb
-cZb
+uhT
+uhT
+wEB
+wEB
+wEB
 cZb
 cZb
 cZb
@@ -193187,13 +194328,13 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+msk
+eks
+iJQ
+cZx
+cTD
+iJQ
 wEB
 iKp
 jWI
@@ -193202,10 +194343,10 @@ wEB
 pOR
 avz
 rsN
-cZb
-cZb
-cZb
-cZb
+uhT
+wiO
+fcl
+wEB
 cZb
 cZb
 cZb
@@ -193376,26 +194517,26 @@ tad
 tad
 tad
 tad
-tad
-tad
 cZb
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+fjd
+cTD
+iJQ
+unM
+rJG
+xRc
 wEB
 iVg
 nXu
@@ -193404,10 +194545,10 @@ wEB
 snr
 kSY
 wEB
-cZb
-cZb
-cZb
-cZb
+fcl
+fcl
+yjP
+wEB
 cZb
 cZb
 cZb
@@ -193578,26 +194719,26 @@ tad
 tad
 tad
 tad
-tad
-tad
 cZb
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+kxx
+aAr
+psf
+psf
+sri
+wEB
+srV
+iJQ
+cTD
+mfd
+lam
+mfd
+khI
+dih
 wEB
 lVS
 lVS
@@ -193606,10 +194747,10 @@ snr
 pQH
 pQH
 wEB
-cZb
-cZb
-cZb
-cZb
+coP
+auT
+rYk
+wEB
 cZb
 cZb
 cZb
@@ -193673,7 +194814,7 @@ hrP
 iPz
 kyK
 diB
-gbE
+kyK
 eKO
 vFE
 mAy
@@ -193780,26 +194921,26 @@ tad
 tad
 tad
 tad
-tad
-tad
 cZb
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+pAb
+rdD
+nGg
+aAr
+aAr
+wEB
+iJQ
+cTD
+iJQ
+cTD
+iJQ
+unM
+iJQ
+cTD
 wEB
 lVS
 lVS
@@ -193808,10 +194949,10 @@ lTo
 qBj
 snr
 wEB
-cZb
-cZb
-cZb
-cZb
+kTw
+aUR
+ihb
+wEB
 cZb
 cZb
 cZb
@@ -193876,8 +195017,8 @@ fkV
 kyK
 diB
 kyK
-fbS
-fbS
+kyK
+qmx
 kyK
 fbS
 sAU
@@ -193983,41 +195124,41 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+uIZ
+aAr
+mLC
+nHv
+uep
+wEB
+iJQ
+iJQ
+tNG
+vrq
+rVs
+saQ
+gbE
+edz
+wEB
+uhT
+wiO
 wEB
 wEB
 wEB
 wEB
 wEB
 wEB
+uPM
 wEB
 wEB
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+fcl
+fcl
+fcl
+fcl
 cZb
 cZb
 cZb
@@ -194185,41 +195326,41 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+bHw
+aAr
+upp
+dkw
+rQq
+wEB
+snM
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+fcl
+fcl
+ksG
+pQH
+pQH
+iQt
+pQH
+snr
+gqE
+snr
+pQH
+gxu
+snr
+fcl
+fcl
 cZb
 cZb
 cZb
@@ -194387,41 +195528,41 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+cRB
+aAr
+aAr
+dUl
+cdi
+oNB
+snr
+gxu
+fcl
+oSk
+fcl
+pIO
+lVS
+mIz
+bOx
+lVS
+pIO
+wEB
+wEB
+njz
+wEB
+wEB
+wEB
+hkQ
+wEB
+wEB
+wEB
+klX
+wEB
+wEB
 cZb
 cZb
 cZb
@@ -194589,41 +195730,41 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+wBb
+aAr
+psf
+rdD
+drY
+wEB
+kxv
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+aba
+wpF
+wEB
+kTw
+mWI
+dqQ
+wEB
+kTw
+mWI
+dqQ
+wEB
+kTw
+mWI
+dqQ
+wEB
 cZb
 cZb
 cZb
@@ -194791,41 +195932,41 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+oVT
+aAr
+nHU
+aAr
+drY
+wEB
+oSV
+oSV
+rPs
+oSV
+oSV
+wEB
+iTN
+uek
+wkl
+lAZ
+gmU
+wEB
+ivN
+vaz
+xJB
+wEB
+xeT
+tGw
+ujt
+wEB
+abY
+mWI
+fOs
+wEB
 cZb
 cZb
 jZv
@@ -194993,41 +196134,41 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+dJq
+aAr
+psf
+aAr
+xFk
+wEB
+mJk
+sEC
+edk
+fIA
+oDG
+wEB
+ijn
+eQo
+wEB
+atI
+lVS
+wEB
+rQh
+mWI
+kTG
+wEB
+rQh
+mWI
+lab
+wEB
+rQh
+lJO
+lab
+wEB
 cZb
 cZb
 jZv
@@ -195195,41 +196336,41 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+rVX
+tVZ
+igw
+fSj
+bOx
+wEB
+npd
+ijh
+xJQ
+wEB
+npd
+ijh
+xJQ
+wEB
+wYU
+ijh
+xJQ
+wEB
 cZb
 cZb
 jZv
@@ -195397,26 +196538,6 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
@@ -195429,9 +196550,29 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
+wEB
+bEA
+qlv
+kmR
+wEB
+iWA
+uvw
+wEB
+udX
+lVS
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
 cZb
 cZb
 jZv
@@ -195600,25 +196741,6 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
@@ -195630,9 +196752,28 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
+wEB
+xnR
+ozC
+fzs
+wEB
+wEB
+wEB
+wEB
+lVS
+bOx
+rLp
+mwD
+eAj
+wEB
+wkK
+kVg
+vUQ
+wEB
+mZO
+iRS
+ejg
+wEB
 cZb
 cZb
 cZb
@@ -195803,24 +196944,6 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
@@ -195831,10 +196954,28 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+aZK
+xnR
+ozC
+aZK
+xnR
+xnR
+uvZ
+bOx
+lVS
+rLp
+xES
+fdq
+wEB
+dlW
+rBc
+oXD
+wEB
+hpn
+aKo
+kRQ
+wEB
 cZb
 cZb
 cZb
@@ -196006,25 +197147,6 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
@@ -196034,9 +197156,28 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
+sju
+sju
+sju
+sju
+sju
+sju
+sju
+sju
+kaU
+lVS
+aHC
+aIT
+via
+wEB
+dKn
+dKn
+dcK
+wEB
+lTq
+lTq
+xes
+wEB
 cZb
 cZb
 cZb
@@ -196209,24 +197350,6 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
@@ -196241,6 +197364,24 @@ cZb
 cZb
 cZb
 cZb
+cZb
+rsN
+xZy
+sNE
+wEB
+wEB
+wEB
+wEB
+hPJ
+wPd
+rhm
+wEB
+kIq
+asi
+xbX
+wEB
+wEB
+wEB
 cZb
 cZb
 cZb
@@ -196414,21 +197555,6 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
@@ -196441,8 +197567,23 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
+wEB
+fcl
+pIO
+lVS
+lVS
+lVS
+lVS
+lVS
+lVS
+lVS
+gTQ
+vRv
+bOx
+lVS
+agV
+agV
+agV
 cZb
 cZb
 cZb
@@ -196617,20 +197758,6 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
@@ -196642,9 +197769,23 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
+wEB
+fcl
+fcl
+wEB
+vso
+wEB
+wEB
+bbk
+wEB
+wEB
+jXK
+wEB
+wEB
+jXK
+wEB
+wEB
+rsN
 cZb
 cZb
 cZb
@@ -196821,21 +197962,6 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
@@ -196845,7 +197971,22 @@ cZb
 cZb
 cZb
 cZb
-cZb
+wEB
+kaU
+uOY
+wEB
+wEY
+qAs
+wEB
+hbp
+sBC
+wEB
+jwD
+wGZ
+wEB
+jwD
+sBC
+wEB
 cZb
 cZb
 cZb
@@ -197024,20 +198165,6 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
@@ -197046,8 +198173,22 @@ cZb
 cZb
 cZb
 cZb
-cZb
-cZb
+wEB
+lVS
+lVS
+wEB
+sZK
+qAs
+wEB
+nuR
+lAc
+wEB
+gCq
+ciK
+wEB
+omI
+ciK
+wEB
 cZb
 cZb
 cZb
@@ -197228,28 +198369,28 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
 cZb
 cZb
 cZb
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+lVS
+bOx
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
 cZb
 cZb
 cZb
@@ -197432,16 +198573,16 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+wEB
+lVS
+spg
+wEB
+cZb
+cZb
 cZb
 cZb
 cZb
@@ -197634,16 +198775,16 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+wEB
+bOx
+bOx
+wEB
+cZb
+cZb
 cZb
 cZb
 cZb
@@ -197837,18 +198978,18 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+wEB
+bOx
+lVS
+wEB
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
@@ -198039,18 +199180,18 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+wEB
+lVS
+lVS
+wEB
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
@@ -198241,18 +199382,18 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+wEB
+lVS
+lVS
+wEB
+cZb
+cZb
+cZb
+cZb
+cZb
 tad
 tad
 tad
@@ -198443,17 +199584,17 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+wEB
+bOx
+bOx
+wEB
+cZb
+cZb
+cZb
+cZb
 tad
 tad
 tad
@@ -198637,6 +199778,7 @@ tad
 tad
 tad
 tad
+uFg
 tad
 tad
 tad
@@ -198644,18 +199786,17 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+wEB
+lVS
+bOx
+wEB
+cZb
+cZb
+cZb
+cZb
 tad
 tad
 tad
@@ -198847,17 +199988,17 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+wEB
+lVS
+izh
+wEB
+cZb
+cZb
+cZb
+cZb
 tad
 tad
 tad
@@ -199049,16 +200190,16 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+wEB
+lVS
+lVS
+wEB
+cZb
+cZb
+cZb
 tad
 tad
 tad
@@ -199251,16 +200392,16 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+wEB
+bOx
+lVS
+wEB
+cZb
+cZb
+cZb
 tad
 tad
 tad
@@ -199453,16 +200594,16 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+wEB
+wiO
+agV
+wEB
+cZb
+cZb
+cZb
 tad
 tad
 tad
@@ -199655,16 +200796,16 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 tad
 tad
 tad
@@ -199858,14 +200999,14 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 tad
 tad
 tad

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -933,6 +933,13 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
+"ajD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/sofa{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ajH" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -1246,6 +1253,14 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security)
+"amS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "amY" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -1625,13 +1640,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"arr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/lathe_disk/any_gun/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ary" = (
 /obj/structure/lattice,
 /obj/structure/railing,
@@ -1796,6 +1804,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai_upload)
+"atb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/material/kitchen/utensil/fork,
+/obj/item/stack/rods/random,
+/turf/simulated/floor/plating,
+/area/colony)
 "atf" = (
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp,
@@ -2467,6 +2482,14 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"azC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/common_oddities/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "azI" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance{
@@ -3255,10 +3278,6 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/forest)
-"aHx" = (
-/obj/structure/janitorialcart,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aHF" = (
 /obj/machinery/disposal/deliveryChute{
 	name = "trash chute"
@@ -3459,8 +3478,12 @@
 /area/nadezhda/maintenance/undergroundfloor1east)
 "aKh" = (
 /obj/structure/table/rack/shelf,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/janitor)
 "aKu" = (
@@ -3470,11 +3493,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
-"aKw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aKG" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -3683,13 +3701,10 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/colony)
-"aMH" = (
+"aMF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/colony)
 "aML" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -3779,11 +3794,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"aNp" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aNy" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -3884,6 +3894,11 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
+"aOT" = (
+/obj/item/reagent_containers/syringe/drugs,
+/obj/item/reagent_containers/pill/floorpill,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aOU" = (
 /obj/item/remains/deer,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -4018,6 +4033,11 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
+"aQN" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/rig_module/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aQO" = (
 /obj/structure/railing{
 	dir = 1
@@ -4031,6 +4051,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
+"aQT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aQV" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/armoryshop)
@@ -4512,14 +4537,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"aXg" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/welding,
-/obj/item/storage/belt,
-/obj/item/clothing/head/welding,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aXu" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -4884,11 +4901,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/cro)
-"bbc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/spiders/low_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bbf" = (
 /mob/living/simple_animal/chicken{
 	name = "Commander Clucky"
@@ -5060,6 +5072,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/hallways)
+"bcG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bcI" = (
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
@@ -5454,11 +5473,6 @@
 /obj/random/junk/cigbutt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
-"bgt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bgB" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -5880,14 +5894,9 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "bjV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/crew_quarters/janitor)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bkg" = (
 /obj/random/booze,
 /obj/random/junkfood/onlypizza,
@@ -6141,14 +6150,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"bnC" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A3";
-	name = "D1-A3"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bnF" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -7141,11 +7142,6 @@
 /obj/item/storage/bag/xenobio,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
-"bxj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bxt" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
@@ -7213,6 +7209,13 @@
 	icon_state = "16,20"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"byo" = (
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/common_oddities/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "byp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
@@ -7386,6 +7389,10 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
+"bzT" = (
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bAc" = (
 /obj/structure/sign/departmentold/botany/small,
 /turf/simulated/wall/r_wall,
@@ -7523,6 +7530,14 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"bBY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/gun_normal/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bBZ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -7619,11 +7634,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"bCS" = (
-/obj/structure/table/glass,
-/obj/structure/curtain/black,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bCU" = (
 /obj/effect/floor_decal/industrial/warningred,
 /obj/structure/extinguisher_cabinet{
@@ -8147,13 +8157,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/dungeon/outside/burned_outpost)
-"bIK" = (
-/obj/machinery/vending/engivend,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bIL" = (
 /obj/random/furniture/painting,
 /turf/simulated/wall,
@@ -8335,6 +8338,18 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfacenorth)
+"bJQ" = (
+/obj/structure/table/rack,
+/obj/structure/curtain/medical,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/organ/external/robotic/junktech/r_leg,
+/obj/item/organ/external/robotic/junktech/r_arm,
+/obj/item/organ/external/robotic/junktech/l_leg,
+/obj/item/organ/external/robotic/junktech/l_arm,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bJY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -8624,6 +8639,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"bMO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/custom/onestar,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/colony)
 "bMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8757,11 +8777,6 @@
 /obj/item/storage/box/donkpockets,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
-"bOO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bOV" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/big/bush2,
@@ -9037,12 +9052,6 @@
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/outside/inside_colony)
-"bSN" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/rig/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bSP" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/bushb1,
@@ -9679,11 +9688,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"bZk" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/autolathe/mechfab/loaded,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bZl" = (
 /obj/effect/overlay/water,
 /obj/effect/overlay/water/top,
@@ -10001,11 +10005,6 @@
 "cco" = (
 /turf/unsimulated/mask,
 /area/nadezhda/dungeon/outside/trashcave)
-"ccw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/eastright,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ccx" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -10063,11 +10062,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
-"cdm" = (
-/obj/structure/bed/chair/office/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cdB" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/security{
@@ -10182,12 +10176,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/clownoffice)
-"ceF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ceJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10559,9 +10547,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"ciN" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ciP" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/railing,
@@ -10905,6 +10890,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"cmn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cmo" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11037,6 +11027,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"cnq" = (
+/obj/random/cluster/slimes,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cnr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/smartfridge/secure/medbay,
@@ -11268,19 +11262,6 @@
 	icon_state = "10,18"
 	},
 /area/nadezhda/engineering/engine_room)
-"cqg" = (
-/obj/structure/closet/crate/secure/large,
-/obj/item/organ/internal/bone/head/robotic,
-/obj/item/organ/internal/bone/l_arm/robotic,
-/obj/item/organ/internal/bone/l_leg/robotic,
-/obj/item/organ/internal/bone/r_arm/robotic,
-/obj/item/organ/internal/bone/r_leg/robotic,
-/obj/item/organ/internal/bone/chest/robotic,
-/obj/effect/decal/cleanable/blood/oil{
-	icon_state = "splatter2"
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cqi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -11801,6 +11782,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"cvN" = (
+/obj/structure/closet/crate/secure/large,
+/obj/item/organ/internal/bone/head/robotic,
+/obj/item/organ/internal/bone/l_arm/robotic,
+/obj/item/organ/internal/bone/l_leg/robotic,
+/obj/item/organ/internal/bone/r_arm/robotic,
+/obj/item/organ/internal/bone/r_leg/robotic,
+/obj/item/organ/internal/bone/chest/robotic,
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "splatter2"
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cvW" = (
 /obj/structure/table/rack,
 /obj/item/rig/ce/equipped,
@@ -12066,6 +12060,16 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/detectives_office)
+"cyT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/open/shower/closed,
+/turf/simulated/floor/plating,
+/area/colony)
+"cyU" = (
+/obj/structure/table/steel,
+/obj/random/powercell/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cyW" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -12202,10 +12206,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"cAE" = (
-/mob/living/bot/cleanbot,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cAF" = (
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
@@ -12871,6 +12871,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"cGZ" = (
+/obj/structure/table/standard,
+/obj/item/storage/freezer/medical,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cHe" = (
 /obj/machinery/light,
 /turf/simulated/shuttle/floor/mining,
@@ -12995,6 +13000,17 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
+"cIh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/eastright,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cIj" = (
 /obj/structure/table/reinforced,
 /obj/random/material/low_chance,
@@ -13110,9 +13126,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
-"cJn" = (
-/obj/machinery/microwave/burnbarrel,
-/turf/simulated/floor/wood/wild4,
+"cJp" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "cJq" = (
 /obj/structure/catwalk,
@@ -13348,6 +13364,10 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
+"cLU" = (
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cLZ" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/orange,
@@ -13707,10 +13727,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/virology)
-"cPi" = (
-/obj/random/science/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cPj" = (
 /obj/structure/low_wall,
 /obj/machinery/door/blast/shutters/glass{
@@ -14082,6 +14098,11 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
+"cSL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/red,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cSM" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/structure/closet/wall_mounted/emcloset{
@@ -14572,10 +14593,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
-"cXw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cXx" = (
 /obj/random/flora/small_jungle_tree,
 /obj/random/flora/jungle_tree,
@@ -14709,6 +14726,11 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm2)
+"cYB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cYC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -14733,16 +14755,6 @@
 	},
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/medical/reception)
-"cYU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/northleft,
-/obj/machinery/door/window/southleft,
-/obj/machinery/cash_register{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cYZ" = (
 /obj/structure/table/rack,
 /obj/random/tank,
@@ -15456,6 +15468,13 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"dhc" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood,
+/obj/random/junkfood,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dhd" = (
 /obj/structure/flora/small/trailrockb4,
 /turf/simulated/floor/asteroid/grass,
@@ -15725,6 +15744,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
+"djp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "djv" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -15747,6 +15774,11 @@
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
+"djP" = (
+/obj/machinery/mech_recharger,
+/obj/random/mecha/low_chance,
+/turf/simulated/floor/plating,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "djU" = (
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
 	pixel_x = 32
@@ -15857,10 +15889,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
-"dlo" = (
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/mineral,
-/area/colony)
 "dlq" = (
 /obj/structure/flora/small/rock5,
 /obj/structure/flora/small/busha3,
@@ -16125,6 +16153,11 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
+"dnO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/lowkeyrandom,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dnQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
@@ -16290,11 +16323,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
-"dpn" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/roach/roachling,
-/turf/simulated/floor/plating,
-/area/colony)
 "dpw" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -16318,6 +16346,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"dpA" = (
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dpF" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "12,2"
@@ -16392,6 +16424,13 @@
 /obj/structure/closet/crate/secure/weapon/amr,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"dqq" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dqt" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -16575,6 +16614,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"dsz" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "dsL" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -16583,6 +16639,14 @@
 /obj/random/pack/gun_loot,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"dsV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dsW" = (
 /obj/machinery/door/airlock/command{
 	id_tag = "wobolt1";
@@ -16900,13 +16964,6 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
-"dvs" = (
-/obj/machinery/door/airlock/maintenance_common,
-/obj/random/traps/low_chance{
-	spawn_nothing_percentage = 90
-	},
-/turf/space,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dvu" = (
 /obj/structure/railing/grey{
 	dir = 8;
@@ -17385,6 +17442,12 @@
 /obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"dzJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dzL" = (
 /obj/effect/floor_decal/industrial/road/curve1,
 /turf/simulated/floor/rock/manmade/road,
@@ -17461,6 +17524,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
+"dAv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dAE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/shuttle/floor/science{
@@ -17577,6 +17644,16 @@
 "dBG" = (
 /turf/simulated/shuttle/wall/mining,
 /area/shuttle/rocinante_shuttle_area)
+"dBI" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/costume/body_animals,
+/obj/random/costume/body_generic,
+/obj/random/costume/body_halloween,
+/obj/random/costume/head_animals,
+/obj/random/costume/head_generic,
+/obj/random/costume/head_halloween,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dBM" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/crate/trashcart,
@@ -17600,6 +17677,13 @@
 	icon_state = "2,3"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"dBX" = (
+/obj/structure/table/reinforced,
+/obj/item/device/makeshift_electrolyser,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dCe" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/big/bush3,
@@ -18095,6 +18179,12 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/command/cro)
+"dGK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dGL" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -18118,6 +18208,12 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
+"dHe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "dHj" = (
@@ -18160,13 +18256,6 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"dHP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dIe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18710,6 +18799,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/genetics)
+"dML" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet_maintloot,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dMM" = (
 /obj/structure/table/standard,
 /obj/item/storage/freezer,
@@ -18904,11 +18998,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/security/barracks)
-"dOX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet_tech/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dOY" = (
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
@@ -19010,16 +19099,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"dQa" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "dQf" = (
 /obj/structure/flora/small/lavarock3,
 /turf/simulated/floor/beach/sand,
@@ -19159,14 +19238,6 @@
 /obj/random/scrap/sparse_weighted,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"dRG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/contraband/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dRK" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -19509,12 +19580,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"dWc" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dWf" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_x = 32
@@ -19635,10 +19700,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfaceeast)
-"dWX" = (
-/obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dWZ" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -19720,11 +19781,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm2)
-"dXF" = (
-/obj/random/booze/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dXR" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -20286,14 +20342,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/outside/inside_colony)
-"edo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "edp" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/virology)
@@ -21217,11 +21265,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"emU" = (
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "emV" = (
 /obj/item/book/manual/fiction/littlewomen,
 /obj/item/book/manual/fiction/aroundtheworld,
@@ -21595,12 +21638,6 @@
 /obj/random/cluster/tengolo,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
-"epU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "epW" = (
 /obj/structure/table/standard,
 /obj/item/device/integrated_electronics/debugger{
@@ -21922,12 +21959,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/engineering/atmos/surface)
-"esq" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "est" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/grey,
@@ -22208,6 +22239,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/chemistry)
+"evC" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "evD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22891,6 +22926,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/outside/inside_colony)
+"eCY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/random/junkfood/rotten,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eDa" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "9,20"
@@ -23016,6 +23057,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/crematorium)
+"eEp" = (
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eEC" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light{
@@ -23266,6 +23314,13 @@
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /turf/simulated/floor/reinforced/airmix,
 /area/nadezhda/engineering/atmos)
+"eIh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eIo" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/prox_sensor,
@@ -23433,11 +23488,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"eJU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eJW" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
@@ -23629,6 +23679,13 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"eLB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/miningdock)
 "eLM" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -24180,6 +24237,10 @@
 	icon_state = "10,15"
 	},
 /area/nadezhda/engineering/engine_room)
+"ePL" = (
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ePN" = (
 /obj/structure/catwalk,
 /obj/structure/invislight,
@@ -24309,6 +24370,10 @@
 	},
 /turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
+"eQC" = (
+/obj/machinery/door/airlock/maintenance_cargo,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eQJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24658,16 +24723,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"eVq" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/costume/body_animals,
-/obj/random/costume/body_generic,
-/obj/random/costume/body_halloween,
-/obj/random/costume/head_animals,
-/obj/random/costume/head_generic,
-/obj/random/costume/head_halloween,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eVv" = (
 /obj/structure/multiz/stairs/enter{
 	dir = 8
@@ -25359,6 +25414,9 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/pros/prep)
+"faV" = (
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fbb" = (
 /obj/item/clothing/under/excelsior/bdu,
 /obj/item/clothing/under/excelsior/bdu,
@@ -25409,11 +25467,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"fbF" = (
-/obj/structure/table/standard,
-/obj/item/storage/freezer/medical,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fbJ" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/small/busha1,
@@ -25425,6 +25478,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
+"fbX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fce" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1
@@ -25645,6 +25703,11 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"ffe" = (
+/obj/machinery/door/window/northleft,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ffp" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = 32
@@ -26040,13 +26103,13 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/outside/inside_colony)
 "fiy" = (
-/obj/landmark/join/start/janitor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 6
 	},
+/obj/landmark/join/start/janitor,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
 "fiz" = (
@@ -26486,12 +26549,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"fmy" = (
-/obj/machinery/vending/assist,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+"fmq" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A20";
+	name = "D1-A20"
 	},
-/turf/simulated/floor/tiled/white/gray_platform,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "fmz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -26537,12 +26601,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"fmL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fmO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -26571,6 +26629,15 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/maingate/west)
+"fnc" = (
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/structure/bedsheetbin,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fnd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -26686,6 +26753,16 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
+"fol" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "foo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -26871,11 +26948,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
-"fpx" = (
-/obj/machinery/door/window/northleft,
-/obj/structure/curtain/black,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fpz" = (
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled/white/techfloor_grid,
@@ -26917,9 +26989,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"fqa" = (
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fqc" = (
 /obj/structure/table/marble,
 /obj/random/toy/plushie_onlycorgi,
@@ -26993,13 +27062,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"fqW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/miningdock)
 "fqZ" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -27052,16 +27114,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
+"frF" = (
+/obj/structure/boulder,
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "frR" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
-"frS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "frV" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/wood/random,
@@ -27247,11 +27310,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
-"fun" = (
-/obj/structure/table/standard,
-/obj/item/storage/pill_bottle/tramadol,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fuG" = (
 /obj/random/spider_trap_burrowing,
 /obj/effect/decal/cleanable/dirt,
@@ -27423,6 +27481,12 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/prime)
+"fwq" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/cheap/elbrus4kk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fws" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/chemistry)
@@ -27740,6 +27804,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/bar)
+"fzv" = (
+/obj/structure/table/rack/shelf,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/computer_hardware/hard_drive/portable/advanced/shady,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fzw" = (
 /obj/machinery/conveyor/south{
 	id = "mining_internal"
@@ -28798,13 +28870,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
-"fLm" = (
-/obj/structure/curtain/open/bed{
-	name = "Privacy curtain"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fLq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -28864,12 +28929,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
-"fLU" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/cheap/elbrus4kk,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fLZ" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -29524,6 +29583,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
+"fTQ" = (
+/obj/machinery/optable,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fTS" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/random/flora/jungle_tree,
@@ -29888,10 +29956,6 @@
 	temperature = 80
 	},
 /area/nadezhda/command/tcommsat/computer)
-"fXR" = (
-/obj/random/cluster/termite_no_despawn_hoard,
-/turf/unsimulated/mineral,
-/area/colony)
 "fXT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild1,
@@ -30283,7 +30347,9 @@
 	name = "Residential District Maintenance"
 	})
 "gbE" = (
-/turf/simulated/floor/tiled/techmaint_perforated,
+/obj/structure/table/standard,
+/obj/item/storage/pill_bottle/tramadol,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "gbL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -30458,10 +30524,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"gdk" = (
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gdo" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1;
@@ -31008,12 +31070,6 @@
 /obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/panic_room)
-"ghJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "ghL" = (
 /obj/structure/table/rack/shelf,
 /obj/random/melee/low_chance,
@@ -31031,6 +31087,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"ghS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/random/cluster/spiders,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ghV" = (
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
@@ -31058,11 +31122,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/west)
-"gip" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "giu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -31126,13 +31185,6 @@
 /obj/machinery/autolathe/mechfab/loaded,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/rnd/robotics)
-"gjr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gjs" = (
 /obj/effect/spider/stickyweb,
 /obj/machinery/light/small{
@@ -32560,9 +32612,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"gwQ" = (
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gwV" = (
 /obj/structure/disposalpipe/up{
 	dir = 8
@@ -33109,11 +33158,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/range)
-"gDj" = (
-/obj/structure/closet/cabinet,
-/obj/random/booze,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gDv" = (
 /obj/random/structures/low_chance,
 /obj/structure/catwalk,
@@ -33279,6 +33323,13 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"gFf" = (
+/obj/machinery/door/window/eastright,
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gFl" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/quartermaster/disposaldrop)
@@ -33378,11 +33429,6 @@
 /obj/item/mine/old/armed,
 /turf/simulated/floor/rock,
 /area/colony)
-"gGI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gGN" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -33452,6 +33498,15 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
+"gHy" = (
+/obj/structure/table/rack,
+/obj/structure/curtain/medical,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/organ/internal/optical_sensor,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gHI" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/small/trailrocka1,
@@ -33704,10 +33759,6 @@
 /obj/random/material/low_chance,
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"gKI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gKN" = (
 /obj/structure/boulder{
 	pixel_x = -1
@@ -33807,11 +33858,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/tcommsat/computer)
-"gLS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gLT" = (
 /obj/item/storage/deferred/crate/alcohol,
 /obj/effect/decal/cleanable/dirt,
@@ -33870,6 +33916,13 @@
 /obj/structure/railing,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"gNb" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A20";
+	name = "D1-A20"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gNf" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 1
@@ -34111,11 +34164,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
-"gOJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gOS" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -34445,10 +34493,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"gRN" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gSc" = (
 /obj/random/cluster/roaches,
 /turf/simulated/floor/tiled/techmaint,
@@ -34710,6 +34754,10 @@
 	opacity = 0
 	},
 /area/shuttle/rocinante_shuttle_area)
+"gUa" = (
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gUb" = (
 /obj/structure/boulder,
 /obj/random/traps/wire_splicing/low_chance,
@@ -34983,13 +35031,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"gWD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gWK" = (
 /obj/effect/floor_decal/corner_oldtile,
 /obj/effect/floor_decal/corner_oldtile{
@@ -35564,11 +35605,6 @@
 /obj/random/cluster/spiders,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
-"hdn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "hdo" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable/cyan{
@@ -35794,10 +35830,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"hfI" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/wall/r_wall,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hfO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -36134,10 +36166,6 @@
 /obj/item/clothing/accessory/magatama,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
-"hjP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hjS" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/structure/cable/cyan{
@@ -36486,6 +36514,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/hallway/side/f2section1)
+"hmG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hnc" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -36540,6 +36574,13 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
+"hnU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hoa" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -36911,6 +36952,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"hrU" = (
+/obj/random/structures,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hrW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36999,10 +37044,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"hsI" = (
-/obj/structure/boulder,
+"hsH" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint_perforated,
+/obj/structure/closet/wall_mounted{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "hsW" = (
 /obj/structure/flora/small/rock3,
@@ -37090,6 +37138,12 @@
 	icon_state = "7,6"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"htJ" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil/random,
+/obj/item/device/robotanalyzer,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "htK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -37154,12 +37208,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"hug" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/mecha_equipment/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hui" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -37636,6 +37684,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/sechall)
+"hzp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/lathe_disk/any_gun/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hzs" = (
 /obj/structure/table/rack/shelf,
 /obj/random/mecha_equipment/low_chance,
@@ -37719,6 +37774,11 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
+"hzQ" = (
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hzR" = (
 /obj/effect/floor_decal/industrial/loading,
 /obj/effect/decal/cleanable/dirt,
@@ -37875,6 +37935,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
+"hBm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hBn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departmentold/restroom{
@@ -37960,6 +38024,10 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"hBZ" = (
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hCk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -38065,14 +38133,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"hDg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "hDn" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -38342,11 +38402,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"hFB" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/rig_module/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hFG" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/effect/decal/cleanable/dirt,
@@ -38409,15 +38464,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"hGy" = (
-/obj/machinery/optable,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hGB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -39110,6 +39156,11 @@
 /obj/structure/boulder,
 /turf/simulated/mineral,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"hLz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hLC" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -39151,6 +39202,17 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"hLI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hLK" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -39336,15 +39398,6 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
-"hNx" = (
-/obj/machinery/firealarm{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel_reinforced,
-/obj/structure/bedsheetbin,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hNy" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/dirt,
@@ -39358,12 +39411,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/tactical_blackshield)
-"hNQ" = (
-/obj/effect/floor_decal/industrial/caution{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "hNT" = (
 /obj/machinery/light,
 /obj/structure/table/bar_special,
@@ -39434,6 +39481,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"hOO" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hPf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -39502,6 +39555,13 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
+"hPR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hPW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -39531,6 +39591,14 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"hQu" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hQM" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -39595,6 +39663,12 @@
 /obj/effect/spider/spiderling/near_grown,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"hRI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hRP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/food/large,
@@ -39890,11 +39964,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
-"hUY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hVb" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -40045,6 +40114,16 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"hWa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/northleft,
+/obj/machinery/door/window/southleft,
+/obj/machinery/cash_register{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hWc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
@@ -40056,12 +40135,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
-"hWj" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hWs" = (
 /obj/structure/mirror{
 	pixel_y = -28
@@ -40195,10 +40268,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/medical/reception)
-"hXt" = (
-/obj/random/cluster/slimes,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hXB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -40375,6 +40444,18 @@
 /obj/item/flame/lighter/zippo/capitalist,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
+"hYK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/storage/freezer,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hYL" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -40556,6 +40637,11 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/barracks)
+"hZN" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hZY" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -41148,6 +41234,11 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
+"ifo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ift" = (
 /obj/structure/scrap/medical/large,
 /obj/effect/decal/cleanable/cobweb,
@@ -41319,6 +41410,12 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"igY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "ihc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -41395,16 +41492,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
-"iin" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iip" = (
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/armory)
@@ -41682,10 +41769,6 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/mineral,
 /area/colony)
-"ilm" = (
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ilq" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/random/scrap/dense_weighted/low_chance,
@@ -41730,11 +41813,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"ilG" = (
-/obj/item/reagent_containers/syringe/drugs,
-/obj/item/reagent_containers/pill/floorpill,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ilH" = (
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 4;
@@ -41749,6 +41827,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"ilJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ilL" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/maingate/east)
@@ -41880,6 +41963,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"imD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/revolver/handmade,
+/obj/item/clothing/accessory/duster/bloodred,
+/obj/item/ammo_magazine/ammobox/pistol_35/scrap,
+/turf/simulated/floor/plating,
+/area/colony)
 "imM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -42014,24 +42105,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"inO" = (
-/obj/structure/table/rack/shelf,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/computer_hardware/hard_drive/portable/advanced/shady,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"inQ" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/curtain/open,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "inU" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -42039,6 +42112,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"inX" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "inZ" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -42134,6 +42211,12 @@
 /obj/effect/floor_decal/industrial/box/white,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical)
+"ioV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/tool/advanced/onestar/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ioZ" = (
 /obj/structure/table/bench/steel,
 /obj/effect/decal/cleanable/dirt,
@@ -42220,6 +42303,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"iqf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iqg" = (
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
@@ -42726,11 +42813,6 @@
 	icon_state = "1,21"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"ivi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ivk" = (
 /obj/item/reagent_containers/dropper{
 	pixel_y = -4
@@ -42790,6 +42872,12 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"ivJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/employment,
+/obj/random/credits/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ivP" = (
 /obj/random/mob/spiders/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -42850,6 +42938,10 @@
 /mob/living/simple_animal/frog,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"iwK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iwT" = (
 /obj/machinery/porta_turret/gate,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -44084,6 +44176,12 @@
 	icon_state = "10,15"
 	},
 /area/nadezhda/rnd/docking)
+"iKh" = (
+/obj/structure/closet/wall_mounted/emcloset{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iKj" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -44132,6 +44230,11 @@
 /obj/effect/floor_decal/industrial/warningdust,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/engine_room)
+"iKI" = (
+/obj/structure/table/rack/shelf,
+/obj/item/modular_computer/wrist,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iKK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44247,15 +44350,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/server)
-"iLZ" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/bodybags,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/random/circuitboard/low_chance,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iMd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -44320,6 +44414,11 @@
 "iML" = (
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
+"iMN" = (
+/obj/structure/bed,
+/obj/item/handcuffs/fuzzy,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iMY" = (
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/grass,
@@ -44744,11 +44843,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"iRj" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iRl" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "4,1"
@@ -44880,13 +44974,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
-"iSK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iSN" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -44896,6 +44983,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
+"iSO" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/material_resources,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iSV" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -45140,11 +45233,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"iVF" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iVJ" = (
 /obj/structure/catwalk,
 /obj/random/scrap/dense_weighted/low_chance,
@@ -45607,16 +45695,6 @@
 /obj/random/dungeon_gun_mods,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"jbe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/southleft,
-/obj/machinery/door/window/northleft,
-/obj/machinery/cash_register{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jbo" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/alarm{
@@ -45882,10 +45960,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/secrecroom)
-"jdC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jdE" = (
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor2north)
@@ -46138,12 +46212,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/security/prisoncells)
-"jgq" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil/random,
-/obj/item/device/robotanalyzer,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jgt" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -46490,9 +46558,6 @@
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"jjL" = (
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jjN" = (
 /obj/machinery/door/airlock/maintenance_common{
 	req_access = list(12)
@@ -46856,9 +46921,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
-"jnh" = (
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jni" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -46889,12 +46951,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"jnm" = (
-/obj/structure/closet/wall_mounted/emcloset{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jno" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -47103,6 +47159,15 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
+"joX" = (
+/obj/structure/table/reinforced,
+/obj/item/device/makeshift_centrifuge,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jpe" = (
 /obj/random/mob/excelsior,
 /obj/effect/decal/cleanable/dirt,
@@ -47187,6 +47252,9 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
+"jqb" = (
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jqc" = (
 /obj/machinery/light/small,
 /obj/machinery/alarm{
@@ -47384,6 +47452,12 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
+"jrJ" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/rig/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jrL" = (
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -47595,6 +47669,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"jug" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "juj" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -47764,13 +47845,6 @@
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"jvq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jvw" = (
 /obj/machinery/light{
 	dir = 1
@@ -49513,17 +49587,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
+"jOw" = (
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jOG" = (
 /obj/landmark/storyevent/hidden_vent_antag,
 /obj/structure/reagent_dispensers/bidon{
 	starting_reagent = "cleaner"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
 "jOI" = (
@@ -49715,6 +49791,9 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/scave)
+"jQU" = (
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jQV" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
@@ -49766,11 +49845,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"jRo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jRr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49834,11 +49908,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"jRV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain/open/shower/closed,
-/turf/simulated/floor/plating,
-/area/colony)
 "jRZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -50291,11 +50360,6 @@
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"jWG" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/mat_katana,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jWI" = (
 /obj/structure/window/reinforced,
 /obj/structure/multiz/stairs/active/bottom{
@@ -50613,12 +50677,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
-"kas" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kau" = (
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -51046,6 +51104,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
+"kfa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kfd" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -51130,6 +51193,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"kfU" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/oddity/common/paper_bundle,
+/obj/machinery/door/window/eastright,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kfY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -51574,12 +51643,6 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/engineering/engine_room)
-"kkm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/double/padded,
-/obj/random/furniture/bedsheetdouble,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kkr" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -52048,6 +52111,14 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"kpl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kpn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -52373,14 +52444,6 @@
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"ksu" = (
-/obj/random/booze,
-/obj/random/junkfood/onlypizza,
-/obj/random/junkfood/onlyburger,
-/obj/random/junkfood,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ksF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -53471,12 +53534,6 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
-"kDe" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kDh" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -53888,11 +53945,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
-"kHC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/spider_shadow_trap,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kHD" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/floor_decal/spline/plain/three_quarters,
@@ -53904,10 +53956,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
-"kHO" = (
-/obj/structure/boulder,
-/obj/structure/boulder,
+"kHK" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "kHW" = (
@@ -53920,11 +53973,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/crew_quarters/hydroponics)
-"kIA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/highsecurity,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kIG" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall8";
@@ -53988,11 +54036,6 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/nadezhda/security/barracks)
-"kJx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kJC" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
@@ -54370,6 +54413,12 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
+"kNZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kOe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54805,13 +54854,6 @@
 /obj/item/storage/firstaid/ifak,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
-"kSq" = (
-/obj/machinery/door/window/eastright,
-/obj/structure/curtain/medical,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kSr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54841,11 +54883,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/fo)
-"kSS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kSX" = (
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/toilet/public)
@@ -54909,6 +54946,10 @@
 "kTO" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/forest)
+"kTQ" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kTU" = (
 /obj/effect/spider/stickyweb,
 /obj/machinery/light/small{
@@ -55124,28 +55165,13 @@
 	icon_state = "1,20"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"kVZ" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+"kVX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"kWf" = (
-/obj/structure/table/rack/shelf,
-/obj/item/modular_computer/wrist,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kWg" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -55570,6 +55596,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"lbS" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/roach/roachling,
+/turf/simulated/floor/plating,
+/area/colony)
 "lbT" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -55759,14 +55790,6 @@
 	icon_state = "4,8"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"ldz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ldA" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -55890,6 +55913,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/hut_cell1)
+"lfe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading/red,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lfh" = (
 /obj/structure/catwalk,
 /obj/structure/table/rack/shelf,
@@ -56221,6 +56249,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/medical)
+"liR" = (
+/obj/machinery/door/unpowered/simple/wood,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "liT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -56261,12 +56293,6 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"ljy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/tool/advanced/onestar/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ljL" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = 32
@@ -56310,6 +56336,24 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"lkc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	dir = 4
+	},
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/barricade,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/crew_quarters/techshop)
 "lkf" = (
 /obj/machinery/door/airlock/glass_security,
 /obj/machinery/holosign/service{
@@ -56336,6 +56380,11 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
+"lkC" = (
+/obj/random/booze/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lkK" = (
 /mob/living/simple_animal/pig{
 	desc = "This intelligent sow has strange, pointy ears.";
@@ -56481,6 +56530,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"lmK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lmN" = (
 /obj/machinery/light/small,
 /obj/item/stool,
@@ -56525,6 +56581,16 @@
 /obj/machinery/flasher/portable,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical)
+"lnB" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "lnD" = (
 /obj/machinery/light{
 	dir = 8
@@ -56954,9 +57020,6 @@
 "lrX" = (
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/hallway/side/f2section1)
-"lrZ" = (
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lsd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57242,14 +57305,6 @@
 /obj/random/junkfood/onlyburger,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/dcave)
-"lvd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/tool/knife/butch,
-/obj/item/material/kitchen/rollingpin,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
@@ -57508,6 +57563,11 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/turret_protected/ai_upload)
+"lyf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lyg" = (
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -57532,6 +57592,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"lyp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lyx" = (
 /obj/random/spider_trap_burrowing/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -57986,6 +58050,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
+"lCX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/simple/wood,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lDf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -57998,10 +58067,6 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"lDl" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lDu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -58147,11 +58212,6 @@
 "lEP" = (
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/medical/sleeper)
-"lES" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lET" = (
 /obj/item/remains/human,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -58534,6 +58594,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"lIH" = (
+/obj/random/cluster/termite_no_despawn_hoard,
+/turf/unsimulated/mineral,
+/area/colony)
 "lIS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58656,6 +58720,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"lJG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/spider_shadow_trap,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lJZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -58808,6 +58877,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/foyer)
+"lLR" = (
+/obj/random/structures,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lLS" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -58834,13 +58907,6 @@
 "lMk" = (
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/dcave)
-"lMm" = (
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/contraband/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lMp" = (
 /obj/structure/flora/ausbushes/fernybush,
 /mob/living/simple_animal/jungle_bird,
@@ -59015,10 +59081,6 @@
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"lOB" = (
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lOI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -59183,12 +59245,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/crematorium)
-"lPX" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lQm" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/techmaint,
@@ -59841,11 +59897,11 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"lWC" = (
-/obj/structure/bonfire,
+"lWz" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
+/obj/random/cluster/roaches,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lWE" = (
 /obj/structure/disposalpipe/sortjunction/wildcard{
 	dir = 8
@@ -59902,6 +59958,11 @@
 	dir = 4
 	},
 /area/nadezhda/maintenance/surfacesec)
+"lXp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/eastright,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lXq" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -59984,11 +60045,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"lXJ" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lXP" = (
 /obj/machinery/door/airlock/security,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -60028,13 +60084,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
-"lYn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "lYp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -60324,6 +60373,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"mbq" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/welding,
+/obj/item/storage/belt,
+/obj/item/clothing/head/welding,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mbs" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -60678,6 +60735,10 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
+"meS" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "meU" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Hulk Mining Barge";
@@ -60996,6 +61057,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"mhd" = (
+/obj/structure/bed/chair/office/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mhk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -61227,6 +61293,14 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"mjI" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A3";
+	name = "D1-A3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mjK" = (
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -61636,6 +61710,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/danger,
 /area/turret_protected/ai_upload)
+"mnR" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A2";
+	name = "D1-A2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mnS" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
@@ -61719,6 +61801,11 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"mpk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "mpm" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/side/f2section1)
@@ -61822,6 +61909,11 @@
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
+"mpV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mqc" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt,
@@ -61863,12 +61955,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"mqy" = (
-/obj/structure/table/bench/glass,
-/obj/structure/curtain/red,
-/obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mqA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -62084,10 +62170,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
-"msJ" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "msL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_panels,
@@ -62097,6 +62179,10 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/pros/shuttle)
+"mti" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mtj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62317,12 +62403,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
-"mvp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/obj/random/cluster/spiders,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mvs" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable/cyan{
@@ -63225,13 +63305,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"mEv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mEx" = (
 /obj/structure/catwalk,
 /obj/machinery/craftingstation,
@@ -63697,18 +63770,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
-"mIj" = (
-/obj/structure/table/rack,
-/obj/structure/curtain/medical,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/organ/external/robotic/junktech/r_leg,
-/obj/item/organ/external/robotic/junktech/r_arm,
-/obj/item/organ/external/robotic/junktech/l_leg,
-/obj/item/organ/external/robotic/junktech/l_arm,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mIl" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "6,10"
@@ -64471,13 +64532,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
-"mPD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mPF" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/effect/decal/cleanable/dirt,
@@ -65419,6 +65473,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
+"mZF" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/surgery,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mZI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -65990,6 +66049,12 @@
 /obj/structure/bedsheetbin{
 	double = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/janitor)
 "nfl" = (
@@ -66187,15 +66252,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"ngY" = (
-/obj/structure/table/rack,
-/obj/structure/curtain/medical,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/organ/internal/optical_sensor,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ngZ" = (
 /obj/random/mob/croaker/low_chance,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -66745,11 +66801,6 @@
 /obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/dungeon/outside/burned_outpost)
-"nmE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nmG" = (
 /obj/random/cluster/termite_no_despawn/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -66898,14 +66949,6 @@
 /mob/living/simple_animal/frog,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"not" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "noA" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos/surface)
@@ -67763,6 +67806,9 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
+"nwl" = (
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nwq" = (
 /obj/item/organ/internal/bone/head{
 	pixel_y = -5
@@ -67815,6 +67861,11 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm3)
+"nwP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nwQ" = (
 /obj/structure/barricade,
 /obj/machinery/door/airlock/vault,
@@ -67872,11 +67923,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"nxF" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/mineral,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nxJ" = (
 /obj/machinery/vending/gamers,
 /turf/simulated/floor/tiled/techmaint,
@@ -68026,11 +68072,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/hut_cell1)
-"nyK" = (
-/obj/machinery/mech_recharger,
-/obj/random/mecha/low_chance,
-/turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nyO" = (
 /obj/machinery/recharger,
 /obj/random/tool_upgrade/low_chance,
@@ -68582,7 +68623,9 @@
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/west)
 "nDt" = (
-/turf/simulated/floor/tiled/dark/monofloor,
+/obj/structure/closet/random_miscellaneous,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "nDv" = (
 /turf/simulated/wall/r_wall,
@@ -68834,15 +68877,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
-"nFG" = (
-/obj/structure/table/reinforced,
-/obj/item/device/makeshift_centrifuge,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nFI" = (
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp,
@@ -68938,11 +68972,10 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
 "nGT" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "nGY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69088,14 +69121,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
-"nIB" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A20";
-	name = "D1-A20"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nIG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/light/small{
@@ -69364,15 +69389,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacesec)
-"nKH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/mineral,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nKM" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/machinery/floodlight,
 /turf/simulated/floor/rock,
 /area/colony)
+"nKP" = (
+/mob/living/bot/cleanbot,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nKS" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/belt/webbing,
@@ -69577,18 +69602,6 @@
 /obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/surfaceeast)
-"nMM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/storage/freezer,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/snacks/meat/monkey,
-/obj/item/reagent_containers/food/snacks/meat/monkey,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nMO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -69979,6 +69992,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
+"nRe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/northleft,
+/obj/machinery/cash_register{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nRf" = (
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/plating,
@@ -70040,6 +70063,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
+"nRA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cabinet,
+/obj/random/booze,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nRZ" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
@@ -70067,6 +70096,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"nSn" = (
+/obj/machinery/door/airlock/maintenance_common,
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
+	},
+/turf/space,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nSr" = (
 /turf/simulated/shuttle/floor/mining,
 /area/turbolift/ElevatorOne/underground)
@@ -70564,6 +70600,11 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/command/cro)
+"nWL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nWM" = (
 /obj/item/modular_computer/console/preset/security/records{
 	dir = 8
@@ -71212,13 +71253,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/crew_quarters/pool)
-"ocf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oci" = (
 /obj/structure/railing{
 	dir = 4;
@@ -71620,10 +71654,8 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/shuttle/surface_transport_lz)
-"ogj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/danger,
+"ogi" = (
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "ogo" = (
 /turf/simulated/shuttle/wall/escpod{
@@ -71682,14 +71714,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/disposaldrop)
 "ogV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/crew_quarters/janitor)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ohb" = (
 /obj/effect/decal/cleanable/solid_biomass,
 /obj/structure/railing{
@@ -71710,6 +71738,11 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/pool)
+"ohr" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ohx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -71887,12 +71920,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"oiZ" = (
-/obj/machinery/door/window/southleft,
-/obj/machinery/door/window/northleft,
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oja" = (
 /obj/structure/flora/small/bushc2,
 /turf/simulated/floor/asteroid/dirt,
@@ -71932,10 +71959,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"ojr" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ojt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71997,6 +72020,12 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"ojG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/mecha_equipment/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ojI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/cable/cyan{
@@ -72021,6 +72050,11 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/nadezhda/engineering/atmos)
+"ojO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/termite_no_despawn/lower_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ojP" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -72076,6 +72110,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
+"okG" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "okJ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/enzyme,
@@ -72442,13 +72483,6 @@
 /obj/effect/window_lwall_spawn/smartspawnplasma,
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai_upload)
-"ooA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/material/kitchen/utensil/fork,
-/obj/item/stack/rods/random,
-/turf/simulated/floor/plating,
-/area/colony)
 "ooF" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -72974,10 +73008,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/lab)
-"otw" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "otx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -73135,12 +73165,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
-"ovm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/cabinet,
-/obj/random/booze,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ovn" = (
 /obj/effect/decal/cleanable/rubble,
 /mob/living/simple_animal/hostile/jelly/bloat,
@@ -73168,14 +73192,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"ovw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/common_oddities/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ovz" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/grille,
@@ -73313,11 +73329,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"owM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "owQ" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -73623,12 +73634,6 @@
 /obj/structure/table/bar_special,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm1)
-"ozY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oAo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/chair{
@@ -74143,13 +74148,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/dorm1)
-"oER" = (
-/obj/structure/closet/wall_mounted{
-	pixel_x = -32
-	},
-/obj/item/storage/box/drinkingglasses,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oET" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -74244,10 +74242,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/inside_colony)
-"oGf" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oGj" = (
 /obj/structure/low_wall,
 /obj/machinery/door/blast/shutters/glass{
@@ -75435,10 +75429,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/security/barracks)
-"oRT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "oRU" = (
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/techmaint,
@@ -77245,11 +77235,6 @@
 /obj/landmark/join/start/foreman,
 /turf/simulated/floor/carpet,
 /area/nadezhda/pros/foreman)
-"pkd" = (
-/obj/structure/closet/random_miscellaneous,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pkg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77277,6 +77262,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"pkz" = (
+/obj/random/booze,
+/obj/random/junkfood/onlypizza,
+/obj/random/junkfood/onlyburger,
+/obj/random/junkfood,
+/obj/structure/closet/secure_closet/freezer,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pkA" = (
 /obj/effect/floor_decal/industrial/outline,
 /obj/effect/decal/cleanable/dirt,
@@ -77626,6 +77619,10 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"poM" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "poN" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -77974,10 +77971,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"psl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "psn" = (
 /obj/machinery/door/window/eastleft,
 /obj/machinery/door/window/brigdoor/westright{
@@ -78010,6 +78003,11 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"psF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "psH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -78229,6 +78227,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"puG" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "puJ" = (
 /obj/random/dungeon_gun_mods,
 /obj/random/dungeon_gun_mods,
@@ -78565,11 +78567,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"pxJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pxW" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/church,
@@ -79192,6 +79189,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"pDJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pDL" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/engineering/engine_room)
@@ -79668,11 +79669,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"pJU" = (
-/obj/structure/bed,
-/obj/item/handcuffs/fuzzy,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pJW" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -81214,6 +81210,10 @@
 	opacity = 0
 	},
 /area/shuttle/rocinante_shuttle_area)
+"pXu" = (
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pXz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -81393,6 +81393,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"pZe" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/random/structures,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pZp" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -81756,6 +81763,12 @@
 /obj/item/mecha_parts/part/ivan_left_leg,
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"qcX" = (
+/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/northleft,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qdc" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -82121,13 +82134,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"qhd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/sofa{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qhh" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/fancy/candle_box,
@@ -82983,6 +82989,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"qpr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/plating,
+/area/colony)
 "qps" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/genericbush,
@@ -83045,10 +83058,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"qqv" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qqw" = (
 /obj/structure/table/standard,
 /obj/random/pack/tech_loot,
@@ -83067,10 +83076,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"qqD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qqF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -83340,6 +83345,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"qsQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qsS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -84045,24 +84057,6 @@
 "qAM" = (
 /turf/simulated/floor/reinforced/airmix,
 /area/nadezhda/engineering/atmos)
-"qAN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	dir = 4
-	},
-/obj/machinery/door/window/northright{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/barricade,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/crew_quarters/techshop)
 "qAQ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/structure/cable/yellow{
@@ -84152,6 +84146,10 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qBI" = (
+/obj/structure/reagent_dispensers/bidon,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qBL" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology)
@@ -84728,12 +84726,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
-"qGX" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/credits/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qHa" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/effect/window_lwall_spawn/reinforced,
@@ -85269,11 +85261,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"qNi" = (
-/obj/random/cluster/roaches/lower_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qNn" = (
 /obj/machinery/power/hydroelectric_control,
 /obj/structure/cable/yellow,
@@ -85335,6 +85322,9 @@
 /obj/structure/bookcase/guncase,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"qNP" = (
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qNS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
@@ -85536,11 +85526,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"qPX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qQa" = (
 /obj/structure/scrap/poor,
 /obj/effect/decal/cleanable/dirt,
@@ -85623,6 +85608,16 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"qQN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/random/structures,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qQP" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -85794,11 +85789,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters/bar)
-"qSP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qSQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -85923,17 +85913,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"qUq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/curtain/open,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qUD" = (
 /obj/structure/closet/crate/secure,
 /obj/item/flame/lighter/zippo/gold,
@@ -86494,14 +86473,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/hallway/side/f2section1)
-"raF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/obj/random/cluster/spiders,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "raM" = (
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/asteroid/grass,
@@ -86718,6 +86689,11 @@
 /obj/item/storage/box/headsets,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/hallway/surface/section1)
+"rde" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/spiders/low_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rdj" = (
 /obj/structure/multiz/stairs/active,
 /obj/structure/window/reinforced{
@@ -87118,14 +87094,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/crew_quarters)
-"rgl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/revolver/handmade,
-/obj/item/clothing/accessory/duster/bloodred,
-/obj/item/ammo_magazine/ammobox/pistol_35/scrap,
-/turf/simulated/floor/plating,
-/area/colony)
 "rgm" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -87142,6 +87110,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"rgx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rgy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -87627,6 +87600,13 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"rlZ" = (
+/obj/machinery/vending/assist,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rmh" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/box/bodybags{
@@ -87961,6 +87941,9 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"rph" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rpk" = (
 /obj/effect/floor_decal/industrial/road/straight1,
 /obj/structure/railing{
@@ -88059,14 +88042,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"rqr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1;
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rqu" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
@@ -88074,25 +88049,14 @@
 /obj/item/circuitboard/puncher,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
-"rqB" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"rqA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 1;
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rqF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -88134,6 +88098,10 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/mineral,
 /area/nadezhda/outside/forest)
+"rrm" = (
+/obj/structure/janitorialcart,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rro" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -88316,6 +88284,11 @@
 /obj/item/device/destTagger,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"rtz" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rtA" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -88848,10 +88821,6 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/quartermaster/miningdock)
-"ryC" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ryI" = (
 /obj/random/scrap/dense_weighted/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -89100,12 +89069,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/servist)
-"rBq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bench/glass,
-/obj/structure/curtain/red,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rBu" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /obj/effect/floor_decal/spline/plain{
@@ -89430,11 +89393,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
-"rEV" = (
+"rFb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "rFc" = (
@@ -89867,6 +89828,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"rJY" = (
+/obj/machinery/door/airlock/maintenance_interior{
+	name = "Hotel Desk"
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rKb" = (
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "BrigFoyer";
@@ -90175,11 +90142,6 @@
 /mob/living/simple_animal/jungle_bird,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
-"rMH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet_maintloot,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rMJ" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -90367,6 +90329,13 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
+"rOo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rOs" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/regular,
@@ -90864,10 +90833,6 @@
 /obj/item/storage/firstaid/adv,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/sleeper)
-"rUm" = (
-/obj/machinery/door/airlock/maintenance_cargo,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rUv" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 8
@@ -91132,11 +91097,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/captain/quarters)
-"rWX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rWZ" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -91627,17 +91587,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"saU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/eastright,
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sbc" = (
 /obj/machinery/light/small,
 /obj/machinery/light_switch{
@@ -92107,6 +92056,11 @@
 /mob/living/carbon/superior_animal/giant_spider/nurse,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"sfv" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sfB" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -92627,11 +92581,6 @@
 /obj/effect/floor_decal/industrial/box/red,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/maintenance/surfacesec)
-"slK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/lowkeyrandom,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "slM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -92678,6 +92627,10 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
+"smo" = (
+/obj/machinery/microwave/burnbarrel,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "smq" = (
 /obj/machinery/light{
 	dir = 8
@@ -93030,6 +92983,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
+"spr" = (
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sps" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -93167,6 +93123,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
+"sqD" = (
+/obj/structure/curtain/open/bed{
+	name = "Privacy curtain"
+	},
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sqE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -94314,6 +94276,11 @@
 	opacity = 0
 	},
 /area/nadezhda/hallway/side/f2section1)
+"sAO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sAP" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -94631,11 +94598,6 @@
 /obj/item/device/lighting/toggleable/lamp/green,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"sEv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain/red,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sEA" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet,
@@ -95443,6 +95405,17 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/virology)
+"sNS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"sNX" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/mat_katana,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sOd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -95951,6 +95924,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"sTe" = (
+/obj/item/device/radio/intercom{
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sTh" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/small/bushc3,
@@ -96262,10 +96242,11 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sXe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/crew_quarters/janitor)
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sXj" = (
 /obj/structure/flora/small/trailrockb2,
 /obj/structure/flora/small/trailrockb5,
@@ -96538,9 +96519,9 @@
 	})
 "sZK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sZL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -96639,6 +96620,10 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
+"tax" = (
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "taE" = (
 /obj/structure/table/bench/steel,
 /obj/effect/decal/cleanable/dirt,
@@ -96839,6 +96824,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"tcY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "tdf" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "8,20"
@@ -96912,11 +96902,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"tdU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tdW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/turcarpet,
@@ -96927,6 +96912,11 @@
 /mob/living/carbon/superior_animal/giant_spider/nurse,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"tec" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tef" = (
 /obj/machinery/r_n_d/server/robotics,
 /turf/simulated/floor/bluegrid{
@@ -96988,12 +96978,6 @@
 /obj/structure/closet/l3closet/janitor,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/crew_quarters/janitor)
-"tey" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "teI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -97127,10 +97111,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"tgo" = (
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tgt" = (
 /obj/structure/table/standard,
 /obj/machinery/light/small{
@@ -97149,6 +97129,11 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
+"tgH" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tgU" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -98246,12 +98231,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"ttx" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/material_resources,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ttG" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -99707,10 +99686,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/lab)
-"tHh" = (
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tHo" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -100028,13 +100003,6 @@
 	},
 /turf/simulated/open,
 /area/nadezhda/outside/scave)
-"tKg" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A20";
-	name = "D1-A20"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tKh" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -100415,6 +100383,13 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/forest)
+"tNF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tNJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera/network/research{
@@ -100422,6 +100397,25 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/genetics)
+"tNL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "tNQ" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -101266,12 +101260,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"tVz" = (
-/obj/machinery/door/airlock/maintenance_interior{
-	name = "Hotel Desk"
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tVB" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -101279,21 +101267,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"tVE" = (
-/obj/machinery/autolathe/loaded,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"tVF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tVO" = (
 /obj/effect/window_lwall_spawn,
 /obj/structure/flora/big/bush3{
@@ -101541,6 +101514,11 @@
 /mob/living/carbon/superior_animal/giant_spider/nurse/recluse,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"tYf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tYn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
@@ -101551,13 +101529,6 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
-"tYq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tYr" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/cable/cyan{
@@ -101997,12 +101968,9 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"ucz" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
+"ucE" = (
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "ucI" = (
 /obj/structure/disposalpipe/segment,
@@ -102294,10 +102262,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/range)
-"ufj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ufk" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -102495,6 +102459,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/servist)
+"ugo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/tool/knife/butch,
+/obj/item/material/kitchen/rollingpin,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ugq" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -103708,13 +103680,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/colony)
-"usp" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "usq" = (
 /obj/item/remains/unathi,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -104708,6 +104673,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"uEu" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uEv" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/small/bushb2,
@@ -105023,13 +104998,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfaceeast)
-"uHM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uHQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -105203,10 +105171,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
-"uJi" = (
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uJn" = (
 /obj/machinery/door/unpowered/simple/wood{
 	color = "#9a977b"
@@ -105276,14 +105240,10 @@
 	name = "Residential District Maintenance"
 	})
 "uJY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/crew_quarters/janitor)
+/obj/effect/decal/cleanable/dirt,
+/obj/random/structures,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/colony)
 "uJZ" = (
 /obj/structure/multiz/stairs/active,
 /turf/simulated/floor/tiled/steel/danger,
@@ -105654,6 +105614,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"uMP" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/makeshift_grinder,
+/obj/effect/decal/cleanable/cobweb{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uMS" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -105857,6 +105825,12 @@
 /obj/structure/closet/l3closet,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"uOt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/double/padded,
+/obj/random/furniture/bedsheetdouble,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uOw" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -106181,13 +106155,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
-"uRj" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uRk" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -106409,6 +106376,13 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/nadezhda/crew_quarters/clownoffice)
+"uTa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uTb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -107087,6 +107061,11 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
+"vap" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vaq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -107410,6 +107389,11 @@
 /obj/structure/multiz/stairs/active,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/hallway/main/stairwell)
+"vdZ" = (
+/obj/structure/bonfire,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "ved" = (
 /obj/effect/floor_decal/corner_oldtile,
 /obj/effect/floor_decal/corner_oldtile{
@@ -107452,13 +107436,6 @@
 /obj/random/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
-"veH" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junkfood,
-/obj/random/junkfood,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "veL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/structures/low_chance,
@@ -107612,10 +107589,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/skyyard)
-"vfW" = (
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vfY" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -107637,11 +107610,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"vgg" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vgm" = (
 /obj/structure/railing{
 	dir = 8
@@ -108161,6 +108129,12 @@
 /obj/random/structures/os,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"vli" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/glass,
+/obj/structure/curtain/red,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vlm" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /obj/machinery/camera/network/colony_surface{
@@ -109138,9 +109112,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
-"vuU" = (
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vuY" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -109383,6 +109354,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"vxb" = (
+/obj/structure/table/glass,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vxh" = (
 /obj/machinery/vending/boozeomat{
 	req_access = list(25)
@@ -109646,11 +109622,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"vAJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/loading/red,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vAL" = (
 /obj/machinery/door/unpowered/simple/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -109698,6 +109669,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"vBC" = (
+/obj/structure/curtain/open/bed{
+	name = "Privacy curtain"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vBE" = (
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /obj/structure/largecrate/animal/cow,
@@ -109714,10 +109692,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"vBQ" = (
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vBR" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/barricade,
@@ -109827,6 +109801,10 @@
 /obj/structure/sign/warning/internals_required/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
+"vCK" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vCR" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -110014,6 +109992,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/captain)
+"vEF" = (
+/obj/machinery/vending/engivend,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vEG" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
@@ -110285,6 +110270,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/medical/ward)
+"vHo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vHt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -110749,12 +110739,6 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
-"vLw" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/oddity/common/paper_bundle,
-/obj/machinery/door/window/eastright,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vLC" = (
 /obj/item/tool/broken_bottle,
 /obj/effect/spider/stickyweb,
@@ -110882,6 +110866,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"vMC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vMD" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/bush3,
@@ -111173,6 +111162,16 @@
 /obj/item/modular_computer/tablet/lease/preset/command,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
+"vPM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"vPN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet_tech/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vPQ" = (
 /obj/machinery/power/breakerbox{
 	RCon_tag = "Mar Substation Bypass"
@@ -112326,6 +112325,12 @@
 /obj/random/tool/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"wad" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "waj" = (
 /obj/item/ammo_magazine/ammobox/shotgun/buckshot{
 	pixel_x = 4;
@@ -112803,6 +112808,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"wet" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wew" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/big/bush2,
@@ -112941,11 +112951,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"wgo" = (
-/obj/structure/table/steel,
-/obj/random/powercell/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wgu" = (
 /obj/structure/table/woodentable,
 /obj/item/stamp/hos2,
@@ -113129,12 +113134,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
-"wio" = (
-/obj/structure/curtain/open/bed{
-	name = "Privacy curtain"
-	},
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wiq" = (
 /obj/machinery/atmospherics/valve/digital{
 	dir = 4;
@@ -113328,13 +113327,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"wkq" = (
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/common_oddities/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wkt" = (
 /obj/machinery/camera/network/medbay{
 	dir = 8
@@ -113614,6 +113606,11 @@
 "wmS" = (
 /turf/simulated/floor/tiled/steel,
 /area/turbolift/ElevatorOne/surface)
+"wmX" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/autolathe/mechfab/loaded,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wmY" = (
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -113688,14 +113685,6 @@
 /obj/random/gun_handmade/low_chance,
 /turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
-"wnZ" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A2";
-	name = "D1-A2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wob" = (
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
@@ -114312,12 +114301,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"wse" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "wsj" = (
 /obj/structure/sink{
 	dir = 8;
@@ -114371,11 +114354,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
-"wsR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wsT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -114415,11 +114393,6 @@
 /obj/structure/closet/secure_closet/personal/engineering_personal,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
-"wtF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wtK" = (
 /obj/structure/boulder,
 /obj/machinery/door/airlock/maintenance_common,
@@ -114632,10 +114605,6 @@
 "wwv" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm4)
-"wwC" = (
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wwG" = (
 /obj/random/material/low_chance,
 /obj/structure/catwalk,
@@ -114826,6 +114795,12 @@
 "wyv" = (
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"wyw" = (
+/obj/effect/floor_decal/industrial/caution{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "wyG" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,10"
@@ -115054,6 +115029,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"wAx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "wAH" = (
 /obj/random/booze/low_chance,
 /obj/random/booze/low_chance,
@@ -116869,6 +116848,13 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/medical/ward)
+"wUE" = (
+/obj/structure/closet/wall_mounted{
+	pixel_x = -32
+	},
+/obj/item/storage/box/drinkingglasses,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wUF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -116909,10 +116895,6 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"wUY" = (
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wVb" = (
 /obj/structure/shuttle_part/escpod{
 	icon_state = "escpodwall9";
@@ -116984,6 +116966,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
+"wVR" = (
+/obj/structure/closet/cabinet,
+/obj/random/booze,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wVT" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -117116,6 +117103,17 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/bar)
+"wWF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"wWH" = (
+/obj/structure/table/bench/glass,
+/obj/structure/curtain/red,
+/obj/effect/decal/cleanable/vomit,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wWI" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -117339,10 +117337,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
-"wZs" = (
-/obj/structure/reagent_dispensers/bidon,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wZu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -117616,19 +117610,16 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"xcN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall_mounted{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/flour,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xcR" = (
 /obj/structure/flora/big/bush3,
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"xcV" = (
+/obj/random/cluster/roaches/lower_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xcW" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -117639,6 +117630,13 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
+"xdi" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xdw" = (
 /obj/item/contraband/poster/placed/generic/high_class_martini,
 /turf/simulated/wall,
@@ -117691,6 +117689,9 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm2)
+"xed" = (
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xem" = (
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -117942,12 +117943,6 @@
 	layer = 1
 	},
 /area/nadezhda/crew_quarters/sleep/bedrooms)
-"xgM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet/employment,
-/obj/random/credits/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xgR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -119311,6 +119306,15 @@
 	dir = 4
 	},
 /area/nadezhda/maintenance/surfacesec)
+"xuA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/common_oddities/low_chance,
+/obj/random/gun_normal/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xuB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/arcade,
@@ -119545,6 +119549,12 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
+"xwH" = (
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xwJ" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 8
@@ -120222,6 +120232,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"xCU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/highsecurity,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xCV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -120268,6 +120283,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/pool)
+"xDE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/random/cluster/spiders,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xDH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -120494,13 +120515,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
-"xFN" = (
-/obj/structure/table/reinforced,
-/obj/item/device/makeshift_electrolyser,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xFQ" = (
 /obj/structure/table/steel,
 /obj/random/lowkeyrandom/low_chance,
@@ -121315,6 +121329,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"xNx" = (
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xNG" = (
 /obj/structure/closet/wardrobe/misc/pjs,
 /obj/item/clothing/under/medigown,
@@ -121602,6 +121620,15 @@
 	opacity = 0
 	},
 /area/shuttle/rocinante_shuttle_area)
+"xQT" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/bodybags,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/random/circuitboard/low_chance,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xQU" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -121880,11 +121907,6 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/rnd/xenobiology)
-"xTH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xTO" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/lighting/toggleable/lamp,
@@ -122051,11 +122073,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"xVu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/termite_no_despawn/lower_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xVB" = (
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/beach/sand,
@@ -122170,14 +122187,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
-"xWy" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/makeshift_grinder,
-/obj/effect/decal/cleanable/cobweb{
-	dir = 4
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xWz" = (
 /obj/random/scrap/dense_weighted,
 /obj/effect/spider/stickyweb,
@@ -122679,6 +122688,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"ybD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/structures,
+/obj/machinery/floor_light,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/colony)
 "ybE" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = 32
@@ -122705,6 +122720,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/engineering/atmos/surface)
+"ybY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/structures,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ycd" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -122752,6 +122772,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
+"ycA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ycC" = (
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
@@ -123022,6 +123047,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
+"yfJ" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/credits/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "yfL" = (
 /obj/machinery/camera/network/research{
 	dir = 4
@@ -150716,7 +150747,7 @@ kUx
 kUx
 kUx
 aFa
-fqW
+eLB
 qxo
 hax
 nzT
@@ -183224,8 +183255,8 @@ gSu
 cAu
 pow
 akB
-ogV
-sXe
+chh
+chh
 aKh
 wFD
 dnz
@@ -183389,9 +183420,9 @@ cvn
 mjZ
 vmZ
 hSX
-hdn
-rqB
-dQa
+mpk
+tNL
+lnB
 sCN
 sCN
 sCN
@@ -183410,9 +183441,9 @@ aOb
 lif
 sRU
 sRU
-hdn
-rqB
-wse
+mpk
+tNL
+dHe
 cCy
 nBz
 cxN
@@ -183426,7 +183457,7 @@ gSu
 ayv
 pow
 owU
-uJY
+chh
 pcB
 jOG
 ktp
@@ -183628,7 +183659,7 @@ gSu
 hua
 pow
 vrt
-bjV
+chh
 fiy
 nfk
 chh
@@ -184022,7 +184053,7 @@ cvc
 dJa
 cCy
 cCy
-qAN
+lkc
 cCy
 cCy
 nCK
@@ -189862,7 +189893,7 @@ whU
 eMU
 whU
 whU
-lYn
+kVX
 nUF
 wnJ
 tIQ
@@ -190064,7 +190095,7 @@ iBR
 nVZ
 iBR
 iBR
-kVZ
+dsz
 iBR
 iBR
 iBR
@@ -190266,7 +190297,7 @@ whU
 qwB
 whU
 whU
-hDg
+amS
 bbM
 rkA
 ilF
@@ -191452,7 +191483,7 @@ hLD
 uTo
 wEB
 wEB
-dlo
+cZb
 cZb
 vpF
 czA
@@ -194274,12 +194305,12 @@ cZb
 cZb
 cZb
 wEB
-bZk
-vAJ
-aXg
-dWX
-kDe
-tdU
+wmX
+lfe
+mbq
+ePL
+pZe
+vMC
 wEB
 wEB
 wEB
@@ -194287,8 +194318,8 @@ wEB
 wEB
 tTB
 vJX
-esq
-esq
+sXe
+sXe
 wEB
 wEB
 wEB
@@ -194476,12 +194507,12 @@ cZb
 cZb
 cZb
 wEB
-jgq
-lES
-qqD
-not
-gwQ
-qqD
+htJ
+ycA
+bjV
+hQu
+qNP
+bjV
 wEB
 iKp
 jWI
@@ -194490,9 +194521,9 @@ wEB
 pOR
 avz
 rsN
-esq
+sXe
 wiO
-iRj
+tgH
 wEB
 cZb
 cZb
@@ -194678,12 +194709,12 @@ wEB
 wEB
 wEB
 wEB
-inO
-gwQ
-qqD
-tey
-uHM
-qqv
+fzv
+qNP
+bjV
+wad
+rOo
+meS
 wEB
 iVg
 nXu
@@ -194692,9 +194723,9 @@ wEB
 snr
 kSY
 wEB
-iRj
-iRj
-ceF
+tgH
+tgH
+dzJ
 wEB
 cZb
 cZb
@@ -194872,20 +194903,20 @@ cZb
 cZb
 cZb
 wEB
-veH
-hjP
-ozY
-ozY
-kWf
+dhc
+pDJ
+hmG
+hmG
+iKI
 wEB
-cPi
-qqD
-gwQ
-frS
-dHP
-frS
-edo
-nyK
+lLR
+ybY
+qNP
+aQT
+hPR
+aQT
+kpl
+djP
 wEB
 lVS
 lVS
@@ -194894,9 +194925,9 @@ snr
 pQH
 pQH
 wEB
-arr
-slK
-kas
+hzp
+dnO
+hRI
 wEB
 cZb
 cZb
@@ -195074,20 +195105,20 @@ cZb
 cZb
 cZb
 wEB
-jWG
-nDt
-mvp
-hjP
-hjP
+sNX
+jQU
+xDE
+pDJ
+pDJ
 wEB
-qqD
-gwQ
-qqD
-gwQ
-qqD
-tey
-qqD
-gwQ
+bjV
+qNP
+bjV
+qNP
+bjV
+wad
+bjV
+qNP
 wEB
 lVS
 lVS
@@ -195096,9 +195127,9 @@ lTo
 qBj
 snr
 wEB
-kJx
-xVu
-eJU
+wWF
+ojO
+wet
 wEB
 cZb
 cZb
@@ -195165,7 +195196,7 @@ kyK
 diB
 kyK
 kyK
-hNQ
+wyw
 kyK
 fbS
 sAU
@@ -195276,22 +195307,22 @@ cZb
 cZb
 cZb
 wEB
-bSN
-hjP
-aKw
-kSS
-iin
+jrJ
+pDJ
+cmn
+nwP
+fol
 wEB
-qqD
-qqD
-ilm
-lPX
-iLZ
-tVE
-fmy
-bIK
+bjV
+bjV
+tax
+hrU
+xQT
+qQN
+rlZ
+vEF
 wEB
-esq
+sXe
 wiO
 wEB
 wEB
@@ -195299,13 +195330,13 @@ wEB
 wEB
 wEB
 wEB
-tKg
+gNb
 wEB
 wEB
-iRj
-iRj
-iRj
-iRj
+tgH
+tgH
+tgH
+tgH
 cZb
 cZb
 cZb
@@ -195478,36 +195509,36 @@ cZb
 cZb
 cZb
 wEB
-hFB
-hjP
-otw
-uRj
-vLw
+aQN
+pDJ
+kTQ
+xdi
+kfU
 wEB
-dvs
-wEB
-wEB
+nSn
 wEB
 wEB
 wEB
 wEB
 wEB
 wEB
-iRj
-iRj
-gip
+wEB
+wEB
+tgH
+tgH
+cYB
 pQH
 pQH
-ldz
+djp
 pQH
 snr
-ciN
+rph
 snr
 pQH
-gWD
+qsQ
 snr
-iRj
-iRj
+tgH
+tgH
 cZb
 cZb
 cZb
@@ -195680,34 +195711,34 @@ cZb
 cZb
 cZb
 wEB
-ttx
-hjP
-hjP
-iSK
-kHC
-nmE
+iSO
+pDJ
+pDJ
+lmK
+lJG
+psF
 snr
-gWD
-iRj
-nxF
-iRj
-ufj
+qsQ
+tgH
+hZN
+tgH
+lyp
 lVS
-aMH
-gbE
+kHK
+faV
 lVS
-ufj
+lyp
 wEB
 wEB
-nIB
-wEB
-wEB
-wEB
-wnZ
+fmq
 wEB
 wEB
 wEB
-bnC
+mnR
+wEB
+wEB
+wEB
+mjI
 wEB
 wEB
 cZb
@@ -195882,35 +195913,35 @@ cZb
 cZb
 cZb
 wEB
-qGX
-hjP
-ozY
-nDt
-qhd
+yfJ
+pDJ
+hmG
+jQU
+ajD
 wEB
-rUm
-wEB
-wEB
+eQC
 wEB
 wEB
 wEB
 wEB
 wEB
 wEB
-jnm
-gjr
 wEB
-kJx
-psl
-ksu
 wEB
-kJx
-psl
-ksu
+iKh
+bcG
 wEB
-kJx
-psl
-ksu
+wWF
+iwK
+pkz
+wEB
+wWF
+iwK
+pkz
+wEB
+wWF
+iwK
+pkz
 wEB
 cZb
 cZb
@@ -196084,35 +196115,35 @@ cZb
 cZb
 cZb
 wEB
-eVq
-hjP
-raF
-hjP
-qhd
+dBI
+pDJ
+ghS
+pDJ
+ajD
 wEB
-vuU
-vuU
-nGT
-vuU
-vuU
+jqb
+jqb
+hOO
+jqb
+jqb
 wEB
-pkd
-gKI
-tVz
-qPX
-wUY
+nDt
+iqf
+rJY
+ilJ
+pXu
 wEB
-hug
-tgo
-rMH
+ojG
+puG
+dML
 wEB
-wgo
-bbc
-owM
+cyU
+rde
+vHo
 wEB
-ljy
-psl
-dOX
+ioV
+iwK
+vPN
 wEB
 cZb
 cZb
@@ -196286,35 +196317,35 @@ cZb
 cZb
 cZb
 wEB
-cqg
-hjP
-ozY
-hjP
-gRN
+cvN
+pDJ
+hmG
+pDJ
+gUa
 wEB
-aHx
-vgg
-wZs
-cAE
-emU
+rrm
+vap
+qBI
+nKP
+hzQ
 wEB
-usp
-dXF
+okG
+lkC
 wEB
-rEV
+uTa
 lVS
 wEB
-saU
-psl
-hWj
+cIh
+iwK
+xwH
 wEB
-saU
-psl
-ocf
+cIh
+iwK
+tNF
 wEB
-saU
-hXt
-ocf
+cIh
+cnq
+tNF
 wEB
 cZb
 cZb
@@ -196491,7 +196522,7 @@ wEB
 wEB
 wEB
 sju
-wwC
+hBZ
 sju
 sju
 sju
@@ -196500,23 +196531,23 @@ wEB
 wEB
 wEB
 wEB
-ucz
-cdm
-oiZ
-tHh
-gbE
+sTe
+mhd
+qcX
+jOw
+faV
 wEB
-qUq
-rqr
-kkm
+hLI
+rqA
+uOt
 wEB
-qUq
-rqr
-kkm
+hLI
+rqA
+uOt
 wEB
-inQ
-rqr
-kkm
+uEu
+rqA
+uOt
 wEB
 cZb
 cZb
@@ -196693,19 +196724,19 @@ cZb
 cZb
 cZb
 sju
-jdC
-ovw
-mPD
-lMm
+dAv
+xuA
+eIh
+eEp
 sju
-dpn
-rgl
-lWC
+lbS
+imD
+vdZ
 wEB
-hNx
-fLU
+fnc
+fwq
 wEB
-bOO
+tec
 lVS
 wEB
 wEB
@@ -196720,8 +196751,8 @@ wEB
 wEB
 wEB
 wEB
-cZb
-cZb
+kUx
+kUx
 jZv
 pxW
 oAU
@@ -196895,35 +196926,35 @@ cZb
 cZb
 cZb
 sju
-jdC
-xTH
-xTH
-jdC
+dAv
+sAO
+sAO
+dAv
 sju
-sZK
-ghJ
-ooA
+nGT
+qpr
+atb
 wEB
 wEB
 wEB
 wEB
 lVS
+faV
+vxb
+wUE
+uMP
+wEB
+ugo
+hYK
+smo
+wEB
 gbE
-bCS
-oER
-xWy
+mZF
+fTQ
 wEB
-lvd
-nMM
-cJn
-wEB
-fun
-iVF
-hGy
-wEB
-cZb
-cZb
-cZb
+aMF
+uJY
+kUx
 jZv
 arM
 izK
@@ -197097,35 +197128,35 @@ cZb
 cZb
 cZb
 sju
-jdC
-dRG
-mPD
-ovw
+dAv
+dsV
+bBY
+azC
 sju
-oRT
-sZK
-ghJ
-oRT
-sZK
-sZK
-jRV
-gbE
+wAx
+nGT
+igY
+wAx
+nGT
+nGT
+cyT
+faV
 lVS
-bCS
-lOB
-xFN
+vxb
+cJp
+dBX
 wEB
-xcN
-jRo
-lDl
+hsH
+rgx
+inX
 wEB
-fbF
-qNi
-fmL
+cGZ
+xcV
+kNZ
 wEB
-cZb
-cZb
-cZb
+bMO
+ybD
+kUx
 jZv
 arM
 dTq
@@ -197299,10 +197330,10 @@ cZb
 cZb
 cZb
 sju
-jdC
-xTH
-rWX
-fqa
+dAv
+sAO
+lWz
+spr
 sju
 sju
 sju
@@ -197313,21 +197344,21 @@ sju
 sju
 lVS
 lVS
-fpx
-jnh
-nFG
+ffe
+nwl
+joX
 wEB
-wsR
-wsR
-ccw
+eCY
+eCY
+lXp
 wEB
-gOJ
-gOJ
-jjL
+tYf
+tYf
+ogi
 wEB
-cZb
-cZb
-cZb
+aMF
+uJY
+kUx
 jZv
 jZv
 jZv
@@ -197501,35 +197532,35 @@ cZb
 cZb
 cZb
 sju
-mPD
-mPD
-mPD
-jdC
+bBY
+eIh
+eIh
+dAv
 sju
-xgM
-vfW
-jbe
-ogj
-vBQ
-jvq
-wtF
-ivi
-hUY
+ivJ
+evC
+nRe
+sZK
+xNx
+jug
+lCX
+mpV
+ogV
 wEB
 wEB
 wEB
 wEB
-rBq
-mqy
-sEv
+vli
+wWH
+cSL
 wEB
-kSq
-ngY
-mIj
+gFf
+gHy
+bJQ
 wEB
+dpA
 wEB
-wEB
-cZb
+kUx
 cZb
 cZb
 cZb
@@ -197699,39 +197730,39 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-sju
-jdC
-jdC
-jdC
-fqa
-sju
-dWc
-jdC
-qSP
-uJi
-epU
-msJ
-sju
-iRj
-ufj
-lVS
-lVS
-lVS
-lVS
-lVS
-lVS
-lVS
-tYq
-bgt
-gbE
-lVS
-gGI
-gGI
-gGI
 cZb
+cZb
+cZb
+sju
+dAv
+dAv
+dAv
+spr
+sju
+dGK
+dAv
+fbX
+ucE
+sNS
+poM
+sju
+tgH
+lyp
+lVS
+lVS
+lVS
+lVS
+lVS
+lVS
+lVS
+hnU
+hLz
+faV
+lVS
+ilJ
+lVS
+vPM
+tcY
 cZb
 cZb
 cZb
@@ -197901,38 +197932,38 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
 sju
-lMm
-wkq
-dRG
-jdC
-kIA
-xTH
-tVF
-cYU
-vBQ
-ogj
-jvq
-hfI
-iRj
-iRj
+eEp
+byo
+dsV
+dAv
+xCU
+sAO
+lyf
+hWa
+xNx
+sZK
+jug
+liR
+tgH
+tgH
 wEB
-ojr
-wEB
-wEB
-fLm
+mti
 wEB
 wEB
-wio
+vBC
 wEB
 wEB
-wio
+sqD
 wEB
 wEB
-rsN
+sqD
+wEB
+wEB
+wEB
 cZb
 cZb
 cZb
@@ -198103,9 +198134,9 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
 sju
 sju
 sju
@@ -198119,20 +198150,20 @@ sju
 sju
 sju
 sju
-hsI
-kHO
+rtz
+frF
 wEB
-ryC
-aNp
+vCK
+ohr
 wEB
-oGf
-ovm
+bzT
+nRA
 wEB
-gLS
-gDj
+kfa
+wVR
 wEB
-gLS
-ovm
+kfa
+nRA
 wEB
 cZb
 cZb
@@ -198305,13 +198336,13 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
@@ -198321,20 +198352,20 @@ cZb
 cZb
 cZb
 rsN
-nKH
-pxJ
+hBm
+ifo
 wEB
-mEv
-aNp
+dqq
+ohr
 wEB
-cXw
-pJU
+nWL
+iMN
 wEB
-lrZ
-lXJ
+xed
+sfv
 wEB
-ilG
-lXJ
+aOT
+sfv
 wEB
 cZb
 cZb
@@ -198507,15 +198538,15 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
@@ -198523,8 +198554,8 @@ cZb
 cZb
 cZb
 wEB
-nKH
-gdk
+hBm
+cLU
 wEB
 wEB
 wEB
@@ -198709,24 +198740,24 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
 cZb
 wEB
-pxJ
-gdk
+ifo
+cLU
 wEB
 cZb
 cZb
@@ -198911,24 +198942,24 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
 cZb
 wEB
-gbE
-gbE
+faV
+faV
 wEB
 cZb
 cZb
@@ -199113,23 +199144,23 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
 wEB
-gbE
+faV
 lVS
 wEB
 cZb
@@ -199315,18 +199346,18 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
@@ -199735,8 +199766,8 @@ cZb
 cZb
 cZb
 wEB
-gbE
-gbE
+faV
+faV
 wEB
 cZb
 cZb
@@ -199925,7 +199956,7 @@ tad
 tad
 tad
 tad
-fXR
+lIH
 tad
 tad
 tad
@@ -199938,7 +199969,7 @@ cZb
 cZb
 wEB
 lVS
-gbE
+faV
 wEB
 cZb
 cZb
@@ -200140,7 +200171,7 @@ cZb
 cZb
 wEB
 lVS
-bxj
+rFb
 wEB
 cZb
 cZb
@@ -200543,7 +200574,7 @@ cZb
 cZb
 cZb
 wEB
-gbE
+faV
 lVS
 wEB
 cZb
@@ -200746,7 +200777,7 @@ cZb
 cZb
 wEB
 wiO
-gGI
+vPM
 wEB
 cZb
 cZb

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -17280,9 +17280,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/holoposter{
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	pixel_y = 8
 	},

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -41,6 +41,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/panic_room)
+"aas" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aaA" = (
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp,
@@ -194,6 +199,16 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"ace" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/northleft,
+/obj/machinery/cash_register{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "acf" = (
 /obj/structure/flora/pottedplant/small,
 /obj/structure/cable/green{
@@ -295,14 +310,6 @@
 /obj/machinery/door/window/northright,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/podrooms2)
-"adi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/obj/random/cluster/spiders,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "adt" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/small/grassb5,
@@ -1191,6 +1198,11 @@
 /obj/effect/decal/mecha_wreckage/ripley,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"amo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "amq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -1470,6 +1482,14 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"apL" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A3";
+	name = "D1-A3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "apT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -1969,12 +1989,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/maingate)
-"auH" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/material_resources,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "auL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard,
@@ -2156,14 +2170,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
-"avX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/item/contraband/poster,
-/obj/item/contraband/poster,
-/obj/item/pen/multi,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "awd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2219,6 +2225,11 @@
 /obj/item/shield/riot,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical)
+"awK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "awL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -2405,6 +2416,11 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/kitchen)
+"ayK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ayS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2994,6 +3010,12 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
+"aEr" = (
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aEs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3075,6 +3097,11 @@
 /obj/structure/sign/warning/hazard_coldloop,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
+"aEQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aFa" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/quartermaster/miningdock)
@@ -3404,6 +3431,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"aJf" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aJq" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/beach/water/flooded,
@@ -3861,10 +3893,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
-"aOD" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aOE" = (
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
@@ -4058,6 +4086,14 @@
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"aRd" = (
+/obj/structure/table/rack/shelf,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/computer_hardware/hard_drive/portable/advanced/shady,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aRf" = (
 /obj/random/material_resources/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -4133,14 +4169,6 @@
 /obj/random/junkfood/rotten,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"aSi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/gun_normal/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aSk" = (
 /obj/structure/table/rack/shelf,
 /obj/item/hand_labeler,
@@ -4160,6 +4188,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"aSo" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aSv" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/drinkingglasses,
@@ -4330,6 +4368,10 @@
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"aVb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aVm" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 8
@@ -4565,12 +4607,6 @@
 	},
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/medical/reception)
-"aXU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "aYf" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -4782,6 +4818,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"aZN" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/makeshift_grinder,
+/obj/effect/decal/cleanable/cobweb{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bab" = (
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest)
@@ -5582,6 +5626,11 @@
 /obj/structure/flora/small/bushc1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"bhN" = (
+/obj/structure/table/standard,
+/obj/item/storage/freezer/medical,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bhS" = (
 /obj/effect/floor_decal/border/carpet/orange,
 /obj/effect/floor_decal/spline/wood{
@@ -5770,12 +5819,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"bje" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bjf" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -5884,9 +5927,9 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "bjV" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/steel/gray_perforated,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/highsecurity,
+/turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "bkg" = (
 /obj/random/booze,
@@ -5928,10 +5971,6 @@
 /obj/effect/floor_decal/industrial/road/curve4,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"bky" = (
-/obj/item/contraband/poster/placed/generic/here_for_your_safety,
-/turf/simulated/wall,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
@@ -5954,6 +5993,12 @@
 /obj/item/oddity/ls/starscope,
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
+"bkU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bkY" = (
 /obj/structure/sign/department/telecoms,
 /turf/simulated/wall/r_wall,
@@ -6013,13 +6058,6 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/lab)
-"blH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "blS" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/cobweb2{
@@ -6053,21 +6091,9 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
-"bmf" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
-"bmg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/random/structures,
-/turf/simulated/floor/tiled/steel/brown_platform,
+"bmn" = (
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "bmp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6355,6 +6381,11 @@
 	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"bpl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bpm" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = -32
@@ -6608,6 +6639,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfacesec)
+"bsf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bsq" = (
 /obj/structure/sign/department/gene,
 /turf/simulated/wall/r_wall,
@@ -6618,10 +6656,6 @@
 	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"bsB" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bsC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/northright{
@@ -7081,6 +7115,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
+"bwx" = (
+/obj/item/device/radio/intercom{
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bwA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7370,6 +7411,13 @@
 /obj/structure/flora/big/bush2,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"bzJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bzM" = (
 /obj/structure/table/woodentable,
 /obj/item/device/lighting/toggleable/lamp/green,
@@ -7404,11 +7452,6 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
-"bzY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bAc" = (
 /obj/structure/sign/departmentold/botany/small,
 /turf/simulated/wall/r_wall,
@@ -7575,6 +7618,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics)
+"bCi" = (
+/obj/machinery/vending/engivend,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bCk" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/rock,
@@ -7714,12 +7764,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"bDI" = (
-/obj/structure/boulder,
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bDQ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7990,6 +8034,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"bGy" = (
+/obj/structure/table/standard,
+/obj/item/storage/pill_bottle/tramadol,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bGJ" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -8352,9 +8401,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfacenorth)
-"bJW" = (
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bJY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -8676,11 +8722,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"bNu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bNv" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
@@ -8744,11 +8785,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"bOd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bOp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -8835,10 +8871,6 @@
 /obj/structure/scrap/medical,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"bPB" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bPD" = (
 /obj/landmark/costume/highlander,
 /obj/structure/table/rack,
@@ -9643,9 +9675,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"bXY" = (
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bYa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -9665,6 +9694,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"bYt" = (
+/obj/machinery/microwave/burnbarrel,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bYF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -9691,6 +9724,9 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/medical/sleeper)
+"bYM" = (
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bYN" = (
 /obj/structure/table/bar_special,
 /obj/machinery/floor_light,
@@ -10015,12 +10051,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
-"ccl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ccn" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/asteroid/grass,
@@ -10033,6 +10063,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"ccy" = (
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ccA" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
@@ -10149,6 +10182,11 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/command/cro)
+"cdR" = (
+/obj/structure/bed/chair/office/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cdY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10182,6 +10220,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/foyer)
+"cej" = (
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ceB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -10466,13 +10508,6 @@
 /mob/living/carbon/superior_animal/roach/roachling,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"chH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "chI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10586,6 +10621,10 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
+"ciT" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ciX" = (
 /obj/machinery/door/airlock/glass{
 	name = "Sauna"
@@ -11074,6 +11113,11 @@
 /obj/structure/sign/warning/armory/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/armory)
+"cnF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cnN" = (
 /obj/item/spider_shadow_trap{
 	pixel_x = -26;
@@ -11083,14 +11127,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"cnP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1;
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cnY" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -11107,11 +11143,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/command/tcommsat/computer)
-"coe" = (
-/obj/machinery/door/window/northleft,
-/obj/structure/curtain/black,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cof" = (
 /obj/item/storage/firstaid/surgery,
 /obj/structure/table/standard,
@@ -11136,10 +11167,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"cot" = (
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "coy" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/grille/broken,
@@ -11319,11 +11346,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"cqt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet_tech/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cqC" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "10,6"
@@ -11387,6 +11409,10 @@
 /obj/structure/table/rack/shelf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"cre" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "cri" = (
 /obj/structure/flora/big/rocks2,
@@ -11458,6 +11484,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"crC" = (
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "crH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -11517,6 +11547,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/engine_room)
+"csw" = (
+/obj/machinery/door/window/eastright,
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "csA" = (
 /obj/structure/railing{
 	dir = 4
@@ -11541,6 +11578,14 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"csL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "csM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11825,6 +11870,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
+"cvR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cvW" = (
 /obj/structure/table/rack,
 /obj/item/rig/ce/equipped,
@@ -11996,14 +12048,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/sechall)
-"cxM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/common_oddities/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cxN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -12011,13 +12055,6 @@
 "cxU" = (
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
-"cxY" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A20";
-	name = "D1-A20"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cyl" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -12122,6 +12159,11 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"czi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "czA" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "13,15"
@@ -12216,6 +12258,10 @@
 /obj/random/junk/nondense,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"cAl" = (
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cAq" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -12585,6 +12631,11 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
+"cDH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/colony)
 "cDL" = (
 /obj/machinery/body_scanconsole,
 /obj/effect/decal/cleanable/dirt,
@@ -12618,6 +12669,14 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
+"cEi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cEj" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/grassybush,
@@ -12764,6 +12823,10 @@
 /obj/structure/barricade,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"cFQ" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cFR" = (
 /obj/effect/window_lwall_spawn,
 /obj/structure/cable/cyan{
@@ -12942,16 +13005,6 @@
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"cHv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/northleft,
-/obj/machinery/door/window/southleft,
-/obj/machinery/cash_register{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cHC" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -13089,14 +13142,6 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/turret_protected/ai)
-"cID" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cIE" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall17";
@@ -13481,12 +13526,6 @@
 /obj/item/stool,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
-"cML" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/credits/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cMQ" = (
 /obj/effect/floor_decal/industrial/road/straight3,
 /obj/effect/decal/cleanable/dirt,
@@ -14390,6 +14429,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"cVQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cVW" = (
 /obj/machinery/light{
 	dir = 4
@@ -14510,6 +14555,9 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/cryo)
+"cWE" = (
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cWF" = (
 /obj/structure/flora/big/rocks1,
 /turf/simulated/floor/asteroid/grass,
@@ -14996,6 +15044,11 @@
 /obj/item/towel,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/command/merchant)
+"dbk" = (
+/obj/random/booze/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dbo" = (
 /obj/random/mob/spiders/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -15062,19 +15115,6 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
-"dcw" = (
-/obj/structure/closet/crate/secure/large,
-/obj/item/organ/internal/bone/head/robotic,
-/obj/item/organ/internal/bone/l_arm/robotic,
-/obj/item/organ/internal/bone/l_leg/robotic,
-/obj/item/organ/internal/bone/r_arm/robotic,
-/obj/item/organ/internal/bone/r_leg/robotic,
-/obj/item/organ/internal/bone/chest/robotic,
-/obj/effect/decal/cleanable/blood/oil{
-	icon_state = "splatter2"
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dcH" = (
 /obj/structure/railing{
 	dir = 1;
@@ -15085,6 +15125,15 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/turret_protected/ai)
+"dcQ" = (
+/obj/machinery/optable,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dcS" = (
 /obj/structure/table/standard,
 /obj/structure/extinguisher_cabinet{
@@ -15145,18 +15194,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/captain)
-"ddv" = (
-/obj/random/booze,
-/obj/random/junkfood/onlypizza,
-/obj/random/junkfood/onlyburger,
-/obj/random/junkfood,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"ddy" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ddz" = (
 /obj/structure/catwalk,
 /obj/random/cluster/spiders,
@@ -15479,6 +15516,12 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"dgC" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dgE" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/beach/water/jungledeep{
@@ -15696,6 +15739,12 @@
 /obj/structure/low_wall,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"div" = (
+/obj/structure/curtain/open/bed{
+	name = "Privacy curtain"
+	},
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "diB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15899,6 +15948,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"dlb" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"dld" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet_tech/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dll" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -16673,12 +16734,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
-"dtc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dtf" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -16768,13 +16823,6 @@
 /obj/effect/floor_decal/industrial/road/straight1,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"dtY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "dua" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -17176,6 +17224,13 @@
 /obj/structure/scrap/poor,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"dxu" = (
+/obj/structure/table/reinforced,
+/obj/item/device/makeshift_electrolyser,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dxx" = (
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -17753,6 +17808,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
+"dDh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dDi" = (
 /obj/random/furniture/pottedplant{
 	pixel_y = 10
@@ -17826,6 +17888,18 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/surfaceeast)
+"dEa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/random/scrap,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"dEh" = (
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dEn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18108,6 +18182,14 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"dGy" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A20";
+	name = "D1-A20"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dGz" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin{
@@ -18214,13 +18296,6 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"dHH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dHL" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/random/flora/small_jungle_tree,
@@ -18397,6 +18472,13 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"dJo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dJx" = (
 /obj/structure/table/woodentable,
 /obj/machinery/recharger,
@@ -18765,6 +18847,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"dMH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dMK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/under,
@@ -18852,13 +18941,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/janitor)
-"dNB" = (
-/obj/structure/curtain/open/bed{
-	name = "Privacy curtain"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dNC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled/techmaint,
@@ -19015,6 +19097,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"dPB" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/rig_module/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dPC" = (
 /turf/simulated/shuttle/floor/science{
 	icon_state = "12,4"
@@ -19687,11 +19774,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"dXl" = (
-/obj/random/cluster/roaches/lower_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dXm" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -20107,12 +20189,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
-"ebA" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/cheap/elbrus4kk,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ebB" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -20290,6 +20366,10 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/range)
+"ecD" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ecO" = (
 /obj/structure/mopbucket,
 /obj/item/reagent_containers/glass/bucket,
@@ -20424,6 +20504,11 @@
 	},
 /turf/simulated/shuttle/floor/mining,
 /area/shuttle/rocinante_shuttle_area)
+"eei" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "ees" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21284,10 +21369,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"end" = (
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eng" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -22500,11 +22581,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"eyb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/termite_no_despawn/lower_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eyj" = (
 /obj/random/mob/nightmare/low_chance,
 /turf/simulated/floor/rock,
@@ -22597,9 +22673,6 @@
 /obj/random/material_ore,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"ezk" = (
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ezl" = (
 /obj/structure/sink{
 	pixel_y = -22
@@ -22923,6 +22996,18 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"eDb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"eDd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance_cargo,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eDh" = (
 /obj/structure/closet/secure_closet/medicine,
 /obj/item/storage/bag/chemistry,
@@ -23003,10 +23088,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/turret_protected/ai_upload)
-"eDP" = (
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eDQ" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/disposalpipe/segment,
@@ -23054,12 +23135,6 @@
 /obj/item/towel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/prime)
-"eEH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eEK" = (
 /obj/structure/catwalk,
 /obj/structure/barricade,
@@ -23167,11 +23242,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
-"eFR" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/rig_module/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eGl" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -23209,6 +23279,11 @@
 /obj/structure/curtain/open/privacy,
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"eGG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eGR" = (
 /obj/structure/railing,
 /obj/structure/disposalpipe/segment{
@@ -23742,13 +23817,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"eMA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eMB" = (
 /obj/structure/table/standard,
 /obj/item/pen{
@@ -24101,14 +24169,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"ePe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/woodentable,
-/obj/random/gun_parts/low,
-/obj/random/ammo,
-/obj/random/gun_parts/low,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ePg" = (
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -24121,11 +24181,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
-"ePp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ePq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -24700,10 +24755,6 @@
 /obj/structure/closet/secure_closet/personal/doctor,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/medical/sleeper)
-"eVk" = (
-/obj/random/structures,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eVm" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/structure/table/woodentable,
@@ -24731,6 +24782,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"eVA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/contraband/poster,
+/obj/item/contraband/poster,
+/obj/item/pen/multi,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eVG" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/wood/wild3,
@@ -24865,14 +24924,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"eWs" = (
-/obj/structure/table/rack/shelf,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/computer_hardware/hard_drive/portable/advanced/shady,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eWu" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -25698,10 +25749,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"fff" = (
-/obj/machinery/door/airlock/maintenance_cargo,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ffp" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_y = 32
@@ -25923,6 +25970,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"fhk" = (
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/structure/bedsheetbin,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fhl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -26317,11 +26373,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
-"fkv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank/derelict,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fkx" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/big/rocks1,
@@ -26443,11 +26494,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"flJ" = (
-/obj/structure/bed,
-/obj/item/handcuffs/fuzzy,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "flM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -26966,11 +27012,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"fqa" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/mineral,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fqc" = (
 /obj/structure/table/marble,
 /obj/random/toy/plushie_onlycorgi,
@@ -27054,10 +27095,6 @@
 "frb" = (
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/merchant)
-"frc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "frd" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
@@ -27089,6 +27126,10 @@
 /obj/random/scrap/dense_weighted,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"fry" = (
+/obj/machinery/door/unpowered/simple/wood,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "frC" = (
 /obj/random/scrap/sparse_even,
 /obj/effect/decal/cleanable/dirt,
@@ -27290,25 +27331,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
-"fuz" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "fuG" = (
 /obj/random/spider_trap_burrowing,
 /obj/effect/decal/cleanable/dirt,
@@ -27356,11 +27378,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"fuS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fuT" = (
 /obj/effect/damagedfloor/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -27467,6 +27484,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/panic_room)
+"fvM" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fvU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -27921,6 +27945,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"fBf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/custom/onestar,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/colony)
 "fBh" = (
 /obj/structure/flora/small/busha2,
 /obj/effect/decal/cleanable/dirt,
@@ -27974,6 +28003,11 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/panic_room)
+"fBG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/lowkeyrandom,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fBI" = (
 /obj/structure/girder,
 /obj/structure/flora/big/rocks1,
@@ -28009,13 +28043,6 @@
 "fCa" = (
 /turf/simulated/mineral,
 /area/nadezhda/outside/bcave)
-"fCd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fCf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28242,10 +28269,6 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
-"fEo" = (
-/obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fEp" = (
 /obj/item/book/manual/nonfiction/ageofreason,
 /obj/item/book/manual/nonfiction/ethics,
@@ -28262,6 +28285,14 @@
 /obj/item/oddity/common/book_omega/closed,
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"fEs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/random/cluster/spiders,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fEt" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -28475,10 +28506,6 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/turret_protected/ai_upload)
-"fGZ" = (
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fHf" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -28746,12 +28773,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/bridge)
-"fJK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/tool/advanced/onestar/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fJM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -28793,10 +28814,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
-"fKk" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fKl" = (
 /obj/structure/firedoor_assembly,
 /obj/structure/barricade,
@@ -29032,6 +29049,11 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"fMK" = (
+/obj/structure/table/rack/shelf,
+/obj/item/modular_computer/wrist,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fMO" = (
 /obj/effect/floor_decal/industrial/road{
 	dir = 1
@@ -29319,6 +29341,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"fQJ" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fQK" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/atmospherics/unary/vent_scrubber,
@@ -29542,11 +29569,6 @@
 /obj/structure/flora/small/grassa4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"fTh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fTj" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -29918,6 +29940,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/east)
+"fXg" = (
+/obj/machinery/door/window/westleft,
+/obj/machinery/door/window/eastleft,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fXj" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central1,
 /obj/structure/cable/green{
@@ -30215,11 +30243,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
-"gao" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gas" = (
 /obj/machinery/camera/network/engineering{
 	dir = 4
@@ -30364,9 +30387,7 @@
 	})
 "gbE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/mecha_equipment/low_chance,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "gbL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -30663,6 +30684,12 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
+"gel" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "geo" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
@@ -31074,12 +31101,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"ghz" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/rig/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ghD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -31137,6 +31158,11 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/west)
+"gir" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "giu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -31279,10 +31305,6 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"gkb" = (
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gkd" = (
 /obj/random/scrap/sparse_even/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -31352,13 +31374,6 @@
 /obj/random/toy/plushie_onlycat,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/psych)
-"gkP" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junkfood,
-/obj/random/junkfood,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gkQ" = (
 /obj/structure/lattice,
 /obj/structure/railing,
@@ -31427,6 +31442,25 @@
 /obj/random/pack,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"glG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "glH" = (
 /obj/item/storage/toolbox/syndicate,
 /obj/item/contraband/poster,
@@ -31501,13 +31535,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/psych)
-"gmj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/material/kitchen/utensil/fork,
-/obj/item/stack/rods/random,
-/turf/simulated/floor/plating,
-/area/colony)
 "gmm" = (
 /obj/structure/medical_stand,
 /obj/item/tank/anesthetic,
@@ -31613,12 +31640,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"gnV" = (
-/obj/effect/floor_decal/industrial/caution{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "gnX" = (
 /turf/simulated/floor/beach/water/jungledeep{
 	desc = "Filthy, stinking bilge water.";
@@ -31723,15 +31744,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"goH" = (
-/obj/machinery/optable,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "goI" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -31792,11 +31804,6 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/command/gmaster)
-"goS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "goX" = (
 /obj/random/furniture/pottedplant,
 /obj/effect/decal/cleanable/dirt,
@@ -32127,6 +32134,20 @@
 /obj/item/storage/bag/trash,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"gru" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/random/structures,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"grv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 1;
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "grw" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -32627,10 +32648,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
-"gvZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gwa" = (
 /obj/machinery/door/window/southright{
 	dir = 1;
@@ -32675,9 +32692,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/colony)
-"gwX" = (
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gwY" = (
 /obj/machinery/vending/gamers,
 /turf/simulated/floor/tiled/steel/monofloor{
@@ -33043,6 +33057,18 @@
 /obj/structure/salvageable/autolathe,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/dungeon/outside/burned_outpost)
+"gAK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/storage/freezer,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gAL" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/colony_surface,
@@ -33243,6 +33269,13 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
+"gDI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/material/kitchen/utensil/fork,
+/obj/item/stack/rods/random,
+/turf/simulated/floor/plating,
+/area/colony)
 "gDM" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small,
@@ -33383,6 +33416,10 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"gFb" = (
+/obj/random/cluster/slimes,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gFl" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/quartermaster/disposaldrop)
@@ -33440,15 +33477,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
-"gFO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/common_oddities/low_chance,
-/obj/random/gun_normal/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gFQ" = (
 /obj/machinery/dna_scannernew,
 /turf/simulated/floor/tiled/white,
@@ -33723,6 +33751,10 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"gJH" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gJN" = (
 /obj/structure/closet/crate/secure,
 /obj/item/stack/os_cash/random,
@@ -34180,6 +34212,13 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
+"gOn" = (
+/obj/machinery/vending/assist,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gOx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -34800,14 +34839,6 @@
 	opacity = 0
 	},
 /area/shuttle/rocinante_shuttle_area)
-"gUa" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A20";
-	name = "D1-A20"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gUb" = (
 /obj/structure/boulder,
 /obj/random/traps/wire_splicing/low_chance,
@@ -35005,11 +35036,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"gVZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gWd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -35186,6 +35212,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology)
+"gXz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gXE" = (
 /obj/effect/floor_decal/industrial/warningwhite{
 	dir = 4
@@ -35355,6 +35386,24 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"gZY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	dir = 4
+	},
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/barricade,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/crew_quarters/techshop)
 "han" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -35471,6 +35520,17 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
+"hbA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/eastright,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hbC" = (
 /obj/random/mecha/low_chance,
 /obj/machinery/mech_recharger,
@@ -35540,6 +35600,11 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
+"hcq" = (
+/obj/item/reagent_containers/syringe/drugs,
+/obj/item/reagent_containers/pill/floorpill,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hct" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/industrial/warningwhite,
@@ -36381,6 +36446,16 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armoryshop)
+"hkZ" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/costume/body_animals,
+/obj/random/costume/body_generic,
+/obj/random/costume/body_halloween,
+/obj/random/costume/head_animals,
+/obj/random/costume/head_generic,
+/obj/random/costume/head_halloween,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hle" = (
 /obj/structure/table/standard,
 /obj/item/stamp/ce,
@@ -36577,18 +36652,6 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
-"hnh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/storage/freezer,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/snacks/meat/monkey,
-/obj/item/reagent_containers/food/snacks/meat/monkey,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hnn" = (
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /obj/machinery/shieldwallgen{
@@ -36635,12 +36698,6 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
-"hnL" = (
-/obj/machinery/door/window/southleft,
-/obj/machinery/door/window/northleft,
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hoa" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -36879,14 +36936,6 @@
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
-"hqj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hqp" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/ifak,
@@ -37108,15 +37157,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"hsP" = (
-/obj/structure/table/rack,
-/obj/structure/curtain/medical,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/organ/internal/optical_sensor,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hsW" = (
 /obj/structure/flora/small/rock3,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -37390,6 +37430,11 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
+"hvL" = (
+/obj/structure/table/steel,
+/obj/random/powercell/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hvN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -37537,6 +37582,17 @@
 "hxo" = (
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm3)
+"hxq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hxL" = (
 /obj/random/furniture/pottedplant,
 /obj/machinery/light{
@@ -37689,6 +37745,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"hyS" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/welding,
+/obj/item/storage/belt,
+/obj/item/clothing/head/welding,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hyT" = (
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -38479,10 +38543,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
-"hGc" = (
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hGl" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -39111,6 +39171,13 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"hKJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "hKK" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Post";
@@ -39290,11 +39357,6 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"hMa" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/mat_katana,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hMc" = (
 /obj/machinery/light{
 	dir = 4
@@ -39633,23 +39695,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
-"hRi" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "hRj" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/floor_decal/industrial/arrows/white,
@@ -39725,6 +39770,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
+"hSK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading/red,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hSR" = (
 /obj/random/scrap/sparse_even,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -39890,6 +39940,10 @@
 /obj/effect/floor_decal/border/carpet/lightblue,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/crew_quarters)
+"hUx" = (
+/obj/random/structures,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hUA" = (
 /obj/machinery/light,
 /obj/structure/closet/wall_mounted/firecloset{
@@ -40069,11 +40123,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
-"hVv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain/red,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hVz" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /mob/living/simple_animal/frog{
@@ -40201,13 +40250,6 @@
 /obj/machinery/chemical_dispenser/soda,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
-"hWP" = (
-/obj/machinery/vending/assist,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hWU" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/extinguisher_cabinet{
@@ -40361,6 +40403,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"hXV" = (
+/obj/structure/boulder,
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hXW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -40437,11 +40485,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"hYy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hYF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster/directional/north,
@@ -40553,10 +40596,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"hZi" = (
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hZj" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
@@ -41085,10 +41124,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/sleeper)
-"idU" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ieb" = (
 /obj/effect/window_lwall_spawn,
 /obj/structure/barricade,
@@ -41501,6 +41536,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
+"iii" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/spider_shadow_trap,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iip" = (
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/armory)
@@ -42343,13 +42383,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"ire" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iri" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/grille/broken,
@@ -42644,6 +42677,10 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/security/maingate/west)
+"iua" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iud" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/fiction/warandpeace,
@@ -43250,6 +43287,11 @@
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"iAM" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/mat_katana,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iAN" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -43290,6 +43332,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"iBd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iBe" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -43400,6 +43447,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"iBU" = (
+/obj/machinery/door/airlock/maintenance_interior{
+	name = "Hotel Desk"
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iBX" = (
 /obj/random/junk/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -43614,11 +43667,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/maintenance/surfaceeast)
-"iEw" = (
-/obj/random/booze/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iEz" = (
 /obj/structure/barricade,
 /obj/structure/grille,
@@ -43783,6 +43831,12 @@
 /obj/random/gun_cheap/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"iGJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cabinet,
+/obj/random/booze,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iGL" = (
 /obj/random/flora/small_jungle_tree,
 /turf/unsimulated/wall/jungle,
@@ -44007,11 +44061,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/chemistry)
-"iIr" = (
-/obj/structure/closet/random_miscellaneous,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iIt" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/light{
@@ -44238,14 +44287,12 @@
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/reception)
-"iLb" = (
-/obj/machinery/firealarm{
-	pixel_y = 32
+"iKY" = (
+/obj/machinery/door/airlock/maintenance_common,
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel_reinforced,
-/obj/structure/bedsheetbin,
-/turf/simulated/floor/carpet/purcarpet,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "iLc" = (
 /obj/structure/boulder,
@@ -44867,6 +44914,10 @@
 "iRG" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/dungeon/outside/trashcave)
+"iRI" = (
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iRP" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central6{
 	pixel_y = -7
@@ -44877,16 +44928,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
-"iRR" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/random/structures,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iRT" = (
 /obj/structure/spider_nest,
 /obj/effect/decal/cleanable/dirt,
@@ -44925,13 +44966,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/cargo)
-"iSs" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iSz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -45138,11 +45172,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
-"iVc" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/roach/roachling,
-/turf/simulated/floor/plating,
-/area/colony)
 "iVd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -45291,6 +45320,10 @@
 /obj/effect/window_lwall_spawn/plasma/reinforced,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology)
+"iWs" = (
+/obj/machinery/door/airlock/maintenance_cargo,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iWC" = (
 /obj/structure/table/glass,
 /obj/random/scrap/dense_even,
@@ -45322,12 +45355,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/maintenance/surfaceeast)
-"iWU" = (
-/obj/structure/curtain/open/bed{
-	name = "Privacy curtain"
-	},
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iWX" = (
 /obj/structure/salvageable/computer,
 /obj/effect/decal/cleanable/dirt,
@@ -45895,6 +45922,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"jcN" = (
+/obj/structure/reagent_dispensers/bidon,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jcP" = (
 /obj/structure/bed/chair/wood{
 	dir = 8;
@@ -45903,13 +45934,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"jcR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -46006,9 +46030,6 @@
 "jdO" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
-"jdQ" = (
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jdU" = (
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -46262,11 +46283,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"jgK" = (
-/obj/structure/table/standard,
-/obj/item/storage/freezer/medical,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jgL" = (
 /obj/machinery/conveyor/north/ccw{
 	id = "QMLoad2"
@@ -46378,6 +46394,12 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/security/armory_blackshield)
+"jhU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/tool/advanced/onestar/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jic" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -46534,11 +46556,6 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
-"jjj" = (
-/obj/structure/bed/chair/office/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jjk" = (
 /obj/structure/flora/small/bushc1,
 /turf/unsimulated/wall/jungle,
@@ -46582,12 +46599,6 @@
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"jjK" = (
-/obj/structure/table/bench/glass,
-/obj/structure/curtain/red,
-/obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jjN" = (
 /obj/machinery/door/airlock/maintenance_common{
 	req_access = list(12)
@@ -46999,11 +47010,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
-"jns" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jnu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -47567,6 +47573,13 @@
 	},
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/dungeon/outside/farm)
+"jsR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/plating,
+/area/colony)
 "jsS" = (
 /obj/structure/flora/small/busha3,
 /obj/effect/decal/cleanable/dirt,
@@ -47586,6 +47599,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"jtg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jti" = (
 /obj/structure/cryofeed{
 	dir = 4;
@@ -47604,17 +47622,21 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"jtn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/common_oddities/low_chance,
+/obj/random/gun_normal/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jtA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack/shelf,
 /obj/random/material_resources/low_chance,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
-"jtC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jtG" = (
 /obj/machinery/door/airlock/command{
 	name = "Telecommunications";
@@ -48075,9 +48097,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"jxX" = (
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jxY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -48167,6 +48186,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/crew_quarters)
+"jzu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jzw" = (
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/generic,
@@ -48299,6 +48323,12 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"jAw" = (
+/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/northleft,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jAz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/multiz/ladder,
@@ -48366,6 +48396,11 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/hallway/side/f2section1)
+"jBL" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jBN" = (
 /obj/structure/multiz/stairs/enter{
 	dir = 1
@@ -48731,6 +48766,12 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/engineering/atmos/surface)
+"jFG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/random/cluster/spiders,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jFH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/danger,
@@ -49879,10 +49920,6 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
-"jRw" = (
-/mob/living/bot/cleanbot,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jRz" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
@@ -49908,11 +49945,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"jRH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jRN" = (
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle/variant,
@@ -49935,6 +49967,13 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"jSc" = (
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jSd" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
@@ -50266,6 +50305,12 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/command/courtroom)
+"jVs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/random/junkfood/rotten,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jVw" = (
 /mob/living/carbon/superior_animal/giant_spider/nurse/queen,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -50281,6 +50326,10 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics)
+"jVP" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jVR" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
@@ -50352,6 +50401,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"jWj" = (
+/obj/structure/table/glass,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jWo" = (
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "shuttle_hatch_bolts";
@@ -50396,6 +50450,10 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/wall,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"jWZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jXq" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -50596,6 +50654,11 @@
 "jZv" = (
 /turf/simulated/wall/church_reinforced,
 /area/nadezhda/absolutism/bioreactor)
+"jZw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jZz" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -51180,6 +51243,12 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1north)
+"kfo" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/cheap/elbrus4kk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kfz" = (
 /obj/structure/bed/chair/office,
 /turf/simulated/floor/beach/sand,
@@ -52018,11 +52087,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
-"knW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "knY" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/dirt,
@@ -52040,13 +52104,6 @@
 	},
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
-"kof" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "koh" = (
 /obj/structure/boulder,
 /obj/structure/cable/cyan{
@@ -52106,6 +52163,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"koW" = (
+/obj/structure/closet/wall_mounted{
+	pixel_x = -32
+	},
+/obj/item/storage/box/drinkingglasses,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kpb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52786,13 +52850,6 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"kvJ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kvR" = (
 /obj/structure/multiz/stairs/enter,
 /turf/simulated/floor/pool,
@@ -53371,6 +53428,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/xenobiology)
+"kAt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/simple/wood,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kAu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor_grid,
@@ -53404,10 +53466,6 @@
 /obj/item/book/manual/nonfiction/suntzu,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"kAU" = (
-/obj/structure/janitorialcart,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kAV" = (
 /obj/structure/toilet{
 	dir = 4
@@ -53513,11 +53571,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/range)
-"kCy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/colony)
 "kCD" = (
 /obj/machinery/vending/assist,
 /obj/machinery/firealarm{
@@ -53885,10 +53938,6 @@
 "kGg" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/prisoncells)
-"kGh" = (
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kGj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -54121,13 +54170,6 @@
 	icon_state = "7,17"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"kKg" = (
-/obj/machinery/door/airlock/maintenance_common,
-/obj/random/traps/low_chance{
-	spawn_nothing_percentage = 90
-	},
-/turf/space,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kKh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
@@ -54468,13 +54510,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
-"kOr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kOv" = (
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/industrial/hatch,
@@ -54487,6 +54522,16 @@
 "kOB" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/dcave)
+"kOD" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/random/structures,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kOH" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	name = "Bar - Room A"
@@ -55304,13 +55349,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"kXh" = (
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/common_oddities/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kXi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -55429,6 +55467,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
+"kYI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kYP" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -55491,6 +55534,12 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"kZQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/employment,
+/obj/random/credits/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kZT" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 4
@@ -56269,11 +56318,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/medical)
-"liO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "liT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
@@ -56327,6 +56371,13 @@
 /obj/effect/floor_decal/industrial/box/red/corners,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
+"ljR" = (
+/obj/structure/table/woodentable,
+/obj/random/gun_parts/low,
+/obj/random/ammo,
+/obj/random/gun_parts/low,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ljU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56433,10 +56484,9 @@
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
-"llr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint_perforated,
+"llo" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "llw" = (
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
@@ -56456,11 +56506,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"llE" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "llJ" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_x = -1;
@@ -56514,16 +56559,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/absolutism/chapel)
-"lmg" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/curtain/open,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lmh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -56776,12 +56811,6 @@
 	},
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/medical/reception)
-"lpn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bench/glass,
-/obj/structure/curtain/red,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lpr" = (
 /obj/machinery/camera/network/security{
 	dir = 1
@@ -56980,13 +57009,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
-"lrl" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/random/structures,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lrq" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -57177,6 +57199,12 @@
 	icon_state = "9,23"
 	},
 /area/turbolift/mountain/colony)
+"ltI" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil/random,
+/obj/item/device/robotanalyzer,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ltL" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/steel/monofloor{
@@ -57206,6 +57234,14 @@
 "lud" = (
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/panic_room)
+"lue" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "luf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -57280,15 +57316,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/absolutism/hallways)
-"luJ" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/bodybags,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/random/circuitboard/low_chance,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "luL" = (
 /obj/machinery/telecomms/server/presets/service,
 /turf/simulated/floor/bluegrid{
@@ -57529,13 +57556,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
-"lxh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lxj" = (
 /obj/machinery/camera/network/medbay{
 	dir = 1
@@ -57574,6 +57594,10 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"lxI" = (
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lxJ" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -57617,10 +57641,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"lyw" = (
-/obj/machinery/microwave/burnbarrel,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lyx" = (
 /obj/random/spider_trap_burrowing/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -57809,6 +57829,9 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"lAs" = (
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lAL" = (
 /obj/structure/flora/ausbushes/genericbush,
 /turf/unsimulated/wall/jungle,
@@ -58075,15 +58098,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"lDb" = (
+"lDd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/item/contraband/poster,
-/obj/item/contraband/poster,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/brown_platform,
+/obj/random/cluster/spiders/low_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "lDf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58092,11 +58110,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"lDi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lDk" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/small/bushb1,
@@ -59380,6 +59393,15 @@
 "lRa" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/fo)
+"lRb" = (
+/obj/structure/table/rack,
+/obj/structure/curtain/medical,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/organ/internal/optical_sensor,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lRi" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -59605,11 +59627,6 @@
 /obj/random/booze,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"lTA" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/autolathe/mechfab/loaded,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lTB" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -59804,6 +59821,10 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"lVc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/colony)
 "lVf" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -60101,16 +60122,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
-"lYm" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/costume/body_animals,
-/obj/random/costume/body_generic,
-/obj/random/costume/body_halloween,
-/obj/random/costume/head_animals,
-/obj/random/costume/head_generic,
-/obj/random/costume/head_halloween,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lYp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -60482,6 +60493,14 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
+"mcz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mcB" = (
 /obj/structure/bed/double/padded{
 	dir = 4
@@ -60592,12 +60611,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"mdG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mdJ" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/mineral,
@@ -60930,6 +60943,19 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"mgm" = (
+/obj/structure/closet/crate/secure/large,
+/obj/item/organ/internal/bone/head/robotic,
+/obj/item/organ/internal/bone/l_arm/robotic,
+/obj/item/organ/internal/bone/l_leg/robotic,
+/obj/item/organ/internal/bone/r_arm/robotic,
+/obj/item/organ/internal/bone/r_leg/robotic,
+/obj/item/organ/internal/bone/chest/robotic,
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "splatter2"
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mgn" = (
 /obj/item/modular_computer/console/preset/security/records{
 	dir = 1
@@ -60984,6 +61010,14 @@
 	icon_state = "9,11"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"mgB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/gun_normal/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mgE" = (
 /obj/structure/barricade,
 /obj/effect/decal/cleanable/dirt,
@@ -61312,11 +61346,6 @@
 "mjK" = (
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"mjO" = (
-/obj/structure/table/rack/shelf,
-/obj/item/modular_computer/wrist,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mjU" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -61583,6 +61612,10 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/main/stairwell)
+"mmD" = (
+/obj/item/contraband/poster/placed/generic/do_not_question,
+/turf/simulated/wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mmE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -61754,24 +61787,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
-"mom" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	dir = 4
-	},
-/obj/machinery/door/window/northright{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/barricade,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/crew_quarters/techshop)
 "mou" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -61945,6 +61960,13 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/captain/quarters)
+"mqj" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood,
+/obj/random/junkfood,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mqn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -62095,6 +62117,10 @@
 /obj/effect/window_lwall_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"mrN" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mrQ" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -62159,16 +62185,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"msz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/southleft,
-/obj/machinery/door/window/northleft,
-/obj/machinery/cash_register{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "msC" = (
 /obj/item/computer_hardware/hard_drive/portable/design/logistics,
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
@@ -62305,11 +62321,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
-"mtZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mul" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/beach/water/shallow,
@@ -62335,6 +62346,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
+"muB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/sofa{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "muD" = (
 /obj/random/spider_trap_burrowing/low_chance,
 /turf/simulated/floor/wood,
@@ -62599,14 +62617,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"mxe" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A2";
-	name = "D1-A2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mxg" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -62876,11 +62886,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
-"mAb" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mAi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/alt{
@@ -62987,11 +62992,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"mBb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/lowkeyrandom,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mBc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -63957,11 +63957,6 @@
 	icon_state = "11,3"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"mKu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mKx" = (
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
@@ -64372,14 +64367,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"mOv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/woodentable,
-/obj/item/tool/hammer,
-/obj/item/tool/screwdriver,
-/obj/item/tool/wirecutters/pliers,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mOx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64704,12 +64691,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"mRy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/cabinet,
-/obj/random/booze,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mRL" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "1,17"
@@ -64920,6 +64901,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/disposaldrop)
+"mTT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "mTV" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 1
@@ -65306,6 +65291,13 @@
 /obj/effect/floor_decal/industrial/box/white,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical)
+"mYh" = (
+/obj/structure/curtain/open/bed{
+	name = "Privacy curtain"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mYi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/small/busha1,
@@ -65315,10 +65307,6 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/bar)
-"mYl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mYn" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -65620,6 +65608,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/unsimulated/mineral,
 /area/asteroid/cave)
+"nar" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nau" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -66623,6 +66617,10 @@
 "nkI" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/dcave)
+"nkJ" = (
+/obj/item/contraband/poster/placed/generic/work_for_a_future,
+/turf/simulated/wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nkL" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -66902,6 +66900,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
+"nna" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nne" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -67177,6 +67182,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"npR" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/rig/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "npS" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/light_switch{
@@ -67292,6 +67303,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/cryo)
+"nra" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nrf" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/decal/cleanable/dirt,
@@ -67394,6 +67411,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
+"nsi" = (
+/obj/random/cluster/spiders,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nsj" = (
 /obj/random/material/low_chance,
 /turf/simulated/floor/wood/wild4,
@@ -67588,6 +67609,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"ntK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/northleft,
+/obj/machinery/door/window/southleft,
+/obj/machinery/cash_register{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ntP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/guestpass{
@@ -67675,17 +67706,6 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"nuz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/curtain/open,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nuC" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "3,7"
@@ -67858,6 +67878,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"nwa" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nwf" = (
 /obj/structure/low_wall,
 /obj/structure/barricade,
@@ -67934,9 +67962,10 @@
 /obj/machinery/door/airlock/vault,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"nwV" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/wall/r_wall,
+"nwR" = (
+/obj/structure/closet/cabinet,
+/obj/random/booze,
+/turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "nwX" = (
 /obj/effect/decal/cleanable/rubble,
@@ -68016,10 +68045,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/west)
-"nxO" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nxP" = (
 /turf/simulated/open,
 /area/nadezhda/engineering/engine_room)
@@ -68746,6 +68771,11 @@
 /obj/structure/railing,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
+"nDQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "nDR" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -68974,11 +69004,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/outside/inside_colony)
-"nGc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "nGh" = (
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
@@ -69037,6 +69062,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/rnd/research)
+"nGD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/revolver/handmade,
+/obj/item/clothing/accessory/duster/bloodred,
+/obj/item/ammo_magazine/ammobox/pistol_35/scrap,
+/turf/simulated/floor/plating,
+/area/colony)
 "nGP" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -69364,6 +69397,16 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/rnd/server)
+"nJS" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nJT" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/machinery/camera/network/security,
@@ -69885,13 +69928,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfacesec)
-"nPf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/lathe_disk/any_gun/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nPg" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
@@ -69916,6 +69952,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
+"nPF" = (
+/obj/effect/floor_decal/industrial/caution{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "nPH" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -70672,12 +70714,6 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/maintenance/surfacesec)
-"nWZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/structures,
-/obj/machinery/floor_light,
-/turf/simulated/floor/tiled/steel/bar_dance,
-/area/colony)
 "nXf" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "4,13"
@@ -71168,6 +71204,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
+"oaV" = (
+/obj/structure/closet/random_miscellaneous,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "obd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/filth,
@@ -71175,11 +71216,6 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
-"obe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "obk" = (
 /obj/structure/railing/grey{
 	dir = 1;
@@ -71642,6 +71678,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"ofT" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "ofU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -71763,9 +71816,7 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/disposaldrop)
 "ogV" = (
-/obj/structure/table/glass,
-/obj/structure/curtain/black,
-/turf/simulated/floor/wood/wild5,
+/turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "ohb" = (
 /obj/effect/decal/cleanable/solid_biomass,
@@ -71787,6 +71838,11 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/pool)
+"ohs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank/derelict,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ohx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -72026,6 +72082,10 @@
 /obj/structure/flora/small/busha3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"ojy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ojA" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -72101,6 +72161,14 @@
 /obj/item/bedsheet/medical,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/panic_room)
+"ojU" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A2";
+	name = "D1-A2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ojV" = (
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor/asteroid/dirt,
@@ -72138,11 +72206,6 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest)
-"okw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "okD" = (
 /obj/structure/flora/small/busha2,
 /obj/effect/decal/cleanable/dirt,
@@ -72443,6 +72506,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"onA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "onB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72766,6 +72834,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/gmaster)
+"oqT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oqZ" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/security/maingate/east)
@@ -73450,12 +73522,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/crew_quarters/bar)
-"oyc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/obj/random/cluster/spiders,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oyd" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -73949,12 +74015,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"oCi" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oCp" = (
 /obj/structure/closet/secure_closet/xenoarchaeologist,
 /obj/effect/decal/cleanable/dirt,
@@ -74037,6 +74097,13 @@
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"oDl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oDs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 8
@@ -74301,10 +74368,6 @@
 "oGo" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/vacantoffice2)
-"oGq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oGv" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -74396,13 +74459,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"oHi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/sofa{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "oHo" = (
 /obj/machinery/door/blast/regular/open{
 	id = "xenobio3";
@@ -75119,6 +75175,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"oOz" = (
+/obj/structure/table/reinforced,
+/obj/item/device/makeshift_centrifuge,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oOA" = (
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/tiled/dark/cyancorner,
@@ -75162,6 +75227,13 @@
 /obj/machinery/newscaster/directional/north,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/shield_generator)
+"oOM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/contraband/poster,
+/obj/item/contraband/poster,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oON" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1
@@ -76274,6 +76346,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/nadezhda/engineering/engine_room)
+"oZu" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/bodybags,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/random/circuitboard/low_chance,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oZy" = (
 /obj/machinery/mineral/processing_unit,
 /turf/simulated/floor/tiled/dark/cargo,
@@ -76469,6 +76550,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"pby" = (
+/obj/machinery/door/airlock/maintenance_cargo,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pbz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -76679,11 +76764,6 @@
 "pdW" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
-"pdX" = (
-/obj/structure/table/steel,
-/obj/random/powercell/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pdY" = (
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/nadezhda/engineering/atmos)
@@ -77012,15 +77092,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics)
-"phl" = (
-/obj/structure/table/reinforced,
-/obj/item/device/makeshift_centrifuge,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "phn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77034,11 +77105,6 @@
 "phr" = (
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
-"pht" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "phB" = (
 /obj/structure/bed/chair/sofa/teal/right{
 	dir = 4
@@ -77308,6 +77374,11 @@
 /obj/landmark/join/start/foreman,
 /turf/simulated/floor/carpet,
 /area/nadezhda/pros/foreman)
+"pjV" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pkg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77615,10 +77686,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"pnY" = (
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pnZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -77918,13 +77985,6 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/bridge)
-"pqT" = (
-/obj/machinery/vending/engivend,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pqZ" = (
 /obj/structure/table/gamblingtable,
 /obj/machinery/alarm{
@@ -78009,6 +78069,13 @@
 	},
 /turf/simulated/mineral,
 /area/nadezhda/outside/scave)
+"prM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/miningdock)
 "prT" = (
 /obj/structure/table/rack,
 /obj/item/storage/backpack/industrial{
@@ -78157,13 +78224,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"ptC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/item/contraband/poster,
-/obj/item/contraband/poster,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ptD" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
@@ -78765,6 +78825,12 @@
 /obj/item/modular_computer/laptop/preset/records,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
+"pze" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pzf" = (
 /obj/machinery/atmospherics/pipe/zpipe/up,
 /obj/structure/cable/green{
@@ -79300,10 +79366,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"pEz" = (
-/obj/item/contraband/poster/placed/generic/work_for_a_future,
-/turf/simulated/wall,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pEE" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light{
@@ -79492,11 +79554,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"pGH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pGM" = (
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
@@ -79604,14 +79661,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"pIg" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/welding,
-/obj/item/storage/belt,
-/obj/item/clothing/head/welding,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pIj" = (
 /obj/machinery/door/unpowered/simple/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -79657,11 +79706,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
-"pJb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/highsecurity,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pJd" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -79747,6 +79791,12 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
+"pJN" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/credits/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pJT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -79875,12 +79925,6 @@
 /obj/machinery/camera/network/cargo,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
-"pKH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pKS" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -80205,11 +80249,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/robotics)
-"pNH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet_maintloot,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pNJ" = (
 /obj/machinery/hologram/holopad{
 	name = "meeting room holopad two"
@@ -80368,6 +80407,10 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/plating/under,
 /area/colony)
+"pPe" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pPi" = (
 /obj/machinery/door/unpowered/simple/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -80392,6 +80435,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"pPm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pPp" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -80445,6 +80495,10 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"pPF" = (
+/obj/structure/janitorialcart,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pPK" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/box/red,
@@ -80920,6 +80974,12 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
+"pUl" = (
+/obj/structure/closet/wall_mounted/emcloset{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pUo" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -81525,11 +81585,6 @@
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/nadezhda/engineering/atmos)
-"pZz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/structures,
-/turf/simulated/floor/tiled/steel/bar_dance,
-/area/colony)
 "pZA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -81635,10 +81690,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/absolutism/skyyard)
-"qaU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qaV" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -81760,6 +81811,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/absolutism/vectorrooms)
+"qbP" = (
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qbQ" = (
 /obj/machinery/floor_light,
 /obj/structure/window/reinforced,
@@ -82035,6 +82089,11 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
+"qeM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "qeO" = (
 /obj/structure/railing{
 	dir = 8
@@ -82051,6 +82110,11 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/security/range)
+"qeT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qfc" = (
 /obj/structure/flora/big/rocks3,
 /obj/structure/flora/small/bushc2,
@@ -82393,11 +82457,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/east)
-"qiO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qiP" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/bushb2,
@@ -82485,10 +82544,6 @@
 	icon_state = "13,15"
 	},
 /area/nadezhda/hallway/surface/section1)
-"qjG" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/mineral,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qjP" = (
 /obj/structure/reagent_dispensers/fueltank/huge,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -82855,6 +82910,10 @@
 /obj/random/toy/plushie,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/server)
+"qmV" = (
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qmW" = (
 /obj/machinery/smartfridge/kitchen/church,
 /turf/simulated/floor/tiled/cafe,
@@ -82864,6 +82923,11 @@
 	icon_state = "9,11"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"qmZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qni" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -83141,6 +83205,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
+"qqd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/common_oddities/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qqj" = (
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -83198,15 +83270,17 @@
 /obj/random/ammo,
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"qqR" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/random/structures,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qqS" = (
 /obj/random/scrap/sparse_even/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
-"qqW" = (
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qra" = (
 /obj/structure/table/standard,
 /obj/random/cloth/armor/low_chance,
@@ -83443,6 +83517,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"qsQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qsS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -83615,6 +83694,16 @@
 /obj/random/mecha/low_chance,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/robotics)
+"quY" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "qvc" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/item/stack/rods,
@@ -83665,11 +83754,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
-"qvI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qvN" = (
 /obj/structure/flora/small/trailrocka4,
 /obj/effect/floor_decal/rust/mono_rusted3,
@@ -83864,6 +83948,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"qxt" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qxv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice,
@@ -84024,11 +84114,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/gmaster)
-"qyZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/spider_shadow_trap,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qzi" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -84137,6 +84222,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"qAG" = (
+/obj/item/contraband/poster/placed/generic/here_for_your_safety,
+/turf/simulated/wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qAJ" = (
 /obj/structure/shuttle_part/escpod{
 	icon_state = "escpodwall10";
@@ -85015,6 +85104,14 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
+"qIG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/tool/knife/butch,
+/obj/item/material/kitchen/rollingpin,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qIL" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -85358,10 +85455,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
-"qNe" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qNn" = (
 /obj/machinery/power/hydroelectric_control,
 /obj/structure/cable/yellow,
@@ -85539,10 +85632,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
-"qPi" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qPl" = (
 /obj/random/flora/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -85732,10 +85821,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
-"qRe" = (
-/obj/item/contraband/poster/placed/generic/do_not_question,
-/turf/simulated/wall,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qRg" = (
 /obj/item/storage/box/costume/gnome,
 /obj/structure/table/steel,
@@ -85863,6 +85948,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters/bar)
+"qSw" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qSC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -85871,12 +85960,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
-"qSL" = (
-/obj/structure/closet/wall_mounted/emcloset{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qSM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -85995,6 +86078,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"qTX" = (
+/obj/machinery/mech_recharger,
+/obj/random/mecha/low_chance,
+/turf/simulated/floor/plating,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qTZ" = (
 /obj/random/closet_maintloot/low_chance,
 /turf/simulated/floor/tiled/techmaint,
@@ -86253,6 +86341,10 @@
 /obj/random/mob/roaches/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfacenorth)
+"qXb" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qXc" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -86532,9 +86624,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"qZS" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qZT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -86899,11 +86988,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
-"reu" = (
-/obj/structure/bonfire,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "rev" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Cargo";
@@ -87455,6 +87539,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics)
+"riF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/contraband/poster,
+/obj/item/contraband/poster,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "riH" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -87580,11 +87674,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/disposaldrop)
-"rkk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/custom/onestar,
-/turf/simulated/floor/tiled/steel/bar_light,
-/area/colony)
 "rkw" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor,
@@ -87851,19 +87940,6 @@
 /obj/random/flora/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"rne" = (
-/obj/machinery/mech_recharger,
-/obj/random/mecha/low_chance,
-/turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"rnj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/contraband/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rns" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1;
@@ -87909,6 +87985,11 @@
 /obj/random/ammo/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
+"rnN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rnP" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -88240,6 +88321,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/security/maingate)
+"rrQ" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rrT" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -88324,13 +88410,6 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/forest)
-"rtb" = (
-/obj/structure/table/reinforced,
-/obj/item/device/makeshift_electrolyser,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rtf" = (
 /obj/random/structures,
 /turf/simulated/floor/tiled/techmaint,
@@ -89491,13 +89570,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
-"rEW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rFc" = (
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -89579,6 +89651,9 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"rFV" = (
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rFX" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "10,1"
@@ -89599,12 +89674,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
-"rGl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rGp" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -90030,10 +90099,6 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/turret_protected/ai)
-"rLc" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rLd" = (
 /obj/structure/table/standard,
 /obj/machinery/centrifuge{
@@ -90360,10 +90425,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"rNs" = (
-/obj/random/cluster/termite_no_despawn_hoard,
-/turf/simulated/mineral,
-/area/colony)
 "rNt" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/small/grassb4,
@@ -90476,6 +90537,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"rOG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/structures,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/colony)
 "rON" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -90576,10 +90642,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
-"rPW" = (
-/obj/structure/reagent_dispensers/bidon,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rQb" = (
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/machinery/door/window/westright,
@@ -90621,6 +90683,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/engineering/atmos/storage)
+"rQA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rQC" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -90915,6 +90982,13 @@
 /obj/structure/barricade,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"rTY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rUb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -91055,6 +91129,18 @@
 /obj/effect/step_trigger/surface_to_forest_1_B,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/forest)
+"rVK" = (
+/obj/structure/table/rack,
+/obj/structure/curtain/medical,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/organ/external/robotic/junktech/r_leg,
+/obj/item/organ/external/robotic/junktech/r_arm,
+/obj/item/organ/external/robotic/junktech/l_leg,
+/obj/item/organ/external/robotic/junktech/l_arm,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rVL" = (
 /obj/structure/table/rack/shelf,
 /obj/item/rig/techno/equipped,
@@ -91295,11 +91381,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
-"rXz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/structures,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rXF" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -91542,11 +91623,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
-"rZy" = (
-/obj/structure/table/standard,
-/obj/item/storage/pill_bottle/tramadol,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rZB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -92109,11 +92185,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"seE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "seL" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -92227,10 +92298,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"sgx" = (
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sgA" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -92357,6 +92424,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/outside/inside_colony)
+"shD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "shR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -92735,11 +92806,6 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/surface/section1)
-"smm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "smn" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/closet/crate,
@@ -93044,6 +93110,12 @@
 	},
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/security/maingate/east)
+"soJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/double/padded,
+/obj/random/furniture/bedsheetdouble,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "soT" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -93287,11 +93359,6 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm3)
-"sqT" = (
-/obj/structure/closet/cabinet,
-/obj/random/booze,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "srf" = (
 /obj/machinery/light{
 	dir = 4
@@ -94661,6 +94728,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/captain/quarters)
+"sDE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet_maintloot,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sDP" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -94684,6 +94756,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
+"sDU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/structures,
+/obj/machinery/floor_light,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/colony)
 "sDV" = (
 /obj/structure/invislight,
 /turf/unsimulated/mineral,
@@ -94760,6 +94838,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/techshop)
+"sFd" = (
+/obj/random/structures,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sFe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -95007,6 +95089,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/medical/psych)
+"sHQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sHW" = (
 /obj/structure/railing{
 	dir = 8
@@ -95084,13 +95171,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"sIN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/plating,
-/area/colony)
 "sIQ" = (
 /obj/structure/table/reinforced,
 /obj/random/rig_module/low_chance,
@@ -95120,6 +95200,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"sJc" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/surgery,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sJf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -96133,6 +96218,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
+"sUi" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/roach/roachling,
+/turf/simulated/floor/plating,
+/area/colony)
 "sUr" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -96342,9 +96432,8 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sXe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor/tiled/white,
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "sXj" = (
 /obj/structure/flora/small/trailrockb2,
@@ -96617,7 +96706,9 @@
 	name = "Residential District Maintenance"
 	})
 "sZK" = (
-/turf/simulated/floor/tiled/dark/gray_perforated,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "sZL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -96717,6 +96808,13 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
+"taB" = (
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/common_oddities/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "taE" = (
 /obj/structure/table/bench/steel,
 /obj/effect/decal/cleanable/dirt,
@@ -96917,12 +97015,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"tcK" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil/random,
-/obj/item/device/robotanalyzer,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tdf" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "8,20"
@@ -97296,13 +97388,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/command/tcommsat/computer)
-"thJ" = (
-/obj/structure/table/woodentable,
-/obj/random/gun_parts/low,
-/obj/random/ammo,
-/obj/random/gun_parts/low,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "thK" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -97609,6 +97694,11 @@
 /obj/random/pack/rare/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"tkU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tkV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -97655,17 +97745,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/turret_protected/ai_upload)
-"tln" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet/employment,
-/obj/random/credits/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"tlo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/eastright,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tls" = (
 /obj/machinery/telecomms/server/presets/unused,
 /turf/simulated/floor/bluegrid{
@@ -97757,6 +97836,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"tlT" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tma" = (
 /obj/structure/flora/rock/variant1,
 /turf/simulated/floor/asteroid/grass,
@@ -97870,6 +97953,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"tnR" = (
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tnX" = (
 /obj/structure/barricade,
 /obj/effect/decal/cleanable/dirt,
@@ -98958,14 +99045,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"tyQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall_mounted{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/flour,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tyY" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
@@ -99104,14 +99183,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
-"tAc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tAg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -99173,16 +99244,6 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"tAW" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tAY" = (
 /obj/item/stool/padded,
 /obj/effect/floor_decal/industrial/warningred{
@@ -99389,6 +99450,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"tDc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tDe" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/turcarpet,
@@ -99603,6 +99671,9 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"tFg" = (
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tFm" = (
 /obj/machinery/porta_turret,
 /turf/simulated/floor/plating/under,
@@ -99617,11 +99688,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
-"tFp" = (
-/obj/machinery/door/airlock/maintenance_cargo,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tFu" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -99973,13 +100039,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"tII" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tIK" = (
 /obj/item/device/lighting/toggleable/lantern{
 	on = 1
@@ -100257,12 +100316,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"tLs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tLv" = (
 /obj/structure/table/standard,
 /obj/item/storage/briefcase/inflatable,
@@ -100367,10 +100420,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
-"tMs" = (
-/obj/random/structures,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tMu" = (
 /obj/structure/noticeboard/anomaly{
 	pixel_x = 31
@@ -100459,6 +100508,12 @@
 /obj/item/rig/combat/knight/equipped,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/prime)
+"tNg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/marble,
+/obj/item/storage/bag/produce,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tNh" = (
 /obj/structure/salvageable/computer,
 /obj/structure/table/steel,
@@ -100533,6 +100588,10 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/forest)
+"tNH" = (
+/obj/random/cluster/termite_no_despawn_hoard,
+/turf/simulated/mineral,
+/area/colony)
 "tNJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera/network/research{
@@ -100988,11 +101047,6 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/captain)
-"tRf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/spiders/low_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tRh" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -101006,6 +101060,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"tRB" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tRD" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/sign/faction/neotheology{
@@ -101014,12 +101073,6 @@
 /obj/machinery/camera/network/church,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"tRF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/random/junkfood/rotten,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tRG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/porta_turret/gate,
@@ -101291,6 +101344,12 @@
 /obj/structure/flora/big/bush1,
 /turf/simulated/wall/wood_old,
 /area/nadezhda/outside/forest)
+"tUp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "tUr" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
@@ -101365,6 +101424,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
+"tVc" = (
+/obj/structure/bonfire,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "tVg" = (
 /mob/living/simple_animal/frog,
 /turf/simulated/floor/beach/water/jungle,
@@ -101402,13 +101466,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"tVD" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tVO" = (
 /obj/effect/window_lwall_spawn,
 /obj/structure/flora/big/bush3{
@@ -102214,10 +102271,6 @@
 	icon_state = "12,3"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"udl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "udt" = (
 /obj/structure/table/bench/padded,
 /obj/structure/disposalpipe/segment{
@@ -102266,6 +102319,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"udU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "udV" = (
 /obj/effect/floor_decal/industrial/danger,
 /turf/simulated/floor/reinforced,
@@ -102762,6 +102822,9 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/detectives_office)
+"uhX" = (
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uhY" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -103842,11 +103905,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"utd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ute" = (
 /obj/machinery/button/remote/airlock{
 	id = "D4A";
@@ -104115,9 +104173,6 @@
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"uwr" = (
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uwB" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "15,2"
@@ -104136,6 +104191,11 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
+"uwQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uxd" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -104626,13 +104686,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
-"uCu" = (
-/obj/structure/closet/wall_mounted{
-	pixel_x = -32
-	},
-/obj/item/storage/box/drinkingglasses,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uCz" = (
 /obj/effect/spider/stickyweb,
 /obj/machinery/light/small{
@@ -104640,6 +104693,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"uCE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/eastright,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uCJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -104828,12 +104886,6 @@
 	opacity = 0
 	},
 /area/shuttle/rocinante_shuttle_area)
-"uEE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uEF" = (
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
@@ -105138,10 +105190,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfaceeast)
-"uHJ" = (
-/obj/random/cluster/spiders,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uHQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -105384,16 +105432,12 @@
 	name = "Residential District Maintenance"
 	})
 "uJY" = (
-/obj/structure/table/rack,
-/obj/structure/curtain/medical,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/organ/external/robotic/junktech/r_leg,
-/obj/item/organ/external/robotic/junktech/r_arm,
-/obj/item/organ/external/robotic/junktech/l_leg,
-/obj/item/organ/external/robotic/junktech/l_arm,
-/turf/simulated/floor/tiled/steel/gray_perforated,
+/obj/random/booze,
+/obj/random/junkfood/onlypizza,
+/obj/random/junkfood/onlyburger,
+/obj/random/junkfood,
+/obj/structure/closet/secure_closet/freezer,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "uJZ" = (
 /obj/structure/multiz/stairs/active,
@@ -105476,6 +105520,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"uKX" = (
+/mob/living/bot/cleanbot,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uLc" = (
 /obj/machinery/door/airlock/maintenance_security{
 	req_access = list(1)
@@ -105964,14 +106012,6 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/side/f2section1)
-"uOn" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uOp" = (
 /obj/structure/closet/l3closet,
 /turf/simulated/floor/tiled/white,
@@ -106815,6 +106855,12 @@
 "uWg" = (
 /turf/simulated/floor/carpet,
 /area/nadezhda/crew_quarters/dorm1)
+"uWi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uWm" = (
 /obj/machinery/light{
 	dir = 8
@@ -107034,6 +107080,11 @@
 	},
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"uYk" = (
+/obj/random/cluster/roaches/lower_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uYn" = (
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/genetics)
@@ -107364,10 +107415,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/rnd/xenobiology)
-"vcf" = (
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vch" = (
 /turf/unsimulated/mask,
 /area/colony)
@@ -107695,6 +107742,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
+"vfN" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/autolathe/mechfab/loaded,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vfQ" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -108228,10 +108280,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"vkp" = (
+/obj/structure/table/bench/glass,
+/obj/structure/curtain/red,
+/obj/effect/decal/cleanable/vomit,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vkB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"vkU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vkX" = (
 /obj/structure/curtain/open/privacy,
 /obj/machinery/camera/network/medbay{
@@ -108361,6 +108424,13 @@
 "vlP" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/pros/prep)
+"vlV" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A20";
+	name = "D1-A20"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vlW" = (
 /turf/simulated/shuttle/wall/escpod,
 /area/nadezhda/crew_quarters/sleep/bedrooms)
@@ -108614,11 +108684,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating,
 /area/nadezhda/security/maingate)
-"vop" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "voq" = (
 /obj/item/modular_computer/console/preset/engineering{
 	dir = 8
@@ -108657,12 +108722,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/cbo)
-"voM" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/oddity/common/paper_bundle,
-/obj/machinery/door/window/eastright,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "voT" = (
 /obj/random/material_resources/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -109086,14 +109145,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"vtv" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/makeshift_grinder,
-/obj/effect/decal/cleanable/cobweb{
-	dir = 4
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vtx" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -109186,13 +109237,6 @@
 /obj/random/material,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
-"vul" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vun" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha1,
@@ -109506,6 +109550,12 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"vwU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/glass,
+/obj/structure/curtain/red,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vxh" = (
 /obj/machinery/vending/boozeomat{
 	req_access = list(25)
@@ -109825,6 +109875,11 @@
 /obj/structure/sign/department/medbay,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/reception)
+"vBH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/open/shower/closed,
+/turf/simulated/floor/plating,
+/area/colony)
 "vBK" = (
 /obj/machinery/light,
 /obj/random/spider_trap/low_chance,
@@ -110092,6 +110147,11 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"vEc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/structures,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vEf" = (
 /obj/structure/sign/directions/room4,
 /turf/simulated/wall,
@@ -110117,13 +110177,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
-"vEv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/wood{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vEE" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -110211,11 +110264,6 @@
 /obj/item/storage/box/syringes,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
-"vFd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vFf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -110278,12 +110326,6 @@
 /obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/outside/pond)
-"vFS" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vFX" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -110383,10 +110425,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/disposaldrop)
-"vHb" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vHj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -111513,11 +111551,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
-"vRR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain/open/shower/closed,
-/turf/simulated/floor/plating,
-/area/colony)
 "vRS" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,18"
@@ -111960,12 +111993,6 @@
 /obj/structure/flora/small/trailrocka1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"vVc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "vVe" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -112247,6 +112274,12 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
+"vXF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "vXJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -112280,11 +112313,6 @@
 /obj/structure/sign/painting/paintingtable,
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm2)
-"vXR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vXX" = (
 /obj/item/modular_computer/console/preset/engineering{
 	dir = 1
@@ -112809,11 +112837,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"wdq" = (
-/obj/item/reagent_containers/syringe/drugs,
-/obj/item/reagent_containers/pill/floorpill,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wdv" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -113119,6 +113142,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
+"wgL" = (
+/obj/machinery/door/airlock/maintenance_cargo,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wgR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -113382,6 +113410,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"wjq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/termite_no_despawn/lower_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wjw" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -113460,6 +113493,10 @@
 /obj/random/mob/excelsior,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"wkn" = (
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wkp" = (
 /obj/structure/table/bench/steel,
 /obj/effect/spider/stickyweb,
@@ -113525,11 +113562,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"wkJ" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wlg" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -113828,9 +113860,8 @@
 /area/nadezhda/outside/forest)
 "wnX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/double/padded,
-/obj/random/furniture/bedsheetdouble,
-/turf/simulated/floor/tiled/white,
+/obj/structure/curtain/red,
+/turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "wob" = (
 /obj/structure/barricade,
@@ -114418,13 +114449,6 @@
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
-"wrV" = (
-/obj/machinery/door/window/eastright,
-/obj/structure/curtain/medical,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wsa" = (
 /obj/item/clothing/suit/gorka/toggle/gorka/crew_o{
 	name = "Digger's gorka jacket";
@@ -114466,6 +114490,14 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm1)
+"wsm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "wsn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -114552,10 +114584,6 @@
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"wtP" = (
-/obj/random/cluster/slimes,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wtQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -114572,14 +114600,6 @@
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"wtX" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A3";
-	name = "D1-A3"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wub" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/big/bush3,
@@ -114635,6 +114655,11 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"wuG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wuK" = (
 /obj/machinery/power/eotp,
 /obj/structure/invislight,
@@ -114925,11 +114950,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"wxY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wyg" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 5
@@ -115161,6 +115181,11 @@
 	},
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
+"wAi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wAk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -115226,14 +115251,6 @@
 /obj/machinery/camera/network/colony_surface,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
-"wBA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/revolver/handmade,
-/obj/item/clothing/accessory/duster/bloodred,
-/obj/item/ammo_magazine/ammobox/pistol_35/scrap,
-/turf/simulated/floor/plating,
-/area/colony)
 "wBD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -115378,14 +115395,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
-"wCL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/random/scrap,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wCM" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/beer,
@@ -115815,10 +115824,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
-"wHI" = (
+"wHA" = (
+/obj/structure/boulder,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_cargo,
-/turf/simulated/floor/tiled/steel/brown_platform,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "wHK" = (
 /obj/structure/cable/green{
@@ -116545,17 +116555,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"wPt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/eastright,
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -116577,6 +116576,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/outside/inside_colony)
+"wPy" = (
+/obj/machinery/door/window/northleft,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wPA" = (
 /obj/structure/closet/acolyte,
 /obj/machinery/alarm{
@@ -116690,11 +116694,6 @@
 /obj/structure/sign/department/prison,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/sechall)
-"wQE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/plating/under,
-/area/colony)
 "wQJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -116962,10 +116961,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
-"wTQ" = (
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wTT" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 9
@@ -117293,13 +117288,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/bar)
-"wWD" = (
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/contraband/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wWI" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -117501,6 +117489,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"wZg" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/material_resources,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wZp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -117772,14 +117766,6 @@
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"xcz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/tool/knife/butch,
-/obj/item/material/kitchen/rollingpin,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xcG" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -117957,14 +117943,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"xfp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "xfu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -118239,11 +118217,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"xhV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xia" = (
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -118267,6 +118240,11 @@
 /obj/random/pack/rare/low_chance,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"xik" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xix" = (
 /obj/item/stool,
 /obj/machinery/light,
@@ -118282,11 +118260,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
-"xiD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xiO" = (
 /obj/machinery/door/airlock/external{
 	name = "Terminal Lounge"
@@ -118307,13 +118280,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
-"xiX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/miningdock)
 "xiY" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -118328,6 +118294,12 @@
 /obj/random/flora/small_jungle_tree,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"xjg" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/oddity/common/paper_bundle,
+/obj/machinery/door/window/eastright,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xjh" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/firealarm{
@@ -118520,6 +118492,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"xky" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/lathe_disk/any_gun/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xkD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -118897,12 +118876,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
-"xox" = (
-/obj/machinery/door/airlock/maintenance_interior{
-	name = "Hotel Desk"
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xoC" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/rock,
@@ -119276,6 +119249,13 @@
 /obj/item/trash/material/circuit,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
+"xsk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xss" = (
 /obj/machinery/light{
 	dir = 8
@@ -119384,6 +119364,12 @@
 /obj/item/clothing/head/helmet/bulletproof/ironhammer_thermal,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"xtk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/mecha_equipment/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xty" = (
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -119495,6 +119481,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"xun" = (
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xur" = (
 /obj/structure/table/glass,
 /obj/effect/spider/stickyweb,
@@ -119770,10 +119761,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
-"xwV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xwW" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -119997,12 +119984,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/servist)
-"xzq" = (
-/obj/machinery/door/window/westleft,
-/obj/machinery/door/window/eastleft,
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xzr" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 4;
@@ -120157,6 +120138,14 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
+"xAR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xAU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -120305,6 +120294,14 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
+"xBH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/woodentable,
+/obj/item/tool/hammer,
+/obj/item/tool/screwdriver,
+/obj/item/tool/wirecutters/pliers,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xBJ" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -121128,6 +121125,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/gmaster)
+"xJF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xJG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -121192,10 +121193,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"xKp" = (
-/obj/machinery/door/airlock/maintenance_cargo,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xKv" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -121443,6 +121440,11 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/crew_quarters/bar)
+"xMw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xMH" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood,
@@ -121475,11 +121477,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"xMY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/loading/red,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xNb" = (
 /obj/machinery/light{
 	dir = 1
@@ -121509,6 +121506,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"xNq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xNt" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -121654,17 +121656,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/surfaceeast)
-"xPG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/marble,
-/obj/item/storage/bag/produce,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"xPM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xPO" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
@@ -122512,6 +122503,14 @@
 	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/nadezhda/crew_quarters/dorm1)
+"xYr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/woodentable,
+/obj/random/gun_parts/low,
+/obj/random/ammo,
+/obj/random/gun_parts/low,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xYw" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible,
 /obj/structure/bed/chair/wood{
@@ -122938,11 +122937,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/bridge)
-"ycm" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ycn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -123149,6 +123143,11 @@
 /obj/effect/floor_decal/spline/wood,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"yeK" = (
+/obj/structure/bed,
+/obj/item/handcuffs/fuzzy,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "yeM" = (
 /obj/machinery/door/window/northleft{
 	dir = 4
@@ -123339,6 +123338,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/detectives_office)
+"yhm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "yhv" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/structure/curtain/open,
@@ -123486,10 +123490,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
-"yiM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/colony)
 "yiS" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -150935,7 +150935,7 @@ kUx
 kUx
 kUx
 aFa
-xiX
+prM
 qxo
 hax
 nzT
@@ -183608,9 +183608,9 @@ cvn
 mjZ
 vmZ
 hSX
-obe
-fuz
-bmf
+nDQ
+glG
+quY
 sCN
 sCN
 sCN
@@ -183629,9 +183629,9 @@ aOb
 lif
 sRU
 sRU
-obe
-fuz
-aXU
+nDQ
+glG
+tUp
 cCy
 nBz
 cxN
@@ -184241,7 +184241,7 @@ cvc
 dJa
 cCy
 cCy
-mom
+gZY
 cCy
 cCy
 nCK
@@ -190081,7 +190081,7 @@ whU
 eMU
 whU
 whU
-dtY
+hKJ
 nUF
 wnJ
 tIQ
@@ -190283,7 +190283,7 @@ iBR
 nVZ
 iBR
 iBR
-hRi
+ofT
 iBR
 iBR
 iBR
@@ -190485,7 +190485,7 @@ whU
 qwB
 whU
 whU
-xfp
+wsm
 bbM
 rkA
 ilF
@@ -194493,12 +194493,12 @@ cZb
 cZb
 cZb
 wEB
-lTA
-xMY
-pIg
-fEo
-lrl
-smm
+vfN
+hSK
+hyS
+cej
+qqR
+gXz
 wEB
 wEB
 wEB
@@ -194506,8 +194506,8 @@ wEB
 wEB
 tTB
 vJX
-bje
-bje
+wHA
+wHA
 wEB
 wEB
 wEB
@@ -194695,12 +194695,12 @@ cZb
 cZb
 cZb
 wEB
-tcK
-gao
-mYl
-uOn
-uwr
-mYl
+ltI
+wAi
+aVb
+nwa
+tFg
+aVb
 wEB
 iKp
 jWI
@@ -194709,9 +194709,9 @@ wEB
 pOR
 avz
 rsN
-bje
+wHA
 wiO
-wkJ
+fQJ
 wEB
 cZb
 cZb
@@ -194897,12 +194897,12 @@ wEB
 wEB
 wEB
 wEB
-eWs
-uwr
-mYl
-mdG
-eMA
-qNe
+aRd
+tFg
+aVb
+gel
+tDc
+qXb
 wEB
 iVg
 nXu
@@ -194911,9 +194911,9 @@ wEB
 snr
 kSY
 wEB
-wkJ
-wkJ
-rGl
+fQJ
+fQJ
+bkU
 wEB
 cZb
 cZb
@@ -195091,20 +195091,20 @@ cZb
 cZb
 cZb
 wEB
-gkP
-oGq
-dtc
-dtc
-mjO
+mqj
+gbE
+uWi
+uWi
+fMK
 wEB
-eVk
-rXz
-uwr
-liO
-jcR
-liO
-cID
-rne
+sFd
+vEc
+tFg
+yhm
+bzJ
+yhm
+csL
+qTX
 wEB
 lVS
 lVS
@@ -195113,9 +195113,9 @@ snr
 pQH
 pQH
 wEB
-nPf
-mBb
-tLs
+xky
+fBG
+nra
 wEB
 cZb
 cZb
@@ -195293,20 +195293,20 @@ cZb
 cZb
 cZb
 wEB
-hMa
-jxX
-oyc
-oGq
-oGq
+iAM
+cWE
+jFG
+gbE
+gbE
 wEB
-mYl
-uwr
-mYl
-uwr
-mYl
-mdG
-mYl
-uwr
+aVb
+tFg
+aVb
+tFg
+aVb
+gel
+aVb
+tFg
 wEB
 lVS
 lVS
@@ -195315,9 +195315,9 @@ lTo
 qBj
 snr
 wEB
-sXe
-eyb
-hYy
+aEQ
+wjq
+tkU
 wEB
 cZb
 cZb
@@ -195384,7 +195384,7 @@ kyK
 diB
 kyK
 kyK
-gnV
+nPF
 kyK
 fbS
 sAU
@@ -195495,22 +195495,22 @@ cZb
 cZb
 cZb
 wEB
-ghz
-oGq
-fuS
-qvI
-tAW
+npR
+gbE
+sHQ
+czi
+aSo
 wEB
-mYl
-mYl
-fGZ
-tMs
-luJ
-iRR
-hWP
-pqT
+aVb
+aVb
+tnR
+hUx
+oZu
+kOD
+gOn
+bCi
 wEB
-bje
+wHA
 wiO
 wEB
 wEB
@@ -195518,13 +195518,13 @@ wEB
 wEB
 wEB
 wEB
-cxY
+vlV
 wEB
 wEB
-wkJ
-wkJ
-wkJ
-wkJ
+fQJ
+fQJ
+fQJ
+fQJ
 cZb
 cZb
 cZb
@@ -195697,36 +195697,36 @@ cZb
 cZb
 cZb
 wEB
-eFR
-oGq
-aOD
-tVD
-voM
+dPB
+gbE
+cre
+fvM
+xjg
 wEB
-kKg
-wEB
-wEB
+iKY
 wEB
 wEB
 wEB
 wEB
 wEB
 wEB
-wkJ
-wkJ
-vFd
+wEB
+wEB
+fQJ
+fQJ
+awK
 pQH
 pQH
-hqj
+mcz
 pQH
 snr
-qZS
+ogV
 snr
 pQH
-chH
+oDl
 snr
-wkJ
-wkJ
+fQJ
+fQJ
 cZb
 cZb
 cZb
@@ -195899,34 +195899,34 @@ cZb
 cZb
 cZb
 wEB
-auH
-oGq
-oGq
-lxh
-qyZ
-gVZ
+wZg
+gbE
+gbE
+dDh
+iii
+qmZ
 snr
-chH
-wkJ
-fqa
-wkJ
-qPi
+oDl
+fQJ
+jBL
+fQJ
+pPe
 lVS
-dHH
-gwX
+dMH
+uhX
 lVS
-qPi
+pPe
 wEB
 wEB
-gUa
-wEB
-wEB
-wEB
-mxe
+dGy
 wEB
 wEB
 wEB
-wtX
+ojU
+wEB
+wEB
+wEB
+apL
 wEB
 wEB
 cZb
@@ -196101,35 +196101,35 @@ cZb
 cZb
 cZb
 wEB
-cML
-oGq
-dtc
-jxX
-oHi
+pJN
+gbE
+uWi
+cWE
+muB
 wEB
-fff
-wEB
-wEB
+iWs
 wEB
 wEB
 wEB
 wEB
 wEB
 wEB
-qSL
-fCd
 wEB
-sXe
-xwV
-ddv
 wEB
-sXe
-xwV
-ddv
+pUl
+udU
 wEB
-sXe
-xwV
-ddv
+aEQ
+iua
+uJY
+wEB
+aEQ
+iua
+uJY
+wEB
+aEQ
+iua
+uJY
 wEB
 cZb
 cZb
@@ -196303,35 +196303,35 @@ cZb
 cZb
 cZb
 wEB
-lYm
-oGq
-adi
-oGq
-oHi
-wEB
-sZK
-sZK
-vFS
-sZK
-sZK
-wEB
-iIr
-gvZ
-xox
-llr
-hGc
-wEB
+hkZ
 gbE
-vcf
-pNH
+fEs
+gbE
+muB
 wEB
-pdX
-tRf
-vop
+qbP
+qbP
+qxt
+qbP
+qbP
 wEB
-fJK
-xwV
-cqt
+oaV
+oqT
+iBU
+ayK
+iRI
+wEB
+xtk
+tlT
+sDE
+wEB
+hvL
+lDd
+onA
+wEB
+jhU
+iua
+dld
 wEB
 cZb
 cZb
@@ -196505,35 +196505,35 @@ cZb
 cZb
 cZb
 wEB
-dcw
-oGq
-dtc
-oGq
-rLc
+mgm
+gbE
+uWi
+gbE
+sXe
 wEB
-kAU
-pht
-rPW
-jRw
-qqW
+pPF
+pjV
+jcN
+uKX
+xun
 wEB
-iSs
-iEw
+dlb
+dbk
 wEB
-vul
+rTY
 lVS
 wEB
-wPt
-xwV
-oCi
+hbA
+iua
+aEr
 wEB
-wPt
-xwV
-blH
+hbA
+iua
+cvR
 wEB
-wPt
-wtP
-blH
+hbA
+gFb
+cvR
 wEB
 cZb
 cZb
@@ -196710,7 +196710,7 @@ wEB
 wEB
 wEB
 sju
-cot
+lxI
 sju
 sju
 sju
@@ -196719,23 +196719,23 @@ wEB
 wEB
 wEB
 wEB
-ire
-jjj
-hnL
-end
-gwX
+bwx
+cdR
+jAw
+bmn
+uhX
 wEB
-nuz
-cnP
-wnX
+hxq
+grv
+soJ
 wEB
-nuz
-cnP
-wnX
+hxq
+grv
+soJ
 wEB
-lmg
-cnP
-wnX
+nJS
+grv
+soJ
 wEB
 cZb
 cZb
@@ -196912,19 +196912,19 @@ cZb
 cZb
 cZb
 sju
-qaU
-gFO
-rEW
-wWD
+ojy
+jtn
+eDb
+jSc
 sju
-iVc
-wBA
-reu
+sUi
+nGD
+tVc
 wEB
-iLb
-ebA
+fhk
+kfo
 wEB
-knW
+sZK
 lVS
 wEB
 wEB
@@ -197114,34 +197114,34 @@ cZb
 cZb
 cZb
 sju
-qaU
-bNu
-bNu
-qaU
+ojy
+jzu
+jzu
+ojy
 sju
-nGc
-sIN
-gmj
+eei
+jsR
+gDI
 wEB
 wEB
 wEB
 wEB
 lVS
-gwX
-ogV
-uCu
-vtv
+uhX
+jWj
+koW
+aZN
 wEB
-xcz
-hnh
-lyw
+qIG
+gAK
+bYt
 wEB
-rZy
-bjV
-goH
+bGy
+sJc
+dcQ
 wEB
-kCy
-pZz
+cDH
+rOG
 kUx
 jZv
 arM
@@ -197316,34 +197316,34 @@ cZb
 cZb
 cZb
 sju
-qaU
-rnj
-aSi
-cxM
+ojy
+cEi
+mgB
+qqd
 sju
-frc
-nGc
-vVc
-frc
-nGc
-nGc
-vRR
-gwX
+mTT
+eei
+vXF
+mTT
+eei
+eei
+vBH
+uhX
 lVS
-ogV
-wTQ
-rtb
+jWj
+gJH
+dxu
 wEB
-tyQ
-okw
-bsB
+lue
+xik
+cFQ
 wEB
-jgK
-dXl
-uEE
+bhN
+uYk
+cVQ
 wEB
-rkk
-nWZ
+fBf
+sDU
 kUx
 jZv
 arM
@@ -197518,10 +197518,10 @@ cZb
 cZb
 cZb
 sju
-qaU
-bNu
-lDi
-bJW
+ojy
+jzu
+rQA
+ccy
 sju
 sju
 sju
@@ -197532,20 +197532,20 @@ sju
 sju
 lVS
 lVS
-coe
-bXY
-phl
+wPy
+lAs
+oOz
 wEB
-tRF
-tRF
-tlo
+jVs
+jVs
+uCE
 wEB
-pGH
-pGH
-ezk
+kYI
+kYI
+rFV
 wEB
-yiM
-pZz
+lVc
+rOG
 kUx
 jZv
 jZv
@@ -197720,33 +197720,33 @@ cZb
 cZb
 cZb
 sju
-aSi
-rEW
-rEW
-qaU
+mgB
+eDb
+eDb
+ojy
 sju
-tln
-gkb
-msz
-ePp
-hZi
-tII
-fTh
-utd
-jRH
+kZQ
+qSw
+ace
+gir
+dEh
+pPm
+kAt
+wuG
+eGG
 wEB
 wEB
 wEB
 wEB
-lpn
-jjK
-hVv
+vwU
+vkp
+wnX
 wEB
-wrV
-hsP
-uJY
+csw
+lRb
+rVK
 wEB
-sgx
+qmV
 wEB
 kUx
 cZb
@@ -197922,20 +197922,20 @@ cZb
 cZb
 cZb
 sju
-qaU
-qaU
-qaU
-bJW
+ojy
+ojy
+ojy
+ccy
 sju
-pKH
-qaU
-mKu
-kGh
-eEH
-idU
+dgC
+ojy
+jZw
+crC
+nar
+llo
 sju
-wkJ
-qPi
+fQJ
+pPe
 lVS
 lVS
 lVS
@@ -197943,14 +197943,14 @@ lVS
 lVS
 lVS
 lVS
-kof
-qiO
-gwX
+dJo
+aas
+uhX
 lVS
-llr
+ayK
 lVS
-bOd
-wQE
+uwQ
+qeM
 cZb
 cZb
 cZb
@@ -198124,31 +198124,31 @@ cZb
 cZb
 cZb
 sju
-wWD
-kXh
-rnj
-qaU
-pJb
-bNu
-jtC
-cHv
-hZi
-ePp
-tII
-nwV
-wkJ
-wkJ
+jSc
+taB
+cEi
+ojy
+bjV
+jzu
+xNq
+ntK
+dEh
+gir
+pPm
+fry
+fQJ
+fQJ
 wEB
-vHb
-wEB
-wEB
-dNB
+ciT
 wEB
 wEB
-iWU
+mYh
 wEB
 wEB
-iWU
+div
+wEB
+wEB
+div
 wEB
 wEB
 wEB
@@ -198338,20 +198338,20 @@ sju
 sju
 sju
 sju
-ycm
-bDI
+rrQ
+hXV
 wEB
-fKk
-mAb
+ecD
+tRB
 wEB
-bPB
-mRy
+cAl
+iGJ
 wEB
-jns
-sqT
+rnN
+nwR
 wEB
-jns
-mRy
+rnN
+iGJ
 wEB
 cZb
 cZb
@@ -198527,33 +198527,33 @@ tad
 cZb
 cZb
 cZb
-wkJ
-wkJ
-wkJ
-wkJ
-wkJ
-wkJ
-wkJ
-wkJ
-ycm
+fQJ
+fQJ
+fQJ
+fQJ
+fQJ
+fQJ
+fQJ
+fQJ
+rrQ
 lVS
 lVS
-gwX
-gwX
+uhX
+uhX
 lVS
-xhV
+bpl
 wEB
-kvJ
-mAb
+nna
+tRB
 wEB
-vXR
-flJ
+amo
+yeK
 wEB
-jdQ
-llE
+bYM
+aJf
 wEB
-wdq
-llE
+hcq
+aJf
 wEB
 cZb
 cZb
@@ -198732,18 +198732,18 @@ cZb
 wEB
 wEB
 wEB
-xKp
+pby
 wEB
-nxO
-nxO
-tFp
+mrN
+mrN
+wgL
 wEB
-wHI
-pnY
-xzq
+eDd
+jVP
+fXg
 wEB
-qjG
-eDP
+xJF
+wkn
 wEB
 wEB
 wEB
@@ -198931,21 +198931,21 @@ tad
 cZb
 cZb
 cZb
-qRe
-ptC
-wCL
-goS
+mmD
+oOM
+dEa
+cnF
 wEB
-xPG
-xiD
-ccl
+tNg
+vkU
+pze
 wEB
 sCI
-bzY
-vEv
+xMw
+bsf
 wEB
-xhV
-eDP
+bpl
+wkn
 wEB
 cZb
 cZb
@@ -199133,21 +199133,21 @@ tad
 cZb
 cZb
 cZb
-pEz
-avX
-kOr
-mtZ
+nkJ
+eVA
+xsk
+qsQ
 wEB
-fkv
-wxY
-ddy
+ohs
+jtg
+jWZ
 wEB
-mOv
+xBH
 sCI
-bmg
+gru
 wEB
-hGc
-gwX
+iRI
+uhX
 wEB
 cZb
 cZb
@@ -199335,20 +199335,20 @@ tad
 cZb
 cZb
 cZb
-bky
-ptC
-lDb
-ptC
+qAG
+oOM
+riF
+oOM
 wEB
-xPM
-tAc
-xPM
-udl
-thJ
-ePe
-thJ
+iBd
+xAR
+iBd
+shD
+ljR
+xYr
+ljR
 wEB
-gwX
+uhX
 lVS
 wEB
 cZb
@@ -199551,7 +199551,7 @@ wEB
 wEB
 wEB
 lVS
-knW
+sZK
 wEB
 cZb
 cZb
@@ -199753,7 +199753,7 @@ cZb
 cZb
 wEB
 lVS
-knW
+sZK
 wEB
 cZb
 cZb
@@ -199954,8 +199954,8 @@ cZb
 cZb
 cZb
 wEB
-gwX
-hGc
+uhX
+iRI
 wEB
 cZb
 cZb
@@ -200144,7 +200144,7 @@ tad
 tad
 tad
 cZb
-rNs
+tNH
 cZb
 cZb
 cZb
@@ -200157,7 +200157,7 @@ cZb
 cZb
 wEB
 lVS
-gwX
+uhX
 wEB
 cZb
 cZb
@@ -200358,8 +200358,8 @@ cZb
 cZb
 cZb
 wEB
-knW
-seE
+sZK
+qeT
 wEB
 cZb
 cZb
@@ -200560,7 +200560,7 @@ cZb
 cZb
 cZb
 wEB
-knW
+sZK
 lVS
 wEB
 cZb
@@ -200762,7 +200762,7 @@ cZb
 cZb
 cZb
 wEB
-uHJ
+nsi
 lVS
 wEB
 cZb
@@ -200965,7 +200965,7 @@ cZb
 cZb
 wEB
 wiO
-bOd
+uwQ
 wEB
 cZb
 cZb

--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -295,6 +295,14 @@
 /obj/machinery/door/window/northright,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/podrooms2)
+"adi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/random/cluster/spiders,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "adt" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/small/grassb5,
@@ -933,13 +941,6 @@
 	},
 /turf/simulated/floor/tiled/white/golden,
 /area/nadezhda/engineering/atmos/surface)
-"ajD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/sofa{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ajH" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 8
@@ -1253,14 +1254,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security)
-"amS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "amY" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -1804,13 +1797,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai_upload)
-"atb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/material/kitchen/utensil/fork,
-/obj/item/stack/rods/random,
-/turf/simulated/floor/plating,
-/area/colony)
 "atf" = (
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp,
@@ -1983,6 +1969,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/maingate)
+"auH" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/material_resources,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "auL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/standard,
@@ -2164,6 +2156,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
+"avX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/contraband/poster,
+/obj/item/contraband/poster,
+/obj/item/pen/multi,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "awd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2482,14 +2482,6 @@
 /obj/structure/invislight,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"azC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/common_oddities/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "azI" = (
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/maintenance{
@@ -3701,10 +3693,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/colony)
-"aMF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/colony)
 "aML" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -3873,6 +3861,10 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
+"aOD" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aOE" = (
 /obj/item/material/shard,
 /obj/effect/decal/cleanable/dirt,
@@ -3894,11 +3886,6 @@
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/pond)
-"aOT" = (
-/obj/item/reagent_containers/syringe/drugs,
-/obj/item/reagent_containers/pill/floorpill,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aOU" = (
 /obj/item/remains/deer,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -4033,11 +4020,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/smc/quarters)
-"aQN" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/rig_module/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aQO" = (
 /obj/structure/railing{
 	dir = 1
@@ -4051,11 +4033,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/absolutism/vectorrooms)
-"aQT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "aQV" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/armoryshop)
@@ -4156,6 +4133,14 @@
 /obj/random/junkfood/rotten,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"aSi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/gun_normal/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "aSk" = (
 /obj/structure/table/rack/shelf,
 /obj/item/hand_labeler,
@@ -4580,6 +4565,12 @@
 	},
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/nadezhda/medical/reception)
+"aXU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/grey,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "aYf" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -5072,13 +5063,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/hallways)
-"bcG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall_mounted/firecloset{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bcI" = (
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
@@ -5786,6 +5770,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"bje" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bjf" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -5894,8 +5884,9 @@
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
 "bjV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/surgery,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "bkg" = (
 /obj/random/booze,
@@ -5937,6 +5928,10 @@
 /obj/effect/floor_decal/industrial/road/curve4,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"bky" = (
+/obj/item/contraband/poster/placed/generic/here_for_your_safety,
+/turf/simulated/wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/window_lwall_spawn/smartspawnplasma,
@@ -6018,6 +6013,13 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/rnd/lab)
+"blH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "blS" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/cobweb2{
@@ -6051,6 +6053,22 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/command/teleporter)
+"bmf" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
+"bmg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/random/structures,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bmp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -6600,6 +6618,10 @@
 	},
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"bsB" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bsC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/northright{
@@ -7209,13 +7231,6 @@
 	icon_state = "16,20"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"byo" = (
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/common_oddities/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "byp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
@@ -7389,9 +7404,10 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
-"bzT" = (
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/wood/wild4,
+"bzY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "bAc" = (
 /obj/structure/sign/departmentold/botany/small,
@@ -7530,14 +7546,6 @@
 /obj/structure/grille/broken,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"bBY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/gun_normal/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "bBZ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -7706,6 +7714,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
+"bDI" = (
+/obj/structure/boulder,
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bDQ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -8338,17 +8352,8 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfacenorth)
-"bJQ" = (
-/obj/structure/table/rack,
-/obj/structure/curtain/medical,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/organ/external/robotic/junktech/r_leg,
-/obj/item/organ/external/robotic/junktech/r_arm,
-/obj/item/organ/external/robotic/junktech/l_leg,
-/obj/item/organ/external/robotic/junktech/l_arm,
-/turf/simulated/floor/tiled/steel/gray_perforated,
+"bJW" = (
+/turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "bJY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8639,11 +8644,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"bMO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/custom/onestar,
-/turf/simulated/floor/tiled/steel/bar_light,
-/area/colony)
 "bMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8676,6 +8676,11 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"bNu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bNv" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
@@ -8739,6 +8744,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"bOd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bOp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -8825,6 +8835,10 @@
 /obj/structure/scrap/medical,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"bPB" = (
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bPD" = (
 /obj/landmark/costume/highlander,
 /obj/structure/table/rack,
@@ -9629,6 +9643,9 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"bXY" = (
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "bYa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -9998,6 +10015,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"ccl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ccn" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/asteroid/grass,
@@ -10443,6 +10466,13 @@
 /mob/living/carbon/superior_animal/roach/roachling,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"chH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "chI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10890,11 +10920,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
-"cmn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cmo" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11027,10 +11052,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"cnq" = (
-/obj/random/cluster/slimes,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cnr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/smartfridge/secure/medbay,
@@ -11062,6 +11083,14 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"cnP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 1;
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cnY" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -11078,6 +11107,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/command/tcommsat/computer)
+"coe" = (
+/obj/machinery/door/window/northleft,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cof" = (
 /obj/item/storage/firstaid/surgery,
 /obj/structure/table/standard,
@@ -11102,6 +11136,10 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"cot" = (
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "coy" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/grille/broken,
@@ -11281,6 +11319,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"cqt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet_tech/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cqC" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "10,6"
@@ -11782,19 +11825,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
-"cvN" = (
-/obj/structure/closet/crate/secure/large,
-/obj/item/organ/internal/bone/head/robotic,
-/obj/item/organ/internal/bone/l_arm/robotic,
-/obj/item/organ/internal/bone/l_leg/robotic,
-/obj/item/organ/internal/bone/r_arm/robotic,
-/obj/item/organ/internal/bone/r_leg/robotic,
-/obj/item/organ/internal/bone/chest/robotic,
-/obj/effect/decal/cleanable/blood/oil{
-	icon_state = "splatter2"
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cvW" = (
 /obj/structure/table/rack,
 /obj/item/rig/ce/equipped,
@@ -11966,6 +11996,14 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/sechall)
+"cxM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/common_oddities/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cxN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
@@ -11973,6 +12011,13 @@
 "cxU" = (
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
+"cxY" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A20";
+	name = "D1-A20"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cyl" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -12060,16 +12105,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/detectives_office)
-"cyT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain/open/shower/closed,
-/turf/simulated/floor/plating,
-/area/colony)
-"cyU" = (
-/obj/structure/table/steel,
-/obj/random/powercell/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cyW" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -12871,11 +12906,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"cGZ" = (
-/obj/structure/table/standard,
-/obj/item/storage/freezer/medical,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cHe" = (
 /obj/machinery/light,
 /turf/simulated/shuttle/floor/mining,
@@ -12912,6 +12942,16 @@
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"cHv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/northleft,
+/obj/machinery/door/window/southleft,
+/obj/machinery/cash_register{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cHC" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -13000,17 +13040,6 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
-"cIh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/eastright,
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cIj" = (
 /obj/structure/table/reinforced,
 /obj/random/material/low_chance,
@@ -13060,6 +13089,14 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/turret_protected/ai)
+"cID" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cIE" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall17";
@@ -13126,10 +13163,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/xenobiology/ameridian)
-"cJp" = (
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cJq" = (
 /obj/structure/catwalk,
 /obj/random/cluster/spiders/low_chance,
@@ -13364,10 +13397,6 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/atmos)
-"cLU" = (
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cLZ" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/orange,
@@ -13452,6 +13481,12 @@
 /obj/item/stool,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security)
+"cML" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/credits/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "cMQ" = (
 /obj/effect/floor_decal/industrial/road/straight3,
 /obj/effect/decal/cleanable/dirt,
@@ -14098,11 +14133,6 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/workshop)
-"cSL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain/red,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cSM" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/structure/closet/wall_mounted/emcloset{
@@ -14726,11 +14756,6 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm2)
-"cYB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "cYC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -15037,6 +15062,19 @@
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/nadezhda/medical/organ_lab)
+"dcw" = (
+/obj/structure/closet/crate/secure/large,
+/obj/item/organ/internal/bone/head/robotic,
+/obj/item/organ/internal/bone/l_arm/robotic,
+/obj/item/organ/internal/bone/l_leg/robotic,
+/obj/item/organ/internal/bone/r_arm/robotic,
+/obj/item/organ/internal/bone/r_leg/robotic,
+/obj/item/organ/internal/bone/chest/robotic,
+/obj/effect/decal/cleanable/blood/oil{
+	icon_state = "splatter2"
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dcH" = (
 /obj/structure/railing{
 	dir = 1;
@@ -15107,6 +15145,18 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/captain)
+"ddv" = (
+/obj/random/booze,
+/obj/random/junkfood/onlypizza,
+/obj/random/junkfood/onlyburger,
+/obj/random/junkfood,
+/obj/structure/closet/secure_closet/freezer,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"ddy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ddz" = (
 /obj/structure/catwalk,
 /obj/random/cluster/spiders,
@@ -15468,13 +15518,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"dhc" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junkfood,
-/obj/random/junkfood,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dhd" = (
 /obj/structure/flora/small/trailrockb4,
 /turf/simulated/floor/asteroid/grass,
@@ -15744,14 +15787,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
-"djp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "djv" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -15774,11 +15809,6 @@
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/command/courtroom)
-"djP" = (
-/obj/machinery/mech_recharger,
-/obj/random/mecha/low_chance,
-/turf/simulated/floor/plating,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "djU" = (
 /obj/structure/closet/wall_mounted/emcloset/escape_pods{
 	pixel_x = 32
@@ -16153,11 +16183,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/crew_quarters/janitor)
-"dnO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/lowkeyrandom,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dnQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
@@ -16346,10 +16371,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
-"dpA" = (
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dpF" = (
 /obj/structure/shuttle_part/mining{
 	icon_state = "12,2"
@@ -16424,13 +16445,6 @@
 /obj/structure/closet/crate/secure/weapon/amr,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"dqq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dqt" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -16614,23 +16628,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"dsz" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "dsL" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -16639,14 +16636,6 @@
 /obj/random/pack/gun_loot,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"dsV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/contraband/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dsW" = (
 /obj/machinery/door/airlock/command{
 	id_tag = "wobolt1";
@@ -16684,6 +16673,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"dtc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dtf" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -16773,6 +16768,13 @@
 /obj/effect/floor_decal/industrial/road/straight1,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"dtY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "dua" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -17442,12 +17444,6 @@
 /obj/machinery/atmospherics/unary/vent_pump,
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
-"dzJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dzL" = (
 /obj/effect/floor_decal/industrial/road/curve1,
 /turf/simulated/floor/rock/manmade/road,
@@ -17524,10 +17520,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/command/hallway)
-"dAv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dAE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/shuttle/floor/science{
@@ -17644,16 +17636,6 @@
 "dBG" = (
 /turf/simulated/shuttle/wall/mining,
 /area/shuttle/rocinante_shuttle_area)
-"dBI" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/costume/body_animals,
-/obj/random/costume/body_generic,
-/obj/random/costume/body_halloween,
-/obj/random/costume/head_animals,
-/obj/random/costume/head_generic,
-/obj/random/costume/head_halloween,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dBM" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/crate/trashcart,
@@ -17677,13 +17659,6 @@
 	icon_state = "2,3"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"dBX" = (
-/obj/structure/table/reinforced,
-/obj/item/device/makeshift_electrolyser,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dCe" = (
 /obj/structure/flora/small/busha3,
 /obj/structure/flora/big/bush3,
@@ -18179,12 +18154,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/command/cro)
-"dGK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dGL" = (
 /obj/effect/floor_decal/industrial/warningred{
 	dir = 4
@@ -18208,12 +18177,6 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
-"dHe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/grey,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
 "dHj" = (
@@ -18251,6 +18214,13 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"dHH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dHL" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/random/flora/small_jungle_tree,
@@ -18799,11 +18769,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/genetics)
-"dML" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet_maintloot,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "dMM" = (
 /obj/structure/table/standard,
 /obj/item/storage/freezer,
@@ -18887,6 +18852,13 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/crew_quarters/janitor)
+"dNB" = (
+/obj/structure/curtain/open/bed{
+	name = "Privacy curtain"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dNC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled/techmaint,
@@ -19715,6 +19687,11 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"dXl" = (
+/obj/random/cluster/roaches/lower_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "dXm" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/beach/water/jungledeep,
@@ -20130,6 +20107,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
+"ebA" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/cheap/elbrus4kk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ebB" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -21301,6 +21284,10 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"end" = (
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eng" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -22239,10 +22226,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/chemistry)
-"evC" = (
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "evD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22517,6 +22500,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"eyb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/termite_no_despawn/lower_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eyj" = (
 /obj/random/mob/nightmare/low_chance,
 /turf/simulated/floor/rock,
@@ -22609,6 +22597,9 @@
 /obj/random/material_ore,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"ezk" = (
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ezl" = (
 /obj/structure/sink{
 	pixel_y = -22
@@ -22926,12 +22917,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/outside/inside_colony)
-"eCY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/random/junkfood/rotten,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eDa" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "9,20"
@@ -23018,6 +23003,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/turret_protected/ai_upload)
+"eDP" = (
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eDQ" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/disposalpipe/segment,
@@ -23057,13 +23046,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/nadezhda/command/crematorium)
-"eEp" = (
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/contraband/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eEC" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light{
@@ -23072,6 +23054,12 @@
 /obj/item/towel,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/command/prime)
+"eEH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eEK" = (
 /obj/structure/catwalk,
 /obj/structure/barricade,
@@ -23179,6 +23167,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
+"eFR" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/rig_module/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eGl" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -23314,13 +23307,6 @@
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /turf/simulated/floor/reinforced/airmix,
 /area/nadezhda/engineering/atmos)
-"eIh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eIo" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/prox_sensor,
@@ -23679,13 +23665,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"eLB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel,
-/area/nadezhda/quartermaster/miningdock)
 "eLM" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -23763,6 +23742,13 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"eMA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eMB" = (
 /obj/structure/table/standard,
 /obj/item/pen{
@@ -24115,6 +24101,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
+"ePe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/woodentable,
+/obj/random/gun_parts/low,
+/obj/random/ammo,
+/obj/random/gun_parts/low,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ePg" = (
 /turf/simulated/floor/asteroid/dirt/mud,
 /area/nadezhda/maintenance/undergroundfloor1west)
@@ -24127,6 +24121,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/engine_room)
+"ePp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ePq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -24237,10 +24236,6 @@
 	icon_state = "10,15"
 	},
 /area/nadezhda/engineering/engine_room)
-"ePL" = (
-/obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ePN" = (
 /obj/structure/catwalk,
 /obj/structure/invislight,
@@ -24370,10 +24365,6 @@
 	},
 /turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
-"eQC" = (
-/obj/machinery/door/airlock/maintenance_cargo,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "eQJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24709,6 +24700,10 @@
 /obj/structure/closet/secure_closet/personal/doctor,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/medical/sleeper)
+"eVk" = (
+/obj/random/structures,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eVm" = (
 /obj/effect/floor_decal/spline/wood,
 /obj/structure/table/woodentable,
@@ -24870,6 +24865,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"eWs" = (
+/obj/structure/table/rack/shelf,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/computer_hardware/hard_drive/portable/advanced/shady,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "eWu" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -25414,9 +25417,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/pros/prep)
-"faV" = (
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fbb" = (
 /obj/item/clothing/under/excelsior/bdu,
 /obj/item/clothing/under/excelsior/bdu,
@@ -25478,11 +25478,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/engine_room)
-"fbX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/window_lwall_spawn/reinforced,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fce" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1
@@ -25703,10 +25698,9 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"ffe" = (
-/obj/machinery/door/window/northleft,
-/obj/structure/curtain/black,
-/turf/simulated/floor/wood/wild5,
+"fff" = (
+/obj/machinery/door/airlock/maintenance_cargo,
+/turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "ffp" = (
 /obj/structure/closet/wall_mounted/firecloset{
@@ -26323,6 +26317,11 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
+"fkv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank/derelict,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fkx" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/big/rocks1,
@@ -26444,6 +26443,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"flJ" = (
+/obj/structure/bed,
+/obj/item/handcuffs/fuzzy,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "flM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -26549,14 +26553,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"fmq" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A20";
-	name = "D1-A20"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fmz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26629,15 +26625,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/maingate/west)
-"fnc" = (
-/obj/machinery/firealarm{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel_reinforced,
-/obj/structure/bedsheetbin,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fnd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -26753,16 +26740,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
-"fol" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "foo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -26989,6 +26966,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"fqa" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fqc" = (
 /obj/structure/table/marble,
 /obj/random/toy/plushie_onlycorgi,
@@ -27072,6 +27054,10 @@
 "frb" = (
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/merchant)
+"frc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "frd" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
@@ -27114,12 +27100,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/security/barracks)
-"frF" = (
-/obj/structure/boulder,
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "frR" = (
 /obj/structure/catwalk,
 /obj/structure/railing,
@@ -27310,6 +27290,25 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
+"fuz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "fuG" = (
 /obj/random/spider_trap_burrowing,
 /obj/effect/decal/cleanable/dirt,
@@ -27357,6 +27356,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"fuS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fuT" = (
 /obj/effect/damagedfloor/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -27481,12 +27485,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/command/prime)
-"fwq" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/cheap/elbrus4kk,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fws" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/chemistry)
@@ -27804,14 +27802,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/crew_quarters/bar)
-"fzv" = (
-/obj/structure/table/rack/shelf,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/computer_hardware/hard_drive/portable/advanced/shady,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fzw" = (
 /obj/machinery/conveyor/south{
 	id = "mining_internal"
@@ -28019,6 +28009,13 @@
 "fCa" = (
 /turf/simulated/mineral,
 /area/nadezhda/outside/bcave)
+"fCd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted/firecloset{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fCf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28245,6 +28242,10 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"fEo" = (
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fEp" = (
 /obj/item/book/manual/nonfiction/ageofreason,
 /obj/item/book/manual/nonfiction/ethics,
@@ -28474,6 +28475,10 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/turret_protected/ai_upload)
+"fGZ" = (
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fHf" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 4
@@ -28741,6 +28746,12 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/bridge)
+"fJK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/tool/advanced/onestar/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fJM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -28782,6 +28793,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"fKk" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fKl" = (
 /obj/structure/firedoor_assembly,
 /obj/structure/barricade,
@@ -29527,6 +29542,11 @@
 /obj/structure/flora/small/grassa4,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"fTh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/unpowered/simple/wood,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "fTj" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -29583,15 +29603,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
-"fTQ" = (
-/obj/machinery/optable,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "fTS" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/random/flora/jungle_tree,
@@ -30204,6 +30215,11 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
+"gao" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gas" = (
 /obj/machinery/camera/network/engineering{
 	dir = 4
@@ -30347,9 +30363,10 @@
 	name = "Residential District Maintenance"
 	})
 "gbE" = (
-/obj/structure/table/standard,
-/obj/item/storage/pill_bottle/tramadol,
-/turf/simulated/floor/tiled/steel/gray_perforated,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/mecha_equipment/low_chance,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "gbL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -31057,6 +31074,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"ghz" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/rig/low_chance,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ghD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -31087,14 +31110,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"ghS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/obj/random/cluster/spiders,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ghV" = (
 /obj/random/flora/small_jungle_tree,
 /turf/simulated/floor/asteroid/grass,
@@ -31264,6 +31279,10 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"gkb" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gkd" = (
 /obj/random/scrap/sparse_even/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -31333,6 +31352,13 @@
 /obj/random/toy/plushie_onlycat,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/medical/psych)
+"gkP" = (
+/obj/structure/closet/crate/secure/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junkfood,
+/obj/random/junkfood,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gkQ" = (
 /obj/structure/lattice,
 /obj/structure/railing,
@@ -31475,6 +31501,13 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/psych)
+"gmj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/material/kitchen/utensil/fork,
+/obj/item/stack/rods/random,
+/turf/simulated/floor/plating,
+/area/colony)
 "gmm" = (
 /obj/structure/medical_stand,
 /obj/item/tank/anesthetic,
@@ -31580,6 +31613,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"gnV" = (
+/obj/effect/floor_decal/industrial/caution{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/nadezhda/engineering/engine_room)
 "gnX" = (
 /turf/simulated/floor/beach/water/jungledeep{
 	desc = "Filthy, stinking bilge water.";
@@ -31684,6 +31723,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"goH" = (
+/obj/machinery/optable,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "goI" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -31744,6 +31792,11 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/nadezhda/command/gmaster)
+"goS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "goX" = (
 /obj/random/furniture/pottedplant,
 /obj/effect/decal/cleanable/dirt,
@@ -32574,6 +32627,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/rnd/robotics)
+"gvZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gwa" = (
 /obj/machinery/door/window/southright{
 	dir = 1;
@@ -32618,6 +32675,9 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/colony)
+"gwX" = (
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gwY" = (
 /obj/machinery/vending/gamers,
 /turf/simulated/floor/tiled/steel/monofloor{
@@ -33323,13 +33383,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"gFf" = (
-/obj/machinery/door/window/eastright,
-/obj/structure/curtain/medical,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gFl" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/quartermaster/disposaldrop)
@@ -33387,6 +33440,15 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/armory)
+"gFO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/common_oddities/low_chance,
+/obj/random/gun_normal/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gFQ" = (
 /obj/machinery/dna_scannernew,
 /turf/simulated/floor/tiled/white,
@@ -33498,15 +33560,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/nadezhda/storage/primary)
-"gHy" = (
-/obj/structure/table/rack,
-/obj/structure/curtain/medical,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/organ/internal/optical_sensor,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gHI" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/flora/small/trailrocka1,
@@ -33916,13 +33969,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
-"gNb" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A20";
-	name = "D1-A20"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "gNf" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 1
@@ -34755,8 +34801,12 @@
 	},
 /area/shuttle/rocinante_shuttle_area)
 "gUa" = (
-/obj/random/furniture/pottedplant,
-/turf/simulated/floor/tiled/dark/monofloor,
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A20";
+	name = "D1-A20"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "gUb" = (
 /obj/structure/boulder,
@@ -34955,6 +35005,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"gVZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "gWd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -36514,12 +36569,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/hallway/side/f2section1)
-"hmG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hnc" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -36528,6 +36577,18 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
+"hnh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/storage/freezer,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hnn" = (
 /obj/effect/floor_decal/industrial/warningdust/fulltile,
 /obj/machinery/shieldwallgen{
@@ -36574,11 +36635,10 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
-"hnU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+"hnL" = (
+/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/northleft,
+/obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "hoa" = (
@@ -36819,6 +36879,14 @@
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/inside_colony)
+"hqj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hqp" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/ifak,
@@ -36952,10 +37020,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"hrU" = (
-/obj/random/structures,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hrW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -37044,13 +37108,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"hsH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wall_mounted{
-	pixel_y = 32
+"hsP" = (
+/obj/structure/table/rack,
+/obj/structure/curtain/medical,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/flour,
-/turf/simulated/floor/wood/wild4,
+/obj/item/organ/internal/optical_sensor,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "hsW" = (
 /obj/structure/flora/small/rock3,
@@ -37138,12 +37203,6 @@
 	icon_state = "7,6"
 	},
 /area/shuttle/vasiliy_shuttle_area)
-"htJ" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil/random,
-/obj/item/device/robotanalyzer,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "htK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -37684,13 +37743,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/sechall)
-"hzp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/lathe_disk/any_gun/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hzs" = (
 /obj/structure/table/rack/shelf,
 /obj/random/mecha_equipment/low_chance,
@@ -37774,11 +37826,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/hallways)
-"hzQ" = (
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/grenade/chem_grenade/cleaner,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hzR" = (
 /obj/effect/floor_decal/industrial/loading,
 /obj/effect/decal/cleanable/dirt,
@@ -37935,10 +37982,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
-"hBm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/mineral,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hBn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departmentold/restroom{
@@ -38024,10 +38067,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"hBZ" = (
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hCk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -38440,6 +38479,10 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
+"hGc" = (
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hGl" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -39156,11 +39199,6 @@
 /obj/structure/boulder,
 /turf/simulated/mineral,
 /area/nadezhda/maintenance/undergroundfloor1west)
-"hLz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hLC" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -39202,17 +39240,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
-"hLI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/curtain/open,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hLK" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -39263,6 +39290,11 @@
 	},
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"hMa" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/mat_katana,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hMc" = (
 /obj/machinery/light{
 	dir = 4
@@ -39481,12 +39513,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"hOO" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hPf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -39555,13 +39581,6 @@
 	icon_state = "9,23"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
-"hPR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hPW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -39591,14 +39610,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"hQu" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hQM" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -39622,6 +39633,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/courtroom)
+"hRi" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "hRj" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /obj/effect/floor_decal/industrial/arrows/white,
@@ -39663,12 +39691,6 @@
 /obj/effect/spider/spiderling/near_grown,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"hRI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hRP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/scrap/food/large,
@@ -40047,6 +40069,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/purcarpet,
 /area/nadezhda/rnd/rbreakroom)
+"hVv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/red,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hVz" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /mob/living/simple_animal/frog{
@@ -40114,16 +40141,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"hWa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/northleft,
-/obj/machinery/door/window/southleft,
-/obj/machinery/cash_register{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hWc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
@@ -40184,6 +40201,13 @@
 /obj/machinery/chemical_dispenser/soda,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/absolutism/vectorrooms)
+"hWP" = (
+/obj/machinery/vending/assist,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hWU" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/extinguisher_cabinet{
@@ -40413,6 +40437,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"hYy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/freezer,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hYF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster/directional/north,
@@ -40444,18 +40473,6 @@
 /obj/item/flame/lighter/zippo/capitalist,
 /turf/simulated/floor/wood,
 /area/nadezhda/pros/shuttle)
-"hYK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/storage/freezer,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/snacks/meat/monkey,
-/obj/item/reagent_containers/food/snacks/meat/monkey,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hYL" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -40536,6 +40553,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"hZi" = (
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "hZj" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
@@ -40637,11 +40658,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/barracks)
-"hZN" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/mineral,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "hZY" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -41069,6 +41085,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/nadezhda/medical/sleeper)
+"idU" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ieb" = (
 /obj/effect/window_lwall_spawn,
 /obj/structure/barricade,
@@ -41234,11 +41254,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
-"ifo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ift" = (
 /obj/structure/scrap/medical/large,
 /obj/effect/decal/cleanable/cobweb,
@@ -41410,12 +41425,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
-"igY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "ihc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -41827,11 +41836,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"ilJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ilL" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/maingate/east)
@@ -41963,14 +41967,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"imD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gun/projectile/revolver/handmade,
-/obj/item/clothing/accessory/duster/bloodred,
-/obj/item/ammo_magazine/ammobox/pistol_35/scrap,
-/turf/simulated/floor/plating,
-/area/colony)
 "imM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -42112,10 +42108,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"inX" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "inZ" = (
 /obj/structure/flora/small/trailrockb2,
 /turf/simulated/floor/asteroid/dirt/dark,
@@ -42211,12 +42203,6 @@
 /obj/effect/floor_decal/industrial/box/white,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/security/tactical)
-"ioV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/tool/advanced/onestar/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ioZ" = (
 /obj/structure/table/bench/steel,
 /obj/effect/decal/cleanable/dirt,
@@ -42303,10 +42289,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
-"iqf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iqg" = (
 /obj/structure/flora/small/busha1,
 /turf/unsimulated/wall/jungle,
@@ -42361,6 +42343,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"ire" = (
+/obj/item/device/radio/intercom{
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iri" = (
 /obj/effect/spider/stickyweb,
 /obj/structure/grille/broken,
@@ -42872,12 +42861,6 @@
 	},
 /turf/simulated/floor/rock,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"ivJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet/employment,
-/obj/random/credits/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ivP" = (
 /obj/random/mob/spiders/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -42938,10 +42921,6 @@
 /mob/living/simple_animal/frog,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"iwK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iwT" = (
 /obj/machinery/porta_turret/gate,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -43635,6 +43614,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/maintenance/surfaceeast)
+"iEw" = (
+/obj/random/booze/low_chance,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iEz" = (
 /obj/structure/barricade,
 /obj/structure/grille,
@@ -44023,6 +44007,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/chemistry)
+"iIr" = (
+/obj/structure/closet/random_miscellaneous,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iIt" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/light{
@@ -44176,12 +44165,6 @@
 	icon_state = "10,15"
 	},
 /area/nadezhda/rnd/docking)
-"iKh" = (
-/obj/structure/closet/wall_mounted/emcloset{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iKj" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -44230,11 +44213,6 @@
 /obj/effect/floor_decal/industrial/warningdust,
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/nadezhda/engineering/engine_room)
-"iKI" = (
-/obj/structure/table/rack/shelf,
-/obj/item/modular_computer/wrist,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iKK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44260,6 +44238,15 @@
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/medical/reception)
+"iLb" = (
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/structure/bedsheetbin,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iLc" = (
 /obj/structure/boulder,
 /obj/structure/barricade,
@@ -44414,11 +44401,6 @@
 "iML" = (
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/bioreactor)
-"iMN" = (
-/obj/structure/bed,
-/obj/item/handcuffs/fuzzy,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iMY" = (
 /obj/structure/flora/small/rock5,
 /turf/simulated/floor/asteroid/grass,
@@ -44895,6 +44877,16 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
+"iRR" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/random/structures,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iRT" = (
 /obj/structure/spider_nest,
 /obj/effect/decal/cleanable/dirt,
@@ -44933,6 +44925,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/cargo)
+"iSs" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iSz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44983,12 +44982,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/absolutism/bioreactor)
-"iSO" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/material_resources,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "iSV" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -45145,6 +45138,11 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/medical/chemistry)
+"iVc" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/superior_animal/roach/roachling,
+/turf/simulated/floor/plating,
+/area/colony)
 "iVd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -45324,6 +45322,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/maintenance/surfaceeast)
+"iWU" = (
+/obj/structure/curtain/open/bed{
+	name = "Privacy curtain"
+	},
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "iWX" = (
 /obj/structure/salvageable/computer,
 /obj/effect/decal/cleanable/dirt,
@@ -45899,6 +45903,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"jcR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jcW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/rubble,
@@ -45995,6 +46006,9 @@
 "jdO" = (
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/triage_blackshield)
+"jdQ" = (
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jdU" = (
 /obj/random/mob/roaches/low_chance,
 /obj/effect/decal/cleanable/rubble,
@@ -46248,6 +46262,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"jgK" = (
+/obj/structure/table/standard,
+/obj/item/storage/freezer/medical,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jgL" = (
 /obj/machinery/conveyor/north/ccw{
 	id = "QMLoad2"
@@ -46515,6 +46534,11 @@
 /obj/effect/floor_decal/industrial/warningred,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical)
+"jjj" = (
+/obj/structure/bed/chair/office/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/purcarpet,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jjk" = (
 /obj/structure/flora/small/bushc1,
 /turf/unsimulated/wall/jungle,
@@ -46558,6 +46582,12 @@
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"jjK" = (
+/obj/structure/table/bench/glass,
+/obj/structure/curtain/red,
+/obj/effect/decal/cleanable/vomit,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jjN" = (
 /obj/machinery/door/airlock/maintenance_common{
 	req_access = list(12)
@@ -46969,6 +46999,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/storage)
+"jns" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/spider_trap_burrowing/low_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jnu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -47159,15 +47194,6 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/scave)
-"joX" = (
-/obj/structure/table/reinforced,
-/obj/item/device/makeshift_centrifuge,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jpe" = (
 /obj/random/mob/excelsior,
 /obj/effect/decal/cleanable/dirt,
@@ -47252,9 +47278,6 @@
 /obj/structure/boulder,
 /turf/simulated/floor/rock,
 /area/asteroid/cave)
-"jqb" = (
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jqc" = (
 /obj/machinery/light/small,
 /obj/machinery/alarm{
@@ -47452,12 +47475,6 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
-"jrJ" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/rig/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jrL" = (
 /obj/random/gun_energy_cheap/low_chance,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -47593,6 +47610,11 @@
 /obj/random/material_resources/low_chance,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/nadezhda/quartermaster/miningdock)
+"jtC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jtG" = (
 /obj/machinery/door/airlock/command{
 	name = "Telecommunications";
@@ -47669,13 +47691,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"jug" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/arrows/white{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "juj" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -48060,6 +48075,9 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"jxX" = (
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jxY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -49587,10 +49605,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/rnd/lab)
-"jOw" = (
-/obj/random/cluster/roaches/low_chance,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jOG" = (
 /obj/landmark/storyevent/hidden_vent_antag,
 /obj/structure/reagent_dispensers/bidon{
@@ -49791,9 +49805,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/rock,
 /area/nadezhda/outside/scave)
-"jQU" = (
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "jQV" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
@@ -49868,6 +49879,10 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
+"jRw" = (
+/mob/living/bot/cleanbot,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jRz" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/under,
@@ -49893,6 +49908,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"jRH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "jRN" = (
 /obj/random/flora/jungle_tree,
 /turf/unsimulated/wall/jungle/variant,
@@ -51104,11 +51124,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos/surface)
-"kfa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/spider_trap_burrowing/low_chance,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kfd" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -51193,12 +51208,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"kfU" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/oddity/common/paper_bundle,
-/obj/machinery/door/window/eastright,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kfY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -52009,6 +52018,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/manmade/road,
 /area/nadezhda/outside/inside_colony)
+"knW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "knY" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/asteroid/dirt,
@@ -52026,6 +52040,13 @@
 	},
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/security/triage_blackshield)
+"kof" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "koh" = (
 /obj/structure/boulder,
 /obj/structure/cable/cyan{
@@ -52111,14 +52132,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"kpl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kpn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -52773,6 +52786,13 @@
 /obj/structure/flora/small/bushb1,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
+"kvJ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kvR" = (
 /obj/structure/multiz/stairs/enter,
 /turf/simulated/floor/pool,
@@ -53384,6 +53404,10 @@
 /obj/item/book/manual/nonfiction/suntzu,
 /turf/simulated/floor/wood/wild1,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"kAU" = (
+/obj/structure/janitorialcart,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kAV" = (
 /obj/structure/toilet{
 	dir = 4
@@ -53489,6 +53513,11 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/security/range)
+"kCy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/colony)
 "kCD" = (
 /obj/machinery/vending/assist,
 /obj/machinery/firealarm{
@@ -53856,6 +53885,10 @@
 "kGg" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/prisoncells)
+"kGh" = (
+/obj/effect/floor_decal/industrial/arrows/white,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kGj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -53956,13 +53989,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
-"kHK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kHW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -54095,6 +54121,13 @@
 	icon_state = "7,17"
 	},
 /area/shuttle/vasiliy_shuttle_area)
+"kKg" = (
+/obj/machinery/door/airlock/maintenance_common,
+/obj/random/traps/low_chance{
+	spawn_nothing_percentage = 90
+	},
+/turf/space,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kKh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/asteroid/grass,
@@ -54413,12 +54446,6 @@
 /obj/structure/flora/small/bushb1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
-"kNZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kOe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54441,6 +54468,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/quartermaster/hangarsupply)
+"kOr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kOv" = (
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/industrial/hatch,
@@ -54946,10 +54980,6 @@
 "kTO" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/outside/forest)
-"kTQ" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "kTU" = (
 /obj/effect/spider/stickyweb,
 /obj/machinery/light/small{
@@ -55165,13 +55195,6 @@
 	icon_state = "1,20"
 	},
 /area/shuttle/rocinante_shuttle_area)
-"kVX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "kWg" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -55281,6 +55304,13 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"kXh" = (
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/common_oddities/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "kXi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -55596,11 +55626,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
-"lbS" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/roach/roachling,
-/turf/simulated/floor/plating,
-/area/colony)
 "lbT" = (
 /obj/structure/filingcabinet{
 	density = 0;
@@ -55913,11 +55938,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/security/hut_cell1)
-"lfe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/loading/red,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lfh" = (
 /obj/structure/catwalk,
 /obj/structure/table/rack/shelf,
@@ -56249,9 +56269,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/substation/medical)
-"liR" = (
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/wall/r_wall,
+"liO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "liT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -56336,24 +56357,6 @@
 /obj/structure/flora/small/bushb2,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"lkc" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	dir = 4
-	},
-/obj/machinery/door/window/northright{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/barricade,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/crew_quarters/techshop)
 "lkf" = (
 /obj/machinery/door/airlock/glass_security,
 /obj/machinery/holosign/service{
@@ -56380,11 +56383,6 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/pool)
-"lkC" = (
-/obj/random/booze/low_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lkK" = (
 /mob/living/simple_animal/pig{
 	desc = "This intelligent sow has strange, pointy ears.";
@@ -56435,6 +56433,11 @@
 /obj/structure/flora/small/rock3,
 /turf/simulated/floor/asteroid/dirt/dust,
 /area/nadezhda/outside/inside_colony)
+"llr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "llw" = (
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
@@ -56453,6 +56456,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"llE" = (
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "llJ" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_x = -1;
@@ -56506,6 +56514,16 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/absolutism/chapel)
+"lmg" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lmh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -56530,13 +56548,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
-"lmK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lmN" = (
 /obj/machinery/light/small,
 /obj/item/stool,
@@ -56581,16 +56592,6 @@
 /obj/machinery/flasher/portable,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/security/tactical)
-"lnB" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "lnD" = (
 /obj/machinery/light{
 	dir = 8
@@ -56775,6 +56776,12 @@
 	},
 /turf/simulated/floor/tiled/white/cyancorner,
 /area/nadezhda/medical/reception)
+"lpn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bench/glass,
+/obj/structure/curtain/red,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lpr" = (
 /obj/machinery/camera/network/security{
 	dir = 1
@@ -56973,6 +56980,13 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/dungeon/outside/farm)
+"lrl" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/random/structures,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lrq" = (
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
@@ -57266,6 +57280,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/absolutism/hallways)
+"luJ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/bodybags,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/random/circuitboard/low_chance,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "luL" = (
 /obj/machinery/telecomms/server/presets/service,
 /turf/simulated/floor/bluegrid{
@@ -57506,6 +57529,13 @@
 	},
 /turf/simulated/floor/carpet,
 /area/nadezhda/absolutism/chapel)
+"lxh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lxj" = (
 /obj/machinery/camera/network/medbay{
 	dir = 1
@@ -57563,11 +57593,6 @@
 	},
 /turf/simulated/floor/fixed/hydrotile,
 /area/turret_protected/ai_upload)
-"lyf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lyg" = (
 /turf/simulated/floor/beach/water/jungle,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -57592,9 +57617,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"lyp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
+"lyw" = (
+/obj/machinery/microwave/burnbarrel,
+/turf/simulated/floor/wood/wild4,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "lyx" = (
 /obj/random/spider_trap_burrowing/low_chance,
@@ -58050,10 +58075,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/hallway/surface/section1)
-"lCX" = (
+"lDb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/simple/wood,
-/turf/simulated/floor/tiled/dark/danger,
+/obj/structure/table/steel,
+/obj/item/contraband/poster,
+/obj/item/contraband/poster,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "lDf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58062,6 +58092,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"lDi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lDk" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/small/bushb1,
@@ -58594,10 +58629,6 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
-"lIH" = (
-/obj/random/cluster/termite_no_despawn_hoard,
-/turf/unsimulated/mineral,
-/area/colony)
 "lIS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58720,11 +58751,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"lJG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/spider_shadow_trap,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lJZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -58877,10 +58903,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/engineering/foyer)
-"lLR" = (
-/obj/random/structures,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lLS" = (
 /obj/structure/boulder,
 /turf/simulated/floor/asteroid/dirt/flood,
@@ -59583,6 +59605,11 @@
 /obj/random/booze,
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"lTA" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/autolathe/mechfab/loaded,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lTB" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -59897,11 +59924,6 @@
 /obj/random/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"lWz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lWE" = (
 /obj/structure/disposalpipe/sortjunction/wildcard{
 	dir = 8
@@ -59958,11 +59980,6 @@
 	dir = 4
 	},
 /area/nadezhda/maintenance/surfacesec)
-"lXp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/eastright,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "lXq" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/techmaint_perforated,
@@ -60084,6 +60101,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/medical/chemistry)
+"lYm" = (
+/obj/structure/closet/crate/secure/large,
+/obj/random/costume/body_animals,
+/obj/random/costume/body_generic,
+/obj/random/costume/body_halloween,
+/obj/random/costume/head_animals,
+/obj/random/costume/head_generic,
+/obj/random/costume/head_halloween,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "lYp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -60373,14 +60400,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
-"mbq" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/welding,
-/obj/item/storage/belt,
-/obj/item/clothing/head/welding,
-/obj/item/computer_hardware/hard_drive/portable/design/misc,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mbs" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -60573,6 +60592,12 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"mdG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mdJ" = (
 /obj/structure/flora/big/rocks3,
 /turf/simulated/mineral,
@@ -60735,10 +60760,6 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1south)
-"meS" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "meU" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Hulk Mining Barge";
@@ -61057,11 +61078,6 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"mhd" = (
-/obj/structure/bed/chair/office/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mhk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -61293,17 +61309,14 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
-"mjI" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A3";
-	name = "D1-A3"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mjK" = (
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"mjO" = (
+/obj/structure/table/rack/shelf,
+/obj/item/modular_computer/wrist,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mjU" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -61710,14 +61723,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/danger,
 /area/turret_protected/ai_upload)
-"mnR" = (
-/obj/machinery/door/airlock/centcom{
-	id_tag = "D1-A2";
-	name = "D1-A2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mnS" = (
 /obj/machinery/atmospherics/unary/vent_pump,
 /obj/effect/decal/cleanable/dirt,
@@ -61749,6 +61754,24 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/research)
+"mom" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	dir = 4
+	},
+/obj/machinery/door/window/northright{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/barricade,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/crew_quarters/techshop)
 "mou" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -61801,11 +61824,6 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
-"mpk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "mpm" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/hallway/side/f2section1)
@@ -61909,11 +61927,6 @@
 	},
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
-"mpV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mqc" = (
 /obj/structure/flora/big/rocks2,
 /turf/simulated/floor/asteroid/dirt,
@@ -62146,6 +62159,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"msz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/northleft,
+/obj/machinery/cash_register{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "msC" = (
 /obj/item/computer_hardware/hard_drive/portable/design/logistics,
 /obj/item/computer_hardware/hard_drive/portable/design/misc,
@@ -62179,10 +62202,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/pros/shuttle)
-"mti" = (
-/obj/machinery/door/airlock,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mtj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62286,6 +62305,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"mtZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mul" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/beach/water/shallow,
@@ -62575,6 +62599,14 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"mxe" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A2";
+	name = "D1-A2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mxg" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -62844,6 +62876,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/danger,
 /area/nadezhda/medical/genetics)
+"mAb" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mAi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/rock/alt{
@@ -62950,6 +62987,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"mBb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/lowkeyrandom,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mBc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -63915,6 +63957,11 @@
 	icon_state = "11,3"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"mKu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mKx" = (
 /turf/simulated/floor/greengrid,
 /area/turret_protected/ai)
@@ -64325,6 +64372,14 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
+"mOv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/woodentable,
+/obj/item/tool/hammer,
+/obj/item/tool/screwdriver,
+/obj/item/tool/wirecutters/pliers,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mOx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64649,6 +64704,12 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"mRy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/cabinet,
+/obj/random/booze,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mRL" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "1,17"
@@ -65254,6 +65315,10 @@
 	},
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/bar)
+"mYl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "mYn" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -65473,11 +65538,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
-"mZF" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "mZI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -67615,6 +67675,17 @@
 /obj/random/closet_maintloot,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"nuz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nuC" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "3,7"
@@ -67806,9 +67877,6 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/engineering/engine_waste)
-"nwl" = (
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nwq" = (
 /obj/item/organ/internal/bone/head{
 	pixel_y = -5
@@ -67861,16 +67929,15 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/crew_quarters/dorm3)
-"nwP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nwQ" = (
 /obj/structure/barricade,
 /obj/machinery/door/airlock/vault,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"nwV" = (
+/obj/machinery/door/unpowered/simple/wood,
+/turf/simulated/wall/r_wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nwX" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/structure/grille,
@@ -67949,6 +68016,10 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/west)
+"nxO" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nxP" = (
 /turf/simulated/open,
 /area/nadezhda/engineering/engine_room)
@@ -68622,11 +68693,6 @@
 	},
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/security/maingate/west)
-"nDt" = (
-/obj/structure/closet/random_miscellaneous,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nDv" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/foyer)
@@ -68908,6 +68974,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/outside/inside_colony)
+"nGc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "nGh" = (
 /obj/structure/flora/small/grassb1,
 /turf/simulated/floor/asteroid/grass,
@@ -68971,11 +69042,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/rnd/xenobiology)
-"nGT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "nGY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69394,10 +69460,6 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/rock,
 /area/colony)
-"nKP" = (
-/mob/living/bot/cleanbot,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nKS" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/belt/webbing,
@@ -69823,6 +69885,13 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/surfacesec)
+"nPf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/random/lathe_disk/any_gun/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "nPg" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
@@ -69992,16 +70061,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/crew_quarters/pool)
-"nRe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/southleft,
-/obj/machinery/door/window/northleft,
-/obj/machinery/cash_register{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nRf" = (
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/plating,
@@ -70063,12 +70122,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
-"nRA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/cabinet,
-/obj/random/booze,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nRZ" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/soda,
@@ -70096,13 +70149,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"nSn" = (
-/obj/machinery/door/airlock/maintenance_common,
-/obj/random/traps/low_chance{
-	spawn_nothing_percentage = 90
-	},
-/turf/space,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nSr" = (
 /turf/simulated/shuttle/floor/mining,
 /area/turbolift/ElevatorOne/underground)
@@ -70600,11 +70646,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/command/cro)
-"nWL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "nWM" = (
 /obj/item/modular_computer/console/preset/security/records{
 	dir = 8
@@ -70631,6 +70672,12 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/maintenance/surfacesec)
+"nWZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/structures,
+/obj/machinery/floor_light,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/colony)
 "nXf" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "4,13"
@@ -71128,6 +71175,11 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
+"obe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "obk" = (
 /obj/structure/railing/grey{
 	dir = 1;
@@ -71654,9 +71706,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/shuttle/surface_transport_lz)
-"ogi" = (
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ogo" = (
 /turf/simulated/shuttle/wall/escpod{
 	icon_state = "escpodwall23";
@@ -71714,9 +71763,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/disposaldrop)
 "ogV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating/under,
+/obj/structure/table/glass,
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "ohb" = (
 /obj/effect/decal/cleanable/solid_biomass,
@@ -71738,11 +71787,6 @@
 /obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/pool)
-"ohr" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ohx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -72020,12 +72064,6 @@
 /area/nadezhda/rnd/circuitlab{
 	name = "Science Expedition prep"
 	})
-"ojG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/mecha_equipment/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ojI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/cable/cyan{
@@ -72050,11 +72088,6 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/nadezhda/engineering/atmos)
-"ojO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/termite_no_despawn/lower_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ojP" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -72105,18 +72138,16 @@
 /obj/random/flora/jungle_tree,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/outside/forest)
+"okw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "okD" = (
 /obj/structure/flora/small/busha2,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/forest)
-"okG" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "okJ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/enzyme,
@@ -73419,6 +73450,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/nadezhda/crew_quarters/bar)
+"oyc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/random/cluster/spiders,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oyd" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -73912,6 +73949,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"oCi" = (
+/obj/item/modular_computer/telescreen/preset/generic{
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oCp" = (
 /obj/structure/closet/secure_closet/xenoarchaeologist,
 /obj/effect/decal/cleanable/dirt,
@@ -74258,6 +74301,10 @@
 "oGo" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/vacantoffice2)
+"oGq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oGv" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/white/techfloor,
@@ -74349,6 +74396,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"oHi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/sofa{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "oHo" = (
 /obj/machinery/door/blast/regular/open{
 	id = "xenobio3";
@@ -76625,6 +76679,11 @@
 "pdW" = (
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/shield_generator)
+"pdX" = (
+/obj/structure/table/steel,
+/obj/random/powercell/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pdY" = (
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/nadezhda/engineering/atmos)
@@ -76953,6 +77012,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/crew_quarters/hydroponics)
+"phl" = (
+/obj/structure/table/reinforced,
+/obj/item/device/makeshift_centrifuge,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "phn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76966,6 +77034,11 @@
 "phr" = (
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/lakeside)
+"pht" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "phB" = (
 /obj/structure/bed/chair/sofa/teal/right{
 	dir = 4
@@ -77262,14 +77335,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"pkz" = (
-/obj/random/booze,
-/obj/random/junkfood/onlypizza,
-/obj/random/junkfood/onlyburger,
-/obj/random/junkfood,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pkA" = (
 /obj/effect/floor_decal/industrial/outline,
 /obj/effect/decal/cleanable/dirt,
@@ -77550,6 +77615,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"pnY" = (
+/obj/effect/window_lwall_spawn/reinforced,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pnZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -77619,10 +77688,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"poM" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "poN" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -77853,6 +77918,13 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/command/bridge)
+"pqT" = (
+/obj/machinery/vending/engivend,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pqZ" = (
 /obj/structure/table/gamblingtable,
 /obj/machinery/alarm{
@@ -78003,11 +78075,6 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"psF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "psH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -78090,6 +78157,13 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
+"ptC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/contraband/poster,
+/obj/item/contraband/poster,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ptD" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
@@ -78227,10 +78301,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"puG" = (
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "puJ" = (
 /obj/random/dungeon_gun_mods,
 /obj/random/dungeon_gun_mods,
@@ -79189,10 +79259,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"pDJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pDL" = (
 /turf/unsimulated/mineral,
 /area/nadezhda/engineering/engine_room)
@@ -79234,6 +79300,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"pEz" = (
+/obj/item/contraband/poster/placed/generic/work_for_a_future,
+/turf/simulated/wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pEE" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light{
@@ -79422,6 +79492,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
+"pGH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pGM" = (
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
@@ -79529,6 +79604,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/nadezhda/rnd/xenobiology/xenoflora)
+"pIg" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/welding,
+/obj/item/storage/belt,
+/obj/item/clothing/head/welding,
+/obj/item/computer_hardware/hard_drive/portable/design/misc,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pIj" = (
 /obj/machinery/door/unpowered/simple/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -79574,6 +79657,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/security/maingate)
+"pJb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/highsecurity,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pJd" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -79787,6 +79875,12 @@
 /obj/machinery/camera/network/cargo,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/miningdock)
+"pKH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pKS" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/asteroid/dirt/mud,
@@ -80111,6 +80205,11 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/rnd/robotics)
+"pNH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet_maintloot,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "pNJ" = (
 /obj/machinery/hologram/holopad{
 	name = "meeting room holopad two"
@@ -81210,10 +81309,6 @@
 	opacity = 0
 	},
 /area/shuttle/rocinante_shuttle_area)
-"pXu" = (
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pXz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/cyan{
@@ -81393,13 +81488,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"pZe" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/random/structures,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "pZp" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -81437,6 +81525,11 @@
 	},
 /turf/simulated/floor/reinforced/oxygen,
 /area/nadezhda/engineering/atmos)
+"pZz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/structures,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/colony)
 "pZA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -81542,6 +81635,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/absolutism/skyyard)
+"qaU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qaV" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -81763,12 +81860,6 @@
 /obj/item/mecha_parts/part/ivan_left_leg,
 /turf/simulated/floor/beach/water/jungledeep,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"qcX" = (
-/obj/machinery/door/window/southleft,
-/obj/machinery/door/window/northleft,
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qdc" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -82302,6 +82393,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/security/maingate/east)
+"qiO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qiP" = (
 /obj/structure/flora/small/bushb1,
 /obj/structure/flora/small/bushb2,
@@ -82389,6 +82485,10 @@
 	icon_state = "13,15"
 	},
 /area/nadezhda/hallway/surface/section1)
+"qjG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qjP" = (
 /obj/structure/reagent_dispensers/fueltank/huge,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -82989,13 +83089,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"qpr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk/cigbutt,
-/turf/simulated/floor/plating,
-/area/colony)
 "qps" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/genericbush,
@@ -83109,6 +83202,11 @@
 /obj/random/scrap/sparse_even/low_chance,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
+"qqW" = (
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qra" = (
 /obj/structure/table/standard,
 /obj/random/cloth/armor/low_chance,
@@ -83345,13 +83443,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
-"qsQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qsS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -83574,6 +83665,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/engineering/atmos)
+"qvI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qvN" = (
 /obj/structure/flora/small/trailrocka4,
 /obj/effect/floor_decal/rust/mono_rusted3,
@@ -83928,6 +84024,11 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/nadezhda/command/gmaster)
+"qyZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/spider_shadow_trap,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qzi" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -84146,10 +84247,6 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"qBI" = (
-/obj/structure/reagent_dispensers/bidon,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qBL" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/rnd/xenobiology)
@@ -85261,6 +85358,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/engineering/atmos)
+"qNe" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qNn" = (
 /obj/machinery/power/hydroelectric_control,
 /obj/structure/cable/yellow,
@@ -85322,9 +85423,6 @@
 /obj/structure/bookcase/guncase,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"qNP" = (
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qNS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/sparse_weighted,
@@ -85441,6 +85539,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/fo)
+"qPi" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qPl" = (
 /obj/random/flora/low_chance,
 /turf/simulated/floor/asteroid/grass,
@@ -85608,16 +85710,6 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"qQN" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/random/structures,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "qQP" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -85640,6 +85732,10 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1west)
+"qRe" = (
+/obj/item/contraband/poster/placed/generic/do_not_question,
+/turf/simulated/wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qRg" = (
 /obj/item/storage/box/costume/gnome,
 /obj/structure/table/steel,
@@ -85775,6 +85871,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/hallway/surface/section1)
+"qSL" = (
+/obj/structure/closet/wall_mounted/emcloset{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qSM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -86430,6 +86532,9 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"qZS" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "qZT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -86689,11 +86794,6 @@
 /obj/item/storage/box/headsets,
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/nadezhda/hallway/surface/section1)
-"rde" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/spiders/low_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rdj" = (
 /obj/structure/multiz/stairs/active,
 /obj/structure/window/reinforced{
@@ -86799,6 +86899,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/vasiliy_shuttle_area)
+"reu" = (
+/obj/structure/bonfire,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "rev" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Cargo";
@@ -87110,11 +87215,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/armory)
-"rgx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches/lower_chance,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rgy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -87480,6 +87580,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/disposaldrop)
+"rkk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/custom/onestar,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/colony)
 "rkw" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor,
@@ -87600,13 +87705,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
-"rlZ" = (
-/obj/machinery/vending/assist,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rmh" = (
 /obj/structure/table/rack/shelf,
 /obj/item/storage/box/bodybags{
@@ -87753,6 +87851,19 @@
 /obj/random/flora/low_chance,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"rne" = (
+/obj/machinery/mech_recharger,
+/obj/random/mecha/low_chance,
+/turf/simulated/floor/plating,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"rnj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rns" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 1;
@@ -87941,9 +88052,6 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/crew_quarters)
-"rph" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rpk" = (
 /obj/effect/floor_decal/industrial/road/straight1,
 /obj/structure/railing{
@@ -88049,14 +88157,6 @@
 /obj/item/circuitboard/puncher,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/engineering/workshop)
-"rqA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1;
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rqF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -88098,10 +88198,6 @@
 /obj/structure/flora/big/bush3,
 /turf/simulated/mineral,
 /area/nadezhda/outside/forest)
-"rrm" = (
-/obj/structure/janitorialcart,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rro" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -88228,6 +88324,13 @@
 /obj/item/scrap_lump,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/forest)
+"rtb" = (
+/obj/structure/table/reinforced,
+/obj/item/device/makeshift_electrolyser,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/liquid_fuel,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rtf" = (
 /obj/random/structures,
 /turf/simulated/floor/tiled/techmaint,
@@ -88284,11 +88387,6 @@
 /obj/item/device/destTagger,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/office)
-"rtz" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rtA" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -89393,10 +89491,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
-"rFb" = (
+"rEW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techmaint_perforated,
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "rFc" = (
 /obj/effect/decal/cleanable/rubble,
@@ -89499,6 +89599,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
+"rGl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap/sparse_weighted,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rGp" = (
 /obj/structure/catwalk,
 /obj/effect/spider/stickyweb,
@@ -89828,12 +89934,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
-"rJY" = (
-/obj/machinery/door/airlock/maintenance_interior{
-	name = "Hotel Desk"
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rKb" = (
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "BrigFoyer";
@@ -89930,6 +90030,10 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/turret_protected/ai)
+"rLc" = (
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rLd" = (
 /obj/structure/table/standard,
 /obj/machinery/centrifuge{
@@ -90256,6 +90360,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"rNs" = (
+/obj/random/cluster/termite_no_despawn_hoard,
+/turf/simulated/mineral,
+/area/colony)
 "rNt" = (
 /obj/structure/flora/small/grassb4,
 /obj/structure/flora/small/grassb4,
@@ -90329,13 +90437,6 @@
 	},
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/crew_quarters/techshop)
-"rOo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "rOs" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/regular,
@@ -90475,6 +90576,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/golden,
 /area/nadezhda/hallway/surface/section1)
+"rPW" = (
+/obj/structure/reagent_dispensers/bidon,
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rQb" = (
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/machinery/door/window/westright,
@@ -91190,6 +91295,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/nadezhda/security/prisoncells)
+"rXz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/structures,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rXF" = (
 /obj/effect/floor_decal/spline/wood{
 	dir = 4
@@ -91432,6 +91542,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/medical/genetics)
+"rZy" = (
+/obj/structure/table/standard,
+/obj/item/storage/pill_bottle/tramadol,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "rZB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -91994,6 +92109,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"seE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "seL" = (
 /obj/structure/catwalk,
 /obj/structure/railing{
@@ -92056,11 +92176,6 @@
 /mob/living/carbon/superior_animal/giant_spider/nurse,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"sfv" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sfB" = (
 /turf/simulated/floor/wood,
 /area/nadezhda/maintenance/undergroundfloor1north)
@@ -92112,6 +92227,10 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"sgx" = (
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "sgA" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -92616,6 +92735,11 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/white/cargo,
 /area/nadezhda/hallway/surface/section1)
+"smm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "smn" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/closet/crate,
@@ -92627,10 +92751,6 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/danger,
 /area/nadezhda/engineering/shield_generator)
-"smo" = (
-/obj/machinery/microwave/burnbarrel,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "smq" = (
 /obj/machinery/light{
 	dir = 8
@@ -92983,9 +93103,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
-"spr" = (
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sps" = (
 /obj/effect/decal/cleanable/rubble,
 /obj/effect/decal/cleanable/dirt,
@@ -93123,12 +93240,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/security/sechall)
-"sqD" = (
-/obj/structure/curtain/open/bed{
-	name = "Privacy curtain"
-	},
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sqE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -93176,6 +93287,11 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm3)
+"sqT" = (
+/obj/structure/closet/cabinet,
+/obj/random/booze,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "srf" = (
 /obj/machinery/light{
 	dir = 4
@@ -94276,11 +94392,6 @@
 	opacity = 0
 	},
 /area/nadezhda/hallway/side/f2section1)
-"sAO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sAP" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -94973,6 +95084,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"sIN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/plating,
+/area/colony)
 "sIQ" = (
 /obj/structure/table/reinforced,
 /obj/random/rig_module/low_chance,
@@ -95405,17 +95523,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/medical/virology)
-"sNS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"sNX" = (
-/obj/structure/closet/crate/secure/large,
-/obj/random/mat_katana,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sOd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -95924,13 +96031,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor1north)
-"sTe" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/purcarpet,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "sTh" = (
 /obj/structure/flora/big/bush2,
 /obj/structure/flora/small/bushc3,
@@ -96242,10 +96342,9 @@
 /turf/simulated/floor/tiled/cafe,
 /area/nadezhda/maintenance/undergroundfloor1west)
 "sXe" = (
-/obj/structure/boulder,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/white,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "sXj" = (
 /obj/structure/flora/small/trailrockb2,
@@ -96518,9 +96617,7 @@
 	name = "Residential District Maintenance"
 	})
 "sZK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/danger,
+/turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "sZL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -96620,10 +96717,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/nadezhda/security/armory_blackshield)
-"tax" = (
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "taE" = (
 /obj/structure/table/bench/steel,
 /obj/effect/decal/cleanable/dirt,
@@ -96824,11 +96917,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/cyancorner,
 /area/nadezhda/hallway/side/f2section1)
-"tcY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/plating/under,
-/area/colony)
+"tcK" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil/random,
+/obj/item/device/robotanalyzer,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tdf" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "8,20"
@@ -96912,11 +97006,6 @@
 /mob/living/carbon/superior_animal/giant_spider/nurse,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"tec" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/scrap/sparse_weighted,
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tef" = (
 /obj/machinery/r_n_d/server/robotics,
 /turf/simulated/floor/bluegrid{
@@ -97129,11 +97218,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/outside/pond)
-"tgH" = (
-/obj/structure/boulder,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tgU" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -97212,6 +97296,13 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/command/tcommsat/computer)
+"thJ" = (
+/obj/structure/table/woodentable,
+/obj/random/gun_parts/low,
+/obj/random/ammo,
+/obj/random/gun_parts/low,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "thK" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -97564,6 +97655,17 @@
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/turret_protected/ai_upload)
+"tln" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/employment,
+/obj/random/credits/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"tlo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/eastright,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tls" = (
 /obj/machinery/telecomms/server/presets/unused,
 /turf/simulated/floor/bluegrid{
@@ -98856,6 +98958,14 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/inside_colony)
+"tyQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall_mounted{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tyY" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
@@ -98994,6 +99104,14 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/virology)
+"tAc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tAg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -99055,6 +99173,16 @@
 /obj/random/cluster/roaches/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"tAW" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tAY" = (
 /obj/item/stool/padded,
 /obj/effect/floor_decal/industrial/warningred{
@@ -99489,6 +99617,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/surfaceeast)
+"tFp" = (
+/obj/machinery/door/airlock/maintenance_cargo,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tFu" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -99840,6 +99973,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"tII" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/arrows/white{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tIK" = (
 /obj/item/device/lighting/toggleable/lantern{
 	on = 1
@@ -100117,6 +100257,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/sechall)
+"tLs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/low_chance,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tLv" = (
 /obj/structure/table/standard,
 /obj/item/storage/briefcase/inflatable,
@@ -100221,6 +100367,10 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
+"tMs" = (
+/obj/random/structures,
+/turf/simulated/floor/tiled/white/gray_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tMu" = (
 /obj/structure/noticeboard/anomaly{
 	pixel_x = 31
@@ -100383,13 +100533,6 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/beach/water/shallow,
 /area/nadezhda/outside/forest)
-"tNF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tNJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera/network/research{
@@ -100397,25 +100540,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/medical/genetics)
-"tNL" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cyancorner,
-/area/nadezhda/hallway/side/f2section1)
 "tNQ" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -100864,6 +100988,11 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/wood,
 /area/nadezhda/command/captain)
+"tRf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/spiders/low_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tRh" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -100885,6 +101014,12 @@
 /obj/machinery/camera/network/church,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"tRF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/random/junkfood/rotten,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tRG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/porta_turret/gate,
@@ -101267,6 +101402,13 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"tVD" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "tVO" = (
 /obj/effect/window_lwall_spawn,
 /obj/structure/flora/big/bush3{
@@ -101514,11 +101656,6 @@
 /mob/living/carbon/superior_animal/giant_spider/nurse/recluse,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"tYf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "tYn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
@@ -101968,10 +102105,6 @@
 /obj/structure/flora/big/bush3,
 /turf/unsimulated/wall/jungle,
 /area/nadezhda/outside/forest)
-"ucE" = (
-/obj/effect/floor_decal/industrial/arrows/white,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ucI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -102081,6 +102214,10 @@
 	icon_state = "12,3"
 	},
 /area/shuttle/rocinante_shuttle_area)
+"udl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "udt" = (
 /obj/structure/table/bench/padded,
 /obj/structure/disposalpipe/segment{
@@ -102459,14 +102596,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/servist)
-"ugo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/tool/knife/butch,
-/obj/item/material/kitchen/rollingpin,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ugq" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -103713,6 +103842,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"utd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ute" = (
 /obj/machinery/button/remote/airlock{
 	id = "D4A";
@@ -103981,6 +104115,9 @@
 /obj/random/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"uwr" = (
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uwB" = (
 /obj/structure/shuttle_part/science{
 	icon_state = "15,2"
@@ -104489,6 +104626,13 @@
 	},
 /turf/simulated/floor/wood/wild3,
 /area/nadezhda/command/prime)
+"uCu" = (
+/obj/structure/closet/wall_mounted{
+	pixel_x = -32
+	},
+/obj/item/storage/box/drinkingglasses,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uCz" = (
 /obj/effect/spider/stickyweb,
 /obj/machinery/light/small{
@@ -104673,16 +104817,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/nadezhda/crew_quarters/sleep/cryo2)
-"uEu" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 1
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/curtain/open,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uEv" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/small/bushb2,
@@ -104694,6 +104828,12 @@
 	opacity = 0
 	},
 /area/shuttle/rocinante_shuttle_area)
+"uEE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uEF" = (
 /obj/structure/catwalk,
 /obj/structure/cable/cyan{
@@ -104998,6 +105138,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/maintenance/surfaceeast)
+"uHJ" = (
+/obj/random/cluster/spiders,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uHQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -105240,10 +105384,17 @@
 	name = "Residential District Maintenance"
 	})
 "uJY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/structures,
-/turf/simulated/floor/tiled/steel/bar_dance,
-/area/colony)
+/obj/structure/table/rack,
+/obj/structure/curtain/medical,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/organ/external/robotic/junktech/r_leg,
+/obj/item/organ/external/robotic/junktech/r_arm,
+/obj/item/organ/external/robotic/junktech/l_leg,
+/obj/item/organ/external/robotic/junktech/l_arm,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uJZ" = (
 /obj/structure/multiz/stairs/active,
 /turf/simulated/floor/tiled/steel/danger,
@@ -105614,14 +105765,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
-"uMP" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/makeshift_grinder,
-/obj/effect/decal/cleanable/cobweb{
-	dir = 4
-	},
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uMS" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -105821,16 +105964,18 @@
 /obj/structure/multiz/stairs/enter/bottom,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/hallway/side/f2section1)
+"uOn" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/cluster/roaches/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "uOp" = (
 /obj/structure/closet/l3closet,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/sleeper)
-"uOt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/double/padded,
-/obj/random/furniture/bedsheetdouble,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uOw" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -106376,13 +106521,6 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/nadezhda/crew_quarters/clownoffice)
-"uTa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "uTb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/boulder,
@@ -107061,11 +107199,6 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/medical/sleeper)
-"vap" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vaq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -107231,6 +107364,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/panels,
 /area/nadezhda/rnd/xenobiology)
+"vcf" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vch" = (
 /turf/unsimulated/mask,
 /area/colony)
@@ -107389,11 +107526,6 @@
 /obj/structure/multiz/stairs/active,
 /turf/simulated/floor/tiled/dark/violetcorener,
 /area/nadezhda/hallway/main/stairwell)
-"vdZ" = (
-/obj/structure/bonfire,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "ved" = (
 /obj/effect/floor_decal/corner_oldtile,
 /obj/effect/floor_decal/corner_oldtile{
@@ -108129,12 +108261,6 @@
 /obj/random/structures/os,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"vli" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/bench/glass,
-/obj/structure/curtain/red,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vlm" = (
 /obj/effect/floor_decal/industrial/road/straight2,
 /obj/machinery/camera/network/colony_surface{
@@ -108488,6 +108614,11 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating,
 /area/nadezhda/security/maingate)
+"vop" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/closet,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "voq" = (
 /obj/item/modular_computer/console/preset/engineering{
 	dir = 8
@@ -108526,6 +108657,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/nadezhda/command/cbo)
+"voM" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/oddity/common/paper_bundle,
+/obj/machinery/door/window/eastright,
+/turf/simulated/floor/tiled/dark/monofloor,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "voT" = (
 /obj/random/material_resources/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -108949,6 +109086,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/nadezhda/maintenance/undergroundfloor1east)
+"vtv" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/makeshift_grinder,
+/obj/effect/decal/cleanable/cobweb{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vtx" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/random/spider_trap_burrowing/low_chance,
@@ -109041,6 +109186,13 @@
 /obj/random/material,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/outside/inside_colony)
+"vul" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vun" = (
 /obj/random/flora/jungle_tree,
 /obj/structure/flora/small/busha1,
@@ -109354,11 +109506,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/rnd/xenobiology/xenoflora)
-"vxb" = (
-/obj/structure/table/glass,
-/obj/structure/curtain/black,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vxh" = (
 /obj/machinery/vending/boozeomat{
 	req_access = list(25)
@@ -109669,13 +109816,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"vBC" = (
-/obj/structure/curtain/open/bed{
-	name = "Privacy curtain"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vBE" = (
 /obj/effect/floor_decal/spline/fancy/three_quarters,
 /obj/structure/largecrate/animal/cow,
@@ -109801,10 +109941,6 @@
 /obj/structure/sign/warning/internals_required/small,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/command/tcommsat/computer)
-"vCK" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/cafe,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vCR" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -109981,6 +110117,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/golden,
 /area/nadezhda/absolutism/chapel)
+"vEv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vEE" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 1
@@ -109992,13 +110135,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/command/captain)
-"vEF" = (
-/obj/machinery/vending/engivend,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vEG" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
@@ -110075,6 +110211,11 @@
 /obj/item/storage/box/syringes,
 /turf/simulated/floor/tiled/white,
 /area/nadezhda/medical/genetics)
+"vFd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vFf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
@@ -110137,6 +110278,12 @@
 /obj/effect/overlay/water/top,
 /turf/simulated/floor/beach/water/flooded,
 /area/nadezhda/outside/pond)
+"vFS" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vFX" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/asteroid/grass,
@@ -110236,6 +110383,10 @@
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/nadezhda/quartermaster/disposaldrop)
+"vHb" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/cafe,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vHj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -110270,11 +110421,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/nadezhda/medical/ward)
-"vHo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vHt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -110866,11 +111012,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"vMC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vMD" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/big/bush3,
@@ -111162,16 +111303,6 @@
 /obj/item/modular_computer/tablet/lease/preset/command,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/nadezhda/command/cbo)
-"vPM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/boulder,
-/turf/simulated/floor/plating/under,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"vPN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/closet_tech/low_chance,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "vPQ" = (
 /obj/machinery/power/breakerbox{
 	RCon_tag = "Mar Substation Bypass"
@@ -111382,6 +111513,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/nadezhda/pros/shuttle)
+"vRR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain/open/shower/closed,
+/turf/simulated/floor/plating,
+/area/colony)
 "vRS" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,18"
@@ -111824,6 +111960,12 @@
 /obj/structure/flora/small/trailrocka1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
+"vVc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/colony)
 "vVe" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -112138,6 +112280,11 @@
 /obj/structure/sign/painting/paintingtable,
 /turf/simulated/wall,
 /area/nadezhda/crew_quarters/dorm2)
+"vXR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk/cigbutt,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "vXX" = (
 /obj/item/modular_computer/console/preset/engineering{
 	dir = 1
@@ -112325,12 +112472,6 @@
 /obj/random/tool/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1south)
-"wad" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "waj" = (
 /obj/item/ammo_magazine/ammobox/shotgun/buckshot{
 	pixel_x = 4;
@@ -112668,6 +112809,11 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"wdq" = (
+/obj/item/reagent_containers/syringe/drugs,
+/obj/item/reagent_containers/pill/floorpill,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wdv" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
@@ -112808,11 +112954,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
-"wet" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wew" = (
 /obj/random/flora/small_jungle_tree,
 /obj/structure/flora/big/bush2,
@@ -113384,6 +113525,11 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/engineering/atmos)
+"wkJ" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/under,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wlg" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -113606,11 +113752,6 @@
 "wmS" = (
 /turf/simulated/floor/tiled/steel,
 /area/turbolift/ElevatorOne/surface)
-"wmX" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/autolathe/mechfab/loaded,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wmY" = (
 /obj/random/cluster/roaches/low_chance,
 /obj/effect/decal/cleanable/dirt,
@@ -113685,6 +113826,12 @@
 /obj/random/gun_handmade/low_chance,
 /turf/simulated/floor/wood_old,
 /area/nadezhda/outside/forest)
+"wnX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/double/padded,
+/obj/random/furniture/bedsheetdouble,
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wob" = (
 /obj/structure/barricade,
 /turf/simulated/floor/plating/under,
@@ -114271,6 +114418,13 @@
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/engineering/atmos)
+"wrV" = (
+/obj/machinery/door/window/eastright,
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wsa" = (
 /obj/item/clothing/suit/gorka/toggle/gorka/crew_o{
 	name = "Digger's gorka jacket";
@@ -114398,6 +114552,10 @@
 /obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"wtP" = (
+/obj/random/cluster/slimes,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wtQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/railing{
@@ -114414,6 +114572,14 @@
 /obj/random/scrap/dense_weighted/low_chance,
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/nadezhda/maintenance/undergroundfloor1west)
+"wtX" = (
+/obj/machinery/door/airlock/centcom{
+	id_tag = "D1-A3";
+	name = "D1-A3"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wub" = (
 /obj/structure/flora/small/busha1,
 /obj/structure/flora/big/bush3,
@@ -114759,6 +114925,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/techfloor,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"wxY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wyg" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 5
@@ -114795,12 +114966,6 @@
 "wyv" = (
 /turf/simulated/floor/reinforced,
 /area/shuttle/rocinante_shuttle_area)
-"wyw" = (
-/obj/effect/floor_decal/industrial/caution{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/nadezhda/engineering/engine_room)
 "wyG" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "7,10"
@@ -115029,10 +115194,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"wAx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/colony)
 "wAH" = (
 /obj/random/booze/low_chance,
 /obj/random/booze/low_chance,
@@ -115065,6 +115226,14 @@
 /obj/machinery/camera/network/colony_surface,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/pros/shuttle)
+"wBA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/projectile/revolver/handmade,
+/obj/item/clothing/accessory/duster/bloodred,
+/obj/item/ammo_magazine/ammobox/pistol_35/scrap,
+/turf/simulated/floor/plating,
+/area/colony)
 "wBD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -115209,6 +115378,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/command/swo/quarters)
+"wCL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/random/scrap,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wCM" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/beer,
@@ -115638,6 +115815,11 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/nadezhda/hallway/surface/section1)
+"wHI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance_cargo,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wHK" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -116363,6 +116545,17 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/maintenance/undergroundfloor2west)
+"wPt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/eastright,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -116497,6 +116690,11 @@
 /obj/structure/sign/department/prison,
 /turf/simulated/wall/r_wall,
 /area/nadezhda/security/sechall)
+"wQE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/plating/under,
+/area/colony)
 "wQJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -116764,6 +116962,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/asteroid/dirt/dark,
 /area/nadezhda/crew_quarters/hydroponics/garden)
+"wTQ" = (
+/obj/random/cluster/roaches/lower_chance,
+/turf/simulated/floor/wood/wild5,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "wTT" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 9
@@ -116848,13 +117050,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/nadezhda/medical/ward)
-"wUE" = (
-/obj/structure/closet/wall_mounted{
-	pixel_x = -32
-	},
-/obj/item/storage/box/drinkingglasses,
-/turf/simulated/floor/wood/wild5,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wUF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -116966,11 +117161,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
-"wVR" = (
-/obj/structure/closet/cabinet,
-/obj/random/booze,
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "wVT" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -117103,16 +117293,12 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/nadezhda/crew_quarters/bar)
-"wWF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
-"wWH" = (
-/obj/structure/table/bench/glass,
-/obj/structure/curtain/red,
-/obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/wood/wild4,
+"wWD" = (
+/obj/structure/table/rack/shelf,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/lowkeyrandom/low_chance,
+/obj/random/contraband/low_chance,
+/turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/maintenance/undergroundfloor2east)
 "wWI" = (
 /obj/structure/bed/chair{
@@ -117586,6 +117772,14 @@
 /obj/random/scrap/dense_even,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor2north)
+"xcz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/tool/knife/butch,
+/obj/item/material/kitchen/rollingpin,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/wood/wild4,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xcG" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -117615,11 +117809,6 @@
 /obj/structure/flora/small/busha1,
 /turf/simulated/floor/asteroid/grass,
 /area/nadezhda/outside/forest)
-"xcV" = (
-/obj/random/cluster/roaches/lower_chance,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xcW" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -117630,13 +117819,6 @@
 /obj/structure/flora/small/rock1,
 /turf/simulated/floor/asteroid/dirt,
 /area/nadezhda/engineering/engine_room)
-"xdi" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xdw" = (
 /obj/item/contraband/poster/placed/generic/high_class_martini,
 /turf/simulated/wall,
@@ -117689,9 +117871,6 @@
 	},
 /turf/simulated/floor/wood/wild2,
 /area/nadezhda/crew_quarters/dorm2)
-"xed" = (
-/turf/simulated/floor/wood/wild4,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xem" = (
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -117778,6 +117957,14 @@
 /area/nadezhda/maintenance{
 	name = "Residential District Maintenance"
 	})
+"xfp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/hallway/side/f2section1)
 "xfu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -118052,6 +118239,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/nadezhda/crew_quarters/sleep/cryo2)
+"xhV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/boulder,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xia" = (
 /obj/random/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -118090,6 +118282,11 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
+"xiD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/scrap,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xiO" = (
 /obj/machinery/door/airlock/external{
 	name = "Terminal Lounge"
@@ -118110,6 +118307,13 @@
 	name = "murky water"
 	},
 /area/nadezhda/maintenance/undergroundfloor1east)
+"xiX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/nadezhda/quartermaster/miningdock)
 "xiY" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -118693,6 +118897,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/security/armory_blackshield)
+"xox" = (
+/obj/machinery/door/airlock/maintenance_interior{
+	name = "Hotel Desk"
+	},
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xoC" = (
 /obj/random/structures/low_chance,
 /turf/simulated/floor/rock,
@@ -119306,15 +119516,6 @@
 	dir = 4
 	},
 /area/nadezhda/maintenance/surfacesec)
-"xuA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack/shelf,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/lowkeyrandom/low_chance,
-/obj/random/common_oddities/low_chance,
-/obj/random/gun_normal/low_chance,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xuB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/arcade,
@@ -119549,12 +119750,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/nadezhda/absolutism/bioreactor)
-"xwH" = (
-/obj/item/modular_computer/telescreen/preset/generic{
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xwJ" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 8
@@ -119575,6 +119770,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/rnd/rbreakroom)
+"xwV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xwW" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -119798,6 +119997,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/substation/servist)
+"xzq" = (
+/obj/machinery/door/window/westleft,
+/obj/machinery/door/window/eastleft,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xzr" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 4;
@@ -120232,11 +120437,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/danger,
 /area/nadezhda/medical/sleeper)
-"xCU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/highsecurity,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xCV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -120283,12 +120483,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/nadezhda/crew_quarters/pool)
-"xDE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/obj/random/cluster/spiders,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xDH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -120998,6 +121192,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor1south)
+"xKp" = (
+/obj/machinery/door/airlock/maintenance_cargo,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xKv" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -121277,6 +121475,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/nadezhda/maintenance/undergroundfloor1north)
+"xMY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading/red,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xNb" = (
 /obj/machinery/light{
 	dir = 1
@@ -121329,10 +121532,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/nadezhda/maintenance/undergroundfloor1east)
-"xNx" = (
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/tiled/dark/danger,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xNG" = (
 /obj/structure/closet/wardrobe/misc/pjs,
 /obj/item/clothing/under/medigown,
@@ -121455,6 +121654,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/nadezhda/maintenance/surfaceeast)
+"xPG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/marble,
+/obj/item/storage/bag/produce,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
+"xPM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/steel/cyancorner,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "xPO" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
@@ -121620,15 +121830,6 @@
 	opacity = 0
 	},
 /area/shuttle/rocinante_shuttle_area)
-"xQT" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/bodybags,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/random/circuitboard/low_chance,
-/turf/simulated/floor/tiled/white/gray_platform,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "xQU" = (
 /turf/simulated/floor/wood/wild5,
 /area/nadezhda/maintenance/undergroundfloor1east)
@@ -122688,12 +122889,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/under,
 /area/nadezhda/maintenance/undergroundfloor2west)
-"ybD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/structures,
-/obj/machinery/floor_light,
-/turf/simulated/floor/tiled/steel/bar_dance,
-/area/colony)
 "ybE" = (
 /obj/structure/closet/wall_mounted/emcloset{
 	pixel_y = 32
@@ -122720,11 +122915,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/nadezhda/engineering/atmos/surface)
-"ybY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/structures,
-/turf/simulated/floor/tiled/dark,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ycd" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -122748,6 +122938,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/monofloor,
 /area/nadezhda/command/bridge)
+"ycm" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techmaint_perforated,
+/area/nadezhda/maintenance/undergroundfloor2east)
 "ycn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -122772,11 +122967,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/nadezhda/outside/inside_colony)
-"ycA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/cluster/roaches,
-/turf/simulated/floor/tiled/white/gray_perforated,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "ycC" = (
 /obj/structure/sign/warning/nosmoking/small,
 /turf/simulated/wall/r_wall,
@@ -123047,12 +123237,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/nadezhda/quartermaster/hangarsupply)
-"yfJ" = (
-/obj/structure/closet/crate/secure/large,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/credits/low_chance,
-/turf/simulated/floor/tiled/dark/monofloor,
-/area/nadezhda/maintenance/undergroundfloor2east)
 "yfL" = (
 /obj/machinery/camera/network/research{
 	dir = 4
@@ -123302,6 +123486,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/nadezhda/security/tactical_blackshield)
+"yiM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/colony)
 "yiS" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/asteroid/dirt/dust,
@@ -150747,7 +150935,7 @@ kUx
 kUx
 kUx
 aFa
-eLB
+xiX
 qxo
 hax
 nzT
@@ -183420,9 +183608,9 @@ cvn
 mjZ
 vmZ
 hSX
-mpk
-tNL
-lnB
+obe
+fuz
+bmf
 sCN
 sCN
 sCN
@@ -183441,9 +183629,9 @@ aOb
 lif
 sRU
 sRU
-mpk
-tNL
-dHe
+obe
+fuz
+aXU
 cCy
 nBz
 cxN
@@ -184053,7 +184241,7 @@ cvc
 dJa
 cCy
 cCy
-lkc
+mom
 cCy
 cCy
 nCK
@@ -189893,7 +190081,7 @@ whU
 eMU
 whU
 whU
-kVX
+dtY
 nUF
 wnJ
 tIQ
@@ -190095,7 +190283,7 @@ iBR
 nVZ
 iBR
 iBR
-dsz
+hRi
 iBR
 iBR
 iBR
@@ -190297,7 +190485,7 @@ whU
 qwB
 whU
 whU
-amS
+xfp
 bbM
 rkA
 ilF
@@ -194305,12 +194493,12 @@ cZb
 cZb
 cZb
 wEB
-wmX
-lfe
-mbq
-ePL
-pZe
-vMC
+lTA
+xMY
+pIg
+fEo
+lrl
+smm
 wEB
 wEB
 wEB
@@ -194318,8 +194506,8 @@ wEB
 wEB
 tTB
 vJX
-sXe
-sXe
+bje
+bje
 wEB
 wEB
 wEB
@@ -194507,12 +194695,12 @@ cZb
 cZb
 cZb
 wEB
-htJ
-ycA
-bjV
-hQu
-qNP
-bjV
+tcK
+gao
+mYl
+uOn
+uwr
+mYl
 wEB
 iKp
 jWI
@@ -194521,9 +194709,9 @@ wEB
 pOR
 avz
 rsN
-sXe
+bje
 wiO
-tgH
+wkJ
 wEB
 cZb
 cZb
@@ -194709,12 +194897,12 @@ wEB
 wEB
 wEB
 wEB
-fzv
-qNP
-bjV
-wad
-rOo
-meS
+eWs
+uwr
+mYl
+mdG
+eMA
+qNe
 wEB
 iVg
 nXu
@@ -194723,9 +194911,9 @@ wEB
 snr
 kSY
 wEB
-tgH
-tgH
-dzJ
+wkJ
+wkJ
+rGl
 wEB
 cZb
 cZb
@@ -194903,20 +195091,20 @@ cZb
 cZb
 cZb
 wEB
-dhc
-pDJ
-hmG
-hmG
-iKI
+gkP
+oGq
+dtc
+dtc
+mjO
 wEB
-lLR
-ybY
-qNP
-aQT
-hPR
-aQT
-kpl
-djP
+eVk
+rXz
+uwr
+liO
+jcR
+liO
+cID
+rne
 wEB
 lVS
 lVS
@@ -194925,9 +195113,9 @@ snr
 pQH
 pQH
 wEB
-hzp
-dnO
-hRI
+nPf
+mBb
+tLs
 wEB
 cZb
 cZb
@@ -195105,20 +195293,20 @@ cZb
 cZb
 cZb
 wEB
-sNX
-jQU
-xDE
-pDJ
-pDJ
+hMa
+jxX
+oyc
+oGq
+oGq
 wEB
-bjV
-qNP
-bjV
-qNP
-bjV
-wad
-bjV
-qNP
+mYl
+uwr
+mYl
+uwr
+mYl
+mdG
+mYl
+uwr
 wEB
 lVS
 lVS
@@ -195127,9 +195315,9 @@ lTo
 qBj
 snr
 wEB
-wWF
-ojO
-wet
+sXe
+eyb
+hYy
 wEB
 cZb
 cZb
@@ -195196,7 +195384,7 @@ kyK
 diB
 kyK
 kyK
-wyw
+gnV
 kyK
 fbS
 sAU
@@ -195307,22 +195495,22 @@ cZb
 cZb
 cZb
 wEB
-jrJ
-pDJ
-cmn
-nwP
-fol
+ghz
+oGq
+fuS
+qvI
+tAW
 wEB
-bjV
-bjV
-tax
-hrU
-xQT
-qQN
-rlZ
-vEF
+mYl
+mYl
+fGZ
+tMs
+luJ
+iRR
+hWP
+pqT
 wEB
-sXe
+bje
 wiO
 wEB
 wEB
@@ -195330,13 +195518,13 @@ wEB
 wEB
 wEB
 wEB
-gNb
+cxY
 wEB
 wEB
-tgH
-tgH
-tgH
-tgH
+wkJ
+wkJ
+wkJ
+wkJ
 cZb
 cZb
 cZb
@@ -195509,36 +195697,36 @@ cZb
 cZb
 cZb
 wEB
-aQN
-pDJ
-kTQ
-xdi
-kfU
+eFR
+oGq
+aOD
+tVD
+voM
 wEB
-nSn
-wEB
-wEB
+kKg
 wEB
 wEB
 wEB
 wEB
 wEB
 wEB
-tgH
-tgH
-cYB
+wEB
+wEB
+wkJ
+wkJ
+vFd
 pQH
 pQH
-djp
+hqj
 pQH
 snr
-rph
+qZS
 snr
 pQH
-qsQ
+chH
 snr
-tgH
-tgH
+wkJ
+wkJ
 cZb
 cZb
 cZb
@@ -195711,34 +195899,34 @@ cZb
 cZb
 cZb
 wEB
-iSO
-pDJ
-pDJ
-lmK
-lJG
-psF
+auH
+oGq
+oGq
+lxh
+qyZ
+gVZ
 snr
-qsQ
-tgH
-hZN
-tgH
-lyp
+chH
+wkJ
+fqa
+wkJ
+qPi
 lVS
-kHK
-faV
+dHH
+gwX
 lVS
-lyp
+qPi
 wEB
 wEB
-fmq
-wEB
-wEB
-wEB
-mnR
+gUa
 wEB
 wEB
 wEB
-mjI
+mxe
+wEB
+wEB
+wEB
+wtX
 wEB
 wEB
 cZb
@@ -195913,35 +196101,35 @@ cZb
 cZb
 cZb
 wEB
-yfJ
-pDJ
-hmG
-jQU
-ajD
+cML
+oGq
+dtc
+jxX
+oHi
 wEB
-eQC
-wEB
-wEB
+fff
 wEB
 wEB
 wEB
 wEB
 wEB
 wEB
-iKh
-bcG
 wEB
-wWF
-iwK
-pkz
 wEB
-wWF
-iwK
-pkz
+qSL
+fCd
 wEB
-wWF
-iwK
-pkz
+sXe
+xwV
+ddv
+wEB
+sXe
+xwV
+ddv
+wEB
+sXe
+xwV
+ddv
 wEB
 cZb
 cZb
@@ -196115,35 +196303,35 @@ cZb
 cZb
 cZb
 wEB
-dBI
-pDJ
-ghS
-pDJ
-ajD
+lYm
+oGq
+adi
+oGq
+oHi
 wEB
-jqb
-jqb
-hOO
-jqb
-jqb
+sZK
+sZK
+vFS
+sZK
+sZK
 wEB
-nDt
-iqf
-rJY
-ilJ
-pXu
+iIr
+gvZ
+xox
+llr
+hGc
 wEB
-ojG
-puG
-dML
+gbE
+vcf
+pNH
 wEB
-cyU
-rde
-vHo
+pdX
+tRf
+vop
 wEB
-ioV
-iwK
-vPN
+fJK
+xwV
+cqt
 wEB
 cZb
 cZb
@@ -196317,35 +196505,35 @@ cZb
 cZb
 cZb
 wEB
-cvN
-pDJ
-hmG
-pDJ
-gUa
+dcw
+oGq
+dtc
+oGq
+rLc
 wEB
-rrm
-vap
-qBI
-nKP
-hzQ
+kAU
+pht
+rPW
+jRw
+qqW
 wEB
-okG
-lkC
+iSs
+iEw
 wEB
-uTa
+vul
 lVS
 wEB
-cIh
-iwK
-xwH
+wPt
+xwV
+oCi
 wEB
-cIh
-iwK
-tNF
+wPt
+xwV
+blH
 wEB
-cIh
-cnq
-tNF
+wPt
+wtP
+blH
 wEB
 cZb
 cZb
@@ -196522,7 +196710,7 @@ wEB
 wEB
 wEB
 sju
-hBZ
+cot
 sju
 sju
 sju
@@ -196531,23 +196719,23 @@ wEB
 wEB
 wEB
 wEB
-sTe
-mhd
-qcX
-jOw
-faV
+ire
+jjj
+hnL
+end
+gwX
 wEB
-hLI
-rqA
-uOt
+nuz
+cnP
+wnX
 wEB
-hLI
-rqA
-uOt
+nuz
+cnP
+wnX
 wEB
-uEu
-rqA
-uOt
+lmg
+cnP
+wnX
 wEB
 cZb
 cZb
@@ -196724,19 +196912,19 @@ cZb
 cZb
 cZb
 sju
-dAv
-xuA
-eIh
-eEp
+qaU
+gFO
+rEW
+wWD
 sju
-lbS
-imD
-vdZ
+iVc
+wBA
+reu
 wEB
-fnc
-fwq
+iLb
+ebA
 wEB
-tec
+knW
 lVS
 wEB
 wEB
@@ -196926,34 +197114,34 @@ cZb
 cZb
 cZb
 sju
-dAv
-sAO
-sAO
-dAv
+qaU
+bNu
+bNu
+qaU
 sju
-nGT
-qpr
-atb
+nGc
+sIN
+gmj
 wEB
 wEB
 wEB
 wEB
 lVS
-faV
-vxb
-wUE
-uMP
+gwX
+ogV
+uCu
+vtv
 wEB
-ugo
-hYK
-smo
+xcz
+hnh
+lyw
 wEB
-gbE
-mZF
-fTQ
+rZy
+bjV
+goH
 wEB
-aMF
-uJY
+kCy
+pZz
 kUx
 jZv
 arM
@@ -197128,34 +197316,34 @@ cZb
 cZb
 cZb
 sju
-dAv
-dsV
-bBY
-azC
+qaU
+rnj
+aSi
+cxM
 sju
-wAx
-nGT
-igY
-wAx
-nGT
-nGT
-cyT
-faV
+frc
+nGc
+vVc
+frc
+nGc
+nGc
+vRR
+gwX
 lVS
-vxb
-cJp
-dBX
+ogV
+wTQ
+rtb
 wEB
-hsH
-rgx
-inX
+tyQ
+okw
+bsB
 wEB
-cGZ
-xcV
-kNZ
+jgK
+dXl
+uEE
 wEB
-bMO
-ybD
+rkk
+nWZ
 kUx
 jZv
 arM
@@ -197330,10 +197518,10 @@ cZb
 cZb
 cZb
 sju
-dAv
-sAO
-lWz
-spr
+qaU
+bNu
+lDi
+bJW
 sju
 sju
 sju
@@ -197344,20 +197532,20 @@ sju
 sju
 lVS
 lVS
-ffe
-nwl
-joX
+coe
+bXY
+phl
 wEB
-eCY
-eCY
-lXp
+tRF
+tRF
+tlo
 wEB
-tYf
-tYf
-ogi
+pGH
+pGH
+ezk
 wEB
-aMF
-uJY
+yiM
+pZz
 kUx
 jZv
 jZv
@@ -197532,33 +197720,33 @@ cZb
 cZb
 cZb
 sju
-bBY
-eIh
-eIh
-dAv
+aSi
+rEW
+rEW
+qaU
 sju
-ivJ
-evC
-nRe
-sZK
-xNx
-jug
-lCX
-mpV
-ogV
+tln
+gkb
+msz
+ePp
+hZi
+tII
+fTh
+utd
+jRH
 wEB
 wEB
 wEB
 wEB
-vli
-wWH
-cSL
+lpn
+jjK
+hVv
 wEB
-gFf
-gHy
-bJQ
+wrV
+hsP
+uJY
 wEB
-dpA
+sgx
 wEB
 kUx
 cZb
@@ -197734,20 +197922,20 @@ cZb
 cZb
 cZb
 sju
-dAv
-dAv
-dAv
-spr
+qaU
+qaU
+qaU
+bJW
 sju
-dGK
-dAv
-fbX
-ucE
-sNS
-poM
+pKH
+qaU
+mKu
+kGh
+eEH
+idU
 sju
-tgH
-lyp
+wkJ
+qPi
 lVS
 lVS
 lVS
@@ -197755,14 +197943,14 @@ lVS
 lVS
 lVS
 lVS
-hnU
-hLz
-faV
+kof
+qiO
+gwX
 lVS
-ilJ
+llr
 lVS
-vPM
-tcY
+bOd
+wQE
 cZb
 cZb
 cZb
@@ -197936,31 +198124,31 @@ cZb
 cZb
 cZb
 sju
-eEp
-byo
-dsV
-dAv
-xCU
-sAO
-lyf
-hWa
-xNx
-sZK
-jug
-liR
-tgH
-tgH
+wWD
+kXh
+rnj
+qaU
+pJb
+bNu
+jtC
+cHv
+hZi
+ePp
+tII
+nwV
+wkJ
+wkJ
 wEB
-mti
-wEB
-wEB
-vBC
+vHb
 wEB
 wEB
-sqD
+dNB
 wEB
 wEB
-sqD
+iWU
+wEB
+wEB
+iWU
 wEB
 wEB
 wEB
@@ -198150,20 +198338,20 @@ sju
 sju
 sju
 sju
-rtz
-frF
+ycm
+bDI
 wEB
-vCK
-ohr
+fKk
+mAb
 wEB
-bzT
-nRA
+bPB
+mRy
 wEB
-kfa
-wVR
+jns
+sqT
 wEB
-kfa
-nRA
+jns
+mRy
 wEB
 cZb
 cZb
@@ -198339,33 +198527,33 @@ tad
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-rsN
-hBm
-ifo
+wkJ
+wkJ
+wkJ
+wkJ
+wkJ
+wkJ
+wkJ
+wkJ
+ycm
+lVS
+lVS
+gwX
+gwX
+lVS
+xhV
 wEB
-dqq
-ohr
+kvJ
+mAb
 wEB
-nWL
-iMN
+vXR
+flJ
 wEB
-xed
-sfv
+jdQ
+llE
 wEB
-aOT
-sfv
+wdq
+llE
 wEB
 cZb
 cZb
@@ -198541,21 +198729,21 @@ tad
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
 wEB
-hBm
-cLU
+wEB
+wEB
+xKp
+wEB
+nxO
+nxO
+tFp
+wEB
+wHI
+pnY
+xzq
+wEB
+qjG
+eDP
 wEB
 wEB
 wEB
@@ -198743,21 +198931,21 @@ tad
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+qRe
+ptC
+wCL
+goS
 wEB
-ifo
-cLU
+xPG
+xiD
+ccl
+wEB
+sCI
+bzY
+vEv
+wEB
+xhV
+eDP
 wEB
 cZb
 cZb
@@ -198945,21 +199133,21 @@ tad
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+pEz
+avX
+kOr
+mtZ
 wEB
-faV
-faV
+fkv
+wxY
+ddy
+wEB
+mOv
+sCI
+bmg
+wEB
+hGc
+gwX
 wEB
 cZb
 cZb
@@ -199147,20 +199335,20 @@ tad
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+bky
+ptC
+lDb
+ptC
 wEB
-faV
+xPM
+tAc
+xPM
+udl
+thJ
+ePe
+thJ
+wEB
+gwX
 lVS
 wEB
 cZb
@@ -199349,21 +199537,21 @@ tad
 cZb
 cZb
 cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
-cZb
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
+wEB
 wEB
 lVS
-lVS
+knW
 wEB
 cZb
 cZb
@@ -199551,21 +199739,21 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
 wEB
 lVS
-lVS
+knW
 wEB
 cZb
 cZb
@@ -199753,21 +199941,21 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
 wEB
-faV
-faV
+gwX
+hGc
 wEB
 cZb
 cZb
@@ -199955,21 +200143,21 @@ tad
 tad
 tad
 tad
-tad
-lIH
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+rNs
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
 wEB
 lVS
-faV
+gwX
 wEB
 cZb
 cZb
@@ -200157,21 +200345,21 @@ tad
 tad
 tad
 tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
-tad
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
+cZb
 cZb
 cZb
 cZb
 wEB
-lVS
-rFb
+knW
+seE
 wEB
 cZb
 cZb
@@ -200372,7 +200560,7 @@ cZb
 cZb
 cZb
 wEB
-lVS
+knW
 lVS
 wEB
 cZb
@@ -200574,7 +200762,7 @@ cZb
 cZb
 cZb
 wEB
-faV
+uHJ
 lVS
 wEB
 cZb
@@ -200777,7 +200965,7 @@ cZb
 cZb
 wEB
 wiO
-vPM
+bOd
 wEB
 cZb
 cZb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Basically what it says on the title
</summary>
<hr>

- Lower Lonestars gets changed with the intent of making it easy to repair damaged piping
- Hallways get a few more firedoors and some atmos related machinery get moved around so in case of trouble the system can't easily create pockets of bad air
- NE main floor maints gets a tight corridor mini slum, good place for more sordid characters to mingle, but as dangerous as any maintenance, it has awful lighting on purpose
- Guild AM room got partially reverted, for ease of use/assembly

Mandatory checklist for when I consider this PR to get out of draft:

- [x] Does not break atmos?
- [x] Does not break power?
- [x] Zero space tiles under windows/doors
- [x] Am I sure all the items before got checked?

<hr>
</details>

## Changelog
:cl:
fix: atmos related changes on hallways and lower Lonestars
add: NE main floor maintenance slum
fix: hopoloster on xenoflora
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
