### PR TITLE
Gives hud-style rig helmets no face covering

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -69,6 +69,7 @@
 /obj/item/clothing/shoes/magboots/rig/light/ultra_light
 /obj/item/clothing/head/helmet/space/rig/light/ultra_light
 	name = "HUD"
+	body_parts_covered = EYES|EARS
 	flags_inv = 0
 	camera_networks = list(NETWORK_RESEARCH)
 
@@ -129,6 +130,7 @@
 //The cybersuit is not space-proof. It does however, have good siemens_coefficient values
 /obj/item/clothing/head/lightrig/hacker
 	name = "HUD"
+	body_parts_covered = EYES|EARS
 	siemens_coefficient = 0.4
 	flags = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	Lets righud users eat
</summary>
<hr>

Adds updated flags so the hacker and spacer rig helmets, which aren't spaceproof, now no longer block the face when deployed. Despite being marked as not airtight, they still retained full face covering flags as being spacesuit helmet subtypes.
	
<hr>
</details>

## Changelog
:cl:
Fix: Updated hud-style rig helmets to no longer block mouths.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
