### PR TITLE
Prospector disks movement PR.2

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -575,8 +575,6 @@
 	new /obj/item/device/radio/headset/heads/foreman(src)
 	new /obj/item/clothing/accessory/cape/prospie(src)
 	new /obj/item/clothing/accessory/halfcape/foreman(src)
-	new /obj/item/computer_hardware/hard_drive/portable/design/scav/forman(src)
-	new /obj/item/computer_hardware/hard_drive/portable/design/guns/vector(src)
 	switch(bag_cache)
 		if("INDUSTRIAL")
 			if(prob(80))


### PR DESCRIPTION
Removing Sweatshop and Vector disks from Foreman's locker. This was meant to be added to PR #5491 but the changes were not made on that PR. 

Both PR's are designed to improve QOL so people stop breaking into foreman's office for the disks during low-pop rounds same that was done with guild and church disks

