### PR TITLE
Adds comb attackverbs

### DIFF
--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -76,6 +76,7 @@
 	name = "purple comb"
 	desc = "A pristine purple comb made from flexible plastic."
 	w_class = ITEM_SIZE_TINY
+	attack_verb = list("combed", "brushes")
 	slot_flags = SLOT_EARS
 	icon = 'icons/obj/items.dmi'
 	icon_state = "purplecomb"


### PR DESCRIPTION
## About The Pull Request
Adds attackverbs to the comb.

Previously, it was only an item that does an emote when you use it, now it's still that, but you can mechanically bush other people's hair too. (Or use it on yourself in a different way)

## Changelog
:cl:
Add: Added attackverbs to comb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
