### PR TITLE
Moved foreman disks to prep

### DIFF
--- a/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
+++ b/maps/__Nadezhda/map/_Nadezhda_Colony_New.dmm
@@ -65399,6 +65399,8 @@
 /obj/random/lathe_disk,
 /obj/machinery/smartfridge/disk,
 /obj/structure/table/steel,
+/obj/item/computer_hardware/hard_drive/portable/design/scav/forman,
+/obj/item/computer_hardware/hard_drive/portable/design/guns/vector,
 /turf/simulated/floor/tiled/dark,
 /area/nadezhda/pros/prep)
 "ngJ" = (


### PR DESCRIPTION
Moved foreman armor disk and vector disk from foreman's office to prep room. On request.